### PR TITLE
RspecRunner: re-export report hash

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -10,7 +10,6 @@ require 'inspec/backend'
 require 'inspec/profile_context'
 require 'inspec/targets'
 require 'inspec/metadata'
-require 'inspec/reporter'
 # spec requirements
 
 module Inspec

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -23,9 +23,6 @@ module Inspec
       @conf = conf.dup
       @conf[:logger] ||= Logger.new(nil)
 
-      # FIXME(sr) necessary hack until log formatting/reporting is decoupled
-      @conf['format'] = 'json' if @conf['report']
-
       @test_collector = @conf.delete(:test_collector) || begin
         require 'inspec/runner_rspec'
         RunnerRspec.new(@conf)

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -56,7 +56,7 @@ module Inspec
     end
 
     def report
-      reporter = RSpec.configuration.formatters.find {|f| f.is_a? Inspec::RSpecReporter }
+      reporter = RSpec.configuration.formatters.find { |f| f.is_a? Inspec::RSpecReporter }
       reporter.output_hash
     end
 
@@ -106,7 +106,7 @@ module Inspec
   class RSpecReporter < RSpec::Core::Formatters::JsonFormatter
     RSpec::Core::Formatters.register Inspec::RSpecReporter
 
-    def initialize(output)
+    def initialize(*)
       super(StringIO.new)
     end
   end

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -55,6 +55,12 @@ module Inspec
       with.run_specs(tests)
     end
 
+    def report
+      # FIXME(sr): formatters.first?! really?
+      # there should be only ONE, but this should still be fixed
+      RSpec.configuration.formatters.first.output_hash
+    end
+
     private
 
     # Empty the list of registered tests.


### PR DESCRIPTION
This lets the user of access the report in a halfway-convenient fashion, e.g.

``` ruby
runner = Inspec::Runner.new
runner.add_tests(['some/tests'])
exitcode = runner.run
pp runner.report
```
