### PR TITLE
bugfix: fix rare inspec shell missing all resources

### DIFF
--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -33,6 +33,8 @@ module Inspec
       @current_load = { file: source }
       if content.is_a? Proc
         @profile_context.instance_eval(&content)
+      elsif source.nil? && line.nil?
+        @profile_context.instance_eval(content)
       else
         @profile_context.instance_eval(content, source || 'unknown', line || 1)
       end

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -101,7 +101,7 @@ module Inspec
     def add_test_to_context(test, ctx)
       content = test[:content]
       return if content.nil? || content.empty?
-      ctx.load(content, test[:ref], test[:line] || 1)
+      ctx.load(content, test[:ref], test[:line])
     end
 
     def filter_controls(controls_map, include_list)

--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -15,7 +15,7 @@ module Inspec
 
     def start
       # store context to run commands in this context
-      c = { content: 'binding.pry', ref: __FILE__, line: __LINE__ }
+      c = { content: 'binding.pry', ref: nil, line: nil }
       @runner.add_content(c, [])
       @runner.run
     end

--- a/test/unit/profile_context_test.rb
+++ b/test/unit/profile_context_test.rb
@@ -91,7 +91,7 @@ describe Inspec::ProfileContext do
     it 'supports empty describe calls' do
       load('describe').must_output ''
       profile.rules.keys.length.must_equal 1
-      profile.rules.keys[0].must_match /^\(generated from unknown:1 [0-9a-f]+\)$/
+      profile.rules.keys[0].must_match /^\(generated from \(eval\):1 [0-9a-f]+\)$/
       profile.rules.values[0].must_be_kind_of Inspec::Rule
     end
 
@@ -99,7 +99,7 @@ describe Inspec::ProfileContext do
       load('describe true do; it { should_eq true }; end')
         .must_output ''
       profile.rules.keys.length.must_equal 1
-      profile.rules.keys[0].must_match /^\(generated from unknown:1 [0-9a-f]+\)$/
+      profile.rules.keys[0].must_match /^\(generated from \(eval\):1 [0-9a-f]+\)$/
       profile.rules.values[0].must_be_kind_of Inspec::Rule
     end
 
@@ -108,7 +108,7 @@ describe Inspec::ProfileContext do
         .must_output ''
       profile.rules.keys.length.must_equal 3
       [0, 1, 2].each do |i|
-        profile.rules.keys[i].must_match /^\(generated from unknown:2 [0-9a-f]+\)$/
+        profile.rules.keys[i].must_match /^\(generated from \(eval\):2 [0-9a-f]+\)$/
         profile.rules.values[i].must_be_kind_of Inspec::Rule
       end
     end


### PR DESCRIPTION
In some instances, when running inspec shell, you don't get any resources inside of it. i.e. `inspec shell` and then `os` will lead to

``` ruby
NameError: undefined local variable or method `os' for
from (pry):1:in `add_content'
```

This is because of instance_eval loading withing the given source/line
information and not attaching to the profile context which actually has
all the resources. Fix it by making sure that inspec shell always
attaches to the profile context with resources by providing nil for
source and line information.
