### PR TITLE
Ease removal of whitespace for Powershell Write-Output and VBScript Echo

### DIFF
--- a/lib/resources/powershell.rb
+++ b/lib/resources/powershell.rb
@@ -36,6 +36,11 @@ module Inspec::Resources
       nil
     end
 
+    # Removes leading and trailing whitespace from stdout
+    def strip
+      result.stdout.strip unless result.stdout.nil?
+    end
+
     def to_s
       'Powershell'
     end

--- a/test/integration/default/powershell_spec.rb
+++ b/test/integration/default/powershell_spec.rb
@@ -9,6 +9,11 @@ describe powershell(script) do
   its('stderr') { should eq '' }
 end
 
+# remove whitespace \r\n from stdout
+describe powershell(script) do
+  its('strip') { should eq "hello" }
+end
+
 # legacy test with `script` resource
 describe script(script) do
   its('stdout') { should eq "hello\r\n" }

--- a/test/integration/default/vbscript_spec.rb
+++ b/test/integration/default/vbscript_spec.rb
@@ -9,6 +9,11 @@ describe vbscript(vbscript) do
   its('stdout') { should eq "hello\r\n" }
 end
 
+# remove whitespace \r\n from stdout
+describe vbscript(vbscript) do
+  its('strip') { should eq "hello" }
+end
+
 # ensure that we do not require a newline
 describe vbscript("Wscript.Stdout.Write \"hello\"") do
   its('stdout') { should eq 'hello' }


### PR DESCRIPTION
This PR implements a new `strip` method to handle stdout

Powershell

```
# Write-Output comes with a newline
describe powershell("Write-Output 'hello'") do
  its('stdout') { should eq "hello\r\n" }
  # remove whitespace \r\n from stdout
  its('strip') { should eq "hello" }
  its('stderr') { should eq '' }
end
```

VBScript:

```
describe vbscript('WScript.Echo "hello"') do
  its('stdout') { should eq "hello\r\n" }
  # remove whitespace \r\n from stdout
  its('strip') { should eq "hello" }
end
```
