### PR TITLE
Add 'static' value as enabled to systemd service enabled check

### DIFF
--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -214,7 +214,7 @@ module Inspec::Resources
       running = params['SubState'] == 'running'
       # test via systemctl --quiet is-enabled
       # ActiveState values eg.g inactive, active
-      enabled = params['UnitFileState'] == 'enabled'
+      enabled = %w{enabled static}.include? params['UnitFileState']
 
       {
         name: params['Id'],

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -178,6 +178,8 @@ class MockLoader
       # show ssh service Centos 7
       'systemctl show --all sshd' => cmd.call('systemctl-show-all-sshd'),
       '/path/to/systemctl show --all sshd' => cmd.call('systemctl-show-all-sshd'),
+      'systemctl show --all dbus' => cmd.call('systemctl-show-all-dbus'),
+      '/path/to/systemctl show --all dbus' => cmd.call('systemctl-show-all-dbus'),
       # services on macos
       'launchctl list' => cmd.call('launchctl-list'),
       # services on freebsd 10

--- a/test/unit/mock/cmd/systemctl-show-all-dbus
+++ b/test/unit/mock/cmd/systemctl-show-all-dbus
@@ -1,0 +1,6 @@
+Id=dbus.service
+Names=messagebus.service dbus.service
+Description=D-Bus System Message Bus
+LoadState=loaded
+UnitFileState=static
+SubState=running

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -94,6 +94,15 @@ describe 'Inspec::Resources::Service' do
     _(resource.running?).must_equal true
   end
 
+  it 'verify centos 7 package parsing with static loaded service' do
+    resource = MockLoader.new(:centos7).load_resource('service', 'dbus')
+    srv = { name: 'dbus.service', description: 'D-Bus System Message Bus', installed: true, running: true, enabled: true, type: 'systemd' }
+    _(resource.info).must_equal srv
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+  end
+
   # freebsd
   it 'verify freebsd10 package parsing' do
     resource = MockLoader.new(:freebsd10).load_resource('service', 'sendmail')


### PR DESCRIPTION
SystemD can have a service `enabled` not only when the `UnitFileState` is `running` but also when it is `static`.

To back this up: https://www.freedesktop.org/wiki/Software/systemd/dbus/

> UnitFileState encodes the install state of the unit file of FragmentPath. It currently knows the following states: enabled, enabled-runtime, linked, linked-runtime, masked, masked-runtime, static, disabled, invalid. enabled indicates that a unit file is permanently enabled. enable-runtime indicates the unit file is only temporarily enabled, and will no longer be enabled after a reboot (that means, it is enabled via /run symlinks, rather than /etc). linked indicates that a unit is linked into /etc permanently, linked indicates that a unit is linked into /run temporarily (until the next reboot). masked indicates that the unit file is masked permanently, masked-runtime indicates that it is only temporarily masked in /run, until the next reboot. **static indicates that the unit is statically enabled, i.e. always enabled and doesn't need to be enabled explicitly**. invalid indicates that it could not be determined whether the unit file is enabled.

Looks like there is other good info in that article as well ... including more states that could be set for `UnitFileState` such as: enabled, enabled-runtime, linked, linked-runtime, masked, masked-runtime, static, disabled, invalid. enabled
