### PR TITLE
semantics: rename CLI plugins registry -> commands

### DIFF
--- a/bin/inspec
+++ b/bin/inspec
@@ -147,7 +147,7 @@ ctl = Inspec::PluginCtl.new
 ctl.list.each { |x| ctl.load(x) }
 
 # load CLI plugins before the Inspec CLI has been started
-Inspec::Plugins::CLI.registry.each { |_subcommand, params|
+Inspec::Plugins::CLI.subcommands.each { |_subcommand, params|
   Inspec::InspecCLI.register(
     params[:klass],
     params[:subcommand_name],

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -142,5 +142,5 @@ module Compliance
   end
 
   # register the subcommand to Inspec CLI registry
-  Inspec::Plugins::CLI.register(ComplianceCLI, 'compliance', 'compliance SUBCOMMAND ...', 'Chef Compliance commands', {})
+  Inspec::Plugins::CLI.add_subcommand(ComplianceCLI, 'compliance', 'compliance SUBCOMMAND ...', 'Chef Compliance commands', {})
 end

--- a/lib/inspec/plugins/cli.rb
+++ b/lib/inspec/plugins/cli.rb
@@ -6,12 +6,12 @@ module Inspec
   module Plugins
     # stores all CLI plugin, we expect those to the `Thor` subclasses
     class CLI
-      def self.registry
-        @registry ||= {}
+      def self.subcommands
+        @subcommands ||= {}
       end
 
-      def self.register(klass, subcommand_name, usage, description, options = {})
-        registry[subcommand_name] = {
+      def self.add_subcommand(klass, subcommand_name, usage, description, options = {})
+        subcommands[subcommand_name] = {
           klass: klass,
           subcommand_name: subcommand_name,
           usage: usage,

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -16,13 +16,12 @@ describe 'plugin system' do
     let(:cli_reg) { Inspec::Plugins::CLI }
 
     before do
-      # TODO: remove this, once the plugin loading is not based on ruby-load time
-      # initialization
-      cli_reg.registry.clear
+      # since the registry is a global singleton, clean it before using
+      cli_reg.subcommands.clear
     end
 
     it 'is empty' do
-      cli_reg.registry.must_equal({})
+      cli_reg.subcommands.must_equal({})
     end
 
     it 'stores one cli plugin' do
@@ -33,14 +32,14 @@ describe 'plugin system' do
         description: 'desc of my_cmd',
         options: { test: 1 }
       }
-      cli_reg.register(
+      cli_reg.add_subcommand(
         plugin[:klass],
         plugin[:subcommand_name],
         plugin[:usage],
         plugin[:description],
         plugin[:options]
       )
-      cli_reg.registry['my_cmd'].must_equal(plugin)
+      cli_reg.subcommands['my_cmd'].must_equal(plugin)
     end
   end
 end


### PR DESCRIPTION
Basically make sure everyone understands these are only subcommands. we might consider adding plugins for options or existing commands instead of new subcommands. this just ensures everyone knows what registry is for
