### PR TITLE
Solaris Support

### DIFF
--- a/lib/resources/etc_group.rb
+++ b/lib/resources/etc_group.rb
@@ -45,7 +45,7 @@ class EtcGroup < Inspec.resource(1)
 
     # skip resource if it is not supported on current OS
     return skip_resource 'The `etc_group` resource is not supported on your OS.' \
-    unless %w{ubuntu debian redhat fedora centos arch darwin freebsd wrlinux aix}.include?(inspec.os[:family])
+    unless inspec.os.unix?
   end
 
   def groups(filter = nil)

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -110,7 +110,7 @@ module Inspec::Resources
     def check_file_permission_by_user(user, flag)
       if linux?
         perm_cmd = "su -s /bin/sh -c \"test -#{flag} #{path}\" #{user}"
-      elsif family == 'freebsd'
+      elsif family == 'freebsd' || solaris?
         perm_cmd = "sudo -u #{user} test -#{flag} #{path}"
       elsif family == 'aix'
         perm_cmd = "su #{user} -c test -#{flag} #{path}"
@@ -138,6 +138,10 @@ module Inspec::Resources
 
     def linux?
       inspec.os.linux?
+    end
+
+    def solaris?
+      inspec.os.solaris?
     end
 
     def family

--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -22,21 +22,21 @@ class Package < Inspec.resource(1)
     @package_name = package_name
     @name = @package_name
     @cache = nil
-
     # select package manager
     @pkgman = nil
-    case inspec.os[:family]
-    when 'ubuntu', 'debian'
+
+    os = inspec.os
+    if os.debian?
       @pkgman = Deb.new(inspec)
-    when 'redhat', 'fedora', 'centos', 'opensuse', 'wrlinux'
+    elsif os.redhat? || os.suse?
       @pkgman = Rpm.new(inspec)
-    when 'arch'
+    elsif ['arch'].include?(os[:family])
       @pkgman = Pacman.new(inspec)
-    when 'darwin'
+    elsif ['darwin'].include?(os[:family])
       @pkgman = Brew.new(inspec)
-    when 'windows'
+    elsif inspec.os.windows?
       @pkgman = WindowsPkg.new(inspec)
-    when 'aix'
+    elsif ['aix'].include?(os[:family])
       @pkgman = BffPkg.new(inspec)
     else
       return skip_resource 'The `package` resource is not supported on your OS yet.'

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -404,7 +404,7 @@ class SolarisPorts < LinuxPorts
 
     # filter all ports, where we listen
     listen = netstat_ports.select { |val|
-      !val['state'].nil? && val['state'].casecamp('listen') == 0
+      !val['state'].nil? && 'listen'.casecmp(val['state']) == 0
     }
 
     # map the data

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -335,7 +335,7 @@ class FreeBsdPorts < PortsInfo
 
   def parse_net_address(net_addr, protocol)
     case protocol
-    when 'tcp4', 'udp4'
+    when 'tcp4', 'udp4', 'tcp', 'udp'
       # replace * with 0.0.0.0
       net_addr = net_addr.gsub(/^\*:/, '0.0.0.0:') if net_addr =~ /^*:(\d+)$/
       ip_addr = URI('addr://'+net_addr)
@@ -391,7 +391,7 @@ class FreeBsdPorts < PortsInfo
   end
 end
 
-class SolarisPorts < LinuxPorts
+class SolarisPorts < FreeBsdPorts
   include SolarisNetstatParser
 
   def info

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -30,18 +30,17 @@ class Port < Inspec.resource(1)
     @port = port
     @port_manager = nil
     @cache = nil
-
-    case inspec.os[:family]
-    when 'ubuntu', 'debian', 'redhat', 'fedora', 'centos', 'arch', 'wrlinux'
+    os = inspec.os
+    if os.linux?
       @port_manager = LinuxPorts.new(inspec)
-    when 'darwin', 'aix'
+    elsif %w{darwin aix}.include?(os[:family])
       # AIX: see http://www.ibm.com/developerworks/aix/library/au-lsof.html#resources
       #      and https://www-01.ibm.com/marketing/iwm/iwm/web/reg/pick.do?source=aixbp
       # Darwin: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man8/lsof.8.html
       @port_manager = LsofPorts.new(inspec)
