### PR TITLE
Correctly detect UDP ports on linux

### DIFF
--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -213,7 +213,7 @@ class LinuxPorts < PortsInfo
   def parse_netstat_line(line)
     # parse each line
     # 1 - Proto, 2 - Recv-Q, 3 - Send-Q, 4 - Local Address, 5 - Foreign Address, 6 - State, 7 - Inode, 8 - PID/Program name
-    parsed = /^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)/.match(line)
+    parsed = /^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)?\s+(\S+)\s+(\S+)\s+(\S+)/.match(line)
 
     return {} if parsed.nil? || line.match(/^proto/i)
 

--- a/test/unit/mock/cmd/netstat-tulpen
+++ b/test/unit/mock/cmd/netstat-tulpen
@@ -3,3 +3,4 @@ Proto Recv-Q Send-Q Local Address           Foreign Address         State       
 tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      0          21699       1/sshd
 tcp6       0      48 2601:1:ad80:1445::54776 2620:0:861:52:208::6667 LISTEN     0          21702       2043/pidgin
 tcp6       0      0 :::22                   :::*                    LISTEN      0          21701       1/sshd
+udp        0      0 0.0.0.0:111             0.0.0.0:*                   0          8689        545/rpcbind

--- a/test/unit/resources/port_test.rb
+++ b/test/unit/resources/port_test.rb
@@ -14,6 +14,14 @@ describe 'Inspec::Resources::Port' do
     _(resource.processes).must_equal ['sshd']
   end
 
+  it 'verify UDP port on Ubuntu 14.04' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('port', 111)
+    _(resource.listening?).must_equal true
+    _(resource.protocols).must_equal %w{ udp }
+    _(resource.pids).must_equal [545]
+    _(resource.processes).must_equal ['rpcbind']
+  end
+
   it 'verify port on MacOs x' do
     resource = MockLoader.new(:osx104).load_resource('port', 2022)
     _(resource.listening?).must_equal true


### PR DESCRIPTION
netstat on UDP lines doesn't display a port state (e.g. LISTEN), so make this
field optional when parsing the netstat line.
