### PR TITLE
adding named resource registry classes

### DIFF
--- a/lib/inspec/plugins/resource.rb
+++ b/lib/inspec/plugins/resource.rb
@@ -2,6 +2,8 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 
+require 'inspec/resource'
+
 module Inspec
   module Plugins
     class Resource
@@ -50,8 +52,10 @@ module Inspec
         end
         # rubocop:enable Lint/NestedMethodDefinition
 
-        # add the resource to the registry by name
-        Inspec::Resource.registry[name] = cl
+        # add the resource to the registry by name with a newly-named registry class
+        klass_name = name.split('_').map(&:capitalize).join
+        Inspec::Resource::Registry.const_set(klass_name, cl)
+        Inspec::Resource.registry[name] = Inspec::Resource::Registry.const_get(klass_name)
       end
 
       # Define methods which are available to all resources

--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -8,6 +8,10 @@ require 'inspec/plugins'
 
 module Inspec
   class Resource
+    class Registry
+      # empty class for namespacing resource classes in the registry
+    end
+
     def self.registry
       @registry ||= {}
     end

--- a/test/unit/plugins/resource_test.rb
+++ b/test/unit/plugins/resource_test.rb
@@ -1,0 +1,60 @@
+require 'helper'
+
+describe Inspec::Plugins::Resource do
+  let(:base) { Inspec::Plugins::Resource }
+
+  describe '#name' do
+    it "won't register a nil resource" do
+      Class.new(base) do name nil; end
+      Inspec::Resource.registry.keys.wont_include nil
+      Inspec::Resource.registry.keys.wont_include ''
+    end
+
+    it "will register a valid name" do
+      Class.new(base) do name 'hello'; end
+      Inspec::Resource.registry['hello'].wont_be :nil?
+    end
+
+    it "will create a good class name" do
+      Class.new(base) do name 'hello_world'; end
+      Inspec::Resource.registry['hello_world'].to_s
+                      .must_equal 'Inspec::Resource::Registry::HelloWorld'
+    end
+  end
+
+  def create(&block)
+    random_name = (0...50).map { (65 + rand(26)).chr }.join
+    Class.new(base) do
+      name random_name
+      instance_eval &block
+    end
+    Inspec::Resource.registry[random_name]
+  end
+
+  describe '#desc' do
+    it "will register a description" do
+      expected = rand.to_s
+      create { desc expected }.desc.must_equal expected
+    end
+
+    it "can change the description" do
+      c = create { desc rand.to_s }
+      c.desc(x = rand.to_s)
+      c.desc.must_equal x
+    end
+  end
+
+  describe '#example' do
+    it "will register a description" do
+      expected = rand.to_s
+      create { example expected }.example.must_equal expected
+    end
+
+    it "can change the description" do
+      c = create { example rand.to_s }
+      c.example(x = rand.to_s)
+      c.example.must_equal x
+    end
+  end
+
+end


### PR DESCRIPTION
This is a cosmetic change to give the anonymous registry classes names to make it a bit clearer where to look when debugging in Pry.

The registry will look more like this:

```
"apache_conf"=>Inspec::Resource::Registry::ApacheConf,
"apt"=>Inspec::Resource::Registry::Apt,
"ppa"=>Inspec::Resource::Registry::Ppa,
"audit_policy"=>Inspec::Resource::Registry::AuditPolicy,
```

... instead of this:

```
"apache_conf"=>#<Class:0x007f991d4a0fc0>,
"apt"=>#<Class:0x007f991d482e58>,
"ppa"=>#<Class:0x007f991d482228>,
"audit_policy"=>#<Class:0x007f991d4799e8>,
```
