### PR TITLE
Initial attempt at isolating resources between dependencies

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -70,7 +70,7 @@ module Inspec
       o[:logger].level = get_log_level(o.log_level)
 
       runner = Inspec::Runner.new(o)
-      targets.each { |target| runner.add_target(target, opts) }
+      targets.each { |target| runner.add_target(target) }
       exit runner.run
     rescue RuntimeError, Train::UserError => e
       $stderr.puts e.message

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -60,7 +60,7 @@ module Inspec
         end
 
         def to_s
-          "Profile Context Run #{profile_name}"
+          "Control Evaluation Context (#{profile_name})"
         end
 
         define_method :profile_name do
@@ -73,6 +73,12 @@ module Inspec
           register_control(rule_class.new(id, profile_id, opts, &block))
         end
 
+        #
+        # Describe allows users to write rspec-like bare describe
+        # blocks without declaring an inclosing control. Here, we
+        # generate a control for them automatically and then execute
+        # the describe block in the context of that control.
+        #
         define_method :describe do |*args, &block|
           loc = block_location(block, caller[0])
           id = "(generated from #{loc} #{SecureRandom.hex})"

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -1,0 +1,139 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+require 'inspec/dsl'
+require 'inspec/dsl_shared'
+
+module Inspec
+  #
+  # ControlEvalContext constructs an anonymous class that control
+  # files will be instance_exec'd against.
+  #
+  # The anonymous class includes the given passed resource_dsl as well
+  # as the basic DSL of the control files (describe, control, title,
+  # etc).
+  #
+  class ControlEvalContext
+    # Create the context for controls. This includes all components of the DSL,
+    # including matchers and resources.
+    #
+    # @param [ResourcesDSL] resources_dsl which has all resources to attach
+    # @return [RuleContext] the inner context of rules
+    def self.rule_context(resources_dsl)
+      require 'rspec/core/dsl'
+      Class.new(Inspec::Rule) do
+        include RSpec::Core::DSL
+        include resources_dsl
+      end
+    end
+
+    # Creates the heart of the control eval context:
+    #
+    # An instantiated object which has all resources registered to it
+    # and exposes them to the a test file.
+    #
+    # @param profile_context [Inspec::ProfileContext]
+    # @param outer_dsl [OuterDSLClass]
+    # @return [ProfileContextClass]
+    #
+    # rubocop:disable Lint/NestedMethodDefinition
+    def self.create(profile_context, resources_dsl) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      rule_class = rule_context(resources_dsl)
+      profile_context_owner = profile_context
+      profile_id = profile_context.profile_id
+
+      Class.new do
+        include Inspec::DSL
+        include Inspec::DSL::RequireOverride
+        include resources_dsl
+
+        def initialize(backend, conf, dependencies, require_loader)
+          @backend = backend
+          @conf = conf
+          @dependencies = dependencies
+          @require_loader = require_loader
+          @skip_profile = false
+        end
+
+        define_method :title do |arg|
+          profile_context_owner.set_header(:title, arg)
+        end
+
+        def to_s
+          "Profile Context Run #{profile_name}"
+        end
+
+        define_method :profile_name do
+          profile_id
+        end
+
+        define_method :control do |*args, &block|
+          id = args[0]
+          opts = args[1] || {}
+          register_control(rule_class.new(id, profile_id, opts, &block))
+        end
+
+        define_method :describe do |*args, &block|
+          loc = block_location(block, caller[0])
+          id = "(generated from #{loc} #{SecureRandom.hex})"
+
+          res = nil
+          rule = rule_class.new(id, profile_id, {}) do
+            res = describe(*args, &block)
+          end
+          register_control(rule, &block)
+
+          res
+        end
+
+        define_method :add_resources do |context|
+          self.class.class_eval do
+            include context.to_resources_dsl
+          end
+
+          rule_class.class_eval do
+            include context.to_resources_dsl
+          end
+        end
+
+        define_method :add_subcontext do |context|
+          profile_context_owner.add_subcontext(context)
+        end
+
+        define_method :register_control do |control, &block|
+          ::Inspec::Rule.set_skip_rule(control, true) if @skip_profile
+
+          profile_context_owner.register_rule(control, &block) unless control.nil?
+        end
+
+        # method for attributes; import attribute handling
+        define_method :attribute do |name, options|
+          profile_context_owner.register_attribute(name, options)
+        end
+
+        define_method :skip_control do |id|
+          profile_context_owner.unregister_rule(id)
+        end
+
+        def only_if
+          return unless block_given?
+          @skip_profile ||= !yield
+        end
+
+        alias_method :rule, :control
+        alias_method :skip_rule, :skip_control
+
+        private
+
+        def block_location(block, alternate_caller)
+          if block.nil?
+            alternate_caller[/^(.+:\d+):in .+$/, 1] || 'unknown'
+          else
+            path, line = block.source_location
+            "#{File.basename(path)}:#{line}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/inspec/dependencies/resolver.rb
+++ b/lib/inspec/dependencies/resolver.rb
@@ -23,9 +23,9 @@ module Inspec
   # implementation of the fetcher being used.
   #
   class Resolver
