### PR TITLE
simplify profile ID handling [stale branch: kept for discussion, don't merge]

### DIFF
--- a/bin/inspec
+++ b/bin/inspec
@@ -16,8 +16,6 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
     desc: 'Show diagnostics (versions, configurations)'
 
   desc 'json PATH', 'read all tests in PATH and generate a JSON summary'
-  option :id, type: :string,
-    desc: 'Attach a profile ID to all test results'
   option :output, aliases: :o, type: :string,
     desc: 'Save the created profile to a path'
   def json(path)

--- a/bin/inspec
+++ b/bin/inspec
@@ -99,8 +99,6 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   end
 
   desc 'exec PATHS', 'run all test files at the specified PATH.'
-  option :id, type: :string,
-    desc: 'Prefix all example IDs with profile ID'
   target_options
   option :format, type: :string
   def exec(*tests)

--- a/bin/inspec
+++ b/bin/inspec
@@ -15,7 +15,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   class_option :diagnose, type: :boolean,
     desc: 'Show diagnostics (versions, configurations)'
 
-  desc 'json PATH', 'read all tests in PATH and generate a JSON summary'
+  desc 'json PATH', 'read profile in PATH and generate a JSON summary'
   option :output, aliases: :o, type: :string,
     desc: 'Save the created profile to a path'
   def json(path)
@@ -100,7 +100,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
 
   desc 'exec PATHS', 'run all test files at the specified PATH.'
   option :id, type: :string,
-    desc: 'Attach a profile ID to all test results'
+    desc: 'Prefix all example IDs with profile ID'
   target_options
   option :format, type: :string
   def exec(*tests)

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -32,9 +32,9 @@ module Inspec::DSL
   # Register a given rule with RSpec and
   # let it run. This happens after everything
   # else is merged in.
-  def self.execute_rule(r, profile_id)
+  def self.execute_rule(r)
     checks = r.instance_variable_get(:@checks)
-    fid = InspecBaseRule.full_id(r, profile_id)
+    fid = InspecBaseRule.full_id(r)
     checks.each do |m, a, b|
       # check if the resource is skippable and skipped
       cres = rule_from_check(m, a, b)

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -139,32 +139,31 @@ module Inspec
       }
     end
 
-    def self.finalize(metadata, profile_id)
-      metadata.params['name'] = profile_id.to_s unless profile_id.to_s.empty?
+    def self.finalize(metadata)
       metadata.params = symbolize_keys(metadata.params || {})
       metadata
     end
 
-    def self.from_yaml(ref, contents, profile_id, logger = nil)
+    def self.from_yaml(ref, contents, logger = nil)
       res = Metadata.new(ref, logger)
       res.params = YAML.load(contents)
-      finalize(res, profile_id)
+      finalize(res)
     end
 
-    def self.from_ruby(ref, contents, profile_id, logger = nil)
+    def self.from_ruby(ref, contents, logger = nil)
       res = Metadata.new(ref, logger)
       res.instance_eval(contents, ref, 1)
-      finalize(res, profile_id)
+      finalize(res)
     end
 
-    def self.from_ref(ref, contents, profile_id, logger = nil)
+    def self.from_ref(ref, contents, logger = nil)
       # NOTE there doesn't have to exist an actual file, it may come from an
       # archive (i.e., contents)
       case File.basename(ref)
       when 'inspec.yml'
-        from_yaml(ref, contents, profile_id, logger)
+        from_yaml(ref, contents, logger)
       when 'metadata.rb'
-        from_ruby(ref, contents, profile_id, logger)
+        from_ruby(ref, contents, logger)
       else
         logger ||= Logger.new(nil)
         logger.error "Don't know how to handle metadata in #{ref}"
@@ -174,17 +173,17 @@ module Inspec
 
     def self.from_contents(contents, logger = nil)
       m = contents.find { |a| a[:type] == :metadata }
-      from_ref(m[:ref], m[:content], nil, logger)
+      from_ref(m[:ref], m[:content], logger)
     end
 
-    def self.from_file(path, profile_id, logger = nil)
+    def self.from_file(path, logger = nil)
       unless File.file?(path)
         logger ||= Logger.new(nil)
         logger.error "Can't find metadata file #{path}"
         return nil
       end
 
-      from_ref(File.basename(path), File.read(path), profile_id, logger)
+      from_ref(File.basename(path), File.read(path), logger)
     end
   end
 end

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -172,6 +172,11 @@ module Inspec
       end
     end
 
