### PR TITLE
Metadata

### DIFF
--- a/lib/vulcano/metadata.rb
+++ b/lib/vulcano/metadata.rb
@@ -6,7 +6,7 @@
 require 'logger'
 
 module Vulcano
-  # Extract vmetadata.rb information
+  # Extract metadata.rb information
   class Metadata
     attr_reader :params
     def initialize(logger = nil)
@@ -46,19 +46,19 @@ module Vulcano
       is_valid = true
       %w{ name title version summary }.each do |field|
         next unless params[field].nil?
-        @log.error("Missing profile #{field} in vmetadata.rb")
+        @log.error("Missing profile #{field} in metadata.rb")
         is_valid = false
       end
       %w{ maintainer copyright }.each do |field|
         next unless params[field].nil?
-        @log.warn("Missing profile #{field} in vmetadata.rb")
+        @log.warn("Missing profile #{field} in metadata.rb")
         is_valid = false
       end
       is_valid && @missing_methods.empty?
     end
 
     def method_missing(sth, *args)
-      @log.warn "vmetadata.rb doesn't support: #{sth} #{args}"
+      @log.warn "metadata.rb doesn't support: #{sth} #{args}"
       @missing_methods.push(sth)
     end
 

--- a/lib/vulcano/profile_context.rb
+++ b/lib/vulcano/profile_context.rb
@@ -42,6 +42,7 @@ module Vulcano
         # TODO: error
         return
       end
+
       # add the rule to the registry
       existing = @rules[full_id]
       if existing.nil?

--- a/lib/vulcano/rule.rb
+++ b/lib/vulcano/rule.rb
@@ -5,6 +5,7 @@
 # author: Christoph Hartmann
 
 require 'rspec/expectations'
+require 'method_source'
 
 module Vulcano
   class ExpectationTarget
@@ -43,8 +44,8 @@ module Vulcano
     def initialize(id, _opts, &block)
       @id = id
       @impact = nil
-      @__code = ''
       @__block = block
+      @__code = __get_block_source(&block)
       @title = nil
       @desc = nil
       # not changeable by the user:
@@ -149,6 +150,12 @@ module Vulcano
       text.strip.split("\n").map(&:strip)
         .map { |x| x.empty? ? "\n" : x }
         .join(' ')
+    end
+
+    # get the rule's source code
+    def __get_block_source(&block)
+      return '' unless block_given?
+      block.source.to_s
     end
   end
 end

--- a/lib/vulcano/rule.rb
+++ b/lib/vulcano/rule.rb
@@ -156,6 +156,8 @@ module Vulcano
     def __get_block_source(&block)
       return '' unless block_given?
       block.source.to_s
+    rescue MethodSource::SourceNotFoundError
+      ''
     end
   end
 end

--- a/lib/vulcano/runner.rb
+++ b/lib/vulcano/runner.rb
@@ -59,6 +59,8 @@ module Vulcano
     end
 
     def add_content(content, source, line = nil)
+      return if content.nil? || content.empty?
+
       # evaluate all tests
       ctx = create_context
       ctx.load(content, source, line || 1)

--- a/lib/vulcano/targets/dir.rb
+++ b/lib/vulcano/targets/dir.rb
@@ -4,7 +4,7 @@
 
 module Vulcano::Targets
   module DirsHelper
-    class ChefAuditDir
+    class ProfileDir
       def handles?(paths)
         paths.include?('recipes') and paths.include?('metadata.rb')
       end
@@ -39,7 +39,7 @@ module Vulcano::Targets
     end
 
     HANDLERS = [
-      ChefAuditDir, ServerspecDir, FlatDir
+      ProfileDir, ServerspecDir, FlatDir
     ].map(&:new)
 
     def self.get_handler(paths)

--- a/lib/vulcano/targets/dir.rb
+++ b/lib/vulcano/targets/dir.rb
@@ -6,6 +6,19 @@ module Vulcano::Targets
   module DirsHelper
     class ProfileDir
       def handles?(paths)
+        paths.include?('test') && paths.include?('metadata.rb')
+      end
+
+      def get_filenames(paths)
+        paths.find_all do |path|
+          (path.start_with?('test') || path.start_with?('lib')) &&
+            path.end_with?('.rb')
+        end
+      end
+    end
+
+    class ChefAuditDir
+      def handles?(paths)
         paths.include?('recipes') and paths.include?('metadata.rb')
       end
 

--- a/lib/vulcano/targets/dir.rb
+++ b/lib/vulcano/targets/dir.rb
@@ -52,7 +52,7 @@ module Vulcano::Targets
     end
 
     HANDLERS = [
-      ProfileDir, ServerspecDir, FlatDir
+      ProfileDir, ChefAuditDir, ServerspecDir, FlatDir
     ].map(&:new)
 
     def self.get_handler(paths)

--- a/lib/vulcano/targets/folder.rb
+++ b/lib/vulcano/targets/folder.rb
@@ -21,10 +21,11 @@ module Vulcano::Targets
       if helper.nil?
         fail "Don't know how to handle folder #{target}"
       end
-      # get all file contents
+
+      # get all test file contents
       file_handler = Vulcano::Targets.modules['file']
-      test_files = helper.get_filenames(files)
-      test_files.map do |f|
+      raw_files = helper.get_filenames(files)
+      raw_files.map do |f|
         file_handler.resolve(File.join(target, f))
       end
     end

--- a/lib/vulcano/targets/folder.rb
+++ b/lib/vulcano/targets/folder.rb
@@ -15,7 +15,7 @@ module Vulcano::Targets
       # find all files in the folder
       files = Dir[File.join(target, '**', '*')]
       # remove the prefix
-      files = files.map { |x| x[target.length + 1..-1] }
+      files = files.map { |x| x.sub(target, '') }
       # get the dirs helper
       helper = DirsHelper.get_handler(files)
       if helper.nil?


### PR DESCRIPTION
- use metadata.rb instead of vmetadata.rb
- auto-include library files for inspec profiles
- minor bugfixes

The auto-include libraries is about providing library functions to all tests within scope:

```
/lib/crypto_lib.rb
/test/crypto_test.rb
```

Here, crypto_lib will be included by default, sothat crypto_test can use it.
