### PR TITLE
Allow port to be specified as a string

### DIFF
--- a/test/unit/resources/port_test.rb
+++ b/test/unit/resources/port_test.rb
@@ -44,6 +44,15 @@ describe 'Inspec::Resources::Port' do
     _(resource.addresses).must_equal ["0.0.0.0"]
   end
 
+  it 'accepts the port as a string' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('port', '111')
+    _(resource.listening?).must_equal true
+    _(resource.protocols).must_equal %w{ udp }
+    _(resource.pids).must_equal [545]
+    _(resource.processes).must_equal ['rpcbind']
+    _(resource.addresses).must_equal ["0.0.0.0"]
+  end
+
   it 'verify port on MacOs x' do
     resource = MockLoader.new(:osx104).load_resource('port', 2022)
     _(resource.listening?).must_equal true


### PR DESCRIPTION
This allows the user to write:

```
describe port(22) do
  it { should be_listening }
end
```

as well as

```
describe port('22') do
  it { should be_listening }
end
```

without hitting an error.

Fixes #867

Signed-off-by: Steven Danna steve@chef.io