-    def self.resolve(dependencies, vendor_index, working_dir)
+    def self.resolve(dependencies, vendor_index, working_dir, backend)
       reqs = dependencies.map do |dep|
-        req = Inspec::Requirement.from_metadata(dep, vendor_index, cwd: working_dir)
+        req = Inspec::Requirement.from_metadata(dep, vendor_index, cwd: working_dir, backend: backend)
         req || fail("Cannot initialize dependency: #{req}")
       end
       new.resolve(reqs)

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -18,19 +18,6 @@ module Inspec::DSL
   alias require_rules require_controls
   alias include_rules include_controls
 
-  def self.rule_from_check(m, a, b)
-    if a.is_a?(Array) && !a.empty? &&
-       a[0].respond_to?(:resource_skipped) &&
-       !a[0].resource_skipped.nil?
-      ::Inspec::Rule.__send__(m, *a) do
-        it a[0].resource_skipped
-      end
-    else
-      # execute the method
-      ::Inspec::Rule.__send__(m, *a, &b)
-    end
-  end
-
   def self.load_spec_files_for_profile(bind_context, opts, &block)
     dependencies = opts[:dependencies]
     profile_id = opts[:profile_id]
@@ -43,11 +30,11 @@ of #{bind_context.profile_name}.
 
 Dependencies available from this context are:
 
-     #{dependencies.list.keys.join("\n    ")}
+    #{dependencies.list.keys.join("\n    ")}
 EOF
     end
 
-    context = load_profile_context(dep_entry.profile, opts[:backend])
+    context = Inspec::ProfileContext.for_profile(dep_entry.profile, opts[:backend])
 
     # if we don't want all the rules, then just make 1 pass to get all rule_IDs
     # that we want to keep from the original
@@ -69,17 +56,5 @@ EOF
         context.rules[id] = nil
       end
     end
-  end
-
-  def self.load_profile_context(profile, backend)
-    ctx = Inspec::ProfileContext.for_profile(profile, backend)
-    profile.libraries.each do |path, content|
-      ctx.load(content.to_s, path, 1)
-      ctx.reload_dsl
-    end
-    profile.tests.each do |path, content|
-      ctx.load(content.to_s, path, 1)
-    end
-    ctx
   end
 end

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -34,21 +34,17 @@ Dependencies available from this context are:
 EOF
     end
 
-    context = Inspec::ProfileContext.for_profile(dep_entry.profile, opts[:backend])
-
+    context = dep_entry.profile.runner_context
     # if we don't want all the rules, then just make 1 pass to get all rule_IDs
     # that we want to keep from the original
     filter_included_controls(context, dep_entry.profile, &block) if !opts[:include_all]
-
     # interpret the block and skip/modify as required
     context.load(block) if block_given?
-
     bind_context.add_subcontext(context)
   end
 
   def self.filter_included_controls(context, profile, &block)
-    mock = Inspec::Backend.create({ backend: 'mock' })
-    include_ctx = Inspec::ProfileContext.for_profile(profile, mock)
+    include_ctx = profile.runner_context
     include_ctx.load(block) if block_given?
     # remove all rules that were not registered
     context.rules.keys.each do |id|

--- a/lib/inspec/dsl_shared.rb
+++ b/lib/inspec/dsl_shared.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+module Inspec
+  #
+  # Contains methods we would like in multiple DSL
+  #
+  module DSL
+    module RequireOverride
+      # Save the toplevel require method to load all ruby dependencies.
+      # It is used whenever the `require 'lib'` is not in libraries.
+      alias __ruby_require require
+
+      def require(path)
+        rbpath = path + '.rb'
+        return __ruby_require(path) if !@require_loader.exists?(rbpath)
+        return false if @require_loader.loaded?(rbpath)
+
+        # This is equivalent to calling `require 'lib'` with lib on disk.
+        # We cannot rely on libraries residing on disk however.
+        # TODO: Sandboxing.
+        content, path, line = @require_loader.load(rbpath)
+        eval(content, TOPLEVEL_BINDING, path, line) # rubocop:disable Lint/Eval
+      end
+    end
+  end
+end

