### PR TITLE
Fix indenting for translated loops and ors

### DIFF
--- a/lib/inspec/objects/each_loop.rb
+++ b/lib/inspec/objects/each_loop.rb
@@ -25,7 +25,7 @@ module Inspec
 
     def to_ruby
       obj = super
-      all_tests = @tests.map(&:to_ruby).join("\n").gsub("\n","\n  ")
+      all_tests = @tests.map(&:to_ruby).join("\n").gsub("\n", "\n  ")
       format("%s.each do |entry|\n  %s\nend", obj, all_tests)
     end
   end

--- a/lib/inspec/objects/each_loop.rb
+++ b/lib/inspec/objects/each_loop.rb
@@ -25,7 +25,7 @@ module Inspec
 
     def to_ruby
       obj = super
-      all_tests = @tests.map(&:to_ruby).join("\n")
+      all_tests = @tests.map(&:to_ruby).join("\n").gsub("\n","\n  ")
       format("%s.each do |entry|\n  %s\nend", obj, all_tests)
     end
   end

--- a/lib/inspec/objects/or_test.rb
+++ b/lib/inspec/objects/or_test.rb
@@ -11,8 +11,8 @@ module Inspec
     end
 
     def to_ruby
-      format("describe.one do\n  %s\nend",
-             @tests.map(&:to_ruby).join("\n"))
+      all_tests = @tests.map(&:to_ruby).join("\n").gsub("\n","\n  ")
+      format("describe.one do\n  %s\nend", all_tests)
     end
 
     def to_hash

--- a/lib/inspec/objects/or_test.rb
+++ b/lib/inspec/objects/or_test.rb
@@ -11,7 +11,7 @@ module Inspec
     end
 
     def to_ruby
-      all_tests = @tests.map(&:to_ruby).join("\n").gsub("\n","\n  ")
+      all_tests = @tests.map(&:to_ruby).join("\n").gsub("\n", "\n  ")
       format("describe.one do\n  %s\nend", all_tests)
     end
 


### PR DESCRIPTION
Translated tests like these:

``` ruby
control "uno" do
  shadow.users(/.*/).entries.each do |entry|
    describe entry do
    its(:passwords) { should match /.+/ }
  end
  end
end
```

``` ruby
control "due" do
  describe.one do
    describe xinetd_conf.services("chargen").socket_types("dgram") do
    it { should be disabled  }
  end
    describe package("xinetd") do
    it { should_not be_installed  }
  end
end
```

become after this code change:

``` ruby
control "uno" do
  shadow.users(/.*/).entries.each do |entry|
    describe entry do
      its(:passwords) { should match /.+/ }
    end
  end
end
```

``` ruby
control "due" do
  describe.one do
    describe xinetd_conf.services("chargen").socket_types("dgram") do
      it { should be disabled  }
    end
    describe package("xinetd") do
      it { should_not be_installed  }
    end
  end
end
```
