### PR TITLE
configure command execution shells to sh/bash/zsh

### DIFF
--- a/test/unit/resources/command_test.rb
+++ b/test/unit/resources/command_test.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+require 'helper'
+require 'inspec/resource'
+
+describe Inspec::Resources::Cmd do
+  it 'runs regular commands' do
+    x = rand.to_s
+    load_resource('command', x).method(:wrap_cmd).call
+      .must_equal x
+  end
+
+  it 'runs sh commands' do
+    x = rand.to_s
+    load_resource('command', '$("'+x+'")', {shell: 'sh'})
+    .method(:wrap_cmd).call
+    .must_equal "sh -c \\$\\(\\\"#{x}\\\"\\)"
+  end
+
+  it 'runs bash commands' do
+    x = rand.to_s
+    load_resource('command', '$("'+x+'")', {shell: 'bash'})
+      .method(:wrap_cmd).call
+      .must_equal "bash -c \\$\\(\\\"#{x}\\\"\\)"
+  end
+
+  it 'runs zsh commands' do
+    x = rand.to_s
+    load_resource('command', '$("'+x+'")', {shell: 'zsh'})
+      .method(:wrap_cmd).call
+      .must_equal "zsh -c \\$\\(\\\"#{x}\\\"\\)"
+  end
+end


### PR DESCRIPTION
Run against docker container:

``` ruby
command('n=($(echo "123")); echo $n').stdout
=> ''
```

Now like this:

``` ruby
command('n=($(echo "123")); echo $n', shell: 'bash').stdout
=> '123\n'
```

Alternative idea for https://github.com/chef/inspec/pull/645
All kudos to @alexpop for raising + original implementation + @srenatus for his input.
