### PR TITLE
expose output option for inspec exec

### DIFF
--- a/lib/utils/base_cli.rb
+++ b/lib/utils/base_cli.rb
@@ -55,6 +55,8 @@ module Inspec
         desc: 'Which formatter to use: progress, documentation, json'
       option :color, type: :boolean, default: true,
         desc: 'Use colors in output.'
+      option :output, type: :string,
+        desc: 'Save the report to a path'
     end
 
     private


### PR DESCRIPTION
This allows user to store the result in files:

```
inspec exec examples/profile --format json --output report.json
cat report.json | jq
```
