### PR TITLE
Fix apache conf

### DIFF
--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -21,7 +21,7 @@ module Inspec::Resources
 
     def initialize(conf_path = nil)
       @conf_path = conf_path || inspec.apache.conf_path
-      @conf_dir = inspec.os.debian? ? File.dirname(@conf_path) : inspec.apache.conf_dir
+      @conf_dir = conf_path ? File.dirname(@conf_path) : inspec.apache.conf_dir
       @files_contents = {}
       @content = nil
       @params = nil

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -21,7 +21,12 @@ module Inspec::Resources
 
     def initialize(conf_path = nil)
       @conf_path = conf_path || inspec.apache.conf_path
-      @conf_dir = File.dirname(@conf_path)
+      case inspec.os[:family]
+      when 'ubuntu', 'debian'
+        @conf_dir = File.dirname(@conf_path)
+      else
+        @conf_dir = inspec.apache.conf_dir
+      end
       @files_contents = {}
       @content = nil
       @params = nil

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -21,12 +21,7 @@ module Inspec::Resources
 
     def initialize(conf_path = nil)
       @conf_path = conf_path || inspec.apache.conf_path
-      case inspec.os[:family]
-      when 'ubuntu', 'debian'
-        @conf_dir = File.dirname(@conf_path)
-      else
-        @conf_dir = inspec.apache.conf_dir
-      end
+      @conf_dir = inspec.os.debian? ? File.dirname(@conf_path) : inspec.apache.conf_dir
       @files_contents = {}
       @content = nil
       @params = nil

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -118,6 +118,8 @@ class MockLoader
       'rootwrap.conf' => mockfile.call('rootwrap.conf'),
       '/etc/apache2/apache2.conf' => mockfile.call('apache2.conf'),
       '/etc/apache2/ports.conf' => mockfile.call('ports.conf'),
+      '/etc/httpd/conf/httpd.conf' => mockfile.call('httpd.conf'),
+      '/etc/httpd/conf.d/ssl.conf' => mockfile.call('ssl.conf'),
       '/etc/apache2/conf-enabled/serve-cgi-bin.conf' => mockfile.call('serve-cgi-bin.conf'),
       '/etc/xinetd.conf' => mockfile.call('xinetd.conf'),
       '/etc/xinetd.d' => mockfile.call('xinetd.d'),
@@ -232,6 +234,7 @@ class MockLoader
       'iptables  -S' => cmd.call('iptables-s'),
       # apache_conf
       'find /etc/apache2/ports.conf -maxdepth 1 -type f' => cmd.call('find-apache2-ports-conf'),
+      'find /etc/httpd/conf.d/*.conf -maxdepth 1 -type f' => cmd.call('find-httpd-ssl-conf'),
       'find /etc/apache2/conf-enabled/*.conf -maxdepth 1 -type f' => cmd.call('find-apache2-conf-enabled'),
       # mount
       "mount | grep -- ' on /'" => cmd.call("mount"),

--- a/test/unit/mock/cmd/find-httpd-ssl-conf
+++ b/test/unit/mock/cmd/find-httpd-ssl-conf
@@ -1,0 +1,1 @@
+/etc/httpd/conf.d/ssl.conf

--- a/test/unit/mock/files/httpd.conf
+++ b/test/unit/mock/files/httpd.conf
@@ -1,6 +1,5 @@
 # This is the main Apache server configuration file.  It contains comments.
 ServerRoot "/etc/httpd"
-Listen 80
 
 # User/Group: The name (or #number) of the user/group to run httpd as.
 #  . On SCO (ODT 3) use "User nouser" and "Group nogroup".

