### PR TITLE
teach `cmp` matcher octal tricks

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -240,14 +240,21 @@ RSpec::Matchers.define :cmp do |expected|
     false
   end
 
+  def octal?(value)
+    return true if value =~ /\A0+\d+\Z/
+    false
+  end
+
   match do |actual|
     # if actual and expected are strings
-    if actual.is_a?(String) && expected.is_a?(String)
+    if expected.is_a?(String) && actual.is_a?(String)
       actual.casecmp(expected) == 0
     elsif expected.is_a?(Integer) && integer?(actual)
       expected == actual.to_i
     elsif expected.is_a?(Float) && float?(actual)
       expected == actual.to_f
+    elsif octal?(expected) && actual.is_a?(Integer)
+      expected.to_i(8) == actual
     # fallback to equal
     else
       actual == expected
@@ -255,10 +262,12 @@ RSpec::Matchers.define :cmp do |expected|
   end
 
   failure_message do |actual|
+    actual = '0' + actual.to_s(8) if octal?(expected)
     "\nexpected: #{expected}\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
   end
 
   failure_message_when_negated do |actual|
+    actual = '0' + actual.to_s(8) if octal?(expected)
     "\nexpected: value != #{expected}\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
   end
 end

--- a/test/integration/test/integration/default/file_spec.rb
+++ b/test/integration/test/integration/default/file_spec.rb
@@ -40,6 +40,8 @@ if os.unix?
     # it { should have_mode }
     its('mode') { should eq 00765 }
     it { should be_mode 00765 }
+    its('mode') { should cmp '0765' }
+    its('mode') { should_not cmp '0777' }
 
     it { should be_readable }
     it { should be_readable.by('owner') }


### PR DESCRIPTION
This addresses #230. The underlying problem is that as far as I can tell no way to figure out if an `Integer` argument to a matcher was given in using octal literals (`0777`) or not (`511`). To work around this, this change lets you use the `cmp` matcher for octal _strings_, for example:

``` ruby
its('mode') { should eq 0766 }
its('mode') { should cmq '0766' }
```

will give you (on a file that has permissions `0765`):

```
Failures:

  1) File /tmp/file mode should eq 502
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }

       expected: 502
            got: 501

       (compared using ==)
     # ./test/integration/default/file_spec.rb:41:in `block (2 levels) in load'

  2) File /tmp/file mode should cmp "0766"
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }

       expected: 0766
            got: 0765

       (compared using `cmp` matcher)
     # ./test/integration/default/file_spec.rb:43:in `block (2 levels) in load'
```

Note that aruba is solving the issue differently: [they introduced a matcher for that](https://github.com/cucumber/aruba/blob/1939c4049d5195ffdd967485f50119bdd86e98a0/lib/aruba/matchers/path/have_permissions.rb#L31). It's up for debate, I slightly prefer the `cmp` matcher.
