### PR TITLE
Resource in resource

### DIFF
--- a/lib/resources/audit_policy.rb
+++ b/lib/resources/audit_policy.rb
@@ -37,7 +37,7 @@ class AuditPolicy < Vulcano.resource(1)
     # expected result:
     # Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclusion Setting
     # WIN-MB8NINQ388J,System,Kerberos Authentication Service,{0CCE9242-69AE-11D9-BED3-505054503030},No Auditing,
-    result ||= vulcano.run_command("Auditpol /get /subcategory:'#{key}' /r").stdout
+    result ||= vulcano.command("Auditpol /get /subcategory:'#{key}' /r").stdout
 
     # find line
     target = nil

--- a/lib/resources/auditd_rules.rb
+++ b/lib/resources/auditd_rules.rb
@@ -14,7 +14,7 @@ class AuditDaemonRules < Vulcano.resource(1)
   name 'audit_daemon_rules'
 
   def initialize
-    @content = vulcano.run_command('/sbin/auditctl -l').stdout.chomp
+    @content = vulcano.command('/sbin/auditctl -l').stdout.chomp
 
     @opts = {
       assignment_re: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
@@ -35,7 +35,7 @@ class AuditDaemonRules < Vulcano.resource(1)
       assignment_re: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
       multiple_values: false,
     }
-    @status_content ||= vulcano.run_command('/sbin/auditctl -s').stdout.chomp
+    @status_content ||= vulcano.command('/sbin/auditctl -s').stdout.chomp
     @status_params = SimpleConfig.new(@status_content, @status_opts).params
 
     status = @status_params['AUDIT_STATUS']

--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -9,7 +9,7 @@ class Cmd < Vulcano.resource(1)
   end
 
   def result
-    @result ||= vulcano.run_command(@command)
+    @result ||= vulcano.backend.run_command(@command)
   end
 
   def stdout

--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -25,7 +25,7 @@ class Cmd < Vulcano.resource(1)
   end
 
   def exist?
-    res = vulcano.run_command("type \"#{@command}\" > /dev/null")
+    res = vulcano.backend.run_command("type \"#{@command}\" > /dev/null")
     res.exit_status.to_i == 0
   end
 end

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -8,7 +8,7 @@ module Vulcano::Resources
 
     def initialize(path)
       @path = path
