### PR TITLE
fix: remove non-existent class

### DIFF
--- a/lib/bundles/inspec-supermarket.rb
+++ b/lib/bundles/inspec-supermarket.rb
@@ -6,7 +6,6 @@ libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
 module Supermarket
-  autoload :Configuration, 'inspec-supermarket/configuration'
   autoload :API, 'inspec-supermarket/api'
 end
 


### PR DESCRIPTION
This removes the trail to load a non-existing class