-    when 'windows'
+    elsif os.windows?
       @port_manager = WindowsPorts.new(inspec)
-    when 'freebsd'
+    elsif ['freebsd'].include?(os[:family])
       @port_manager = FreeBsdPorts.new(inspec)
     else
       return skip_resource 'The `port` resource is not supported on your OS yet.'

--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -44,9 +44,9 @@ class Service < Inspec.resource(1)
   end
 
   def select_service_mgmt # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-    family = inspec.os[:family]
+    os = inspec.os
+    family = os[:family]
 
-    case family
     # Ubuntu
     # @see: https://wiki.ubuntu.com/SystemdForUpstartUsers
     # Ubuntu 15.04 : Systemd
@@ -55,38 +55,38 @@ class Service < Inspec.resource(1)
     # Ubuntu < 15.04 : Upstart
     # Upstart runs with PID 1 as /sbin/init.
     # Systemd runs with PID 1 as /lib/systemd/systemd.
-    when 'ubuntu'
+    if %w{ubuntu}.include?(family)
       version = inspec.os[:release].to_f
       if version < 15.04
         Upstart.new(inspec, service_ctl)
       else
         Systemd.new(inspec, service_ctl)
       end
-    when 'debian'
+    elsif %w{debian}.include?(family)
       version = inspec.os[:release].to_i
       if version > 7
         Systemd.new(inspec, service_ctl)
       else
         SysV.new(inspec, service_ctl || '/usr/sbin/service')
       end
-    when 'redhat', 'fedora', 'centos'
+    elsif %w{redhat fedora centos}.include?(family)
       version = inspec.os[:release].to_i
       if (%w{ redhat centos }.include?(family) && version >= 7) || (family == 'fedora' && version >= 15)
         Systemd.new(inspec, service_ctl)
       else
         SysV.new(inspec, service_ctl || '/sbin/service')
       end
-    when 'wrlinux'
+    elsif %w{wrlinux}.include?(family)
       SysV.new(inspec, service_ctl)
-    when 'darwin'
+    elsif %w{darwin}.include?(family)
       LaunchCtl.new(inspec, service_ctl)
-    when 'windows'
+    elsif os.windows?
       WindowsSrv.new(inspec)
-    when 'freebsd'
+    elsif %w{freebsd}.include?(family)
       BSDInit.new(inspec, service_ctl)
-    when 'arch', 'opensuse'
+    elsif %w{arch opensuse}.include?(family)
       Systemd.new(inspec, service_ctl)
-    when 'aix'
+    elsif %w{aix}.include?(family)
       SrcMstr.new(inspec)
     end
   end

--- a/lib/resources/user.rb
+++ b/lib/resources/user.rb
@@ -76,42 +76,42 @@ class User < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
   end
 
   def uid
-    identity.nil? ? nil : identity[:uid]
+     identity[:uid] unless identity.nil?
   end
 
   def gid
-    identity.nil? ? nil : identity[:gid]
+    identity[:gid] unless identity.nil?
   end
 
   def group
-    identity.nil? ? nil : identity[:group]
+    identity[:group] unless identity.nil?
   end
 
   def groups
-    identity.nil? ? nil : identity[:groups]
+    identity[:groups] unless identity.nil?
   end
 
   def home
-    meta_info.nil? ? nil : meta_info[:home]
+    meta_info[:home] unless meta_info.nil?
   end
 
   def shell
-    meta_info.nil? ? nil : meta_info[:shell]
+    meta_info[:shell] unless meta_info.nil?
   end
 
   # returns the minimum days between password changes
   def mindays
-    credentials.nil? ? nil : credentials[:mindays]
+    credentials[:mindays] unless credentials.nil?
   end
 
   # returns the maximum days between password changes
   def maxdays
-    credentials.nil? ? nil : credentials[:maxdays]
+    credentials[:maxdays] unless credentials.nil?
   end
 
   # returns the days for password change warning
   def warndays
-    credentials.nil? ? nil : credentials[:warndays]
+    credentials[:warndays] unless credentials.nil?
   end
 
   # implement 'mindays' method to be compatible with serverspec

