### PR TITLE
upstart_service: fallback to config files if `show-config` is not available

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -151,6 +151,8 @@ class MockLoader
       'initctl status ssh' => cmd.call('initctl-status-ssh'),
       # service config for upstart on ubuntu
       'initctl show-config ssh' => cmd.call('initctl-show-config-ssh'),
+      # upstart version on ubuntu
+      'initctl --version' => cmd.call('initctl--version'),
       # show ssh service Centos 7
       'systemctl show --all sshd' => cmd.call('systemctl-show-all-sshd'),
       '/path/to/systemctl show --all sshd' => cmd.call('systemctl-show-all-sshd'),

--- a/test/integration/cookbooks/os_prepare/recipes/_upstart_service_centos.rb
+++ b/test/integration/cookbooks/os_prepare/recipes/_upstart_service_centos.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+# author: Stephan Renatus
+
+file "/etc/init/upstart-running.conf" do
+  content "exec tail -f /dev/null"
+end
+
+file "/etc/init/upstart-enabled-not-running.conf" do
+  content "exec tail -f /dev/null\nstart on networking"
+end
+
+file "/etc/init/upstart-enabled-and-running.conf" do
+  content "exec tail -f /dev/null\nstart on networking"
+end
+
+%w{ enabled-and-running running }.each do |srv|
+  service "upstart-#{srv}" do
+    provider Chef::Provider::Service::Upstart
+    action :start
+  end
+end

--- a/test/integration/cookbooks/os_prepare/recipes/service.rb
+++ b/test/integration/cookbooks/os_prepare/recipes/service.rb
@@ -13,4 +13,5 @@ when 'ubuntu'
 when 'centos'
   # install runit for alternative service mgmt
   include_recipe 'os_prepare::_runit_service_centos'
+  include_recipe 'os_prepare::_upstart_service_centos'
 end

--- a/test/integration/test/integration/default/service_spec.rb
+++ b/test/integration/test/integration/default/service_spec.rb
@@ -78,4 +78,28 @@ if os[:family] == 'centos'
     it { should_not be_installed }
     it { should_not be_running }
   end
+
+  describe upstart_service('upstart-running') do
+    it { should_not be_enabled }
+    it { should be_installed }
+    it { should be_running }
+  end
+
+  describe upstart_service('upstart-enabled-and-running') do
+    it { should be_enabled }
+    it { should be_installed }
+    it { should be_running }
+  end
+
+  describe upstart_service('upstart-enabled-not-running') do
+    it { should be_enabled }
+    it { should be_installed }
+    it { should_not be_running }
+  end
+
+  describe upstart_service('unknown') do
+    it { should_not be_enabled }
+    it { should_not be_installed }
+    it { should_not be_running }
+  end
 end

--- a/test/unit/mock/cmd/initctl--version
+++ b/test/unit/mock/cmd/initctl--version
@@ -1,0 +1,5 @@
+initctl (upstart 1.12.1)
+Copyright (C) 2006-2014 Canonical Ltd., 2011 Scott James Remnant
+
+This is free software; see the source for copying conditions.  There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR
+A PARTICULAR PURPOSE.


### PR DESCRIPTION
Fixes #417.
