### PR TITLE
cmp not treating 0 as integer only as string

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -232,7 +232,7 @@ end
 RSpec::Matchers.define :cmp do |first_expected|
 
   def integer?(value)
-    !(value =~ /\A[1-9]\d*\Z/).nil?
+    !(value =~ /\A[0-9]\d*\Z/).nil?
   end
 
   def float?(value)

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -232,7 +232,7 @@ end
 RSpec::Matchers.define :cmp do |first_expected|
 
   def integer?(value)
-    !(value =~ /\A[0-9]\d*\Z/).nil?
+    !(value =~ /\A0+\Z|\A[1-9]\d*\Z/).nil?
   end
 
   def float?(value)

--- a/test/integration/default/cmp_matcher_spec.rb
+++ b/test/integration/default/cmp_matcher_spec.rb
@@ -119,6 +119,7 @@ if os.linux?
     it { should cmp '0' }
     it { should cmp '00' }
     it { should_not cmp 1 }
+    it { should_not cmp '01' }
   end
 
 end

--- a/test/integration/default/cmp_matcher_spec.rb
+++ b/test/integration/default/cmp_matcher_spec.rb
@@ -112,4 +112,9 @@ if os.linux?
     it { should cmp 'False' }
     it { should cmp false }
   end
+
+  describe 0 do
+    it { should cmp 0 }
+    it { should cmp '0' }
+  end
 end

--- a/test/integration/default/cmp_matcher_spec.rb
+++ b/test/integration/default/cmp_matcher_spec.rb
@@ -115,6 +115,10 @@ if os.linux?
 
   describe 0 do
     it { should cmp 0 }
+    it { should cmp 00 }
     it { should cmp '0' }
+    it { should cmp '00' }
+    it { should_not cmp 1 }
   end
+
 end


### PR DESCRIPTION
This change allows both tests to pass, which I believe is the intent of the `cmp` matcher.

```
describe 0 do
  it { should cmp 0 }
  it { should cmp '0' }
end
```

Without the change from this PR, it fails one of the tests:

```
~/Devel/ChefProject/inspec (cmp_treat_0_as_integer $%=)$ inspec exec ../tmp/cmp_test.rb --format=documentation

0
  should cmp 0
  should cmp "0" (FAILED - 1)

Failures:

  1) 0 should cmp "0"
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }

       expected: "0"
            got: 0

       (compared using `cmp` matcher)
     # ../tmp/sshd_test.rb:7:in `block (2 levels) in load'

Finished in 0.01047 seconds (files took 0.79418 seconds to load)
2 examples, 1 failure

Failed examples:

rspec  # 0 should cmp "0"

~/Devel/ChefProject/inspec (cmp_treat_0_as_integer $%=)$
```
