### PR TITLE
[resources/processes] add user(s), state(s) attribute

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -3424,7 +3424,7 @@ A ``processes`` |inspec resource| block declares the name of the process to be t
 where
 
 * ``processes('process_name')`` must specify the name of a process that is running on the system
-* Multiple properties may be tested; for each property to be tested, use an ``its('property_name')`` statement
+* The ``user`` and ``state`` properties may be tested; they are exposed via ``users`` and ``states``, respectively.
 
 Matchers
 -----------------------------------------------------
@@ -3466,7 +3466,7 @@ The following examples show how to use this InSpec audit resource.
 .. code-block:: ruby
 
    describe processes('init') do
-     its('user') { should eq 'root' }
+     its('users') { should eq ['root'] }
    end
 
 **Test if a high-priority process is running**
@@ -3474,7 +3474,7 @@ The following examples show how to use this InSpec audit resource.
 .. code-block:: ruby
 
    describe processes('some_process') do
-     its('state') { should eq 'R<' }
+     its('states') { should eq ['R<'] }
    end
 
 

--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -10,10 +10,15 @@ class Processes < Inspec.resource(1)
   example "
     describe processes('mysqld') do
       its('list.length') { should eq 1 }
+      its('users') { should eq ['mysql'] }
+      its('states') { should include 'S' }
     end
   "
 
-  attr_reader :list
+  attr_reader :list,
+              :users,
+              :states
+
   def initialize(grep)
     # turn into a regexp if it isn't one yet
     if grep.class == String
@@ -24,6 +29,11 @@ class Processes < Inspec.resource(1)
     all_cmds = ps_aux
     @list = all_cmds.find_all do |hm|
       hm[:command] =~ grep
+    end
+
+    { users: :user,
+      states: :stat }.each do |var, key|
+      instance_variable_set("@#{var}", @list.map { |l| l[key] }.uniq)
     end
   end
 

--- a/test/unit/mock/cmd/ps-aux
+++ b/test/unit/mock/cmd/ps-aux
@@ -1,3 +1,5 @@
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 root         1  0.0  0.0  18084  3228 ?        Ss   14:15   0:00 /bin/bash
 root        13  0.0  0.0  15284  2148 ?        R+   15:08   0:00 ps aux
+noot        19  0.0  0.0  24521  1536 s001     Ss   09:23   0:00 svc
+noot        23  0.0  0.0  25044  1908 s000     S    08:46   0:00 svc

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -29,4 +29,10 @@ describe 'Inspec::Resources::Processes' do
 
     _(resource.list.length).must_equal 1
   end
+
+  it 'retrieves the users and states as arrays' do
+    resource = load_resource('processes', 'svc')
+    _(resource.users.sort).must_equal ['noot']
+    _(resource.states.sort).must_equal ['S', 'Ss']
+  end
 end


### PR DESCRIPTION
processes('bash').user will be non-nil iff the process owner of each
process is the same. Analogous for processes('bash').state.

These are the only two attributes where asking for them to be unique
among multiple processes makes sense.

The attributes 'users' and 'states' expose the values corresponding to
that property of each entry in the process list.

Fixes #295.
