### PR TITLE
add `wmi` resource

### DIFF
--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -99,6 +99,7 @@ require 'resources/user'
 require 'resources/vbscript'
 require 'resources/windows_feature'
 require 'resources/xinetd'
+require 'resources/wmi'
 require 'resources/yum'
 
 # file formats, depend on json implementation

--- a/lib/resources/json.rb
+++ b/lib/resources/json.rb
@@ -2,6 +2,8 @@
 # author: Christoph Hartmann
 # author: Dominik Richter
 
+require 'utils/object_traversal'
+
 module Inspec::Resources
   class JsonConfig < Inspec.resource(1)
     name 'json'
@@ -11,6 +13,8 @@ module Inspec::Resources
         its('cookbook_locks.omnibus.version') { should eq('2.2.0') }
       end
     "
+
+    include ObjectTraverser
 
     # make params readable
     attr_reader :params
@@ -58,27 +62,6 @@ module Inspec::Resources
 
     def to_s
       "Json #{@path}"
-    end
-
-    private
-
-    def extract_value(keys, value)
-      key = keys.shift
-      return nil if key.nil?
-
-      # if value is an array, iterate over each child
-      if value.is_a?(Array)
-        value = value.map { |i|
-          extract_value([key], i)
-        }
-      else
-        value = value[key.to_s].nil? ? nil : value[key.to_s]
-      end
-
-      # if there are no more keys, just return the value
-      return value if keys.first.nil?
-      # if there are more keys, extract more
-      extract_value(keys.clone, value)
     end
   end
 end

--- a/lib/resources/wmi.rb
+++ b/lib/resources/wmi.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+class WMI < Inspec.resource(1)
+  name 'wmi'
+  desc 'request wmi information'
+  example "
+    describe wmi('RSOP_SecuritySettingNumeric', {
+      namespace: 'root\\rsop\\computer',
+      filter: 'KeyName = 'MinimumPasswordAge' And precedence=1'
+    }) do
+       its('Setting') { should eq true }
+    end
+  "
+
+  # This would be the same as:
+  # WMIC /NAMESPACE:\\root\rsop\computer PATH RSOP_SecuritySettingNumeric WHERE "KeyName = 'MinimumPasswordAge' And precedence=1" GET Setting
+  attr_accessor :content
+  def initialize(wmiclass, opts)
+    @wmiclass = wmiclass
+    @wminamespace = opts[:namespace]
+    @wmifilter = opts[:filter]
+
+    # verify that this resource is only supported on Windows
+    return skip_resource 'The `windows_feature` resource is not supported on your OS.' unless inspec.os.windows?
+  end
+
+  # returns nil, if not existant or value
+  def method_missing(property)
+    info[property.to_s]
+  end
+
+  def to_s
+    "WMI #{@wmiclass} where #{@wmifilter}"
+  end
+
+  def info
+    return @content if defined?(@content)
+    @content = {}
+    cmd = inspec.command("Get-WmiObject -namespace #{@wminamespace} -class #{@wmiclass} -filter \"#{@wmifilter}\" | ConvertTo-Json")
+    @content = JSON.parse(cmd.stdout)
+    # sometimes we get multiple values
+    if @content.is_a?(Array)
+      # select the first entry
+      @content = @content.first
+    end
+  rescue JSON::ParserError => e
+    @content
+  end
+end

--- a/lib/resources/wmi.rb
+++ b/lib/resources/wmi.rb
@@ -4,61 +4,62 @@
 
 require 'utils/object_traversal'
 
