### PR TITLE
Rename internal File and OS resource classes

### DIFF
--- a/lib/resources/apache.rb
+++ b/lib/resources/apache.rb
@@ -14,12 +14,12 @@ module Inspec::Resources
       when 'ubuntu', 'debian'
         @service = 'apache2'
         @conf_dir = '/etc/apache2/'
-        @conf_path = ::File.join @conf_dir, 'apache2.conf'
+        @conf_path = File.join @conf_dir, 'apache2.conf'
         @user = 'www-data'
       else
         @service = 'httpd'
         @conf_dir = '/etc/httpd/'
-        @conf_path = ::File.join @conf_dir, '/conf/httpd.conf'
+        @conf_path = File.join @conf_dir, '/conf/httpd.conf'
         @user = 'apache'
       end
     end

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -21,7 +21,7 @@ module Inspec::Resources
 
     def initialize(conf_path = nil)
       @conf_path = conf_path || inspec.apache.conf_path
-      @conf_dir = ::File.dirname(@conf_path)
+      @conf_dir = File.dirname(@conf_path)
       @files_contents = {}
       @content = nil
       @params = nil
@@ -105,7 +105,7 @@ module Inspec::Resources
 
       includes = []
       (include_files + include_files_optional).each do |f|
-        id = ::File.join(@conf_dir, f)
+        id = File.join(@conf_dir, f)
         files = find_files(id, depth: 1, type: 'file')
 
         includes.push(files) if files

--- a/lib/resources/bond.rb
+++ b/lib/resources/bond.rb
@@ -5,7 +5,7 @@
 require 'resources/file'
 
 module Inspec::Resources
-  class Bond < File
+  class Bond < FileResource
     name 'bond'
     desc 'Use the bond InSpec audit resource to test a logical, bonded network interface (i.e. "two or more network interfaces aggregated into a single, logical network interface"). On Linux platforms, any value in the /proc/net/bonding directory may be tested.'
     example "

--- a/lib/resources/directory.rb
+++ b/lib/resources/directory.rb
@@ -5,7 +5,7 @@
 require 'resources/file'
 
 module Inspec::Resources
-  class Directory < File
+  class Directory < FileResource
     name 'directory'
     desc 'Use the directory InSpec audit resource to test if the file type is a directory. This is equivalent to using the file InSpec audit resource and the be_directory matcher, but provides a simpler and more direct way to test directories. All of the matchers available to file may be used with directory.'
     example "

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -5,7 +5,7 @@
 # license: All rights reserved
 
 module Inspec::Resources
-  class File < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
+  class FileResource < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     name 'file'
     desc 'Use the file InSpec audit resource to test all system file types, including files, directories, symbolic links, named pipes, sockets, character devices, block devices, and doors.'
     example "

--- a/lib/resources/mysql_conf.rb
+++ b/lib/resources/mysql_conf.rb
@@ -89,7 +89,7 @@ module Inspec::Resources
         to_read = to_read.drop(1)
         # see if there is more stuff to include
 
-        dir = ::File.dirname(cur_file)
+        dir = File.dirname(cur_file)
         to_read += include_files(dir, raw_conf).find_all do |fp|
           not @files_contents.key? fp
         end
@@ -110,7 +110,7 @@ module Inspec::Resources
 
     def abs_path(dir, f)
       return f if f.start_with? '/'
-      ::File.join(dir, f)
+      File.join(dir, f)
     end
 
     def read_file(path)

--- a/lib/resources/os.rb
+++ b/lib/resources/os.rb
@@ -3,7 +3,7 @@
 # author: Christoph Hartmann
 
 module Inspec::Resources
-  class OS < Inspec.resource(1)
+  class OSResource < Inspec.resource(1)
     name 'os'
     desc 'Use the os InSpec audit resource to test the platform on which the system is running.'
     example "

--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -16,19 +16,19 @@ module Inspec::Resources
         @data_dir = '/var/lib/postgresql'
         @version = inspec.command('ls /etc/postgresql/').stdout.chomp
         @conf_dir = "/etc/postgresql/#{@version}/main"
-        @conf_path = ::File.join @conf_dir, 'postgresql.conf'
+        @conf_path = File.join @conf_dir, 'postgresql.conf'
 
       when 'arch'
         @service = 'postgresql'
         @data_dir = '/var/lib/postgres/data'
         @conf_dir = '/var/lib/postgres/data'
-        @conf_path = ::File.join @conf_dir, 'postgresql.conf'
+        @conf_path = File.join @conf_dir, 'postgresql.conf'
 
       else
         @service = 'postgresql'
         @data_dir = '/var/lib/postgresql'
         @conf_dir = '/var/lib/pgsql/data'
-        @conf_path = ::File.join @conf_dir, 'postgresql.conf'
+        @conf_path = File.join @conf_dir, 'postgresql.conf'
       end
     end
 

--- a/lib/resources/postgres_conf.rb
+++ b/lib/resources/postgres_conf.rb
@@ -22,7 +22,7 @@ module Inspec::Resources
 
     def initialize(conf_path = nil)
       @conf_path = conf_path || inspec.postgres.conf_path
-      @conf_dir = ::File.expand_path(::File.dirname(@conf_path))
+      @conf_dir = File.expand_path(File.dirname(@conf_path))
       @files_contents = {}
       @content = nil
       @params = nil

--- a/test/unit/resources/file_test.rb
+++ b/test/unit/resources/file_test.rb
@@ -18,7 +18,7 @@ def shared_file_permission_tests(method_under_test)
   end
 end
 
-describe Inspec::Resources::File do
+describe Inspec::Resources::FileResource do
   let(:resource) { load_resource('file', '/fakepath/fakefile') }
 
   describe '#readable?' do

--- a/test/unit/resources/mount_test.rb
+++ b/test/unit/resources/mount_test.rb
@@ -5,7 +5,7 @@
 require 'helper'
 require 'inspec/resource'
 
-describe Inspec::Resources::File do
+describe Inspec::Resources::FileResource do
   let(:root_resource) { load_resource('mount', '/') }
 
   it 'parses the mount data properly' do


### PR DESCRIPTION
This is a follow-up to https://github.com/chef/inspec/pull/526 by @adamleff . Although it already prevents clashes on the global plane, I still think it's easy enough to accidentally call `File` inside a new resource and instead of getting `::File` you get access to inspec's internal resource - which leads to potentially frustrating debugging. So as an additional layer to the MR ^^, we rename these resources and re-expose simple `File` calls, i.e. detect any problems early on.
