### PR TITLE
cmp matcher should compare expected string == number

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -248,6 +248,8 @@ RSpec::Matchers.define :cmp do |expected|
     # if actual and expected are strings
     if expected.is_a?(String) && actual.is_a?(String)
       actual.casecmp(expected) == 0
+    elsif expected.is_a?(String) && integer?(expected) && actual.is_a?(Integer)
+      expected.to_i == actual
     elsif expected.is_a?(Integer) && integer?(actual)
       expected == actual.to_i
     elsif expected.is_a?(Float) && float?(actual)

--- a/test/integration/test/integration/default/compare_matcher_spec.rb
+++ b/test/integration/test/integration/default/compare_matcher_spec.rb
@@ -29,4 +29,9 @@ if os.linux?
     it { should include 'root' }
     it { should_not cmp 'root' }
   end
+
+  len = passwd.passwords.length
+  describe len do
+    it { should cmp len.to_s }
+  end
 end


### PR DESCRIPTION
Enable `cmp` matcher to catch the case where expected is a number string, and actual is a number. This catches cases, where we expect `"2"`, but the returned value is `2`
