### PR TITLE
Provide service params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Berksfile.lock
 .librarian
 Puppetfile.lock
 .kitchen.local.yml
+profile.tar.gz

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rspec', '~> 3'
   spec.add_dependency 'rspec-its', '~> 1.2'
   spec.add_dependency 'pry', '~> 0'
+  spec.add_dependency 'hashie', '~> 3.4'
 
   spec.add_development_dependency 'mocha', '~> 1.1'
 end

--- a/test/cookbooks/os_prepare/recipes/_upstart_service_centos.rb
+++ b/test/cookbooks/os_prepare/recipes/_upstart_service_centos.rb
@@ -1,6 +1,10 @@
 # encoding: utf-8
 # author: Stephan Renatus
 
+directory '/etc/init' do
+  action :create
+end
+
 file "/etc/init/upstart-running.conf" do
   content "exec tail -f /dev/null"
 end

--- a/test/integration/default/service_spec.rb
+++ b/test/integration/default/service_spec.rb
@@ -89,6 +89,9 @@ if os[:family] == 'centos' && os[:release].to_i >= 6
     it { should be_enabled }
     it { should be_installed }
     it { should be_running }
+    its('type') { should be 'upstart' }
+    its('name') { should be 'upstart-enabled-and-running' }
+    its('description') { should be nil }
   end
 
   describe upstart_service('upstart-enabled-not-running') do
@@ -101,6 +104,7 @@ if os[:family] == 'centos' && os[:release].to_i >= 6
     it { should_not be_enabled }
     it { should_not be_installed }
     it { should_not be_running }
+    its('type') { should be nil }
   end
 end
 

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -4,6 +4,7 @@
 
 require 'helper'
 require 'inspec/resource'
+require 'hashie'
 
 describe 'Inspec::Resources::Service' do
   let(:runlevels) { {0=>false, 1=>false, 2=>true, 3=>true, 4=>true, 5=>true, 6=>false} }
@@ -11,191 +12,254 @@ describe 'Inspec::Resources::Service' do
   # windows
   it 'verify service parsing' do
     resource = MockLoader.new(:windows).load_resource('service', 'dhcp')
