### PR TITLE
Add `inspec env` command to configure shell tab-completion

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -10,6 +10,7 @@ require 'pp'
 require 'utils/json_log'
 require 'inspec/base_cli'
 require 'inspec/runner_mock'
+require 'inspec/env_printer'
 
 class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   class_option :diagnose, type: :boolean,
@@ -168,6 +169,12 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
     end
   rescue RuntimeError, Train::UserError => e
     $stderr.puts e.message
+  end
+
+  desc 'env', 'Output shell-appropriate completion configuration'
+  def env(shell = nil)
+    p = Inspec::EnvPrinter.new(self.class, shell)
+    p.print_and_exit!
   end
 
   desc 'version', 'prints the version of this tool'

--- a/lib/inspec/completions/bash.sh.erb
+++ b/lib/inspec/completions/bash.sh.erb
@@ -1,0 +1,45 @@
+_inspec() {
+    local _inspec_top_level_commands="<%= top_level_commands.join(" ") %>"
+    <% subcommands_with_commands.each do |name, subcommands| -%>
+local _inspec_<%= name %>_commands="<%= subcommands.join(" ") -%>"
+    <% end -%>
+
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+
+    if [ "$COMP_CWORD" -eq 1 ]; then
+        case "$prev" in
+            inspec)
+                COMPREPLY=( $( compgen -W "$_inspec_top_level_commands" -- "$cur" ) )
+                ;;
+        esac
+    elif [ "$COMP_CWORD" -eq 2 ]; then
+        case "$prev" in
+            archive|check|exec|json)
+                COMPREPLY=( $( compgen -f -- "$cur" ) )
+                ;;
+            help)
+                COMPREPLY=( $( compgen -W "$_inspec_top_level_commands" -- "$cur" ) )
+                ;;
+<% subcommands_with_commands.each do |name, subcommands| -%>
+           <%= name %>)
+                COMPREPLY=( $( compgen -W "$_inspec_<%= name %>_commands" -- "$cur" ) )
+                ;;
+<% end -%>
+        esac
+    elif [ "$COMP_CWORD" -eq 3 ]; then
+        prev2=${COMP_WORDS[COMP_CWORD-2]}
+        case "$prev2-$prev" in
+            compliance-upload)
+                COMPREPLY=( $( compgen -f -- "$cur" ) )
+                ;;
+<% subcommands_with_commands.each do |name, subcommands| -%>
+           <%= name %>-help)
+                COMPREPLY=( $( compgen -W "$_inspec_<%= name %>_commands" -- "$cur" ) )
+                ;;
+<% end -%>
+        esac
+    fi
+}
+
+complete -F _inspec inspec

--- a/lib/inspec/completions/zsh.sh.erb
+++ b/lib/inspec/completions/zsh.sh.erb
@@ -1,0 +1,61 @@
+function _inspec() {
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+
+    local -a _top_level_commands <%= subcommands_with_commands_and_descriptions.keys.map {|i| "_#{i}_commands" }.join(' ') %>
+
+    _top_level_commands=(
+<%= top_level_commands_with_descriptions.map {|i| " "*8 + "\"#{i}\"" }. join("\n") %>
+    )
+
+<% subcommands_with_commands_and_descriptions.each do |name, entry| -%>
+    _<%= name %>_commands=(
+<%= entry.map {|i| " "*8 + "\"#{i}\"" }.join("\n") %>
+    )
+
+<% end -%>
+    _arguments '1:::->toplevel' && return 0
+    _arguments '2:::->subcommand' && return 0
+    _arguments '3:::->subsubcommand' && return 0
+
+    #
+    # Are you thinking? "Jeez, whoever wrote this really doesn't get
+    # zsh's completion system?" If so, you are correct. However, I
+    # have goodnews! Pull requests are accepted!
+    #
+    case $state in
+        toplevel)
+            _describe -t commands "InSpec subcommands" _top_level_commands
+            ;;
+        subcommand)
+            case "$words[2]" in
+                archive|check|exec|json)
+                    _alternative 'files:filenames:_files'
+                    ;;
+                help)
+                    _describe -t commands "InSpec subcommands" _top_level_commands
+                    ;;
+<% subcommands_with_commands_and_descriptions.each do |name, entry| -%>
+                <%= name %>)
+                    _describe -t <%= name %>_commands "InSpec <%= name -%> subcommands" _<%= name %>_commands
+                    ;;
+<% end -%>
+            esac
+            ;;
+        subsubcommand)
+            case "$words[2]-$words[3]" in
+                compliance-upload)
+                    _alternative 'files:filenames:_files'
+                    ;;
+<% subcommands_with_commands_and_descriptions.each do |name, entry| -%>
+                <%= name %>-help)
+                    _describe -t <%= name %>_commands "InSpec <%= name %> subcommands" _<%= name %>_commands
+                    ;;
+<% end -%>
+            esac
+
+    esac
+
+}
+
+compdef _inspec inspec

