### PR TITLE
travis workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ cache: bundler
 
 bundler_args: --without integration tools maintenance
 
+before_install:
+  - gem update --system 2.4.5
+  - gem --version
+
 matrix:
   include:
   - rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: required
 language: ruby
 cache: bundler
 
+# necessary for docker to work
+dist: trusty
+services:
+  - docker
+
 bundler_args: --without integration tools maintenance
 
 before_install:
@@ -18,10 +23,6 @@ matrix:
   - rvm: 2.2
     gemfile: Gemfile
     script: bundle exec rake lint test test:resources config=test/test.yaml
-    before_script:
-      - source <(curl -sL https://raw.githubusercontent.com/zuazo/kitchen-in-travis/0.3.0/scripts/start_docker.sh)
   - rvm: 2.2
     gemfile: Gemfile
     script: bundle exec rake test:resources config=test/test-extra.yaml
-    before_script:
-      - source <(curl -sL https://raw.githubusercontent.com/zuazo/kitchen-in-travis/0.3.0/scripts/start_docker.sh)


### PR DESCRIPTION
builds are green again! yay \o/

This is what happened, today travis started routing 50% of the precise-based legacy builds to a new infrastructure (incl. new versions of things). Switched to Trusty since fixing the gem issue brought up an issue with installing lxc in this new infrastructure, so I switched us to that.

References:
- https://github.com/travis-ci/travis-ci/issues/5142#issuecomment-160859891
- https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future