--- a/lib/inspec/library_eval_context.rb
+++ b/lib/inspec/library_eval_context.rb
@@ -1,0 +1,47 @@
+# encoding: utf-8
+# author: Steven Danna
+# author: Victoria Jeffrey
+require 'inspec/plugins/resource'
+require 'inspec/dsl_shared'
+
+module Inspec
+  #
+  # LibaryEvalContext constructs an instance of an anonymous class
+  # that library files will be instance_exec'd against.
+  #
+  # The anonymous class ensures that `Inspec.resource(1)` will return
+  # an anonymouse class that is suitable as the parent class of an
+  # inspec resource. The class returned will have the resource
+  # registry used by all dsl methods bound to the resource registry
+  # passed into the #create constructor.
+  #
+  #
+  class LibraryEvalContext
+    def self.create(registry, require_loader)
+      c = Class.new do
+        extend Inspec::ResourceDSL
+        include Inspec::ResourceBehaviors
+        define_singleton_method :__resource_registry do
+          registry
+        end
+      end
+
+      c2 = Class.new do
+        define_singleton_method :resource do |version|
+          Inspec.validate_resource_dsl_version!(version)
+          c
+        end
+      end
+
+      c3 = Class.new do
+        include Inspec::DSL::RequireOverride
+        def initialize(require_loader) # rubocop:disable Lint/NestedMethodDefinition
+          @require_loader = require_loader
+        end
+      end
+
+      c3.const_set(:Inspec, c2)
+      c3.new(require_loader)
+    end
+  end
+end

--- a/lib/inspec/plugins/resource.rb
+++ b/lib/inspec/plugins/resource.rb
@@ -48,12 +48,9 @@ module Inspec
             @__backend_runner__
           end
         end
-        # rubocop:enable Lint/NestedMethodDefinition
 
-        # add the resource to the registry by name with a newly-named registry class
-        klass_name = name.split('_').map(&:capitalize).join
-        Inspec::Resource::Registry.const_set(klass_name, cl)
-        Inspec::Resource.registry[name] = Inspec::Resource::Registry.const_get(klass_name)
+        # rubocop:enable Lint/NestedMethodDefinition
+        Inspec::Resource.registry[name] = cl
       end
 
       # Define methods which are available to all resources

--- a/lib/inspec/plugins/resource.rb
+++ b/lib/inspec/plugins/resource.rb
@@ -3,80 +3,83 @@
 # author: Christoph Hartmann
 
 module Inspec
-  module Plugins
-    class Resource
-      def self.name(name = nil)
-        return if name.nil?
-        @name = name
-        Inspec::Plugins::Resource.__register(name, self)
-      end
-
-      def self.desc(description = nil)
-        return if description.nil?
-        Inspec::Resource.registry[@name].desc(description)
-      end
-
-      def self.example(example = nil)
-        return if example.nil?
-        Inspec::Resource.registry[@name].example(example)
-      end
-
-      def self.__register(name, obj)
-        # rubocop:disable Lint/NestedMethodDefinition, Lint/DuplicateMethods
-        cl = Class.new(obj) do
-          # add some common methods
-          include Inspec::Plugins::ResourceCommon
-          def initialize(backend, name, *args)
-            # attach the backend to this instance
-            @__backend_runner__ = backend
-            @__resource_name__ = name
-            # call the resource initializer
-            super(*args)
-          end
-
-          def self.desc(description = nil)
-            return @description if description.nil?
-            @description = description
-          end
-
-          def self.example(example = nil)
-            return @example if example.nil?
-            @example = example
-          end
-
-          def inspec
-            @__backend_runner__
-          end
-        end
-
-        # rubocop:enable Lint/NestedMethodDefinition
-        Inspec::Resource.registry[name] = cl
-      end
-
-      # Define methods which are available to all resources
-      # and may be overwritten.
-
-      # Print the name of the resource
-      def to_s
-        @__resource_name__
-      end
-
-      # Overwrite inspect to provide better output to RSpec results.
-      #
-      # @return [String] full name of the resource
-      def inspect
-        to_s
-      end
+  module ResourceBehaviors
+    def to_s
+      @__resource_name__
     end
 
