### PR TITLE
WIP: add a require sample profile

### DIFF
--- a/test/unit/mock/profiles/require/controls/require.rb
+++ b/test/unit/mock/profiles/require/controls/require.rb
@@ -1,0 +1,9 @@
+# encoding: utf-8
+
+control 'require' do
+  title 'tests if inspec is able to load source via require'
+  impact 0.5
+  describe require_load do
+    it { should be_working }
+  end
+end

--- a/test/unit/mock/profiles/require/inspec.yml
+++ b/test/unit/mock/profiles/require/inspec.yml
@@ -1,0 +1,8 @@
+name: require
+title: profile with require dependency tree
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
+copyright_email: support@chef.io
+license: Apache 2 license
+summary: Demonstrates the use of require in Inspec
+version: 1.0.0

--- a/test/unit/mock/profiles/require/libraries/1_require_load.rb
+++ b/test/unit/mock/profiles/require/libraries/1_require_load.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+require '3_dependency'
+
+class RequireResource < Inspec.resource(1)
+  name 'require_load'
+
+  desc "
+    tests inspec `require`
+  "
+
+  example "
+    describe require_load do
+      it { should be_working }
+    end
+  "
+
+  def initialize(opts = {})
+
+  end
+
+  def working?
+    Dependency::dep_method
+  end
+
+
+  def to_s
+    "require load tester"
+  end
+end

--- a/test/unit/mock/profiles/require/libraries/2_sec_level_dep.rb
+++ b/test/unit/mock/profiles/require/libraries/2_sec_level_dep.rb
@@ -1,0 +1,5 @@
+module Dependency
+  RESULT = {
+    a: true
+  }.freeze
+end

--- a/test/unit/mock/profiles/require/libraries/3_dependency.rb
+++ b/test/unit/mock/profiles/require/libraries/3_dependency.rb
@@ -1,0 +1,9 @@
+# encoding: utf-8
+
+require '2_sec_level_dep'
+
+module Dependency
+  def self.dep_method
+    ::Dependency::RESULT[:a]
+  end
+end


### PR DESCRIPTION
With the introduction of https://github.com/chef/inspec/pull/780 we changed the way how inspec loads requires. This was essential to support the execution from profiles that are packages as tar or zip.

Now it occurs that the loading of files is not always occurring in the right order:

```
# run the require profile test
inspec exec demo       

Profile: demo profile with require (demo)
Version: 1.0.0
Target:  local://

  ✖  require: tests if inspec is able to load source via require (1 failed)
     undefined method `dep_method' for #<Class:0x007fbae8907db0>::Dependency

Summary:   0 successful    1 failures    0 skipped

# from tar, run inspec archive on the profile
inspec exec demo.tar.gz 
libraries/3_dependency.rb:3:in `require': cannot load such file -- 2_sec_level_dep (LoadError)
    from libraries/3_dependency.rb:3:in `<main>'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/inspec/profile_context.rb:159:in `eval'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/inspec/profile_context.rb:159:in `require'
    from libraries/1_require_load.rb:2:in `load'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/inspec/profile_context.rb:66:in `instance_eval'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/inspec/profile_context.rb:66:in `load'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/inspec/profile_context.rb:53:in `block in load_libraries'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/inspec/profile_context.rb:51:in `each'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/inspec/profile_context.rb:51:in `load_libraries'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/inspec/runner.rb:123:in `add_content'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/inspec/runner.rb:108:in `add_profile'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/inspec/runner.rb:72:in `add_target'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/utils/base_cli.rb:71:in `block in run_tests'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/utils/base_cli.rb:71:in `each'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/utils/base_cli.rb:71:in `run_tests'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/lib/inspec/cli.rb:115:in `exec'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/gems/inspec-0.26.0/bin/inspec:9:in `<top (required)>'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/bin/inspec:23:in `load'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/bin/inspec:23:in `<main>'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `eval'
    from /Users/chartmann/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `<main>'
```
