### PR TITLE
align inspec's check, detect, and exec cli formatters

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -138,7 +138,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
     else
       headline('Operating System Details')
       %w{name family release arch}.each { |item|
-        puts "#{mark_text(item.to_s.capitalize + ':')} #{res[item.to_sym]}"
+        puts format('%-10s %s', item.to_s.capitalize + ':',
+                    mark_text(res[item.to_sym]))
       }
     end
   end

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -66,20 +66,25 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
       if result[:errors].empty? and result[:warnings].empty?
         puts 'No errors or warnings'
       else
+        red    = "\033[31m"
+        yellow = "\033[33m"
+        rst    = "\033[0m"
+
         item_msg = lambda { |item|
           pos = [item[:file], item[:line], item[:column]].compact.join(':')
           pos.empty? ? item[:msg] : pos + ': ' + item[:msg]
         }
         result[:errors].each do |item|
-          puts "\033[31m  ✖  #{item_msg.call(item)}\033[0m"
+          puts "#{red}  ✖  #{item_msg.call(item)}#{rst}"
         end
         result[:warnings].each do |item|
-          puts "\033[33m  !  #{item_msg.call(item)}\033[0m"
+          puts "#{yellow}  !  #{item_msg.call(item)}#{rst}"
         end
 
         puts
-        puts format('Summary:   %3d errors  %3d warnings',
-                    result[:errors].length, result[:warnings].length)
+        puts format('Summary:     %s%d errors%s, %s%d warnings%s',
+                    red, result[:errors].length, rst,
+                    yellow, result[:warnings].length, rst)
       end
     end
     exit 1 unless result[:summary][:valid]

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -202,8 +202,10 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
 
     res = @output_hash[:summary]
     passed = res[:example_count] - res[:failure_count] - res[:skip_count]
-    s = format('Summary: %3d successful  %3d failures  %3d skipped',
-               passed, res[:failure_count], res[:skip_count])
+    s = format('Summary: %s%d successful%s, %s%d failures%s, %s%d skipped%s',
+               COLORS['passed'], passed, COLORS['reset'],
+               COLORS['failed'], res[:failure_count], COLORS['reset'],
+               COLORS['skipped'], res[:skip_count], COLORS['reset'])
     output.puts(s)
   end
 

--- a/lib/utils/base_cli.rb
+++ b/lib/utils/base_cli.rb
@@ -136,13 +136,11 @@ module Inspec
     end
 
     def mark_text(text)
-      "\e[0;32m#{text}\e[0m"
+      "\e[0;36m#{text}\e[0m"
     end
 
     def headline(title)
-      puts title
-      title.each_char { print '-' }
-      puts
+      puts "== #{title}\n\n"
     end
 
     def li(entry)

--- a/lib/utils/base_cli.rb
+++ b/lib/utils/base_cli.rb
@@ -140,7 +140,7 @@ module Inspec
     end
 
     def headline(title)
-      puts "== #{title}\n\n"
+      puts "\n== #{title}\n\n"
     end
 
     def li(entry)

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -18,7 +18,7 @@ describe 'inspec exec' do
 \e[37m  ○  gordon-1.0: Verify the version number of Gordon (1 skipped)\e[0m
 \e[37m     Can't find file \"/tmp/gordon/config.yaml\"\e[0m
 "
-    stdout.must_include "\nSummary:   4 successful    0 failures    1 skipped\n"
+    stdout.must_include "\nSummary: \e[32m4 successful\e[0m, \e[31m0 failures\e[0m, \e[37m1 skipped\e[0m\n"
   end
 
   it 'executes a minimum metadata-only profile' do
@@ -32,7 +32,7 @@ Target:  local://
 
      No tests executed.\e[0m
 
-Summary:   0 successful    0 failures    0 skipped
+Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m
 "
   end
 
@@ -47,7 +47,7 @@ Target:  local://
 
      No tests executed.\e[0m
 
-Summary:   0 successful    0 failures    0 skipped
+Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m
 "
   end
 
@@ -66,7 +66,7 @@ Target:  local://
      \n     (compared using ==)
      \e[0m
 
-Summary:   1 successful    1 failures    1 skipped
+Summary: \e[32m1 successful\e[0m, \e[31m1 failures\e[0m, \e[37m1 skipped\e[0m
 "
   end
 
@@ -74,14 +74,14 @@ Summary:   1 successful    1 failures    1 skipped
     out = inspec('exec ' + example_profile + ' --controls tmp-1.0')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
-    out.stdout.must_include "\nSummary:   1 successful    0 failures    0 skipped\n"
+    out.stdout.must_include "\nSummary: \e[32m1 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
   end
 
   it 'can execute a simple file with the default formatter' do
     out = inspec('exec ' + example_control)
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
-    out.stdout.must_include 'Summary:   2 successful    0 failures    0 skipped'
+    out.stdout.must_include "\nSummary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
   end
 
   describe 'with a profile that is not supported on this OS/platform' do

--- a/test/functional/inspec_test.rb
+++ b/test/functional/inspec_test.rb
@@ -26,10 +26,11 @@ describe 'command tests' do
       out.stderr.must_equal ''
       out.exit_status.must_equal 0
       std = out.stdout
-      std.must_include 'Name:'
-      std.must_include 'Family:'
-      std.must_include 'Arch:'
-      std.must_include 'Release:'
+      std.must_include "\n== Operating System Details\n\n"
+      std.must_include "\nName:      \e[0;36m"
+      std.must_include "\nFamily:    \e[0;36m"
+      std.must_include "\nArch:      \e[0;36m"
+      std.must_include "\nRelease:   \e[0;36m"
     end
   end
 


### PR DESCRIPTION
Currently we have:

---

**Detect**

![screenshot from 2016-06-16 11-05-45](https://cloud.githubusercontent.com/assets/1307529/16114007/58b5cde4-33bf-11e6-88eb-0c5622d9ad53.png)

---

**Check**

![screenshot from 2016-06-16 11-05-59](https://cloud.githubusercontent.com/assets/1307529/16114012/5dbfc27c-33bf-11e6-88d7-dee722207b73.png)

---

**Exec**

Inspec's new exec formatter isn't well-aligned with this:

![screenshot from 2016-06-16 12-40-52](https://cloud.githubusercontent.com/assets/1307529/16114076/a5884598-33bf-11e6-99fd-dc40700a2bb7.png)

This MR is a starting point for discussing the desired state. imho it'd be great to use some of the colorized utf-8 driven cli output for detect and check as well.
