### PR TITLE
fix url target resolution with zip and tar

### DIFF
--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -46,10 +46,7 @@ module Compliance
     def build_target_url(target)
       owner, profile = target.split('/')
       config = Compliance::Configuration.new
-      url = "#{config['server']}/owners/%owner_name%/compliance/%profile_name%/tar"
-            .gsub('%owner_name%', owner)
-            .gsub('%profile_name%', profile)
-      url
+      "#{config['server']}/owners/#{owner}/compliance/#{profile}/tar"
     end
 
     def to_s

--- a/lib/inspec/targets/zip.rb
+++ b/lib/inspec/targets/zip.rb
@@ -23,7 +23,7 @@ module Inspec::Targets
             type: opts[:as] || :test,
             ref: entry.name,
           }
-          abort
+          break
         end
       end
       content

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -14,12 +14,15 @@ SimpleCov.start do
   add_group 'Backends', 'lib/inspec/backend'
 end
 
+require 'fileutils'
+
 require 'utils/base_cli'
 require 'inspec/targets'
 require 'inspec/resource'
 require 'inspec/backend'
 require 'inspec/profile'
-
+require 'inspec/runner'
+require 'inspec/runner_mock'
 
 class MockLoader
   # collects emulation operating systems
@@ -237,6 +240,33 @@ class MockLoader
   def self.mock_command(resource, cmd, res = {})
     resource.inspec.backend
             .mock_command(cmd, res[:stdout], res[:stderr], res[:exit_status])
+  end
+
+  def self.home
+    File.join(File.dirname(__FILE__), 'unit')
+  end
+
+  def self.load_profile(name, opts = {})
+    opts[:test_collector] = Inspec::RunnerMock.new
+    dst = name
+    dst = "#{home}/mock/profiles/#{name}" unless name.start_with?(home)
+    Inspec::Profile.from_path(dst, opts)
+  end
+
+  def self.profile_tgz(name)
+    path = "#{home}/mock/profiles/#{name}"
+    dst = "#{path}.tgz"
+    FileUtils.rm(dst) if File.file?(dst)
+    `tar zcvf #{dst} #{path}`
+    dst
+  end
+
+  def self.profile_zip(name, opts = {})
+    path = "#{home}/mock/profiles/#{name}"
+    dst = "#{path}.zip"
+    FileUtils.rm(dst) if File.file?(dst)
+    `zip #{dst} #{path}`
+    dst
   end
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,6 +15,7 @@ SimpleCov.start do
 end
 
 require 'fileutils'
+require 'zip'
 
 require 'utils/base_cli'
 require 'inspec/targets'
@@ -265,7 +266,11 @@ class MockLoader
     path = "#{home}/mock/profiles/#{name}"
     dst = "#{path}.zip"
     FileUtils.rm(dst) if File.file?(dst)
-    `zip #{dst} #{path}`
+    Zip::File.open(dst, 'w') do |zipfile|
+      Dir["#{path}/**/**"].reject { |f| f == dst }.each do |file|
+        zipfile.add(file.sub(path+'/', ''), file)
+      end
+    end
     dst
   end
 end

--- a/test/unit/targets/url_test.rb
+++ b/test/unit/targets/url_test.rb
@@ -3,131 +3,137 @@
 # author: Dominik Richter
 
 require 'helper'
+require 'mocha/setup'
 
 describe Inspec::Targets::UrlHelper do
-  let(:helper) { Inspec::Targets::UrlHelper.new }
+  let(:url_helper) { Inspec::Targets::UrlHelper.new }
 
   it 'handles http' do
-    helper.handles?('http://chef.io').must_equal true
+    url_helper.handles?('http://chef.io').must_equal true
   end
 
   it 'handles https' do
-    helper.handles?('https://chef.io').must_equal true
+    url_helper.handles?('https://chef.io').must_equal true
   end
 
   it 'returns false if given an invalid URL' do
-    helper.handles?('cheshire_cat').must_equal false
+    url_helper.handles?('cheshire_cat').must_equal false
   end
 
   it 'returns false if given an URL with a protocol different from http[s]' do
-    helper.handles?('gopher://chef.io').must_equal false
+    url_helper.handles?('gopher://chef.io').must_equal false
   end
 
   it 'resolves various github urls' do
