### PR TITLE
Expose label for processes only on linux

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -137,6 +137,7 @@ class MockLoader
 
     mock.commands = {
       'ps aux' => cmd.call('ps-aux'),
+      'ps auxZ' => cmd.call('ps-auxZ'),
       'Get-Content win_secpol.cfg' => cmd.call('secedit-export'),
       'secedit /export /cfg win_secpol.cfg' => cmd.call('success'),
       'Remove-Item win_secpol.cfg' => cmd.call('success'),

--- a/test/unit/mock/cmd/ps-auxZ
+++ b/test/unit/mock/cmd/ps-auxZ
@@ -1,0 +1,3 @@
+LABEL                            USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+system_u:system_r:kernel_t:s0    root         1  0.0  0.0  19232  1492 ?        Ss   May04   0:01 /sbin/init
+system_u:system_r:kernel_t:s0    root        39  0.0  0.0      0     0 ?        S    May04   0:00 crypto/0

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -12,8 +12,9 @@ describe 'Inspec::Resources::Processes' do
   end
 
   it 'verify processes resource' do
-    resource = load_resource('processes', '/bin/bash')
+    resource = MockLoader.new(:freebsd10).load_resource('processes', '/bin/bash')
     _(resource.list).must_equal [{
+      label: nil,
       user: 'root',
       pid: 1,
       cpu: '0.0',
@@ -30,9 +31,35 @@ describe 'Inspec::Resources::Processes' do
     _(resource.list.length).must_equal 1
   end
 
+  it 'verify processes resource on linux os' do
+    resource = MockLoader.new(:centos6).load_resource('processes', '/sbin/init')
+    _(resource.list).must_equal [{
+      label: 'system_u:system_r:kernel_t:s0',
+      user: 'root',
+      pid: 1,
+      cpu: '0.0',
+      mem: '0.0',
+      vsz: 19232,
+      rss: 1492,
+      tty: '?',
+      stat: 'Ss',
+      start: 'May04',
+      time: '0:01',
+      command: '/sbin/init',
+    }]
+
+    _(resource.list.length).must_equal 1
+  end
+
   it 'retrieves the users and states as arrays' do
-    resource = load_resource('processes', 'svc')
+    resource = MockLoader.new(:freebsd10).load_resource('processes', 'svc')
     _(resource.users.sort).must_equal ['noot']
     _(resource.states.sort).must_equal ['S', 'Ss']
+  end
+
+  it 'retrieves the users and states as arrays on linux os' do
+    resource = MockLoader.new(:centos6).load_resource('processes', 'crypto/0')
+    _(resource.users.sort).must_equal ['root']
+    _(resource.states.sort).must_equal ['S']
   end
 end


### PR DESCRIPTION
expose label field on linux only using ps auxZ,
needed for https://github.com/chef/inspec-scap/pull/142
