### PR TITLE
ensure permissions of inspec-compliance config.json on store

### DIFF
--- a/lib/bundles/inspec-compliance/configuration.rb
+++ b/lib/bundles/inspec-compliance/configuration.rb
@@ -40,6 +40,7 @@ module Compliance
     # stores a hash to json
     def store
       File.open(@config_file, 'w') do |f|
+        f.chmod(0600)
         f.write(@config.to_json)
       end
     end


### PR DESCRIPTION
The default umask might allow for reading the authentication token by anyone. It will ensure that it's only readable/writable by the user (`0600`) now.

NB there's no measure to _not read a world-writable config.json_ on `get`.
