### PR TITLE
Add Windows support to the `os_env` resource

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -109,6 +109,7 @@ class MockLoader
       'secedit /export /cfg win_secpol.cfg' => cmd.call('success'),
       'del win_secpol.cfg' => cmd.call('success'),
       'env' => cmd.call('env'),
+      '$Env:PATH'  => cmd.call('$env-PATH'),
       # registry key test
       '2790db1e88204a073ed7fd3493f5445e5ce531afd0d2724a0e36c17110c535e6' => cmd.call('reg_schedule'),
       'Auditpol /get /subcategory:\'User Account Management\' /r' => cmd.call('auditpol'),

--- a/test/unit/mock/cmd/$env-PATH
+++ b/test/unit/mock/cmd/$env-PATH
@@ -1,0 +1,1 @@
+C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\opscode\chef\bin\

--- a/test/unit/resources/os_env_test.rb
+++ b/test/unit/resources/os_env_test.rb
@@ -6,8 +6,13 @@ require 'helper'
 require 'inspec/resource'
 
 describe 'Inspec::Resources::OsEnv' do
-  it 'verify ntp config parsing' do
+  it 'verify env parsing' do
     resource = load_resource('os_env', 'PATH')
     _(resource.split).must_equal %w{/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin}
+  end
+
+  it 'read env variable on Windows' do
+    resource = MockLoader.new(:windows).load_resource('os_env', 'PATH')
+    _(resource.split).must_equal ['C:\Windows\system32', 'C:\Windows', 'C:\Windows\System32\Wbem', 'C:\Windows\System32\WindowsPowerShell\v1.0\\', 'C:\opscode\chef\bin\\']
   end
 end


### PR DESCRIPTION
This change allows checks like:

``` ruby
describe os_env('PATH') do
  its('split') { should include('C:\wix') }
end
```

/cc @chef/compliance @chef/engineering-services @chef/client-windows
