### PR TITLE
ssl resource fix and speed improvement

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hashie', '~> 3.4'
   spec.add_dependency 'mixlib-log'
   spec.add_dependency 'sslshake', '~> 1'
+  spec.add_dependency 'parallel', '~> 1.9'
 end


### PR DESCRIPTION
- Handled hostname differently for WinRM::Connection. Without this, remote windows scans are skipped with error: `Cannot determine host for SSL test. Please specify it or use a different target.` 
- Parallelize protocol checks to speed up scanning. For each port, five protocols checks are done. Since most ports are not SSL or blocked by firewall, scans can take minutes. Before parallelizing the calls, I scanned a vanilla Windows 2012r2 server in 90 seconds. After applying the change in this PR, it got down to 22 seconds.
