### PR TITLE
Fix systemd service enabled check

### DIFF
--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -142,7 +142,7 @@ class Systemd < ServiceManager
     params['SubState'] == 'running' ? (running = true) : (running = false)
     # test via systemctl --quiet is-enabled
     # ActiveState values eg.g inactive, active
-    params['ActiveState'] == 'active' ? (enabled = true) : (enabled = false)
+    params['UnitFileState'] == 'enabled' ? (enabled = true) : (enabled = false)
 
     {
       name: params['Id'],

--- a/test/unit/mock/cmd/systemctl-show-all-sshd
+++ b/test/unit/mock/cmd/systemctl-show-all-sshd
@@ -2,5 +2,5 @@ Id=sshd.service
 Names=sshd.service
 Description=OpenSSH server daemon
 LoadState=loaded
-ActiveState=active
+UnitFileState=enabled
 SubState=running


### PR DESCRIPTION
I believe the wrong param from `systemctl show` is being checked to determine if a service is enabled/disabled in systemd.

Currently I have tests passing as enabled when I have a service disabled in systemd:

```
describe service('corosync') do
  it { should be_running }
  it { should be_enabled }
end
```

Is passing when I see the following from systemd:

```
[root@default-centos-71 ~]# systemctl status corosync
corosync.service - Corosync Cluster Engine
   Loaded: loaded (/usr/lib/systemd/system/corosync.service; disabled)
   Active: active (running) since Mon 2016-01-11 21:02:11 UTC; 32min ago
 Main PID: 13283 (corosync)
   CGroup: /system.slice/corosync.service
           └─13283 corosync
```

Notice how in `Loaded` at the end it shows 'disabled'.

Also, please see the `ActiveState` vs `UnitFileState` when enabling and disabling the service with systemd:

```
[root@default-centos-71 ~]# systemctl show --all corosync | grep -e UnitFileState -e ActiveState
ActiveState=active
UnitFileState=disabled
[root@default-centos-71 ~]# systemctl enable corosync
ln -s '/usr/lib/systemd/system/corosync.service' '/etc/systemd/system/multi-user.target.wants/corosync.service'
[root@default-centos-71 ~]# systemctl show --all corosync | grep -e UnitFileState -e ActiveState
ActiveState=active
UnitFileState=enabled
[root@default-centos-71 ~]# systemctl disable corosync
rm '/etc/systemd/system/multi-user.target.wants/corosync.service'
[root@default-centos-71 ~]# systemctl show --all corosync | grep -e UnitFileState -e ActiveState
ActiveState=active
UnitFileState=disabled
```

This PR addresses the issue by updating the check to use param `UnitFileState` to check if the service is enabled or disabled instead of `ActiveState`.
