### PR TITLE
Fix os exception in mysql resource

### DIFF
--- a/lib/resources/mysql.rb
+++ b/lib/resources/mysql.rb
@@ -33,7 +33,7 @@ module Inspec::Resources
       @log_dir = '/var/log/'
       @log_path = '/var/log/mysql.log'
       @log_group = 'adm'
-      case os[:release]
+      case inspec.os[:release]
       when '14.04'
         @log_dir_group = 'syslog'
       else


### PR DESCRIPTION
Fixes the following exception:

```
$ ~/git/inspec/bin/inspec version
0.32.0

$ ~/git/inspec/bin/inspec exec /tmp/profile.rb --sudo --password 'xxx' -t ssh://vagrant@192.168.56.78
WARN: Unresolved specs during Gem::Specification.reset:
      mixlib-shellout (~> 2.0)
      net-ssh (< 4.0, >= 2.6.5, >= 2.9)
      httpclient (>= 2.2.0.2, ~> 2.2)
      excon (>= 0.38.0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
/Users/apop/git/inspec/lib/resources/mysql.rb:36:in `init_ubuntu': undefined local variable or method `os' for MySQL:Inspec::Resource::Registry::Mysql (NameError)
  from /Users/apop/git/inspec/lib/resources/mysql.rb:16:in `initialize'
  from /Users/apop/git/inspec/lib/inspec/plugins/resource.rb:34:in `initialize'
  from /Users/apop/git/inspec/lib/inspec/resource.rb:31:in `new'
  from /Users/apop/git/inspec/lib/inspec/resource.rb:31:in `block (3 levels) in create_dsl'
  from /tmp/profile.rb:12:in `block in load'
  from /Users/apop/git/inspec/lib/inspec/rule.rb:33:in `instance_eval'
  from /Users/apop/git/inspec/lib/inspec/rule.rb:33:in `initialize'
  from /Users/apop/git/inspec/lib/inspec/profile_context.rb:202:in `new'
  from /Users/apop/git/inspec/lib/inspec/profile_context.rb:202:in `block (2 levels) in create_context'
  from /tmp/profile.rb:5:in `load'
  from /Users/apop/git/inspec/lib/inspec/profile_context.rb:90:in `instance_eval'
  from /Users/apop/git/inspec/lib/inspec/profile_context.rb:90:in `load'
  from /Users/apop/git/inspec/lib/inspec/profile_context.rb:55:in `block in load_tests'
  from /Users/apop/git/inspec/lib/inspec/profile_context.rb:52:in `each'
  from /Users/apop/git/inspec/lib/inspec/profile_context.rb:52:in `load_tests'
  from /Users/apop/git/inspec/lib/inspec/runner.rb:152:in `add_content_from_profile'
  from /Users/apop/git/inspec/lib/inspec/runner.rb:133:in `add_profile'
  from /Users/apop/git/inspec/lib/inspec/runner.rb:126:in `add_target'
  from /Users/apop/git/inspec/lib/inspec/base_cli.rb:73:in `block in run_tests'
  from /Users/apop/git/inspec/lib/inspec/base_cli.rb:73:in `each'
  from /Users/apop/git/inspec/lib/inspec/base_cli.rb:73:in `run_tests'
  from /Users/apop/git/inspec/lib/inspec/cli.rb:149:in `exec'
  from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
  from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
  from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
  from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
  from /Users/apop/git/inspec/bin/inspec:9:in `<main>'
```
