### PR TITLE
Concurrent integrationtest

### DIFF
--- a/lib/vulcano/runner.rb
+++ b/lib/vulcano/runner.rb
@@ -18,9 +18,6 @@ module Vulcano
       @profile_id = profile_id
       @conf = Vulcano::Backend.target_config(normalize_map(conf))
 
-      # global reset
-      RSpec.world.reset
-
       configure_output
       configure_backend
     end
@@ -34,8 +31,6 @@ module Vulcano
     end
 
     def configure_output
-      # RSpec.configuration.output_stream = $stdout
-      # RSpec.configuration.error_stream = $stderr
       RSpec.configuration.add_formatter(@conf['format'] || 'progress')
     end
 

--- a/lib/vulcano/runner.rb
+++ b/lib/vulcano/runner.rb
@@ -9,9 +9,6 @@ require 'vulcano/profile_context'
 # spec requirements
 require 'rspec'
 require 'rspec/its'
-require 'specinfra'
-require 'specinfra/helper'
-require 'specinfra/helper/set'
 require 'vulcano/rspec_json_formatter'
 
 module Vulcano

--- a/lib/vulcano/runner.rb
+++ b/lib/vulcano/runner.rb
@@ -17,6 +17,7 @@ module Vulcano
       @rules = []
       @profile_id = profile_id
       @conf = Vulcano::Backend.target_config(normalize_map(conf))
+      @tests = RSpec::Core::World.new
 
       configure_output
       configure_backend
@@ -87,14 +88,17 @@ module Vulcano
           end
 
           set_rspec_ids(example, rule_id)
-          RSpec.world.register(example)
+          @tests.register(example)
         end
       end
     end
 
     def run
-      rspec_runner = RSpec::Core::Runner.new(nil)
-      rspec_runner.run_specs(RSpec.world.ordered_example_groups)
+      run_with(RSpec::Core::Runner.new(nil))
+    end
+
+    def run_with(rspec_runner)
+      rspec_runner.run_specs(@tests.ordered_example_groups)
     end
 
     def set_rspec_ids(example, id)

--- a/test/docker.rb
+++ b/test/docker.rb
@@ -2,6 +2,7 @@
 
 require 'docker'
 require 'yaml'
+require 'concurrent'
 require_relative '../lib/vulcano'
 
 tests = ARGV
@@ -18,14 +19,14 @@ class DockerTester
   end
 
   def run
-    puts ["Running tests:", @tests].flatten.join("\n- ")
+    puts ['Running tests:', @tests].flatten.join("\n- ")
     puts ''
     # test all images
-    promises = @conf['images'].map{|n|
-      Concurrent::Promise.new{ prepare_image(n) }.execute
+    promises = @conf['images'].map { |n|
+      Concurrent::Promise.new { prepare_image(n) }.execute
     }
 
-    sleep(0.1) while !promises.all?{|x|x.fulfilled?}
+    sleep(0.1) until promises.all?(&:fulfilled?)
 
     res = promises.map do |promise|
       container = promise.value
@@ -33,11 +34,11 @@ class DockerTester
     end
 
     done = promises.map do |promise|
-      promise.then{|container| stop_container(container) }
+      promise.then { |c| stop_container(c) }
     end
-    sleep(0.1) while !done.all?{|x| x.fulfilled?}
+    sleep(0.1) until done.all?(&:fulfilled?)
 
-    res.all? or raise 'Test failures'
+    res.all? or fail 'Test failures'
   end
 
   def docker_images_by_tag
@@ -53,38 +54,38 @@ class DockerTester
 
   def tests_conf
     # get the test configuration
-    conf_path = File::join(File::dirname(__FILE__), '..', '.tests.yaml')
-    raise "Can't find tests config in #{conf_path}" unless File::file?(conf_path)
-    conf = YAML.load(File::read(conf_path))
+    conf_path = File.join(File.dirname(__FILE__), '..', '.tests.yaml')
+    fail "Can't find tests config in #{conf_path}" unless File.file?(conf_path)
+    YAML.load(File.read(conf_path))
   end
 
   def test_container(container_id)
+    puts "--> run test on docker #{container_id}"
     opts = { 'target' => "docker://#{container_id}" }
     runner = Vulcano::Runner.new(nil, opts)
     runner.add_tests(@tests)
     runner.run
   end
 
-  def test_image(name)
+  def prepare_image(name)
     dname = "docker-#{name}:latest"
     image = @images[dname]
-    raise "Can't find docker image #{dname}" if image.nil?
+    fail "Can't find docker image #{dname}" if image.nil?
 
     puts "--> start docker #{name}"
     container = Docker::Container.create(
-      'Cmd' => [ '/bin/bash' ],
+      'Cmd' => ['/bin/bash'],
       'Image' => image.id,
       'OpenStdin' => true,
     )
     container.start
+    container
+  end
 
-    puts "--> run test on docker #{name}"
-    res = test_container(container.id)
-
-    puts "--> killrm docker #{name}"
+  def stop_container(container)
+    puts "--> killrm docker #{container.id}"
     container.kill
     container.delete(force: true)
-    res
   end
 end
 

--- a/vulcano.gemspec
+++ b/vulcano.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rubocop', '~> 0.33.0'
   spec.add_development_dependency 'simplecov', '~> 0.10'
+  spec.add_development_dependency 'concurrent-ruby', '~> 0.9'
 
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '~> 1.8'


### PR DESCRIPTION
Make sure all container-based integration tests are run fully concurrently without duplicate output in rspec.
