### PR TITLE
FIX #823 wrong postgres path detection for conf_dir and conf_path

### DIFF
--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -24,6 +24,13 @@ module Inspec::Resources
         @conf_dir = '/var/lib/postgres/data'
         @conf_path = File.join @conf_dir, 'postgresql.conf'
 
+      when 'centos', 'redhat'
+        @service = 'postgresql'
+        @version = inspec.command('ls /var/lib/pgsql/').stdout.chomp
+        @data_dir = "/var/lib/pgsql/#{@version}/data"
+        @conf_dir = "/var/lib/pgsql/#{@version}/data"
+        @conf_path = File.join @conf_dir, 'postgresql.conf'
+
       else
         @service = 'postgresql'
         @data_dir = '/var/lib/postgresql'


### PR DESCRIPTION
This fixed the #823 wrong postgres path detection. I added the missing part for centos and redhat in postgres.rb resource.

Signed-off-by: Patrick Münch patrick.muench1111@gmail.com