-    module ResourceCommon
-      def resource_skipped
-        @resource_skipped
+    # Overwrite inspect to provide better output to RSpec results.
+    #
+    # @return [String] full name of the resource
+    def inspect
+      to_s
+    end
+  end
+
+  module ResourceDSL
+    def name(name = nil)
+      return if name.nil?
+      @name = name
+      __register(name, self)
+    end
+
+    def desc(description = nil)
+      return if description.nil?
+      __resource_registry[@name].desc(description)
+    end
+
+    def example(example = nil)
+      return if example.nil?
+      __resource_registry[@name].example(example)
+    end
+
+    def __resource_registry
+      Inspec::Resource.registry
+    end
+
+    def __register(name, obj)
+      # rubocop:disable Lint/NestedMethodDefinition
+      cl = Class.new(obj) do
+        def initialize(backend, name, *args)
+          # attach the backend to this instance
+          @__backend_runner__ = backend
+          @__resource_name__ = name
+          # call the resource initializer
+          super(*args)
+        end
+
+        def self.desc(description = nil)
+          return @description if description.nil?
+          @description = description
+        end
+
+        def self.example(example = nil)
+          return @example if example.nil?
+          @example = example
+        end
+
+        def resource_skipped
+          @resource_skipped
+        end
+
+        def skip_resource(message)
+          @resource_skipped = message
+        end
+
+        def inspec
+          @__backend_runner__
+        end
       end
 
-      def skip_resource(message)
-        @resource_skipped = message
-      end
+      # rubocop:enable Lint/NestedMethodDefinition
+      __resource_registry[name] = cl
+    end
+  end
+
+  module Plugins
+    class Resource
+      extend Inspec::ResourceDSL
+      include Inspec::ResourceBehaviors
     end
   end
 end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -75,7 +75,7 @@ module Inspec
         tests.each do |path, content|
           next if content.nil? || content.empty?
           abs_path = source_reader.target.abs_path(path)
-          @runner_context.load(content, abs_path, nil)
+          @runner_context.load_control_file(content, abs_path, nil)
         end
         @tests_collected = true
       end

--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -3,26 +3,10 @@
 # license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
-require 'thread'
 require 'inspec/plugins'
 
 module Inspec
   class Resource
-    REGISTRY_LOCK = Mutex.new
-
-    class Registry
-      # empty class for namespacing resource classes in the registry
-    end
-
-    def self.with_local_registry(my_registry, &block)
-      REGISTRY_LOCK.synchronize do
-        old_registry = @registry
-        @registry = my_registry
-        block.call
-        @registry = old_registry
-      end
-    end
-
     def self.default_registry
       @default_registry ||= {}
     end
@@ -59,10 +43,14 @@ module Inspec
   # @param [int] version the resource version to use
   # @return [Resource] base class for creating a new resource
   def self.resource(version)
+    validate_resource_dsl_version!(version)
+    Inspec::Plugins::Resource
+  end
+
+  def self.validate_resource_dsl_version!(version)
     if version != 1
       fail 'Only resource version 1 is supported!'
     end
-    Inspec::Plugins::Resource
   end
 end
 

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -33,6 +33,10 @@ module Inspec
       instance_eval(&block) if block_given?
     end
 
+    def to_s
+      Inspec::Rule.rule_id(self)
+    end
+
     def id(*_)
       # never overwrite the ID
       @id

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -52,14 +52,6 @@ module Inspec
       @test_collector.tests
     end
 
-    def normalize_map(hm)
-      res = {}
-      hm.each {|k, v|
-        res[k.to_s] = v
-      }
-      res
-    end
-
     def configure_transport
       @backend = Inspec::Backend.create(@conf)
       @test_collector.backend = @backend
@@ -138,18 +130,6 @@ module Inspec
 
       ctx = Inspec::ProfileContext.for_profile(profile, @backend)
       profile.runner_context = ctx
-
-      libs = profile.libraries.map do |k, v|
-        [v, k]
-      end
-
-      tests = profile.tests.map do |ref, content|
-        r = profile.source_reader.target.abs_path(ref)
-        { ref: r, content: content }
-      end
-
-      ctx.load_libraries(libs)
-      ctx.load_tests(tests)
       @attributes |= ctx.attributes
 
       filter_controls(ctx.all_rules, controls).each do |rule|

