### PR TITLE
add params and content method to parse_config

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -123,6 +123,7 @@ class MockLoader
       '/etc/xinetd.d' => mockfile.call('xinetd.d'),
       '/etc/xinetd.d/chargen-stream' => mockfile.call('xinetd.d_chargen-stream'),
       '/etc/xinetd.d/chargen-dgram' => mockfile.call('xinetd.d_chargen-dgram'),
+      '/etc/sysctl.conf' => mockfile.call('sysctl.conf'),
     }
 
     # create all mock commands

--- a/test/unit/mock/files/sysctl.conf
+++ b/test/unit/mock/files/sysctl.conf
@@ -1,0 +1,7 @@
+#
+# /etc/sysctl.conf - Configuration file for setting system variables
+# See /etc/sysctl.d/ for additional system variables.
+# See sysctl.conf (5) for information.
+#
+
+kernel.domainname = example.com

--- a/test/unit/resources/parse_config_test.rb
+++ b/test/unit/resources/parse_config_test.rb
@@ -1,0 +1,26 @@
+require 'helper'
+require 'inspec/resource'
+
+describe 'Inspec::Resources::ParseConfig' do
+
+  it 'verify parse_config resource' do
+    options = {
+      assignment_re: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/
+    }
+    resource = MockLoader.new(:centos6).load_resource('parse_config', 'kernel.domainname = example.com', options)
+    result = {"kernel.domainname"=>"example.com"}
+    _(resource.params).must_equal result
+    _(resource.content).must_equal 'kernel.domainname = example.com'
+    _(resource.send('kernel.domainname')).must_equal 'example.com'
+  end
+
+  it 'verify parse_config_file resource' do
+    options = {
+      assignment_re: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/
+    }
+    resource = MockLoader.new(:centos6).load_resource('parse_config_file', '/etc/sysctl.conf', options)
+    result = {"kernel.domainname"=>"example.com"}
+    _(resource.params).must_equal result
+    _(resource.send('kernel.domainname')).must_equal 'example.com'
+  end
+end


### PR DESCRIPTION
This PR allows users to access the content easier:
- `parse_config_file('/etc/sysctl.conf', options).params['kernel.domainname']`
- `parse_config_file('/etc/sysctl.conf', options).params`
- `parse_config_file('/etc/sysctl.conf', options).content`

```
Welcome to the interactive InSpec Shell
To find out how to use it, type: help

inspec> parse_config_file('/etc/sysctl.conf', options).params['kernel.domainname']
NameError: undefined local variable or method `options' for #<#<Class:0x007fec28acf910>:0x007fec28acf4d8>
from (pry):1:in `load'
inspec> options = {
inspec>   assignment_re: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/  
inspec> }  
=> {:assignment_re=>/^\s*([^=]*?)\s*=\s*(.*?)\s*$/}
inspec> parse_config_file('/etc/sysctl.conf', options).params['kernel.domainname']
=> "example.com"
inspec> parse_config_file('/etc/sysctl.conf', options).params
=> {"kernel.domainname"=>"example.com"}
inspec> parse_config_file('/etc/sysctl.conf', options).content
=> "#\n# /etc/sysctl.conf - Configuration file for setting system variables\n# See /etc/sysctl.d/ for additional system variables.\n# See sysctl.conf (5) for information.\n#\n\nkernel.domainname = example.com\n\n# Uncomment the following to stop low-level messages on console\n#kernel.printk = 3 4 1 3\n\n##############################################################3\n# Functions previously found in netbase\n#\n\n# Uncomment the next two lines to enable Spoof protection (reverse-path filter)\n# Turn on Source Address Verification in all interfaces to\n# prevent some spoofing attacks\n#net.ipv4.conf.default.rp_filter=1\n#net.ipv4.conf.all.rp_filter=1\n\n# Uncomment the next line to enable TCP/IP SYN cookies\n# See http://lwn.net/Articles/277146/\n# Note: This may impact IPv6 TCP sessions too\n#net.ipv4.tcp_syncookies=1\n\n# Uncomment the next line to enable packet forwarding for IPv4\n#net.ipv4.ip_forward=1\n\n# Uncomment the next line to enable packet forwarding for IPv6\n#  Enabling this option disables Stateless Address Autoconfiguration\n#  based on Router Advertisements for this host\n#net.ipv6.conf.all.forwarding=1\n\n\n###################################################################\n# Additional settings - these settings can improve the network\n# security of the host and prevent against some network attacks\n# including spoofing attacks and man in the middle attacks through\n# redirection. Some network environments, however, require that these\n# settings are disabled so review and enable them as needed.\n#\n# Do not accept ICMP redirects (prevent MITM attacks)\n#net.ipv4.conf.all.accept_redirects = 0\n#net.ipv6.conf.all.accept_redirects = 0\n# _or_\n# Accept ICMP redirects only for gateways listed in our default\n# gateway list (enabled by default)\n# net.ipv4.conf.all.secure_redirects = 1\n#\n# Do not send ICMP redirects (we are not a router)\n#net.ipv4.conf.all.send_redirects = 0\n#\n# Do not accept IP source route packets (we are not a router)\n#net.ipv4.conf.all.accept_source_route = 0\n#net.ipv6.conf.all.accept_source_route = 0\n#\n# Log Martian Packets\n#net.ipv4.conf.all.log_martians = 1\n#\n"
inspec> 

```
