### PR TITLE
be descriptive on shadow.entries

### DIFF
--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -67,7 +67,11 @@ module Inspec::Resources
     end
 
     def entries
-      @lines.map { |line| Shadow.new(@path, content: line, filters: @filters) }
+      @lines.map do |line|
+        params = parse_shadow_line(line)
+        Shadow.new(@path, content: line,
+                   filters: "#{@filters} on entry user=#{params['user']}")
+      end
     end
 
     def users(name = nil)


### PR DESCRIPTION
When used in combination: `shadow[.filter(...)].entries.each { |entry| ... }`, these entries would not  be very descriptive at all. You would basically only retrieve the full filter chain e.g. 20 times, without any information about what entry you are currently looking at. This fixes it, by providing the entry identified by the user name
