### PR TITLE
Raise error when an invalid URI is received

### DIFF
--- a/lib/bundles/inspec-compliance/http.rb
+++ b/lib/bundles/inspec-compliance/http.rb
@@ -41,6 +41,7 @@ module Compliance
     # post a file
     def self.post_file(url, token, file_path, insecure, basic_auth = false)
       uri = URI.parse(url)
+      fail "Unable to parse URL: #{url}" if uri.nil? || uri.host.nil?
       http = Net::HTTP.new(uri.host, uri.port)
 
       # set connection flags
@@ -71,6 +72,7 @@ module Compliance
       }
       opts[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if insecure
 
+      fail "Unable to parse URI: #{uri}" if uri.nil? || uri.host.nil?
       res = Net::HTTP.start(uri.host, uri.port, opts) {|http|
         http.request(req)
       }


### PR DESCRIPTION
It changes how the `audit` cookbook informs the end user when an invalid Compliance Server URL is provided:

```
Recipe: audit::default
 * ruby_block[exchange_refresh_token] action run

   ================================================================================
   Error executing action `run` on resource 'ruby_block[exchange_refresh_token]'
   ================================================================================

   NoMethodError
   -------------
   undefined method `+' for nil:NilClass

   Cookbook Trace:
   ---------------
   /tmp/kitchen/cache/cookbooks/audit/libraries/compliance.rb:8:in `retrieve_access_token'
   /tmp/kitchen/cache/cookbooks/audit/recipes/default.rb:34:in `block (2 levels) in from_file'
   /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:78:in `run_action'
   /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:106:in `block (2 levels) in converge'
   /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:106:in `each'
   /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:106:in `block in converge'
   /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:105:in `converge'
```

to:

```
Recipe: audit::default
  * ruby_block[exchange_refresh_token] action run

    ================================================================================
    Error executing action `run` on resource 'ruby_block[exchange_refresh_token]'
    ================================================================================

    RuntimeError
    ------------
    Unable to parse URI: ap-cc6.opschef.tv/login
```
