### PR TITLE
Add readline ignore markers to color escape codes in the shell

### DIFF
--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -32,7 +32,7 @@ module Inspec
 
       # configure pry shell prompt
       Pry.config.prompt_name = 'inspec'
-      Pry.prompt = [proc { "\e[0;32m#{Pry.config.prompt_name}>\e[0m " }]
+      Pry.prompt = [proc { "#{readline_ignore("\e[0;32m")}#{Pry.config.prompt_name}> #{readline_ignore("\e[0m")}" }]
 
       # Add a help menu as the default intro
       Pry.hooks.add_hook(:before_session, :intro) do
@@ -40,8 +40,12 @@ module Inspec
       end
     end
 
+    def readline_ignore(code)
+      "\001#{code}\002"
+    end
+
     def mark(x)
-      "\033[1m#{x}\033[0m"
+      "#{readline_ignore("\033[1m")}#{x}#{readline_ignore("\033[0m")}"
     end
 
     def print_example(example)
@@ -83,6 +87,7 @@ You can use resources in this environment to test the target machine. For exampl
 
 You are currently running on:
 
+    OS platform:  #{mark ctx.os[:name] || 'unknown'}
     OS family:  #{mark ctx.os[:family] || 'unknown'}
     OS release: #{mark ctx.os[:release] || 'unknown'}
 


### PR DESCRIPTION
Previously, if you typed more than 20 characters at the prompt and
attempted to press Ctrl+a (readline's "Move to start of line" command),
your prompt would appear at the ~11th character from the start of the
line, unable to go further back.

<img width="579" alt="screen shot 2016-08-10 at 10 00 29 am" src="https://cloud.githubusercontent.com/assets/852371/17548177/a201da30-5ee2-11e6-8e6d-ee7dafdb129f.png">

This was a result readline counting the terminal escape sequences we use
for color output as part of the line.

Wrapping these sequences in \001 and \002 instructs readline to ignore
them when doing calculations regarding line-length, resolving the
problem.

<img width="597" alt="screen shot 2016-08-10 at 10 07 09 am" src="https://cloud.githubusercontent.com/assets/852371/17548193/adb21ac0-5ee2-11e6-8fbd-8f6aaeb7816e.png">
