### PR TITLE
Hpux

### DIFF
--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -138,6 +138,8 @@ module Inspec::Resources
         perm_cmd = "sudo -u #{user} test -#{flag} #{path}"
       elsif inspec.os.aix?
         perm_cmd = "su #{user} -c test -#{flag} #{path}"
+      elsif inspec.os.hpux?
+        perm_cmd = "su #{user} -c \"test -#{flag} #{path}\""
       else
         return skip_resource 'The `file` resource does not support `by_user` on your OS.'
       end

--- a/lib/resources/os.rb
+++ b/lib/resources/os.rb
@@ -13,7 +13,7 @@ module Inspec::Resources
     "
 
     # reuse helper methods from backend
-    %w{aix? redhat? debian? suse? bsd? solaris? linux? unix? windows?}.each do |os_family|
+    %w{aix? redhat? debian? suse? bsd? solaris? linux? unix? windows? hpux?}.each do |os_family|
       define_method(os_family.to_sym) do
         inspec.backend.os.send(os_family)
       end

--- a/test/unit/resources/file_test.rb
+++ b/test/unit/resources/file_test.rb
@@ -4,7 +4,6 @@
 
 require 'helper'
 require 'inspec/resource'
-require 'pry'
 
 def shared_file_permission_tests(method_under_test)
   it 'returns false if the file does not exist' do

--- a/test/unit/resources/file_test.rb
+++ b/test/unit/resources/file_test.rb
@@ -4,6 +4,7 @@
 
 require 'helper'
 require 'inspec/resource'
+require 'pry'
 
 def shared_file_permission_tests(method_under_test)
   it 'returns false if the file does not exist' do
@@ -139,6 +140,27 @@ describe Inspec::Resources::FileResource do
 
       it 'returns true when the cmd exits non-zero' do
         MockLoader.mock_command(resource, 'sudo -u user test -flag /fakepath/fakefile', exit_status: 1)
+        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(false)
+      end
+    end
+
+    describe 'when on hpux' do
+      before do
+        MockLoader.mock_os(resource, :hpux)
+      end
+
+      it 'executes a properly formatted command' do
+        MockLoader.mock_command(resource, "su user -c \"test -flag /fakepath/fakefile\"", exit_status: 0)
+        resource.send(:check_file_permission_by_user, 'user', 'flag')
+      end
+
+      it 'returns true when the cmd exits 0' do
+        MockLoader.mock_command(resource, "su user -c \"test -flag /fakepath/fakefile\"", exit_status: 0)
+        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(true)
+      end
+
+      it 'returns false when the cmd exits non-zero' do
+        MockLoader.mock_command(resource, "su user -c \"test -flag /fakepath/fakefile\"", exit_status: 1)
         resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(false)
       end
     end


### PR DESCRIPTION
Added file permission check on hp-ux. The command has to be enclosed in quotes to pickup flags in hp-ux. Not sure about AIX. If its true for AIX as well, we can merge both of them in the same elsif statement.
