### PR TITLE
fix delivery dependencies

### DIFF
--- a/.delivery/build-cookbook/Berksfile
+++ b/.delivery/build-cookbook/Berksfile
@@ -1,10 +1,16 @@
+# encoding: utf-8
 source 'https://supermarket.chef.io'
 
 metadata
 
-group :delivery do
-  cookbook 'delivery-sugar-extras', git: 'https://github.com/chef-cookbooks/delivery-sugar-extras.git'
-  cookbook 'delivery-sugar', git: 'https://github.com/chef-cookbooks/delivery-sugar.git'
-  cookbook 'delivery_build', git: 'https://github.com/chef-cookbooks/delivery_build'
-  cookbook 'delivery-truck', git: 'https://github.com/chef-cookbooks/delivery-truck.git'
-end
+cookbook 'delivery-truck',
+         git: 'https://github.com/chef-cookbooks/delivery-truck.git',
+         branch: 'master'
+
+cookbook 'delivery-sugar',
+         git: 'https://github.com/chef-cookbooks/delivery-sugar.git',
+         branch: 'master'
+
+cookbook 'delivery-sugar-extras',
+         git: 'https://github.com/chef-cookbooks/delivery-sugar-extras.git',
+         branch: 'master'

--- a/.delivery/build-cookbook/metadata.rb
+++ b/.delivery/build-cookbook/metadata.rb
@@ -6,5 +6,7 @@ version '0.1.0'
 
 depends 'docker', '~> 1.0'
 depends 'fancy_execute'
+depends 'chef-sugar'
 depends 'delivery-truck'
+depends 'delivery-sugar'
 depends 'delivery-sugar-extras'


### PR DESCRIPTION
- move delivery truck and sugar to flat berks dependencies
- remove delivery_build as github dependency
- add chef-sugar
