### PR TITLE
Explicitly require docker transport to avoid autoload bug

### DIFF
--- a/test/docker_test.rb
+++ b/test/docker_test.rb
@@ -3,6 +3,14 @@
 
 require_relative 'docker_run'
 require_relative '../lib/inspec'
+#
+# BUGON: These requires are to get around concurrency issues with
+# autoloading in Ruby
+#
+require 'train'
+require 'train/plugins'
+require 'train/plugins/transport'
+require 'train/transports/docker'
 
 tests = ARGV
 if tests.empty?


### PR DESCRIPTION
Ruby's autoload feature is not threadsafe.  We are hoping requiring the
docker plugin early will fix odd failures we have been seeing.

Signed-off-by: Steven Danna steve@chef.io