--- a/test/docker_test.rb
+++ b/test/docker_test.rb
@@ -50,7 +50,7 @@ class DockerTester
     puts "--> run test on docker #{container.id}"
     opts = { 'target' => "docker://#{container.id}" }
     runner = Inspec::Runner.new(opts)
-    @tests.each { |test| runner.add_target(test, opts) }
+    @tests.each { |test| runner.add_target(test) }
     runner.tests.map { |g| g.run(report) }
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -292,6 +292,7 @@ class MockLoader
 
   def self.load_profile(name, opts = {})
     opts[:test_collector] = Inspec::RunnerMock.new
+    opts[:backend] = Inspec::Backend.create(opts)
     Inspec::Profile.for_target(profile_path(name), opts)
   end
 

--- a/test/unit/dsl/control_test.rb
+++ b/test/unit/dsl/control_test.rb
@@ -10,7 +10,7 @@ describe 'controls' do
       'inspec.yml' => "name: mock",
       'controls/mock.rb' => "control '1' do\n#{content}\nend\n",
     }
-    opts = { test_collector: Inspec::RunnerMock.new, backend: Inspec::Backend.create({}) }
+    opts = { test_collector: Inspec::RunnerMock.new, backend: Inspec::Backend.create({ backend: 'mock' }) }
     Inspec::Profile.for_target(data, opts)
                    .params[:controls]['1']
   end

--- a/test/unit/dsl/control_test.rb
+++ b/test/unit/dsl/control_test.rb
@@ -10,7 +10,7 @@ describe 'controls' do
       'inspec.yml' => "name: mock",
       'controls/mock.rb' => "control '1' do\n#{content}\nend\n",
     }
-    opts = { test_collector: Inspec::RunnerMock.new }
+    opts = { test_collector: Inspec::RunnerMock.new, backend: Inspec::Backend.create({}) }
     Inspec::Profile.for_target(data, opts)
                    .params[:controls]['1']
   end

--- a/test/unit/mock/profiles/dependencies/inheritance/controls/example.rb
+++ b/test/unit/mock/profiles/dependencies/inheritance/controls/example.rb
@@ -2,8 +2,3 @@
 
 include_controls 'profile_a'
 include_controls 'profile_b'
-include_controls 'ssh-hardening' do
-  12.upto(12) do |i|
-    skip_control "ssh-%02d" % i
-  end
-end

--- a/test/unit/mock/profiles/dependencies/inheritance/inspec.yml
+++ b/test/unit/mock/profiles/dependencies/inheritance/inspec.yml
@@ -10,5 +10,3 @@ depends:
     path: ../profile_a
   - name: profile_b
     path: ../profile_b
-  - name: ssh-hardening
-    url: https://github.com/dev-sec/tests-ssh-hardening/archive/master.tar.gz

--- a/test/unit/mock/profiles/dependencies/profile_a/controls/example.rb
+++ b/test/unit/mock/profiles/dependencies/profile_a/controls/example.rb
@@ -20,3 +20,9 @@ control 'profilea-1' do                        # A unique ID for this control
     it { should be_directory }
   end
 end
+
+control 'profilea-2' do
+  describe gordon_config do
+    its('version') { should eq('1.0') }
+  end
+end

--- a/test/unit/mock/profiles/dependencies/profile_b/controls/example.rb
+++ b/test/unit/mock/profiles/dependencies/profile_b/controls/example.rb
@@ -14,3 +14,9 @@ control 'profileb-1' do                        # A unique ID for this control
     it { should be_directory }
   end
 end
+
+control 'profileb-2' do
+  describe gordon_config do
+    its('version') { should eq('1.0') }
+  end
+end

--- a/test/unit/mock/profiles/dependencies/profile_b/controls/example.rb
+++ b/test/unit/mock/profiles/dependencies/profile_b/controls/example.rb
@@ -17,6 +17,6 @@ end
 
 control 'profileb-2' do
   describe gordon_config do
-    its('version') { should eq('1.0') }
+    its('version') { should eq('2.0') }
   end
 end

