### PR TITLE
force encoding to utf-8

### DIFF
--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -5,7 +5,7 @@
 # license: All rights reserved
 
 module Inspec::Resources
-  class File < Inspec.resource(1)
+  class File < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     name 'file'
     desc 'Use the file InSpec audit resource to test all system file types, including files, directories, symbolic links, named pipes, sockets, character devices, block devices, and doors.'
     example "
@@ -29,12 +29,18 @@ module Inspec::Resources
     %w{
       type exist? file? block_device? character_device? socket? directory?
       symlink? pipe? mode mode? owner owned_by? group grouped_into? link_target
-      link_path linked_to? content mtime size selinux_label immutable?
+      link_path linked_to? mtime size selinux_label immutable?
       product_version file_version version? md5sum sha256sum
     }.each do |m|
       define_method m.to_sym do |*args|
         file.method(m.to_sym).call(*args)
       end
+    end
+
+    def content
+      res = file.content
+      return nil if res.nil?
+      res.force_encoding('utf-8')
     end
 
     def contain(*_)


### PR DESCRIPTION
This is just a starting point. In a few (rare or less so) cases, we retrieve data from target machines whose input will be written in a strange or ancient language. It's called non-utf-8 encoding. RSpec doesn't like it (or rather: it's formatter doesn't). Even without that, we should make sure to unify encodings across interfaces.

As a starting point, this only serves to relieve a small problem that is currently blocking me. Let's move this conversation to train later on.
