### PR TITLE
warn about legacy supports fields in metadata

### DIFF
--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -73,7 +73,9 @@ module Inspec
         family = try_support[:'os-family']
         release = try_support[:release]
       elsif entry.is_a?(String)
-        @logger.warn("Using deprecated `supports` syntax: using `#{entry}` as OS family")
+        @logger.warn(
+          "Do not use deprecated `supports: #{entry}` syntax. Instead use "\
+          "`supports: {os-family: #{entry}}`.")
         family = entry
       end
 


### PR DESCRIPTION
I.e.: Prevent users from writing `supports: linux` and similar. These are deprecated and will be removed. Also improve the warning to indicate what the user should do instead. Finally add tests to make sure we get all these.

This MR just adds the relevant tests and changes the message a bit.
