### PR TITLE
bugfix: verify the target resolver before using it

### DIFF
--- a/lib/inspec/targets/core.rb
+++ b/lib/inspec/targets/core.rb
@@ -35,7 +35,8 @@ module Inspec
     # @return [Inspec::Targets::*] the handler for this target
     def self.find_handler(target)
       resolver = find_resolver(target)
-      return resolver unless resolver.ancestors.include? DirsResolver
+      return resolver unless resolver.is_a?(Module) &&
+                             resolver.ancestors.include?(DirsResolver)
       resolver.from_target(target).handler
     end
 


### PR DESCRIPTION
Resolvers are both classes and modules. The request `resolver.ancestors` only works for modules, classes would require `resolver.class.ancestors`. Since `DirsHelper`s are never classes, we can safely limit this check to modules only.
