### PR TITLE
Resolved an issue checking ports on windows

### DIFF
--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -31,6 +31,10 @@ class Host < Inspec.resource(1)
     describe host('example.com') do
       it { should be_reachable }
     end
+or    
+    describe host('example.com', port: '80') do
+      it { should be_reachable }
+    end
   "
 
   def initialize(hostname, params = {})
@@ -48,7 +52,7 @@ class Host < Inspec.resource(1)
     end
   end
 
-  # if we get the IP adress, the host is resolvable
+  # if we get the IP address, the host is resolvable
   def resolvable?(type = nil)
     warn "The `host` resource ignores #{type} parameters. Continue to resolve host." if !type.nil?
     resolve.nil? || resolve.empty? ? false : true
@@ -59,7 +63,7 @@ class Host < Inspec.resource(1)
     ping.nil? ? false : ping
   end
 
-  # returns all A records of the IP adress, will return an array
+  # returns all A records of the IP address, will return an array
   def ipaddress
     resolve.nil? || resolve.empty? ? nil : resolve
   end
@@ -121,9 +125,8 @@ class WindowsHostProvider < HostProvider
     # TCP and port: Test-NetConnection -ComputerName www.microsoft.com -RemotePort 80
     request = "Test-NetConnection -ComputerName #{hostname}"
     request += " -RemotePort #{port}" unless port.nil?
-    request += '| Select-Object -Property ComputerName, RemoteAddress, RemotePort, SourceAddress, PingSucceeded | ConvertTo-Json'
+    request += '| Select-Object -Property ComputerName, RemoteAddress, RemotePort, SourceAddress, TcpTestSucceeded, PingSucceeded | ConvertTo-Json'
     p request
-    request += '| Select-Object -Property ComputerName, PingSucceeded | ConvertTo-Json'
     cmd = inspec.command(request)
 
     begin
@@ -132,7 +135,12 @@ class WindowsHostProvider < HostProvider
       return nil
     end
 
-    ping['PingSucceeded']
+    # Logic being if you provided a port you wanted to check it was open  
+    if port.nil?
+      ping['PingSucceeded']
+    else
+      ping['TcpTestSucceeded']
+    end
   end
 
   def resolve(hostname)


### PR DESCRIPTION
The previous version wasn't really checking if a port was accessible as we were only validating if the ping succeeded. Using the TcpTestSucceeded attribute to determine if the connection worked or not.

scenario being that there is a firewall in between filtering icmp

Added a working example to the help to allow the user to copy and paste the test