-class WMI < Inspec.resource(1)
-  name 'wmi'
-  desc 'request wmi information'
-  example "
-    describe wmi('RSOP_SecuritySettingNumeric', {
-      namespace: 'root\\rsop\\computer',
-      filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
-    }) do
-       its('Setting') { should eq true }
+module Inspec::Resources
+  class WMI < Inspec.resource(1)
+    name 'wmi'
+    desc 'request wmi information'
+    example "
+      describe wmi('RSOP_SecuritySettingNumeric', {
+        namespace: 'root\\rsop\\computer',
+        filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
+      }) do
+         its('Setting') { should eq true }
+      end
+    "
+
+    include ObjectTraverser
+
+    # This would be the same as:
+    # WMIC /NAMESPACE:\\root\rsop\computer PATH RSOP_SecuritySettingNumeric WHERE "KeyName = 'MinimumPasswordAge' And precedence=1" GET Setting
+    attr_accessor :content
+    def initialize(wmiclass, opts = {})
+      @wmiclass = wmiclass
+      @wminamespace = opts[:namespace]
+      @wmifilter = opts[:filter]
+
+      # verify that this resource is only supported on Windows
+      return skip_resource 'The `windows_feature` resource is not supported on your OS.' unless inspec.os.windows?
     end
-  "
 
-  include ObjectTraverser
+    # returns nil, if not existant or value
+    def method_missing(*keys)
+      # catch bahavior of rspec its implementation
+      # @see https://github.com/rspec/rspec-its/blob/master/lib/rspec/its.rb#L110
+      keys.shift if keys.is_a?(Array) && keys[0] == :[]
+      value(keys)
+    end
 
-  # This would be the same as:
-  # WMIC /NAMESPACE:\\root\rsop\computer PATH RSOP_SecuritySettingNumeric WHERE "KeyName = 'MinimumPasswordAge' And precedence=1" GET Setting
-  attr_accessor :content
-  def initialize(wmiclass, opts = {})
-    @wmiclass = wmiclass
-    @wminamespace = opts[:namespace]
-    @wmifilter = opts[:filter]
+    def value(key)
+      extract_value(key, info)
+    end
 
-    # verify that this resource is only supported on Windows
-    return skip_resource 'The `windows_feature` resource is not supported on your OS.' unless inspec.os.windows?
+    def info
+      return @content if defined?(@content)
+      @content = {}
+
+      # optional params
+      cmd_namespace = "-namespace #{@wminamespace}" unless @wminamespace.nil?
+      cmd_filter = "-filter \"#{@wmifilter}\"" unless @wmifilter.nil?
+
+      # run wmi command
+      cmd = inspec.command("Get-WmiObject -class #{@wmiclass} #{cmd_namespace} #{cmd_filter} | ConvertTo-Json")
+      @content = JSON.parse(cmd.stdout)
+    rescue JSON::ParserError => e
+      @content
+    end
+
+    def to_s
+      "WMI #{@wmiclass} where #{@wmifilter}"
+    end
   end
-
-  # returns nil, if not existant or value
-  def method_missing(*keys)
-    # catch bahavior of rspec its implementation
-    # @see https://github.com/rspec/rspec-its/blob/master/lib/rspec/its.rb#L110
-    keys.shift if keys.is_a?(Array) && keys[0] == :[]
-    value(keys)
-  end
-
-  def value(key)
-    extract_value(key, info)
-  end
-
-  def info
-    return @content if defined?(@content)
-    @content = {}
-
-    # optional params
-    cmd_namespace = "-namespace #{@wminamespace}" unless @wminamespace.nil?
-    cmd_filter = "-filter \"#{@wmifilter}\"" unless @wmifilter.nil?
-
-    # run wmi command
-    cmd = inspec.command("Get-WmiObject -class #{@wmiclass} #{cmd_namespace} #{cmd_filter} | ConvertTo-Json")
-    @content = JSON.parse(cmd.stdout)
-  rescue JSON::ParserError => e
-    @content
-  end
-
-  def to_s
-    "WMI #{@wmiclass} where #{@wmifilter}"
-  end
-
 end

--- a/lib/resources/wmi.rb
+++ b/lib/resources/wmi.rb
@@ -2,22 +2,26 @@
 # author: Christoph Hartmann
 # author: Dominik Richter
 
+require 'utils/object_traversal'
+
 class WMI < Inspec.resource(1)
   name 'wmi'
   desc 'request wmi information'
   example "
     describe wmi('RSOP_SecuritySettingNumeric', {
       namespace: 'root\\rsop\\computer',
-      filter: 'KeyName = 'MinimumPasswordAge' And precedence=1'
+      filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
     }) do
        its('Setting') { should eq true }
     end
   "
 
