### PR TITLE
add fulljson formatter

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -3,6 +3,7 @@
 # author: Christoph Hartmann
 
 require 'rspec/core'
+require 'rspec/core/formatters/json_formatter'
 
 # Extend the basic RSpec JSON Formatter
 # to give us an ID in its output
@@ -21,10 +22,34 @@ module RSpec::Core::Formatters
         run_time: example.execution_result.run_time,
         pending_message: example.execution_result.pending_message,
         id: example.metadata[:id],
-        impact: example.metadata[:impact],
-        title: example.metadata[:title],
-        desc: example.metadata[:desc],
       }
     end
+  end
+end
+
+class InspecRspecFormatter < RSpec::Core::Formatters::JsonFormatter
+  RSpec::Core::Formatters.register self, :message, :dump_summary, :dump_profile, :stop, :close
+
+  private
+
+  def format_example(example)
+    res = {
+      id: example.metadata[:id],
+      title: example.metadata[:title],
+      desc: example.metadata[:desc],
+      code: example.metadata[:code],
+      impact: example.metadata[:impact],
+      status: example.execution_result.status.to_s,
+      code_desc: example.full_description,
+      ref: example.metadata['file_path'],
+      ref_line: example.metadata['line_number'],
+      run_time: example.execution_result.run_time,
+      start_time: example.execution_result.started_at.to_s,
+    }
+
+    # pending messages are embedded in the resources description
+    res[:pending] = example.metadata[:description] if res[:status] == 'pending'
+
+    res
   end
 end

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -22,6 +22,7 @@ module RSpec::Core::Formatters
         run_time: example.execution_result.run_time,
         pending_message: example.execution_result.pending_message,
         id: example.metadata[:id],
+        impact: example.metadata[:impact],
       }
     end
   end
@@ -29,6 +30,20 @@ end
 
 class InspecRspecFormatter < RSpec::Core::Formatters::JsonFormatter
   RSpec::Core::Formatters.register self, :message, :dump_summary, :dump_profile, :stop, :close
+
+  def add_profile(profile)
+    @profiles ||= []
+    @profiles.push(profile)
+  end
+
+  def dump_summary(summary)
+    super(summary)
+    @output_hash[:profiles] = @profiles.map do |profile|
+      r = profile.params.dup
+      r.delete(:rules)
+      r
+    end
+  end
 
   private
 

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -55,6 +55,7 @@ module Inspec
     def add_profile(profile, options = {})
       return unless options[:ignore_supports] ||
                     profile.metadata.supports_transport?(@backend)
+      @test_collector.add_profile(profile)
 
       libs = profile.libraries.map do |k, v|
         { ref: k, content: v }

--- a/lib/inspec/runner_mock.rb
+++ b/lib/inspec/runner_mock.rb
@@ -4,9 +4,14 @@
 
 module Inspec
   class RunnerMock
-    attr_reader :tests
+    attr_reader :tests, :profiles
     def initialize
       @tests = []
+      @profiles = []
+    end
+
+    def add_profile(profile)
+      @profiles.push(profile)
     end
 
     def add_test(example, _rule_id, _rule)

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -29,6 +29,18 @@ module Inspec
       RSpec::Core::ExampleGroup.describe(*args, &block)
     end
 
+    # Add a full profile to the runner. Only pulls in metadata
+    #
+    # @param [Inspec::Profile] profile
+    # @return [nil]
+    def add_profile(profile)
+      RSpec.configuration.formatters
+           .find_all { |c| c.is_a? InspecRspecFormatter }
+           .each do |fmt|
+        fmt.add_profile(profile)
+      end
+    end
+
     # Add an example group to the list of registered tests.
     #
     # @param [RSpecExampleGroup] example test

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -81,7 +81,9 @@ module Inspec
         RSpec.configuration.output_stream = @conf['output']
       end
 
-      RSpec.configuration.add_formatter(@conf['format'] || 'progress')
+      format = @conf['format'] || 'progress'
+      format = 'InspecRspecFormatter' if format == 'fulljson'
+      RSpec.configuration.add_formatter(format)
       RSpec.configuration.color = @conf['color']
 
       setup_reporting if @conf['report']

