### PR TITLE
Prevent nil.include?

### DIFF
--- a/lib/inspec/objects/test.rb
+++ b/lib/inspec/objects/test.rb
@@ -49,7 +49,7 @@ module Inspec
       if @qualifier.length > 1
         last = @qualifier[-1]
         # preventing its('to_i') as the value returned is always 0
-        if last.length == 1 && last[0] !~ /^to_.$/ && !last[0].include?('[')
+        if last.length == 1 && last[0] !~ /^to_.$/ && !last[0].nil? && !last[0].include?('[')
           xres = last[0]
         else
           res += '.' + ruby_qualifier(last)

--- a/lib/inspec/objects/test.rb
+++ b/lib/inspec/objects/test.rb
@@ -48,11 +48,13 @@ module Inspec
 
       if @qualifier.length > 1
         last = @qualifier[-1]
-        # preventing its('to_i') as the value returned is always 0
-        if last.length == 1 && last[0] !~ /^to_.$/ && !last[0].nil? && !last[0].include?('[')
-          xres = last[0]
-        else
-          res += '.' + ruby_qualifier(last)
+        unless last.is_a?(Array) && last[0].to_s.empty?
+          if last.length == 1 && last[0] !~ /^to_.$/ && !last[0].include?('[')
+            # this will go in its()
+            xres = last[0]
+          else
+            res += '.' + ruby_qualifier(last)
+          end
         end
       end
 


### PR DESCRIPTION
Caught by the inspec-scap unit tests:

```
OvalRegistry::symlink_test#test_0002_parses xml to ruby (check existence):
NoMethodError: undefined method `include?' for nil:NilClass
    /home/travis/build/chef/inspec-scap/vendor/bundle/ruby/2.2.0/gems/inspec-0.21.5/lib/inspec/objects/test.rb:52:in `describe_chain'
    /home/travis/build/chef/inspec-scap/vendor/bundle/ruby/2.2.0/gems/inspec-0.21.5/lib/inspec/objects/test.rb:65:in `rb_describe'
```
