### PR TITLE
FIX: file(hba_config_file) test in documentation

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1239,9 +1239,9 @@ The following complete example tests the ``pg_hba.conf`` file in |postgresql| fo
 .. code-block:: bash
 
    describe file(hba_config_file) do
-     its('content') { should match /local\s.*?all\s.*?all\s.*?md5/ }
-     its('content') { should match %r{/host\s.*?all\s.*?all\s.*?127.0.0.1\/32\s.*?md5/} }
-     its('content') { should match %r{/host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5/} }
+     its('content') { should match(%r{local\s.*?all\s.*?all\s.*?md5}) }
+     its('content') { should match(%r{host\s.*?all\s.*?all\s.*?127.0.0.1\/32\s.*?md5}) }
+     its('content') { should match(%r{host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5}) }
    end
 
 exist


### PR DESCRIPTION
I got a rubocop issue with `its('content') { should match /local\s.*?all\s.*?all\s.*?md5/ }`, rubocop message: "Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the / if it should be a division."

the last two tests were not working because of this /\/host\s._?all\s._?all\s._?::1\/128\s._?md5\//

Signed-off-by: Patrick Münch patrick.muench1111@gmail.com
