### PR TITLE
expose resources inside of describe blocks

### DIFF
--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -11,7 +11,7 @@ module Inspec
     # Create the transport backend with aggregated resources.
     #
     # @param [Hash] config for the transport backend
-    # @return [TransportBackend] enriched transport instance
+    # @return [TransportBackend] enriched transport module
     def self.create(config)
       conf = Train.target_config(config)
       name = Train.validate_backend(conf)
@@ -25,7 +25,7 @@ module Inspec
         fail "Can't connect to transport backend '#{name}'."
       end
 
-      cls = Class.new do
+      Module.new do
         define_method :backend do
           connection
         end
@@ -36,12 +36,21 @@ module Inspec
         end
       end
 
-      cls.new
-
     rescue Train::ClientError => e
       raise "Client error, can't connect to '#{name}' backend: #{e.message}"
     rescue Train::TransportError => e
       raise "Transport error, can't connect to '#{name}' backend: #{e.message}"
+    end
+
+    # Creates an instance of the transport backend with all resources.
+    # It can be used to invoce methods directly.
+    #
+    # @param [Hash] config of the backend
+    # @param [Any] base optional base class
+    # @return [TransportBackend] backend instance
+    def self.instance(config, base = Object)
+      dsl = create(config)
+      Class.new(base) { include dsl }.new
     end
   end
 end

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -47,8 +47,9 @@ module Inspec
     end
 
     def configure_transport
-      @backend = Inspec::Backend.create(@conf)
-      @test_collector.backend = @backend
+      dsl = Inspec::Backend.create(@conf)
+      @test_collector.backend = dsl
+      @backend = Class.new { include dsl }.new
     end
 
     # determine all attributes before the execution, fetch data from secrets backend

--- a/lib/inspec/runner_mock.rb
+++ b/lib/inspec/runner_mock.rb
@@ -5,7 +5,7 @@
 module Inspec
   class RunnerMock
     attr_reader :tests, :profiles
-    attr_writer :backend
+    attr_accessor :backend
     def initialize
       @tests = []
       @profiles = []

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -70,7 +70,7 @@ class MockLoader
     scriptpath = ::File.realpath(::File.dirname(__FILE__))
 
     # create mock backend
-    @backend = Inspec::Backend.create({ backend: :mock })
+    @backend = Inspec::Backend.instance(backend: :mock)
     mock = @backend.backend
 
     # set os emulation

--- a/test/unit/utils/find_files_test.rb
+++ b/test/unit/utils/find_files_test.rb
@@ -8,7 +8,7 @@ describe FindFiles do
     class FindFilesTest
       include FindFiles
       def inspec
-        Inspec::Backend.create(backend: :mock)
+        Inspec::Backend.instance(backend: :mock)
       end
     end
     FindFilesTest.new


### PR DESCRIPTION
Please find the initial user request here: https://github.com/chef/inspec/issues/451

tldr:

``` ruby
describe 'something...' do
  # i can access resources vv
  if os.redhat?
    ...
  end
end
```

In this example ^^ the resource `os` is currently not available inside of a `describe` block.

Fixes https://github.com/chef/inspec/issues/451

Let's pick the discussion back up in here. I'm not sure at this point whether we should actually get this feature into inspec.
# 

RSpec in its pure form did not allow for this. What we are starting to do, is to get our own resource keywords inside of `describe` blocks. This may lead to clashes in the namespace (ie resource names colliding with rspec functions), which is virtually impossible to resolve.

It is possible in its traditional application to define terms outside the block and use them, which also works in inspec:

``` ruby
val = os.redhat?
describe 'my test' do
  if val
    it { should eq true }
  end
end
```

(although obviously a better choice would be to use inspec's `supports` flag ...)

The question now becomes, is it worth diluting the DSL inside the describe block to get this in. i.e. what are the use-cases we are trying to solve?

Please help with this discussion
