### PR TITLE
adds a insecure option 

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -8,19 +8,20 @@ require 'uri'
 module Compliance
   # API Implementation does not hold any state by itself,
   # everything will be stored in local Configuration store
-  class API
+  class API # rubocop:disable Metrics/ClassLength
     # logs into the server, retrieves a token and stores it locally
-    def self.login(server, username, password)
+    def self.login(server, username, password, insecure)
       config = Compliance::Configuration.new
       config['server'] = server
       url = "#{server}/oauth/token"
 
-      success, data = Compliance::API.post(url, username, password)
+      success, data = Compliance::API.post(url, username, password, insecure)
       if !data.nil?
         tokendata = JSON.parse(data)
         if tokendata['access_token']
           config['user'] = username
           config['token'] = tokendata['access_token']
+          config['insecure'] = insecure
           config.store
           success = true
           msg = 'Successfully authenticated'
@@ -36,7 +37,7 @@ module Compliance
     def self.logout
       config = Compliance::Configuration.new
       url = "#{config['server']}/logout"
-      Compliance::API.post(url, config['token'], nil)
+      Compliance::API.post(url, config['token'], nil, config['insecure'])
       config.destroy
     end
 
@@ -45,7 +46,7 @@ module Compliance
       config = Compliance::Configuration.new
       url = "#{config['server']}/version"
 
-      _success, data = Compliance::API.get(url, nil, nil)
+      _success, data = Compliance::API.get(url, nil, nil, config['insecure'])
       if !data.nil?
         JSON.parse(data)
       else
@@ -56,9 +57,8 @@ module Compliance
     # return all compliance profiles available for the user
     def self.profiles
       config = Compliance::Configuration.new
-
       url = "#{config['server']}/user/compliance"
-      _success, data = get(url, config['token'], '')
+      _success, data = get(url, config['token'], '', config['insecure'])
 
       if !data.nil?
         profiles = JSON.parse(data)
@@ -86,28 +86,33 @@ module Compliance
       end
     end
 
-    def self.get(url, username, password)
+    def self.get(url, username, password, insecure)
       uri = URI.parse(url)
       req = Net::HTTP::Get.new(uri.path)
       req.basic_auth username, password
 
-      send_request(uri, req)
+      send_request(uri, req, insecure)
     end
 
-    def self.post(url, username, password)
+    def self.post(url, username, password, insecure)
       # form request
       uri = URI.parse(url)
       req = Net::HTTP::Post.new(uri.path)
       req.basic_auth username, password
       req.form_data={}
 
-      send_request(uri, req)
+      send_request(uri, req, insecure)
     end
 
     # upload a file
-    def self.post_file(url, username, password, file_path)
+    def self.post_file(url, username, password, file_path, insecure)
       uri = URI.parse(url)
       http = Net::HTTP.new(uri.host, uri.port)
+
+      # set connection flags
+      http.use_ssl = (uri.scheme == 'https')
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE if insecure
+
       req = Net::HTTP::Post.new(uri.path)
       req.basic_auth username, password
 
@@ -123,9 +128,13 @@ module Compliance
       [res.is_a?(Net::HTTPSuccess), res.body]
     end
 
-    def self.send_request(uri, req)
-      # send request
-      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') {|http|
+    def self.send_request(uri, req, insecure)
+      opts = {
+        use_ssl: uri.scheme == 'https',
+      }
+      opts[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if insecure
+
+      res = Net::HTTP.start(uri.host, uri.port, opts) {|http|
         http.request(req)
       }
       [res.is_a?(Net::HTTPSuccess), res.body]

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -13,8 +13,10 @@ module Compliance
       desc: 'Chef Compliance Username'
     option :password, type: :string, required: true,
       desc: 'Chef Compliance Password'
+    option :insecure, aliases: :k, type: :boolean,
+      desc: 'Explicitly allows InSpec to perform "insecure" SSL connections and transfers'
     def login(server)
-      success, msg = Compliance::API.login(server, options['user'], options['password'])
+      success, msg = Compliance::API.login(server, options['user'], options['password'], options['insecure'])
       if success
         puts 'Successfully authenticated'
       else
@@ -112,7 +114,7 @@ module Compliance
       url = "#{config['server']}/owners/#{owner}/compliance/#{profile_name}/tar"
 
       puts "Uploading to #{url}"
-      success, msg = Compliance::API.post_file(url, config['token'], '', archive_path)
+      success, msg = Compliance::API.post_file(url, config['token'], '', archive_path, config['insecure'])
       if success
         puts 'Successfully uploaded profile'
       else


### PR DESCRIPTION
This PR allows `inspec compliance profiles` to work with Chef Compliance servers that use self-signed ssl. During login, you have the `--insecure` or `-k` option.

`inspec compliance login https://yourserver/api --user=admin --password='admin' --insecure`

fixes #511