--- a/lib/resources/user.rb
+++ b/lib/resources/user.rb
@@ -178,7 +178,7 @@ class UserInfo
   include Converter
 
   attr_reader :inspec
-  def initialize(inspec, _id_cmd)
+  def initialize(inspec)
     @inspec = inspec
   end
 
@@ -189,7 +189,7 @@ end
 # implements generic unix id handling
 class UnixUser < UserInfo
   attr_reader :inspec, :id_cmd
-  def initialize(inspec, id_cmd = nil)
+  def initialize(inspec)
     @inspec = inspec
     @id_cmd ||= 'id'
     super
@@ -275,7 +275,7 @@ class LinuxUser < UnixUser
 end
 
 class SolarisUser < LinuxUser
-  def initialize(inspec, id_cmd = nil)
+  def initialize(inspec)
     @inspec = inspec
     @id_cmd ||= 'id -a'
     super

--- a/lib/resources/user.rb
+++ b/lib/resources/user.rb
@@ -53,16 +53,16 @@ class User < Inspec.resource(1)
 
     # select package manager
     @user_provider = nil
-    case inspec.os[:family]
-    when 'ubuntu', 'debian', 'redhat', 'fedora', 'centos', 'arch', 'opensuse', 'wrlinux'
+    os = inspec.os
+    if os.linux?
       @user_provider = LinuxUser.new(inspec)
-    when 'windows'
+    elsif os.windows?
       @user_provider = WindowsUser.new(inspec)
-    when 'darwin'
+    elsif ['darwin'].include?(os[:family])
       @user_provider = DarwinUser.new(inspec)
-    when 'freebsd'
+    elsif ['freebsd'].include?(os[:family])
       @user_provider = FreeBSDUser.new(inspec)
-    when 'aix'
+    elsif ['aix'].include?(os[:family])
       @user_provider = AixUser.new(inspec)
     else
       return skip_resource 'The `user` resource is not supported on your OS yet.'

--- a/lib/resources/user.rb
+++ b/lib/resources/user.rb
@@ -76,7 +76,7 @@ class User < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
   end
 
   def uid
-     identity[:uid] unless identity.nil?
+    identity[:uid] unless identity.nil?
   end
 
   def gid

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -40,6 +40,8 @@ class MockLoader
       ubuntu1504: { family: 'ubuntu', release: '15.04', arch: 'x86_64' },
       windows:    { family: 'windows', release: nil, arch: nil },
       wrlinux:    { family: 'wrlinux', release: '7.0(3)I2(2)', arch: 'x86_64' },
+      solaris11:  { family: "solaris", release: '11', arch: 'i386'},
+      solaris10:  { family: "solaris", release: '10', arch: 'i386'},
       undefined:  { family: nil, release: nil, arch: nil },
     }
 
@@ -202,6 +204,12 @@ class MockLoader
       # mount
       "mount | grep -- ' on /'" => cmd.call("mount"),
       "mount | grep -- ' on /mnt/iso-disk'" => cmd.call("mount-multiple"),
+      # solaris 10 package manager
+      'pkginfo -l SUNWzfsr' => cmd.call('pkginfo-l-SUNWzfsr'),
+      # solaris 11 package manager
+      'pkg info system/file-system/zfs' => cmd.call('pkg-info-system-file-system-zfs'),
+      # port netstat on solaris 10 & 11
+      'netstat -an -f inet -f inet6' => cmd.call('s11-netstat-an-finet-finet6'),
     }
 
     @backend

--- a/test/integration/cookbooks/os_prepare/recipes/file.rb
+++ b/test/integration/cookbooks/os_prepare/recipes/file.rb
@@ -11,6 +11,8 @@ if node['platform_family'] != 'windows'
           'system'
         when 'freebsd'
           'wheel'
+        when 'solaris', 'solaris2'
+          'sys'
         else
           'root'
         end

--- a/test/integration/cookbooks/os_prepare/recipes/json_yaml_csv_ini.rb
+++ b/test/integration/cookbooks/os_prepare/recipes/json_yaml_csv_ini.rb
@@ -9,6 +9,8 @@ gid = case node['platform_family']
         'system'
       when 'freebsd'
         'wheel'
+      when 'solaris', 'solaris2'
+        'sys'
       else
         'root'
       end

