### PR TITLE
add `describe.one`: collection of tests with at least one passing

### DIFF
--- a/docs/dsl_inspec.rst
+++ b/docs/dsl_inspec.rst
@@ -45,9 +45,22 @@ where
 * ``its('Port')`` is the matcher; ``{ should eq('22') }`` is the test. A ``describe`` block must contain at least one matcher, but may contain as many as required
 
 
-Author Tests
------------------------------------------------------
-It is recommended that test files are located in the ``/tests`` directory. When writing controls, the ``impact``, ``title``, ``desc`` metadata are _optional_, but are highly recommended.
+Advanced concepts
+=====================================================
+
+With inspec it is possible to check if at least one of a collection of checks is true. For example: If a setting is configured in two different locations, you may want to test if either configuration A or configuration B have been set. This is accomplished via ``describe.one``. It defines a block of tests with at least one valid check.
+
+.. code-block:: ruby
+
+   describe.one do
+     describe ConfigurationA do
+       its('setting_1') { should eq true }
+     end
+
+     describe ConfigurationB do
+       its('setting_2') { should eq true }
+     end
+   end
 
 Examples
 =====================================================

--- a/lib/inspec/describe.rb
+++ b/lib/inspec/describe.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+
+module Inspec
+  class DescribeBase
+    def initialize(action)
+      @action = action
+      @checks = []
+    end
+
+    # Evaluate the given block and collect all checks. These will be registered
+    # with the callback function under the 'describe.one' name.
+    #
+    # @param [Proc] ruby block containing checks (e.g. via describe)
+    # @return [nil]
+    def one(&block)
+      return unless block_given?
+      instance_eval(&block)
+      @action.call('describe.one', @checks, nil)
+    end
+
+    def describe(*args, &block)
+      @checks.push(['describe', args, block])
+    end
+  end
+end

--- a/lib/inspec/expect.rb
+++ b/lib/inspec/expect.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+# copyright: 2016, Chef Software Inc.
+# author: Dominik Richter
+# author: Christoph Hartmann
+
+require 'rspec/expectations'
+
+module Inspec
+  class Expect
+    attr_reader :calls, :value, :block
+    def initialize(value, &block)
+      @value = value
+      @block = block
+      @calls = []
+    end
+
+    def to(*args, &block)
+      @calls.push([:to, args, block, caller])
+    end
+
+    def not_to(*args, &block)
+      @calls.push([:not_to, args, block, caller])
+    end
+
+    def example_group
+      that = self
+
+      opts = { 'caller' => calls[0][3] }
+      if !calls[0][3].nil? && !calls[0][3].empty? &&
+         (m = calls[0][3][0].match(/^([^:]*):(\d+):/))
+        opts['file_path'] = m[0]
+        opts['line_number'] = m[1]
+      end
+
+      RSpec::Core::ExampleGroup.describe(that.value, opts) do
+        that.calls.each do |method, args, block, clr|
+          it(nil, caller: clr) do
+            x = expect(that.value, &that.block).method(method)
+            x.call(*args, &block)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This also includes:
- start the separation of expect and describe statements (i.e. give them their own file to be found more easily)
- bugfix: a global describe call without a block has resultet in a nil-checking failure

Next steps will have to target the example group structure, which is still bound to RSpec (last remaining close coupling) and the underlying check/test-registry.
