### PR TITLE
fix loading order of plugins

### DIFF
--- a/lib/inspec.rb
+++ b/lib/inspec.rb
@@ -25,3 +25,7 @@ require 'utils/base_cli'
 # targets
 require 'inspec/resource'
 require 'inspec/plugins'
+
+# Load all plugins on startup
+ctl = Inspec::PluginCtl.new
+ctl.list.each { |x| ctl.load(x) }

--- a/lib/inspec/plugins.rb
+++ b/lib/inspec/plugins.rb
@@ -44,7 +44,3 @@ module Inspec
     end
   end
 end
-
-# Load all plugins on startup
-ctl = Inspec::PluginCtl.new
-ctl.list.each { |x| ctl.load(x) }


### PR DESCRIPTION
Current issue: Any plugin that is targeting the resource structure cannot be created, as plugins are loaded before resources come into existance.

Make sure that `require 'plugins'` doesn't auto-load all plugins. Instead load InSpec to completion first.
