### PR TITLE
Set exit status to return value of Inspec Runner

### DIFF
--- a/bin/inspec
+++ b/bin/inspec
@@ -87,7 +87,7 @@ class InspecCLI < Thor # rubocop:disable Metrics/ClassLength
 
     runner = Inspec::Runner.new(opts)
     runner.add_tests(tests)
-    runner.run
+    exit runner.run
   rescue RuntimeError => e
     puts e.message
   end


### PR DESCRIPTION
When invoking inspec using `inspec exec PATH`, the script always
exits with a 0 status code. This pull request proposes to exit with the
same status code as the Inspec Runner. This behavior is consistent with
how testing platforms of this type typically work.
