### PR TITLE
File permission checks should return false unless file exists

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rspec', '~> 3.3'
   spec.add_dependency 'rspec-its', '~> 1.2'
   spec.add_dependency 'pry', '~> 0'
+
+  spec.add_development_dependency 'mocha', '~> 1.1'
 end

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -19,7 +19,7 @@ module Inspec::Resources
       end
     "
 
-    attr_reader :path
+    attr_reader :file, :path
     def initialize(path)
       @path = path
       @file = inspec.backend.file(@path)
@@ -32,7 +32,7 @@ module Inspec::Resources
       product_version file_version version? md5sum sha256sum
     }.each do |m|
       define_method m.to_sym do |*args|
-        @file.method(m.to_sym).call(*args)
+        file.method(m.to_sym).call(*args)
       end
     end
 
@@ -40,82 +40,82 @@ module Inspec::Resources
       fail 'Contain is not supported. Please use standard RSpec matchers.'
     end
 
-    def readable?(by_owner, by_user)
-      if inspec.os.unix?
-        by_owner, by_user = check_preconditions(by_owner, by_user)
+    def readable?(by_usergroup, by_specific_user)
+      return false unless exist?
 
-        if by_user.nil?
-          m = @file.unix_mode_mask(by_owner, 'r') ||
-              fail("#{by_owner} is not a valid unix owner.")
-          (@file.mode & m) != 0
-        else
-          check_user_access(by_user, @path, 'r')
-        end
-      else
-        fail "`file(#{@path}).executable?` is not suported on you OS: #{inspec.os['family']}"
-      end
+      file_permission_granted?('r', by_usergroup, by_specific_user)
     end
 
-    def writable?(by_owner, by_user)
-      if inspec.os.unix?
-        by_owner, by_user = check_preconditions(by_owner, by_user)
+    def writable?(by_usergroup, by_specific_user)
+      return false unless exist?
 
-        if by_user.nil?
-          m = @file.unix_mode_mask(by_owner, 'w') ||
-              fail("#{by_owner} is not a valid unix owner.")
-          (@file.mode & m) != 0
-        else
-          check_user_access(by_user, @path, 'w')
-        end
-      else
-        fail "`file(#{@path}).executable?` is not suported on you OS: #{inspec.os['family']}"
-      end
+      file_permission_granted?('w', by_usergroup, by_specific_user)
     end
 
-    def executable?(by_owner, by_user)
-      if inspec.os.unix?
-        by_owner, by_user = check_preconditions(by_owner, by_user)
+    def executable?(by_usergroup, by_specific_user)
+      return false unless exist?
 
-        if by_user.nil?
-          m = @file.unix_mode_mask(by_owner, 'x') ||
-              fail("#{by_owner} is not a valid unix owner.")
-          return (@file.mode & m) != 0
-        else
-          return check_user_access(by_user, @path, 'x')
-        end
-      else
-        fail "`file(#{@path}).executable?` is not suported on you OS: #{inspec.os['family']}"
-      end
+      file_permission_granted?('x', by_usergroup, by_specific_user)
     end
 
     def to_s
-      "File #{@path}"
+      "File #{path}"
     end
 
     private
 
-    def check_preconditions(by_owner, by_user)
-      by_owner = 'other' if by_owner == 'others'
-      by_owner = 'all' if (by_owner.nil? || by_owner.empty?) && (by_user.nil?)
-      [by_owner, by_user]
+    def file_permission_granted?(flag, by_usergroup, by_specific_user)
+      fail 'Checking file permissions is not supported on your os' unless unix?
+
+      usergroup = usergroup_for(by_usergroup, by_specific_user)
+
+      if by_specific_user.nil?
+        check_file_permission_by_mask(usergroup, flag)
+      else
+        check_file_permission_by_user(by_specific_user, flag)
+      end
     end
 
-    # check permissions on linux
-    def check_user_access(user, file, flag)
-      if inspec.os.linux? == true
-        # use sh on linux
-        perm_cmd = "su -s /bin/sh -c \"test -#{flag} #{file}\" #{user}"
-      elsif inspec.os[:family] == 'freebsd'
-        # use sudo on freebsd
-        perm_cmd = "sudo -u #{user} test -#{flag} #{file}"
-      end
+    def check_file_permission_by_mask(usergroup, flag)
+      mask = file.unix_mode_mask(usergroup, flag)
+      fail 'Invalid usergroup/owner provided' if mask.nil?
 