+  include ObjectTraverser
+
   # This would be the same as:
   # WMIC /NAMESPACE:\\root\rsop\computer PATH RSOP_SecuritySettingNumeric WHERE "KeyName = 'MinimumPasswordAge' And precedence=1" GET Setting
   attr_accessor :content
-  def initialize(wmiclass, opts)
+  def initialize(wmiclass, opts = {})
     @wmiclass = wmiclass
     @wminamespace = opts[:namespace]
     @wmifilter = opts[:filter]
@@ -27,25 +31,34 @@ class WMI < Inspec.resource(1)
   end
 
   # returns nil, if not existant or value
-  def method_missing(property)
-    info[property.to_s]
+  def method_missing(*keys)
+    # catch bahavior of rspec its implementation
+    # @see https://github.com/rspec/rspec-its/blob/master/lib/rspec/its.rb#L110
+    keys.shift if keys.is_a?(Array) && keys[0] == :[]
+    value(keys)
+  end
+
+  def value(key)
+    extract_value(key, info)
+  end
+
+  def info
+    return @content if defined?(@content)
+    @content = {}
+
+    # optional params
+    cmd_namespace = "-namespace #{@wminamespace}" unless @wminamespace.nil?
+    cmd_filter = "-filter \"#{@wmifilter}\"" unless @wmifilter.nil?
+
+    # run wmi command
+    cmd = inspec.command("Get-WmiObject -class #{@wmiclass} #{cmd_namespace} #{cmd_filter} | ConvertTo-Json")
+    @content = JSON.parse(cmd.stdout)
+  rescue JSON::ParserError => e
+    @content
   end
 
   def to_s
     "WMI #{@wmiclass} where #{@wmifilter}"
   end
 
-  def info
-    return @content if defined?(@content)
-    @content = {}
-    cmd = inspec.command("Get-WmiObject -namespace #{@wminamespace} -class #{@wmiclass} -filter \"#{@wmifilter}\" | ConvertTo-Json")
-    @content = JSON.parse(cmd.stdout)
-    # sometimes we get multiple values
-    if @content.is_a?(Array)
-      # select the first entry
-      @content = @content.first
-    end
-  rescue JSON::ParserError => e
-    @content
-  end
 end

--- a/lib/utils/object_traversal.rb
+++ b/lib/utils/object_traversal.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+module ObjectTraverser
+  def extract_value(keys, value)
+    key = keys.shift
+    return nil if key.nil?
+
+    # if value is an array, iterate over each child
+    if value.is_a?(Array)
+      value = value.map { |i|
+        extract_value([key], i)
+      }
+    else
+      value = value[key.to_s].nil? ? nil : value[key.to_s]
+    end
+
+    # if there are no more keys, just return the value
+    return value if keys.first.nil?
+    # if there are more keys, extract more
+    extract_value(keys.clone, value)
+  end
+end

--- a/lib/utils/object_traversal.rb
+++ b/lib/utils/object_traversal.rb
@@ -4,7 +4,7 @@
 module ObjectTraverser
   def extract_value(keys, value)
     key = keys.shift
-    return nil if key.nil?
+    return nil if key.nil? || value.nil?
 
     # if value is an array, iterate over each child
     if value.is_a?(Array)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -237,6 +237,8 @@ class MockLoader
       'netstat -an -f inet -f inet6' => cmd.call('s11-netstat-an-finet-finet6'),
       # xinetd configuration
       'find /etc/xinetd.d -type f' => cmd.call('find-xinetd.d'),
+      # wmi test
+      "Get-WmiObject -class win32_service  -filter \"name like '%winrm%'\" | ConvertTo-Json" => cmd.call('get-wmiobject'),
     }
 
     @backend

