### PR TITLE
ensure all test directories are on the runner $LOAD_PATH

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -52,6 +52,14 @@ module Inspec
       tests = items.find_all { |i| i[:type] == :test }
       libs = items.find_all { |i| i[:type] == :library }
 
+      # Ensure each test directory exists on the $LOAD_PATH. This
+      # will ensure traditional RSpec-isms like `require 'spec_helper'`
+      # continue to work.
+      tests.flatten.each do |test|
+        test_directory = File.dirname(test[:ref])
+        $LOAD_PATH.unshift test_directory unless $LOAD_PATH.include?(test_directory)
+      end
+
       # add all tests (raw) to the runtime
       tests.flatten.each do |test|
         add_content(test, libs)


### PR DESCRIPTION
This change builds on chef/kitchen-inspec#12. All test directories should be on the `$LOAD_PATH` when `Inspec::Runner` executes the test suites with `RSpec::Core::Runner`. This will allow things like `require 'spec_helper'` to work as expected.

/cc @chef/compliance @chef/engineering-services 
