### PR TITLE
Add table-style filter utility

### DIFF
--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -3,9 +3,10 @@
 # author: Dominik Richter
 
 require 'utils/parser'
+require 'utils/filter'
 
 module Inspec::Resources
-  class XinetdConf < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
+  class XinetdConf < Inspec.resource(1)
     name 'xinetd_conf'
     desc 'Xinetd services configuration.'
     example "
@@ -20,111 +21,44 @@ module Inspec::Resources
 
     include XinetdParser
 
-    def initialize(conf_path = '/etc/xinetd.conf', opts = {})
+    def initialize(conf_path = '/etc/xinetd.conf')
       @conf_path = conf_path
-      @params = opts[:params] unless opts[:params].nil?
-      @filters = opts[:filters] || ''
+      @filters = ''
       @contents = {}
     end
 
     def to_s
-      "Xinetd config #{@conf_path}"
-    end
-
-    def services(condition = nil)
-      condition.nil? ? params['services'].keys : filter(service: condition)
-    end
-
-    def ids(condition = nil)
-      condition.nil? ? services_field('id') : filter(id: condition)
-    end
-
-    def socket_types(condition = nil)
-      condition.nil? ? services_field('socket_type') : filter(socket_type: condition)
-    end
-
-    def types(condition = nil)
-      condition.nil? ? services_field('type') : filter(type: condition)
-    end
-
-    def wait(condition = nil)
-      condition.nil? ? services_field('wait') : filter(wait: condition)
-    end
-
-    def disabled?
-      filter(disable: 'no').services.empty?
-    end
-
-    def enabled?
-      filter(disable: 'yes').services.empty?
+      "Xinetd config #{@conf_path}#{@filters}"
     end
 
     def params
-      return @params if defined?(@params)
-      return @params = {} if read_content.nil?
-      flat_params = parse_xinetd(read_content)
-      @params = { 'services' => {} }
-      flat_params.each do |k, v|
-        name = k[/^service (.+)$/, 1]
-        if name.nil?
-          @params[k] = v
-        else
-          @params['services'][name] = v
-        end
-      end
-      @params
+      @params ||= read_params
     end
 
-    def filter(conditions = {})
-      res = params.dup
-      filters = ''
-      conditions.each do |k, v|
-        v = v.to_s if v.is_a? Integer
-        filters += " #{k} = #{v.inspect}"
-        res['services'] = filter_by(res['services'], k.to_s, v)
-      end
-      XinetdConf.new(@conf_path, params: res, filters: filters)
+    extend Inspec::Filter
+    add_filter 'service'
+    add_filter 'id'
+    add_filter 'socket_type'
+    add_filter 'type'
+    add_filter 'wait'
+
+    def disabled?
+      where({ 'disable' => 'no' }).services.empty?
+    end
+
+    def enabled?
+      where({ 'disable' => 'yes' }).services.empty?
+    end
+
+    def where(conditions = {})
+      fields, filters = Inspec::Filter.where(service_lines, conditions)
+      res = clone
+      res.instance_variable_set(:@filters, @filters + filters)
+      res.instance_variable_set(:@services, fields)
+      res
     end
 
     private
-
-    # Retrieve the provided field from all configured services.
-    #
-    # @param [String] field name, e.g. `socket_type`
-    # @return [Array[String]] all values of this field across services
-    def services_field(field)
-      params['services'].values.compact.flatten
-                        .map { |x| x.params[field] }.flatten.compact
-    end
-
-    def match_condition(sth, condition)
-      case sth
-      # this does Regex-matching as well as string comparison
-      when condition
-        true
-      else
-        false
-      end
-    end
-
-    # Filter services by a criteria. This allows for search queries for
-    # certain values.
-    #
-    # @param [Hash] service collection
-    # @param [String] search key you want to query
-    # @param [Any] search value that the key should match
-    # @return [Hash] filtered service collection
-    def filter_by(services, k, v)
-      if k == 'service'
-        return Hash[services.find_all { |name, _| match_condition(v, name) }]
-      end
-      Hash[services.map { |name, service_arr|
-        found = service_arr.find_all { |service|
-          match_condition(service.params[k], v)
-        }
-        found.empty? ? nil : [name, found]
-      }.compact]
-    end
 
     def read_content(path = @conf_path)
       return @contents[path] if @contents.key?(path)
@@ -139,6 +73,37 @@ module Inspec::Resources
       end
 
       @contents[path]