--- a/test/integration/default/wmi_spec.rb
+++ b/test/integration/default/wmi_spec.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+# Get-WmiObject win32_service
+# Get-WmiObject -class win32_service
+# returns an array of service objects
+describe wmi('win32_service') do
+  its(['Path','ClassName']) { should include 'Win32_Service' }
+  its('DisplayName') { should include 'Windows Remote Management (WS-Management)'}
+end
+
+# Use win32_service with filter
+# this returns a single service object
+describe wmi('win32_service', {
+  filter: "name like '%winrm%'"
+}) do
+  its(['Path','ClassName']) { should eq 'Win32_Service' }
+  its('DisplayName') { should eq 'Windows Remote Management (WS-Management)'}
+end
+
+# TODO: this works on domain controllers only
+describe wmi('RSOP_SecuritySettingNumeric', {
+  namespace: 'root\\rsop\\computer',
+  filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
+}) do
+   its('Setting') { should eq 1 }
+end

--- a/test/unit/mock/cmd/get-wmiobject
+++ b/test/unit/mock/cmd/get-wmiobject
@@ -1,0 +1,10 @@
+{
+    "Path":  {
+                 "ClassName":  "Win32_Service"
+             },
+    "Caption":  "Windows Remote Management (WS-Management)",
+    "CreationClassName":  "Win32_Service",
+    "DisplayName":  "Windows Remote Management (WS-Management)",
+    "Name":  "WinRM",
+    "PathName":  "C:\\Windows\\System32\\svchost.exe -k NetworkService"
+}

--- a/test/unit/resources/wmi_test.rb
+++ b/test/unit/resources/wmi_test.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+require 'helper'
+require 'inspec/resource'
+
+describe 'Inspec::Resources::WMI' do
+
+  # Check the following as unit test
+  # describe wmi('win32_service', {
+  #   filter: "name like '%winrm%'"
+  # }) do
+  #   its(['Path','ClassName']) { should eq 'Win32_Service' }
+  #   its('DisplayName') { should eq 'Windows Remote Management (WS-Management)'}
+  # end
+
+  # windows
+  it 'verify wmi parsing on windows' do
+    resource = MockLoader.new(:windows).load_resource('wmi', 'win32_service', { filter: "name like '%winrm%'" })
+    _(resource.send('DisplayName')).must_equal 'Windows Remote Management (WS-Management)'
+    _(resource.send('method_missing', 'Path', 'ClassName')).must_equal 'Win32_Service'
+  end
+
+  # ubuntu 14.04 with upstart
+  it 'fail wmi on ubuntu' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('wmi', 'win32_service', { filter: "name like '%winrm%'" })
+    _(resource.send('DisplayName')).must_equal nil
+    _(resource.send('method_missing', 'Path', 'ClassName')).must_equal nil
+  end
+
+  # centos 7 with systemd
+  it 'fail wmi on centos' do
+    resource = MockLoader.new(:centos7).load_resource('wmi', 'win32_service', { filter: "name like '%winrm%'" })
+    _(resource.send('DisplayName')).must_equal nil
+    _(resource.send('method_missing', 'Path', 'ClassName')).must_equal nil
+  end
+
+  # unknown OS
+  it 'fail wmi on unknown os' do
+    resource = MockLoader.new(:undefined).load_resource('wmi', 'win32_service', { filter: "name like '%winrm%'" })
+    _(resource.send('DisplayName')).must_equal nil
+    _(resource.send('method_missing', 'Path', 'ClassName')).must_equal nil
+  end
+end


### PR DESCRIPTION
The new WMI resource allows users to query Windows Management Instrumentation (WMI). Under the hood we use Powershell to retrieve the information:

```
# Get-WmiObject -class win32_service
# returns an array of results
describe wmi('win32_service') do
  its(['Path','ClassName']) { should include 'Win32_Service' }
  its('DisplayName') { should include 'Windows Remote Management (WS-Management)'}
end

# Its also possible to add filter to narrow down the result set
# therefore we can use `eq` instead of `include` here
describe wmi('win32_service', {
  filter: "name like '%winrm%'"
}) do
  its(['Path','ClassName']) { should eq 'Win32_Service' }
  its('DisplayName') { should eq 'Windows Remote Management (WS-Management)'}
end
```
