### PR TITLE
Verify profile metadata contents correctly

### DIFF
--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -44,12 +44,12 @@ module Inspec
 
     def valid?
       is_valid = true
-      %w{ name title version summary }.each do |field|
+      %w{ name version }.each do |field|
         next unless params[field.to_sym].nil?
         @logger.error("Missing profile #{field} in metadata.rb")
         is_valid = false
       end
-      %w{ maintainer copyright }.each do |field|
+      %w{ title summary maintainer copyright }.each do |field|
         next unless params[field.to_sym].nil?
         @logger.warn("Missing profile #{field} in metadata.rb")
         is_valid = false

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -6,7 +6,7 @@
 require 'inspec/metadata'
 
 module Inspec
-  class Profile # rubocop:disable Metrics/ClassLength
+  class Profile
     def self.from_path(path, options = nil)
       opt = {}
       options.each { |k, v| opt[k.to_sym] = v } unless options.nil?
@@ -35,6 +35,7 @@ module Inspec
         id: @profile_id,
         backend: :mock,
       )
+
       @runner.add_tests([@path])
       @runner.rules.each do |id, rule|
         file = rule.instance_variable_get(:@__file)
@@ -91,24 +92,11 @@ module Inspec
       }
 
       @logger.info "Checking profile in #{@path}"
-
-      if @params[:name].to_s.empty?
-        error.call('No profile name defined')
-      elsif !(@params[:name].to_s =~ %r{^\S+\/\S+$})
-        error.call('Profile name must be defined as: OWNER/ID')
-      end
-
-      warn.call('No version defined') if @params[:name].to_s.empty?
-      warn.call('No title defined') if @params[:title].to_s.empty?
-      warn.call('No maintainer defined') if @params[:maintainer].to_s.empty?
-      if Array(@params[:supports]).empty?
-        warn.call('No supports defined (supported operating systems)')
-      end
-      @logger.info 'Metadata OK.' if no_warnings
+      @logger.info 'Metadata OK.' if @metadata.valid?
 
       no_warnings = true
       if @params[:rules].empty?
-        warn.call('No rules were found.')
+        warn.call('No controls or tests were defined.')
       else
         @logger.debug "Found #{@params[:rules].length} rules."
       end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -99,16 +99,18 @@ module Inspec
       end
 
       warn.call('No version defined') if @params[:name].to_s.empty?
-      warn.call('No title defined') if @params[:name].to_s.empty?
-      warn.call('No maintainer defined') if @params[:name].to_s.empty?
-      warn.call('No supports defined') if @params[:name].empty?
+      warn.call('No title defined') if @params[:title].to_s.empty?
+      warn.call('No maintainer defined') if @params[:maintainer].to_s.empty?
+      if Array(@params[:supports]).empty?
+        warn.call('No supports defined (supported operating systems)')
+      end
       @logger.info 'Metadata OK.' if no_warnings
 
       no_warnings = true
-      if @params[:name].empty?
+      if @params[:rules].empty?
         warn.call('No rules were found.')
       else
-        @logger.debug "Found #{@params[:name].length} rules."
+        @logger.debug "Found #{@params[:rules].length} rules."
       end
 
       # iterate over hash of groups

--- a/test/unit/mock/profiles/complete-meta/metadata.rb
+++ b/test/unit/mock/profiles/complete-meta/metadata.rb
@@ -1,0 +1,7 @@
+name 'name'
+version '1.2.3'
+maintainer 'bob'
+title 'title'
+copyright 'left'
+summary 'nothing'
+supports nil


### PR DESCRIPTION
The check is currently in two places, which leads to errors while checking this file. Remove all handling structures from `profile.rb` and instead refer it to `metadata.rb` which already has up-to-date profile structure checking.

Also finally adds tests the frist tests for `inspec check`.
