### PR TITLE
Fix errant 0 exit status on SSH errors

### DIFF
--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -42,6 +42,10 @@ module Inspec
       raise "Client error, can't connect to '#{name}' backend: #{e.message}"
     rescue Train::TransportError => e
       raise "Transport error, can't connect to '#{name}' backend: #{e.message}"
+    rescue Errno::EPIPE => e
+      # The SSH backend may raise an EPIPE if the remote end closes
+      # the connection unexpectedly.
+      raise "Can't connect to '#{name}' backend: #{e.message}"
     end
   end
 end


### PR DESCRIPTION
Thor, the command line framework we use, rescues Errno::EPIPE
exceptions and exits 0.  It does this because for many unix-style
command line applications it is a good decision.  For example, if your
command is being used in a pipeline with head(1):

```
my_command | head -10
```

It will get an EPIPE after head exits. You don't want this command to
fail because of the EPIPE as it is what you expected.

However, in our case, the SSH transport will raise EPIPE if the remote
server unexpectedly closed the connection.  This can happen, for
example, if your ssh configuration has a bad ProxyCommand configuration.
In these cases we do not want to exit successfully.

Explicitly rescuing the EPIPE in Inspec::Backend#create solves the issue
reported by users, but it may be better to rescue this exception in
Train itself.

Fixes #840

Signed-off-by: Steven Danna steve@chef.io
