### PR TITLE
expose control impacts in json

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -21,6 +21,7 @@ module RSpec::Core::Formatters
         run_time: example.execution_result.run_time,
         pending_message: example.execution_result.pending_message,
         id: example.metadata[:id],
+        impact: example.metadata[:impact],
       }
     end
   end

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -155,7 +155,7 @@ module Inspec
         # scope.
         dsl = Inspec::Resource.create_dsl(backend)
         example.send(:include, dsl)
-        @test_collector.add_test(example, rule_id)
+        @test_collector.add_test(example, rule_id, rule)
       end
     end
   end

--- a/lib/inspec/runner_mock.rb
+++ b/lib/inspec/runner_mock.rb
@@ -9,7 +9,7 @@ module Inspec
       @tests = []
     end
 
-    def add_test(example, _rule_id)
+    def add_test(example, _rule_id, _rule)
       @tests.push(example)
     end
 

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -34,8 +34,8 @@ module Inspec
     # @param [RSpecExampleGroup] example test
     # @param [String] rule_id the ID associated with this check
     # @return [nil]
-    def add_test(example, rule_id)
-      set_rspec_ids(example, rule_id)
+    def add_test(example, rule_id, rule)
+      set_rspec_ids(example, rule_id, rule)
       @tests.register(example)
     end
 
@@ -92,13 +92,15 @@ module Inspec
     # @param [RSpecExampleGroup] example object which contains a check
     # @param [Type] id describe id
     # @return [Type] description of returned object
-    def set_rspec_ids(example, id)
+    def set_rspec_ids(example, id, rule)
       example.metadata[:id] = id
+      example.metadata[:impact] = rule.impact
       example.filtered_examples.each do |e|
         e.metadata[:id] = id
+        e.metadata[:impact] = rule.impact
       end
       example.children.each do |child|
-        set_rspec_ids(child, id)
+        set_rspec_ids(child, id, rule)
       end
     end
   end


### PR DESCRIPTION
basically get `--format json` to include `impact` fields
