### PR TITLE
prevent circular loading of resource library

### DIFF
--- a/lib/inspec/plugins/resource.rb
+++ b/lib/inspec/plugins/resource.rb
@@ -2,8 +2,6 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'inspec/resource'
-
 module Inspec
   module Plugins
     class Resource


### PR DESCRIPTION
A warning we get during `rake test`
