### PR TITLE
api: change `--disable-sudo` to `--sudo`

### DIFF
--- a/bin/inspec
+++ b/bin/inspec
@@ -26,8 +26,8 @@ class InspecCLI < Thor
       desc: 'Login key or certificate file for a remote scan.'
     option :path, type: :string, default: nil,
       desc: 'Login path to use when connecting to the target.'
-    option :disable_sudo, type: :boolean, default: false,
-      desc: 'To not run remote scans via sudo.'
+    option :sudo, type: :boolean, default: false,
+      desc: 'Run scans with sudo. Only activates on Unix and non-root user.'
     option :sudo_password, type: :string, default: nil,
       desc: 'Specify a sudo password, if it is required.'
     option :sudo_options, type: :string, default: '',

--- a/docs/ctl_inspec.rst
+++ b/docs/ctl_inspec.rst
@@ -11,8 +11,8 @@ The following options may be used with any of the InSpec CLI subcommands:
 ``-b``, ``--backend``
    Specify the backend. Possible values: ``local`` (default), ``ssh``, ``winrm``, or ``docker``.
 
-``--disable_sudo``
-   Use to prevent remote scanning via sudo. Default value: ``false``.
+``--sudo``
+   Run scans with sudo. Only activates on Unix and non-root user. Default value: ``false``.
 
 ``--host``
    The remote host to be tested.


### PR DESCRIPTION
Remove the old default and use:

```
--sudo
--no-sudo
```

for configuration. By default, sudo is now disabled (as it is in train).
