### PR TITLE
bugfix: write given ID to metadata json

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -33,6 +33,7 @@ module Inspec
       @params = @metadata.params
       # use the id from parameter, name or fallback to nil
       @profile_id = options[:id] || params[:name] || nil
+      @params[:name] = @profile_id
 
       @params[:rules] = rules = {}
       @runner = Runner.new(

--- a/test/unit/profile_test.rb
+++ b/test/unit/profile_test.rb
@@ -41,7 +41,8 @@ describe Inspec::Profile do
   end
 
   describe 'with simple metadata in profile' do
-    let(:profile) { load_profile('simple-metadata') }
+    let(:profile_id) { 'simple-metadata' }
+    let(:profile) { load_profile(profile_id) }
 
     it 'has metadata' do
       profile.params[:name].must_equal 'yumyum profile'
@@ -49,6 +50,12 @@ describe Inspec::Profile do
 
     it 'has no rules' do
       profile.params[:rules].must_equal({})
+    end
+
+    it 'can overwrite the profile ID' do
+      testID = rand.to_s
+      res = load_profile(profile_id, id: testID)
+      res.params[:name].must_equal testID
     end
   end
 


### PR DESCRIPTION
Whenever the user provides an ID under which the profile is scoped, make sure the ID is used consistently in all layers of the profile. At the moment, this manifests when the user-provided ID does not show up in the JSON generation. 
