### PR TITLE
avoid automatic plugin loading via library

### DIFF
--- a/bin/inspec
+++ b/bin/inspec
@@ -142,6 +142,10 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   end
 end
 
+# Load all plugins on startup
+ctl = Inspec::PluginCtl.new
+ctl.list.each { |x| ctl.load(x) }
+
 # load CLI plugins before the Inspec CLI has been started
 Inspec::Plugins::CLI.registry.each { |_subcommand, params|
   Inspec::InspecCLI.register(

--- a/lib/inspec.rb
+++ b/lib/inspec.rb
@@ -25,7 +25,3 @@ require 'utils/base_cli'
 # targets
 require 'inspec/resource'
 require 'inspec/plugins'
-
-# Load all plugins on startup
-ctl = Inspec::PluginCtl.new
-ctl.list.each { |x| ctl.load(x) }


### PR DESCRIPTION
only load plugins through the binary, never through the library. This avoids issues we have in accidentally loading plugins in tests and integration work. They should only be loaded when users request them.
