### PR TITLE
remove tests and dev dependencies from released gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :test do
   gem 'rubocop', '~> 0.36.0'
   gem 'simplecov', '~> 0.10'
   gem 'concurrent-ruby', '~> 0.9'
+  gem 'mocha', '~> 1.1'
 end
 
 group :integration do

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     README.md Rakefile MAINTAINERS.toml MAINTAINERS.md LICENSE inspec.gemspec
     Gemfile CHANGELOG.md .rubocop.yml
   } + Dir.glob(
-    '{bin,docs,examples,lib,tasks,test}/**/*', File::FNM_DOTMATCH
+    '{bin,docs,examples,lib}/**/*', File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }
 
   spec.executables   = %w{ inspec }

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -36,6 +36,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hashie', '~> 3.4'
   spec.add_dependency 'molinillo', '~> 0'
   spec.add_dependency 'sslshake', '~> 1'
-
-  spec.add_development_dependency 'mocha', '~> 1.1'
 end


### PR DESCRIPTION
Focus on the git repo for development, i.e. group all development/test dependencies in `Gemfile` and remove the `test` folder from the released gem.

This together with the fact that we are not using git-ls-files has led to a 30mb gem recently!
