### PR TITLE
Remove redundant space when missing expectation

### DIFF
--- a/lib/inspec/objects/test.rb
+++ b/lib/inspec/objects/test.rb
@@ -65,8 +65,8 @@ module Inspec
       res, xtra = describe_chain
       itsy = xtra.nil? ? 'it' : 'its(' + xtra.to_s.inspect + ')'
       naughty = @negated ? '_not' : ''
-      xpect = defined?(@expectation) ? expectation.inspect : ''
-      format("%sdescribe %s do\n  %s { should%s %s %s }\nend",
+      xpect = defined?(@expectation) ? expectation.inspect+' ' : ''
+      format("%sdescribe %s do\n  %s { should%s %s %s}\nend",
              vars, res, itsy, naughty, matcher, xpect)
     end
 


### PR DESCRIPTION
This code change removes an extra space that's added when an expectation is not provided. I always noticed that extra space and thought for a second that something is wrong.

Diff for one of the translated tests after this change:

``` ruby
   describe file("/boot/grub2/grub.cfg") do
-    it { should exist  }
+    it { should exist }
   end
   describe file("/boot/grub2/grub.cfg") do
     it { should_not be_executable.by "group" }
   end
```
