### PR TITLE
Attempt at a bug fix to read backslashes as forward slashes

### DIFF
--- a/lib/fetchers/local.rb
+++ b/lib/fetchers/local.rb
@@ -10,6 +10,7 @@ module Fetchers
     attr_reader :files
 
     def self.resolve(target)
+      target.gsub!(/\\/, '/')
       return nil unless File.exist?(target)
       new(target)
     end

--- a/test/unit/fetchers_test.rb
+++ b/test/unit/fetchers_test.rb
@@ -20,38 +20,39 @@ describe Inspec::Plugins::RelFetcher do
   let(:src_fetcher) { mock() }
 
   IN_AND_OUT = {
-    []                        => [],
-    %w{file}                  => %w{file},
+    []                           => [],
+    %w{file}                     => %w{file},
     # don't prefix just by filename
-    %w{file file_a}           => %w{file file_a},
-    %w{path/file path/file_a} => %w{file file_a},
-    %w{path/to/file}          => %w{file},
-    %w{/path/to/file}         => %w{file},
-    %w{alice bob}             => %w{alice bob},
+    %w{file file_a}              => %w{file file_a},
+    %w{path/file path/file_a}    => %w{file file_a},
+    %w{path/to/file}             => %w{file},
+    %w{/path/to/file}            => %w{file},
+    %w{alice bob}                => %w{alice bob},
     # mixed paths
-    %w{x/a y/b}               => %w{x/a y/b},
-    %w{/x/a /y/b}             => %w{x/a y/b},
-    %w{z/x/a z/y/b}           => %w{x/a y/b},
-    %w{/z/x/a /z/y/b}         => %w{x/a y/b},
+    %w{x/a y/b}                  => %w{x/a y/b},
+    %w{/x/a /y/b}                => %w{x/a y/b},
+    %w{z/x/a z/y/b}              => %w{x/a y/b},
+    %w{/z/x/a /z/y/b}            => %w{x/a y/b},
     # mixed with relative path
-    %w{a path/to/b}           => %w{a path/to/b},
-    %w{path/to/b a}           => %w{path/to/b a},
-    %w{path/to/b path/a}      => %w{to/b a},
-    %w{path/to/b path/a c}    => %w{path/to/b path/a c},
+    %w{a path/to/b}              => %w{a path/to/b},
+    %w{path/to/b a}              => %w{path/to/b a},
+    %w{path/to/b path/a}         => %w{to/b a},
+    %w{path/to/b path/a c}       => %w{path/to/b path/a c},
     # mixed with absolute paths
-    %w{/path/to/b /a}         => %w{path/to/b a},
-    %w{/path/to/b /path/a}    => %w{to/b a},
-    %w{/path/to/b /path/a /c} => %w{path/to/b path/a c},
+    %w{/path/to/b /a}            => %w{path/to/b a},
+    %w{/path/to/b /path/a}       => %w{to/b a},
+    %w{/path/to/b /path/a /c}    => %w{path/to/b path/a c},
     # mixing absolute and relative paths
-    %w{path/a /path/b}        => %w{path/a /path/b},
-    %w{/path/a path/b}        => %w{/path/a path/b},
+    %w{path/a /path/b}           => %w{path/a /path/b},
+    %w{/path/a path/b}           => %w{/path/a path/b},
     # extract folder structure buildup
-    %w{/a /a/b /a/b/c}        => %w{c},
-    %w{/a /a/b /a/b/c/d/e}    => %w{e},
+    %w{/a /a/b /a/b/c}           => %w{c},
+    %w{/a /a/b /a/b/c/d/e}       => %w{e},
     # ignore pax_global_header, which are commonly seen in github tars and are not
     # ignored by all tar streaming tools, its not extracted by GNU tar since 1.14
-    %w{/pax_global_header /a/b}    => %w{b},
+    %w{/pax_global_header /a/b}  => %w{b},
     %w{pax_global_header a/b}    => %w{b},
+    %w{.\\path\\}                => %w{./path/}
   }.each do |ins, outs|
     describe 'empty profile' do
       let(:in_files) { ins }


### PR DESCRIPTION
@mhedgpeth and I attempted to solve the issue for #672. 

We used the `gsub!` method in `self.resolve` to change the backslashes to forward slashes in `local.rb`.

We tested it in `irb` using `File.exist?`, `File.join`, and `File.file?`, and all of those worked once the backslash was changed to a forward slash. 

However, when we tried unit testing using `bundle exec ruby -W -Ilib:test test/unit/fetchers_test.rb` it failed stating:

```
Expected: ["./path/"]
  Actual: [".\\path\\"]
```

So am I correct to assume that we didn't fix the correct module? Or did we write the right test?
