### PR TITLE
Fix custom resource loading from `libraries`

### DIFF
--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -19,11 +19,15 @@ module Inspec
       @profile_id = profile_id
       @rules = profile_registry
       @only_ifs = only_ifs
+      @backend = backend
 
-      dsl = create_inner_dsl(backend)
+      reload_dsl
+    end
+
+    def reload_dsl
+      dsl = create_inner_dsl(@backend)
       outer_dsl = create_outer_dsl(dsl)
       ctx = create_context(outer_dsl)
-
       @profile_context = ctx.new
     end
 

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -84,6 +84,7 @@ module Inspec
       ctx = create_context
       libs.each do |lib|
         ctx.load(lib[:content].to_s, lib[:ref], lib[:line] || 1)
+        ctx.reload_dsl
       end
 
       # evaluate the test content


### PR DESCRIPTION
This is a temporary workaround, but it makes sure that any custom resource loaded from libraries forces the profile context to rebuild its DSL.

It'd be even better to build it without reload, by using a baseline module/class which new resources get connected to. When that happens, these resources would automatically become available.