+    end
+
+    def read_params
+      return {} if read_content.nil?
+      flat_params = parse_xinetd(read_content)
+      params = { 'services' => {} }
+
+      # parse services that were defined:
+      flat_params.each do |k, v|
+        name = k[/^service (.+)$/, 1]
+        if name.nil?
+          params[k] = v
+        else
+          params['services'][name] = v
+          # add the service identifier to its parameters
+          v.each { |service| service.params['service'] = name }
+        end
+      end
+      params
+    end
+
+    def service_lines
+      @services ||= params['services'].values.flatten.map(&:params)
+    end
+
+    def get_fields(*fields)
+      res = service_lines.map do |line|
+        fields.map { |f| line[f] }
+      end.flatten
+      return res unless fields == ['service']
+      res.uniq
     end
   end
 end

--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -34,8 +34,9 @@ module Inspec::Resources
       @params ||= read_params
     end
 
-    filter = FilterTable.create(self, :service_lines)
-    filter.add_delegator(:where)
+    filter = FilterTable.create
+    filter.add_accessor(:where)
+          .add_accessor(:entries)
           .add(:services,     field: 'service')
           .add(:ids,          field: 'id')
           .add(:socket_types, field: 'socket_type')
@@ -43,6 +44,7 @@ module Inspec::Resources
           .add(:wait,         field: 'wait')
           .add(:disabled?) { |x| x.where('disable' => 'no').services.empty? }
           .add(:enabled?) { |x| x.where('disable' => 'yes').services.empty? }
+          .connect(self, :service_lines)
 
     private
 

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+
+module Inspec
+  module Filter
+    module Show; end
+
+    def add_filter(field_name)
+      fail "Called add_filter in resource #{self} with field name nil!" if field_name.nil?
+      method_name = field_name.to_s
+      # methods will alwas target plurals; this is why the suffix 's' is mandatory
+      method_name += 's' unless method_name.end_with? 's'
+
+      define_method method_name.to_sym do |condition = Show|
+        return get_fields(field_name) if condition == Show
+        where({ field_name => condition })
+      end
+    end
+
+    def self.where(table, conditions = {})
+      return self if !conditions.is_a?(Hash) || conditions.empty?
+      filters = ''
+      conditions.each do |field, condition|
+        filters += " #{field} = #{condition.inspect}"
+        table = filter_lines(table, field, condition)
+      end
+      [table, filters]
+    end
+
+    def self.filter_lines(table, field, condition)
+      table.find_all do |line|
+        next unless line.key?(field)
+        case line[field]
+        when condition
+          true
+        else
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -1,34 +1,45 @@
 # encoding: utf-8
 # author: Dominik Richter
+# author: Stephan Renatus
 # author: Christoph Hartmann
 
-module Inspec
-  module Filter
-    module Show; end
+module FilterTable
+  module Show; end
 
-    def add_filter(field_name)
-      fail "Called add_filter in resource #{self} with field name nil!" if field_name.nil?
-      method_name = field_name.to_s
-      # methods will alwas target plurals; this is why the suffix 's' is mandatory
-      method_name += 's' unless method_name.end_with? 's'
-
-      define_method method_name.to_sym do |condition = Show|
-        return get_fields(field_name) if condition == Show
-        where({ field_name => condition })
-      end
+  class Table
+    attr_reader :params
+    def initialize(resource, params, filters)
+      @resource = resource
+      @params = params
+      @filters = filters
     end
 
-    def self.where(table, conditions = {})
+    def where(conditions)
       return self if !conditions.is_a?(Hash) || conditions.empty?
       filters = ''
+      table = @params
       conditions.each do |field, condition|
         filters += " #{field} = #{condition.inspect}"
         table = filter_lines(table, field, condition)
       end
-      [table, filters]
+      self.class.new(@resource, table, @filters + filters)
     end
 
-    def self.filter_lines(table, field, condition)
+    def get_fields(*fields)
+      @params.map do |line|
+        fields.map { |f| line[f] }
+      end.flatten
+    end
+
+    def to_s
+      @resource.to_s + @filters
+    end
+
+    alias inspect to_s
+
+    private
+
+    def filter_lines(table, field, condition)
       table.find_all do |line|
         next unless line.key?(field)
         case line[field]
@@ -39,5 +50,49 @@ module Inspec
         end
       end
     end
