### PR TITLE
bugfix: print cmp expectations

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -282,13 +282,13 @@ RSpec::Matchers.define :cmp do |first_expected|
   end
 
   failure_message do |actual|
-    actual = '0' + actual.to_s(8) if octal?(expected)
-    "\nexpected: value #{@operation} #{expected}\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
+    actual = '0' + actual.to_s(8) if octal?(@expected)
+    "\nexpected: value #{@operation} #{@expected}\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
   end
 
   failure_message_when_negated do |actual|
-    actual = '0' + actual.to_s(8) if octal?(expected)
-    "\nexpected: value ! #{@operation} #{expected}\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
+    actual = '0' + actual.to_s(8) if octal?(@expected)
+    "\nexpected: value ! #{@operation} #{@expected}\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
   end
 end
 


### PR DESCRIPTION
I carried the wrong variable before... this fixes it.
