### PR TITLE
Ensure simplecov starts before everything else

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,11 +1,6 @@
 # encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
-
-require 'minitest/autorun'
-require 'minitest/spec'
-require 'mocha/setup'
-
 require 'simplecov'
 SimpleCov.start do
   add_filter '/test/'
@@ -14,6 +9,9 @@ SimpleCov.start do
   add_group 'Backends', 'lib/inspec/backend'
 end
 
+require 'minitest/autorun'
+require 'minitest/spec'
+require 'mocha/setup'
 require 'fileutils'
 require 'pathname'
 require 'tempfile'


### PR DESCRIPTION
Before this change, simplecov was reporting

```
1864 / 5198 LOC (35.86%) covered
```

After this change it is reporting

```
4131 / 5275 LOC (78.31%) covered.
```

Keeping the require at the top of the file ensure that simplecov is
loaded before any of our application code.
