### PR TITLE
Add Ruby 2.3 to the test matrix, make it the primary test for most suites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,42 +15,42 @@ before_install:
 matrix:
   include:
   - rvm: 1.9.3
-  - rvm: 2.0
   - rvm: 2.1.8
-  - rvm: 2.2
+  - rvm: 2.2.5
+  - rvm: 2.3.1
     script: bundle exec rake $SUITE
     env: SUITE="lint test test:functional"
-  - rvm: 2.2
+  - rvm: 2.3.1
     script: bundle exec rake $SUITE
     env: SUITE="test:resources config=test/test.yaml" N=2
-  - rvm: 2.2
+  - rvm: 2.3.1
     script: bundle exec rake $SUITE
     env: SUITE="test:resources config=test/test-extra.yaml" N=2
-  - rvm: 2.2
+  - rvm: 2.3.1
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS=default-ubuntu-1204 DOCKER=true
-  - rvm: 2.2
+  - rvm: 2.3.1
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-ubuntu-1604' DOCKER=true
-  - rvm: 2.2
+  - rvm: 2.3.1
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-centos-68' DOCKER=true
-  - rvm: 2.2
+  - rvm: 2.3.1
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-centos-7' DOCKER=true
-  - rvm: 2.2
+  - rvm: 2.3.1
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-debian-8' DOCKER=true
-  - rvm: 2.2
+  - rvm: 2.3.1
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-oracle-72' DOCKER=true
-  - rvm: 2.2
+  - rvm: 2.3.1
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-fedora-24' DOCKER=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
   matrix:
     - ruby_version: "193"
     - ruby_version: "22"
+    - ruby_version: "23"
 
 clone_folder: c:\projects\inspec
 clone_depth: 1

--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 # author: Christoph Hartmann
 # author: Dominik Richter
 

--- a/lib/inspec/version.rb
+++ b/lib/inspec/version.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/resources/iis_site.rb
+++ b/lib/resources/iis_site.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 # check for site in IIS
 # Usage:
 # describe iis_site('Default Web Site') do


### PR DESCRIPTION
Chef and ChefDK will soon ship with Ruby 2.3, so we should make sure the inspec suite works on it.
