### PR TITLE
Expand relative paths based on profile location

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -134,7 +134,15 @@ module Inspec
       # logging singleton Inspec::Log. Eventually it would be nice to
       # move internal debug logging to use this logging singleton.
       #
-      Inspec::Log.init(o.log_location)
+      loc = if o.log_location
+              o.log_location
+            elsif %w{json json-min}.include?(o['format'])
+              STDERR
+            else
+              STDOUT
+            end
+
+      Inspec::Log.init(loc)
       Inspec::Log.level = get_log_level(o.log_level)
 
       o[:logger] = Logger.new(STDOUT)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -18,8 +18,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   class_option :log_level, aliases: :l, type: :string,
                desc: 'Set the log level: info (default), debug, warn, error'
 
-  class_option :log_location, type: :string, default: STDERR,
-               desc: 'Location to send diagnostic log messages to. (default: STDERR)'
+  class_option :log_location, type: :string,
+               desc: 'Location to send diagnostic log messages to. (default: STDOUT or STDERR)'
 
   class_option :diagnose, type: :boolean,
     desc: 'Show diagnostics (versions, configurations)'

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -18,8 +18,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   class_option :log_level, aliases: :l, type: :string,
                desc: 'Set the log level: info (default), debug, warn, error'
 
-  class_option :log_location, type: :string, default: STDOUT,
-               desc: 'Location to send diagnostic log messages to. (default: STDOUT)'
+  class_option :log_location, type: :string, default: STDERR,
+               desc: 'Location to send diagnostic log messages to. (default: STDERR)'
 
   class_option :diagnose, type: :boolean,
     desc: 'Show diagnostics (versions, configurations)'

--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -91,7 +91,7 @@ module Inspec
 
     def source_url
       if opts[:path]
-        "file://#{opts[:path]}"
+        "file://#{File.expand_path(opts[:path], @cwd)}"
       elsif opts[:url]
         opts[:url]
       end


### PR DESCRIPTION
Also: Log to STDERR by default

NB: This will result in absolute paths being rendered to lock files. We
think that is OK for now since we are going to build some UX around
path-based dependencies and lock files.  Namely, we are going to tell
people it is a bad idea.

Signed-off-by: Steven Danna steve@chef.io
