### PR TITLE
Make list properties accessible in its

### DIFF
--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -3,6 +3,7 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 # license: All rights reserved
+require 'hashie'
 
 module Inspec::Resources
   class Processes < Inspec.resource(1)
@@ -36,6 +37,8 @@ module Inspec::Resources
         states: :stat }.each do |var, key|
         instance_variable_set("@#{var}", @list.map { |l| l[key] }.uniq)
       end
+      # Make each array item a Mash so that we can have item.pid, etc
+      @list.map! { |p| Hashie::Mash.new(p) }
     end
 
     def to_s

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -4,6 +4,7 @@
 
 require 'helper'
 require 'inspec/resource'
+require 'hashie'
 
 describe 'Inspec::Resources::Processes' do
   it 'handles empty process results' do
@@ -13,7 +14,7 @@ describe 'Inspec::Resources::Processes' do
 
   it 'verify processes resource' do
     resource = MockLoader.new(:freebsd10).load_resource('processes', '/bin/bash')
-    _(resource.list).must_equal [{
+    _(resource.list).must_equal [Hashie::Mash.new({
       label: nil,
       user: 'root',
       pid: 1,
@@ -26,14 +27,14 @@ describe 'Inspec::Resources::Processes' do
       start: '14:15',
       time: '0:00',
       command: '/bin/bash',
-    }]
+    })]
 
     _(resource.list.length).must_equal 1
   end
 
   it 'verify processes resource on linux os' do
     resource = MockLoader.new(:centos6).load_resource('processes', '/sbin/init')
-    _(resource.list).must_equal [{
+    _(resource.list).must_equal [Hashie::Mash.new({
       label: 'system_u:system_r:kernel_t:s0',
       user: 'root',
       pid: 1,
@@ -46,7 +47,7 @@ describe 'Inspec::Resources::Processes' do
       start: 'May04',
       time: '0:01',
       command: '/sbin/init',
-    }]
+    })]
 
     _(resource.list.length).must_equal 1
   end


### PR DESCRIPTION
The change is needed in order to access process properties like this:

``` ruby
processes("*").list.each do |entry|
  describe entry do
    its("pid") { should be > 0 }
  end
  describe entry do
    its("command") { should match ".+" }
  end
end
```