--- a/lib/inspec/env_printer.rb
+++ b/lib/inspec/env_printer.rb
@@ -1,0 +1,149 @@
+# encoding: utf-8
+require 'inspec/shell_detector'
+require 'erb'
+require 'shellwords'
+
+module Inspec
+  class EnvPrinter
+    def initialize(command_class, shell = nil)
+      if !shell
+        @detected = true
+        @shell = Inspec::ShellDetector.new.shell
+      else
+        @shell = shell
+      end
+      @command_class = command_class
+    end
+
+    def print_and_exit!
+      exit_no_shell if !have_shell?
+      exit_no_completion if !have_shell_completion?
+
+      print_completion_for_shell
+      print_detection_warning($stdout) if @detected
+      print_usage_guidance
+      exit 0
+    end
+
+    private
+
+    def print_completion_for_shell
+      erb = ERB.new(File.read(completion_template_path), nil, '-')
+      puts erb.result(TemplateContext.new(@command_class).get_bindings)
+    end
+
+    def have_shell?
+      ! (@shell.nil? || @shell.empty?)
+    end
+
+    def have_shell_completion?
+      File.exist?(completion_template_path)
+    end
+
+    def completion_dir
+      File.join(File.dirname(__FILE__), 'completions')
+    end
+
+    def completion_template_path
+      File.join(completion_dir, "#{@shell}.sh.erb")
+    end
+
+    def shells_with_completions
+      Dir.glob("#{completion_dir}/*.sh.erb").map { |f| File.basename(f, '.sh.erb') }
+    end
+
+    def print_usage_guidance
+      puts <<EOF
+# To use this, eval it in your shell
+#
+#    eval "$(inspec env #{@shell})"
+#
+#
+EOF
+    end
+
+    def print_detection_warning(device)
+      device.puts <<EOF
+#
+# The shell #{@shell} was auto-detected. If this is incorrect, please
+# specify a shell explicitly by running:
+#
+#     inspec env SHELLNAME
+#
+# Currently supported shells are: #{shells_with_completions.join(', ')}
+#
+EOF
+    end
+
+    def exit_no_completion
+      $stderr.puts "# No completion script for #{@shell}!"
+      print_detection_warning($stderr) if @detected
+      exit 1
+    end
+
+    def exit_no_shell
+      if @detected
+        $stderr.puts '# Unable to automatically detect shell and no shell was provided.'
+      end
+      $stderr.puts <<EOF
+#
+# Please provide the name of your shell via the command line:
+#
+#    inspec env SHELLNAME
+#
+# Currently supported shells are: #{shells_with_completions.join(', ')}
+EOF
+      exit 1
+    end
+
+    class TemplateContext
+      def initialize(command_class)
+        @command_class = command_class
+      end
+
+      def get_bindings # rubocop:disable Style/AccessorMethodName
+        binding
+      end
+
+      #
+      # The following functions all assume that @command_class
+      # is something that provides a Thor-like API
+      #
+      def top_level_commands
+        commands_for_thor_class(@command_class)
+      end
+
+      def top_level_commands_with_descriptions
+        descript_lines_for_class(@command_class)
+      end
+
+      def subcommands_with_commands
+        ret = {}
+        @command_class.subcommand_classes.each do |k, v|
+          ret[k] = commands_for_thor_class(v)
+        end
+        ret
+      end
+
+      def subcommands_with_commands_and_descriptions
+        ret = {}
+        @command_class.subcommand_classes.each do |k, v|
+          ret[k] = descript_lines_for_class(v)
+        end
+        ret
+      end
+
+      def commands_for_thor_class(thor_class)
+        thor_class.all_commands.values.map { |c| c.usage.split.first }
+      end
+
+      def descript_lines_for_class(thor_class)
+        thor_class.all_commands.values.map { |c| descript_line_for_command(c) }
+      end
+
+      def descript_line_for_command(c)
+        "#{c.usage.split.first}:#{Shellwords.escape(c.description)}"
+      end
+    end
+  end
+end

