### PR TITLE
Implement Supermarket Extension

### DIFF
--- a/lib/bundles/inspec-supermarket/README.md
+++ b/lib/bundles/inspec-supermarket/README.md
@@ -1,0 +1,12 @@
+# InSpec Extension for Chef Supermarket
+
+To use the CLI, this InSpec add-on adds the following commands:
+
+ * `$ inspec supermarket configure` - configures the supermarket server
+ * `$ inspec supermarket search` - searches for a compliance profile on supermarket
+ * `$ inspec supermarket exec nathenharvey/tmp-compliance-profile` - extends execute to load the profile
+
+ Compliance profiles from Supermarket can be executed in two mays:
+
+ - via supermarket exec: `inspec supermarket exec nathenharvey/tmp-compliance-profile`
+ - via supermarket scheme: `inspec exec supermarket://nathenharvey/tmp-compliance-profile`

--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -1,0 +1,82 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+module Supermarket
+  class API
+    SUPERMARKET_URL = 'https://supermarket.chef.io'.freeze
+
+    def self.supermarket_url
+      SUPERMARKET_URL
+    end
+
+    # displays a list of profiles
+    def self.profiles
+      url = "#{SUPERMARKET_URL}/api/v1/tools-search"
+      _success, data = get(url, { q: 'compliance_profile' })
+      if !data.nil?
+        profiles = JSON.parse(data)
+        profiles['items']
+      else
+        []
+      end
+    end
+
+    def self.profile_name(profile)
+      uri = URI(profile)
+      [uri.host, uri.path[1..-1]]
+    rescue URI::Error => _e
+      nil
+    end
+
+    # displays profile infos
+    def self.info(profile)
+      _tool_owner, tool_name = profile_name("supermarket://#{profile}")
+      url = "#{SUPERMARKET_URL}/api/v1/tools/#{tool_name}"
+      _success, data = get(url, {})
+      if !data.nil?
+        JSON.parse(data)
+      else
+        {}
+      end
+    rescue JSON::ParserError
+      {}
+    end
+
+    # compares a profile with the supermarket tool info
+    def self.same?(profile, supermarket_tool)
+      tool_owner, tool_name = profile_name(profile)
+      tool = "#{SUPERMARKET_URL}/api/v1/tools/#{tool_name}"
+      supermarket_tool['tool_owner'] == tool_owner && supermarket_tool['tool'] == tool
+    end
+
+    def self.find(profile)
+      profiles = Supermarket::API.profiles
+      if !profiles.empty?
+        index = profiles.index { |t| same?(profile, t) }
+        # return profile or nil
+        profiles[index] if !index.nil? && index >= 0
+      end
+    end
+
+    # verifies that a profile exists
+    def self.exist?(profile)
+      !find(profile).nil?
+    end
+
+    def self.get(url, params)
+      uri = URI.parse(url)
+      uri.query = URI.encode_www_form(params)
+      req = Net::HTTP::Get.new(uri)
+      send_request(uri, req)
+    end
+
+    def self.send_request(uri, req)
+      # send request
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') {|http|
+        http.request(req)
+      }
+      [res.is_a?(Net::HTTPSuccess), res.body]
+    end
+  end
+end

--- a/lib/bundles/inspec-supermarket/cli.rb
+++ b/lib/bundles/inspec-supermarket/cli.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+module Supermarket
+  class SupermarketCLI < Inspec::BaseCLI
+    namespace 'supermarket'
+
+    desc 'profiles', 'list all available profiles in Chef Supermarket'
+    def profiles
+      # display profiles in format user/profile
+      supermarket_profiles = Supermarket::API.profiles
+
+      headline('Available profiles:')
+      supermarket_profiles.each { |p|
+        m = %r{^#{Supermarket::API.supermarket_url}/api/v1/tools/(?<slug>[\w-]+)(/)?$}.match(p['tool'])
+        li("#{p['tool_owner']}/#{m[:slug]}")
+      }
+    end
+
+    desc 'exec PROFILE', 'executes a Supermarket profile'
+    option :id, type: :string,
+      desc: 'Attach a profile ID to all test results'
+    target_options
+    option :format, type: :string
+    def exec(*tests)
+      # iterate over tests and add compliance scheme
+      tests = tests.map { |t| 'supermarket://' + t }
+
+      # execute profile from inspec exec implementation
+      diagnose
+      run_tests(opts, tests)
+    end
+
+    desc 'info profile', 'display profile details'
+    def info(profile)
+      info = Supermarket::API.info(profile)
+
+      puts "#{mark_text('name: ')}  #{info['slug']}"
+      puts "#{mark_text('owner:')}  #{info['owner']}"
+      puts "#{mark_text('url:  ')}  #{info['source_url']}"
+      puts
+      puts "#{mark_text('description:  ')} #{info['description']}"
+    end
+  end
+
+  # register the subcommand to Inspec CLI registry
+  Inspec::Plugins::CLI.register(Supermarket::SupermarketCLI, 'supermarket', 'supermarket SUBCOMMAND ...', 'Supermarket commands', {})
+end

--- a/lib/bundles/inspec-supermarket/target.rb
+++ b/lib/bundles/inspec-supermarket/target.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+require 'uri'
+
+# InSpec Target Helper for Supermarket
+module Supermarket
+  class SupermarketHelper < Inspec::Targets::UrlHelper
+    def handles?(profile)
+      # check for local scheme supermarket://
+      return unless URI(profile).scheme == 'supermarket'
+
+      # verifies that the target e.g base/ssh exists
+      Supermarket::API.exist?(profile)
+    rescue URI::Error => _e
+      false
+    end
+
+    # generates proper url
+    def resolve(profile, opts = {})
+      tool_info = Supermarket::API.find(profile)
+      super(tool_info['tool_source_url'], opts)
+    end
+
+    def to_s
+      'Chef Compliance Profile Loader'
+    end
+  end
+
+  Inspec::Targets.add_module('supermarket', Supermarket::SupermarketHelper.new)
+end


### PR DESCRIPTION
This PR implement the ability to find profiles on Chef Supermarket:

Display available profiles:

```
$ inspec supermarket profiles                                    
Available profiles:
-------------------
 * nathenharvey/tmp-compliance-profile
```

Display details about the profile:

```
inspec supermarket info nathenharvey/tmp-compliance-profile
name:   tmp-compliance-profile
owner:  nathenharvey
url:    https://github.com/nathenharvey/tmp_compliance_profile/

description:   An InSpec compliance profile for use with Chef Compliance Server.
```

Execute a profile:

```
$ inspec supermarket exec nathenharvey/tmp-compliance-profile
..

Finished in 0.01352 seconds (files took 4.37 seconds to load)
2 examples, 0 failures
```

Alternatively you could also use:

```
inspec exec supermarket://nathenharvey/tmp-compliance-profile
..

Finished in 0.03779 seconds (files took 5.16 seconds to load)
2 examples, 0 failures

```
