### PR TITLE
fail gracefully on inspec compliance profiles when bad token is provided

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -70,7 +70,7 @@ Please login using `inspec compliance login https://compliance.test --user admin
 
     # verifies that a profile
     def self.exist?(config, profile)
-      profiles = Compliance::API.profiles(config)
+      _msg, profiles = Compliance::API.profiles(config)
       if !profiles.empty?
         index = profiles.index { |p| "#{p[:org]}/#{p[:name]}" == profile }
         !index.nil? && index >= 0

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -62,6 +62,7 @@ module Compliance
         }
       else
         puts msg, 'Could not find any profiles'
+        exit 1
       end
     end
 
@@ -153,6 +154,7 @@ module Compliance
       else
         puts 'Error during profile upload:'
         puts msg
+        exit 1
       end
     end
 
@@ -164,6 +166,7 @@ module Compliance
         puts "Chef Compliance version: #{info['version']}"
       else
         puts 'Could not determine server version.'
+        exit 1
       end
     end
 

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -53,7 +53,7 @@ module Compliance
       config = Compliance::Configuration.new
       return if !loggedin(config)
 
-      profiles = Compliance::API.profiles(config)
+      msg, profiles = Compliance::API.profiles(config)
       if !profiles.empty?
         # iterate over profiles
         headline('Available profiles:')
@@ -61,7 +61,7 @@ module Compliance
           li("#{profile[:org]}/#{profile[:name]}")
         }
       else
-        puts 'Could not find any profiles'
+        puts msg, 'Could not find any profiles'
       end
     end
 

--- a/lib/bundles/inspec-compliance/test/integration/default/cli.rb
+++ b/lib/bundles/inspec-compliance/test/integration/default/cli.rb
@@ -5,6 +5,10 @@ inspec_bin = 'BUNDLE_GEMFILE=/inspec/Gemfile bundle exec inspec'
 api_url = 'https://0.0.0.0'
 profile = '/inspec/examples/profile'
 
+user = command('whoami').stdout.strip
+pwd = command('pwd').stdout.strip
+puts "Run test as #{user} in path #{pwd}"
+
 # TODO: determine tokens automatically, define in kitchen yml
 access_token = ENV['COMPLIANCE_ACCESSTOKEN']
 refresh_token = ENV['COMPLIANCE_REFRESHTOKEN']
@@ -28,7 +32,7 @@ refresh_token = ENV['COMPLIANCE_REFRESHTOKEN']
   describe command("#{inspec_bin} compliance version") do
     its('stdout') { should include 'Server configuration information is missing' }
     its('stderr') { should eq '' }
-    its('exit_status') { should eq 0 }
+    its('exit_status') { should eq 1 }
   end
 
   # submitting a wrong token should have an exit of 0

--- a/lib/bundles/inspec-compliance/test/integration/default/cli.rb
+++ b/lib/bundles/inspec-compliance/test/integration/default/cli.rb
@@ -37,6 +37,13 @@ refresh_token = ENV['COMPLIANCE_REFRESHTOKEN']
     its('exit_status') { should eq 0 }
   end
 
+  # profiles command fails gracefully when token/server info is incorrect
+  describe command("#{inspec_bin} compliance profiles") do
+    its('stdout') { should include '401 Unauthorized. Please check your token' }
+    its('stderr') { should eq '' }
+    its('exit_status') { should eq 1 }
+  end
+
   # login via access token token
   describe command("#{inspec_bin} compliance login #{api_url} --insecure --user 'admin' #{token_options}") do
     its('stdout') { should include 'token', 'stored' }


### PR DESCRIPTION
just a quick fix to handle inspec compliance profiles when an incorrect token has been previously provided.  
![screen shot 2016-08-17 at 12 18 02 pm](https://cloud.githubusercontent.com/assets/10341541/17744197/ae8c8736-6474-11e6-9b7a-12688ffdde02.png)
@chris-rock 
