### PR TITLE
separate directory resolver from target resolver

### DIFF
--- a/lib/inspec/targets/core.rb
+++ b/lib/inspec/targets/core.rb
@@ -8,18 +8,21 @@ module Inspec
   module Targets
     extend Modulator
 
-    def self.__resolve(items)
-      items.map do |_|
-        # @TODO
-      end.flatten
+    def self.find_resolver(target)
+      modules.values.find { |m| m.handles?(target) }
+    end
+
+    def self.find_handler(target)
+      resolver = find_resolver(target)
+      return resolver unless resolver.is_a?DirsResolver
+      files = resolver.get_files(target)
+      DirsHelper.get_handler(files)
     end
 
     def self.resolve(targets, opts = {})
       Array(targets).map do |target|
-        handler = modules.values.find { |m| m.handles?(target) }
-        if handler.nil?
-          fail "Don't know how to handle target: #{target}"
-        end
+        handler = find_resolver(target) ||
+                  fail("Don't know how to handle target: #{target}")
         handler.resolve(target, opts)
       end.flatten
     end

--- a/lib/inspec/targets/dir.rb
+++ b/lib/inspec/targets/dir.rb
@@ -3,79 +3,92 @@
 # author: Christoph Hartmann
 
 module Inspec::Targets
+  # DirsHelper manages resolvers for directories. Wherever directories are,
+  # either a local folder, archive, or remote, this module provides all helpers
+  # than can resolve these.
+  #
+  # Resolvers provide these methods
+  # * handles?(paths)  =>  true if the resolver is responsible for this target
+  # * get_filenames    =>  Array[String] of files where tests/controls are found
+  # * get_metadata     =>  String path with metadata information [optional]
+  # * get_libraries    =>  Array[String] of library files [optional]
+  #
+  # Resolvers must register with this DirsHelper via #add_module .
   module DirsHelper
-    # InSpec profile Loader
-    # Previous versions used the `test` directory instead of the new `controls`
-    # directory. Usage of the test directory is deprecated and not recommended
-    # anymore. Support for `test` will be removed in InSpec 1.0
-    # TODO: remove `test` support for InSpec 1.0
-    class ProfileDir
-      def handles?(paths)
-        return true if paths.include?('inspec.yml')
-        (
-          !paths.grep(/^controls/).empty? ||
-          !paths.grep(/^test/).empty?
-        ) && paths.include?('metadata.rb')
-      end
-
-      def get_libraries(paths)
-        paths.find_all do |path|
-          path.start_with?('libraries') && path.end_with?('.rb')
-        end
-      end
-
-      def get_filenames(paths)
-        paths.find_all do |path|
-          path.start_with?('controls', 'test') && path.end_with?('.rb')
-        end
-      end
-
-      def get_metadata(paths)
-        return 'inspec.yml' if paths.include?('inspec.yml')
-        return 'metadata.rb' if paths.include?('metadata.rb')
-      end
-    end
-
-    class ChefAuditDir
-      def handles?(paths)
-        paths.include?('recipes') and paths.include?('metadata.rb')
-      end
-
-      def get_filenames(paths)
-        paths.find_all do |x|
-          x.start_with? 'recipes/' and x.end_with? '.rb'
-        end
-      end
-    end
-
-    class ServerspecDir
-      def handles?(paths)
-        paths.include?('spec')
-      end
-
-      def get_filenames(paths)
-        paths.find_all do |path|
-          path.start_with? 'spec' and path.end_with? '_spec.rb'
-        end
-      end
-    end
-
-    class FlatDir
-      def handles?(paths)
-        get_filenames(paths).empty? == false
-      end
-
-      def get_filenames(paths)
-        paths.find_all { |x| x.end_with?('.rb') and !x.include?('/') }
-      end
-    end
-
-    HANDLERS = [
-      ProfileDir, ChefAuditDir, ServerspecDir, FlatDir
-    ].map(&:new)
+    extend Modulator
 
     def self.get_handler(paths)
-      HANDLERS.find { |x| x.handles? paths }
+      modules.values.find { |x| x.handles?(paths) }
     end
   end
