### PR TITLE
allow direct access to iis configuration parameters

### DIFF
--- a/lib/resources/iis_site.rb
+++ b/lib/resources/iis_site.rb
@@ -38,6 +38,22 @@ module Inspec::Resources
       return skip_resource 'The `iis_site` resource is not supported on your OS.' if inspec.os[:family] != 'windows'
     end
 
+    def app_pool
+      iis_site[:app_pool]
+    end
+
+    def bindings
+      iis_site[:bindings]
+    end
+
+    def state
+      iis_site[:state]
+    end
+
+    def path
+      iis_site[:path]
+    end
+
     def exists?
       !iis_site.nil? && !iis_site[:name].nil?
     end

--- a/test/integration/default/iis_site_spec.rb
+++ b/test/integration/default/iis_site_spec.rb
@@ -2,22 +2,25 @@
 
 return unless os.windows?
 
-# iis service is running 
-describe service('W3SVC') do 
+# iis service is running
+describe service('W3SVC') do
   it { should be_installed }
   it { should be_running }
 end
 
-# test the site without the iis resource 
+# test the site without the iis resource
 describe powershell("Get-Website") do
   its(:stdout) {should match '.*?Default Web Site.*?'}
 end
 
-# test the site with the resource 
+# test the site with the resource
 describe iis_site('Default Web Site') do
   it { should exist }
   it { should be_running }
   it { should have_app_pool('DefaultAppPool') }
+  its('app_pool') { should eq 'DefaultAppPool' }
   it { should have_binding('http *:80:') }
-  it { should have_path('%SystemDrive%\\inetpub\\wwwroot\\') }
+  its('bindings') { should include 'http *:80:' }
+  it { should have_path('%SystemDrive%\\inetpub\\wwwroot') }
+  its('path') { should eq '%SystemDrive%\\inetpub\\wwwroot' }
 end


### PR DESCRIPTION
The current IIS resource has not exposed the data without a matcher:

```
# test the site with the resource
describe iis_site('Default Web Site') do
  it { should exist }
  it { should be_running }
  it { should have_app_pool('DefaultAppPool') }
  it { should have_binding('http *:80:') }
  it { should have_path('%SystemDrive%\\inetpub\\wwwroot') }
end
```

This PR allows users to access the data directly

```
# test the site with the resource
describe iis_site('Default Web Site') do
  it { should exist }
  it { should be_running }
  its('app_pool') { should eq 'DefaultAppPool' }
  its('bindings') { should include 'http *:80:' }
  its('path') { should eq '%SystemDrive%\\inetpub\\wwwroot' }
end
```
