### PR TITLE
Only test PRs and pushes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: required
+branches:
+  only:
+    - master
 language: ruby
 cache: bundler
 dist: trusty


### PR DESCRIPTION
Without this, Travis often ends up running 2 CI jobs for updates to a
PR: 1 for the update to the PR, 1 for the push to the branch.

By adding this bit of config, travis will still run a job for any update
to a PR, but won't run a duplicate job for the push to the branch that
the PR is based off of. We use this in chef/chef and chef/chef-server
to reduce unnecessary use of TravisCI resource.
