### PR TITLE
[resources/apache_conf]: add tests, fix bug

### DIFF
--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -94,19 +94,16 @@ class ApacheConf < Inspec.resource(1)
     include_files = params['Include'] || []
     include_files_optional = params['IncludeOptional'] || []
 
-    required = []
-    include_files.each do |f|
+    includes = []
+    (include_files + include_files_optional).each do |f|
       id = File.join(@conf_dir, f)
-      required.push(find_files(id, depth: 1, type: 'file'))
+      files = find_files(id, depth: 1, type: 'file')
+
+      includes.push(files) if files
     end
 
-    optional = []
-    include_files_optional.each do |f|
-      id = File.join(@conf_dir, f)
-      optional.push(find_files(id, depth: 1, type: 'file'))
-    end
-
-    required.flatten! + optional.flatten!
+    # [].flatten! == nil
+    includes.flatten! || []
   end
 
   def read_file(path)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -93,6 +93,9 @@ class MockLoader
       'policyfile.lock.json' => mockfile.call('policyfile.lock.json'),
       '/sys/class/net/br0/bridge' => mockdir.call(true),
       'rootwrap.conf' => mockfile.call('rootwrap.conf'),
+      '/etc/apache2/apache2.conf' => mockfile.call('apache2.conf'),
+      '/etc/apache2/ports.conf' => mockfile.call('ports.conf'),
+      '/etc/apache2/conf-enabled/serve-cgi-bin.conf' => mockfile.call('serve-cgi-bin.conf'),
     }
 
     # create all mock commands
@@ -189,6 +192,10 @@ class MockLoader
       "find /etc/apt/ -name *.list -exec sh -c 'cat {} || echo -n' \\;" => cmd.call('etc-apt'),
       # iptables
       'iptables  -S' => cmd.call('iptables-s'),
+      # apache_conf
+      'find /etc/apache2/ports.conf -maxdepth 1 -type f' => cmd.call('find-apache2-ports-conf'),
+      'find /etc/apache2/conf-enabled/*.conf -maxdepth 1 -type f' => cmd.call('find-apache2-conf-enabled'),
+
     }
 
     @backend

--- a/test/unit/mock/cmd/find-apache2-conf-enabled
+++ b/test/unit/mock/cmd/find-apache2-conf-enabled
@@ -1,0 +1,1 @@
+/etc/apache2/conf-enabled/serve-cgi-bin.conf

--- a/test/unit/mock/cmd/find-apache2-ports-conf
+++ b/test/unit/mock/cmd/find-apache2-ports-conf
@@ -1,0 +1,1 @@
+/etc/apache2/ports.conf

--- a/test/unit/mock/files/apache2.conf
+++ b/test/unit/mock/files/apache2.conf
@@ -1,0 +1,14 @@
+# This is the main Apache server configuration file.  It contains comments.
+ServerRoot "/etc/apache2"
+
+User ${APACHE_RUN_USER}
+Include ports.conf
+
+<Directory />
+	Options FollowSymLinks
+	AllowOverride None
+	Require all denied
+</Directory>
+
+# Include generic snippets of statements
+IncludeOptional conf-enabled/*.conf

--- a/test/unit/mock/files/ports.conf
+++ b/test/unit/mock/files/ports.conf
@@ -1,0 +1,6 @@
+# apache ports.conf
+Listen 80
+
+<IfModule ssl_module>
+	Listen 443
+</IfModule>

--- a/test/unit/mock/files/serve-cgi-bin.conf
+++ b/test/unit/mock/files/serve-cgi-bin.conf
@@ -1,0 +1,20 @@
+<IfModule mod_alias.c>
+	<IfModule mod_cgi.c>
+		Define ENABLE_USR_LIB_CGI_BIN
+	</IfModule>
+
+	<IfModule mod_cgid.c>
+		Define ENABLE_USR_LIB_CGI_BIN
+	</IfModule>
+
+	<IfDefine ENABLE_USR_LIB_CGI_BIN>
+		ScriptAlias /cgi-bin/ /usr/lib/cgi-bin/
+		<Directory "/usr/lib/cgi-bin">
+			AllowOverride None
+			Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+			Require all granted
+		</Directory>
+	</IfDefine>
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+# author: Stephan Renatus
+
+require 'helper'
+
+describe 'Inspec::Resources::ApacheConf' do
+  let(:resource) { load_resource('apache_conf') }
+
+  it 'verify content is a string' do
+    _(resource.content).must_be_kind_of String
+  end
+
+  it 'verify params is a hashmap' do
+    _(resource.params).must_be_kind_of Hash
+  end
+
+  it 'reads values in apache2.conf' do
+    _(resource.params('ServerRoot')).must_equal ['"/etc/apache2"']
+  end
+
+  it 'reads values in from the direct include ports.conf' do
+    _(resource.params('Listen').sort).must_equal ['443', '80']
+  end
+
+  it 'reads values in from wildcard include serve-cgi-bin.conf' do
+    # TODO(sr) currently, the parser only merges parameter across separate
+    # source files, not in one file
+    _(resource.params('Define')).must_equal ['ENABLE_USR_LIB_CGI_BIN',
+                                             'ENABLE_USR_LIB_CGI_BIN']
+  end
+end


### PR DESCRIPTION
before, the resource would throw an exception when include_files
returned nil (i.e., [].flatten!)

added basic unit tests capturing the include_files behaviour (addresses #290)