--- a/test/unit/mock/files/httpd.conf
+++ b/test/unit/mock/files/httpd.conf
@@ -1,0 +1,26 @@
+# This is the main Apache server configuration file.  It contains comments.
+ServerRoot "/etc/httpd"
+Listen 80
+
+# User/Group: The name (or #number) of the user/group to run httpd as.
+#  . On SCO (ODT 3) use "User nouser" and "Group nogroup".
+#  . On HPUX you may not be able to use shared memory as nobody, and the
+#    suggested workaround is to create a user www and use that user.
+#  NOTE that some kernels refuse to setgid(Group) or semctl(IPC_SET)
+#  when the value of (unsigned)Group is above 60000;
+#  don't use Group #-1 on these systems!
+#
+User apache
+Group apache
+
+# Load config files from the config directory "/etc/httpd/conf.d".
+#
+Include conf.d/*.conf
+
+# First, we configure the "default" to be a very restrictive set of
+# features.
+#
+<Directory />
+    Options FollowSymLinks
+    AllowOverride None
+</Directory>

--- a/test/unit/mock/files/ssl.conf
+++ b/test/unit/mock/files/ssl.conf
@@ -1,0 +1,6 @@
+# apache ssl.conf
+Listen 80
+
+<IfModule ssl_module>
+	Listen 443
+</IfModule>

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -6,7 +6,8 @@ require 'inspec/resource'
 require 'hashie'
 
 describe 'Inspec::Resources::ApacheConf' do
-  it 'reads values in apache2.conf' do
+  # debian style apache2
+  it 'reads values in apache2.conf and from Include, IncludeOptional params' do
     resource = MockLoader.new(:ubuntu1404).load_resource('apache_conf')
     _(resource.params).must_be_kind_of Hash
     require 'pp'
@@ -20,7 +21,8 @@ describe 'Inspec::Resources::ApacheConf' do
                                              'ENABLE_USR_LIB_CGI_BIN']
   end
 
-  it 'reads values in httpd.conf' do
+  # non debian style httpd
+  it 'reads values in httpd.conf and from Include, IncludeOptional params' do
     resource = MockLoader.new(:centos6).load_resource('apache_conf')
     _(resource.params).must_be_kind_of Hash
     _(resource.content).must_be_kind_of String

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -10,8 +10,6 @@ describe 'Inspec::Resources::ApacheConf' do
   it 'reads values in apache2.conf and from Include, IncludeOptional params' do
     resource = MockLoader.new(:ubuntu1404).load_resource('apache_conf')
     _(resource.params).must_be_kind_of Hash
-    require 'pp'
-    pp resource.content
     _(resource.content).must_be_kind_of String
     _(resource.params('ServerRoot')).must_equal ['"/etc/apache2"']
     _(resource.params('Listen').sort).must_equal ['443', '80']

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -2,30 +2,30 @@
 # author: Stephan Renatus
 
 require 'helper'
+require 'inspec/resource'
+require 'hashie'
 
 describe 'Inspec::Resources::ApacheConf' do
-  let(:resource) { load_resource('apache_conf') }
-
-  it 'verify content is a string' do
-    _(resource.content).must_be_kind_of String
-  end
-
-  it 'verify params is a hashmap' do
-    _(resource.params).must_be_kind_of Hash
-  end
-
   it 'reads values in apache2.conf' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('apache_conf')
+    _(resource.params).must_be_kind_of Hash
+    require 'pp'
+    pp resource.content
+    _(resource.content).must_be_kind_of String
     _(resource.params('ServerRoot')).must_equal ['"/etc/apache2"']
-  end
-
-  it 'reads values in from the direct include ports.conf' do
     _(resource.params('Listen').sort).must_equal ['443', '80']
-  end
-
-  it 'reads values in from wildcard include serve-cgi-bin.conf' do
     # TODO(sr) currently, the parser only merges parameter across separate
     # source files, not in one file
     _(resource.params('Define')).must_equal ['ENABLE_USR_LIB_CGI_BIN',
                                              'ENABLE_USR_LIB_CGI_BIN']
   end
+
+  it 'reads values in httpd.conf' do
+    resource = MockLoader.new(:centos6).load_resource('apache_conf')
+    _(resource.params).must_be_kind_of Hash
+    _(resource.content).must_be_kind_of String
+    _(resource.params('ServerRoot')).must_equal ['"/etc/httpd"']
+    _(resource.params('Listen').sort).must_equal ['443', '80']
+  end
+
 end


### PR DESCRIPTION
`apache_conf.conf_dir` was resolving incorrectly when OS was NOT Ubuntu || Debian.

It would end up resulting in find_file() exit 1 errors like below:

```
[vagrant@default-centos-67 ~]$ /opt/chef/embedded/bin/inspec shell
Welcome to the interactive InSpec Shell
To find out how to use it, type: help

inspec> apache_conf
find_files(): exit 1 from `find /etc/httpd/conf/conf.d/*.conf -maxdepth 1 -type f`
=> Apache Config /etc/httpd/conf/httpd.conf
inspec>
```

It should be using a `conf_dir` of `/etc/httpd` so that find_files will search `/etc/httpd/conf.d/*.conf` instead of `/etc/httpd/conf/conf.d/*.conf`.  

This PR corrects the problem and resolves #1013 
