### PR TITLE
make metadata.rb legacy mode consistent for supports

### DIFF
--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -35,14 +35,9 @@ module Inspec
     end
 
     def supports(sth, version = nil)
-      params[:supports] ||= []
-      params[:supports].push(
-        # do not use hash syntax for `-` to work properly with ruby 1.9.3 parser
-        {
-          :'os-name' => sth, # rubocop:disable Style/HashSyntax, Lint/UnneededDisable
-          version: version,
-        },
-      )
+      # Ignore supports with metadata.rb. This file is legacy and the way it
+      # it handles `supports` deprecated. A deprecation warning will be printed
+      # already.
     end
 
     def is_supported(os, entry)

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -17,6 +17,7 @@ module Inspec
 
     attr_reader :params
     attr_reader :path
+    attr_reader :metadata
 
     def initialize(options = nil)
       @options = options || {}
@@ -104,7 +105,7 @@ module Inspec
       # check if the profile is using the old test directory instead of the
       # new controls directory
       if Pathname.new(path).join('test').exist? && !Pathname.new(path).join('controls').exist?
-        warn.call('Profile uses deprecated `test` directory, rename it to `controls`')
+        warn.call('Profile uses deprecated `test` directory, rename it to `controls`.')
       end
 
       count = rules_count

--- a/test/unit/mock/profiles/complete-meta/metadata.rb
+++ b/test/unit/mock/profiles/complete-meta/metadata.rb
@@ -4,4 +4,4 @@ maintainer 'bob'
 title 'title'
 copyright 'left'
 summary 'nothing'
-supports nil
+supports 'linux'

--- a/test/unit/profile_test.rb
+++ b/test/unit/profile_test.rb
@@ -69,18 +69,22 @@ describe Inspec::Profile do
       end
     end
 
-    describe 'a complete metadata profile' do
+    describe 'a complete metadata profile (legacy mode)' do
       let(:profile) { load_profile('complete-meta', {logger: logger}) }
 
       it 'prints ok messages' do
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/complete-meta"]
         logger.expect :warn, nil, ['The use of `metadata.rb` is deprecated. Use `inspec.yml`.']
         logger.expect :info, nil, ['Metadata OK.']
-        logger.expect :warn, nil, ["Profile uses deprecated `test` directory, rename it to `controls`"]
+        logger.expect :warn, nil, ["Profile uses deprecated `test` directory, rename it to `controls`."]
         logger.expect :warn, nil, ['No controls or tests were defined.']
 
         profile.check
         logger.verify
+      end
+
+      it 'doesnt have constraints on supported systems' do
+        profile.metadata.params.wont_include(:supports)
       end
     end
 


### PR DESCRIPTION
Before introducing InSpec profiles in https://github.com/chef/inspec/pull/252 we had `metadata.rb` keep all information. This included an undisclosed field called `supports`. However, this field was never actually used in practice. So for legacy profiles, this means that `supports` was ignored. In order to keep old profiles running in exactly the way they were before, ignore this field when reading from metadata.rb
