### PR TITLE
inspec-compliance: fix upload of profiles

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -116,8 +116,7 @@ module Compliance
       req = Net::HTTP::Post.new(uri.path)
       req.basic_auth username, password
 
-      req.body_stream=File.open(file_path)
-      req['Content-Type'] = 'multipart/form-data'
+      req.body_stream=File.open(file_path, 'rb')
       req.add_field('Content-Length', File.size(file_path))
       req.add_field('Content-Type', 'application/x-gtar')
 

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -97,10 +97,10 @@ module Compliance
 
       # if it is a directory, tar it to tmp directory
       if File.directory?(path)
-        file = Tempfile.new([profile_name, '.tar.gz'])
-        archive_path = file.path
+        archive_path = Dir::Tmpname.create([profile_name, '.tar.gz']) {}
+        # archive_path = file.path
         puts "Generate temporary profile archive at #{archive_path}"
-        profile.archive({ archive: archive_path, ignore_errors: false, overwrite: true })
+        profile.archive({ output: archive_path, ignore_errors: false, overwrite: true })
       else
         archive_path = path
       end


### PR DESCRIPTION
Fixes #572.

The bug was a change in `Inspec::Profile.archive`.

Removed some caveats that seemed to be possible reasons but were not:
- Use `Dir::Tmpname.create` when we only need a temp name, not a file.
- Use _binary mode_ for reading the tarball, because it's binary data.
- Don't set content-type header twice.
