### PR TITLE
Use target helpers in Inspec::Profile#from_file

### DIFF
--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -146,6 +146,8 @@ module Inspec
     end
 
     def self.from_ref(ref, contents, profile_id, logger = nil)
+      # NOTE there doesn't have to exist an actual file, it may come from an
+      # archive (i.e., contents)
       case File.basename(ref)
       when 'inspec.yml'
         from_yaml(ref, contents, profile_id, logger)

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -35,7 +35,6 @@ module Inspec
       # use the id from parameter, name or fallback to nil
       @profile_id = options[:id] || params[:name] || nil
       @params[:name] = @profile_id
-
       @params[:rules] = rules = {}
 
       @runner = Runner.new(

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -26,11 +26,12 @@ module Inspec
       @logger = options[:logger] || Logger.new(nil)
 
       @path = @options[:path]
-      fail 'Cannot read an empty path.' if @path.nil? || @path.empty?
-      fail "Cannot find directory #{@path}" unless File.directory?(@path)
+      # fail 'Cannot read an empty path.' if @path.nil? || @path.empty?
+      # fail "Cannot find directory #{@path}" unless File.directory?(@path)
 
-      @metadata = read_metadata
-      @params = @metadata.params
+      # @metadata = read_metadata
+      # @params = @metadata.params
+      @params = {}
       # use the id from parameter, name or fallback to nil
       @profile_id = options[:id] || params[:name] || nil
       @params[:name] = @profile_id
@@ -98,17 +99,17 @@ module Inspec
 
       @logger.info "Checking profile in #{@path}"
 
-      if Pathname.new(path).join('metadata.rb').exist?
-        warn.call('The use of `metadata.rb` is deprecated. Use `inspec.yml`.')
-      end
+      # if Pathname.new(path).join('metadata.rb').exist?
+      #   warn.call('The use of `metadata.rb` is deprecated. Use `inspec.yml`.')
+      # end
 
-      @logger.info 'Metadata OK.' if @metadata.valid?
+      # @logger.info 'Metadata OK.' if @metadata.valid?
 
       # check if the profile is using the old test directory instead of the
       # new controls directory
-      if Pathname.new(path).join('test').exist? && !Pathname.new(path).join('controls').exist?
-        warn.call('Profile uses deprecated `test` directory, rename it to `controls`.')
-      end
+      # if Pathname.new(path).join('test').exist? && !Pathname.new(path).join('controls').exist?
+      #   warn.call('Profile uses deprecated `test` directory, rename it to `controls`.')
+      # end
 
       count = rules_count
       if count == 0

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -37,12 +37,16 @@ module Inspec
       @params[:name] = @profile_id
 
       @params[:rules] = rules = {}
+
       @runner = Runner.new(
         id: @profile_id,
         backend: :mock,
         test_collector: @options.delete(:test_collector),
       )
-      @runner.add_tests([@path], @options)
+
+      @options[:ignore_supports] = true
+      tests, libs, metadata = @runner.add_tests([@path], @options)
+
       @runner.rules.each do |id, rule|
         file = rule.instance_variable_get(:@__file)
         rules[file] ||= {}

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -32,6 +32,7 @@ module Inspec
         test_collector: @options.delete(:test_collector),
       )
 
+      # we're checking a profile, we don't care if it runs on the host machine
       @options[:ignore_supports] = true
       tests, libs, metadata = @runner.add_tests([@path], @options)
       @content = tests + libs + metadata

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -66,6 +66,7 @@ module Inspec
 
       tests = items.find_all { |i| i[:type] == :test }
       libs = items.find_all { |i| i[:type] == :library }
+      meta = items.find_all { |i| i[:type] == :metadata }
 
       # Ensure each test directory exists on the $LOAD_PATH. This
       # will ensure traditional RSpec-isms like `require 'spec_helper'`
@@ -82,6 +83,8 @@ module Inspec
       tests.flatten.each do |test|
         add_content(test, libs)
       end
+
+      [tests, libs, meta]
     end
 
     def create_context

--- a/lib/inspec/targets/tar.rb
+++ b/lib/inspec/targets/tar.rb
@@ -39,7 +39,8 @@ module Inspec::Targets
           elsif entry.file?
             if files.include?(entry.full_name.gsub(rootdir, ''))
               h = {
-                content: entry.read,
+                # NB if some file is empty, return empty-string, not nil
+                content: entry.read || '',
                 type: opts[:as] || :test,
                 ref: entry.full_name,
               }

--- a/lib/inspec/targets/tar.rb
+++ b/lib/inspec/targets/tar.rb
@@ -41,7 +41,7 @@ module Inspec::Targets
               h = {
                 content: entry.read,
                 type: opts[:as] || :test,
-                # ref: File.join(input, entry.name),
+                ref: entry.full_name,
               }
               content.push(h)
             end

