### PR TITLE
Activate centos, debian and oracle linux in our travis tests

### DIFF
--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -84,5 +84,8 @@ platforms:
 suites:
   - name: default
     run_list:
+      - recipe[apt]
+      - recipe[yum]
+      - recipe[ssh-hardening]
       - recipe[os_prepare]
     attributes:

--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -12,28 +12,18 @@ verifier:
 platforms:
   - name: centos-7.1
   - name: centos-6.7
-  - name: centos-6.7-i386
   - name: centos-5.11
-  - name: centos-5.11-i386
   - name: debian-6.0.10
-  - name: debian-6.0.10-i386
   - name: debian-7.8
-  - name: debian-7.8-i386
   - name: debian-8.1
-  - name: debian-8.1-i386
   - name: fedora-21
-  - name: fedora-21-i386
   - name: fedora-22
   - name: freebsd-9.3
   - name: freebsd-10.2
   - name: opensuse-13.2-x86_64
-  - name: opensuse-13.2-i386
   - name: ubuntu-14.04
-  - name: ubuntu-14.04-i386
   - name: ubuntu-12.04
-  - name: ubuntu-12.04-i386
   - name: ubuntu-10.04
-  - name: ubuntu-10.04-i386
   - name: mint-17.2-cinnamon
     driver_config:
       box: artem-sidorenko/mint-17.2-cinnamon
@@ -41,5 +31,8 @@ platforms:
 suites:
   - name: default
     run_list:
+      - recipe[apt]
+      - recipe[yum]
+      - recipe[ssh-hardening]
       - recipe[os_prepare]
     attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -61,6 +61,18 @@ platforms:
     # running it within the chef recipe is too late :-(
     - RUN /usr/bin/apt-get install -y procps lsb-release
     pid_one_command: /bin/systemd
+- name: fedora-23
+  driver:
+    image: fedora:23
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+    - RUN dnf install -y yum
+- name: fedora-24
+  driver:
+    image: fedora:24
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+    - RUN dnf install -y yum
 
 suites:
 - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,10 +21,6 @@ platforms:
 - name: ubuntu-14.04
   driver:
     image: ubuntu:14.04
-- name: ubuntu-15.10
-  driver:
-    image: ubuntu:15.10
-    pid_one_command: /bin/systemd
 - name: ubuntu-16.04
   driver:
     image: ubuntu:16.04
@@ -34,37 +30,36 @@ platforms:
 - name: centos-6.6
   driver:
     image: centos:6.6
-- name: centos-6.7
+- name: centos-6.8
   driver:
-    image: centos:6.7
+    image: centos:6.8
     intermediate_instructions:
       - RUN yum install -y initscripts
 - name: centos-7
   driver:
     image: centos:7
     pid_one_command: /usr/lib/systemd/systemd
-- name: oracle-6.6
-  driver:
-    image: oraclelinux:6.6
 - name: oracle-6.7
   driver:
     image: oraclelinux:6.7
-- name: oracle-7.1
+- name: oracle-7.2
   driver:
-    image: oraclelinux:7.1
+    image: oraclelinux:7.2
     pid_one_command: /usr/lib/systemd/systemd
 - name: debian-7
   driver:
-    image: debian:7
+    image: debian:7.11
     intermediate_instructions:
     - RUN /usr/bin/apt-get update
-    - RUN /usr/bin/apt-get install -y procps
+    # running it within the chef recipe is too late :-(
+    - RUN /usr/bin/apt-get install -y procps lsb-release
 - name: debian-8
   driver:
-    image: debian:8
+    image: debian:8.5
     intermediate_instructions:
     - RUN /usr/bin/apt-get update
-    - RUN /usr/bin/apt-get install -y procps
+    # running it within the chef recipe is too late :-(
+    - RUN /usr/bin/apt-get install -y procps lsb-release
     pid_one_command: /bin/systemd
 
 suites:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,36 @@ matrix:
   - rvm: 2.2
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='default-ubuntu-1404' DOCKER=true
+  - rvm: 2.2
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-ubuntu-1604' DOCKER=true
+  - rvm: 2.2
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='default-centos-68' DOCKER=true
+  - rvm: 2.2
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='default-centos-7' DOCKER=true
+  - rvm: 2.2
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='default-debian-7' DOCKER=true
+  - rvm: 2.2
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='default-debian-8' DOCKER=true
+  - rvm: 2.2
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='default-oracle-67' DOCKER=true
+  - rvm: 2.2
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='default-oracle-72' DOCKER=true
+
 deploy:
   provider: rubygems
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,14 @@ matrix:
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-oracle-72' DOCKER=true
+  - rvm: 2.2
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='default-fedora-23' DOCKER=true
+  - rvm: 2.2
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='default-fedora-24' DOCKER=true
 
 deploy:
   provider: rubygems

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ You will require:
 **Run `integration` tests with vagrant:**
 
 ```bash
-bundle exec kitchen test
+KITCHEN_YAML=.kitchen.vagrant.yml bundle exec kitchen test
 ```
 
 **Run `integration` tests with AWS EC2:**
@@ -349,8 +349,7 @@ export AWS_ACCESS_KEY_ID=enteryouryourkey
 export AWS_SECRET_ACCESS_KEY=enteryoursecreykey
 export AWS_KEYPAIR_NAME=enteryoursshkeyid
 export EC2_SSH_KEY_PATH=~/.ssh/id_aws.pem
