### PR TITLE
reset rspec configuration when initializing Inspec::Runner

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -23,6 +23,9 @@ module Inspec
       @conf[:logger] ||= Logger.new(nil)
       @tests = RSpec::Core::World.new
 
+      # resets "pending examples" in reporter
+      RSpec.configuration.reset
+
       configure_output
       configure_transport
     end


### PR DESCRIPTION
It was all just a matter of [reporter carrying its pending_examples around](https://github.com/rspec/rspec-core/blob/19761e35a0fa8e7d61eaf4af52226fa0c2a39817/lib/rspec/core/reporter.rb#L167). Luckily `RSpec.configuration.reset` [let's us trigger](https://github.com/rspec/rspec-core/blob/v3.3.1/lib/rspec/core/configuration.rb#L386-L390) a [re-instantiation of RSpec::Reporter](https://github.com/rspec/rspec-core/blob/v3.3.1/lib/rspec/core/configuration.rb#L785).

fixes https://github.com/chef/kitchen-inspec/issues/15
