### PR TITLE
temporary: allow profiles with custom resources to load twice

### DIFF
--- a/lib/inspec/plugins/resource.rb
+++ b/lib/inspec/plugins/resource.rb
@@ -24,6 +24,15 @@ module Inspec
       end
 
       def self.__register(name, obj)
+        # In cases where we use json formatter with profiles, custom resources get loaded twice.
+        # this is caused by Inspec::Profile::load_params (it uses a MockRunner to parse all metadata)
+        # At this point of time we assume, that a resource with the same name is the same reource
+        # - we are not sure, that the same name is the same implementation
+        # - we should not load profiles multiple times
+        # - resources should be scoped to profiles where they are loaded
+        # TODO: all custom resources should be scoped into a profile instance
+        return Inspec::Resource.registry[name] unless Inspec::Resource.registry[name].nil?
+
         # rubocop:disable Lint/NestedMethodDefinition, Lint/DuplicateMethods
         cl = Class.new(obj) do
           # add some common methods

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -230,6 +230,10 @@ module Inspec
       Pathname.new(Dir.pwd).join("#{slug}.#{ext}")
     end
 
+    # this initializes a new Runner with the mock backend
+    # Be aware:
+    # This reloads the complete profile, e.g if used in combination with the
+    # json formatter and custom resources, this loads resources twice.
     def load_params
       params = @source_reader.metadata.params
       params[:name] = @profile_id unless @profile_id.nil?


### PR DESCRIPTION
In case we use the json formatter in combination with a profile that has custom resources, InSpec will crash due to the restriction to load resources only once.

This PR will return the loaded resource instead of throwing an error. It is a temporary fix only, until all custom resources are scoped within a profile.