-cd test/integration
-KITCHEN_LOCAL_YAML=.kitchen.ec2.yml bundle exec kitchen test
+KITCHEN_YAML=.kitchen.ec2.yml bundle exec kitchen test
 ```
 
 In addition you may need to add your ssh key to `.kitchen.ec2.yml`

--- a/test/cookbooks/os_prepare/recipes/apt.rb
+++ b/test/cookbooks/os_prepare/recipes/apt.rb
@@ -5,13 +5,13 @@
 # add nginx apt repository
 case node['platform']
 when 'ubuntu'
-  include_recipe('apt')
+  # use ppa
   apt_repository 'nginx' do
     uri 'ppa:nginx/stable'
     distribution node['lsb']['codename']
   end
 when 'debian'
-  include_recipe('apt')
+  # use plain repo
   apt_repository 'nginx' do
     uri 'http://nginx.org/packages/debian'
     distribution node['lsb']['codename']

--- a/test/cookbooks/os_prepare/recipes/default.rb
+++ b/test/cookbooks/os_prepare/recipes/default.rb
@@ -4,6 +4,8 @@
 #
 # prepare all operating systems with the required configuration
 
+# container preparation
+include_recipe('os_prepare::prep_container')
 
 # basic tests
 include_recipe('os_prepare::file')

--- a/test/cookbooks/os_prepare/recipes/package.rb
+++ b/test/cookbooks/os_prepare/recipes/package.rb
@@ -5,9 +5,8 @@
 # installs everything to do the package test
 
 case node['platform']
-when 'ubuntu'
+when 'ubuntu', 'debian'
   include_recipe('apt')
-
   package 'curl'
 when 'rhel', 'centos', 'fedora'
   include_recipe('yum')

--- a/test/cookbooks/os_prepare/recipes/postgres.rb
+++ b/test/cookbooks/os_prepare/recipes/postgres.rb
@@ -10,6 +10,8 @@ when 'ubuntu', 'centos'
   # also skip it on ubuntu 15.10, because the cookbook is not supported
   # with `enable_pgdg_apt` yet
   return if node['platform_version'] == "15.10"
+  # skip it on centos 5, because ca-certificates is not available
+  return if node['platform_version'] == "5"
 
   node.default['postgresql']['enable_pgdg_apt'] = true
   node.default['postgresql']['config']['listen_addresses'] = 'localhost'

--- a/test/cookbooks/os_prepare/recipes/prep_container.rb
+++ b/test/cookbooks/os_prepare/recipes/prep_container.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+#
+# prepares container for normal use :-)
+
+# install docker pre-conditions
+if ['ubuntu', 'debian'].include?(node['platform'])
+  include_recipe('apt')
+
+  # if package lsb-release & procps is not installed
+  # chef returns an empty node['lsb']['codename']
+  package("lsb-release")
+  package("procps")
+end

--- a/test/cookbooks/os_prepare/recipes/service.rb
+++ b/test/cookbooks/os_prepare/recipes/service.rb
@@ -13,7 +13,7 @@ when 'ubuntu'
 when 'centos'
   # install runit for alternative service mgmt
   if node['platform_version'].to_i == 6
-    include_recipe 'os_prepare::_runit_service_centos'
-    include_recipe 'os_prepare::_upstart_service_centos'
+    include_recipe 'os_prepare::_runit_service_centos' unless node['osprepare']['docker']
+    include_recipe 'os_prepare::_upstart_service_centos' unless node['osprepare']['docker']
   end
 end

--- a/test/cookbooks/os_prepare/recipes/service.rb
+++ b/test/cookbooks/os_prepare/recipes/service.rb
@@ -12,7 +12,7 @@ when 'ubuntu'
 
 when 'centos'
   # install runit for alternative service mgmt
-  if node['platform_version'].to_i >= 6
+  if node['platform_version'].to_i == 6
     include_recipe 'os_prepare::_runit_service_centos'
     include_recipe 'os_prepare::_upstart_service_centos'
   end

--- a/test/integration/default/apt_spec.rb
+++ b/test/integration/default/apt_spec.rb
@@ -29,11 +29,6 @@ elsif os[:family] == 'debian'
     it { should be_enabled }
   end
 
-  describe apt('http://nginx.org/packages/debian') do
-    it { should exist }
-    it { should be_enabled }
-  end
-
   describe apt('https://deb.nodesource.com/node_4.x/dists/precise/') do
     it { should_not exist }
     it { should_not be_enabled }

--- a/test/integration/default/package_spec.rb
+++ b/test/integration/default/package_spec.rb
@@ -11,7 +11,6 @@ when 'aix'
     its('version') { should match /^(6|7)[.|\d]+\d$/ }
   end
 when 'solaris'
-
   if os[:release] == '11'
     pkg = 'system/file-system/zfs'
     ver = /^0\.5.+$/
@@ -24,8 +23,6 @@ when 'solaris'
     it { should be_installed }
     its('version') { should match ver }
   end
-
-
 end
 
 describe package('nginx') do


### PR DESCRIPTION
- activates centos, debian and oracle linux in our travis tests
- adds fedora 23 and 24 as docker integration test
- update docs for running integration tests
- remove i386 in kitchen vagrant

partly addresses #861
