### PR TITLE
Allow functional tests to pass on OSX

### DIFF
--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -3,6 +3,7 @@
 # author: Christoph Hartmann
 
 require 'functional/helper'
+require 'tmpdir'
 
 describe 'inspec archive' do
   include FunctionalHelper
@@ -34,11 +35,13 @@ describe 'inspec archive' do
   end
 
   it 'archive on invalid archive' do
-    out = inspec('archive /proc --output ' + dst.path)
-    # out.stdout.must_equal '' => we have partial stdout output right now
-    out.stderr.must_include "Don't understand inspec profile in \"/proc\""
-    out.exit_status.must_equal 1
-    File.exist?(dst.path).must_equal false
+    Dir.tmpdir do |target_dir|
+      out = inspec('archive #{target_dir} --output ' + dst.path)
+      # out.stdout.must_equal '' => we have partial stdout output right now
+      out.stderr.must_include "Don't understand inspec profile in \"#{target_dir}\""
+      out.exit_status.must_equal 1
+      File.exist?(dst.path).must_equal false
+    end
   end
 
   it 'archive wont overwrite existing files' do

--- a/test/unit/mock/profiles/complete-metadata/inspec.yml
+++ b/test/unit/mock/profiles/complete-metadata/inspec.yml
@@ -4,4 +4,6 @@ maintainer: bob
 title: title
 copyright: left
 summary: nothing
-supports: linux
+supports:
+  - linux
+  - darwin

--- a/test/unit/mock/profiles/library/inspec.yml
+++ b/test/unit/mock/profiles/library/inspec.yml
@@ -7,4 +7,5 @@ license: Proprietary, All rights reserved
 summary: Testing stub
 version: 1.0.0
 supports:
-- os-family: linux
+  - linux
+  - darwin


### PR DESCRIPTION
A few minor issues were causing 3 functional test failures on OS X.
These were not program errors but where rather the result of the
profiles under test assuming a linux environment.

Since many of the developers who will work on this project in the future
will be running OS X, let's ensure they can run the functional tests
easily.

Signed-off-by: Steven Danna steve@chef.io
