### PR TITLE
Allow JSON 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Berksfile.lock
 .librarian
 Puppetfile.lock
 .kitchen.local.yml
+binstubs

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ before_install:
 
 matrix:
   include:
-  - rvm: 1.9.3
-  - rvm: 2.0
-  - rvm: 2.2
+  - rvm: 2.2.5
+  - rvm: 2.3.1
+  - rvm: 2.3.1
     script: bundle exec rake lint test test:resources config=test/test.yaml
-  - rvm: 2.2
+  - rvm: 2.3.1
     script: N=5 bundle exec rake test:functional test:resources config=test/test-extra.yaml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ platform:
 
 environment:
   matrix:
-    - ruby_version: "200-x64"
-    - ruby_version: "21"
+    - ruby_version: "23-x64"
+    - ruby_version: "23"
 
 clone_folder: c:\projects\inspec
 clone_depth: 1

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'r-train', '~> 0.10.4'
   spec.add_dependency 'thor', '~> 0.19'
-  spec.add_dependency 'json', '~> 1.8'
+  spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'rainbow', '~> 2'
   spec.add_dependency 'method_source', '~> 0.8'
   spec.add_dependency 'rubyzip', '~> 1.1'

--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 # author: Christoph Hartmann
 # author: Dominik Richter
 

--- a/lib/inspec/plugins/resource.rb
+++ b/lib/inspec/plugins/resource.rb
@@ -2,8 +2,6 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'inspec/resource'
-
 module Inspec
   module Plugins
     class Resource

--- a/lib/inspec/version.rb
+++ b/lib/inspec/version.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/tasks/maintainers.rb
+++ b/tasks/maintainers.rb
@@ -27,9 +27,10 @@ begin
   require 'tomlrb'
   require 'octokit'
   require 'pp'
-  task default: :generate
 
   namespace :maintainers do
+    task default: :generate
+
     desc 'Generate MarkDown version of MAINTAINERS file'
     task :generate do
       maintainers = Tomlrb.load_file SOURCE


### PR DESCRIPTION
As Chef and ChefDK move to Ruby 2.3 (which is happening as of this next release), we're moving away from Ruby 2.1 support. This means that the JSON version can finally be bumped. In the meantime it's best to allow both the old and new version (which allows us to upgrade when ready).