-    srv = { name: 'dhcp', description: 'DHCP Client', installed: true, running: true, enabled: true, type: 'windows' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'windows'
+    _(resource.name).must_equal 'dhcp'
+    _(resource.description).must_equal 'DHCP Client'
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   # ubuntu 14.04 with upstart
   it 'verify ubuntu package parsing' do
     resource = MockLoader.new(:ubuntu1404).load_resource('service', 'ssh')
-    srv = { name: 'ssh', description: nil, installed: true, running: true, enabled: true, type: 'upstart' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'upstart'
+    _(resource.name).must_equal 'ssh'
+    _(resource.description).must_equal nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   it 'verify ubuntu package parsing with default upstart_service' do
     resource = MockLoader.new(:ubuntu1404).load_resource('upstart_service', 'ssh')
-    srv = { name: 'ssh', description: nil, installed: true, running: true, enabled: true, type: 'upstart' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'upstart'
+    _(resource.name).must_equal 'ssh'
+    _(resource.description).must_equal nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+    _(resource.params.UnitFileState).must_equal nil
   end
 
   # ubuntu 15.04 with systemd
   it 'verify ubuntu package parsing' do
     resource = MockLoader.new(:ubuntu1504).load_resource('service', 'sshd')
-    srv = { name: 'sshd.service', description: 'OpenSSH server daemon', installed: true, running: true, enabled: true, type: 'systemd', :properties=>{"Id"=>"sshd.service", "Names"=>"sshd.service", "Description"=>"OpenSSH server daemon", "LoadState"=>"loaded", "UnitFileState"=>"enabled", "SubState"=>"running"} }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({ 'Description' => 'OpenSSH server daemon', 'Id' => 'sshd.service', 'LoadState' => 'loaded', 'Names' => 'sshd.service', 'SubState' => 'running', 'UnitFileState' => 'enabled' })
+    _(resource.type).must_equal 'systemd'
+    _(resource.name).must_equal 'sshd.service'
+    _(resource.description).must_equal 'OpenSSH server daemon'
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+    _(resource.params.SubState).must_equal 'running'
   end
 
   it 'verify ubuntu package parsing with default systemd_service' do
     resource = MockLoader.new(:ubuntu1504).load_resource('systemd_service', 'sshd')
-    srv = { name: 'sshd.service', description: 'OpenSSH server daemon', installed: true, running: true, enabled: true, type: 'systemd', :properties=>{"Id"=>"sshd.service", "Names"=>"sshd.service", "Description"=>"OpenSSH server daemon", "LoadState"=>"loaded", "UnitFileState"=>"enabled", "SubState"=>"running"} }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({ 'Description' => 'OpenSSH server daemon', 'Id' => 'sshd.service', 'LoadState' => 'loaded', 'Names' => 'sshd.service', 'SubState' => 'running', 'UnitFileState' => 'enabled' })
+    _(resource.type).must_equal 'systemd'
+    _(resource.name).must_equal 'sshd.service'
+    _(resource.description).must_equal 'OpenSSH server daemon'
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   # centos 6 with sysv
   it 'verify centos 6 package parsing' do
     resource = MockLoader.new(:centos6).load_resource('service', 'sshd')
-    srv = { name: 'sshd', description: nil, installed: true, running: true, enabled: true, runlevels: runlevels, type: 'sysv' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'sysv'
+    _(resource.name).must_equal 'sshd'
+    _(resource.description).must_equal nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+    _(resource.params.SubState).must_equal nil
   end
 
   it 'verify centos 6 package parsing with default sysv_service' do
     resource = MockLoader.new(:centos6).load_resource('sysv_service', 'sshd')
-    srv = { name: 'sshd', description: nil, installed: true, running: true, enabled: true, runlevels: runlevels, type: 'sysv' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'sysv'
+    _(resource.name).must_equal 'sshd'
+    _(resource.description).must_equal nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   # centos 7 with systemd
   it 'verify centos 7 package parsing' do
     resource = MockLoader.new(:centos7).load_resource('service', 'sshd')
-    srv = { name: 'sshd.service', description: 'OpenSSH server daemon', installed: true, running: true, enabled: true, type: 'systemd', :properties=>{"Id"=>"sshd.service", "Names"=>"sshd.service", "Description"=>"OpenSSH server daemon", "LoadState"=>"loaded", "UnitFileState"=>"enabled", "SubState"=>"running"} }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({ 'Description' => 'OpenSSH server daemon', 'Id' => 'sshd.service', 'LoadState' => 'loaded', 'Names' => 'sshd.service', 'SubState' => 'running', 'UnitFileState' => 'enabled' })
+    _(resource.type).must_equal 'systemd'
+    _(resource.name).must_equal 'sshd.service'
+    _(resource.description).must_equal 'OpenSSH server daemon'
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   it 'verify centos 7 package parsing with systemd_service and service_ctl override' do
     resource = MockLoader.new(:centos7).load_resource('systemd_service', 'sshd', '/path/to/systemctl')
-    srv = { name: 'sshd.service', description: 'OpenSSH server daemon', installed: true, running: true, enabled: true, type: 'systemd', :properties=>{"Id"=>"sshd.service", "Names"=>"sshd.service", "Description"=>"OpenSSH server daemon", "LoadState"=>"loaded", "UnitFileState"=>"enabled", "SubState"=>"running"} }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({ 'Description' => 'OpenSSH server daemon', 'Id' => 'sshd.service', 'LoadState' => 'loaded', 'Names' => 'sshd.service', 'SubState' => 'running', 'UnitFileState' => 'enabled' })
+    _(resource.type).must_equal 'systemd'
+    _(resource.name).must_equal 'sshd.service'
+    _(resource.description).must_equal 'OpenSSH server daemon'
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   it 'verify centos 7 package parsing with static loaded service' do
     resource = MockLoader.new(:centos7).load_resource('service', 'dbus')
-    srv = { name: 'dbus.service', description: 'D-Bus System Message Bus', installed: true, running: true, enabled: true, type: 'systemd', :properties=>{"Id"=>"dbus.service", "Names"=>"messagebus.service dbus.service", "Description"=>"D-Bus System Message Bus", "LoadState"=>"loaded", "UnitFileState"=>"static", "SubState"=>"running"} }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({ 'Description' => 'D-Bus System Message Bus', 'Id' => 'dbus.service', 'LoadState' => 'loaded', 'Names' => 'messagebus.service dbus.service', 'SubState' => 'running', 'UnitFileState' => 'static' })
+    _(resource.type).must_equal 'systemd'
+    _(resource.name).must_equal 'dbus.service'
+    _(resource.description).must_equal 'D-Bus System Message Bus'
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+    _(resource.params.UnitFileState).must_equal 'static'
   end
 
   # freebsd
   it 'verify freebsd10 package parsing' do
     resource = MockLoader.new(:freebsd10).load_resource('service', 'sendmail')
-    srv = { name: 'sendmail', description: nil, installed: true, running: true, enabled: true, type: 'bsd-init' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'bsd-init'
+    _(resource.name).must_equal 'sendmail'
+    _(resource.description).must_equal nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   it 'verify freebsd10 package parsing with default bsd_service' do
     resource = MockLoader.new(:freebsd10).load_resource('bsd_service', 'sendmail')
-    srv = { name: 'sendmail', description: nil, installed: true, running: true, enabled: true, type: 'bsd-init' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'bsd-init'
+    _(resource.name).must_equal 'sendmail'
+    _(resource.description).must_equal nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   # arch linux with systemd
   it 'verify arch linux package parsing' do
     resource = MockLoader.new(:arch).load_resource('service', 'sshd')
-    srv = { name: 'sshd.service', description: 'OpenSSH server daemon', installed: true, running: true, enabled: true, type: 'systemd', :properties=>{"Id"=>"sshd.service", "Names"=>"sshd.service", "Description"=>"OpenSSH server daemon", "LoadState"=>"loaded", "UnitFileState"=>"enabled", "SubState"=>"running"} }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({ 'Description' => 'OpenSSH server daemon', 'Id' => 'sshd.service', 'LoadState' => 'loaded', 'Names' => 'sshd.service', 'SubState' => 'running', 'UnitFileState' => 'enabled' })
+    _(resource.type).must_equal 'systemd'
+    _(resource.name).must_equal 'sshd.service'
+    _(resource.description).must_equal 'OpenSSH server daemon'
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   # debian 7 with systemv
   it 'verify debian 7 package parsing' do
     resource = MockLoader.new(:debian7).load_resource('service', 'sshd')
-    srv = { name: 'sshd', description: nil, installed: true, running: true, enabled: true, runlevels: runlevels, type: 'sysv' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'sysv'
+    _(resource.name).must_equal 'sshd'
+    _(resource.description).must_equal nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   # debian 8 with systemd
   it 'verify debian 8 package parsing' do
     resource = MockLoader.new(:debian8).load_resource('service', 'sshd')
-    srv = { name: 'sshd.service', description: 'OpenSSH server daemon', installed: true, running: true, enabled: true, type: 'systemd', :properties=>{"Id"=>"sshd.service", "Names"=>"sshd.service", "Description"=>"OpenSSH server daemon", "LoadState"=>"loaded", "UnitFileState"=>"enabled", "SubState"=>"running"} }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({ 'Description' => 'OpenSSH server daemon', 'Id' => 'sshd.service', 'LoadState' => 'loaded', 'Names' => 'sshd.service', 'SubState' => 'running', 'UnitFileState' => 'enabled' })
+    _(resource.type).must_equal 'systemd'
+    _(resource.name).must_equal 'sshd.service'
+    _(resource.description).must_equal 'OpenSSH server daemon'
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   # macos test
   it 'verify mac osx package parsing' do
     resource = MockLoader.new(:osx104).load_resource('service', 'ssh')
-    srv = { name: 'org.openbsd.ssh-agent', description: nil, installed: true, running: true, enabled: true, type: 'darwin' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'darwin'
+    _(resource.name).must_equal 'org.openbsd.ssh-agent'
+    _(resource.description).must_equal nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   it 'verify mac osx package parsing with not-running service' do
     resource = MockLoader.new(:osx104).load_resource('service', 'FilesystemUI')
-    srv = { name: 'com.apple.FilesystemUI', description: nil, installed: true, running: false, enabled: true, type: 'darwin' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'darwin'
+    _(resource.name).must_equal 'com.apple.FilesystemUI'
+    _(resource.description).must_equal nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal false
+    _(resource.params).must_equal params
   end
 
   it 'verify mac osx package parsing with default launchd_service' do
     resource = MockLoader.new(:osx104).load_resource('launchd_service', 'ssh')
-    srv = { name: 'org.openbsd.ssh-agent', description: nil, installed: true, running: true, enabled: true, type: 'darwin' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'darwin'
+    _(resource.name).must_equal 'org.openbsd.ssh-agent'
+    _(resource.description).must_equal nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
   # wrlinux
   it 'verify wrlinux package parsing' do
     resource = MockLoader.new(:wrlinux).load_resource('service', 'sshd')
-    srv = { name: 'sshd', description: nil, installed: true, running: true, enabled: true, runlevels: runlevels, type: 'sysv' }
-    _(resource.info).must_equal srv
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'sysv'
+    _(resource.name).must_equal 'sshd'
+    _(resource.description).must_equal nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
+    _(resource.params).must_equal params
   end
 
 
   # unknown OS
   it 'verify package handling on unsupported os' do
     resource = MockLoader.new(:undefined).load_resource('service', 'dhcp')
+    params = Hashie::Mash.new({})
     _(resource.installed?).must_equal false
-    _(resource.info).must_equal nil
+    _(resource.description).must_equal nil
+    _(resource.params).must_equal params
   end
 
   # runlevel detection


### PR DESCRIPTION
Replacing the current method of accessing these params:

``` ruby
describe service('avahi-daemon').info[:properties]['UnitFileState'] do
  it { should be 'enabled' }
end
```

with this:

``` ruby
  # This test will succeed if the service is not enabled
  describe service('avahi-daemon').params do
    its('UnitFileState') { should_not eq 'enabled' }
  end

  # This test will fail with expected: "enabled", got nil
  describe service('MissingInActionService').params do
    its('MissingInActionParam') { should eq 'enabled' }
  end
```
1. Not happy with the `hashie` dependency, but wanted to share the vision and start the discussion.
2. Should we make the `info` method private now?
3. `params` looks to be an internal inspec way of handing attributes. Is `properties` a better name for this method? For example:

``` ruby
  describe service('avahi-daemon').properties do
    its('UnitFileState') { should_not eq 'enabled' }
  end
```
