### PR TITLE
Handle xinetd config with only one entry

### DIFF
--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -66,17 +66,26 @@ module Inspec::Resources
     def read_params
       return {} if read_content.nil?
       flat_params = parse_xinetd(read_content)
+      # we need to map service data in order to use it with filtertable
       params = { 'services' => {} }
 
-      # parse services that were defined:
+      # map services that were defined and map it to the service hash
       flat_params.each do |k, v|
         name = k[/^service (.+)$/, 1]
+        # its not a service, no change required
         if name.nil?
           params[k] = v
+        # handle service entries
         else
+          # store service
           params['services'][name] = v
+
           # add the service identifier to its parameters
-          v.each { |service| service.params['service'] = name }
+          if v.is_a?(Array)
+            v.each { |service| service.params['service'] = name }
+          else
+            v.params['service'] = name
+          end
         end
       end
       params

--- a/lib/utils/parser.rb
+++ b/lib/utils/parser.rb
@@ -179,6 +179,7 @@ module SolarisNetstatParser
   end
 end
 
+# This parser for xinetd (extended Internet daemon) configuration files
 module XinetdParser
   def xinetd_include_dir(dir)
     return [] if dir.nil?
@@ -198,10 +199,12 @@ module XinetdParser
     simple_conf = []
     rest = raw
     until rest.empty?
+      # extract content line
       nl = rest.index("\n") || (rest.length-1)
       comment = rest.index('#') || (rest.length-1)
       dst_idx = (comment < nl) ? comment : nl
       inner_line = (dst_idx == 0) ? '' : rest[0..dst_idx-1].strip
+      # update unparsed content
       rest = rest[nl+1..-1]
       next if inner_line.empty?
 
@@ -213,6 +216,7 @@ module XinetdParser
         simple_conf = []
         rest = rest[rest.index("\n")+1..-1]
       elsif cur_group.nil?
+        # parse all included files
         others = xinetd_include_dir(inner_line[/includedir (.+)/, 1])
 
         # complex merging of included configurations, as multiple services

--- a/test/unit/resources/xinetd_test.rb
+++ b/test/unit/resources/xinetd_test.rb
@@ -57,4 +57,13 @@ describe 'Inspec::Resources::XinetdConf' do
       _(resource.enabled?).must_equal false
     end
   end
+
+  describe 'with single services and no child configs' do
+    let (:resource) { load_resource('xinetd_conf', '/etc/xinetd.d/chargen-stream') }
+
+    it 'checks if all are disabled on one disabled service' do
+      one = resource.ids('chargen-stream')
+      _(one.disabled?).must_equal true
+    end
+  end
 end


### PR DESCRIPTION
This PR handles a bug reported by @kdshah1 via gitter:

is this the correct way to check xinetd services are disabled?

```
        describe xinetd_conf.services('telnet') do
         it{ should be_disabled }
       end
```

It fails with following message:

```
 ✖  services-04: System Must Disable telnet Service. (1 failed)
     expected `Xinetd config /etc/xinetd.conf with service == "telnet".disabled?` to return true, got false
```

whereas my telnet file under /etc/xinet.d reads this:

```
 # default: on
# description: The telnet server serves telnet sessions; it uses \
#       unencrypted username/password pairs for authentication.
service telnet
{
        disable = yes
        flags           = REUSE
        socket_type     = stream
        wait            = no
        user            = root
        server          = /usr/sbin/in.telnetd
        log_on_failure  += USERID
}
```

The problem was, that the xinetd resource was expecting multiple entries via `includedir /etc/xinetd.d`. This PR also adds another test to catch that case.
