### PR TITLE
Add integration tests for file owner on windows

### DIFF
--- a/test/integration/default/file_spec.rb
+++ b/test/integration/default/file_spec.rb
@@ -192,4 +192,10 @@ if os.windows?
     # Only works on Windows 2012 R2
     its('file_version') { should eq '6.3.9600.17415' }
   end
+
+  # read the owner of a file
+  describe directory('C:/opscode/chef') do
+    its('owner') { should cmp 'NT AUTHORITY\SYSTEM' }
+    it { should be_owned_by 'NT AUTHORITY\SYSTEM' }
+  end
 end


### PR DESCRIPTION
partially implements #783
requires https://github.com/chef/train/pull/132 
