### PR TITLE
dont fail with stacktrace on connection errors

### DIFF
--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -37,6 +37,11 @@ module Inspec
       end
 
       cls.new
+
+    rescue Train::ClientError => e
+      raise "Client error, can't connect to '#{name}' backend: #{e.message}"
+    rescue Train::TransportError => e
+      raise "Transport error, can't connect to '#{name}' backend: #{e.message}"
     end
   end
 end


### PR DESCRIPTION
turn 

```
bin/inspec exec examples/profile/ -t ssh://192.168.12.34 --password sth
...
/usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/transports/ssh_connection.rb:182:in `rescue in establish_connection': SSH session could not be established (Train::Transports::SSHFailed)
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/transports/ssh_connection.rb:177:in `establish_connection'
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/transports/ssh_connection.rb:205:in `session'
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/transports/ssh_connection.rb:79:in `run_command'
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/extras/os_detect_darwin.rb:14:in `detect_darwin'
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/extras/os_common.rb:115:in `detect_family_type'
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/extras/os_common.rb:80:in `detect_family'
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/extras/os_common.rb:26:in `initialize'
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/transports/ssh_connection.rb:221:in `initialize'
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/transports/ssh_connection.rb:58:in `new'
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/transports/ssh_connection.rb:58:in `os'
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/extras/command_wrapper.rb:133:in `load'
    from /usr/lib/ruby/gems/2.3.0/gems/r-train-0.10.3/lib/train/transports/ssh_connection.rb:45:in `initialize'
...
```

into this

```
bin/inspec exec examples/profile/ -t ssh://192.168.12.34 --password sth
...
Transport error, can't connect to 'ssh' backend: SSH session could not be established
```