-      if !perm_cmd.nil?
-        cmd = inspec.command(perm_cmd)
-        cmd.exit_status == 0 ? true : false
+      (file.mode & mask) != 0
+    end
+
+    def check_file_permission_by_user(user, flag)
+      if linux?
+        perm_cmd = "su -s /bin/sh -c \"test -#{flag} #{path}\" #{user}"
+      elsif family == 'freebsd'
+        perm_cmd = "sudo -u #{user} test -#{flag} #{path}"
       else
         return skip_resource 'The `file` resource does not support `by_user` on your OS.'
       end
+
+      cmd = inspec.command(perm_cmd)
+      cmd.exit_status == 0 ? true : false
+    end
+
+    def usergroup_for(usergroup, specific_user)
+      if usergroup == 'others'
+        'other'
+      elsif (usergroup.nil? || usergroup.empty?) && specific_user.nil?
+        'all'
+      else
+        usergroup
+      end
+    end
+
+    def unix?
+      inspec.os.unix?
+    end
+
+    def linux?
+      inspec.os.linux?
+    end
+
+    def family
+      inspec.os[:family]
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,6 +4,7 @@
 
 require 'minitest/autorun'
 require 'minitest/spec'
+require 'mocha/setup'
 
 require 'simplecov'
 SimpleCov.start do

