### PR TITLE
update to winrm 1.6.1 command scheme

### DIFF
--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -92,7 +92,7 @@ class RegistryKey < Inspec.resource(1)
   end
 
   def registry_key(path)
-    return @registy_cache if defined?(@registy_cache)
+    return @registry_cache if defined?(@registry_cache)
 
     # load registry key and all properties
     script = <<-EOH
@@ -115,16 +115,16 @@ class RegistryKey < Inspec.resource(1)
     # cannot rely on exit code for now, successful command returns exit code 1
     # return nil if cmd.exit_status != 0, try to parse json
     begin
-      @registy_cache = JSON.parse(cmd.stdout)
+      @registry_cache = JSON.parse(cmd.stdout)
       # convert keys to lower case
-      @registy_cache = Hash[@registy_cache.map do |key, value|
+      @registry_cache = Hash[@registry_cache.map do |key, value|
         [key.downcase, value]
       end]
     rescue JSON::ParserError => _e
-      @registy_cache = nil
+      @registry_cache = nil
     end
 
-    @registy_cache
+    @registry_cache
   end
 
   # Registry key value types

--- a/lib/resources/script.rb
+++ b/lib/resources/script.rb
@@ -18,17 +18,15 @@ class Script < Cmd
   "
 
   def initialize(script)
-    case inspec.os[:family]
-    when 'windows'
-      # encodes a script as base64 to run as powershell encodedCommand
-      # this comes with performance issues: @see https://gist.github.com/fnichol/7b20596b950e65fb96f9
-      require 'winrm'
-      script = WinRM::PowershellScript.new(script)
-      cmd = "powershell -encodedCommand #{script.encoded}"
-    else
-      cmd = ''
+    unless inspec.os.windows?
       return skip_resource 'The `script` resource is not supported on your OS yet.'
     end
+
+    # encodes a script as base64 to run as powershell encodedCommand
+    # this comes with performance issues: @see https://gist.github.com/fnichol/7b20596b950e65fb96f9
+    require 'winrm'
+    script = WinRM::PowershellScript.new(script)
+    cmd = "powershell -encodedCommand #{script.encoded}"
     super(cmd)
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -121,8 +121,9 @@ class MockLoader
       'Remove-Item win_secpol.cfg' => cmd.call('success'),
       'env' => cmd.call('env'),
       '$Env:PATH'  => cmd.call('$env-PATH'),
-      # registry key test
+      # registry key test (winrm 1.6.0, 1.6.1)
       '2790db1e88204a073ed7fd3493f5445e5ce531afd0d2724a0e36c17110c535e6' => cmd.call('reg_schedule'),
+      'b00eb49a98c96a808c469e4894b5123a913e354c9ffea5b785898fe30d288ee0' => cmd.call('reg_schedule'),
       'Auditpol /get /subcategory:\'User Account Management\' /r' => cmd.call('auditpol'),
       '/sbin/auditctl -l' => cmd.call('auditctl'),
       'yum -v repolist all'  => cmd.call('yum-repolist-all'),
@@ -179,8 +180,9 @@ class MockLoader
       'dscl -q . -read /Users/chartmann NFSHomeDirectory PrimaryGroupID RecordName UniqueID UserShell' => cmd.call('dscl'),
       # user info for freebsd
       'pw usershow root -7' => cmd.call('pw-usershow-root-7'),
-      # user info for windows
+      # user info for windows (winrm 1.6.0, 1.6.1)
       '650b6b72a66316418b25421a54afe21a230704558082914c54711904bb10e370' => cmd.call('GetUserAccount'),
+      '272e1d767fe6e28c86cfba1a75c3d458acade1f4a36cfd5e711b97884879de24' => cmd.call('GetUserAccount'),
       # group info for windows
       'Get-WmiObject Win32_Group | Select-Object -Property Caption, Domain, Name, SID, LocalAccount | ConvertTo-Json' => cmd.call('GetWin32Group'),
       # network interface

--- a/test/unit/resources/script_test.rb
+++ b/test/unit/resources/script_test.rb
@@ -14,6 +14,10 @@ describe 'Inspec::Resources::Script' do
 
   it 'check if script for windows is properly generated ' do
     resource = MockLoader.new(:windows).load_resource('script', ps1_script)
-    _(resource.command).must_equal 'powershell -encodedCommand IAAgACAAIAAjACAAYwBhAGwAbAAgAGgAZQBsAHAAIABmAG8AcgAgAGcAZQB0ACAAYwBvAG0AbQBhAG4AZAAKACAAIAAgACAARwBlAHQALQBIAGUAbABwACAARwBlAHQALQBDAG8AbQBtAGEAbgBkAAoA'
+    if Gem.loaded_specs['winrm'].version < Gem::Version.new('1.6.1')
+      _(resource.command).must_equal 'powershell -encodedCommand IAAgACAAIAAjACAAYwBhAGwAbAAgAGgAZQBsAHAAIABmAG8AcgAgAGcAZQB0ACAAYwBvAG0AbQBhAG4AZAAKACAAIAAgACAARwBlAHQALQBIAGUAbABwACAARwBlAHQALQBDAG8AbQBtAGEAbgBkAAoA'
+    else
+      _(resource.command).must_equal 'powershell -encodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsAIAAgACAAIAAjACAAYwBhAGwAbAAgAGgAZQBsAHAAIABmAG8AcgAgAGcAZQB0ACAAYwBvAG0AbQBhAG4AZAAKACAAIAAgACAARwBlAHQALQBIAGUAbABwACAARwBlAHQALQBDAG8AbQBtAGEAbgBkAAoA'
+    end
   end
 end


### PR DESCRIPTION
... + typos + minor

only relevant for unit tests

Also: we should consider either pinning the winrm gem version ourselves or find a different way to depend on it. Simplest solution would be to force train to use winrm 1.6.1+, but then again these errors only occur in our unit tests because of expectations. It's perfectly fine to use winrm 1.6.0 for this as well... ideas?
