### PR TITLE
Minor refactor and explanatory comments

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -15,9 +15,8 @@ module Inspec
   class Profile # rubocop:disable Metrics/ClassLength
     extend Forwardable
 
-    def self.resolve_target(target, opts)
+    def self.resolve_target(target)
       # Fetchers retrieve file contents
-      opts[:target] = target
       fetcher = Inspec::Fetcher.resolve(target)
       if fetcher.nil?
         fail("Could not fetch inspec profile in #{target.inspect}.")
@@ -33,7 +32,7 @@ module Inspec
     end
 
     def self.for_target(target, opts)
-      new(resolve_target(target, opts), opts)
+      new(resolve_target(target), opts.merge(target: target))
     end
 
     attr_reader :source_reader

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -48,6 +48,14 @@ module Inspec
       @subcontexts << context
     end
 
+    def load_tests(tests)
+      tests.each do |t|
+        content = t[:content]
+        next if content.nil? || content.empty?
+        load(content, t[:ref], t[:line])
+      end
+    end
+
     def load_libraries(libs)
       lib_prefix = 'libraries' + File::SEPARATOR
       autoloads = []


### PR DESCRIPTION
This is a minor refactor that I did while studying our loading code in
preparation for some deeper changes to how content loading works. The
overall goal of the refactor is to remove a few places where we were
passing a generic options hash and then only accessing a single item.

The comment hopefully clarifies to new developers in the code base how
content loading works at a high level.

Signed-off-by: Steven Danna steve@chef.io
