### PR TITLE
bugfix: restore pax_global_header fetcher filter

### DIFF
--- a/lib/inspec/plugins/fetcher.rb
+++ b/lib/inspec/plugins/fetcher.rb
@@ -34,6 +34,7 @@ module Inspec
     end
 
     BLACKLIST_FILES = [
+      '/pax_global_header',
       'pax_global_header',
     ].freeze
 

--- a/test/unit/fetchers_test.rb
+++ b/test/unit/fetchers_test.rb
@@ -51,6 +51,7 @@ describe Inspec::Plugins::RelFetcher do
     # ignore pax_global_header, which are commonly seen in github tars and are not
     # ignored by all tar streaming tools, its not extracted by GNU tar since 1.14
     %w{/pax_global_header /a/b}    => %w{b},
+    %w{pax_global_header a/b}    => %w{b},
   }.each do |ins, outs|
     describe 'empty profile' do
       let(:in_files) { ins }


### PR DESCRIPTION
The original tests were deactivated. Reactivate and fix the implementation.

TODO: verify that this matches expectations
