### PR TITLE
fix warning in #find_files[_or_error]

### DIFF
--- a/lib/utils/find_files.rb
+++ b/lib/utils/find_files.rb
@@ -33,7 +33,7 @@ module FindFiles
     exit_status = result.exit_status
 
     unless exit_status == 0
-      warn "find_files(): exit #{exit_status} from `#{find}`"
+      warn "find_files(): exit #{exit_status} from `#{cmd}`"
       return nil
     end
 


### PR DESCRIPTION
This should shed some lights on the errors reported here: https://github.com/chef/kitchen-inspec/issues/37
