### PR TITLE
improvement: simplify runner configuration

### DIFF
--- a/bin/vulcano
+++ b/bin/vulcano
@@ -71,7 +71,7 @@ class VulcanoCLI < Thor
     desc: 'Configure WinRM scans to run via SSL instead of pure HTTP.'
   option :format, type: :string, default: 'progress'
   def exec(*tests)
-    runner = Vulcano::Runner.new(options[:id], options)
+    runner = Vulcano::Runner.new(options)
     runner.add_tests(tests)
     runner.run
   rescue RuntimeError => e

--- a/lib/vulcano/runner.rb
+++ b/lib/vulcano/runner.rb
@@ -14,9 +14,9 @@ require 'vulcano/rspec_json_formatter'
 module Vulcano
   class Runner
     attr_reader :tests
-    def initialize(profile_id, conf)
+    def initialize(conf = {})
       @rules = []
-      @profile_id = profile_id
+      @profile_id = @conf[:id]
       @conf = Vulcano::Backend.target_config(normalize_map(conf))
       @tests = RSpec::Core::World.new
 

--- a/test/docker.rb
+++ b/test/docker.rb
@@ -77,7 +77,7 @@ class DockerTester
   def test_container(container, report)
     puts "--> run test on docker #{container.id}"
     opts = { 'target' => "docker://#{container.id}" }
-    runner = Vulcano::Runner.new(nil, opts)
+    runner = Vulcano::Runner.new(opts)
     runner.add_tests(@tests)
     tests = runner.tests.ordered_example_groups
     tests.map { |g| g.run(report) }


### PR DESCRIPTION
Don't separate profile_id configuration from the remaining configuration.