--- a/test/integration/cookbooks/os_prepare/recipes/mount.rb
+++ b/test/integration/cookbooks/os_prepare/recipes/mount.rb
@@ -4,26 +4,30 @@
 #
 # file mount tests
 
-# copy iso file for mount tests
-# NB created using `mkdir empty; mkisofs -o empty.iso empty/`
-cookbook_file '/root/empty.iso' do
-  owner 'root'
-  group 'root'
-  mode '0755'
-  action :create
-end
+case node['platform']
+when 'ubuntu', 'rhel', 'centos', 'fedora'
 
-# create mount directory
-directory '/mnt/iso-disk' do
-  owner 'root'
-  group 'root'
-  mode '0755'
-  action :create
-end
+  # copy iso file for mount tests
+  # NB created using `mkdir empty; mkisofs -o empty.iso empty/`
+  cookbook_file '/root/empty.iso' do
+    owner 'root'
+    group 'root'
+    mode '0755'
+    action :create
+  end
 
-# mount -o loop /root/empty.iso /mnt/iso-disk
-mount '/mnt/iso-disk' do
-  device '/root/empty.iso'
-  options 'loop'
-  action [:mount, :enable]
+  # create mount directory
+  directory '/mnt/iso-disk' do
+    owner 'root'
+    group 'root'
+    mode '0755'
+    action :create
+  end
+
+  # mount -o loop /root/empty.iso /mnt/iso-disk
+  mount '/mnt/iso-disk' do
+    device '/root/empty.iso'
+    options 'loop'
+    action [:mount, :enable]
+  end
 end

--- a/test/integration/test/integration/default/_debug_spec.rb
+++ b/test/integration/test/integration/default/_debug_spec.rb
@@ -1,1 +1,1 @@
-p "You are currently running on OS family: #{os[:family] || 'unknown'}, OS release: #{os[:release] || 'unknown'}"
+p "You are currently running on OS: #{os[:name] || 'unknown'}, OS release: #{os[:release] || 'unknown'}, OS family: #{os[:family] || 'unknown'}"

--- a/test/integration/test/integration/default/compare_matcher_spec.rb
+++ b/test/integration/test/integration/default/compare_matcher_spec.rb
@@ -1,19 +1,21 @@
 # encoding: utf-8
 
-# uses the `cmp` matcher instead of the eq matcher
-describe sshd_config do
-  its('Port') { should eq '22' }
-  its('Port') { should_not eq 22 }
+if os.linux?
+  # uses the `cmp` matcher instead of the eq matcher
+  describe sshd_config do
+    its('Port') { should eq '22' }
+    its('Port') { should_not eq 22 }
 
-  its('Port') { should cmp '22' }
-  its('Port') { should cmp 22 }
-  its('Port') { should cmp 22.0 }
-  its('Port') { should_not cmp 22.1 }
+    its('Port') { should cmp '22' }
+    its('Port') { should cmp 22 }
+    its('Port') { should cmp 22.0 }
+    its('Port') { should_not cmp 22.1 }
 
-  its('LogLevel') { should eq 'INFO' }
-  its('LogLevel') { should_not eq 'info'}
+    its('LogLevel') { should eq 'INFO' }
+    its('LogLevel') { should_not eq 'info'}
 
-  its('LogLevel') { should cmp 'INFO' }
-  its('LogLevel') { should cmp 'info' }
-  its('LogLevel') { should cmp 'InfO' }
+    its('LogLevel') { should cmp 'INFO' }
+    its('LogLevel') { should cmp 'info' }
+    its('LogLevel') { should cmp 'InfO' }
+  end
 end

--- a/test/integration/test/integration/default/etc_group_spec.rb
+++ b/test/integration/test/integration/default/etc_group_spec.rb
@@ -1,13 +1,14 @@
 # encoding: utf-8
 
-root_group = case os[:family]
-             when 'aix'
-               'system'
-             when 'freebsd'
-               'wheel'
-             else
-               'root'
-             end
+root_group = 'root'
+
+if os[:family] == 'aix'
+  root_group = 'system'
+elsif os[:family] == 'freebsd'
+  root_group = 'wheel'
+elsif os.solaris?
+  root_group = 'sys'
+end
 
 if os.unix?
   describe etc_group do

