### PR TITLE
runit_service: fix resource, improve integration tests

### DIFF
--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -351,14 +351,15 @@ class Runit < ServiceManager
     super
   end
 
+  # rubocop:disable Style/DoubleNegation
   def info(service_name)
     # get the status of runit service
     cmd = inspec.command("#{service_ctl} status #{service_name}")
     # return nil unless cmd.exit_status == 0 # NOTE(sr) why do we do this?
 
     installed = cmd.exit_status == 0
-    running = installed && (cmd.stdout =~ /^run:/)
-    enabled = installed && (running || (cmd.stdout =~ /normally up/) || (cmd.stdout =~ /want up/))
+    running = installed && !!(cmd.stdout =~ /^run:/)
+    enabled = installed && (running || !!(cmd.stdout =~ /normally up/) || !!(cmd.stdout =~ /want up/))
 
     {
       name: service_name,

--- a/test/integration/cookbooks/os_prepare/templates/default/sv-default-svlog-run.erb
+++ b/test/integration/cookbooks/os_prepare/templates/default/sv-default-svlog-run.erb
@@ -1,3 +1,2 @@
 #!/bin/sh
-exec > /dev/null
-exec yes 
+exec tail -f /dev/null


### PR DESCRIPTION
Turns out using `/usr/bin/yes` to imitate a daemon process is a TERRIBLE idea.
