### PR TITLE
integer?("0300") should not be true

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -232,7 +232,7 @@ end
 RSpec::Matchers.define :cmp do |first_expected|
 
   def integer?(value)
-    !(value =~ /\A\d+\Z/).nil?
+    !(value =~ /\A[1-9]\d*\Z/).nil?
   end
 
   def float?(value)

--- a/test/integration/default/compare_matcher_spec.rb
+++ b/test/integration/default/compare_matcher_spec.rb
@@ -71,6 +71,11 @@ if os.linux?
     it { should_not cmp >= 13 }
   end
 
+  # Don't compare octal to number
+  describe '07' do
+    it { should_not cmp 7 }
+  end
+
   describe 'some 123' do
     it { should cmp 'some 123' }
     it { should cmp /^SOME\s\d+(1|2|3)3/i }


### PR DESCRIPTION
because if it is, `cmp` can never compare "octal strings", since it doesn't reach https://github.com/chef/inspec/blob/master/lib/matchers/matchers.rb#L262