--- a/lib/inspec/targets/zip.rb
+++ b/lib/inspec/targets/zip.rb
@@ -18,9 +18,10 @@ module Inspec::Targets
         while (entry = io.get_next_entry)
           next if !files.include?(entry.name.gsub(rootdir, ''))
           h = {
-            content: io.read,
+            # NB if some file is empty, return empty-string, not nil
+            content: io.read || '',
             type: opts[:as] || :test,
-            # ref: File.join(input, entry.name),
+            ref: entry.name,
           }
           content.push(h)
         end

--- a/test/unit/profile_test.rb
+++ b/test/unit/profile_test.rb
@@ -171,7 +171,7 @@ describe Inspec::Profile do
         logger.expect :debug, nil, ["Verify all rules in  #{home}/mock/profiles/#{profile_id}/controls/filesystem_spec.rb"]
         logger.expect :info, nil, ['Rule definitions OK.']
 
-        load_profile(profile_id, {logger: logger, ignore_supports: true}).check
+        load_profile(profile_id, {logger: logger}).check
         logger.verify
       end
     end
@@ -187,7 +187,7 @@ describe Inspec::Profile do
         logger.expect :debug, nil, ["Verify all rules in  #{home}/mock/profiles/#{profile_id}/controls/filesystem_spec.rb"]
         logger.expect :info, nil, ['Rule definitions OK.']
 
-        load_profile(profile_id, {logger: logger, ignore_supports: true}).check
+        load_profile(profile_id, {logger: logger}).check
         logger.verify
       end
     end
@@ -203,7 +203,7 @@ describe Inspec::Profile do
         logger.expect :debug, nil, ["Verify all rules in  #{home}/mock/profiles/#{profile_id}/controls/filesystem_spec.rb"]
         logger.expect :info, nil, ['Rule definitions OK.']
 
-        load_profile(profile_id, {logger: logger, ignore_supports: true}).check
+        load_profile(profile_id, {logger: logger}).check
         logger.verify
       end
     end

--- a/test/unit/profile_test.rb
+++ b/test/unit/profile_test.rb
@@ -6,6 +6,7 @@ require 'helper'
 require 'inspec/profile_context'
 require 'inspec/runner'
 require 'inspec/runner_mock'
+require 'fileutils'
 
 describe Inspec::Profile do
   let(:logger) { Minitest::Mock.new }
@@ -14,6 +15,20 @@ describe Inspec::Profile do
   def load_profile(name, opts = {})
     opts[:test_collector] = Inspec::RunnerMock.new
     Inspec::Profile.from_path("#{home}/mock/profiles/#{name}", opts)
+  end
+
+  def load_profile_tgz(name, opts = {})
+    path = "#{home}/mock/profiles/#{name}"
+    `tar zcvf #{path}.tgz #{path}`
+    load_profile("#{name}.tgz", opts)
+    FileUtils.rm("#{path}.tgz")
+  end
+
+  def load_profile_zip(name, opts = {})
+    path = "#{home}/mock/profiles/#{name}"
+    `zip #{path}.zip #{path}`
+    load_profile("#{name}.zip", opts)
+    FileUtils.rm("#{path}.zip")
   end
 
   describe 'with an empty profile' do
@@ -76,13 +91,14 @@ describe Inspec::Profile do
       let(:profile_id) { 'empty-metadata' }
 
       it 'prints loads of warnings' do
+        inspec_yml = "#{home}/mock/profiles/#{profile_id}/inspec.yml"
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]
-        logger.expect :error, nil, ['Missing profile name in inspec.yml']
-        logger.expect :error, nil, ['Missing profile version in inspec.yml']
-        logger.expect :warn, nil, ['Missing profile title in inspec.yml']
-        logger.expect :warn, nil, ['Missing profile summary in inspec.yml']
-        logger.expect :warn, nil, ['Missing profile maintainer in inspec.yml']
-        logger.expect :warn, nil, ['Missing profile copyright in inspec.yml']
+        logger.expect :error, nil, ["Missing profile name in #{inspec_yml}"]
+        logger.expect :error, nil, ["Missing profile version in #{inspec_yml}"]
+        logger.expect :warn, nil, ["Missing profile title in #{inspec_yml}"]
+        logger.expect :warn, nil, ["Missing profile summary in #{inspec_yml}"]
+        logger.expect :warn, nil, ["Missing profile maintainer in #{inspec_yml}"]
+        logger.expect :warn, nil, ["Missing profile copyright in #{inspec_yml}"]
         logger.expect :warn, nil, ['No controls or tests were defined.']
 
         load_profile(profile_id, {logger: logger}).check
@@ -94,14 +110,15 @@ describe Inspec::Profile do
       let(:profile_id) { 'legacy-empty-metadata' }
 
       it 'prints loads of warnings' do
+        metadata_rb = "#{home}/mock/profiles/#{profile_id}/metadata.rb"
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]
         logger.expect :warn, nil, ['The use of `metadata.rb` is deprecated. Use `inspec.yml`.']