-      @file = vulcano.file(@path)
+      @file = vulcano.backend.file(@path)
     end
 
     %w{

--- a/lib/resources/gem.rb
+++ b/lib/resources/gem.rb
@@ -14,7 +14,7 @@ class GemPackage < Vulcano.resource(1)
   def info
     return @info if defined?(@info)
 
-    cmd = vulcano.run_command("gem list --local -a -q \^#{@package_name}\$")
+    cmd = vulcano.command("gem list --local -a -q \^#{@package_name}\$")
     @info = {
       installed: cmd.exit_status == 0,
       type: 'gem',

--- a/lib/resources/group_policy.rb
+++ b/lib/resources/group_policy.rb
@@ -19,7 +19,7 @@ class GroupPolicy < Vulcano.resource(1)
   def get_registry_value(entry)
     keys = entry['registry_information'][0]
     cmd = "(Get-Item 'Registry::#{keys['path']}').GetValue('#{keys['key']}')"
-    command_result ||= vulcano.run_command(cmd)
+    command_result ||= vulcano.command(cmd)
     val = { exit_code: command_result.exit_status.to_i, data: command_result.stdout }
     val
   end

--- a/lib/resources/kernel_module.rb
+++ b/lib/resources/kernel_module.rb
@@ -18,7 +18,7 @@ class KernelModule < Vulcano.resource(1)
 
   def loaded?
     # get list of all modules
-    cmd = vulcano.run_command('lsmod')
+    cmd = vulcano.command('lsmod')
     return false if cmd.exit_status != 0
 
     # check if module is loaded

--- a/lib/resources/kernel_parameter.rb
+++ b/lib/resources/kernel_parameter.rb
@@ -16,7 +16,7 @@ class KernelParameter < Vulcano.resource(1)
   end
 
   def value
-    cmd = vulcano.run_command("/sbin/sysctl -q -n #{@parameter}")
+    cmd = vulcano.command("/sbin/sysctl -q -n #{@parameter}")
     return nil if cmd.exit_status != 0
     # remove whitespace
     cmd = cmd.stdout.chomp.strip

--- a/lib/resources/mysql_session.rb
+++ b/lib/resources/mysql_session.rb
@@ -18,7 +18,7 @@ class MysqlSession < Vulcano.resource(1)
     escaped_query = q.gsub(/\\/, '\\\\').gsub(/"/, '\\"').gsub(/\$/, '\\$')
 
     # run the query
-    cmd = vulcano.run_command("mysql -u#{@user} -p#{@pass} #{db} -s -e \"#{escaped_query}\"")
+    cmd = vulcano.command("mysql -u#{@user} -p#{@pass} #{db} -s -e \"#{escaped_query}\"")
     out = cmd.stdout + "\n" + cmd.stderr
     if out =~ /Can't connect to .* MySQL server/ or
        out.downcase =~ /^error/
@@ -34,7 +34,7 @@ class MysqlSession < Vulcano.resource(1)
 
   def init_fallback
     # support debian mysql administration login
-    debian = vulcano.run_command('test -f /etc/mysql/debian.cnf && cat /etc/mysql/debian.cnf').stdout
+    debian = vulcano.command('test -f /etc/mysql/debian.cnf && cat /etc/mysql/debian.cnf').stdout
     return if debian.empty?
 
     user = debian.match(/^\s*user\s*=\s*([^ ]*)\s*$/)

--- a/lib/resources/npm.rb
+++ b/lib/resources/npm.rb
@@ -15,7 +15,7 @@ class NpmPackage < Vulcano.resource(1)
   def info
     return @info if defined?(@info)
 
-    cmd = vulcano.run_command("npm ls -g --json #{@package_name}")
+    cmd = vulcano.command("npm ls -g --json #{@package_name}")
     @info = {
       name: @package_name,
       type: 'npm',

--- a/lib/resources/oneget.rb
+++ b/lib/resources/oneget.rb
@@ -25,7 +25,7 @@ class OneGetPackage < Vulcano.resource(1)
     @info[:type] = 'oneget'
     @info[:installed] = false
 
-    cmd = vulcano.run_command("Get-Package -Name '#{@package_name}' | ConvertTo-Json")
+    cmd = vulcano.command("Get-Package -Name '#{@package_name}' | ConvertTo-Json")
     # cannot rely on exit code for now, successful command returns exit code 1
     # return nil if cmd.exit_status != 0
     # try to parse json

--- a/lib/resources/os.rb
+++ b/lib/resources/os.rb
@@ -5,7 +5,7 @@ module Vulcano::Resources
     name 'os'
 
     def [](name)
-      vulcano.os[name]
+      vulcano.backend.os[name]
     end
   end
 end

--- a/lib/resources/os_env.rb
+++ b/lib/resources/os_env.rb
@@ -15,7 +15,7 @@ class OsEnv < Vulcano.resource(1)
   attr_reader :content
   def initialize(env)
     @osenv = env
-    @command_result = vulcano.run_command("su - root -c 'echo $#{env}'")
+    @command_result = vulcano.command("su - root -c 'echo $#{env}'")
     @content = @command_result.stdout.chomp
   end
 

--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -65,7 +65,7 @@ end
 # Debian / Ubuntu
 class Deb < PkgManagement
   def info(package_name)
-    cmd = @vulcano.run_command("dpkg -s #{package_name}")
+    cmd = @vulcano.command("dpkg -s #{package_name}")
     return nil if cmd.exit_status.to_i != 0
 
     params = SimpleConfig.new(
@@ -85,7 +85,7 @@ end
 # RHEL family
 class Rpm < PkgManagement
   def info(package_name)
-    cmd = @vulcano.run_command("rpm -qia #{package_name}")
+    cmd = @vulcano.command("rpm -qia #{package_name}")
     return nil if cmd.exit_status.to_i != 0
     params = SimpleConfig.new(
       cmd.stdout.chomp,
@@ -104,7 +104,7 @@ end
 # MacOS / Darwin implementation
 class Brew < PkgManagement
   def info(package_name)
-    cmd = @vulcano.run_command("brew info --json=v1 #{package_name}")
+    cmd = @vulcano.command("brew info --json=v1 #{package_name}")
     return nil if cmd.exit_status.to_i != 0
     # parse data
     pkg = JSON.parse(cmd.stdout)[0]
@@ -120,7 +120,7 @@ end
 # Arch Linux
 class Pacman < PkgManagement
   def info(package_name)
-    cmd = @vulcano.run_command("pacman -Qi #{package_name}")
+    cmd = @vulcano.command("pacman -Qi #{package_name}")
     return nil if cmd.exit_status.to_i != 0
 
     params = SimpleConfig.new(
@@ -145,7 +145,7 @@ end
 class WindowsPkg < PkgManagement
   def info(package_name)
     # Find the package
-    cmd = @vulcano.run_command("Get-WmiObject -Class Win32_Product | Where-Object {$_.Name -eq '#{package_name}'} | Select-Object -Property Name,Version,Vendor,PackageCode,Caption,Description | ConvertTo-Json")
+    cmd = @vulcano.command("Get-WmiObject -Class Win32_Product | Where-Object {$_.Name -eq '#{package_name}'} | Select-Object -Property Name,Version,Vendor,PackageCode,Caption,Description | ConvertTo-Json")
 
     begin
       package = JSON.parse(cmd.stdout)

--- a/lib/resources/pip.rb
+++ b/lib/resources/pip.rb
@@ -17,7 +17,7 @@ class PipPackage < Vulcano.resource(1)
 
     @info = {}
     @info[:type] = 'pip'
-    cmd = vulcano.run_command("#{pip_cmd} show #{@package_name}")
+    cmd = vulcano.command("#{pip_cmd} show #{@package_name}")
     return @info if cmd.exit_status != 0
 
     params = SimpleConfig.new(
@@ -52,7 +52,7 @@ class PipPackage < Vulcano.resource(1)
     case family
     when 'windows'
       # we need to detect the pip command on Windows
-      cmd = vulcano.run_command('New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Pip -Value (Invoke-Command -ScriptBlock {where.exe pip}) -PassThru | Add-Member -MemberType NoteProperty -Name Python -Value (Invoke-Command -ScriptBlock {where.exe python}) -PassThru | ConvertTo-Json')
+      cmd = vulcano.command('New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Pip -Value (Invoke-Command -ScriptBlock {where.exe pip}) -PassThru | Add-Member -MemberType NoteProperty -Name Python -Value (Invoke-Command -ScriptBlock {where.exe python}) -PassThru | ConvertTo-Json')
       begin
         paths = JSON.parse(cmd.stdout)
         # use pip if it on system path

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -89,7 +89,7 @@ end
 class WindowsPorts < PortsInfo
   def info
     # get all port information
-    cmd = @vulcano.run_command('Get-NetTCPConnection | Select-Object -Property State, Caption, Description, LocalAddress, LocalPort, RemoteAddress, RemotePort, DisplayName, Status | ConvertTo-Json')
+    cmd = @vulcano.command('Get-NetTCPConnection | Select-Object -Property State, Caption, Description, LocalAddress, LocalPort, RemoteAddress, RemotePort, DisplayName, Status | ConvertTo-Json')
 
     begin
       ports = JSON.parse(cmd.stdout)
@@ -115,7 +115,7 @@ end
 class DarwinPorts < PortsInfo
   def info
     # collects UDP and TCP information
-    cmd = @vulcano.run_command('lsof -nP -iTCP -iUDP -sTCP:LISTEN')
+    cmd = @vulcano.command('lsof -nP -iTCP -iUDP -sTCP:LISTEN')
     return nil if cmd.exit_status.to_i != 0
 
     ports = []
@@ -154,7 +154,7 @@ end
 # extract port information from netstat
 class LinuxPorts < PortsInfo
   def info
-    cmd = @vulcano.run_command('netstat -tulpen')
+    cmd = @vulcano.command('netstat -tulpen')
     return nil if cmd.exit_status.to_i != 0
 
     ports = []
@@ -218,7 +218,7 @@ end
 # extracts information from sockstat
 class FreeBsdPorts < PortsInfo
   def info
-    cmd = @vulcano.run_command('sockstat -46l')
+    cmd = @vulcano.command('sockstat -46l')
     return nil if cmd.exit_status.to_i != 0
 
     ports = []

--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -11,7 +11,7 @@ class Postgres < Vulcano.resource(1)
     when 'ubuntu', 'debian'
       @service = 'postgresql'
       @data_dir = '/var/lib/postgresql'
-      @version = vulcano.run_command('ls /etc/postgresql/').stdout.chomp
+      @version = vulcano.command('ls /etc/postgresql/').stdout.chomp
       @conf_dir = "/etc/postgresql/#{@version}/main"
       @conf_path = File.join @conf_dir, 'postgresql.conf'
 

--- a/lib/resources/postgres_session.rb
+++ b/lib/resources/postgres_session.rb
@@ -33,7 +33,7 @@ class PostgresSession
     # that does this securely
     escaped_query = query.gsub(/\\/, '\\\\').gsub(/"/, '\\"').gsub(/\$/, '\\$')
     # run the query
-    cmd = vulcano.run_command("PGPASSWORD='#{@pass}' psql -U #{@user} #{dbs} -c \"#{escaped_query}\"")
+    cmd = vulcano.command("PGPASSWORD='#{@pass}' psql -U #{@user} #{dbs} -c \"#{escaped_query}\"")
     out = cmd.stdout + "\n" + cmd.stderr
     if out =~ /could not connect to .*/ or
        out.downcase =~ /^error/

--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -23,7 +23,7 @@ class Processes < Vulcano.resource(1)
 
   def ps_aux
     # get all running processes
-    cmd = vulcano.run_command('ps aux')
+    cmd = vulcano.command('ps aux')
     all = cmd.stdout.split("\n")[1..-1]
 
     lines = all.map do |line|

--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -23,7 +23,7 @@ class RegistryKey < Vulcano.resource(1)
 
   def registry_value(path, key)
     cmd = "(Get-Item 'Registry::#{path}').GetValue('#{key}')"
-    command_result ||= vulcano.run_command(cmd)
+    command_result ||= vulcano.command(cmd)
     val = { exit_code: command_result.exit_status.to_i, data: command_result.stdout }
     val
   end

--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -22,11 +22,11 @@ class SecurityPolicy < Vulcano.resource(1)
   # load security content
   def load
     # export the security policy
-    vulcano.run_command('secedit /export /cfg win_secpol.cfg')
+    vulcano.command('secedit /export /cfg win_secpol.cfg')
     # store file content
-    command_result ||= vulcano.run_command('type win_secpol.cfg')
+    command_result ||= vulcano.command('type win_secpol.cfg')
     # delete temp file
-    vulcano.run_command('del win_secpol.cfg')
+    vulcano.command('del win_secpol.cfg')
 
     @exit_status = command_result.exit_status.to_i
     @policy = command_result.stdout

--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -111,7 +111,7 @@ end
 # @see: http://www.freedesktop.org/software/systemd/man/systemd-system.conf.html
 class Systemd < ServiceManager
   def info(service_name)
-    cmd = @vulcano.run_command("systemctl show --all #{service_name}")
+    cmd = @vulcano.command("systemctl show --all #{service_name}")
     return nil if cmd.exit_status.to_i != 0
 
     # parse data
@@ -145,7 +145,7 @@ end
 class Upstart < ServiceManager
   def info(service_name)
     # get the status of upstart service
-    cmd = @vulcano.run_command("initctl status #{service_name}")
+    cmd = @vulcano.command("initctl status #{service_name}")
     return nil if cmd.exit_status != 0
 
     # @see: http://upstart.ubuntu.com/cookbook/#job-states
@@ -156,7 +156,7 @@ class Upstart < ServiceManager
     # check if a service is enabled
     # http://upstart.ubuntu.com/cookbook/#determine-if-a-job-is-disabled
     # $ initctl show-config $job | grep -q "^  start on" && echo enabled || echo disabled
-    config = @vulcano.run_command("initctl show-config #{service_name}")
+    config = @vulcano.command("initctl show-config #{service_name}")
     match_enabled = /^\s*start on/.match(config.stdout)
     !match_enabled.nil? ? (enabled = true) : (enabled = false)
 
@@ -175,7 +175,7 @@ class SysV < ServiceManager
   def info(service_name)
     # check if service is installed
     # read all available services via ls /etc/init.d/
-    srvlist = @vulcano.run_command('ls -1 /etc/init.d/')
+    srvlist = @vulcano.command('ls -1 /etc/init.d/')
     return nil if srvlist.exit_status != 0
 
     # check if the service is in list
@@ -187,7 +187,7 @@ class SysV < ServiceManager
     # read all enabled services from runlevel
     # on rhel via: 'chkconfig --list', is not installed by default
     # bash: for i in `find /etc/rc*.d -name S*`; do basename $i | sed -r 's/^S[0-9]+//'; done | sort | uniq
-    enabled_services_cmd = @vulcano.run_command('find /etc/rc*.d -name S*')
+    enabled_services_cmd = @vulcano.command('find /etc/rc*.d -name S*')
     enabled_services = enabled_services_cmd.stdout.split("\n").select { |line|
       /(^.*#{service_name}.*)/.match(line)
     }
@@ -196,7 +196,7 @@ class SysV < ServiceManager
     # check if service is really running
     # service throws an exit code if the service is not installed or
     # not enabled
-    cmd = @vulcano.run_command("service #{service_name} status")
+    cmd = @vulcano.command("service #{service_name} status")
     cmd.exit_status == 0 ? (running = true) : (running = false)
 
     {
@@ -220,7 +220,7 @@ class BSDInit < ServiceManager
     # service SERVICE status returns the following result if not activated:
     #   Cannot 'status' sshd. Set sshd_enable to YES in /etc/rc.conf or use 'onestatus' instead of 'status'.
     # gather all enabled services
-    cmd = @vulcano.run_command('service -e')
+    cmd = @vulcano.command('service -e')
     return nil if cmd.exit_status != 0
 
     # search for the service
@@ -230,7 +230,7 @@ class BSDInit < ServiceManager
 
     # check if the service is running
     # if the service is not available or not running, we always get an error code
-    cmd = @vulcano.run_command("service #{service_name} onestatus")
+    cmd = @vulcano.command("service #{service_name} onestatus")
     cmd.exit_status == 0 ? (running = true) : (running = false)
 
     {
@@ -249,7 +249,7 @@ end
 class LaunchCtl < ServiceManager
   def info(service_name)
     # get the status of upstart service
-    cmd = @vulcano.run_command('launchctl list')
+    cmd = @vulcano.command('launchctl list')
     return nil if cmd.exit_status != 0
 
     # search for the service
@@ -311,7 +311,7 @@ class WindowsSrv < ServiceManager
   # - 6: Pause Pending
   # - 7: Paused
   def info(service_name)
-    cmd = @vulcano.run_command("New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Service -Value (Get-Service -Name #{service_name}| Select-Object -Property Name, DisplayName, Status) -PassThru | Add-Member -MemberType NoteProperty -Name WMI -Value (Get-WmiObject -Class Win32_Service | Where-Object {$_.Name -eq '#{service_name}' -or $_.DisplayName -eq '#{service_name}'} | Select-Object -Property StartMode) -PassThru | ConvertTo-Json")
+    cmd = @vulcano.command("New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Service -Value (Get-Service -Name #{service_name}| Select-Object -Property Name, DisplayName, Status) -PassThru | Add-Member -MemberType NoteProperty -Name WMI -Value (Get-WmiObject -Class Win32_Service | Where-Object {$_.Name -eq '#{service_name}' -or $_.DisplayName -eq '#{service_name}'} | Select-Object -Property StartMode) -PassThru | ConvertTo-Json")
 
     # cannot rely on exit code for now, successful command returns exit code 1
     # return nil if cmd.exit_status != 0

--- a/lib/resources/user.rb
+++ b/lib/resources/user.rb
@@ -188,7 +188,7 @@ class UnixUser < UserInfo
 
   # extracts the identity
   def identity(username)
-    cmd = @vulcano.run_command("id #{username}")
+    cmd = @vulcano.command("id #{username}")
     return nil if cmd.exit_status != 0
 
     # parse words
@@ -214,7 +214,7 @@ class LinuxUser < UnixUser
   include ContentParser
 
   def meta_info(username)
-    cmd = @vulcano.run_command("getent passwd #{username}")
+    cmd = @vulcano.command("getent passwd #{username}")
     return nil if cmd.exit_status != 0
     # returns: root:x:0:0:root:/root:/bin/bash
     passwd = parse_passwd_line(cmd.stdout.chomp)
@@ -225,7 +225,7 @@ class LinuxUser < UnixUser
   end
 
   def credentials(username)
-    cmd = @vulcano.run_command("chage -l #{username}")
+    cmd = @vulcano.command("chage -l #{username}")
     return nil if cmd.exit_status != 0
 
     params = SimpleConfig.new(
@@ -250,7 +250,7 @@ end
 # @see http://superuser.com/questions/592921/mac-osx-users-vs-dscl-command-to-list-user
 class DarwinUser < UnixUser
   def meta_info(username)
-    cmd = @vulcano.run_command("dscl -q . -read /Users/#{username} NFSHomeDirectory PrimaryGroupID RecordName UniqueID UserShell")
+    cmd = @vulcano.command("dscl -q . -read /Users/#{username} NFSHomeDirectory PrimaryGroupID RecordName UniqueID UserShell")
     return nil if cmd.exit_status != 0
 
     params = SimpleConfig.new(
@@ -279,7 +279,7 @@ class FreeBSDUser < UnixUser
   include ContentParser
 
   def meta_info(username)
-    cmd = @vulcano.run_command("pw usershow #{username} -7")
+    cmd = @vulcano.command("pw usershow #{username} -7")
     return nil if cmd.exit_status != 0
     # returns: root:*:0:0:Charlie &:/root:/bin/csh
     passwd = parse_passwd_line(cmd.stdout.chomp)
@@ -340,7 +340,7 @@ class WindowsUser < UserInfo
     # TODO: move to winrm backend
     require 'winrm'
     script = WinRM::PowershellScript.new(script)
-    cmd = @vulcano.run_command("powershell -encodedCommand #{script.encoded}")
+    cmd = @vulcano.command("powershell -encodedCommand #{script.encoded}")
 
     # cannot rely on exit code for now, successful command returns exit code 1
     # return nil if cmd.exit_status != 0, try to parse json

--- a/lib/resources/windows_feature.rb
+++ b/lib/resources/windows_feature.rb
@@ -45,7 +45,7 @@ class WindowsFeature < Vulcano.resource(1)
   def info
     return @cache if !@cache.nil?
     features_cmd = "Get-WindowsFeature | Where-Object {$_.Name -eq '#{@feature}' -or $_.DisplayName -eq '#{@feature}'} | Select-Object -Property Name,DisplayName,Description,Installed,InstallState | ConvertTo-Json"
-    cmd = vulcano.run_command(features_cmd)
+    cmd = vulcano.command(features_cmd)
 
     @cache = {
       name: @feature,

--- a/lib/resources/yum.rb
+++ b/lib/resources/yum.rb
@@ -42,7 +42,7 @@ module Vulcano::Resources
       return @cache if defined?(@cache)
       # parse the repository data from yum
       # we cannot use -C, because this is not reliable and may lead to errors
-      @command_result = vulcano.run_command('yum -v repolist all')
+      @command_result = vulcano.command('yum -v repolist all')
       @content = @command_result.stdout
       @cache = []
       repo = {}

--- a/lib/vulcano/backend.rb
+++ b/lib/vulcano/backend.rb
@@ -39,6 +39,26 @@ module Vulcano
       # return the updated config
       conf
     end
+
+    def self.create(name, conf)
+      backend_class = @registry[name]
+      return nil if backend_class.nil?
+      backend_instance = backend_class.new(conf)
+
+      # Create wrapper class with all resources
+      cls = Class.new do
+        define_method :backend do
+          backend_instance
+        end
+        Vulcano::Resource.registry.each do |id, r|
+          define_method id.to_sym do |*args|
+            r.new(self, *args)
+          end
+        end
+      end
+
+      cls.new
+    end
   end
 
   def self.backend(version = 1)

--- a/test/resource/command_test.rb
+++ b/test/resource/command_test.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 describe command('echo hello') do
   its(:stdout) { should eq "hello\n" }
   its(:stderr) { should eq '' }

--- a/test/runner/docker_test_container.rb
+++ b/test/runner/docker_test_container.rb
@@ -11,9 +11,8 @@ puts ''
 
 backends = {}
 backends[:docker] = proc {
-  backend_conf = Vulcano::Backend.target_config({ 'host' => container_id })
-  backend_class = Vulcano::Backend.registry['docker']
-  backend_class.new(backend_conf)
+  opt = { 'host' => container_id }
+  Vulcano::Backend.create('docker', opt)
 }
 
 backends.each do |type, get_backend|

--- a/test/runner/test_local.rb
+++ b/test/runner/test_local.rb
@@ -5,15 +5,12 @@ require 'vulcano/backend'
 backends = {}
 
 backends[:local] = proc {
-  backend_conf = Vulcano::Backend.target_config({})
-  backend_class = Vulcano::Backend.registry['local']
-  backend_class.new(backend_conf)
+  Vulcano::Backend.create('local', {}).backend
 }
 
 backends[:specinfra_local] = proc {
-  backend_conf = Vulcano::Backend.target_config({ 'backend' => 'exec' })
-  backend_class = Vulcano::Backend.registry['specinfra']
-  backend_class.new(backend_conf)
+  opt = { 'backend' => 'exec' }
+  Vulcano::Backend.create('specinfra', opt).backend
 }
 
 tests = ARGV

--- a/test/runner/test_ssh.rb
+++ b/test/runner/test_ssh.rb
@@ -3,19 +3,17 @@ require_relative 'helper'
 require 'vulcano/backend'
 
 backends = {}
-backend_conf = Vulcano::Backend.target_config({
+backend_conf = {
   'target' => 'ssh://vagrant@localhost',
   'key_file' => '/root/.ssh/id_rsa',
-})
+}
 
 backends[:specinfra_ssh] = proc {
-  backend_class = Vulcano::Backend.registry['specinfra']
-  backend_class.new(backend_conf)
+  Vulcano::Backend.create('specinfra', backend_conf).backend
 }
 
 backends[:ssh] = proc {
-  backend_class = Vulcano::Backend.registry['ssh']
-  backend_class.new(backend_conf)
+  Vulcano::Backend.create('ssh', backend_conf).backend
 }
 
 tests = ARGV


### PR DESCRIPTION
What is currently available as `vulcano` inside resources (e.g. to call `vulcano.file(...)`, is now wrapped inside `vulcano.backend`. All other resources are now added to `vulcano.<RESOURCE>`, e.g. `vulcano.user`.

In effect:
- When creating a resource, you can access the transport backend via: `vulcano.backend`.
- To access other resources, you can call `vulcano.<RESOURCE>`.
- The transport backend currently exposes `run_command`, `file`, and `os`.
