### PR TITLE
Adding ability to specify private Supermarket

### DIFF
--- a/lib/bundles/inspec-supermarket.rb
+++ b/lib/bundles/inspec-supermarket.rb
@@ -11,3 +11,4 @@ end
 
 require 'inspec-supermarket/cli'
 require 'inspec-supermarket/target'
+require 'inspec-supermarket/helper'

--- a/lib/bundles/inspec-supermarket/helper.rb
+++ b/lib/bundles/inspec-supermarket/helper.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+# author: Jeremy Miller
+
+module Supermarket
+  class Helper
+    def self.parse_host(location)
+      uri = URI(location)
+      return nil if uri.scheme != 'supermarket' || uri.path =~ %r{/\A}
+      case uri.path.count('/')
+      when 0, 2, 4
+        Supermarket::API.update_config('supermarket_url', "https://#{uri.host}")
+      end
+    rescue URI::Error => _e
+      nil
+    end
+  end
+end

--- a/lib/bundles/inspec-supermarket/target.rb
+++ b/lib/bundles/inspec-supermarket/target.rb
@@ -13,7 +13,9 @@ module Supermarket
     priority 500
 
     def self.resolve(target, opts = {})
-      return nil unless URI(target).scheme == 'supermarket'
+      uri = URI(target)
+      return nil unless uri.scheme == 'supermarket'
+      Supermarket::Helper.parse_host(target)
       return nil unless Supermarket::API.exist?(target)
       tool_info = Supermarket::API.find(target)
       super(tool_info['tool_source_url'], opts)

--- a/lib/bundles/inspec-supermarket/target.rb
+++ b/lib/bundles/inspec-supermarket/target.rb
@@ -13,8 +13,7 @@ module Supermarket
     priority 500
 
     def self.resolve(target, opts = {})
-      uri = URI(target)
-      return nil unless uri.scheme == 'supermarket'
+      return nil unless URI(target).scheme == 'supermarket'
       Supermarket::Helper.parse_host(target)
       return nil unless Supermarket::API.exist?(target)
       tool_info = Supermarket::API.find(target)

--- a/test/functional/inspec_supermarket_test.rb
+++ b/test/functional/inspec_supermarket_test.rb
@@ -7,7 +7,7 @@ require 'functional/helper'
 describe 'inspec supermarket' do
   include FunctionalHelper
 
-  it 'outpus help message' do
+  it 'outputs help message' do
     out = inspec('supermarket help')
     out.exit_status.must_equal 0
     out.stdout.must_include 'inspec supermarket exec PROFILE'

--- a/test/functional/inspec_supermarket_test.rb
+++ b/test/functional/inspec_supermarket_test.rb
@@ -1,0 +1,92 @@
+# encoding: utf-8
+# author: Jeremy Miller
+
+require 'functional/helper'
+
+# basic testing without availability of any server
+describe 'inspec supermarket' do
+  include FunctionalHelper
+
+  it 'outpus help message' do
+    out = inspec('supermarket help')
+    out.exit_status.must_equal 0
+    out.stdout.must_include 'inspec supermarket exec PROFILE'
+  end
+
+  it 'lists info on profile without supermarket uri scheme' do
+    out = inspec('supermarket info hardening/os-hardening')
+    out.exit_status.must_equal 0
+    out.stdout.must_match %r{supermarket:.*https://supermarket.chef.io}
+    out.stdout.must_match %r{name:.*os-hardening}
+  end
+
+  it 'lists info on profile with supermarket uri scheme but no host' do
+    out = inspec('supermarket info supermarket://hardening/os-hardening')
+    out.exit_status.must_equal 0
+    out.stdout.must_match %r{supermarket:.*https://supermarket.chef.io}
+    out.stdout.must_match %r{name:.*os-hardening}
+  end
+
+  it 'list info on profile with supermarket uri scheme with host' do
+    out = inspec('supermarket info supermarket://supermarket.chef.io/hardening/os-hardening')
+    out.exit_status.must_equal 0
+    out.stdout.must_match %r{supermarket:.*https://supermarket.chef.io}
+    out.stdout.must_match %r{name:.*os-hardening}
+  end
+
+  it 'doest not list info on profile when bad supermarket host specified' do
+    out = inspec('supermarket info supermarket://1nyp2cl3uzxydyf4ved/hardening/os-hardening')
+    out.exit_status.must_equal 1
+    out.stderr.must_match %r{SocketError}
+  end
+
+  it 'lists profiles' do
+    out = inspec('supermarket profiles')
+    out.exit_status.must_equal 0
+    out.stdout.must_match %r{supermarket:.*https://supermarket.chef.io}
+    out.stdout.must_match %r{Available profiles}
+  end
+
+  it 'lists profiles when supermarket host specified' do
+    out = inspec('supermarket profiles supermarket://supermarket.chef.io')
+    out.exit_status.must_equal 0
+    out.stdout.must_match %r{supermarket:.*https://supermarket.chef.io}
+    out.stdout.must_match %r{Available profiles}
+  end
+
+  it 'does not list profiles when bad supermarket host specified' do
+    out = inspec('supermarket profiles supermarket://1nyp2cl3uzxydyf4ved')
+    out.exit_status.must_equal 1
+    out.stderr.must_match %r{SocketError}
+  end
+
+  it 'executes profile from supermarket' do
+    out = inspec('supermarket exec hardening/ssh-hardening')
+    out.stdout.must_match %r{Failures:}
+  end
+
+  it 'executes profile from supermarket when supermarket uri scheme specified' do
+    out = inspec('supermarket exec supermarket://hardening/ssh-hardening')
+    out.stdout.must_match %r{Failures:}
+  end
+
+  it 'executes profile from supermarket when supermarket uri scheme specified with host' do
+    out = inspec('supermarket exec supermarket://supermarket.chef.io/hardening/ssh-hardening')
+    out.stdout.must_match %r{Failures:}
+  end
+
+  it 'does not execute profile from supermarket when supermarket uri scheme specified with bad host' do
+    out = inspec('supermarket exec supermarket://1nyp2cl3uzxydyf4ved/hardening/ssh-hardening')
+    out.stderr.must_match %r{SocketError}
+  end
+
+  it 'executes profile from supermarket when not using supermarket subcommand' do
+    out = inspec('exec supermarket://hardening/ssh-hardening')
+    out.stdout.must_match %r{Failures:}
+  end
+
+  it 'executes profile from supermarket when not using supermarket subcommand and specifying host' do
+    out = inspec('exec supermarket://supermarket.chef.io/hardening/ssh-hardening')
+    out.stdout.must_match %r{Failures:}
+  end
+end


### PR DESCRIPTION
This implementation provides the ability to specify a custom Supermarket host.

For example:

```
inspec supermarket profiles supermarket://my.supermarket.com
inspec supermarket info supermarket://nathenharvey/tmp-compliance-profile
inspec supermarket info supermarket://my.supermarket.com/nathenharvey/tmp-compliance-profile
inspec supermarket exec supermarket://supermarket.chef.io/nathenharvey/tmp-compliance-profile
inspec exec supermarket://my.supermarket.com/hardening/ssh-hardening
```
