### PR TITLE
Ignore comment lines in /etc/passwd

### DIFF
--- a/lib/utils/parser.rb
+++ b/lib/utils/parser.rb
@@ -9,8 +9,9 @@ module PasswdParser
   # @return [Array] Collection of passwd entries
   def parse_passwd(content)
     content.to_s.split("\n").map do |line|
+      next if line[0] == '#'
       parse_passwd_line(line)
-    end
+    end.compact
   end
 
   # Parse a line of /etc/passwd

--- a/test/unit/utils/passwd_parser_test.rb
+++ b/test/unit/utils/passwd_parser_test.rb
@@ -16,6 +16,22 @@ describe PasswdParser do
       parser.parse_passwd('').must_equal([])
     end
 
+    it 'parses a comment line' do
+      content = <<EOF
+# This is a comment
+# this is another comment
+root:x:0:0:root:/root:/bin/sh
+EOF
+      info = [{ "user"=>"root",
+                "password"=>"x",
+                "uid"=>"0",
+                "gid"=>"0",
+                "desc"=>"root",
+                "home"=>"/root",
+                "shell"=>"/bin/sh" }]
+      parser.parse_passwd(content).must_equal(info)
+    end
+
     it 'parses a valid passwd line' do
       info = [{
         "user"=>"root",


### PR DESCRIPTION
Most passwd/shadow implementations treat lines that start with '#' as
comments. For example, the implementation in OS X:

```
 if (buf[0] == '#') {
      /* skip comments for Rhapsody. */
      continue;
 }
```

https://opensource.apple.com/source/remote_cmds/remote_cmds-41/rpc_yppasswdd.tproj/passwd.c

Fixes #725

Signed-off-by: Steven Danna steve@chef.io
