### PR TITLE
Fix license warning during gem build.

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Infrastructure and compliance testing.'
   spec.description   = 'InSpec provides a framework for creating end-to-end infrastructure tests. You can use it for integration or even compliance testing. Create fully portable test profiles and use them in your workflow to ensure stability and security. Integrate InSpec in your change lifecycle for local testing, CI/CD, and deployment verification.'
   spec.homepage      = 'https://github.com/chef/inspec'
-  spec.license       = 'Apache 2.0'
+  spec.license       = 'Apache-2.0'
 
   spec.files = %w{
     README.md Rakefile MAINTAINERS.toml MAINTAINERS.md LICENSE inspec.gemspec


### PR DESCRIPTION
WARNING:  WARNING: license value 'Apache 2.0' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
