### PR TITLE
bugfix: rspec world handling on rspec 3.5

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rainbow', '~> 2'
   spec.add_dependency 'method_source', '~> 0.8'
   spec.add_dependency 'rubyzip', '~> 1.1'
-  spec.add_dependency 'rspec', '~> 3.3'
+  spec.add_dependency 'rspec', '~> 3'
   spec.add_dependency 'rspec-its', '~> 1.2'
   spec.add_dependency 'pry', '~> 0'
 

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -48,7 +48,7 @@ module Inspec
     # @return [nil]
     def add_test(example, rule_id, rule)
       set_rspec_ids(example, rule_id, rule)
-      @tests.register(example)
+      @tests.example_groups.push(example)
     end
 
     # Retrieve the list of tests that have been added.


### PR DESCRIPTION
This accessor is designed to work with rspec 3.0 - 3.5 (and potentially up).

Fixes https://github.com/chef/inspec/issues/642
