### PR TITLE
improve wmi resource

### DIFF
--- a/lib/resources/wmi.rb
+++ b/lib/resources/wmi.rb
@@ -13,7 +13,8 @@ module Inspec::Resources
     name 'wmi'
     desc 'request wmi information'
     example "
-      describe wmi('RSOP_SecuritySettingNumeric', {
+      describe wmi({
+        class: 'RSOP_SecuritySettingNumeric',
         namespace: 'root\\rsop\\computer',
         filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
       }) do
@@ -24,13 +25,18 @@ module Inspec::Resources
     include ObjectTraverser
     attr_accessor :content
 
-    def initialize(wmiclass, opts = {})
+    def initialize(wmiclass = nil, opts = nil)
       # verify that this resource is only supported on Windows
       return skip_resource 'The `windows_feature` resource is not supported on your OS.' unless inspec.os.windows?
 
-      @wmiclass = wmiclass
-      @wminamespace = opts[:namespace]
-      @wmifilter = opts[:filter]
+      @options = opts || {}
+      # if wmiclass is not a hash, we have to handle deprecation behavior
+      if wmiclass.is_a?(Hash)
+        @options.merge!(wmiclass)
+      else
+        warn '[DEPRECATION] `wmi(\'wmiclass\')` is deprecated.  Please use `wmi({class: \'wmiclass\'})` instead.'
+        @options[:class] = wmiclass
+      end
     end
 
     # returns nil, if not existant or value
@@ -40,36 +46,69 @@ module Inspec::Resources
       keys.shift if keys.is_a?(Array) && keys[0] == :[]
 
       # map all symbols to strings
-      keys = keys.map(&:to_s) if keys.is_a?(Array)
+      keys = keys.map { |x| x.to_s.downcase } if keys.is_a?(Array)
 
       value(keys)
     end
 
     def value(key)
-      extract_value(key, info)
+      extract_value(key, params)
     end
 
-    def info
+    def params
       return @content if defined?(@content)
       @content = {}
 
-      # we should abort execution, if wmi class is not given or wmi resource is
-      # executed on a non-windows system
-      return @content if @wmiclass.nil?
+      # abort if no options are available
+      return @content unless defined?(@options)
 
-      # optional params
-      cmd_namespace = "-namespace #{@wminamespace}" unless @wminamespace.nil?
-      cmd_filter = "-filter \"#{@wmifilter}\"" unless @wmifilter.nil?
+      # filter for supported options
+      args = @options.select { |key, _value| [:class, :namespace, :query, :filter].include?(key) }
+
+      # convert to Get-WmiObject arguments
+      params = ''
+      args.each { |key, value| params += " -#{key} \"#{value}\"" }
+
+      # run wmi command and filter empty wmi
+      script = <<-EOH
+      Filter Aggregate
+      {
+          $arr = @{}
+          $_.properties | % {
+              $arr.Add($_.name, $_.value)
+          }
+          $arr
+      }
+      Get-WmiObject #{params} | Aggregate | ConvertTo-Json
+      EOH
 
       # run wmi command
-      cmd = inspec.command("Get-WmiObject -class #{@wmiclass} #{cmd_namespace} #{cmd_filter} | ConvertTo-Json")
+      cmd = inspec.powershell(script)
       @content = JSON.parse(cmd.stdout)
+
+      # make all keys case-insensitive
+      @content = lowercase_keys(@content)
     rescue JSON::ParserError => _e
       @content
     end
 
     def to_s
-      "WMI #{@wmiclass} where #{@wmifilter}"
+      "WMI with #{@options}"
+    end
+
+    private
+
+    def lowercase_keys(content)
+      if content.is_a?(Hash)
+        content.keys.each do |key|
+          new_key = key.to_s.downcase
+          content[new_key] = content.delete(key)
+          lowercase_keys(content[new_key])
+        end
+      elsif content.respond_to?(:each)
+        content.each { |item| lowercase_keys(item) }
+      end
+      content
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -243,7 +243,7 @@ class MockLoader
       # xinetd configuration
       'find /etc/xinetd.d -type f' => cmd.call('find-xinetd.d'),
       # wmi test
-      "Get-WmiObject -class win32_service  -filter \"name like '%winrm%'\" | ConvertTo-Json" => cmd.call('get-wmiobject'),
+      "4762fab9e8180997634ae70aae6d5f59e641084111fb9f5e5bf2848a583aa5f5" => cmd.call('get-wmiobject'),
       #user info on hpux
       "logins -x -l root" => cmd.call('logins-x'),
       #packages on hpux

--- a/test/integration/default/wmi_spec.rb
+++ b/test/integration/default/wmi_spec.rb
@@ -2,27 +2,62 @@
 
 return unless os.windows?
 
-# Get-WmiObject win32_service
-# Get-WmiObject -class win32_service
+# Get-WmiObject win32_service or Get-WmiObject -class win32_service
 # returns an array of service objects
-describe wmi('win32_service') do
-  its(['Path','ClassName']) { should include 'Win32_Service' }
+describe wmi({class: 'win32_service'}) do
   its('DisplayName') { should include 'Windows Remote Management (WS-Management)'}
 end
 
-# Use win32_service with filter
-# this returns a single service object
-describe wmi('win32_service', {
+# Use win32_service with filter, it returns a single service object
+describe wmi({
+  class: 'win32_service',
   filter: "name like '%winrm%'"
 }) do
-  its(['Path','ClassName']) { should eq 'Win32_Service' }
+  its('Status') { should cmp 'ok' }
+  its('State') { should cmp 'Running' }
+  its('ExitCode') { should cmp 0 }
   its('DisplayName') { should eq 'Windows Remote Management (WS-Management)'}
 end
 
 # TODO: this works on domain controllers only
+describe wmi({
+  class: 'RSOP_SecuritySettingNumeric',
+  namespace: 'root\\rsop\\computer',
+  filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
+}) do
+   its('Setting') { should eq 1 }
+end
+
+# new syntax
+describe wmi({
+  namespace: 'root\rsop\computer',
+  query: "SELECT Setting FROM RSOP_SecuritySettingBoolean WHERE KeyName='LSAAnonymousNameLookup' AND Precedence=1"
+}) do
+  its('Setting') { should eq false }
+end
+
+describe wmi({
+  namespace: 'root\cimv2',
+  query: 'SELECT filesystem FROM win32_logicaldisk WHERE drivetype=3'
+}).params.values.join do
+  it { should eq 'NTFS' }
+end
+
+# deprecated syntax
+describe wmi('win32_service') do
+  its('DisplayName') { should include 'Windows Remote Management (WS-Management)'}
+end
+
 describe wmi('RSOP_SecuritySettingNumeric', {
   namespace: 'root\\rsop\\computer',
   filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
 }) do
    its('Setting') { should eq 1 }
+   its('setting') { should eq 1 }
+end
+
+describe wmi('win32_service', {
+  filter: "name like '%winrm%'"
+}) do
+  its('DisplayName') { should eq 'Windows Remote Management (WS-Management)'}
 end

--- a/test/unit/mock/cmd/get-wmiobject
+++ b/test/unit/mock/cmd/get-wmiobject
@@ -1,10 +1,9 @@
 {
-    "Path":  {
-                 "ClassName":  "Win32_Service"
-             },
-    "Caption":  "Windows Remote Management (WS-Management)",
-    "CreationClassName":  "Win32_Service",
     "DisplayName":  "Windows Remote Management (WS-Management)",
+    "Caption":  "Windows Remote Management (WS-Management)",
+    "DesktopInteract":  false,
     "Name":  "WinRM",
-    "PathName":  "C:\\Windows\\System32\\svchost.exe -k NetworkService"
+    "StartMode":  "Auto",
+    "ExitCode":  0,
+    "Status":  "OK"
 }

--- a/test/unit/resources/wmi_test.rb
+++ b/test/unit/resources/wmi_test.rb
@@ -8,7 +8,8 @@ require 'inspec/resource'
 describe 'Inspec::Resources::WMI' do
 
   # Check the following as unit test
-  # describe wmi('win32_service', {
+  # describe wmi({
+  #   class: 'win32_service',
   #   filter: "name like '%winrm%'"
   # }) do
   #   its(['Path','ClassName']) { should eq 'Win32_Service' }
@@ -17,29 +18,25 @@ describe 'Inspec::Resources::WMI' do
 
   # windows
   it 'verify wmi parsing on windows' do
-    resource = MockLoader.new(:windows).load_resource('wmi', 'win32_service', { filter: "name like '%winrm%'" })
+    resource = MockLoader.new(:windows).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
     _(resource.send('DisplayName')).must_equal 'Windows Remote Management (WS-Management)'
-    _(resource.send('method_missing', 'Path', 'ClassName')).must_equal 'Win32_Service'
   end
 
   # ubuntu 14.04 with upstart
   it 'fail wmi on ubuntu' do
-    resource = MockLoader.new(:ubuntu1404).load_resource('wmi', 'win32_service', { filter: "name like '%winrm%'" })
+    resource = MockLoader.new(:ubuntu1404).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
     _(resource.send('DisplayName')).must_equal nil
-    _(resource.send('method_missing', 'Path', 'ClassName')).must_equal nil
   end
 
   # centos 7 with systemd
   it 'fail wmi on centos' do
-    resource = MockLoader.new(:centos7).load_resource('wmi', 'win32_service', { filter: "name like '%winrm%'" })
+    resource = MockLoader.new(:centos7).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
     _(resource.send('DisplayName')).must_equal nil
-    _(resource.send('method_missing', 'Path', 'ClassName')).must_equal nil
   end
 
   # unknown OS
   it 'fail wmi on unknown os' do
-    resource = MockLoader.new(:undefined).load_resource('wmi', 'win32_service', { filter: "name like '%winrm%'" })
+    resource = MockLoader.new(:undefined).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
     _(resource.send('DisplayName')).must_equal nil
-    _(resource.send('method_missing', 'Path', 'ClassName')).must_equal nil
   end
 end


### PR DESCRIPTION
This improves the wmi resource:

```
# new syntax
describe wmi({
  class: 'RSOP_SecuritySettingNumeric',
  namespace: 'root\\rsop\\computer',
  filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
}) do
   its('Setting') { should eq 1 }
end

# deprecated syntax
describe wmi('RSOP_SecuritySettingNumeric', {
  namespace: 'root\\rsop\\computer',
  filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
}) do
   its('Setting') { should eq 1 }
   its('setting') { should eq 1 }
end
```

In addition this resource supports `query` now:

```
describe wmi({
  namespace: 'root\rsop\computer',
  query: "SELECT Setting FROM RSOP_SecuritySettingBoolean WHERE KeyName='LSAAnonymousNameLookup' AND Precedence=1"
}) do
  its('Setting') { should eq false }
end
```
