### PR TITLE
Fix `rake` to work again

### DIFF
--- a/tasks/maintainers.rb
+++ b/tasks/maintainers.rb
@@ -27,9 +27,10 @@ begin
   require 'tomlrb'
   require 'octokit'
   require 'pp'
-  task default: :generate
 
   namespace :maintainers do
+    task default: :generate
+
     desc 'Generate MarkDown version of MAINTAINERS file'
     task :generate do
       maintainers = Tomlrb.load_file SOURCE


### PR DESCRIPTION
It was searching for `rake generate` because that is the default task, and does not exist.