+
+  # InSpec profile Loader
+  # Previous versions used the `test` directory instead of the new `controls`
+  # directory. Usage of the test directory is deprecated and not recommended
+  # anymore. Support for `test` will be removed in InSpec 1.0
+  # TODO: remove `test` support for InSpec 1.0
+  class ProfileDir
+    def handles?(paths)
+      return true if paths.include?('inspec.yml')
+      (
+        !paths.grep(/^controls/).empty? ||
+        !paths.grep(/^test/).empty?
+      ) && paths.include?('metadata.rb')
+    end
+
+    def get_libraries(paths)
+      paths.find_all do |path|
+        path.start_with?('libraries') && path.end_with?('.rb')
+      end
+    end
+
+    def get_filenames(paths)
+      paths.find_all do |path|
+        path.start_with?('controls', 'test') && path.end_with?('.rb')
+      end
+    end
+
+    def get_metadata(paths)
+      return 'inspec.yml' if paths.include?('inspec.yml')
+      return 'metadata.rb' if paths.include?('metadata.rb')
+    end
+  end
+  DirsHelper.add_module('inspec-profile', ProfileDir.new)
+
+  class ChefAuditDir
+    def handles?(paths)
+      paths.include?('recipes') and paths.include?('metadata.rb')
+    end
+
+    def get_filenames(paths)
+      paths.find_all do |x|
+        x.start_with? 'recipes/' and x.end_with? '.rb'
+      end
+    end
+  end
+  DirsHelper.add_module('chef-cookbook', ChefAuditDir.new)
+
+  class ServerspecDir
+    def handles?(paths)
+      paths.include?('spec')
+    end
+
+    def get_filenames(paths)
+      paths.find_all do |path|
+        path.start_with? 'spec' and path.end_with? '_spec.rb'
+      end
+    end
+  end
+  DirsHelper.add_module('serverspec-folder', ServerspecDir.new)
+
+  class FlatDir
+    def handles?(paths)
+      get_filenames(paths).empty? == false
+    end
+
+    def get_filenames(paths)
+      paths.find_all { |x| x.end_with?('.rb') and !x.include?('/') }
+    end
+  end
+  DirsHelper.add_module('flat-ruby-folder', FlatDir.new)
 end

--- a/lib/inspec/targets/dir.rb
+++ b/lib/inspec/targets/dir.rb
@@ -22,6 +22,16 @@ module Inspec::Targets
     end
   end
 
+  # Base class for all directory resolvers. I.e. any target helper that
+  # takes a directory/archive/... and ultimately calls DirsHelper to resolve it.
+  #
+  # These resolvers must implement the required methods of this class.
+  class DirsResolver
+    def get_files(_target)
+      fail NotImplementedError, "Directory resolver #{self.class} must implement #get_files"
+    end
+  end
+
   # InSpec profile Loader
   # Previous versions used the `test` directory instead of the new `controls`
   # directory. Usage of the test directory is deprecated and not recommended

--- a/lib/inspec/targets/folder.rb
+++ b/lib/inspec/targets/folder.rb
@@ -6,22 +6,24 @@ require 'inspec/targets/dir'
 require 'inspec/targets/file'
 
 module Inspec::Targets
-  class FolderHelper
+  class FolderHelper < DirsResolver
     def handles?(target)
       File.directory?(target)
     end
 
-    def resolve(target, _opts = {})
+    def get_files(target)
       # find all files in the folder
       files = Dir[File.join(target, '**', '*')]
       # remove the prefix
       prefix = File.join(target, '')
-      files = files.map { |x| x.sub(prefix, '') }
+      files.map { |x| x.sub(prefix, '') }
+    end
+
+    def resolve(target, _opts = {})
       # get the dirs helper
-      helper = DirsHelper.get_handler(files)
-      if helper.nil?
-        fail "Don't know how to handle folder #{target}"
-      end
+      files = get_files(target)
+      helper = DirsHelper.get_handler(files) ||
+               fail("Don't know how to handle folder #{target}")
 
       # get all test file contents
       file_handler = Inspec::Targets.modules['file']


### PR DESCRIPTION
Our target resolvers are split up into "retrieve that file / url / ..." and "understand what this thing is you are handling and get me inspec code". The division between these has not been clean, they are still sharing their space in the Targets library.

This MR puts our `DirsHelper` into the special position it is in: A collection of resolvers that take a folder structure of any kind (be it local or e.g. inside of a tar-archive) and turns it into raw string'y content.

These directory resolvers now register with `DirsHelper`. They inherit from `DirsResolver` and must provide a method to get relevant filenames from their (virtual/local) folder via `get_files`.

Directory resolvers themselves haven't changed: they still default to `handles?`, `get_filenames`, `get_libraries`, and `get_metadata`. This has been added as a description in code.
