### PR TITLE
improvement: add default print method to resources

### DIFF
--- a/lib/vulcano/backend.rb
+++ b/lib/vulcano/backend.rb
@@ -56,7 +56,7 @@ module Vulcano
         end
         Vulcano::Resource.registry.each do |id, r|
           define_method id.to_sym do |*args|
-            r.new(self, *args)
+            r.new(self, id.to_s, *args)
           end
         end
       end

--- a/lib/vulcano/plugins/resource.rb
+++ b/lib/vulcano/plugins/resource.rb
@@ -14,9 +14,10 @@ module Vulcano
         cl = Class.new(obj) do
           # add some common methods
           include Vulcano::Plugins::ResourceCommon
-          def initialize(backend, *args)
+          def initialize(backend, name, *args)
             # attach the backend to this instance
             @__backend_runner__ = backend
+            @__resource_name__ = name
             # call the resource initializer
             super(*args)
           end
@@ -29,6 +30,14 @@ module Vulcano
 
         # add the resource to the registry by name
         Vulcano::Resource.registry[name] = cl
+      end
+
+      # Define methods which are available to all resources
+      # and may be overwritten.
+
+      # Print the name of the resource
+      def to_s
+        @__resource_name__
       end
     end
 

--- a/lib/vulcano/profile_context.rb
+++ b/lib/vulcano/profile_context.rb
@@ -63,7 +63,7 @@ module Vulcano
       Module.new do
         Vulcano::Resource.registry.each do |id, r|
           define_method id.to_sym do |*args|
-            r.new(backend, *args)
+            r.new(backend, id.to_s, *args)
           end
         end
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -151,7 +151,7 @@ class MockLoader
   def load_resource(resource, *args)
     # initialize resource with backend and parameters
     @resource_class = Vulcano::Resource.registry[resource]
-    @resource = @resource_class.new(backend, *args)
+    @resource = @resource_class.new(backend, resource, *args)
   end
 end
 


### PR DESCRIPTION
solves #78

let's stick to simple printing for now just to avoid cryptic `<Class...>` results in any logs.