--- a/test/integration/test/integration/default/file_spec.rb
+++ b/test/integration/test/integration/default/file_spec.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
-case os[:family]
-when 'freebsd'
+if os[:family] == 'freebsd'
   filedata = {
     user: 'root',
     group: 'wheel',
@@ -9,10 +8,18 @@ when 'freebsd'
     dir_md5sum: '598f4fe64aefab8f00bcbea4c9239abf',
     dir_sha256sum: '9b4fb24edd6d1d8830e272398263cdbf026b97392cc35387b991dc0248a628f9',
   }
-when 'aix'
+elsif os[:family] == 'aix'
   filedata = {
     user: 'root',
     group: 'system',
+    dir_content: nil,
+    dir_md5sum: nil,
+    dir_sha256sum: nil,
+  }
+elsif os.solaris?
+  filedata = {
+    user: 'root',
+    group: 'sys',
     dir_content: nil,
     dir_md5sum: nil,
     dir_sha256sum: nil,
@@ -116,7 +123,9 @@ if os.unix?
     its('group') { should eq filedata[:group] }
     its('type') { should eq :directory }
   end
+end
 
+if os.linux?
   # for server spec compatibility
   # Do not use `.with` or `.only_with`, this syntax is deprecated and will be removed
   # in InSpec version 1
@@ -140,8 +149,9 @@ if os.unix?
       })
     }
   end
+end
 
-elsif os.windows?
+if os.windows?
   describe file('C:\\Windows') do
     it { should exist }
     it { should be_directory }

--- a/test/integration/test/integration/default/group_spec.rb
+++ b/test/integration/test/integration/default/group_spec.rb
@@ -11,10 +11,7 @@ if os.linux?
     it { should_not exist }
     its('gid') { should eq nil }
   end
-end
-
-if os[:family] == 'freebsd'
-
+elsif os[:family] == 'freebsd'
   describe group('wheel') do
     it { should exist }
     its('gid') { should eq 0 }
@@ -29,10 +26,23 @@ if os[:family] == 'freebsd'
     it { should_not exist }
     its('gid') { should eq nil }
   end
-end
-
-if os[:family] == 'aix'
+elsif os[:family] == 'aix'
   describe group('system') do
+    it { should exist }
+    its('gid') { should eq 0 }
+  end
+
+  describe group('bin') do
+    it { should exist }
+    its('gid') { should eq 2 }
+  end
+
+  describe group('noroot') do
+    it { should_not exist }
+    its('gid') { should eq nil }
+  end
+elsif os.solaris?
+  describe group('root') do
     it { should exist }
     its('gid') { should eq 0 }
   end

--- a/test/integration/test/integration/default/mount_spec.rb
+++ b/test/integration/test/integration/default/mount_spec.rb
@@ -1,10 +1,12 @@
 # encoding: utf-8
 
-# instead of `.with` or `.only_with` we recommend to use the `mount` resource
-describe mount '/mnt/iso-disk' do
-  it { should be_mounted }
-  its('count') { should eq  1 }
-  its('device') { should eq '/root/empty.iso' }
-  its('type') { should eq  'iso9660' }
-  its('options') { should eq  ['ro'] }
+if os.linux?
+  # instead of `.with` or `.only_with` we recommend to use the `mount` resource
+  describe mount '/mnt/iso-disk' do
+    it { should be_mounted }
+    its('count') { should eq  1 }
+    its('device') { should eq '/root/empty.iso' }
+    its('type') { should eq  'iso9660' }
+    its('options') { should eq  ['ro'] }
+  end
 end

--- a/test/integration/test/integration/default/package_spec.rb
+++ b/test/integration/test/integration/default/package_spec.rb
@@ -10,6 +10,22 @@ when 'aix'
     it { should be_installed }
     its('version') { should match /^(6|7)[.|\d]+\d$/ }
   end
+when 'solaris'
+
+  if os[:release] == '11'
+    pkg = 'system/file-system/zfs'
+    ver = /^0\.5.+$/
+  else
+    pkg = 'SUNWzfsr'
+    ver = /^11\.10.+$/
+  end
+
+  describe package(pkg) do
+    it { should be_installed }
+    its('version') { should match ver }
+  end
+
+
 end
 
 describe package('nginx') do

