### PR TITLE
Bugfix: make registry_key resource case-insensitive

### DIFF
--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -105,12 +105,14 @@ class RegistryKey < Inspec.resource(1)
     begin
       @registy_cache = JSON.parse(cmd.stdout)
       # convert keys to lower case
-      return @registy_cache = Hash[@registy_cache.map do |key, value|
+      @registy_cache = Hash[@registy_cache.map do |key, value|
         [key.downcase, value]
       end]
     rescue JSON::ParserError => _e
-      return @registy_cache = nil
+      @registy_cache = nil
     end
+
+    @registy_cache
   end
 
   # Registry key value types

--- a/test/integration/cookbooks/os_prepare/recipes/registry_key.rb
+++ b/test/integration/cookbooks/os_prepare/recipes/registry_key.rb
@@ -66,4 +66,9 @@ if node['platform_family'] == 'windows'
     action :create
   end
 
+  registry_key 'HKLM\System\CurrentControlSet\Control\Lsa\MSV1_0' do
+    values [{ name: 'NTLMMinServerSec', type: :dword, data: 537_395_200 }]
+    recursive true
+    action :create
+  end
 end

--- a/test/integration/test/integration/default/registry_key_spec.rb
+++ b/test/integration/test/integration/default/registry_key_spec.rb
@@ -50,4 +50,8 @@ if os.windows?
     its('MinEncryptionLevel') { should eq 3 }
   end
 
+  describe registry_key('HKLM\System\CurrentControlSet\Control\Lsa\MSV1_0') do
+    it { should exist }
+    its('NtlmMinClientSec') { should eq 537_395_200 }
+  end
 end

--- a/test/integration/test/integration/default/registry_key_spec.rb
+++ b/test/integration/test/integration/default/registry_key_spec.rb
@@ -6,11 +6,16 @@ if os.windows?
     it { should exist }
     it { should have_value('test') }
     it { should have_property('binary value', :binary) }
+    it { should have_property('Binary value', :binary) }
     it { should have_property('string value') }
+    it { should have_property('String value') }
     it { should have_property('dword value', :dword) }
     it { should have_property_value('multistring value', :multi_string, ['test', 'multi','string','data']) }
+    it { should have_property_value('Multistring Value', :multi_string, ['test', 'multi','string','data']) }
     it { should have_property_value('qword value', :qword, 0) }
+    it { should have_property_value('Qword value', :qword, 0) }
     it { should have_property_value('binary value', :binary, 'dfa0f066') }
+    it { should have_property_value('Binary value', :binary, 'dfa0f066') }
   end
 
   # serverspec compatability
@@ -33,6 +38,8 @@ if os.windows?
   describe registry_key('HKLM\System\CurrentControlSet\Control\Session Manager') do
     it { should exist }
     it { should_not have_property_value('SafeDllSearchMode', :type_dword, 0) }
+    # case-insensitive test
+    it { should_not have_property_value('safedllsearchmode', :type_dword, 0) }
   end
 
   describe registry_key('HKLM\System\CurrentControlSet\Services\LanManServer\Parameters') do
@@ -43,6 +50,8 @@ if os.windows?
   describe registry_key('HKLM\Software\Policies\Microsoft\Internet Explorer\Main') do
     it { should exist }
     its('Isolation64Bit') { should eq 1 }
+    # check that its is case-insensitive
+    its('isolation64bit') { should eq 1 }
   end
 
   describe registry_key('HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services') do
@@ -52,6 +61,7 @@ if os.windows?
 
   describe registry_key('HKLM\System\CurrentControlSet\Control\Lsa\MSV1_0') do
     it { should exist }
-    its('NtlmMinClientSec') { should eq 537_395_200 }
+    its('NTLMMinServerSec') { should eq 537_395_200 }
+    its('NtlmMinServerSec') { should eq 537_395_200 }
   end
 end


### PR DESCRIPTION
Add integration test for `NtlmMinClientSec` 

Once https://github.com/chef/inspec/issues/254 is fixed, we should add a test for `NTLMMinServerSec`
