### PR TITLE
EL package resource improvements: catch missing newlines & add release info

### DIFF
--- a/docs/dsl_inspec.rst
+++ b/docs/dsl_inspec.rst
@@ -2,7 +2,7 @@
 InSpec DSL
 =====================================================
 
-|inspec| is a run-time framework and rule language used to specify compliance, securuty, and policy requirements. It includes a collection of resources that help you write auditing controls quickly and easily. The syntax used by both open source and |chef compliance| auditing is the same. The open source |inspec resource| framework is compatible with |chef compliance|.
+|inspec| is a run-time framework and rule language used to specify compliance, security, and policy requirements. It includes a collection of resources that help you write auditing controls quickly and easily. The syntax used by both open source and |chef compliance| auditing is the same. The open source |inspec resource| framework is compatible with |chef compliance|.
 
 The InSpec DSL is a Ruby DSL for writing audit controls, which includes audit resources that you can invoke.
 

--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -105,10 +105,22 @@ class Rpm < PkgManagement
       assignment_re: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
       multiple_values: false,
     ).params
+    # On some (all?) systems, the linebreak before the vendor line is missing
+    if params['Version'] =~ /\s*Vendor:/
+      v = params['Version'].split(' ')[0]
+    else
+      v = params['Version']
+    end
+    # On some (all?) systems, the linebreak before the build line is missing
+    if params['Release'] =~ /\s*Build Date:/
+      r = params['Release'].split(' ')[0]
+    else
+      r = params['Release']
+    end
     {
       name: params['Name'],
       installed: true,
-      version: params['Version'],
+      version: "#{v}-#{r}",
       type: 'rpm',
     }
   end

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -27,18 +27,18 @@ describe 'Inspec::Resources::Package' do
   # centos
   it 'verify centos package parsing' do
     resource = MockLoader.new(:centos7).load_resource('package', 'curl')
-    pkg = { name: 'curl', installed: true, version: '7.29.0', type: 'rpm' }
+    pkg = { name: 'curl', installed: true, version: '7.29.0-19.el7', type: 'rpm' }
     _(resource.installed?).must_equal true
-    _(resource.version).must_equal '7.29.0'
+    _(resource.version).must_equal '7.29.0-19.el7'
     _(resource.info).must_equal pkg
   end
 
   # wrlinux
   it 'verify wrlinux package parsing' do
     resource = MockLoader.new(:wrlinux).load_resource('package', 'curl')
-    pkg = { name: 'curl', installed: true, version: '7.29.0', type: 'rpm' }
+    pkg = { name: 'curl', installed: true, version: '7.29.0-19.el7', type: 'rpm' }
     _(resource.installed?).must_equal true
-    _(resource.version).must_equal '7.29.0'
+    _(resource.version).must_equal '7.29.0-19.el7'
     _(resource.info).must_equal pkg
   end
 


### PR DESCRIPTION
3 commits here -- happy to adjust / squash / toss as appropriate:

c8bebf9: I'm seeing output like the following from the [rpm command](https://github.com/chef/inspec/blob/master/lib/resources/package.rb#L92):

```
Name        : sudo                         Relocations: (not relocatable)\nVersion     : 1.8.6p3                           Vendor: Red Hat, Inc.\nRelease     : 7.el6                         Build Date: Wed 23 Jan 2013 08:57:14 AM PST\nInstall Date: Wed 11 Dec 2013 04:05:49 PM PST      Build Host: x86-023.build.eng.bos.redhat.com\nGroup       : Applications/System           Source RPM: sudo-1.8.6p3-7.el6.src.rpm\nSize        : 2461511                          License: ISC\nSignature   : RSA/8, Thu 24 Jan 2013 06:07:51 AM PST, Key ID 199e2f91fd431d51\nPackager    : Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>\nURL         : http://www.courtesan.com/sudo/\nSummary     : Allows restricted root access for specified users\nDescription :\nSudo (superuser do) allows a system administrator to give certain\nusers (or groups of users) the ability to run some (or all) commands\nas root while logging all commands and arguments. Sudo operates on a\nper-command basis.  It is not a replacement for the shell.  Features\ninclude: the ability to restrict what commands a user may run on a\nper-host basis, copious logging of each command (providing a clear\naudit trail of who did what), a configurable timeout of the sudo\ncommand, and the ability to use the same configuration file (sudoers)\non many different machines.
```

This is returning version strings like `1.8.6p3                           Vendor: Red Hat, Inc.`. I've put in a simple check and correction for this.

46a68de: Added a `release` method to get EL package release info in the DSL

f429ae5: Added a `version_and_release` method so a simple `its('version_and_release') { should match 'foov1-el61.2' }` is possible. Let me know if there's a better way to do this or if the naming should be different or whatever.

Once the technical particulars are worked out I can add some info to the documentation too.