--- a/test/integration/test/integration/default/port_spec.rb
+++ b/test/integration/test/integration/default/port_spec.rb
@@ -1,15 +1,21 @@
 # encoding: utf-8
 
+# check that ssh runs
 if os.unix?
-  # check that ssh runs
   describe port(22) do
     it { should be_listening }
     its('protocols') { should include('tcp') }
     its('protocols') { should_not include('udp') }
-    its('processes') { should include 'sshd' }
   end
 
   describe port(65432) do
     it { should_not be_listening }
+  end
+end
+
+# extra test for linux
+if os.linux?
+  describe port(22) do
+    its('processes') { should include 'sshd' }
   end
 end

--- a/test/integration/test/integration/default/service_spec.rb
+++ b/test/integration/test/integration/default/service_spec.rb
@@ -13,13 +13,16 @@ elsif ['ubuntu'].include?(os[:family])
   # Ubuntu
   unavailable_service = 'sshd'
   available_service = 'ssh'
-elsif ['windows'].include?(os[:family])
+elsif os.windows?
   # Ubuntu
   unavailable_service = 'sshd'
   available_service = 'dhcp'
 elsif ['aix'].include?(os[:family])
   unavailable_service = 'clamav'
   available_service = 'xntpd'
+elsif os.solaris?
+  unavailable_service = 'clamav'
+  available_service = 'ssh'
 end
 
 describe service(unavailable_service) do

--- a/test/unit/mock/cmd/pkg-info-system-file-system-zfs
+++ b/test/unit/mock/cmd/pkg-info-system-file-system-zfs
@@ -1,0 +1,8 @@
+Name: system/file-system/zfs
+Summary: ZFS file system
+Category: System/File System
+State: Installed
+Version: 0.5.11
+Build Release: 5.11
+Branch: 0.175.3.1.0.5.0
+Packaging Date: October  6, 2015 02:23:22 PM

--- a/test/unit/mock/cmd/pkginfo-l-SUNWzfsr
+++ b/test/unit/mock/cmd/pkginfo-l-SUNWzfsr
@@ -1,0 +1,7 @@
+PKGINST:  SUNWzfsr
+   NAME:  ZFS (Root)
+CATEGORY:  system
+   ARCH:  i386
+VERSION:  11.10.0,REV=2006.05.18.01.46
+   DESC:  ZFS root components
+ STATUS:  completely installed

--- a/test/unit/mock/cmd/s11-netstat-an-finet-finet6
+++ b/test/unit/mock/cmd/s11-netstat-an-finet-finet6
@@ -1,0 +1,32 @@
+
+UDP: IPv4
+   Local Address        Remote Address      State
+-------------------- -------------------- ----------
+      *.*                                 Unbound
+10.0.2.15.68                              Idle
+192.168.59.103.68                         Idle
+
+UDP: IPv6
+   Local Address                     Remote Address                   State      If
+--------------------------------- --------------------------------- ---------- -----
+      *.*                                                           Unbound
+      *.546                                                         Idle
+
+TCP: IPv4
+   Local Address        Remote Address     Swind  Send-Q  Rwind  Recv-Q    State
+-------------------- -------------------- ------- ------ ------- ------ -----------
+127.0.0.1.5999             *.*                  0      0  128000      0 LISTEN
+      *.111                *.*                  0      0  128000      0 LISTEN
+      *.*                  *.*                  0      0  128000      0 IDLE
+      *.111                *.*                  0      0  128000      0 LISTEN
+      *.*                  *.*                  0      0  128000      0 IDLE
+192.168.59.103.22    192.168.59.3.55016    131008      0  128872      0 ESTABLISHED
+      *.22                 *.*                  0      0  128000      0 LISTEN
+      *.22                 *.*                  0      0  128000      0 LISTEN
+
+TCP: IPv6
+   Local Address                     Remote Address                  Swind  Send-Q  Rwind  Recv-Q   State      If
+--------------------------------- --------------------------------- ------- ------ ------- ------ ----------- -----
+::1.5999                                *.*                               0      0  128000      0 LISTEN
+      *.111                             *.*                               0      0  128000      0 LISTEN
+      *.*                               *.*                               0      0  128000      0 IDLE

