### PR TITLE
fix travis builds for 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 language: ruby
 cache: bundler
 
+bundler_args: --without integration tools
+
 matrix:
   include:
   - rvm: 1.9.3


### PR DESCRIPTION
Remove integration and tools sections from Gemfile in travis install.