-    hlpr = Minitest::Mock.new
-    helper.stub :resolve_zip, hlpr do
+    mock = Minitest::Mock.new
+    url_helper.stub :download_archive, mock do
       %w{https://github.com/chef/inspec
          https://github.com/chef/inspec.git
          https://www.github.com/chef/inspec.git
          http://github.com/chef/inspec
          http://github.com/chef/inspec.git
          http://www.github.com/chef/inspec.git}.each do |github|
-        hlpr.expect :call, nil, ['https://github.com/chef/inspec/archive/master.tar.gz', {}]
+        mock.expect :call, nil, ['https://github.com/chef/inspec/archive/master.tar.gz', {}]
 
-        helper.resolve(github)
+        url_helper.resolve(github)
       end
-      hlpr.verify
+      mock.verify
     end
   end
 
   it 'leaves proper, non-github urls unchanged' do
     url = 'https://chef.io/something.tar.gz'
-    hlpr = Minitest::Mock.new
-    hlpr.expect :call, nil, [url, {}]
-    helper.stub :resolve_zip, hlpr do
-        helper.resolve(url)
+    mock = Minitest::Mock.new
+    mock.expect :call, nil, [url, {}]
+    url_helper.stub :download_archive, mock do
+        url_helper.resolve(url)
     end
-    hlpr.verify
+    mock.verify
   end
 
-  let (:url) { 'https://github.com/chef/inspec/archive/master.tar.gz' }
-  let (:opts) { { http_basic_authentication: ['', ''] } }
-
   def archive_of_type(type)
-    archive = Minitest::Mock.new
-    archive.expect :write, nil, ["#{type}-content"]
-    archive.expect :path, "/path/to/#{type}-archive.tar.gz" # always tar.gz!
+    mock = Minitest::Mock.new
+    mock.expect :write, nil, ["#{type}-content"]
+    mock.expect :path, "/path/to/#{type}-archive.tar.gz" # always tar.gz!
     [:binmode, :rewind, :close, :unlink].each do |meth|
-      archive.expect meth, nil
+      mock.expect meth, nil
     end
-    archive
+    mock
   end
 
   def remote_of_type(type, content_type)
-    remote = Minitest::Mock.new
-    remote.expect :read, "#{type}-content"
-    remote.expect :meta, { 'content-type' => content_type }
-    remote
+    mock = Minitest::Mock.new
+    mock.expect :read, "#{type}-content"
+    mock.expect :meta, { 'content-type' => content_type }
+    mock
   end
 
-  let (:archive_sth) { archive_of_type('sth') }
-  let (:remote_sth) { remote_of_type('sth', 'application/x-very-funny') }
+  describe 'with a funny archive and content-type' do
+    let (:url) { 'https://github.com/chef/inspec/archive/master.tar.gz' }
+    let (:remote_mock) { remote_of_type('sth', 'application/x-very-funny') }
 
-  it 'downloads an archive and returns it with its content-type' do
-    helper.stub :open, remote_sth, [url, opts] do
-      helper.download_archive(url, archive_sth, {}).must_equal([archive_sth, 'application/x-very-funny'])
+    it 'will download, but fails at resolving this content-type' do
+      url_helper.expects(:open).returns(remote_mock)
+      proc { url_helper.resolve(url) }.must_throw RuntimeError
+      remote_mock.verify
     end
-    remote_sth.verify
-  end
 
-  it 'downloads an archive and returns it with its content-type using options, too' do
-    helper.stub :open, remote_sth, [url, { http_basic_authentication: ['alice', 'pw'] }] do
-      helper.download_archive(url, archive_sth, 'user' => 'alice', 'password' => 'pw').must_equal([archive_sth, 'application/x-very-funny'])
-    end
-    remote_sth.verify
-  end
-
-  let (:archive_zip) { archive_of_type('zip') }
-  let (:archive_tgz) { archive_of_type('tgz') }
-
-  let (:tarhelper) do
-    th = Minitest::Mock.new
-    th.expect :resolve, 'tgz-content', ['/path/to/tgz-archive.tar.gz']
-    th
-  end
-
-  %w{ application/gzip application/x-gzip }.each do |content_type|
-    it "unpacks a tarball (#{content_type}) with TarHelper and returns the content" do
-      Tempfile.stub :new, archive_tgz, [['inspec-dl-', '.tar.gz']] do
-        helper.stub :download_archive, [archive_tgz, content_type], [url, archive_tgz, opts] do
-          Inspec::Targets::TarHelper.stub :new, tarhelper do
-            helper.resolve_zip(url, {}).must_equal('tgz-content')
-          end
-        end
-      end
-      tarhelper.verify
+    it 'downloads an archive and returns it with its content-type using options, too' do
+      url_helper.expects(:open).returns(remote_mock)
+      r, m = url_helper.method(:download_archive)
+                       .call(url, 'user' => 'alice', 'password' => 'pw')
+      m.must_equal('application/x-very-funny')
+      r.must_be_kind_of(File)
+      r.unlink
+      remote_mock.verify
     end
   end
 
-  let (:ziphelper) do
-    zip = Minitest::Mock.new
-    zip.expect :resolve, 'zip-content', [Pathname.new('/path/to/zip-archive.zip')]
-    zip
+  describe 'with a tar.gz archive' do
+    let (:url) { 'https://github.com/chef/inspec/archive/master.tar.gz' }
+    let (:profile_path) { MockLoader.profile_tgz('complete-profile') }
+    let (:archive_path) { profile_path.sub(/.tgz$/, '')[1..-1] }
+
+    it 'resolves the url' do
+      url_helper.expects(:download_archive).returns([File.new(profile_path), 'application/x-gzip'])
+      res = url_helper.resolve(url)
+      # TODO: the leading '/' is removed due to tar-handling; this should be
+      # a different ref altogether containing the right relative path of the tar
+
+      res.must_be_kind_of Array
+      res.length.must_equal 2
+
+      res[0][:type].must_equal :test
+      res[0][:content].wont_be_empty
+      res[0][:ref].must_equal "#{archive_path}/controls/filesystem_spec.rb"
+
+      res[1][:type].must_equal :metadata
+      res[1][:content].wont_be_empty
+      res[1][:ref].must_equal "#{archive_path}/inspec.yml"
+    end
   end
 
-  %w{ application/zip application/x-zip-compressed }.each do |content_type|
-    it "renames and unpacks a zip file (#{content_type}) with ZipHelper and returns the content" do
-      helper.stub :download_archive, [archive_zip, content_type], [url, archive_zip, opts] do
-        Tempfile.stub :new, archive_zip, [['inspec-dl-', '.tar.gz']] do
-          File.stub :rename, nil, ['/path/to/zip-archive.tar.gz', '/path/to/zip-archive.zip'] do
-            Inspec::Targets::ZipHelper.stub :new, ziphelper do
-              File.stub :unlink, nil, ['/path/to/zip-archive.zip'] do
-                helper.resolve_zip(url, {}).must_equal('zip-content')
-              end
-            end
-          end
-        end
-      end
+  describe 'with a zip archive' do
+    let (:url) { 'https://github.com/chef/inspec/archive/master.zip' }
+    let (:profile_path) { MockLoader.profile_zip('complete-profile') }
+    let (:archive_path) { profile_path.sub(/.zip$/, '')[1..-1] }
+
+    it 'resolves the url' do
+      url_helper.expects(:download_archive).returns([File.new(profile_path), 'application/zip'])
+      res = url_helper.resolve(url)
+      # TODO: the leading '/' is removed due to tar-handling; this should be
+      # a different ref altogether containing the right relative path of the tar
+
+      res.must_be_kind_of Array
+      res.length.must_equal 2
+
+      res[0][:type].must_equal :test
+      res[0][:content].wont_be_empty
+      res[0][:ref].must_equal "#{archive_path}/controls/filesystem_spec.rb"
+
+      res[1][:type].must_equal :metadata
+      res[1][:content].wont_be_empty
+      res[1][:ref].must_equal "#{archive_path}/inspec.yml"
     end
   end
 end

--- a/test/unit/targets/url_test.rb
+++ b/test/unit/targets/url_test.rb
@@ -92,7 +92,7 @@ describe Inspec::Targets::UrlHelper do
   describe 'with a tar.gz archive' do
     let (:url) { 'https://github.com/chef/inspec/archive/master.tar.gz' }
     let (:profile_path) { MockLoader.profile_tgz('complete-profile') }
-    let (:archive_path) { profile_path.sub(/.tgz$/, '')[1..-1] }
+    let (:archive_path) { profile_path.sub(/.tgz$/, '')[1..-1] + '/' }
 
     it 'resolves the url' do
       url_helper.expects(:download_archive).returns([File.new(profile_path), 'application/x-gzip'])
@@ -105,18 +105,18 @@ describe Inspec::Targets::UrlHelper do
 
       res[0][:type].must_equal :test
       res[0][:content].wont_be_empty
-      res[0][:ref].must_equal "#{archive_path}/controls/filesystem_spec.rb"
+      res[0][:ref].must_equal "#{archive_path}controls/filesystem_spec.rb"
 
       res[1][:type].must_equal :metadata
       res[1][:content].wont_be_empty
-      res[1][:ref].must_equal "#{archive_path}/inspec.yml"
+      res[1][:ref].must_equal "#{archive_path}inspec.yml"
     end
   end
 
   describe 'with a zip archive' do
     let (:url) { 'https://github.com/chef/inspec/archive/master.zip' }
     let (:profile_path) { MockLoader.profile_zip('complete-profile') }
-    let (:archive_path) { profile_path.sub(/.zip$/, '')[1..-1] }
+    let (:archive_path) { '' }
 
     it 'resolves the url' do
       url_helper.expects(:download_archive).returns([File.new(profile_path), 'application/zip'])
@@ -129,11 +129,11 @@ describe Inspec::Targets::UrlHelper do
 
       res[0][:type].must_equal :test
       res[0][:content].wont_be_empty
-      res[0][:ref].must_equal "#{archive_path}/controls/filesystem_spec.rb"
+      res[0][:ref].must_equal "#{archive_path}controls/filesystem_spec.rb"
 
       res[1][:type].must_equal :metadata
       res[1][:content].wont_be_empty
-      res[1][:ref].must_equal "#{archive_path}/inspec.yml"
+      res[1][:ref].must_equal "#{archive_path}inspec.yml"
     end
   end
 end

--- a/test/unit/targets/url_test.rb
+++ b/test/unit/targets/url_test.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 # author: Stephan Renatus
+# author: Dominik Richter
 
 require 'helper'
 

--- a/test/unit/targets/url_test.rb
+++ b/test/unit/targets/url_test.rb
@@ -9,11 +9,11 @@ describe Inspec::Targets::UrlHelper do
   let(:url_helper) { Inspec::Targets::UrlHelper.new }
 
   it 'handles http' do
-    url_helper.handles?('http://chef.io').must_equal true
+    url_helper.handles?('http://chef.io.tar.gz').must_equal true
   end
 
   it 'handles https' do
-    url_helper.handles?('https://chef.io').must_equal true
+    url_helper.handles?('https://chef.io.zip').must_equal true
   end
 
   it 'returns false if given an invalid URL' do
@@ -105,11 +105,11 @@ describe Inspec::Targets::UrlHelper do
 
       res[0][:type].must_equal :test
       res[0][:content].wont_be_empty
-      res[0][:ref].must_equal "#{archive_path}controls/filesystem_spec.rb"
+      res[0][:ref].must_equal "controls/filesystem_spec.rb"
 
       res[1][:type].must_equal :metadata
       res[1][:content].wont_be_empty
-      res[1][:ref].must_equal "#{archive_path}inspec.yml"
+      res[1][:ref].must_equal "inspec.yml"
     end
   end
 
@@ -129,11 +129,11 @@ describe Inspec::Targets::UrlHelper do
 
       res[0][:type].must_equal :test
       res[0][:content].wont_be_empty
-      res[0][:ref].must_equal "#{archive_path}controls/filesystem_spec.rb"
+      res[0][:ref].must_equal "controls/filesystem_spec.rb"
 
       res[1][:type].must_equal :metadata
       res[1][:content].wont_be_empty
-      res[1][:ref].must_equal "#{archive_path}inspec.yml"
+      res[1][:ref].must_equal "inspec.yml"
     end
   end
 end


### PR DESCRIPTION
supersedes the bug that https://github.com/chef/inspec/pull/458 is targeting
does not yet split out the plugin system for `Targets` and `DirsHelper`

cheers @chris-rock for finding this one!
