### PR TITLE
Escape os_env command on Windows to handle env variables containing parentheses.

### DIFF
--- a/lib/resources/os_env.rb
+++ b/lib/resources/os_env.rb
@@ -51,7 +51,7 @@ module Inspec::Resources
 
     def value_for(env)
       command = if inspec.os.windows?
-                  "$Env:#{env}"
+                  "${Env:#{env}}"
                 else
                   'env'
                 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -142,7 +142,7 @@ class MockLoader
       'secedit /export /cfg win_secpol.cfg' => cmd.call('success'),
       'Remove-Item win_secpol.cfg' => cmd.call('success'),
       'env' => cmd.call('env'),
-      '$Env:PATH'  => cmd.call('$env-PATH'),
+      '${Env:PATH}'  => cmd.call('$env-PATH'),
       # registry key test (winrm 1.6.0, 1.6.1)
       '2790db1e88204a073ed7fd3493f5445e5ce531afd0d2724a0e36c17110c535e6' => cmd.call('reg_schedule'),
       '25a1a38fafc289a646d30f7aa966ce0901c267798f47abf2f9440e27d31a5b7d' => cmd.call('reg_schedule'),


### PR DESCRIPTION
One of the common environment variable is "ProgramFile(x86)", and the previous implementation does not handle that correctly.
