### PR TITLE
use struct for processes list

### DIFF
--- a/lib/inspec/polyfill.rb
+++ b/lib/inspec/polyfill.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2016, Chef Software Inc.
+# author: Dominik Richter
+# author: Christoph Hartmann
+# license: All rights reserved
+
+class Struct
+  unless instance_methods.include? :to_h
+    def to_h
+      Hash[each_pair.to_a]
+    end
+  end
+end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -4,6 +4,7 @@
 # author: Christoph Hartmann
 
 require 'forwardable'
+require 'inspec/polyfill'
 require 'inspec/fetcher'
 require 'inspec/source_reader'
 require 'inspec/metadata'

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -13,7 +13,8 @@ describe 'Inspec::Resources::Processes' do
 
   it 'verify processes resource' do
     resource = MockLoader.new(:freebsd10).load_resource('processes', '/bin/bash')
-    _(resource.list).must_equal [{
+    _(resource.list.length).must_equal 1
+    _(resource.list[0].to_h).must_equal({
       label: nil,
       user: 'root',
       pid: 1,
@@ -26,14 +27,13 @@ describe 'Inspec::Resources::Processes' do
       start: '14:15',
       time: '0:00',
       command: '/bin/bash',
-    }]
-
-    _(resource.list.length).must_equal 1
+    })
   end
 
   it 'verify processes resource on linux os' do
     resource = MockLoader.new(:centos6).load_resource('processes', '/sbin/init')
-    _(resource.list).must_equal [{
+    _(resource.list.length).must_equal 1
+    _(resource.list[0].to_h).must_equal({
       label: 'system_u:system_r:kernel_t:s0',
       user: 'root',
       pid: 1,
@@ -46,9 +46,16 @@ describe 'Inspec::Resources::Processes' do
       start: 'May04',
       time: '0:01',
       command: '/sbin/init',
-    }]
+    })
+  end
 
-    _(resource.list.length).must_equal 1
+  it 'access attributes of a process' do
+    resource = MockLoader.new(:centos6).load_resource('processes', '/sbin/init')
+    process = resource.list[0]
+    process.user.must_equal 'root'
+    process[:user].must_equal 'root'
+    process['user'].must_equal 'root'
+    process[1].must_equal 'root'
   end
 
   it 'retrieves the users and states as arrays' do


### PR DESCRIPTION
we know all the fields + struct is fully compatible to the curren hash implementation

this gives us access to accessor methods:

```
describe processes.list[0] do
  its('user') { ... }
end
```

without method_missing or analogous

as originally proposed by @alexpop in https://github.com/chef/inspec/pull/743
Kudos!!