+    def self.from_contents(contents, logger = nil)
+      m = contents.find { |a| a[:type] == :metadata }
+      from_ref(m[:ref], m[:content], nil, logger)
+    end
+
     def self.from_file(path, profile_id, logger = nil)
       unless File.file?(path)
         logger ||= Logger.new(nil)

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -173,6 +173,7 @@ module Inspec
 
     def self.from_contents(contents, logger = nil)
       m = contents.find { |a| a[:type] == :metadata }
+      return nil unless m
       from_ref(m[:ref], m[:content], logger)
     end
 

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -5,9 +5,12 @@
 
 require 'inspec/metadata'
 require 'pathname'
+require 'forwardable'
 
 module Inspec
   class Profile # rubocop:disable Metrics/ClassLength
+    extend Forwardable
+
     def self.from_path(path, options = nil)
       opt = {}
       options.each { |k, v| opt[k.to_sym] = v } unless options.nil?
@@ -15,10 +18,12 @@ module Inspec
       Profile.new(opt)
     end
 
-    attr_reader :params
     attr_reader :path
     attr_reader :metadata
     attr_reader :content
+    attr_reader :name
+
+    def_delegator :@metadata, :params
 
     # rubocop:disable Metrics/AbcSize
     def initialize(options = nil)
@@ -34,20 +39,16 @@ module Inspec
       @metadata_source = content.find { |a| a[:type] == :metadata }
 
       # read profile_id from metadata as the sole source of this information
-      @metadata = Metadata.from_ref(@metadata_source[:ref], @metadata_source[:content], nil, @logger)
-      profile_id = metadata.params[:name]
+      @metadata = Metadata.from_ref(@metadata_source[:ref], @metadata_source[:content], @logger)
+      @name = params[:name]
 
-      # add tests, using the profile_id as prefix for example IDs
       @runner = Runner.new(
-        id: profile_id,
         backend: :mock,
         test_collector: @options.delete(:test_collector),
       )
-      @runner.add_test_contents(content, profile_id, @options)
+      @runner.add_test_contents(content)
 
-      @params = metadata.params
-      @params[:rules] = rules = {}
-
+      params[:rules] = rules = {}
       @runner.rules.each do |id, rule|
         file = rule.instance_variable_get(:@__file)
         rules[file] ||= {}
@@ -64,7 +65,7 @@ module Inspec
     end
 
     def info
-      res = @params.dup
+      res = params.dup
       rules = {}
       res[:rules].each do |gid, group|
         next if gid.to_s.empty?
@@ -140,7 +141,7 @@ module Inspec
       @logger.info 'Metadata OK.' if m_errors.empty? && m_unsupported.empty?
 
       # extract profile name
-      result[:summary][:profile] = @metadata.params[:name]
+      result[:summary][:profile] = params[:name]
 
       # check if the profile is using the old test directory instead of the
       # new controls directory
@@ -157,7 +158,7 @@ module Inspec
       end
 
       # iterate over hash of groups
