### PR TITLE
return token stored message on login

### DIFF
--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -30,26 +30,22 @@ module Compliance
       url = options['server'] + options['apipath']
       if !options['user'].nil? && !options['password'].nil?
         # username / password
-        success, msg = login_legacy(url, options['user'], options['password'], options['insecure'])
+        _success, msg = login_legacy(url, options['user'], options['password'], options['insecure'])
       elsif !options['user'].nil? && !options['token'].nil?
         # access token
-        success, msg = store_access_token(url, options['user'], options['token'], options['insecure'])
+        _success, msg = store_access_token(url, options['user'], options['token'], options['insecure'])
       elsif !options['refresh_token'].nil? && !options['user'].nil?
         # refresh token
-        success, msg = store_refresh_token(url, options['refresh_token'], true, options['user'], options['insecure'])
+        _success, msg = store_refresh_token(url, options['refresh_token'], true, options['user'], options['insecure'])
         # TODO: we should login with the refreshtoken here
       elsif !options['refresh_token'].nil?
-        success, msg = login_refreshtoken(url, options)
+        _success, msg = login_refreshtoken(url, options)
       else
         puts 'Please run `inspec compliance login` with options --token or --refresh_token and --user'
         exit 1
       end
 
-      if success
-        puts '', 'Successfully authenticated'
-      else
-        puts msg
-      end
+      puts '', msg
     end
 
     desc 'profiles', 'list all available profiles in Chef Compliance'
@@ -220,7 +216,7 @@ module Compliance
           success = true
           msg = 'Successfully authenticated'
         else
-          msg = 'Reponse does not include a token'
+          msg = 'Response does not include a token'
         end
       else
         msg = "Authentication failed for Server: #{url}"

--- a/lib/bundles/inspec-compliance/test/integration/default/cli.rb
+++ b/lib/bundles/inspec-compliance/test/integration/default/cli.rb
@@ -31,9 +31,15 @@ refresh_token = ENV['COMPLIANCE_REFRESHTOKEN']
     its('exit_status') { should eq 0 }
   end
 
+  # submitting a wrong token should have an exit of 0
+  describe command("#{inspec_bin} compliance login #{api_url} --insecure --user 'admin' --token 'wrong-token'") do
+    its('stdout') { should include 'token stored' }
+    its('exit_status') { should eq 0 }
+  end
+
   # login via access token token
   describe command("#{inspec_bin} compliance login #{api_url} --insecure --user 'admin' #{token_options}") do
-    its('stdout') { should include 'Successfully authenticated' }
+    its('stdout') { should include 'token', 'stored' }
     its('stdout') { should_not include 'Your server supports --user and --password only' }
     its('stderr') { should eq '' }
     its('exit_status') { should eq 0 }


### PR DESCRIPTION
at the moment, on master, we respond with 'successfully authenticated' even when there's an obviously wrong token, so this is just a small change to send back the actual message instead: 
<img width="937" alt="screen shot 2016-08-17 at 8 12 49 pm" src="https://cloud.githubusercontent.com/assets/10341541/17757711/06132068-64b7-11e6-90f3-db6cc168811d.png">
