### PR TITLE
fix integration tests for Chef Compliance

### DIFF
--- a/lib/bundles/inspec-compliance/.kitchen.yml
+++ b/lib/bundles/inspec-compliance/.kitchen.yml
@@ -11,7 +11,6 @@ provisioner:
 
 verifier:
   name: inspec
-  sudo: true
 
 platforms:
   - name: ubuntu-14.04

--- a/lib/bundles/inspec-compliance/README.md
+++ b/lib/bundles/inspec-compliance/README.md
@@ -117,8 +117,10 @@ Pending: (Failures listed here are expected and do not affect your suite's statu
 
 Finished in 0.02862 seconds (files took 0.62628 seconds to load)
 5 examples, 0 failures, 1 pending
+```
 
-# logout from Chef Compliance
+# Logout from Chef Compliance
+
 ```
 $ inspec compliance logout
 Successfully logged out
@@ -130,11 +132,14 @@ At this point of time, InSpec is not able to pick up the token directly, therefo
 
  * run `kitchen converge`
  * open https://192.168.251.2 and log in with user `admin` and password `admin`
- * click on user->about and obtain the refresh token
+ * click on user->about and obtain the access token and the refresh token
  * run `kitchen verify` with the required env variables:
 
 ```
-COMPLIANCE_REFRESH_TOKEN=myrefreshtoken COMPLIANCE_ACCESS_TOKEN=mycompliancetoken b kitchen verify
+# both token need to be set, since the test suite runs for each token type
+export COMPLIANCE_ACCESSTOKEN='mycompliancetoken'
+export COMPLIANCE_REFRESHTOKEN='myrefreshtoken'
+kitchen verify
 -----> Starting Kitchen (v1.7.3)
 -----> Verifying <default-ubuntu-1404>...
        Search `/Users/chartmann/Development/compliance/inspec/lib/bundles/inspec-compliance/test/integration/default` for tests

--- a/lib/bundles/inspec-compliance/bootstrap.sh
+++ b/lib/bundles/inspec-compliance/bootstrap.sh
@@ -20,18 +20,26 @@ sudo apt-get install chef-compliance
 sudo chef-compliance-ctl reconfigure --accept-license
 sudo chef-compliance-ctl restart
 
-# build master version of inspec
-sudo /opt/chef-compliance/embedded/bin/gem list inspec
-
-cd /inspec
-sudo /opt/chef-compliance/embedded/bin/gem build *.gemspec
-sudo /opt/chef-compliance/embedded/bin/gem install inspec*.gem
-sudo /opt/chef-compliance/embedded/bin/inspec version
-sudo /opt/chef-compliance/embedded/bin/gem list inspec
-
 # finalize setup
 cd /
 /opt/chef-compliance/embedded/service/core/bin/core setup --endpoint "http://127.0.0.1:10500/setup" --login "admin" --password "admin" --name "John Doe" --accept-eula
 
 # wget --no-check-certificate http://127.0.0.1/api/version
 # cat version
+
+# install ruby 2.3
+sudo apt-get install -y software-properties-common
+sudo apt-add-repository -y ppa:brightbox/ruby-ng
+sudo apt-get update
+sudo apt-get install -y ruby2.3 ruby2.3-dev
+ruby2.3 -v
+
+# build master version of inspec
+sudo gem list inspec
+sudo cp -R /inspec /inspec-build
+cd  /inspec-build
+sudo rm -f inspec*.gem
+sudo gem build *.gemspec
+sudo gem install inspec*.gem
+sudo inspec version
+sudo gem list inspec

--- a/lib/bundles/inspec-compliance/test/integration/default/cli.rb
+++ b/lib/bundles/inspec-compliance/test/integration/default/cli.rb
@@ -1,13 +1,13 @@
 # encoding: utf-8
 
 # options
-inspec_bin = '/opt/chef-compliance/embedded/bin/inspec'
+inspec_bin = '/usr/local/bin/inspec'
 api_url = 'https://0.0.0.0'
 profile = '/inspec/examples/profile'
 
 # TODO: determine tokens automatically, define in kitchen yml
-access_token = ENV['COMPLIANCE_ACCESS_TOKEN']
-refresh_token = ENV['COMPLIANCE_REFRESH_TOKEN']
+access_token = ENV['COMPLIANCE_ACCESSTOKEN']
+refresh_token = ENV['COMPLIANCE_REFRESHTOKEN']
 
 %w{refresh_token access_token}.each do |type|
   case type
@@ -25,7 +25,7 @@ refresh_token = ENV['COMPLIANCE_REFRESH_TOKEN']
   end
 
   # login via access token token
-  describe command("#{inspec_bin} compliance login #{api_url} --insecure --user admin #{token_options}") do
+  describe command("#{inspec_bin} compliance login #{api_url} --insecure --user 'admin' #{token_options}") do
     its('stdout') { should include 'Successfully authenticated' }
     its('stderr') { should eq '' }
     its('exit_status') { should eq 0 }


### PR DESCRIPTION
As @vjeffrey pointed out, the integration test have not produced the expected results. This PR:
- updates the docs
- names the environment variables for tokens as in https://github.com/chef-cookbooks/audit/tree/master/examples/kitchen
- installs a separate ruby environment for InSpec, to work independently of Chef Compliance ruby environment
