### PR TITLE
Remove SourceReader::Inspec#prepare_load_path

### DIFF
--- a/lib/source_readers/inspec.rb
+++ b/lib/source_readers/inspec.rb
@@ -34,7 +34,6 @@ module SourceReaders
 
       @tests = load_tests
       @libraries = load_libs
-      prepare_load_paths
     end
 
     private
@@ -51,28 +50,6 @@ module SourceReaders
         path.start_with?('libraries') && path.end_with?('.rb')
       end
       Hash[tests.map { |x| [x, @target.read(x)] }]
-    end
-
-    # Ensure each test directory exists on the $LOAD_PATH. This
-    # will ensure traditional RSpec-isms like `require 'spec_helper'`
-    # continue to work. The method outlined here is only meant to be temporary!
-    def prepare_load_paths
-      t = @target
-      t = @target.parent unless @target.parent.nil?
-      unless t.is_a?(Fetchers::Local)
-        return # no need to mess with load-paths if this is not on disk
-      end
-
-      rel_dirs = (@libraries.keys + @tests.keys)
-                 .map { |x| File.dirname(x) }.uniq
-
-      abs_dirs = rel_dirs.map { |x| @target.abs_path(x) }
-                         .find_all { |x| File.directory?(x) }
-                         .map { |x| File.expand_path(x) }
-
-      abs_dirs.each do |dir|
-        $LOAD_PATH.unshift dir unless $LOAD_PATH.include?(dir)
-      end
     end
   end
 end


### PR DESCRIPTION
We already monkeypatch require so that it is redirected through the
require_loader.  All of the tests pass with this removal.  We might
cause some breakage with this removal that we aren't testing, but given
that we are mucking with `require` it seems preferable to have one
mechanism by which we do that and solve any bugs with that single path.

Signed-off-by: Steven Danna steve@chef.io
