### PR TITLE
Fixing issue with security policy always returning nil

### DIFF
--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -30,15 +30,19 @@ class SecurityPolicy < Inspec.resource(1)
   # load security content
   def load
     # export the security policy
-    inspec.command('secedit /export /cfg win_secpol.cfg')
-    # store file content
-    command_result ||= inspec.command('type win_secpol.cfg')
-    # delete temp file
-    inspec.command('del win_secpol.cfg')
+    cmd = inspec.command('secedit /export /cfg win_secpol.cfg')
+    return nil if cmd.exit_status.to_i != 0
 
-    @exit_status = command_result.exit_status.to_i
-    @policy = command_result.stdout
+    # store file content
+    cmd = inspec.command('Get-Content win_secpol.cfg')
+    @exit_status = cmd.exit_status.to_i
+    return nil if @exit_status != 0
+    @policy = cmd.stdout
     @loaded = true
+    
+    # delete temp file
+    cmd = inspec.command('Remove-Item win_secpol.cfg')
+    return nil if cmd.exit_status.to_i != 0
 
     # returns self
     self

--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -40,12 +40,12 @@ class SecurityPolicy < Inspec.resource(1)
     @policy = cmd.stdout
     @loaded = true
     
-    # delete temp file
-    cmd = inspec.command('Remove-Item win_secpol.cfg')
-    return nil if cmd.exit_status.to_i != 0
-
     # returns self
     self
+
+  ensure
+    # delete temp file
+    inspec.command('Remove-Item win_secpol.cfg').exit_status.to_i
   end
 
   def method_missing(method)

--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -39,7 +39,7 @@ class SecurityPolicy < Inspec.resource(1)
     return nil if @exit_status != 0
     @policy = cmd.stdout
     @loaded = true
-    
+
     # returns self
     self
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -111,9 +111,9 @@ class MockLoader
 
     mock.commands = {
       'ps aux' => cmd.call('ps-aux'),
-      'type win_secpol.cfg' => cmd.call('secedit-export'),
+      'Get-Content win_secpol.cfg' => cmd.call('secedit-export'),
       'secedit /export /cfg win_secpol.cfg' => cmd.call('success'),
-      'del win_secpol.cfg' => cmd.call('success'),
+      'Remove-Item win_secpol.cfg' => cmd.call('success'),
       'env' => cmd.call('env'),
       '$Env:PATH'  => cmd.call('$env-PATH'),
       # registry key test

--- a/test/integration/test/integration/default/secpol_spec.rb
+++ b/test/integration/test/integration/default/secpol_spec.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+
+if os.windows?
+    describe security_policy do
+    its('EnableAdminAccount') { should eq 1 }
+    its('EnableGuestAccount') { should eq 0 }
+  end
+end

--- a/test/integration/test/integration/default/secpol_spec.rb
+++ b/test/integration/test/integration/default/secpol_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 if os.windows?
-    describe security_policy do
+  describe security_policy do
     its('EnableAdminAccount') { should eq 1 }
     its('EnableGuestAccount') { should eq 0 }
   end


### PR DESCRIPTION
All of the Security Policies were evaluating to nil.
This fixes the issues and allows it to work correctly.
I imagine this wasn't caught earlier due to a file artifact (win_secpol.cfg) being left around from a manual execution of the secedit export command.

Here is an example of what happens when trying to evaluate any security_policy:

<pre>
Failures:

  1) Security Policy EnableAdminAccount should eq 1
     Failure/Error: its('EnableAdminAccount') { should eq 1 }

       expected: 1
            got: nil

       (compared using ==)
     # ./test/integration/default/guest_account_spec.rb:5:in `block (3 levels) in load'
     # /Users/jmiller/.chefdk/gem/ruby/2.1.0/gems/kitchen-inspec-0.9.6/lib/kitchen/verifier/inspec.rb:55:in `call'

Finished in 0.91339 seconds (files took 0.70664 seconds to load)
8 examples, 1 failure

Failed examples:

rspec  # Security Policy EnableAdminAccount should eq 1
</pre>