+  end
+
+  class Factory
+    def initialize(resource, accessor)
+      @resource = resource
+      @accessor = accessor
+      @table = Class.new(Table)
+    end
+
+    def table(instance)
+      table.new(self, instance.method(table_accessor).call, '')
+    end
+
+    def add_delegator(method_name)
+      if method_name.nil?
+        throw RuntimeError, "Called filter.add_delegator for resource #{@resource} with method name nil!"
+      end
+      table_accessor = @accessor
+      table = @table
+      @resource.send(:define_method, method_name.to_sym) do |*args|
+        filter = table.new(self, method(table_accessor).call, '')
+        filter.method(method_name.to_sym).call(*args)
+      end
+      self
+    end
+
+    def add(method_name, opts = {}, &block)
+      if method_name.nil?
+        throw RuntimeError, "Called filter.add for resource #{@resource} with method name nil!"
+      end
+
+      field_name = opts[:field] || method_name
+      @table.send(:define_method, method_name.to_sym) do |condition = Show|
+        return block.call(self) unless block.nil? # rubocop:disable Performance/RedundantBlockCall
+        return where(nil).get_fields(field_name) if condition == Show
+        where({ field_name => condition })
+      end
+
+      add_delegator(method_name)
+    end
+  end
+
+  def self.create(resource, accessor)
+    Factory.new(resource, accessor)
   end
 end

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -19,10 +19,23 @@ module FilterTable
       filters = ''
       table = @params
       conditions.each do |field, condition|
-        filters += " #{field} = #{condition.inspect}"
+        filters += " #{field} == #{condition.inspect}"
         table = filter_lines(table, field, condition)
       end
       self.class.new(@resource, table, @filters + filters)
+    end
+
+    def new_entry(*_)
+      fail "#{self.class} must not be used on its own. It must be inherited "\
+           'and the #new_entry method must be implemented. This is an internal '\
+           'error and should not happen.'
+    end
+
+    def entries
+      f = @resource.to_s + @filters.to_s + ' one entry'
+      @params.map do |line|
+        new_entry(line, f)
+      end
     end
 
     def get_fields(*fields)
@@ -53,26 +66,60 @@ module FilterTable
   end
 
   class Factory
-    def initialize(resource, accessor)
-      @resource = resource
-      @accessor = accessor
-      @table = Class.new(Table)
+    def initialize
+      @accessors = []
+      @fields = {}
+      @blocks = {}
     end
 
-    def table(instance)
-      table.new(self, instance.method(table_accessor).call, '')
+    def connect(resource, table_accessor) # rubocop:disable Metrics/AbcSize
+      # create the table structure
+      fields = @fields
+      blocks = @blocks
+      struct_fields = fields.values
+
+      # the struct to hold single items from the #entries method
+      entry_struct = Struct.new(*struct_fields.map(&:to_sym)) do
+        attr_accessor :__filter
+        def to_s # rubocop:disable Lint/NestedMethodDefinition
+          @__filter || super
+        end
+      end unless struct_fields.empty?
+
+      # the main filter table
+      table = Class.new(Table) {
+        fields.each do |method, field_name|
+          block = blocks[method]
+          define_method method.to_sym do |condition = Show|
+            return block.call(self) unless block.nil?
+            return where(nil).get_fields(field_name) if condition == Show
+            where({ field_name => condition })
+          end
+        end
+
+        define_method :new_entry do |hashmap, filter = ''|
+          return entry_struct.new if hashmap.nil?
+          res = entry_struct.new(*struct_fields.map { |x| hashmap[x] })
+          res.__filter = filter
+          res
+        end
+      }
+
+      # define all access methods with the parent resource
+      accessors = @accessors + @fields.keys
+      accessors.each do |method_name|
+        resource.send(:define_method, method_name.to_sym) do |*args|
+          filter = table.new(self, method(table_accessor).call, ' with')
+          filter.method(method_name.to_sym).call(*args)
+        end
+      end
     end
 
-    def add_delegator(method_name)
+    def add_accessor(method_name)
       if method_name.nil?
         throw RuntimeError, "Called filter.add_delegator for resource #{@resource} with method name nil!"
       end
-      table_accessor = @accessor
-      table = @table
-      @resource.send(:define_method, method_name.to_sym) do |*args|
-        filter = table.new(self, method(table_accessor).call, '')
-        filter.method(method_name.to_sym).call(*args)
-      end
+      @accessors.push(method_name)
       self
     end
 
@@ -82,17 +129,13 @@ module FilterTable
       end
 
       field_name = opts[:field] || method_name
-      @table.send(:define_method, method_name.to_sym) do |condition = Show|
-        return block.call(self) unless block.nil? # rubocop:disable Performance/RedundantBlockCall
-        return where(nil).get_fields(field_name) if condition == Show
-        where({ field_name => condition })
-      end
-
-      add_delegator(method_name)
+      @fields[method_name.to_sym] = field_name
+      @blocks[method_name.to_sym] = block
+      self
     end
   end
 
-  def self.create(resource, accessor)
-    Factory.new(resource, accessor)
+  def self.create
+    Factory.new
   end
 end

