### PR TITLE
suport for ruby 2.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('1.9.3')
   gem 'net-ssh', '~> 2.9'
 end
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.0')
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
   gem 'json', '~> 1.8'
   gem 'rack', '< 2.0'
 end


### PR DESCRIPTION
Fixes the error when we try to install InSpec on ruby 2.2.2

```
Using multi_xml 0.5.5
Installing rack 2.0.1

Gem::InstallError: rack requires Ruby version >= 2.2.2.
Using method_source 0.8.2
Using slop 3.6.0
```
