### PR TITLE
supports keyword marks tests as skipped instead of removing them

### DIFF
--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -138,4 +138,26 @@ describe 'inspec exec' do
     end
   end
 
+  describe 'with a profile that is not supported on this OS/platform' do
+    let(:out) { inspec('exec ' + File.join(profile_path, 'skippy-profile-os') + ' --format fulljson') }
+    let(:json) { JSON.load(out.stdout) }
+
+    it 'exits cleanly' do
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+    end
+
+    it 'has one pending' do
+      json['summary']['pending_count'].must_equal 1
+      json['summary']['example_count'].must_equal 1
+    end
+
+    it 'delivers the pending message' do
+      json['examples'][0]['pending'].must_match %r{^This OS/platform \([^)]+\) is not supported by this profile\.$}
+    end
+
+    it 'never runs the actual resource' do
+      File.exist?('/tmp/inspec_test_DONT_CREATE').must_equal false
+    end
+  end
 end

--- a/test/unit/mock/profiles/skippy-profile-os/controls/one.rb
+++ b/test/unit/mock/profiles/skippy-profile-os/controls/one.rb
@@ -1,0 +1,3 @@
+describe command('touch /tmp/inspec_test_DONT_CREATE') do
+  its(:exit_status) { should eq 123 }
+end

--- a/test/unit/mock/profiles/skippy-profile-os/inspec.yml
+++ b/test/unit/mock/profiles/skippy-profile-os/inspec.yml
@@ -1,0 +1,5 @@
+name: skippy
+title: skip-like functionality
+version: 1.0.0
+supports:
+- os-family: definitely_not_supported


### PR DESCRIPTION
Instead of just removing tests, go for proper skipping via the `supports` keyword in `inspec.yml`. This will ensure that tests don't move into limbo.

Requires https://github.com/chef/inspec/pull/619/files to be merged.
