### PR TITLE
Add basename parameter and add tests

### DIFF
--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -32,7 +32,7 @@ module Inspec::Resources
       symlink? pipe? mode mode? owner owned_by? group grouped_into?
       link_path linked_to? mtime size selinux_label immutable?
       product_version file_version version? md5sum sha256sum
-      path source source_path uid gid
+      path basename source source_path uid gid
     }.each do |m|
       define_method m.to_sym do |*args|
         file.method(m.to_sym).call(*args)

--- a/test/integration/default/file_spec.rb
+++ b/test/integration/default/file_spec.rb
@@ -96,6 +96,8 @@ if os.unix?
     its('sha256sum') { should eq 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9' }
     its('product_version') { should eq nil }
     its('file_version') { should eq nil }
+    its('basename') { should cmp 'file' }
+    its('path') { should cmp '/tmp/file' }
 
     its('owner') { should eq filedata[:user] }
     its('group') { should eq filedata[:group] }
@@ -118,6 +120,8 @@ if os.unix?
     its('sha256sum') { should eq filedata[:dir_sha256sum] }
     its('product_version') { should eq nil }
     its('file_version') { should eq nil }
+    its('basename') { should cmp 'folder' }
+    its('path') { should cmp '/tmp/folder' }
 
     its('owner') { should eq filedata[:user] }
     its('group') { should eq filedata[:group] }
@@ -153,8 +157,10 @@ if os.linux?
 end
 
 if os.windows?
-  describe file('C:\\Windows') do
+  describe file('C:\Windows') do
     it { should exist }
     it { should be_directory }
+    its('basename') { should cmp 'Windows' }
+    its('path') { should cmp "C:\\Windows" }
   end
 end

--- a/test/unit/resources/file_test.rb
+++ b/test/unit/resources/file_test.rb
@@ -33,6 +33,13 @@ describe Inspec::Resources::FileResource do
     shared_file_permission_tests(:executable?)
   end
 
+  describe '#basename' do
+    it 'returns the basename' do
+      resource.stubs(:basename).returns('fakefile')
+      resource.basename.must_equal('fakefile')
+    end
+  end
+
   describe '#to_s' do
     it 'returns a properly formatted string' do
       resource.to_s.must_equal('File /fakepath/fakefile')


### PR DESCRIPTION
Working on the tests for this PR, I've noticed this train error for Windows:

``` ruby
inspec> f=file('c:\Users\vagrant')
ArgumentError: wrong number of arguments (2 for 3)
from /Users/apop/.chefdk/gem/ruby/2.1.0/gems/r-train-0.11.1/lib/train/extras/file_windows.rb:14:in `initialize'
```