--- a/test/unit/mock/profiles/dependencies/profile_c/libraries/gordon_config.rb
+++ b/test/unit/mock/profiles/dependencies/profile_c/libraries/gordon_config.rb
@@ -1,0 +1,54 @@
+require 'yaml'
+puts "Loading gordon_config from c"
+
+# Custom resource based on the InSpec resource DSL
+class GordonConfig < Inspec.resource(1)
+  name 'gordon_config'
+
+  desc "
+    Gordon's resource description ...
+  "
+
+  example "
+    describe gordon_config do
+      its('version') { should eq('1.0') }
+      its('file_size') { should > 1 }
+    end
+  "
+
+  # Load the configuration file on initialization
+  def initialize
+    @params = {}
+    @path = '/tmp/gordon/config.yaml'
+    @file = inspec.file(@path)
+    return skip_resource "Can't find file \"#{@path}\"" if !@file.file?
+
+    # Protect from invalid YAML content
+    begin
+      @params = YAML.load(@file.content)
+      # Add two extra matchers
+      @params['file_size'] = @file.size
+      @params['file_path'] = @path
+      @params['ruby'] = 'RUBY IS HERE TO HELP ME!'
+    rescue Exception
+      return skip_resource "#{@file}: #{$!}"
+    end
+  end
+
+  # Example method called by 'it { should exist }'
+  # Returns true or false from the 'File.exists?' method
+  def exists?
+    return File.exists?(@path)
+  end
+
+  # Example matcher for the number of commas in the file
+  def comma_count
+    text = @file.content
+    return text.count(',')
+  end
+
+  # Expose all parameters
+  def method_missing(name)
+    return @params[name.to_s]
+  end
+end

--- a/test/unit/mock/profiles/dependencies/profile_c/libraries/gordon_config.rb
+++ b/test/unit/mock/profiles/dependencies/profile_c/libraries/gordon_config.rb
@@ -1,54 +1,15 @@
-require 'yaml'
-puts "Loading gordon_config from c"
-
-# Custom resource based on the InSpec resource DSL
 class GordonConfig < Inspec.resource(1)
   name 'gordon_config'
 
-  desc "
-    Gordon's resource description ...
-  "
+  desc "Gordon's resource description ..."
 
   example "
     describe gordon_config do
       its('version') { should eq('1.0') }
-      its('file_size') { should > 1 }
     end
   "
 
-  # Load the configuration file on initialization
-  def initialize
-    @params = {}
-    @path = '/tmp/gordon/config.yaml'
-    @file = inspec.file(@path)
-    return skip_resource "Can't find file \"#{@path}\"" if !@file.file?
-
-    # Protect from invalid YAML content
-    begin
-      @params = YAML.load(@file.content)
-      # Add two extra matchers
-      @params['file_size'] = @file.size
-      @params['file_path'] = @path
-      @params['ruby'] = 'RUBY IS HERE TO HELP ME!'
-    rescue Exception
-      return skip_resource "#{@file}: #{$!}"
-    end
-  end
-
-  # Example method called by 'it { should exist }'
-  # Returns true or false from the 'File.exists?' method
-  def exists?
-    return File.exists?(@path)
-  end
-
-  # Example matcher for the number of commas in the file
-  def comma_count
-    text = @file.content
-    return text.count(',')
-  end
-
-  # Expose all parameters
-  def method_missing(name)
-    return @params[name.to_s]
+  def version
+    "1.0"
   end
 end

--- a/test/unit/mock/profiles/dependencies/profile_d/libraries/gordon_config.rb
+++ b/test/unit/mock/profiles/dependencies/profile_d/libraries/gordon_config.rb
@@ -1,0 +1,54 @@
+require 'yaml'
+puts "Loading gordon_config from d"
+
+# Custom resource based on the InSpec resource DSL
+class GordonConfig < Inspec.resource(1)
+  name 'gordon_config'
+
+  desc "
+    Gordon's resource description ...
+  "
+
+  example "
+    describe gordon_config do
+      its('version') { should eq('1.0') }
+      its('file_size') { should > 1 }
+    end
+  "
+
+  # Load the configuration file on initialization
+  def initialize
+    @params = {}
+    @path = '/tmp/gordon/config2.yaml'
+    @file = inspec.file(@path)
+    return skip_resource "Can't find file \"#{@path}\"" if !@file.file?
+
+    # Protect from invalid YAML content
+    begin
+      @params = YAML.load(@file.content)
+      # Add two extra matchers
+      @params['file_size'] = @file.size
+      @params['file_path'] = @path
+      @params['ruby'] = 'RUBY IS HERE TO HELP ME!'
+    rescue Exception
+      return skip_resource "#{@file}: #{$!}"
+    end
+  end
+
+  # Example method called by 'it { should exist }'
+  # Returns true or false from the 'File.exists?' method
+  def exists?
+    return File.exists?(@path)
+  end
+
+  # Example matcher for the number of commas in the file
+  def comma_count
+    text = @file.content
+    return text.count(',')
+  end
+
+  # Expose all parameters
+  def method_missing(name)
+    return @params[name.to_s]
+  end
+end

