### PR TITLE
Promote cmp usage as it provides results with octal mode

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1308,7 +1308,7 @@ The ``mode`` matcher tests if the mode assigned to the file matches the specifie
 
 .. code-block:: ruby
 
-   its('mode') { should eq 0644 }
+   its('mode') { should cmp '0644' }
 
 mtime
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -1491,7 +1491,7 @@ The following examples show how to use this InSpec audit resource.
 .. code-block:: bash
 
    describe file('/dev') do
-    its('mode') { should eq 00755 }
+    its('mode') { should cmp '00755' }
    end
 
 **Test the owner of a file**
@@ -4331,7 +4331,7 @@ The following examples show how to use this InSpec audit resource.
 
    describe ssh_config do
      its('owner') { should eq 'root' }
-     its('mode') { should eq 644 }
+     its('mode') { should cmp '0644' }
    end
 
 **Test SSH configuration**

--- a/docs/ruby_usage.rst
+++ b/docs/ruby_usage.rst
@@ -38,7 +38,7 @@ The following example shows how you can use pure |ruby| code(variables, loops, c
           # check key file owners and permissions
           describe file(intern['key']) do
             it { should be_owned_by username }
-            its('mode') { should eq 0600 }
+            its('mode') { should cmp '0600' }
           end
         end
       end

--- a/test/integration/default/file_spec.rb
+++ b/test/integration/default/file_spec.rb
@@ -60,8 +60,8 @@ if os.unix?
     # it { should have_mode }
     its('mode') { should eq 00765 }
     it { should be_mode 00765 }
-    its('mode') { should cmp 0765 }
-    its('mode') { should_not cmp 0777 }
+    its('mode') { should cmp '0765' }
+    its('mode') { should_not cmp '0777' }
     its('suid') { should eq false }
     its('sgid') { should eq false }
     its('sticky') { should eq false }

--- a/test/resource/file_test.rb
+++ b/test/resource/file_test.rb
@@ -68,6 +68,8 @@ end
 
 describe file('/dev') do
   its('mode') { should eq 00755 }
+  its('mode') { should cmp '00755' }
+  its('mode') { should_not cmp '00777' }
 end
 
 describe file('/dev') do


### PR DESCRIPTION
The default rspec `eq` matcher outputs the expected mode as decimal:

```
its('mode') { should eq 0644 }

=>

 File /etc/ssh/ssh_config
     ✔  should be mode 420
```

where the inspec `cmp` matcher is outputting it as octal:

```
its('mode') { should cmp '0644' }

=>

  File /etc/ssh/ssh_config
     ✔  mode should cmp "0644"
```
