### PR TITLE
resources/launchd_service: fix parsing of non-running services

### DIFF
--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -387,15 +387,15 @@ class LaunchCtl < ServiceManager
     return nil if srv.nil? || srv[0].nil?
 
     # extract values from service
-    parsed_srv = /^([0-9]+)\s*(\w*)\s*(\S*)/.match(srv[0])
-    enabled = !parsed_srv.nil?
+    parsed_srv = /^(?<pid>[0-9-]+)\t(?<exit>[0-9]+)\t(?<name>\S*)$/.match(srv[0])
+    enabled = !parsed_srv['name'].nil? # it's in the list
 
     # check if the service is running
-    pid = parsed_srv[0]
-    running = !pid.nil?
+    pid = parsed_srv['pid']
+    running = pid != '-'
 
     # extract service label
-    srv = parsed_srv[3] || service_name
+    srv = parsed_srv['name'] || service_name
 
     {
       name: srv,

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -152,6 +152,15 @@ describe 'Inspec::Resources::Service' do
     _(resource.running?).must_equal true
   end
 
+  it 'verify mac osx package parsing with not-running service' do
+    resource = MockLoader.new(:osx104).load_resource('service', 'FilesystemUI')
+    srv = { name: 'com.apple.FilesystemUI', description: nil, installed: true, running: false, enabled: true, type: 'darwin' }
+    _(resource.info).must_equal srv
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal false
+  end
+
   it 'verify mac osx package parsing with default launchd_service' do
     resource = MockLoader.new(:osx104).load_resource('launchd_service', 'ssh')
     srv = { name: 'org.openbsd.ssh-agent', description: nil, installed: true, running: true, enabled: true, type: 'darwin' }


### PR DESCRIPTION
If the service is not running, its pid is given as `"-"`.
