### PR TITLE
Service-related docs, bugs, integration tests

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -3875,6 +3875,45 @@ The following examples show how to use this InSpec audit resource.
    end
 
 
+**Test the runlevels for Sys-V services**
+
+On targets using Sys-V services, the existing runlevels can also be checked:
+
+.. code-block:: ruby
+
+   describe service('sshd').runlevels do
+     its('keys') { should include(2) }
+   end
+
+   describe service('sshd').runlevels(2,4) do
+     it { should be_enabled }
+   end
+
+**Override the service manager**
+
+Under some circumstances, it may be required to override the logic in place to select the right service manager. For example, if you want to check a service managed by Upstart, you can explicitly do so:
+
+.. code-block:: ruby
+
+  describe upstart_service('service') do
+    it { should_not be_enabled }
+    it { should be_installed }
+    it { should be_running }
+  end
+
+This is also possible with `systemd_service`, `runit_service`, `sysv_service`, `bsd_service`, and `launchd_service`.
+You can also provide the control command, for when it is not to be found at the default location.
+For example, if your `sv` command for services managed by Runit is not in PATH:
+
+.. code-block:: ruby
+
+  describe runit_service('service', '/opt/chef/embedded/sbin/sv') do
+    it { should be_enabled }
+    it { should be_installed }
+    it { should be_running }
+  end
+
+
 ssh_config
 =====================================================
 Use the ``ssh_config`` |inspec resource| to test |openssh| |ssh| client configuration data located at ``/etc/ssh/ssh_config`` on |linux| and |unix| platforms.

--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -189,7 +189,7 @@ end
 # @see: http://www.freedesktop.org/software/systemd/man/systemd-system.conf.html
 class Systemd < ServiceManager
   def initialize(inspec, service_ctl = nil)
-    @service_ctl ||= 'systemctl'
+    @service_ctl = service_ctl || 'systemctl'
     super
   end
 
@@ -270,7 +270,7 @@ end
 # @see: http://upstart.ubuntu.com
 class Upstart < ServiceManager
   def initialize(service_name, service_ctl = nil)
-    @service_ctl ||= 'initctl'
+    @service_ctl = service_ctl || 'initctl'
     super
   end
 
@@ -334,7 +334,7 @@ class SysV < ServiceManager
   RUNLEVELS = { 0=>false, 1=>false, 2=>false, 3=>false, 4=>false, 5=>false, 6=>false }.freeze
 
   def initialize(service_name, service_ctl = nil)
-    @service_ctl ||= 'service'
+    @service_ctl = service_ctl || 'service'
     super
   end
 
@@ -386,7 +386,7 @@ end
 # @see: https://www.freebsd.org/cgi/man.cgi?query=rc.conf&sektion=5
 class BSDInit < ServiceManager
   def initialize(service_name, service_ctl = nil)
-    @service_ctl ||= 'service'
+    @service_ctl = service_ctl || 'service'
     super
   end
 
@@ -423,7 +423,7 @@ end
 
 class Runit < ServiceManager
   def initialize(service_name, service_ctl = nil)
-    @service_ctl ||= 'sv'
+    @service_ctl = service_ctl || 'sv'
     super
   end
 
@@ -452,7 +452,7 @@ end
 # new launctl on macos 10.10
 class LaunchCtl < ServiceManager
   def initialize(service_name, service_ctl = nil)
-    @service_ctl ||= 'launchctl'
+    @service_ctl = service_ctl || 'launchctl'
     super
   end
 
@@ -562,7 +562,7 @@ end
 # Solaris services
 class Svcs < ServiceManager
   def initialize(service_name, service_ctl = nil)
-    @service_ctl ||= 'svcs'
+    @service_ctl = service_ctl || 'svcs'
     super
   end
 

--- a/test/integration/cookbooks/os_prepare/recipes/service.rb
+++ b/test/integration/cookbooks/os_prepare/recipes/service.rb
@@ -12,6 +12,8 @@ when 'ubuntu'
 
 when 'centos'
   # install runit for alternative service mgmt
-  include_recipe 'os_prepare::_runit_service_centos'
-  include_recipe 'os_prepare::_upstart_service_centos'
+  if node['platform_version'].to_i >= 6
+    include_recipe 'os_prepare::_runit_service_centos'
+    include_recipe 'os_prepare::_upstart_service_centos'
+  end
 end

--- a/test/integration/test/integration/default/service_spec.rb
+++ b/test/integration/test/integration/default/service_spec.rb
@@ -47,7 +47,7 @@ if os[:family] == 'ubuntu'
 end
 
 # extra tests for alt. runit on centos with runit_service
-if os[:family] == 'centos'
+if os[:family] == 'centos' && os[:release].to_i >= 6
   describe runit_service('running-runit-service') do
     it { should be_enabled }
     it { should be_installed }
@@ -105,7 +105,7 @@ if os[:family] == 'centos'
 end
 
 # extra tests for sys-v runlevels
-if os[:family] == 'centos'
+if os[:family] == 'centos' && os[:release].to_i <= 6
   describe service('sshd').runlevels do
     its('keys') { should include(2) }
   end

--- a/test/integration/test/integration/default/service_spec.rb
+++ b/test/integration/test/integration/default/service_spec.rb
@@ -103,3 +103,18 @@ if os[:family] == 'centos'
     it { should_not be_running }
   end
 end
+
+# extra tests for sys-v runlevels
+if os[:family] == 'centos'
+  describe service('sshd').runlevels do
+    its('keys') { should include(2) }
+  end
+
+  describe service('sshd').runlevels(2, 4) do
+    it { should be_enabled }
+  end
+
+  describe service('sshd').runlevels(0, 1) do
+    it { should_not be_enabled }
+  end
+end


### PR DESCRIPTION
- document sysv runlevels and service overrides
- add integration tests, skip upstart/runit on centos 5.
- fix bug in service_ctl overrides

Fixes #456.
