### PR TITLE
add kitchen.yml for non-public kitchen boxes

### DIFF
--- a/.kitchen.chef.yml
+++ b/.kitchen.chef.yml
@@ -1,0 +1,67 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+  require_chef_omnibus:  12.12.15
+
+verifier:
+  name: inspec
+  sudo: true
+
+platforms:
+# The following (private) boxes are shared via Atlas and are only
+# available to users working for Chef. Sorry, it's about software licensing.
+#
+# Chef-internal users, you will need to:
+# 1.  Create an Atlas account:  https://atlas.hashicorp.com/
+# 2.  Ping #eng-services-support with your Atlas account name
+#     to be added to the relevant team in Atlas,
+# 3.  Do `vagrant login` with your Atlas creds so that you can download
+#     the private boxes.
+#
+# The Mac OS X boxes are VMware only also. You can enable VMware Fusion
+# by activating the `.kitchen.vmware.yml` file with the `KITCHEN_LOCAL_YAML`
+# environment variable:
+#
+#   KITCHEN_LOCAL_YAML=.kitchen.vmware.yml kitchen converge inspec-macosx-109
+#
+<% %w(
+  10.9
+  10.10
+  10.11
+).each do |mac_version| %>
+- name: macosx-<%= mac_version %>
+  driver:
+    box: chef/macosx-<%= mac_version %> # private
+    synced_folders:
+    - ['..', '/Users/vagrant/chef']
+    - ['../../omnibus', '/Users/vagrant/omnibus']
+    - ['../../omnibus-software', '/Users/vagrant/omnibus-software']
+<% end %>
+#
+# # By adding an `i386` to the name the Omnibus cookbook's `load-omnibus-toolchain.bat`
+# # will load the 32-bit version of the MinGW toolchain.
+<% [ '', '-i386' ].each do |win_suffix| %>
+- name: windows-2012r2-standard<%= win_suffix %>
+  driver:
+    box: chef/windows-server-2012r2-standard # private
+    synced_folders:
+    # We have to mount this repos enclosing folder as the Omnibus build
+    # gets cranky if the mounted source folder is a symlink. This
+    # mounts at `C:\vagrant\code` and the inspec source folder is available
+    # at `C:\vagrant\code\inspec`
+    - ['../..', '/vagrant/code']
+<% end %>
+
+<% [ '10.11', '11.3' ].each do |solaris_version| %>
+- name: solaris-<%= solaris_version %>
+  driver:
+    box: chef/solaris-<%= solaris_version %>
+<% end %>
+
+suites:
+  - name: default
+    run_list:
+      - recipe[os_prepare]


### PR DESCRIPTION
This PR adds macos, windows and solaris to our kitchen environment to ease integration testing. These boxes are only available for chef employees. Therefore its not merged into `.kitchen.yml` and uses `.kitchen.chef.yml`. To run integration test against those machines run:

```
KITCHEN_YAML=.kitchen.chef.yml bundle exec kitchen test default-windows-2012r2-standard
```