--- a/test/unit/mock/profiles/dependencies/profile_d/libraries/gordon_config.rb
+++ b/test/unit/mock/profiles/dependencies/profile_d/libraries/gordon_config.rb
@@ -1,54 +1,15 @@
-require 'yaml'
-puts "Loading gordon_config from d"
-
-# Custom resource based on the InSpec resource DSL
 class GordonConfig < Inspec.resource(1)
   name 'gordon_config'
 
-  desc "
-    Gordon's resource description ...
-  "
+  desc "Gordon's resource description ..."
 
   example "
     describe gordon_config do
-      its('version') { should eq('1.0') }
-      its('file_size') { should > 1 }
+      its('version') { should eq('2.0') }
     end
   "
 
-  # Load the configuration file on initialization
-  def initialize
-    @params = {}
-    @path = '/tmp/gordon/config2.yaml'
-    @file = inspec.file(@path)
-    return skip_resource "Can't find file \"#{@path}\"" if !@file.file?
-
-    # Protect from invalid YAML content
-    begin
-      @params = YAML.load(@file.content)
-      # Add two extra matchers
-      @params['file_size'] = @file.size
-      @params['file_path'] = @path
-      @params['ruby'] = 'RUBY IS HERE TO HELP ME!'
-    rescue Exception
-      return skip_resource "#{@file}: #{$!}"
-    end
-  end
-
-  # Example method called by 'it { should exist }'
-  # Returns true or false from the 'File.exists?' method
-  def exists?
-    return File.exists?(@path)
-  end
-
-  # Example matcher for the number of commas in the file
-  def comma_count
-    text = @file.content
-    return text.count(',')
-  end
-
-  # Expose all parameters
-  def method_missing(name)
-    return @params[name.to_s]
+  def version
+    "2.0"
   end
 end

--- a/test/unit/plugins/resource_test.rb
+++ b/test/unit/plugins/resource_test.rb
@@ -14,12 +14,6 @@ describe Inspec::Plugins::Resource do
       Class.new(base) do name 'hello'; end
       Inspec::Resource.registry['hello'].wont_be :nil?
     end
-
-    it "will create a good class name" do
-      Class.new(base) do name 'hello_world'; end
-      Inspec::Resource.registry['hello_world'].to_s
-                      .must_equal 'Inspec::Resource::Registry::HelloWorld'
-    end
   end
 
   def create(&block)

--- a/test/unit/profiles/library_eval_context_tests.rb
+++ b/test/unit/profiles/library_eval_context_tests.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+# author: Steven Danna
+
+require 'helper'
+require 'inspec/resource'
+require 'inspec/library_eval_context'
+
+describe Inspec::LibraryEvalContext do
+  let(:resource_content) { <<EOF
+class MyTestResource < Inspec.resource(1)
+  name 'my_test_resource'
+
+  desc 'A test description'
+  example 'Forgot to write docs, sorry'
+
+  def version
+    '2.0'
+  end
+end
+EOF
+  }
+
+  let(:registry) { Inspec::Resource.new_registry }
+  let(:eval_context) { Inspec::LibraryEvalContext.create(registry, nil) }
+
+  it 'accepts a registry' do
+    Inspec::LibraryEvalContext.create(registry, nil)
+  end
+
+  it 'adds the resource to our registry' do
+    eval_context.instance_eval(resource_content)
+    registry.keys.include?("my_test_resource").must_equal true
+  end
+
+  it 'adds nothing to the default registry' do
+    old_default_registry = Inspec::Resource.default_registry.dup
+    eval_context.instance_eval(resource_content)
+    old_default_registry.must_equal Inspec::Resource.default_registry
+  end
+end


### PR DESCRIPTION
Previously, all resources were loaded into a single resource registry.
Now, each profile context has a resource registry, when a profile's
library is loaded into the profile context, we update the
profile-context-specific resource registry.  This local registry is
then used to populate the execution context that the rules are
evaluated in.

Signed-off-by: Steven Danna steve@chef.io
