### PR TITLE
dont generate pretty json by default

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -28,7 +28,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
     profile = Inspec::Profile.for_target(target, o)
     dst = o[:output].to_s
     if dst.empty?
-      puts JSON.pretty_generate(profile.info)
+      puts JSON.dump(profile.info)
     else
       if File.exist? dst
         puts "----> updating #{dst}"


### PR DESCRIPTION
we have [jq](https://stedolan.github.io/jq/) for that!

having json in one line makes parsing easier. Also: this is meant for machine-to-machine cases; use jq to make it more machine-to-developer friendly:

``` bash
inspec json example/profile | jq .
```
