### PR TITLE
Add a init subcommand

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   - 'test/**/*'
   - 'examples/**/*'
   - 'vendor/**/*'
+  - 'lib/bundles/inspec-init/templates/**/*'
 Documentation:
   Enabled: false
 AlignParameters:

--- a/lib/bundles/inspec-generate.rb
+++ b/lib/bundles/inspec-generate.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+libdir = File.dirname(__FILE__)
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+
+require 'inspec-generate/cli'

--- a/lib/bundles/inspec-generate/cli.rb
+++ b/lib/bundles/inspec-generate/cli.rb
@@ -1,0 +1,84 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+
+module Generate
+  class CLI < Inspec::BaseCLI
+    namespace 'generate'
+
+    # read template directoy
+    template_dir = File.join(File.dirname(__FILE__), 'templates')
+    Dir.glob(File.join(template_dir, '*')) do |template|
+      relative = Pathname.new(template).relative_path_from(Pathname.new(template_dir))
+
+      # register command for the template
+      desc "#{relative} NAME", "Scaffolds a new #{relative}"
+      option :overwrite, type: :boolean, default: false,
+         desc: 'Overwrites existing directory'
+      define_method relative.to_s.to_sym do |name|
+        generator(relative.to_s, { name: name }, options)
+      end
+    end
+
+    private
+
+    # 1. iterate over all files
+    # 2. read content in erb
+    # 3. write to target
+    def generator(type, attributes = {}, options = {})
+      # path of this script
+      dir = File.dirname(__FILE__)
+      # look for template directory
+      base_dir = File.join(dir, 'templates', type)
+      # prepare glob for all subdirectories and files
+      template = File.join(base_dir, '**', '{*,.*}')
+      # generate target path
+      target = Pathname.new(Dir.pwd).join(attributes[:name])
+      puts "Generate new #{type} at #{mark_text(target)}"
+
+      # check that the directory does not exist
+      if File.exist?(target) && !options['overwrite']
+        error "#{mark_text(target)} exists already, use --overwrite"
+        exit 1
+      end
+
+      # iterate over files and write to target path
+      Dir.glob(template) do |file|
+        relative = Pathname.new(file).relative_path_from(Pathname.new(base_dir))
+        destination = Pathname.new(target).join(relative)
+
+        if File.directory?(file)
+          li "Create directory #{mark_text(relative)}"
+          FileUtils.mkdir_p(destination)
+        elsif File.file?(file)
+          li "Generate file #{mark_text(relative)}"
+          # read & render content
+          content = render(File.read(file), attributes)
+          # write file content
+          File.write(destination, content)
+        else
+          puts "ignore #{file}, because its not an file or directoy"
+        end
+      end
+    end
+
+    # This is a render helper to bind hash values to a ERB template
+    def render(content, hash)
+      # create a new binding class
+      cls = Class.new do
+        hash.each do |key, value|
+          define_method key.to_sym do
+            value
+          end
+        end
+        # expose binding
+        define_method :bind do
+          binding
+        end
+      end
+      ERB.new(content).result(cls.new.bind)
+    end
+  end
+
+  # register the subcommand to Inspec CLI registry
+  Inspec::Plugins::CLI.add_subcommand(Generate::CLI, 'generate', 'generate SUBCOMMAND ...', 'Template commands', {})
+end

--- a/lib/bundles/inspec-init.rb
+++ b/lib/bundles/inspec-init.rb
@@ -5,4 +5,4 @@
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
-require 'inspec-generate/cli'
+require 'inspec-init/cli'

--- a/lib/bundles/inspec-init/cli.rb
+++ b/lib/bundles/inspec-init/cli.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 # author: Christoph Hartmann
 
-module Generate
+module Init
   class CLI < Inspec::BaseCLI
-    namespace 'generate'
+    namespace 'init'
 
     # read template directoy
     template_dir = File.join(File.dirname(__FILE__), 'templates')
@@ -11,7 +11,7 @@ module Generate
       relative = Pathname.new(template).relative_path_from(Pathname.new(template_dir))
 
       # register command for the template
-      desc "#{relative} NAME", "Scaffolds a new #{relative}"
+      desc "#{relative} NAME", "Create a new #{relative}"
       option :overwrite, type: :boolean, default: false,
          desc: 'Overwrites existing directory'
       define_method relative.to_s.to_sym do |name|
@@ -24,7 +24,7 @@ module Generate
     # 1. iterate over all files
     # 2. read content in erb
     # 3. write to target
-    def generator(type, attributes = {}, options = {})
+    def generator(type, attributes = {}, options = {}) # rubocop:disable Metrics/AbcSize
       # path of this script
       dir = File.dirname(__FILE__)
       # look for template directory
@@ -33,7 +33,7 @@ module Generate
       template = File.join(base_dir, '**', '{*,.*}')
       # generate target path
       target = Pathname.new(Dir.pwd).join(attributes[:name])
-      puts "Generate new #{type} at #{mark_text(target)}"
+      puts "Create new #{type} at #{mark_text(target)}"
 
       # check that the directory does not exist
       if File.exist?(target) && !options['overwrite']
@@ -41,22 +41,24 @@ module Generate
         exit 1
       end
 
+      # ensure that target directory is available
+      FileUtils.mkdir_p(target)
+
       # iterate over files and write to target path
       Dir.glob(template) do |file|
         relative = Pathname.new(file).relative_path_from(Pathname.new(base_dir))
         destination = Pathname.new(target).join(relative)
-
         if File.directory?(file)
           li "Create directory #{mark_text(relative)}"
           FileUtils.mkdir_p(destination)
         elsif File.file?(file)
-          li "Generate file #{mark_text(relative)}"
+          li "Create file #{mark_text(relative)}"
           # read & render content
           content = render(File.read(file), attributes)
           # write file content
           File.write(destination, content)
         else
-          puts "ignore #{file}, because its not an file or directoy"
+          puts "Ignore #{file}, because its not an file or directoy"
         end
       end
     end
@@ -80,5 +82,5 @@ module Generate
   end
 
   # register the subcommand to Inspec CLI registry
-  Inspec::Plugins::CLI.add_subcommand(Generate::CLI, 'generate', 'generate SUBCOMMAND ...', 'Template commands', {})
+  Inspec::Plugins::CLI.add_subcommand(Init::CLI, 'init', 'init TEMPLATE ...', 'Scaffolds a new project', {})
 end

--- a/lib/bundles/inspec-init/templates/profile/README.md
+++ b/lib/bundles/inspec-init/templates/profile/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec [profile](../../docs/profiles.rst).

--- a/lib/bundles/inspec-init/templates/profile/controls/example.rb
+++ b/lib/bundles/inspec-init/templates/profile/controls/example.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+# license: All rights reserved
+
+title 'sample section'
+
+# you can also use plain tests
+describe file('/tmp') do
+  it { should be_directory }
+end
+
+# you add controls here
+control 'tmp-1.0' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/lib/bundles/inspec-init/templates/profile/inspec.yml
+++ b/lib/bundles/inspec-init/templates/profile/inspec.yml
@@ -1,0 +1,8 @@
+name: <%= name %>
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile
+version: 0.1.0


### PR DESCRIPTION
This command eases the scaffolding of a projects. This initial version ships with
- InSpec profile

The command is as follows:

```
$ inspec init
Commands:
  inspec init help [COMMAND]  # Describe subcommands or one specific subcommand
  inspec init profile NAME    # Scaffolds a new profile
```
