### PR TITLE
ssh_config parse should be case insensitive

### DIFF
--- a/lib/resources/ssh_conf.rb
+++ b/lib/resources/ssh_conf.rb
@@ -32,8 +32,16 @@ module Inspec::Resources
       end
     end
 
+    def convert_hash(hash)
+      new_hash = {}
+      hash.each do |k,v|
+        new_hash[k.downcase] = v
+      end
+      new_hash
+    end
+
     def method_missing(name)
-      param = read_params[name.to_s]
+      param = read_params[name.to_s.downcase]
       return nil if param.nil?
       # extract first value if we have only one value in array
       return param[0] if param.length == 1
@@ -69,7 +77,7 @@ module Inspec::Resources
         assignment_re: /^\s*(\S+?)\s+(.*?)\s*$/,
         multiple_values: true,
       )
-      @params = conf.params
+      @params = convert_hash(conf.params)
     end
   end
 

--- a/lib/resources/ssh_conf.rb
+++ b/lib/resources/ssh_conf.rb
@@ -34,7 +34,7 @@ module Inspec::Resources
 
     def convert_hash(hash)
       new_hash = {}
-      hash.each do |k,v|
+      hash.each do |k, v|
         new_hash[k.downcase] = v
       end
       new_hash

--- a/test/unit/mock/files/ssh_config
+++ b/test/unit/mock/files/ssh_config
@@ -3,3 +3,4 @@ Host *
 #   Tunnel no
     SendEnv LANG LC_*
     HashKnownHosts yes
+    GSSAPIAuthentication no

--- a/test/unit/resources/ssh_conf_test.rb
+++ b/test/unit/resources/ssh_conf_test.rb
@@ -14,6 +14,12 @@ describe 'Inspec::Resources::SshConf' do
       _(resource.Tunnel).must_equal nil
       _(resource.SendEnv).must_equal 'LANG LC_*'
       _(resource.HashKnownHosts).must_equal 'yes'
+      puts resource
+    end
+
+    it 'is case insensitive' do
+      resource = load_resource('ssh_config')
+      _(resource.gssapiauthentication).must_equal 'no'
     end
   end
 

--- a/test/unit/resources/ssh_conf_test.rb
+++ b/test/unit/resources/ssh_conf_test.rb
@@ -14,12 +14,12 @@ describe 'Inspec::Resources::SshConf' do
       _(resource.Tunnel).must_equal nil
       _(resource.SendEnv).must_equal 'LANG LC_*'
       _(resource.HashKnownHosts).must_equal 'yes'
-      puts resource
     end
 
     it 'is case insensitive' do
       resource = load_resource('ssh_config')
       _(resource.gssapiauthentication).must_equal 'no'
+      _(resource.GSSAPIAuthentication).must_equal 'no'
     end
   end
 


### PR DESCRIPTION
https://github.com/chef/inspec/issues/759
![screen shot 2016-08-15 at 4 05 33 pm](https://cloud.githubusercontent.com/assets/10341541/17677725/1de63934-6302-11e6-9fd5-9051039a9bf8.png)

Please let me know if there's a cleaner way to do this. I looked around and tried to find a different way (one that doesn't involve me messing with the hash), but this was the only solution I could find. Happy to change it up if there's something better out there :) 