-      @params[:rules].each { |group, controls|
+      params[:rules].each { |group, controls|
         @logger.info "Verify all controls in #{group}"
         controls.each { |id, control|
           sfile, sline = control[:source_location]
@@ -179,13 +180,13 @@ module Inspec
     end
 
     def rules_count
-      @params[:rules].values.map { |hm| hm.values.length }.inject(:+) || 0
+      params[:rules].values.map { |hm| hm.values.length }.inject(:+) || 0
     end
 
     # generates a archive of a folder profile
     # assumes that the profile was checked before
     def archive(opts) # rubocop:disable Metrics/AbcSize
-      profile_name = @params[:name]
+      profile_name = params[:name]
 
       ext = opts[:zip] ? 'zip' : 'tar.gz'
 

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -9,13 +9,12 @@ require 'securerandom'
 module Inspec
   class ProfileContext
     attr_reader :rules, :only_ifs
-    def initialize(profile_id, backend, profile_registry = {}, only_ifs = [])
+    def initialize(backend, profile_registry = {}, only_ifs = [])
       if backend.nil?
         fail 'ProfileContext is initiated with a backend == nil. ' \
              'This is a backend error which must be fixed upstream.'
       end
 
-      @profile_id = profile_id
       @rules = profile_registry
       @only_ifs = only_ifs
       @backend = backend
@@ -35,7 +34,7 @@ module Inspec
     end
 
     def unregister_rule(id)
-      full_id = Inspec::Rule.full_id(@profile_id, id)
+      full_id = Inspec::Rule.full_id(id)
       @rules[full_id] = nil
     end
 
@@ -43,7 +42,7 @@ module Inspec
       # get the full ID
       r.instance_variable_set(:@__file, @current_load[:file])
       r.instance_variable_set(:@__group_title, @current_load[:title])
-      full_id = Inspec::Rule.full_id(@profile_id, r)
+      full_id = Inspec::Rule.full_id(r)
       if full_id.nil?
         # TODO: error
         return

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -121,7 +121,7 @@ module Inspec
     # for the rule. If the rule's profile id is empty,
     # the given profile_id will be used instead and also
     # set for the rule.
-    def self.full_id(profile_id, rule)
+    def self.full_id(rule)
       if rule.is_a?(String) or rule.nil?
         rid = rule
       else
@@ -134,16 +134,8 @@ module Inspec
           return nil
         end
       end
-      pid = rule.instance_variable_get(:@profile_id)
-      if pid.nil?
-        rule.instance_variable_set(:@profile_id, profile_id)
-        pid = profile_id
-      end
 
-      # if we don't have a profile id, just return the rule's ID
-      return rid if pid.nil? or pid.empty?
-      # otherwise combine them
-      "#{pid}/#{rid}"
+      rid
     end
 
     private

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -64,7 +64,10 @@ module Inspec
         add_test_profile(test, options[:ignore_supports])
       end.flatten
 
-      add_test_contents(items, options[:id], options)
+      metadata = Metadata.from_contents(items, @conf[:logger])
+
+      # profile name IS the ID
+      add_test_contents(items, metadata.params[:name], options)
     end
 
     def add_test_contents(items, id, options = {})

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -64,7 +64,7 @@ module Inspec
       end.flatten
 
       meta = Metadata.from_contents(items, @conf[:logger])
-      @conf[:logger].warn 'invalid metadata' unless meta.valid?
+      @conf[:logger].warn 'invalid metadata' unless meta && meta.valid?
 
       add_test_contents(items)
     end

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -64,10 +64,17 @@ module Inspec
         add_test_profile(test, options[:ignore_supports])
       end.flatten
 
-      metadata = Metadata.from_contents(items, @conf[:logger])
+      # if we're given a proper profile, its name is our profile id
+      # if we're just given naked test code, a profile id may be provided
+      # using CLI options
+      meta = items.find { |a| a[:type] == :metadata }
+      profile_id = if meta
+                     Metadata.from_ref(meta[:ref], meta[:content], nil, @conf[:logger])
+                   else
+                     options[:id]
+                   end
 
-      # profile name IS the ID
-      add_test_contents(items, metadata.params[:name], options)
+      add_test_contents(items, profile_id, options)
     end
 
     def add_test_contents(items, id, options = {})

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -18,7 +18,6 @@ module Inspec
     attr_reader :backend, :rules
     def initialize(conf = {})
       @rules = {}
-      @profile_id = conf[:id]
       @conf = conf.dup
       @conf[:logger] ||= Logger.new(nil)
 
@@ -50,7 +49,7 @@ module Inspec
       assets = Inspec::Targets.resolve(test, @conf)
       meta_assets = assets.find_all { |a| a[:type] == :metadata }
       metas = meta_assets.map do |x|
-        Inspec::Metadata.from_ref(x[:ref], x[:content], @profile_id, @conf[:logger])
+        Inspec::Metadata.from_ref(x[:ref], x[:content], nil, @conf[:logger])
       end
       metas.each do |meta|
         return [] unless ignore_supports || meta.supports_transport?(@backend)
@@ -64,25 +63,15 @@ module Inspec
         add_test_profile(test, options[:ignore_supports])
       end.flatten
 
-      # if we're given a proper profile, its name is our profile id
-      # if we're just given naked test code, a profile id may be provided
-      # using CLI options
-      meta = items.find { |a| a[:type] == :metadata }
-      profile_id = if meta
-                     Metadata.from_ref(meta[:ref], meta[:content], nil, @conf[:logger])
-                   else
-                     options[:id]
-                   end
+      meta = Metadata.from_contents(items, @conf[:logger])
+      @conf[:logger].warn 'invalid metadata' unless meta.valid?
 
-      add_test_contents(items, profile_id, options)
+      add_test_contents(items)
     end
 
-    def add_test_contents(items, id, options = {})
-      @profile_id ||= id
-
+    def add_test_contents(items)
       tests = items.find_all { |i| i[:type] == :test }
       libs = items.find_all { |i| i[:type] == :library }
-      meta = items.find_all { |i| i[:type] == :metadata }
 
       # Ensure each test directory exists on the $LOAD_PATH. This
       # will ensure traditional RSpec-isms like `require 'spec_helper'`
@@ -102,7 +91,7 @@ module Inspec
     end
 
     def create_context
-      Inspec::ProfileContext.new(@profile_id, @backend)
+      Inspec::ProfileContext.new(@backend)
     end
 
     def add_content(test, libs)

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -64,6 +64,12 @@ module Inspec
         add_test_profile(test, options[:ignore_supports])
       end.flatten
 
+      add_test_contents(items, options[:id], options)
+    end
+
+    def add_test_contents(items, id, options = {})
+      @profile_id ||= id
+
       tests = items.find_all { |i| i[:type] == :test }
       libs = items.find_all { |i| i[:type] == :library }
       meta = items.find_all { |i| i[:type] == :metadata }
@@ -83,8 +89,6 @@ module Inspec
       tests.flatten.each do |test|
         add_content(test, libs)
       end
-
-      [tests, libs, meta]
     end
 
     def create_context

--- a/test/unit/metadata_test.rb
+++ b/test/unit/metadata_test.rb
@@ -11,27 +11,15 @@ describe 'metadata with supported operating systems' do
   describe 'running on ubuntu 14.04' do
     let (:backend) { MockLoader.new(:ubuntu1404).backend }
 
-    it 'finalizes a loaded metadata via Profile ID' do
-      res = Inspec::Metadata.from_yaml('mock', '---', nil)
-      Inspec::Metadata.finalize(res, 'mock')
-      res.params[:name].must_equal('mock')
-    end
-
-    it 'finalizes a loaded metadata via Profile ID and overwrites the ID' do
-      res = Inspec::Metadata.from_yaml('mock', "---\nname: hello", nil)
-      Inspec::Metadata.finalize(res, 'mock')
-      res.params[:name].must_equal('mock')
-    end
-
     it 'finalizes a loaded metadata by turning strings into symbols' do
-      res = Inspec::Metadata.from_yaml('mock', "---\nauthor: world", nil)
-      Inspec::Metadata.finalize(res, 'mock')
+      res = Inspec::Metadata.from_yaml('mock', "---\nauthor: world")
+      Inspec::Metadata.finalize(res)
       res.params[:author].must_equal('world')
     end
 
     it 'loads the support field from metadata' do
       res = Inspec::Metadata.from_yaml('mock',
-        "---\nsupports:\n  - os: ubuntu", nil)
+        "---\nsupports:\n  - os: ubuntu")
       res.params[:supports].must_equal([{ 'os' => 'ubuntu' }])
     end
 
@@ -40,10 +28,10 @@ describe 'metadata with supported operating systems' do
     # @param [Type] params describe params
     # @return [Type] description of returned object
     def create_meta(params)
-      res = Inspec::Metadata.from_yaml('mock', "---", nil, logger)
+      res = Inspec::Metadata.from_yaml('mock', "---", logger)
       # manually inject supported parameters
       res.params[:supports] = params
-      Inspec::Metadata.finalize(res, 'mock')
+      Inspec::Metadata.finalize(res)
       res
     end
 

--- a/test/unit/profile_context_test.rb
+++ b/test/unit/profile_context_test.rb
@@ -7,7 +7,7 @@ require 'inspec/profile_context'
 
 describe Inspec::ProfileContext do
   let(:backend) { MockLoader.new.backend }
-  let(:profile) { Inspec::ProfileContext.new(nil, backend) }
+  let(:profile) { Inspec::ProfileContext.new(backend) }
 
   it 'must be able to load empty content' do
     profile.load('', 'dummy', 1).must_be_nil

--- a/test/unit/profile_test.rb
+++ b/test/unit/profile_test.rb
@@ -66,12 +66,6 @@ describe Inspec::Profile do
     it 'has no rules' do
       profile.params[:rules].must_equal({})
     end
-
-    it 'can overwrite the profile ID' do
-      testID = rand.to_s
-      res = load_profile(profile_id, id: testID)
-      res.params[:name].must_equal testID
-    end
   end
 
   describe 'with simple metadata in profile (legacy mode)' do


### PR DESCRIPTION
This suggests using the profile's metadata as the _single source of truth_ when it is present:
1. `inspec json PROFILE` will use the profile's name as profile ID: `linux`
2. `inspec exec` will use the profile's name if it is given a profile, if not, it depends on the `--id` CLI param.

Opinions? :smile: 
