### PR TITLE
WIP: Provide option to force bash for the command resource

### DIFF
--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -18,13 +18,24 @@ module Inspec::Resources
     "
 
     attr_reader :command
+    attr_reader :options
 
-    def initialize(cmd)
+    def initialize(cmd, opts={})
       @command = cmd
+      if opts.is_a?(String)
+        warn "WARN: Ignoring invalid command option '#{opts}', use the 'option: value' format. For example: 'command(\"ls\", bash: true)'"
+        opts = {}
+      end
+      @options = opts
     end
 
     def result
-      @result ||= inspec.backend.run_command(@command)
+      if @options[:bash].to_s == "true"
+        full_command = "bash -c #{Shellwords.escape(@command)}"
+      else
+        full_command = @command
+      end
+      @result ||= inspec.backend.run_command(full_command)
     end
 
     def stdout

--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -22,7 +22,7 @@ module Inspec::Resources
 
     def initialize(cmd, opts={})
       @command = cmd
-      if opts.is_a?(String)
+      unless opts.is_a?(Hash)
         warn "WARN: Ignoring invalid command option '#{opts}', use the 'option: value' format. For example: 'command(\"ls\", bash: true)'"
         opts = {}
       end


### PR DESCRIPTION
At the moment, the `command` resource, through `train` and `Mixlib::shellout` executes local commands using `/bin/sh`.

Depending on the operating system, this can be `sh`, `dash`, `bash`. 
Some commands require `bash` to succeed, like this one from the Ubuntu 14.04 translated SCAP content:

``` ruby
 describe command("ui=($(echo 0022 -n | fold -w1));sys=($(stat -L --format=\"%a\" /etc/hosts.allow | awk '{printf \"%04d\\n\", $0;}' | fold -w1));for (( i=0; i<4; i++ )); do echo -n $(( ${ui[$i]} & ${sys[$i]})); done;").stdout.to_s.[](/^(\d+)$/, 1) do
    it { should eq "0000" }
  end
```
