### PR TITLE
identify enabled/disabled accounts for windows

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -208,7 +208,7 @@ class MockLoader
       # user info for freebsd
       'pw usershow root -7' => cmd.call('pw-usershow-root-7'),
       # user info for windows (winrm 1.6.0, 1.6.1)
-      '1f2dd0691487fe7ca8169dfd764e0197e6303f17de416e7c1b7439aedef87ae7' => cmd.call('GetUserAccount'),
+      '942eeec2b290bda610229d4bd29981ee945ed27b0f4ce7cca099aabe38af6386' => cmd.call('GetUserAccount'),
       # group info for windows
       'Get-WmiObject Win32_Group | Select-Object -Property Caption, Domain, Name, SID, LocalAccount | ConvertTo-Json' => cmd.call('GetWin32Group'),
       # network interface

--- a/test/unit/mock/cmd/GetUserAccount
+++ b/test/unit/mock/cmd/GetUserAccount
@@ -11,7 +11,8 @@
     "PasswordRequired": true,
     "SID": "S-1-5-21-725088257-906184668-2367214287-500",
     "SIDType": 1,
-    "Status": "OK"
+    "Status": "OK",
+    "Disabled": false
   },
   "Groups": [{
     "Caption": "WIN-K0AKLED332V\\Administrators",

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -109,6 +109,7 @@ describe 'Inspec::Resources::User' do
     _(resource.mindays).must_equal nil
     _(resource.maxdays).must_equal nil
     _(resource.warndays).must_equal nil
+    _(resource.disabled?).must_equal false
   end
 
   it 'read user on undefined os' do


### PR DESCRIPTION
This PR adds a feature to the `user` and `users` resource to identifies enabled and disabled accounts. Usage examples are: 

```
describe user('Administrator') do
  it { should be_disabled }
end
```

```
describe users.where { uid =~ /S\-1\-5\-21\-\d+\-\d+\-\d+\-500/ } do
  it { should be_disabled }
end
```

Further PRs will add that feature for other operating systems. That is tracked in #1040
