### PR TITLE
another doc tweak.

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -788,7 +788,7 @@ A ``etc_group`` |inspec resource| block declares a collection of properties to b
 
 .. code-block:: ruby
 
-   describe etc_group('path') do
+   describe etc_group('/etc/group') do
      its('matcher') { should eq 'some_value' }
    end
 
@@ -796,7 +796,7 @@ or:
 
 .. code-block:: ruby
 
-   describe etc_group.where(item: 'value', item: 'value') do
+   describe etc_group.where(item: 'wheel') do
      its('gids') { should_not contain_duplicates }
      its('groups') { should include 'user_name' }
      its('users') { should include 'user_name' }


### PR DESCRIPTION
the docs on this resource matcher are very confusing to someone
with no prior inspec experience.  the meaning of 'item' and 'value' are
totally opaque.   it needs less generic and more relevant examples.

(and i'm still not quite sure i've gotten it right here)