--- a/test/unit/resources/file_test.rb
+++ b/test/unit/resources/file_test.rb
@@ -156,6 +156,7 @@ describe Inspec::Resources::File do
     describe 'when not on linux or freebsd' do
       before do
         resource.stubs(:linux?).returns(false)
+        resource.stubs(:solaris?).returns(false)
         resource.stubs(:family).returns('fakefamily')
       end
 

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -51,6 +51,24 @@ describe 'Inspec::Resources::Package' do
     _(resource.info).must_equal pkg
   end
 
+  # solaris 10
+  it 'verify windows package parsing' do
+    resource = MockLoader.new(:solaris10).load_resource('package', 'SUNWzfsr')
+    pkg = { name: 'SUNWzfsr', installed: true, version: '11.10.0-2006.05.18.01.46', type: 'pkg' }
+    _(resource.installed?).must_equal true
+    _(resource.version).must_equal '11.10.0-2006.05.18.01.46'
+    _(resource.info).must_equal pkg
+  end
+
+  # solaris 11
+  it 'verify windows package parsing' do
+    resource = MockLoader.new(:solaris11).load_resource('package', 'system/file-system/zfs')
+    pkg = { name: 'system/file-system/zfs', installed: true, version: '0.5.11-0.175.3.1.0.5.0', type: 'pkg' }
+    _(resource.installed?).must_equal true
+    _(resource.version).must_equal '0.5.11-0.175.3.1.0.5.0'
+    _(resource.info).must_equal pkg
+  end
+
   # undefined
   it 'verify package handling on unsupported os' do
     resource = MockLoader.new(:undefined).load_resource('package', 'curl')

--- a/test/unit/resources/port_test.rb
+++ b/test/unit/resources/port_test.rb
@@ -71,4 +71,14 @@ describe 'Inspec::Resources::Port' do
     resource = MockLoader.new(:ubuntu1404).load_resource('port', '127.0.0.1', 22)
     _(resource.listening?).must_equal false
   end
+
+  it 'verify port on Solaris 10' do
+    resource = MockLoader.new(:solaris10).load_resource('port', 22)
+    _(resource.listening?).must_equal true
+  end
+
+  it 'verify port on Solaris 11' do
+    resource = MockLoader.new(:solaris11).load_resource('port', 22)
+    _(resource.listening?).must_equal true
+  end
 end

--- a/test/unit/utils/passwd_parser_test.rb
+++ b/test/unit/utils/passwd_parser_test.rb
@@ -2,6 +2,8 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 
+require 'helper'
+
 describe PasswdParser do
   let (:parser) { Class.new() { include PasswdParser }.new }
 

