### PR TITLE
Adding support for Wind River Linux

### DIFF
--- a/lib/resources/etc_group.rb
+++ b/lib/resources/etc_group.rb
@@ -45,7 +45,7 @@ class EtcGroup < Inspec.resource(1)
 
     # skip resource if it is not supported on current OS
     return skip_resource 'The `etc_group` resource is not supported on your OS.' \
-    unless %w{ubuntu debian redhat fedora centos arch darwin freebsd}.include?(inspec.os[:family])
+    unless %w{ubuntu debian redhat fedora centos arch darwin freebsd wrlinux}.include?(inspec.os[:family])
   end
 
   def groups(filter = nil)

--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -28,7 +28,7 @@ class Package < Inspec.resource(1)
     case inspec.os[:family]
     when 'ubuntu', 'debian'
       @pkgman = Deb.new(inspec)
-    when 'redhat', 'fedora', 'centos', 'opensuse'
+    when 'redhat', 'fedora', 'centos', 'opensuse', 'wrlinux'
       @pkgman = Rpm.new(inspec)
     when 'arch'
       @pkgman = Pacman.new(inspec)

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -31,7 +31,7 @@ class Port < Inspec.resource(1)
     @cache = nil
 
     case inspec.os[:family]
-    when 'ubuntu', 'debian', 'redhat', 'fedora', 'centos', 'arch'
+    when 'ubuntu', 'debian', 'redhat', 'fedora', 'centos', 'arch', 'wrlinux'
       @port_manager = LinuxPorts.new(inspec)
     when 'darwin'
       @port_manager = DarwinPorts.new(inspec)

--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -70,6 +70,8 @@ class Service < Inspec.resource(1)
       else
         @service_mgmt = SysV.new(inspec)
       end
+    when 'wrlinux'
+      @service_mgmt = SysV.new(inspec)
     when 'darwin'
       @service_mgmt = LaunchCtl.new(inspec)
     when 'windows'

--- a/lib/resources/user.rb
+++ b/lib/resources/user.rb
@@ -54,7 +54,7 @@ class User < Inspec.resource(1)
     # select package manager
     @user_provider = nil
     case inspec.os[:family]
-    when 'ubuntu', 'debian', 'redhat', 'fedora', 'centos', 'arch', 'opensuse'
+    when 'ubuntu', 'debian', 'redhat', 'fedora', 'centos', 'arch', 'opensuse', 'wrlinux'
       @user_provider = LinuxUser.new(inspec)
     when 'windows'
       @user_provider = WindowsUser.new(inspec)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -36,6 +36,7 @@ class MockLoader
       ubuntu1404: { family: 'ubuntu', release: '14.04', arch: 'x86_64' },
       ubuntu1504: { family: 'ubuntu', release: '15.04', arch: 'x86_64' },
       windows:    { family: 'windows', release: nil, arch: nil },
+      wrlinux:    { family: 'wrlinux', release: '7.0(3)I2(2)', arch: 'x86_64' },
       undefined:  { family: nil, release: nil, arch: nil },
     }
 

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -33,6 +33,15 @@ describe 'Inspec::Resources::Package' do
     _(resource.info).must_equal pkg
   end
 
+  # wrlinux
+  it 'verify wrlinux package parsing' do
+    resource = MockLoader.new(:wrlinux).load_resource('package', 'curl')
+    pkg = { name: 'curl', installed: true, version: '7.29.0', type: 'rpm' }
+    _(resource.installed?).must_equal true
+    _(resource.version).must_equal '7.29.0'
+    _(resource.info).must_equal pkg
+  end
+
   # windows
   it 'verify windows package parsing' do
     resource = MockLoader.new(:windows).load_resource('package', 'Microsoft Visual C++ 2008 Redistributable - x64 9.0.30729.6161')

--- a/test/unit/resources/port_test.rb
+++ b/test/unit/resources/port_test.rb
@@ -36,6 +36,13 @@ describe 'Inspec::Resources::Port' do
     _(resource.process).must_equal ['sshd']
   end
 
+  it 'verify port on wrlinux' do
+    resource = MockLoader.new(:wrlinux).load_resource('port', 22)
+    _(resource.listening?).must_equal true
+    _(resource.protocol).must_equal %w{ tcp tcp6 }
+    _(resource.process).must_equal ['sshd']
+  end
+
   it 'verify running on undefined' do
     resource = MockLoader.new(:undefined).load_resource('port', 22)
     _(resource.listening?).must_equal false

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -107,6 +107,16 @@ describe 'Inspec::Resources::Service' do
     _(resource.running?).must_equal true
   end
 
+  # wrlinux
+  it 'verify wrlinux package parsing' do
+    resource = MockLoader.new(:wrlinux).load_resource('service', 'sshd')
+    srv = { name: 'sshd', description: nil, installed: true, running: true, enabled: true, type: 'sysv' }
+    _(resource.info).must_equal srv
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+  end
+
   # unknown OS
   it 'verify package handling on unsupported os' do
     resource = MockLoader.new(:undefined).load_resource('service', 'dhcp')

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -56,6 +56,18 @@ describe 'Inspec::Resources::User' do
     _(resource.warndays).must_equal 7
   end
 
+  it 'read user on centos7' do
+    resource = MockLoader.new(:wrlinux).load_resource('user', 'root')
+    _(resource.exists?).must_equal true
+    _(resource.group).must_equal 'root'
+    _(resource.groups).must_equal ['root']
+    _(resource.home).must_equal '/root'
+    _(resource.shell).must_equal '/bin/bash'
+    _(resource.mindays).must_equal 0
+    _(resource.maxdays).must_equal 99999
+    _(resource.warndays).must_equal 7
+  end
+
   it 'read user on freebsd' do
     resource = MockLoader.new(:freebsd10).load_resource('user', 'root')
     _(resource.exists?).must_equal true


### PR DESCRIPTION
WRL is used as the OS on Cisco Nexus devices and acts like a Red
Hat variant. These changes add support for WRL.