--- a/test/unit/resources/xinetd_test.rb
+++ b/test/unit/resources/xinetd_test.rb
@@ -25,7 +25,7 @@ describe 'Inspec::Resources::XinetdConf' do
     end
 
     it 'can filter by name' do
-      _(resource.services('not here').params['services']).must_be_empty
+      _(resource.services('not here').services).must_be_empty
     end
 
     it 'can chain filters' do

--- a/test/unit/resources/xinetd_test.rb
+++ b/test/unit/resources/xinetd_test.rb
@@ -17,7 +17,7 @@ describe 'Inspec::Resources::XinetdConf' do
 
   describe 'with services from child configs' do
     it 'has one service name' do
-      _(resource.services).must_equal %w{chargen}
+      _(resource.services.uniq).must_equal %w{chargen}
     end
 
     it 'has multiple service definitions' do
@@ -30,7 +30,7 @@ describe 'Inspec::Resources::XinetdConf' do
 
     it 'can chain filters' do
       one = resource.services('chargen').socket_types('dgram')
-      _(one.params['services'].length).must_equal 1
+      _(one.services.length).must_equal 1
       _(one.ids).must_equal %w{chargen-dgram}
     end
 

--- a/test/unit/utils/filter_table_test.rb
+++ b/test/unit/utils/filter_table_test.rb
@@ -1,0 +1,102 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Stephan Renatus
+# author: Christoph Hartmann
+
+require 'helper'
+
+describe FilterTable do
+  let (:data) {[
+    { foo: 3, bar: true, baz: 'yay', num: nil },
+    { foo: 2, bar: false, baz: 'noo', num: 1 },
+    { foo: 2, bar: false, baz: 'whatever', num: 2 },
+  ]}
+
+  let (:resource) {
+    Class.new do
+      attr_reader :data
+      def initialize(data)
+        @data = data
+      end
+    end
+  }
+
+  let (:factory) { FilterTable.create(resource, :data) }
+  let (:instance) { resource.new(data) }
+
+  it 'has a create utility which creates a filter factory' do
+    factory.must_be_kind_of FilterTable::Factory
+  end
+
+  describe 'when calling add_delegator' do
+    it 'is chainable' do
+      factory.add_delegator(:sth).must_equal factory
+    end
+
+    it 'wont add nil' do
+      proc { factory.add_delegator(nil) }.must_throw RuntimeError
+    end
+
+    it 'can expose the where method' do
+      factory.add_delegator(:where)
+      _(instance.respond_to?(:where)).must_equal true
+      instance.where({ baz: 'yay' }).params.must_equal [data[0]]
+    end
+
+    it 'will delegate even non-existing methods' do
+      factory.add_delegator(:not_here)
+      _(instance.respond_to?(:not_here)).must_equal true
+    end
+  end
+
+  describe 'when calling add' do
+    it 'is chainable' do
+      factory.add(:sth).must_equal factory
+    end
+
+    it 'wont add nil' do
+      proc { factory.add(nil) }.must_throw RuntimeError
+    end
+
+    it 'can expose a data column' do
+      factory.add(:baz)
+      instance.baz(123).must_be_kind_of(FilterTable::Table)
+    end
+  end
+
+  describe 'with the number field' do
+    before { factory.add(:num) }
+
+    it 'filter by nil' do
+      instance.num(nil).params.must_equal [data[0]]
+    end
+
+    it 'filter by existing numbers' do
+      instance.num(1).params.must_equal [data[1]]
+    end
+
+    it 'filter by missing number' do
+      instance.num(-1).params.must_equal []
+    end
+  end
+
+  describe 'with the string field' do
+    before { factory.add(:baz) }
+
+    it 'filter by existing strings' do
+      instance.baz('yay').params.must_equal [data[0]]
+    end
+
+    it 'filter by missing string' do
+      instance.baz('num').params.must_equal []
+    end
+
+    it 'filter by existing regex' do
+      instance.baz(/A/i).params.must_equal [data[0], data[2]]
+    end
+
+    it 'filter by missing regex' do
+      instance.baz(/zzz/).params.must_equal []
+    end
+  end
+end


### PR DESCRIPTION
This adds a new filter utility inspired by Stephan's filter_array. It is much more complex, however, as it aims to:
- only filter on known fields, not unknown ones
- fields in the source map can be strings or symbols
- optimized for printing the filtering chain
- can act on any type of field, including `nil`
- extend the owner class with accessor methods for this filter
- can retrieve entries as an embedded object with easy accessors to all fields

WIP: This is wip and discussions are highly welcome!
