### PR TITLE
0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,29 @@
 # Change Log
 
-## [0.12.0](https://github.com/chef/inspec/tree/0.12.0) (2016-02-15)
-[Full Changelog](https://github.com/chef/inspec/compare/v0.11.0...0.12.0)
+## [0.13.0](https://github.com/chef/inspec/tree/0.13.0) (2016-02-19)
+[Full Changelog](https://github.com/chef/inspec/compare/v0.12.0...0.13.0)
+
+**Implemented enhancements:**
+
+- add shadow resource for /etc/shadow [\#471](https://github.com/chef/inspec/pull/471) ([arlimus](https://github.com/arlimus))
+- improve url handling [\#470](https://github.com/chef/inspec/pull/470) ([chris-rock](https://github.com/chris-rock))
+- add filters to passwd resource + deprecate old accessors [\#467](https://github.com/chef/inspec/pull/467) ([arlimus](https://github.com/arlimus))
+- cmp for single-entry arrays; add cmp docs [\#466](https://github.com/chef/inspec/pull/466) ([arlimus](https://github.com/arlimus))
+
+**Fixed bugs:**
+
+- Windows 2008 Still not detected correctly [\#453](https://github.com/chef/inspec/issues/453)
+- Service-related docs, bugs, integration tests [\#463](https://github.com/chef/inspec/pull/463) ([srenatus](https://github.com/srenatus))
+- fix url target resolution with zip and tar [\#462](https://github.com/chef/inspec/pull/462) ([arlimus](https://github.com/arlimus))
+- ensure permissions of inspec-compliance config.json on store [\#461](https://github.com/chef/inspec/pull/461) ([srenatus](https://github.com/srenatus))
+
+**Closed issues:**
+
+- No way to reload the add resources from test code [\#459](https://github.com/chef/inspec/issues/459)
+- add documentation for new server runlevel support [\#456](https://github.com/chef/inspec/issues/456)
+
+## [v0.12.0](https://github.com/chef/inspec/tree/v0.12.0) (2016-02-15)
+[Full Changelog](https://github.com/chef/inspec/compare/v0.11.0...v0.12.0)
 
 **Implemented enhancements:**
 
@@ -17,6 +39,7 @@
 
 **Merged pull requests:**
 
+- 0.12.0 [\#457](https://github.com/chef/inspec/pull/457) ([arlimus](https://github.com/arlimus))
 - rework target to resolver connection [\#447](https://github.com/chef/inspec/pull/447) ([arlimus](https://github.com/arlimus))
 - separate directory resolver from target resolver [\#446](https://github.com/chef/inspec/pull/446) ([arlimus](https://github.com/arlimus))
 

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'r-train', '~> 0.9', '>= 0.9.6'
+  spec.add_dependency 'r-train', '~> 0.10'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '~> 1.8'
   spec.add_dependency 'rainbow', '~> 2'

--- a/lib/inspec/version.rb
+++ b/lib/inspec/version.rb
@@ -3,5 +3,5 @@
 # author: Christoph Hartmann
 
 module Inspec
-  VERSION = '0.12.0'.freeze
+  VERSION = '0.13.0'.freeze
 end


### PR DESCRIPTION
This release includes a breaking API change for Windows. If you checked for a specific release version, it changed from `Server 2012 R2` to `6.3.9600`. This harmonizes the Windows version detection with our Unix detection.

The same Windows 2012 would return:

```
# old, not usable anymore
os[:name] == nil
os[:family] == "windows"
os[:release] == "Server 2012 R2"
os[:arch] == nil
```

```
# new result set, which is more specific
os[:name] == 'Windows Server 2012 R2 Datacenter'
os[:family] == "windows"
os[:release] == '6.3.9600'
os[:arch] == '64-bit'
```
