### PR TITLE
Remove false username/passwd msg from inspec compliance login

### DIFF
--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -23,11 +23,8 @@ module Compliance
       desc: 'Chef Compliance access token'
     option :refresh_token, type: :string, required: false,
       desc: 'Chef Compliance refresh token'
-    def login(server) # rubocop:disable Metrics/AbcSize, PerceivedComplexity
+    def login(server) # rubocop:disable Metrics/AbcSize
       # show warning if the Compliance Server does not support
-      if !Compliance::Configuration.new.supported?(:oidc)
-        puts 'Your server supports --user and --password only'
-      end
 
       options['server'] = server
       url = options['server'] + options['apipath']
@@ -49,7 +46,7 @@ module Compliance
       end
 
       if success
-        puts 'Successfully authenticated'
+        puts '', 'Successfully authenticated'
       else
         puts msg
       end

--- a/lib/bundles/inspec-compliance/test/integration/default/cli.rb
+++ b/lib/bundles/inspec-compliance/test/integration/default/cli.rb
@@ -34,6 +34,7 @@ refresh_token = ENV['COMPLIANCE_REFRESHTOKEN']
   # login via access token token
   describe command("#{inspec_bin} compliance login #{api_url} --insecure --user 'admin' #{token_options}") do
     its('stdout') { should include 'Successfully authenticated' }
+    its('stdout') { should_not include 'Your server supports --user and --password only' }
     its('stderr') { should eq '' }
     its('exit_status') { should eq 0 }
   end


### PR DESCRIPTION
![793](https://cloud.githubusercontent.com/assets/10341541/17706456/2348da3c-63aa-11e6-8451-46c16805bec4.png)

Removed msg saying username and password is needed, since on the "latest version of Chef Compliance the login method via username/password is not supported anymore". 

fixes https://github.com/chef/inspec/issues/793
