### PR TITLE
pin gem version for ffi due to appveyor failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('1.9.3')
   gem 'net-ssh', '~> 2.9'
 end
 
+# TODO: ffi 1.9.11 is currently erroneous on windows tests
+gem 'ffi', '= 1.9.10'
+
 group :test do
   gem 'bundler', '~> 1.5'
   gem 'minitest', '~> 5.5'


### PR DESCRIPTION
See https://ci.appveyor.com/project/chef/inspec/build/1.0.889/job/19sdqmtmie1wgece