--- a/test/functional/command_test.rb
+++ b/test/functional/command_test.rb
@@ -250,6 +250,84 @@ describe 'Inspec::InspecCLI' do
         ex3['pending_message'].must_equal 'Not yet implemented'
       end
     end
+
+    describe 'execute a profile with fulljson formatting' do
+      let(:json) { JSON.load(inspec('exec ' + path + ' --format fulljson').stdout) }
+      let(:examples) { json['examples'] }
+      let(:metadata) { json['profiles'][0] }
+      let(:ex1) { examples.find{|x| x['id'] == 'tmp-1.0'} }
+      let(:ex2) { examples.find{|x| x['id'] =~ /generated/} }
+      let(:ex3) { examples.find{|x| x['id'] == 'gordon-1.0'} }
+
+      it 'has all the metadata' do
+        metadata.must_equal({
+          "name" => "profile",
+          "title" => "InSpec Example Profile",
+          "maintainer" => "Chef Software, Inc.",
+          "copyright" => "Chef Software, Inc.",
+          "copyright_email" => "support@chef.io",
+          "license" => "Apache 2 license",
+          "summary" => "Demonstrates the use of InSpec Compliance Profile",
+          "version" => "1.0.0",
+          "supports" => [{"os-family" => "linux"}]
+        })
+      end
+
+      it 'must have 3 examples' do
+        json['examples'].length.must_equal 3
+      end
+
+      it 'id in json' do
+        examples.find { |ex| !ex.key? 'id' }.must_be :nil?
+      end
+
+      it 'title in json' do
+        ex3['title'].must_equal 'Verify the version number of Gordon'
+      end
+
+      it 'desc in json' do
+        ex3['desc'].must_equal 'An optional description...'
+      end
+
+      it 'code in json' do
+        ex3['code'].wont_be :nil?
+      end
+
+      it 'code_desc in json' do
+        ex3['code_desc'].wont_be :nil?
+      end
+
+      it 'impact in json' do
+        ex1['impact'].must_equal 0.7
+        ex2['impact'].must_be :nil?
+      end
+
+      it 'status in json' do
+        ex1['status'].must_equal 'passed'
+        ex3['status'].must_equal 'pending'
+      end
+
+      it 'ref in json' do
+        ex1['ref'].must_match %r{examples/profile/controls/example.rb$}
+      end
+
+      it 'ref_line in json' do
+        ex1['ref_line'].must_equal 14
+      end
+
+      it 'run_time in json' do
+        ex1['run_time'].wont_be :nil?
+      end
+
+      it 'start_time in json' do
+        ex1['start_time'].wont_be :nil?
+      end
+
+      it 'pending message in json' do
+        ex1['pending'].must_be :nil?
+        ex3['pending'].must_equal "Can't find file \"/etc/gordon/config.yaml\""
+      end
+    end
   end
 
   describe 'example inheritance profile' do


### PR DESCRIPTION
This is a separate formatter which will always include all information on controls. For regular json runs this is most likely too noisy.

``` bash
inspec exec example/profile --format fulljson
```

snips from example output:

``` json
  "examples": [
    {
      "id": "tmp-1.0",
      "title": "Create /tmp directory",
      "desc": "An optional description...",
      "code": "control \"tmp-1.0\" do                        # A unique ID for this control\n  impact 0.7                                # The criticality, if this control fails.\n  title \"Create /tmp directory\"             # A human-readable title\n  desc \"An optional description...\"         # Describe why this is needed\n  ref \"Document A-12\", url: 'http://...'    # Additional references\n\n  describe file('/tmp') do                  # The actual test\n    it { should be_directory }\n  end\nend\n",
      "impact": 0.7,
      "status": "passed",
      "code_desc": "File /tmp should be directory",
      "ref": "examples/profile/controls/example.rb",
      "ref_line": 14,
      "run_time": 0.001749978,
      "start_time": "2016-03-18 02:45:29 +0100"
    }]

  "profiles": [
    {
      "name": "profile",
      "title": "InSpec Example Profile",
      "maintainer": "Chef Software, Inc.",
      "copyright": "Chef Software, Inc.",
...
```
