### PR TITLE
Prevent its(:to_i) from generated tests

### DIFF
--- a/lib/inspec/objects/test.rb
+++ b/lib/inspec/objects/test.rb
@@ -48,7 +48,8 @@ module Inspec
 
       if @qualifier.length > 1
         last = @qualifier[-1]
-        if last.length == 1
+        # preventing its(:to_i) as the value returned is always 0
+        if last.length == 1 && last[0] != 'to_i'
           xres = last[0]
         else
           res += '.' + ruby_qualifier(last)


### PR DESCRIPTION
This is because the `rspec-its` dependency is not working properly for strings:

```
require 'rspec/its'

describe "655555" do
  its("size") { should be <= 4 }
  its(:size) { should be <= 4 }
  its(:to_i) { should be <= 4 }
  its("length") { should be <= 4 }
end
```

Expecting all tests to fail:

```
$ rspec

655555
  size
    should be <= 4
  size
    should be <= 4
  to_i
    should be <= 4
  length
    should be <= 4 (FAILED - 1)

Failures:

  1) 655555 length should be <= 4
     Failure/Error: its("length") { should be <= 4 }

       expected: <= 4
            got:    6
     # ./spec/unit/default_spec.rb:7:in `block (2 levels) in <top (required)>'

Finished in 0.01098 seconds (files took 0.08507 seconds to load)
4 examples, 1 failure
```
