### PR TITLE
Ease testing of compliance integration tests

### DIFF
--- a/lib/bundles/inspec-compliance/bootstrap.sh
+++ b/lib/bundles/inspec-compliance/bootstrap.sh
@@ -34,12 +34,8 @@ sudo apt-get update
 sudo apt-get install -y ruby2.3 ruby2.3-dev
 ruby2.3 -v
 
-# build master version of inspec
-sudo gem list inspec
-sudo cp -R /inspec /inspec-build
-cd  /inspec-build
-sudo rm -f inspec*.gem
-sudo gem build *.gemspec
-sudo gem install inspec*.gem
-sudo inspec version
-sudo gem list inspec
+# prepare the usage of bundler
+sudo gem install bundler
+cd /inspec
+bundle install
+BUNDLE_GEMFILE=/inspec/Gemfile bundle exec inspec version

--- a/lib/bundles/inspec-compliance/test/integration/default/cli.rb
+++ b/lib/bundles/inspec-compliance/test/integration/default/cli.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 # options
-inspec_bin = '/usr/local/bin/inspec'
+inspec_bin = 'BUNDLE_GEMFILE=/inspec/Gemfile bundle exec inspec'
 api_url = 'https://0.0.0.0'
 profile = '/inspec/examples/profile'
 


### PR DESCRIPTION
- use bundler instead of gem
- this help to make local changes and use them directly with your integration tests
