### PR TITLE
api: report source location with field identifiers

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -145,7 +145,8 @@ module Inspec
 
       # iterate over hash of groups
       params[:controls].each { |id, control|
-        sfile, sline = control[:source_location]
+        sfile = control[:source_location][:ref]
+        sline = control[:source_location][:line]
         error.call(sfile, sline, nil, id, 'Avoid controls with empty IDs') if id.nil? or id.empty?
         next if id.start_with? '(generated '
         warn.call(sfile, sline, nil, id, "Control #{id} has no title") if control[:title].to_s.empty?

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -199,10 +199,11 @@ module Inspec
 
     # get the source location of the block
     def __get_block_source_location(&block)
-      return [nil, nil] unless block_given?
-      block.source_location
+      return {} unless block_given?
+      r, l = block.source_location
+      { ref: r, line: l }
     rescue MethodSource::SourceNotFoundError
-      [nil, nil]
+      {}
     end
   end
 end

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -80,8 +80,8 @@ describe 'inspec exec with json formatter' do
       actual = ex1.dup
 
       src = actual.delete('source_location')
-      src[0].must_match %r{examples/profile/controls/example.rb$}
-      src[1].must_equal 8
+      src['ref'].must_match %r{examples/profile/controls/example.rb$}
+      src['line'].must_equal 8
 
       result = actual.delete('results')[0]
       result.wont_be :nil?

--- a/test/functional/inspec_json_profile_test.rb
+++ b/test/functional/inspec_json_profile_test.rb
@@ -67,7 +67,8 @@ describe 'inspec json' do
 
       it 'has a source location' do
         loc = File.join(example_profile, '/controls/example.rb')
-        control['source_location'].must_equal [loc, 8]
+        control['source_location']['ref'].must_equal loc
+        control['source_location']['line'].must_equal 8
       end
 
       it 'has a the source code' do


### PR DESCRIPTION
Mixing types in an array without specifying what these fields point to is not just confusing, but also causes issues with endpoints that may consume this data and dont process mixed types. We strive to have a stable api for 1.0 and this is a sin that was left after the major overhaul. Time to fix it.