--- a/lib/inspec/shell_detector.rb
+++ b/lib/inspec/shell_detector.rb
@@ -1,0 +1,90 @@
+# encoding: utf-8
+require 'etc'
+require 'rbconfig'
+
+module Inspec
+  #
+  # ShellDetector attempts to detect the shell the invoking user is
+  # running by checking:
+  #
+  #  - The command of our parent
+  #  - The SHELL environment variable
+  #  - The shell returned by getpwuid for our process UID
+  #
+  # Since none of these methods is fullproof, the detected shell is
+  # verified against a list of known shells before being returned to
+  # the caller.
+  #
+  class ShellDetector
+    NOT_DETECTED = Object.new.freeze
+    KNOWN_SHELLS = %w{bash zsh ksh csh sh fish}.freeze
+
+    def initialize
+      @shell = NOT_DETECTED
+    end
+
+    def shell
+      @shell = detect if !detected?(@shell)
+      @shell
+    end
+
+    def shell!
+      @shell = detect
+    end
+
+    private
+
+    def detect
+      # Most of our detection code assumes a unix-like environment
+      return nil if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+
+      shellpath = detect_by_ppid
+
+      if shellpath.nil? || shellpath.empty? || !known_shell?(shellpath)
+        shellpath = detect_by_env
+      end
+
+      if shellpath.nil? || shellpath.empty? || !known_shell?(shellpath)
+        shellpath = detect_by_getpwuid
+      end
+
+      shellname(shellpath) if known_shell?(shellpath)
+    end
+
+    def detected?(arg)
+      arg != NOT_DETECTED
+    end
+
+    def detect_by_ppid
+      ppid = Process.ppid
+      if Dir.exist?('/proc')
+        File.readlink("/proc/#{ppid}/exe")
+      else
+        `ps -cp #{ppid} -o command=`.chomp
+      end
+    end
+
+    def detect_by_env
+      ENV['SHELL']
+    end
+
+    def detect_by_getpwuid
+      Etc.getpwuid(Process.uid).shell
+    end
+
+    #
+    # Strip any leading path elements
+    #
+    def shellname(shellpath)
+      shellpath.split('/').last
+    end
+
+    #
+    # Only return shells that we know about, just to be sure we never
+    # do anything very silly.
+    #
+    def known_shell?(shell)
+      KNOWN_SHELLS.include?(shellname(shell))
+    end
+  end
+end

--- a/test/unit/shell_detector_test.rb
+++ b/test/unit/shell_detector_test.rb
@@ -1,0 +1,78 @@
+# encoding: utf-8
+# author: Steven Danna <steve@chef.io>
+#
+require 'helper'
+require 'rbconfig'
+require 'mocha/test_unit'
+require 'inspec/shell_detector'
+
+module ShellDetectorTestHelpers
+  def no_proc
+    Dir.expects(:exist?).with('/proc').returns(false)
+  end
+
+  def with_proc(shell)
+    Dir.expects(:exist?).with('/proc').returns(true)
+    File.expects(:readlink).with("/proc/#{ppid}/exe").returns(shell)
+  end
+
+  def with_ps(output)
+    subject.expects(:'`').with("ps -cp #{ppid} -o command=").returns(output)
+  end
+
+  def with_env(shell)
+    ENV.expects(:[]).with('SHELL').returns(shell)
+  end
+
+  def with_pwuid(shell)
+    Process.expects(:uid).returns(9999)
+    @mock_user = Minitest::Mock.new
+    @mock_user.expect :shell, shell
+    Etc.expects(:getpwuid).with(9999).returns(@mock_user)
+  end
+end
+
+describe Inspec::ShellDetector do
+  include ShellDetectorTestHelpers
+
+  let(:subject) { Inspec::ShellDetector.new }
+  let(:ppid) { Process.ppid }
+
+  # Small hack to ensure we can test on windows
+  it "returns nil immediately if running on windows" do
+    RbConfig::CONFIG.expects(:[]).with('host_os').returns('mswin')
+    subject.shell!.must_equal(nil)
+  end
+
+  describe "not on windows" do
+    before do
+      RbConfig::CONFIG.expects(:[]).with('host_os').returns('beos')
+    end
+
+    it "detects the shell via /proc if it exists" do
+      with_proc("/usr/bin/fish")
+      subject.shell!.must_equal("fish")
+    end
+
+    it "detects via `ps` if /proc doesn't exist" do
+      no_proc; with_ps("/usr/bin/ksh")
+      subject.shell!.must_equal("ksh")
+    end
+
+    it "detects via ENV if parent process methods failed" do
+      no_proc; with_ps(""); with_env("fish")
+      subject.shell!.must_equal("fish")
+    end
+
+    it "detects via getpwuid if all else fails" do
+      no_proc; with_ps(""); with_env(""); with_pwuid("/usr/bin/fish")
+      subject.shell!.must_equal("fish")
+      @mock_user.verify
+    end
+
+    it "returns nil if the shell isn't in the whitelist" do
+      no_proc; with_ps(""); with_env("badshell"); with_pwuid("/usr/bin/badshell")
+      subject.shell!.must_equal(nil)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new subcommand:

```
inspec env [SHELL]
```

which outputs a shell-appropriate completion script that the user can
source into their shell:

```
eval "$(inspec env SHELL)"
```

Currently, we provide completions for ZSH and Bash. The completion
scripts are generated from the data Thor collects.

If the user doesn't provide SHELL we attempt to detect what the user's
shell may be using a number of methods.

Fixes #607

Signed-off-by: Steven Danna steve@chef.io