-        logger.expect :error, nil, ['Missing profile name in metadata.rb']
-        logger.expect :error, nil, ['Missing profile version in metadata.rb']
-        logger.expect :warn, nil, ['Missing profile title in metadata.rb']
-        logger.expect :warn, nil, ['Missing profile summary in metadata.rb']
-        logger.expect :warn, nil, ['Missing profile maintainer in metadata.rb']
-        logger.expect :warn, nil, ['Missing profile copyright in metadata.rb']
+        logger.expect :error, nil, ["Missing profile name in #{metadata_rb}"]
+        logger.expect :error, nil, ["Missing profile version in #{metadata_rb}"]
+        logger.expect :warn, nil, ["Missing profile title in #{metadata_rb}"]
+        logger.expect :warn, nil, ["Missing profile summary in #{metadata_rb}"]
+        logger.expect :warn, nil, ["Missing profile maintainer in #{metadata_rb}"]
+        logger.expect :warn, nil, ["Missing profile copyright in #{metadata_rb}"]
         logger.expect :warn, nil, ['No controls or tests were defined.']
 
         load_profile(profile_id, {logger: logger}).check
@@ -131,7 +148,8 @@ describe Inspec::Profile do
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]
         logger.expect :warn, nil, ['The use of `metadata.rb` is deprecated. Use `inspec.yml`.']
         logger.expect :info, nil, ['Metadata OK.']
-        logger.expect :warn, nil, ["Profile uses deprecated `test` directory, rename it to `controls`."]
+        # NB we only look at content that is loaded, i.e., there're no empty directories anymore
+        # logger.expect :warn, nil, ["Profile uses deprecated `test` directory, rename it to `controls`."]
         logger.expect :warn, nil, ['No controls or tests were defined.']
 
         profile.check
@@ -145,6 +163,38 @@ describe Inspec::Profile do
 
     describe 'a complete metadata profile with controls' do
       let(:profile_id) { 'complete-profile' }
+
+      it 'prints ok messages and counts the rules' do
+        logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]
+        logger.expect :info, nil, ['Metadata OK.']
+        logger.expect :info, nil, ['Found 1 rules.']
+        logger.expect :debug, nil, ["Verify all rules in  #{home}/mock/profiles/#{profile_id}/controls/filesystem_spec.rb"]
+        logger.expect :info, nil, ['Rule definitions OK.']
+
+        load_profile(profile_id, {logger: logger, ignore_supports: true}).check
+        logger.verify
+      end
+    end
+
+    describe 'a complete metadata profile with controls in a tarball' do
+      let(:profile_id) { 'complete-profile' }
+      let(:profile) { load_profile_tgz(profile_id, {logger: logger}) }
+
+      it 'prints ok messages and counts the rules' do
+        logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]
+        logger.expect :info, nil, ['Metadata OK.']
+        logger.expect :info, nil, ['Found 1 rules.']
+        logger.expect :debug, nil, ["Verify all rules in  #{home}/mock/profiles/#{profile_id}/controls/filesystem_spec.rb"]
+        logger.expect :info, nil, ['Rule definitions OK.']
+
+        load_profile(profile_id, {logger: logger, ignore_supports: true}).check
+        logger.verify
+      end
+    end
+
+    describe 'a complete metadata profile with controls in zipfile' do
+      let(:profile_id) { 'complete-profile' }
+      let(:profile) { load_profile_zip(profile_id, {logger: logger}) }
 
       it 'prints ok messages and counts the rules' do
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]

--- a/test/unit/profile_test.rb
+++ b/test/unit/profile_test.rb
@@ -112,13 +112,13 @@ describe Inspec::Profile do
       it 'prints loads of warnings' do
         metadata_rb = "#{home}/mock/profiles/#{profile_id}/metadata.rb"
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]
-        logger.expect :warn, nil, ['The use of `metadata.rb` is deprecated. Use `inspec.yml`.']
         logger.expect :error, nil, ["Missing profile name in #{metadata_rb}"]
         logger.expect :error, nil, ["Missing profile version in #{metadata_rb}"]
         logger.expect :warn, nil, ["Missing profile title in #{metadata_rb}"]
         logger.expect :warn, nil, ["Missing profile summary in #{metadata_rb}"]
         logger.expect :warn, nil, ["Missing profile maintainer in #{metadata_rb}"]
         logger.expect :warn, nil, ["Missing profile copyright in #{metadata_rb}"]
+        logger.expect :warn, nil, ['The use of `metadata.rb` is deprecated. Use `inspec.yml`.']
         logger.expect :warn, nil, ['No controls or tests were defined.']
 
         load_profile(profile_id, {logger: logger}).check


### PR DESCRIPTION
Before: Inspec::Profile was expecting a profile in a filesystem.
After: Inspec::Profile operates on the contents as returned from the target helper 

Fixes #408.