--- a/test/unit/resources/file_test.rb
+++ b/test/unit/resources/file_test.rb
@@ -1,0 +1,181 @@
+require 'helper'
+require 'inspec/resource'
+
+def shared_file_permission_tests(method_under_test)
+  it 'returns false if the file does not exist' do
+    resource.stubs(:exist?).returns(false)
+    resource.send(method_under_test, nil, nil).must_equal(false)
+  end
+
+  it 'returns the value of #file_permission_granted?' do
+    resource.stubs(:exist?).returns(true)
+    resource.stubs(:file_permission_granted?).returns('test_result')
+    resource.send(method_under_test, nil, nil).must_equal('test_result')
+  end
+end
+
+describe Inspec::Resources::File do
+  let(:resource) { load_resource('file', '/fakepath/fakefile') }
+  let(:os)       { stub(:[] => { 'family' => 'fakefamily' }) }
+  let(:inspec)   { stub(os: os) }
+
+  before { resource.stubs(:inspec).returns(inspec) }
+
+  describe '#readable?' do
+    shared_file_permission_tests(:readable?)
+  end
+
+  describe '#writable?' do
+    shared_file_permission_tests(:writable?)
+  end
+
+  describe '#executable?' do
+    shared_file_permission_tests(:executable?)
+  end
+
+  describe '#to_s' do
+    it 'returns a properly formatted string' do
+      resource.to_s.must_equal('File /fakepath/fakefile')
+    end
+  end
+
+  describe '#file_permission_granted?' do
+    describe 'when not on a unix OS' do
+      it 'raises an exception' do
+        resource.stubs(:unix?).returns(false)
+
+        proc { resource.send(:file_permission_granted?, 'flag', nil, nil) }.must_raise(RuntimeError)
+      end
+    end
+
+    describe 'when on a unix OS' do
+      before do
+        resource.stubs(:unix?).returns(true)
+      end
+
+      describe 'when no user is provided' do
+        it 'checks file permission by mask' do
+          resource.expects(:check_file_permission_by_mask).with('usergroup', 'flag')
+          resource.send(:file_permission_granted?, 'flag', 'usergroup', nil)
+        end
+      end
+
+      describe 'when a user is provided' do
+        it 'checks file permission by user' do
+          resource.expects(:check_file_permission_by_user).with('user', 'flag')
+          resource.send(:file_permission_granted?, 'flag', nil, 'user')
+        end
+      end
+    end
+  end
+
+  describe '#check_file_permission_by_mask' do
+    describe 'when no mask is returned' do
+      let(:file) { stub(unix_mode_mask: nil) }
+
+      it 'raises an exception' do
+        file = stub(unix_mode_mask: nil)
+        resource.stubs(:file).returns(file)
+        proc { resource.send(:check_file_permission_by_mask, 'usergroup', 'flag') }.must_raise(RuntimeError)
+      end
+    end
+
+    describe 'when a mask is returned' do
+      describe 'when the bitwise AND returns a non-zero' do
+        let(:file) { stub(unix_mode_mask: 292, mode: 420) }
+        it 'returns true' do
+          resource.stubs(:file).returns(file)
+          resource.send(:check_file_permission_by_mask, 'usergroup', 'flag').must_equal(true)
+        end
+      end
+
+      describe 'when the bitwise AND returns zero' do
+        let(:file) { stub(unix_mode_mask: 73, mode: 420) }
+        it 'returns false' do
+          resource.stubs(:file).returns(file)
+          resource.send(:check_file_permission_by_mask, 'usergroup', 'flag').must_equal(false)
+        end
+      end
+    end
+  end
+
+  describe 'check_file_permission_by_user' do
+    describe 'when on linux' do
+      before do
+        resource.stubs(:linux?).returns(true)
+      end
+
+      it 'executes a properly formatted command' do
+        cmd = stub(exit_status: 0)
+        inspec.expects(:command).with('su -s /bin/sh -c "test -flag /fakepath/fakefile" user').returns(cmd)
+        resource.send(:check_file_permission_by_user, 'user', 'flag')
+      end
+
+      it 'returns true when the cmd exits 0' do
+        cmd = stub(exit_status: 0)
+        inspec.stubs(:command).returns(cmd)
+        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(true)
+      end
+
+      it 'returns true when the cmd exits non-zero' do
+        cmd = stub(exit_status: 1)
+        inspec.stubs(:command).returns(cmd)
+        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(false)
+      end
+    end
+
+    describe 'when on freebsd' do
+      before do
+        resource.stubs(:linux?).returns(false)
+        resource.stubs(:family).returns('freebsd')
+      end
+
+      it 'executes a properly formatted command' do
+        cmd = stub(exit_status: 0)
+        inspec.expects(:command).with('sudo -u user test -flag /fakepath/fakefile').returns(cmd)
+        resource.send(:check_file_permission_by_user, 'user', 'flag')
+      end
+
+      it 'returns true when the cmd exits 0' do
+        cmd = stub(exit_status: 0)
+        inspec.stubs(:command).returns(cmd)
+        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(true)
+      end
+
+      it 'returns true when the cmd exits non-zero' do
+        cmd = stub(exit_status: 1)
+        inspec.stubs(:command).returns(cmd)
+        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(false)
+      end
+    end
+
+    describe 'when not on linux or freebsd' do
+      before do
+        resource.stubs(:linux?).returns(false)
+        resource.stubs(:family).returns('fakefamily')
+      end
+
+      it 'returns an error string' do
+        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal('The `file` resource does not support `by_user` on your OS.')
+      end
+    end
+  end
+
+  describe '#usergroup_for' do
+    it 'returns "other" if "others" is provided' do
+      resource.send(:usergroup_for, 'others', nil).must_equal('other')
+    end
+
+    it 'returns "all" if no usergroup or user is specified' do
+      resource.send(:usergroup_for, nil, nil).must_equal('all')
+    end
+
+    it 'returns nil if the usergroup is nil and a user is specified' do
+      resource.send(:usergroup_for, nil, 'user').must_equal(nil)
+    end
+
+    it 'returns the passed-in usergroup if usergroup is not nil and user is nil' do
+      resource.send(:usergroup_for, 'mygroup', nil).must_equal('mygroup')
+    end
+  end
+end


### PR DESCRIPTION
Currently, #readable?, #writeable?, and #executable? will incorrectly
return true if the file does not exist.

```
$ cat test.rb
describe file('/tmp/test.txt') do
  it { should be_readable }
  it { should be_writeable }
  it { should be_executable }
end

$ stat /tmp/test.txt
stat: /tmp/test.txt: stat: No such file or directory

$ inspec exec ./test.rb
...

Finished in 0.03351 seconds (files took 0.12235 seconds to load)
3 examples, 0 failures
```

This patch forces these three methods to immediately return false unless the file exists.
