### PR TITLE
Not using git in the gemspec file

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -13,8 +13,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/chef/inspec'
   spec.license       = 'Apache 2.0'
 
-  spec.files         = `hash git 2>/dev/null && git ls-files -z`.split("\x0").find_all { |x| x !~ /^\.delivery/ }
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.files = %w(README.md Rakefile MAINTAINERS.toml MAINTAINERS.md LICENSE inspec.gemspec Gemfile CHANGELOG.md .rubocop.yml) +
+    Dir.glob("{bin,docs,examples,lib,tasks,test}/**/*", File::FNM_DOTMATCH).reject { |f|  File.directory?(f) }
+  spec.executables   = %w( inspec )
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
 Because inside the ChefDK the folder isn't a git directory, it is just installed from a gem

\cc @chris-rock @arlimus 

I copied this from how we managed the [chefdk gemspec](https://github.com/chef/chef-dk/blob/master/chef-dk.gemspec#L33-L35)
