### PR TITLE
Don't resolve `send` calls with dot-notation

### DIFF
--- a/lib/resources/json.rb
+++ b/lib/resources/json.rb
@@ -49,10 +49,13 @@ class JsonConfig < Inspec.resource(1)
     end
   end
 
+  # Shorthand to retrieve a parameter name via `#its`.
+  # Example: describe json('file') { its('paramX') { should eq 'Y' } }
+  #
+  # @param [String] name name of the field to retrieve
+  # @return [Object] the value stored at this position
   def method_missing(name)
-    # split dotted path
-    keys = name.to_s.split('.')
-    extract_value(keys, @params.clone)
+    @params[name.to_s]
   end
 
   def to_s

--- a/test/unit/mock/files/kitchen.yml
+++ b/test/unit/mock/files/kitchen.yml
@@ -1,7 +1,7 @@
+name: vagrant
 driver:
-  name: vagrant
   customize:
     memory: 1024
 platforms:
-  - name: centos-5.11
-  - name: centos-6.7
+  - linux
+  - mac

--- a/test/unit/mock/files/policyfile.lock.json
+++ b/test/unit/mock/files/policyfile.lock.json
@@ -1,12 +1,12 @@
 {
   "name": "demo",
   "run_list": [
-    "apache2",
-    "omnibus"
+    "a",
+    "b"
   ],
-  "cookbook_locks": {
-    "omnibus": {
-      "version": "2.2.0"
+  "x": {
+    "y": {
+      "z": 123
     }
   }
 }

--- a/test/unit/resources/csv_test.rb
+++ b/test/unit/resources/csv_test.rb
@@ -6,10 +6,30 @@ require 'helper'
 require 'inspec/resource'
 
 describe 'Inspec::Resources::CSV' do
-  it 'verify csv parsing' do
-    resource = load_resource('csv', 'example.csv')
-    _(resource.params).wont_equal nil
-    _(resource.send('1.addressable')).must_equal 'astrolabe'
-    _(resource.send('addressable')).must_equal %w{ast astrolabe berkshelf}
+  describe 'when loading a valid csv' do
+    let (:resource) { load_resource('csv', 'example.csv') }
+    let (:params) {
+      {}
+    }
+
+    it 'captures an array of params' do
+      _(resource.params).must_be_kind_of Array
+    end
+
+    it 'gets all value lines' do
+      _(resource.params.length).must_equal 3
+    end
+
+    it 'captures a hashmap of entries of a line' do
+      _(resource.params[0]).must_be_kind_of Hash
+    end
+
+    it 'gets params by header fields' do
+      _(resource.params[0]['addressable']).must_equal 'ast'
+    end
+
+    it 'retrieves nil if a param is missing' do
+      _(resource.params[0]['missing']).must_be_nil
+    end
   end
 end

--- a/test/unit/resources/json_test.rb
+++ b/test/unit/resources/json_test.rb
@@ -6,11 +6,31 @@ require 'helper'
 require 'inspec/resource'
 
 describe 'Inspec::Resources::JSON' do
-  it 'verify json parsing' do
-    resource = load_resource('json', 'policyfile.lock.json')
-    _(resource.params).wont_equal nil
-    _(resource.send('name')).must_equal 'demo'
-    _(resource.send('run_list')).must_equal %w{apache2 omnibus}
-    _(resource.send('cookbook_locks.omnibus.version')).must_equal '2.2.0'
+  describe 'when loading a valid json' do
+    let (:resource) { load_resource('json', 'policyfile.lock.json') }
+
+    it 'gets params as a hashmap' do
+      _(resource.params).must_be_kind_of Hash
+    end
+
+    it 'retrieves nil if a param is missing' do
+      _(resource.params['missing']).must_be_nil
+    end
+
+    it 'retrieves params by name' do
+      _(resource.send('name')).must_equal 'demo'
+    end
+
+    it 'retrieves an array by name' do
+      _(resource.send('run_list')).must_equal %w{a b}
+    end
+
+    it 'doesnt resolve dot-notation names' do
+      _(resource.send('x.y.z')).must_be_nil
+    end
+
+    it 'doesnt resolve symbol-notation names' do
+      _(resource.send(:'x.y.z')).must_be_nil
+    end
   end
 end

--- a/test/unit/resources/yaml_test.rb
+++ b/test/unit/resources/yaml_test.rb
@@ -4,12 +4,31 @@ require 'helper'
 require 'inspec/resource'
 
 describe 'Inspec::Resources::YAML' do
-  it 'verify yaml parsing' do
-    resource = load_resource('yaml', 'kitchen.yml')
-    _(resource.params).wont_be_nil
-    _(resource.send('driver.name')).must_equal 'vagrant'
-    _(resource.send('driver.customize.memory')).must_equal 1024
-    _(resource.send('platforms.1.name')).must_equal 'centos-6.7'
-    _(resource.send('platforms.name')).must_equal %w{centos-5.11 centos-6.7}
+  describe 'when loading a valid yaml' do
+    let (:resource) { load_resource('yaml', 'kitchen.yml') }
+
+    it 'gets params as a hashmap' do
+      _(resource.params).must_be_kind_of Hash
+    end
+
+    it 'retrieves nil if a param is missing' do
+      _(resource.params['missing']).must_be_nil
+    end
+
+    it 'retrieves params by name' do
+      _(resource.send('name')).must_equal 'vagrant'
+    end
+
+    it 'retrieves an array by name' do
+      _(resource.send('platforms')).must_equal %w{linux mac}
+    end
+
+    it 'doesnt resolve dot-notation names' do
+      _(resource.send('driver.customize.memory')).must_be_nil
+    end
+
+    it 'doesnt resolve symbol-notation names' do
+      _(resource.send(:'driver.customize.memory')).must_be_nil
+    end
   end
 end


### PR DESCRIPTION
Also extend json+yaml+csv tests.
