### PR TITLE
remove format default for `inspec exec`

### DIFF
--- a/bin/inspec
+++ b/bin/inspec
@@ -81,7 +81,7 @@ class InspecCLI < Thor # rubocop:disable Metrics/ClassLength
   option :id, type: :string,
     desc: 'Attach a profile ID to all test results'
   target_options
-  option :format, type: :string, default: 'progress'
+  option :format, type: :string
   def exec(*tests)
     diagnose
 


### PR DESCRIPTION
behaviour is unchanged. (this caused trouble in chef-compliance, using JSON configuration)
