### PR TITLE
fix: kitchen-inspec cannot use supermarket

### DIFF
--- a/lib/bundles/inspec-supermarket/target.rb
+++ b/lib/bundles/inspec-supermarket/target.rb
@@ -15,6 +15,7 @@ module Supermarket
     def self.resolve(target, opts = {})
       return nil unless URI(target).scheme == 'supermarket'
       return nil unless Supermarket::API.exist?(target)
+      puts "Target: #{target}"
       tool_info = Supermarket::API.find(target)
       super(tool_info['tool_source_url'], opts)
     rescue URI::Error => _e

--- a/lib/inspec.rb
+++ b/lib/inspec.rb
@@ -19,6 +19,7 @@ require 'inspec/runner'
 require 'inspec/shell'
 
 # all utils that may be required by plugins
+require 'inspec/cli'
 require 'utils/base_cli'
 require 'inspec/fetcher'
 require 'inspec/source_reader'


### PR DESCRIPTION
This fixes: https://github.com/chef/kitchen-inspec/issues/80

Without this change one cannot use a Supermarket hosted Profile in Test Kitchen.
The following results:

```
suites:
  - name: default
    run_list:
      - recipe[test-ohai::default]
    attributes:
    verifier:
      inspec_tests:
        - supermarket://hardening/ssh-hardening
...

>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Failed to complete #verify action: [Could not fetch inspec profile in "supermarket://hardening/ssh-hardening".]
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

This fix simply `include`s the "Cli" library which instantiates a new Plugin controller where the Supermarket bundle lives.  Without this the Supermarket and Compliance plugins are not loaded.

```
# Load all plugins on startup
ctl = Inspec::PluginCtl.new
```
