### PR TITLE
matcher for less-restrictive comparison

### DIFF
--- a/docs/inspec_and_friends.rst
+++ b/docs/inspec_and_friends.rst
@@ -64,7 +64,7 @@ One of the key differences is that InSpec targets more user groups. It is optimi
       insecure SSHv1 connections anymore.
     "
     describe sshd_config do
-      its('Protocol') { should eq('2') }
+      its('Protocol') { should cmp 2 }
     end
   end
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -275,6 +275,13 @@ This |inspec resource| matches any keyword that is listed in the ``auditd.conf``
 
    its('log_format') { should eq 'raw' }
 
+Since all option names and values are case insensitive for ``auditd_conf``, we recommend to compare values with `cmp` instead of the `eq`.
+
+.. code-block:: ruby
+
+   its('log_format') { should cmp 'raw' }
+   its('max_log_file') { should cmp 6 }
+
 Examples
 -----------------------------------------------------
 The following examples show how to use this InSpec audit resource.
@@ -284,20 +291,20 @@ The following examples show how to use this InSpec audit resource.
 .. code-block:: ruby
 
    describe auditd_conf do
-     its('log_file') { should eq '/full/path/to/file' }
-     its('log_format') { should eq 'raw' }
-     its('flush') { should eq 'none' }
-     its('freq') { should eq '1' }
-     its('num_logs') { should eq '0' }
-     its('max_log_file') { should eq '6' }
-     its('max_log_file_action') { should eq 'email' }
-     its('space_left') { should eq '2' }
-     its('action_mail_acct') { should eq 'root' }
-     its('space_left_action') { should eq 'email' }
-     its('admin_space_left') { should eq '1' }
-     its('admin_space_left_action') { should eq 'halt' }
-     its('disk_full_action') { should eq 'halt' }
-     its('disk_error_action') { should eq 'halt' }
+     its('log_file') { should cmp '/full/path/to/file' }
+     its('log_format') { should cmp 'raw' }
+     its('flush') { should cmp 'none' }
+     its('freq') { should cmp 1 }
+     its('num_logs') { should cmp 0 }
+     its('max_log_file') { should cmp 6 }
+     its('max_log_file_action') { should cmp 'email' }
+     its('space_left') { should cmp 2 }
+     its('action_mail_acct') { should cmp 'root' }
+     its('space_left_action') { should cmp 'email' }
+     its('admin_space_left') { should cmp 1 }
+     its('admin_space_left_action') { should cmp 'halt' }
+     its('disk_full_action') { should cmp 'halt' }
+     its('disk_error_action') { should cmp 'halt' }
    end
 
 
@@ -3910,7 +3917,7 @@ The following examples show how to use this InSpec audit resource.
 .. code-block:: ruby
 
    describe sshd_config do
-     its('Protocol') { should eq '2' }
+     its('Protocol') { should cmp 2 }
    end
 
 **Test ciphers**
@@ -3926,7 +3933,7 @@ The following examples show how to use this InSpec audit resource.
 .. code-block:: ruby
 
    describe sshd_config do
-     its('Port') { should eq '22' }
+     its('Port') { should cmp 22 }
      its('UsePAM') { should eq 'yes' }
      its('ListenAddress') { should eq nil }
      its('HostKey') { should eq [

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -258,7 +258,7 @@ A ``auditd_conf`` |inspec resource| block declares configuration settings that s
 .. code-block:: ruby
 
    describe auditd_conf('path') do
-     its('keyword') { should eq 'value' }
+     its('keyword') { should cmp 'value' }
    end
 
 where
@@ -269,13 +269,7 @@ where
 
 Matchers
 -----------------------------------------------------
-This |inspec resource| matches any keyword that is listed in the ``auditd.conf`` configuration file:
-
-.. code-block:: ruby
-
-   its('log_format') { should eq 'raw' }
-
-Since all option names and values are case insensitive for ``auditd_conf``, we recommend to compare values with `cmp` instead of the `eq`.
+This |inspec resource| matches any keyword that is listed in the ``auditd.conf`` configuration file. Since all option names and values are case insensitive for ``auditd_conf``, we recommend to compare values with `cmp` instead of the `eq`:
 
 .. code-block:: ruby
 

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -255,7 +255,7 @@ RSpec::Matchers.define :cmp do |expected|
     "\nexpected: #{expected}\n     got: #{actual}\n\n(compared using .casecmp?)\n"
   end
 
-  failure_message_when_negated  do |actual|
+  failure_message_when_negated do |actual|
     "\nexpected: value != #{expected}\n     got: #{actual}\n\n(compared using .casecmp?)\n"
   end
 end

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -252,10 +252,10 @@ RSpec::Matchers.define :cmp do |expected|
   end
 
   failure_message do |actual|
-    "\nexpected: #{expected}\n     got: #{actual}\n\n(compared using .casecmp?)\n"
+    "\nexpected: #{expected}\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
   end
 
   failure_message_when_negated do |actual|
-    "\nexpected: value != #{expected}\n     got: #{actual}\n\n(compared using .casecmp?)\n"
+    "\nexpected: value != #{expected}\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
   end
 end

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -236,7 +236,7 @@ RSpec::Matchers.define :cmp do |expected|
   def float?(value)
     return true if Float(value)
     false
-  rescue ArgumentError => ex
+  rescue ArgumentError => _ex
     false
   end
 

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -234,7 +234,10 @@ RSpec::Matchers.define :cmp do |expected|
   end
 
   def float?(value)
-    true if Float(value) rescue false
+    return true if Float(value)
+    false
+  rescue ArgumentError => ex
+    false
   end
 
   match do |actual|

--- a/test/integration/test/integration/default/compare_matcher_spec.rb
+++ b/test/integration/test/integration/default/compare_matcher_spec.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+# uses the `cmp` matcher instead of the eq matcher
+describe sshd_config do
+  its('Port') { should eq '22' }
+  its('Port') { should_not eq 22 }
+
+  its('Port') { should cmp '22' }
+  its('Port') { should cmp 22 }
+  its('Port') { should cmp 22.0 }
+  its('Port') { should_not cmp 22.1 }
+
+  its('LogLevel') { should eq 'INFO' }
+  its('LogLevel') { should_not eq 'info'}
+
+  its('LogLevel') { should cmp 'INFO' }
+  its('LogLevel') { should cmp 'info' }
+  its('LogLevel') { should cmp 'InfO' }
+end


### PR DESCRIPTION
This matcher implements a less-restrictive comparison. Currently, it was not possible to write integer comparison (#308)

``` ruby
describe sshd_config do
  its('Port') { should eq '22' } # works
  its('Port') { should eq 22 } # does not work
end
```

As highlighted in #307 some resources have case-insensitive values, and I would like tests write

``` ruby
describe auditd_conf do
   its('log_format') { should eq 'raw' } # works
   its('log_format') { should eq 'RAW' } # does not work
end
```

This PR introduces a new comparison matcher `cmp`, that covers those cases:

``` ruby
describe sshd_config do
  its('Port') { should cmp '22' }
  its('Port') { should cmp 22 } # works with integer
  its('Port') { should cmp 22.0 } # also understand float
  its('Port') { should_not cmp 22.1 }

  # case-insensitive
  its('LogLevel') { should cmp 'INFO' } 
  its('LogLevel') { should cmp 'info' }
  its('LogLevel') { should cmp 'InfO' }
end

```
