### PR TITLE
connect `port` and filter table

### DIFF
--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -200,19 +200,17 @@ module FilterTable
     private
 
     def create_connector(c)
-      if !c.block.nil?
-        showblock = ->(cond = Show) { c.block.call(self, cond) }
-      else
-        showblock = lambda { |condition = Show, &cond_block|
-          if condition == Show && !block_given?
-            r = where(nil).get_field(c.field_name)
-            r = r.flatten.uniq.compact if c.opts[:style] == :simple
-            r
-          else
-            where({ c.field_name => condition }, &cond_block)
-          end
-        }
-      end
+      return ->(cond = Show) { c.block.call(self, cond) } if !c.block.nil?
+
+      lambda { |condition = Show, &cond_block|
+        if condition == Show && !block_given?
+          r = where(nil).get_field(c.field_name)
+          r = r.flatten.uniq.compact if c.opts[:style] == :simple
+          r
+        else
+          where({ c.field_name => condition }, &cond_block)
+        end
+      }
     end
   end
 

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -81,10 +81,10 @@ module FilterTable
       end
     end
 
-    def get_fields(*fields)
+    def get_field(field)
       @params.map do |line|
-        fields.map { |f| line[f] }
-      end.flatten
+        line[field]
+      end
     end
 
     def to_s
@@ -132,17 +132,20 @@ module FilterTable
   end
 
   class Factory
+    Connector = Struct.new(:field_name, :block, :opts)
+
     def initialize
       @accessors = []
-      @fields = {}
-      @blocks = {}
+      @connectors = {}
     end
 
-    def connect(resource, table_accessor) # rubocop:disable Metrics/AbcSize
+    def connect(resource, table_accessor)
       # create the table structure
-      fields = @fields
-      blocks = @blocks
-      struct_fields = fields.values
+      connectors = @connectors
+      struct_fields = connectors.values.map(&:field_name)
+      connector_blocks = connectors.map do |method, c|
+        [method.to_sym, create_connector(c)]
+      end
 
       # the struct to hold single items from the #entries method
       entry_struct = Struct.new(*struct_fields.map(&:to_sym)) do
@@ -154,13 +157,8 @@ module FilterTable
 
       # the main filter table
       table = Class.new(Table) {
-        fields.each do |method, field_name|
-          block = blocks[method]
-          define_method method.to_sym do |condition = Show, &cond_block|
-            return block.call(self, condition) unless block.nil?
-            return where(nil).get_fields(field_name) if condition == Show && !block_given?
-            where({ field_name => condition }, &cond_block)
-          end
+        connector_blocks.each do |x|
+          define_method x[0], &x[1]
         end
 
         define_method :new_entry do |hashmap, filter = ''|
@@ -172,7 +170,7 @@ module FilterTable
       }
 
       # define all access methods with the parent resource
-      accessors = @accessors + @fields.keys
+      accessors = @accessors + @connectors.keys
       accessors.each do |method_name|
         resource.send(:define_method, method_name.to_sym) do |*args, &block|
           filter = table.new(self, method(table_accessor).call, ' with')
@@ -194,10 +192,27 @@ module FilterTable
         throw RuntimeError, "Called filter.add for resource #{@resource} with method name nil!"
       end
 
-      field_name = opts[:field] || method_name
-      @fields[method_name.to_sym] = field_name
-      @blocks[method_name.to_sym] = block
+      @connectors[method_name.to_sym] =
+        Connector.new(opts[:field] || method_name, block, opts)
       self
+    end
+
+    private
+
+    def create_connector(c)
+      if !c.block.nil?
+        showblock = ->(cond = Show) { c.block.call(self, cond) }
+      else
+        showblock = lambda { |condition = Show, &cond_block|
+          if condition == Show && !block_given?
+            r = where(nil).get_field(c.field_name)
+            r = r.flatten.uniq.compact if c.opts[:style] == :simple
+            r
+          else
+            where({ c.field_name => condition }, &cond_block)
+          end
+        }
+      end
     end
   end
 

--- a/test/unit/resources/port_test.rb
+++ b/test/unit/resources/port_test.rb
@@ -15,6 +15,26 @@ describe 'Inspec::Resources::Port' do
     _(resource.addresses).must_equal ["0.0.0.0", "::"]
   end
 
+  it 'lists all ports' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('port')
+    _(resource.entries.length).must_equal 4
+    _(resource.listening?).must_equal true
+    _(resource.protocols).must_equal %w{ tcp tcp6 udp }
+    _(resource.pids).must_equal [1, 2043, 545]
+    _(resource.processes).must_equal ['sshd', 'pidgin', 'rpcbind']
+    _(resource.addresses).must_equal ['0.0.0.0', '::']
+  end
+
+  it 'filter ports by conditions' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('port').where { protocol =~ /udp/i }
+    _(resource.entries.length).must_equal 1
+    _(resource.listening?).must_equal true
+    _(resource.protocols).must_equal ['udp']
+    _(resource.pids).must_equal [545]
+    _(resource.processes).must_equal ['rpcbind']
+    _(resource.addresses).must_equal ['0.0.0.0']
+  end
+
   it 'verify UDP port on Ubuntu 14.04' do
     resource = MockLoader.new(:ubuntu1404).load_resource('port', 111)
     _(resource.listening?).must_equal true

--- a/test/unit/utils/filter_table_test.rb
+++ b/test/unit/utils/filter_table_test.rb
@@ -69,6 +69,19 @@ describe FilterTable do
       factory.add(:baz).connect(resource, :data)
       instance.baz(123).must_be_kind_of(FilterTable::Table)
     end
+
+    it 'retrieves all entries' do
+      factory.add(:foo).connect(resource, :data)
+      instance.foo.must_equal([3, 2, 2])
+    end
+
+    it 'retrieves entries with simple style' do
+      factory.add(:foo, style: :simple)
+             .add(:num, style: :simple)
+             .connect(resource, :data)
+      instance.foo.must_equal([3, 2])
+      instance.num.must_equal([1, 2])
+    end
   end
 
   describe 'when calling entries' do


### PR DESCRIPTION
(1) Adds style handling to filter table + optimizes its internals. It's the equivalent of:

``` ruby
resource.entries.flatten.uniq.compact
```

and can be used by:

``` ruby
filter.add(:field, style: :simple)
```

(2) Puts filter table into port. A forgettable internal change, if it weren't for:

``` ruby
port.where { protocol =~ /tcp/ && port > 80 }.listening?
```

(becomes especially useful if you want all listening ports on the node and then do some action on those, e.g. 

``` ruby
port.protocols(/tcp/).entries.each do |socket|
  describe ssl(port: socket.port).protocols('ssl2') do
    it { should_not be_enabled }
  end
end
```

)
