### PR TITLE
port resource: array attributes, resource alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ end
 
 describe port(443) do
   it { should be_listening }
-  its('protocol') {should eq 'tcp'}
+  its('protocols') {should include 'tcp'}
 end
 ```
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -3176,10 +3176,10 @@ A ``port`` |inspec resource| block declares a port, and then depending on what n
 
    describe port(514) do
      it { should be_listening }
-     its('process') {should eq 'syslog'}
+     its('processes') {should include 'syslog'}
    end
 
-where the ``process`` returns the process listening on port 514.
+where the ``processes`` returns the processes listening on port 514.
 
 Matchers
 -----------------------------------------------------
@@ -3195,33 +3195,33 @@ The ``be_listening`` matcher tests if the port is listening for traffic:
 
 pid
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-The ``pid`` matcher tests the process identifier (PID):
+The ``pids`` matcher tests the process identifier (PID):
 
 .. code-block:: ruby
 
-   its('pid') { should eq '27808' }
+   its('pids') { should eq ['27808'] }
 
 process
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-The ``process`` matcher tests if the named process is running on the system:
+The ``processes`` matcher tests if the named process is running on the system:
 
 .. code-block:: ruby
 
-   its('process') { should eq 'syslog' }
+   its('processes') { should eq ['syslog'] }
 
 protocol
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-The ``protocol`` matcher tests the Internet protocol: |icmp| (``'icmp'``), |tcp| (``'tcp'`` or ``'tcp6'``), or |udp| (``'udp'`` or ``'udp6'``):
+The ``protocols`` matcher tests the Internet protocol: |icmp| (``'icmp'``), |tcp| (``'tcp'`` or ``'tcp6'``), or |udp| (``'udp'`` or ``'udp6'``):
 
 .. code-block:: ruby
 
-   its('protocol') { should eq 'tcp' }
+   its('protocols') { should eq ['tcp'] }
 
 or for the |ipv6| protocol:
 
 .. code-block:: ruby
 
-   its('protocol') { should eq 'tcp6' }
+   its('protocols') { should eq ['tcp6'] }
 
 Examples
 -----------------------------------------------------
@@ -3233,7 +3233,7 @@ The following examples show how to use this InSpec audit resource.
 
    describe port(80) do
      it { should be_listening }
-     its('protocol') {should eq 'tcp'}
+     its('protocols') {should eq ['tcp']}
    end
 
 **Test port 80, listening with TCP version IPv6 protocol**
@@ -3242,7 +3242,7 @@ The following examples show how to use this InSpec audit resource.
 
    describe port(80) do
      it { should be_listening }
-     its('protocol') {should eq 'tcp6'}
+     its('protocols') {should eq ['tcp6']}
    end
 
 **Test ports for HTTPs**
@@ -3255,7 +3255,22 @@ The following examples show how to use this InSpec audit resource.
 
    describe port(443) do
      it { should be_listening }
-     its('protocol') {should eq 'tcp'}
+     its('protocols') {should eq ['tcp']}
+   end
+
+**Test port 80 on a specific address**
+
+This check can be implemented in two equivalent ways:
+
+.. code-block:: ruby
+
+   describe port(80) do
+     it { should be_listening }
+     its('addresses') {should include '0.0.0.0'}
+   end
+
+   describe port('0.0.0.0', 80) do
+     it { should be_listening }
    end
 
 postgres_conf

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -21,7 +21,7 @@ class Port < Inspec.resource(1)
   example "
     describe port(80) do
       it { should be_listening }
-      its('protocol') {should eq 'tcp'}
+      its('protocols') {should eq ['tcp']}
     end
   "
 
@@ -48,17 +48,17 @@ class Port < Inspec.resource(1)
     info.size > 0
   end
 
-  def protocol
+  def protocols
     res = info.map { |x| x[:protocol] }.uniq.compact
     res.size > 0 ? res : nil
   end
 
-  def process
+  def processes
     res = info.map { |x| x[:process] }.uniq.compact
     res.size > 0 ? res : nil
   end
 
-  def pid
+  def pids
     res = info.map { |x| x[:pid] }.uniq.compact
     res.size > 0 ? res : nil
   end

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -25,7 +25,8 @@ class Port < Inspec.resource(1)
     end
   "
 
-  def initialize(port)
+  def initialize(ip = nil, port) # rubocop:disable OptionalArguments
+    @ip = ip
     @port = port
     @port_manager = nil
     @cache = nil
@@ -75,18 +76,21 @@ class Port < Inspec.resource(1)
     return @cache = [] if @port_manager.nil?
     # query ports
     ports = @port_manager.info || []
-    @cache = ports.select { |p| p[:port] == @port }
+    @cache = ports.select { |p| p[:port] == @port && (!@ip || p[:address] == @ip) }
   end
 end
 
 # implements an info method and returns all ip adresses and protocols for
 # each port
 # [{
-#   port: 80,
-#   address: [{
-#     ip: '0.0.0.0'
-#     protocol: 'tcp'
-#   }],
+#   port: 22,
+#   address: '0.0.0.0'
+#   protocol: 'tcp'
+# },
+# {
+#   port: 22,
+#   address: '::'
+#   protocol: 'tcp6'
 # }]
 class PortsInfo
   attr_reader :inspec

--- a/test/integration/test/integration/default/port_spec.rb
+++ b/test/integration/test/integration/default/port_spec.rb
@@ -4,6 +4,6 @@ if os.unix?
   # check that ssh runs
   describe port(22) do
     it { should be_listening }
-    its('protocol') { should include('tcp') }
+    its('protocols') { should include('tcp') }
   end
 end

--- a/test/unit/resources/port_test.rb
+++ b/test/unit/resources/port_test.rb
@@ -9,45 +9,45 @@ describe 'Inspec::Resources::Port' do
   it 'verify port on Ubuntu 14.04' do
     resource = MockLoader.new(:ubuntu1404).load_resource('port', 22)
     _(resource.listening?).must_equal true
-    _(resource.protocol).must_equal %w{ tcp tcp6 }
-    _(resource.pid).must_equal [1]
-    _(resource.process).must_equal ['sshd']
+    _(resource.protocols).must_equal %w{ tcp tcp6 }
+    _(resource.pids).must_equal [1]
+    _(resource.processes).must_equal ['sshd']
   end
 
   it 'verify port on MacOs x' do
     resource = MockLoader.new(:osx104).load_resource('port', 2022)
     _(resource.listening?).must_equal true
-    _(resource.protocol).must_equal ['tcp']
-    _(resource.process).must_equal ['VBoxHeadl']
+    _(resource.protocols).must_equal ['tcp']
+    _(resource.processes).must_equal ['VBoxHeadl']
   end
 
   it 'verify port on Windows' do
     resource = MockLoader.new(:windows).load_resource('port', 135)
     _(resource.listening?).must_equal true
-    _(resource.protocol).must_equal ['tcp']
-    _(resource.process).must_equal nil
+    _(resource.protocols).must_equal ['tcp']
+    _(resource.processes).must_equal nil
   end
 
   it 'verify port on FreeBSD' do
     resource = MockLoader.new(:freebsd10).load_resource('port', 22)
     _(resource.listening?).must_equal true
-    _(resource.protocol).must_equal %w{ tcp6 tcp }
-    _(resource.pid).must_equal [668]
-    _(resource.process).must_equal ['sshd']
+    _(resource.protocols).must_equal %w{ tcp6 tcp }
+    _(resource.pids).must_equal [668]
+    _(resource.processes).must_equal ['sshd']
   end
 
   it 'verify port on wrlinux' do
     resource = MockLoader.new(:wrlinux).load_resource('port', 22)
     _(resource.listening?).must_equal true
-    _(resource.protocol).must_equal %w{ tcp tcp6 }
-    _(resource.process).must_equal ['sshd']
+    _(resource.protocols).must_equal %w{ tcp tcp6 }
+    _(resource.processes).must_equal ['sshd']
   end
 
   it 'verify running on undefined' do
     resource = MockLoader.new(:undefined).load_resource('port', 22)
     _(resource.listening?).must_equal false
-    _(resource.protocol).must_equal nil
-    _(resource.pid).must_equal nil
-    _(resource.process).must_equal nil
+    _(resource.protocols).must_equal nil
+    _(resource.pids).must_equal nil
+    _(resource.processes).must_equal nil
   end
 end

--- a/test/unit/resources/port_test.rb
+++ b/test/unit/resources/port_test.rb
@@ -50,4 +50,17 @@ describe 'Inspec::Resources::Port' do
     _(resource.pids).must_equal nil
     _(resource.processes).must_equal nil
   end
+
+  it 'verify port and interface on Ubuntu 14.04' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('port', '0.0.0.0', 22)
+    _(resource.listening?).must_equal true
+    _(resource.protocols).must_equal %w{ tcp }
+    _(resource.pids).must_equal [1]
+    _(resource.processes).must_equal ['sshd']
+  end
+
+  it 'verify not listening port on interface on Ubuntu 14.04' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('port', '127.0.0.1', 22)
+    _(resource.listening?).must_equal false
+  end
 end


### PR DESCRIPTION
Fixes #256.

Not sure if there might not be some potential for misunderstanding here, though: practically, a process listening in `0.0.0.0:80` is of course reachable on, say, `192.168.1.1:80` on the same machine -- but asking inspec for the latter will say that it isn't.