--- a/test/unit/utils/solaris_netstat_parser.rb
+++ b/test/unit/utils/solaris_netstat_parser.rb
@@ -1,0 +1,124 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+require 'helper'
+
+describe SolarisNetstatParser do
+  let (:parser) { Class.new() { include SolarisNetstatParser }.new }
+
+  describe '#parse_solaris_netset' do
+    it 'parses nil content' do
+      parser.parse_netstat(nil).must_equal([])
+    end
+
+    it 'parses an empty line' do
+      parser.parse_netstat('').must_equal([])
+    end
+
+    it 'parses udpv4' do
+      content =
+"""
+UDP: IPv4
+   Local Address        Remote Address      State
+-------------------- -------------------- ----------
+      *.631                               Idle
+"""
+
+      info = [{
+        "protocol"=>"udp",
+        "local-address"=>"*.631",
+        "remote-address"=>"",
+        "state"=>"Idle"
+      }]
+      parser.parse_netstat(content).must_equal(info)
+    end
+
+    it 'parses udpv6' do
+      content =
+"""
+UDP: IPv6
+   Local Address                     Remote Address                   State      If
+--------------------------------- --------------------------------- ---------- -----
+      *.546                                                         Idle
+"""
+
+      info = [{
+        "protocol"=>"udp6",
+        "local-address"=>"*.546",
+        "remote-address"=>"",
+        "state"=>"Idle",
+        "if"=>"",
+      }]
+      parser.parse_netstat(content).must_equal(info)
+    end
+
+    it 'parses tcpv4' do
+      content =
+"""
+TCP: IPv4
+   Local Address        Remote Address     Swind  Send-Q  Rwind  Recv-Q    State
+-------------------- -------------------- ------- ------ ------- ------ -----------
+127.0.0.1.5999             *.*                  0      0  128000      0 LISTEN
+"""
+
+      info = [{
+        "protocol"=>"tcp",
+        "local-address"=>"127.0.0.1.5999",
+        "remote-address"=>"*.*",
+        "swind"=>"0",
+        "send-q"=>"0",
+        "rwind"=>"128000",
+        "recv-q"=>"0",
+        "state"=>"LISTEN",
+      }]
+      parser.parse_netstat(content).must_equal(info)
+    end
+
+    it 'parses tcpv6' do
+      content =
+"""
+TCP: IPv6
+   Local Address                     Remote Address                  Swind  Send-Q  Rwind  Recv-Q   State      If
+--------------------------------- --------------------------------- ------- ------ ------- ------ ----------- -----
+::1.5999                                *.*                               0      0  128000      0 LISTEN
+"""
+
+      info = [{
+        "protocol"=>"tcp6",
+        "local-address"=>"::1.5999",
+        "remote-address"=>"*.*",
+        "swind"=>"0",
+        "send-q"=>"0",
+        "rwind"=>"128000",
+        "recv-q"=>"0",
+        "state"=>"LISTEN",
+        "if"=>"",
+      }]
+      parser.parse_netstat(content).must_equal(info)
+    end
+
+    it 'parses sctp' do
+      content =
+"""
+SCTP:
+        Local Address                   Remote Address          Swind  Send-Q Rwind  Recv-Q StrsI/O  State
+------------------------------- ------------------------------- ------ ------ ------ ------ ------- -----------
+0.0.0.0                         0.0.0.0                              0      0 102400      0  32/32  CLOSED
+"""
+    info = [{
+      "protocol"=>"sctp",
+      "local-address"=>"0.0.0.0",
+      "remote-address"=>"0.0.0.0",
+      "swind"=>"0",
+      "send-q"=>"0",
+      "rwind"=>"102400",
+      "recv-q"=>"0",
+      "strsi_o"=>"32/32",
+      "state"=>"CLOSED",
+    }]
+    parser.parse_netstat(content).must_equal(info)
+    end
+
+  end
+end


### PR DESCRIPTION
- tested against Solaris 10, Solaris 11, SmartOS and OmniOS
- implements `file`, `os`, `package`, `service`, `group`, `user`, `post`, `etc_group` for Solaris

Test against Solaris 10:

```
$ KITCHEN_LOCAL_YAML=.kitchen.chef.yml b kitchen verify default-chef-solaris-1011
-----> Starting Kitchen (v1.5.0)
-----> Verifying <default-chef-solaris-1011>...
"You are currently running on OS: solaris, OS release: 10, OS family: solaris"
.............................................................................................

Finished in 2.66 seconds (files took 2.04 seconds to load)
96 examples, 0 failures

       Finished verifying <default-chef-solaris-1011> (0m4.57s).
-----> Kitchen is finished. (0m6.89s)
```

Test against Solaris 11:

```
$ inspec exec test/integration/test/integration/default  -t ssh://inspec@192.168.59.103 --password password --sudo --sudo-password=password
"You are currently running on OS: solaris, OS release: 11, OS family: solaris"
..............................................................................
...............

Finished in 2.34 seconds (files took 1.32 seconds to load)
96 examples, 0 failures

```

Test against OmniOS

```
$ inspec exec test/integration/test/integration/default -t ssh://vagrant@localhost:2201 --password vagrant --sudo-password=vagrant
"You are currently running on OS: omnios, OS release: 11, OS family: omnios"
.......................................................................................

Finished in 0.52465 seconds (files took 0.7729 seconds to load)
87 examples, 0 failures

```

Test against SmartOS

```
$ inspec exec test/integration/test/integration/default -t ssh://root@localhost:2202 --password vagrant
"You are currently running on OS: smartos, OS release: 11, OS family: smartos"
.......................................................................................

Finished in 1.64 seconds (files took 2.89 seconds to load)
87 examples, 0 failures

```
