### PR TITLE
Fix `bundle install` on Ruby 2.1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
   include:
   - rvm: 1.9.3
   - rvm: 2.0
+  - rvm: 2.1.8
   - rvm: 2.2
     script: bundle exec rake $SUITE
     env: SUITE="lint test test:functional"

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,9 @@ if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('1.9.3')
   gem 'net-ssh', '~> 2.9'
 end
 
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('2.1.0')
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.0')
   gem 'json', '~> 1.8'
+  gem 'rack', '< 2.0'
 end
 
 # TODO: ffi 1.9.11 is currently erroneous on windows tests


### PR DESCRIPTION
`rack` is another gem whose latest version does not work on Ruby 2.1.9.

I also fixed it so `<= 2.1.0` became `< 2.2`, since `2.1.9` was not being covered.

Finally, I added 2.1.9 to the Travis matrix the current `chef` and `chef-dk` stable releases still run 2.1.9, and gave specific versions to all the Rubies we run, since on Travis 2.1 means 2.1.0, which has known bugs and which no one runs.
