### PR TITLE
add helper methods for os resource

### DIFF
--- a/lib/resources/os.rb
+++ b/lib/resources/os.rb
@@ -7,8 +7,16 @@ module Inspec::Resources
     name 'os'
     desc 'Use the os InSpec audit resource to test the platform on which the system is running.'
     example "
-      describe os[:family] do
+      describe os.family do
         it { should eq 'redhat' }
+      end
+
+      describe os.redhat? do
+        it { should eq true }
+      end
+
+      describe os.linux? do
+        it { should eq true }
       end
     "
 
@@ -25,6 +33,15 @@ module Inspec::Resources
       inspec.backend.os[name]
     end
 
+    # add helper methods for easy access of properties
+    # allows users to use os.name, os.family, os.release, os.arch
+    %w{name family release arch}.each do |property|
+      define_method(property.to_sym) do
+        inspec.backend.os[property.to_sym]
+      end
+    end
+
+    # helper to collect a hash object easily
     def params
       {
         name: inspec.backend.os[:name],

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -51,7 +51,7 @@ class MockLoader
     ubuntu1204: { family: 'ubuntu', release: '12.04', arch: 'x86_64' },
     ubuntu1404: { family: 'ubuntu', release: '14.04', arch: 'x86_64' },
     ubuntu1504: { family: 'ubuntu', release: '15.04', arch: 'x86_64' },
-    windows:    { family: 'windows', release: nil, arch: nil },
+    windows:    { family: 'windows', release: '6.2.9200', arch: 'x86_64' },
     wrlinux:    { family: 'wrlinux', release: '7.0(3)I2(2)', arch: 'x86_64' },
     solaris11:  { family: "solaris", release: '11', arch: 'i386'},
     solaris10:  { family: "solaris", release: '10', arch: 'i386'},

--- a/test/unit/resources/os_test.rb
+++ b/test/unit/resources/os_test.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+require 'helper'
+require 'inspec/resource'
+
+describe 'Inspec::Resources::Os' do
+  it 'verify os parsing on CentOS' do
+    resource = MockLoader.new(:centos7).load_resource('os')
+    _(resource.name).must_equal nil
+    _(resource.family).must_equal 'redhat'
+    _(resource.release).must_equal '7.1.1503'
+    _(resource.arch).must_equal 'x86_64'
+  end
+
+  it 'read env variable on Windows' do
+    resource = MockLoader.new(:windows).load_resource('os')
+    _(resource.name).must_equal nil
+    _(resource.family).must_equal 'windows'
+    _(resource.release).must_equal '6.2.9200'
+    _(resource.arch).must_equal 'x86_64'
+  end
+
+  it 'verify os parsing on Debian' do
+    resource = MockLoader.new(:debian8).load_resource('os')
+    _(resource.name).must_equal nil
+    _(resource.family).must_equal 'debian'
+    _(resource.release).must_equal '8'
+    _(resource.arch).must_equal 'x86_64'
+  end
+
+  it 'verify os parsing on Ubuntu' do
+    resource = MockLoader.new(:ubuntu1504).load_resource('os')
+    _(resource.name).must_equal nil
+    _(resource.family).must_equal 'ubuntu'
+    _(resource.release).must_equal '15.04'
+    _(resource.arch).must_equal 'x86_64'
+  end
+end


### PR DESCRIPTION
This PR allows users to

```
describe os.family do
  it { should eq 'redhat' }
end
```

instead of

```
describe os[:family] do
  it { should eq 'redhat' }
end
```
