### PR TITLE
revert control_summary field in output

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -154,12 +154,7 @@ class InspecRspecJson < InspecRspecMiniJson
       end
     end
 
-    @output_hash[:control_summary] = {
-      total: total,
-      failed: failed,
-      skipped: skipped,
-      passed: passed,
-    }
+    # TODO: provide this information in the output
   end
 
   private

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -23,7 +23,6 @@ describe 'inspec exec with json formatter' do
 
   describe 'execute a profile with json formatting' do
     let(:json) { JSON.load(inspec('exec ' + example_profile + ' --format json').stdout) }
-    let(:control_summary) { json['control_summary'] }
     let(:profile) { json['profiles']['profile'] }
     let(:controls) { profile['controls'] }
     let(:ex1) { controls['tmp-1.0'] }
@@ -61,7 +60,6 @@ describe 'inspec exec with json formatter' do
 
     it 'must have 4 controls' do
       controls.length.must_equal 4
-      control_summary['total'].must_equal 4
     end
 
     it 'has an id for every control' do
@@ -108,13 +106,6 @@ describe 'inspec exec with json formatter' do
         },
         "code" => "control \"tmp-1.0\" do                        # A unique ID for this control\n  impact 0.7                                # The criticality, if this control fails.\n  title \"Create /tmp directory\"             # A human-readable title\n  desc \"An optional description...\"         # Describe why this is needed\n  tag data: \"temp data\"                     # A tag allows you to associate key information\n  tag \"security\"                            # to the test\n  ref \"Document A-12\", url: 'http://...'    # Additional references\n\n  describe file('/tmp') do                  # The actual test\n    it { should be_directory }\n  end\nend\n",
       })
-    end
-
-    it 'must report 3 passing controls' do
-      control_summary['passed'].must_equal 3
-    end
-    it 'must report 1 skipped control' do
-      control_summary['skipped'].must_equal 1
     end
   end
 


### PR DESCRIPTION
(1) The field naming is not yet optimal, the calculations are great!
(2) Changing this field should go together with all other breaking json changes, especially if https://github.com/chef/inspec/pull/811 results in a change.
