### PR TITLE
Fixed API calls for inspec compliance

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -10,10 +10,10 @@ module Compliance
   # everything will be stored in local Configuration store
   class API # rubocop:disable Metrics/ClassLength
     # logs into the server, retrieves a token and stores it locally
-    def self.login(server, username, password, insecure)
+    def self.login(server, username, password, insecure, apipath)
       config = Compliance::Configuration.new
-      config['server'] = server
-      url = "#{server}/oauth/token"
+      config['server'] = "#{server}#{apipath}"
+      url = "#{config['server']}/oauth/token"
 
       success, data = Compliance::API.post(url, username, password, insecure)
       if !data.nil?

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -16,8 +16,10 @@ module Compliance
       desc: 'Chef Compliance Password'
     option :insecure, aliases: :k, type: :boolean,
       desc: 'Explicitly allows InSpec to perform "insecure" SSL connections and transfers'
+    option :apipath, type: :string, default: '/api',
+      desc: 'Set the path to the API, defaults to /api'
     def login(server)
-      success, msg = Compliance::API.login(server, options['user'], options['password'], options['insecure'])
+      success, msg = Compliance::API.login(server, options['user'], options['password'], options['insecure'], options['apipath'])
       if success
         puts 'Successfully authenticated'
       else


### PR DESCRIPTION
Since the API of chef compliance is reachable via https://$YOUR_SERVER/api/$API_CALL the /api was missing in chef-compliance api calls. Using the cli for compliance, you could just give the /api part with your server url, but that is not really intuitive.
