### PR TITLE
update dependencies and loosen molinillo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :test do
 end
 
 group :integration do
-  gem 'berkshelf', '~> 4.0'
+  gem 'berkshelf', '~> 4.3'
   gem 'test-kitchen', '~> 1.6'
   gem 'kitchen-vagrant'
   gem 'kitchen-inspec', '0.12.5'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rspec-its', '~> 1.2'
   spec.add_dependency 'pry', '~> 0'
   spec.add_dependency 'hashie', '~> 3.4'
-  spec.add_dependency 'molinillo', '~> 0.5'
+  spec.add_dependency 'molinillo', '~> 0'
 
   spec.add_development_dependency 'mocha', '~> 1.1'
 end


### PR DESCRIPTION
This prevents gecode from being pulled in as a gem dependency
