### PR TITLE
In ApacheConf#include_files, check for abs paths

### DIFF
--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -105,7 +105,7 @@ module Inspec::Resources
 
       includes = []
       (include_files + include_files_optional).each do |f|
-        id = File.join(@conf_dir, f)
+        id    = Pathname.new(f).absolute? ? f : File.join(@conf_dir, f)
         files = find_files(id, depth: 1, type: 'file')
 
         includes.push(files) if files

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -118,6 +118,7 @@ class MockLoader
       '/etc/apache2/ports.conf' => mockfile.call('ports.conf'),
       '/etc/httpd/conf/httpd.conf' => mockfile.call('httpd.conf'),
       '/etc/httpd/conf.d/ssl.conf' => mockfile.call('ssl.conf'),
+      '/etc/httpd/mods-enabled/status.conf' => mockfile.call('status.conf'),
       '/etc/apache2/conf-enabled/serve-cgi-bin.conf' => mockfile.call('serve-cgi-bin.conf'),
       '/etc/xinetd.conf' => mockfile.call('xinetd.conf'),
       '/etc/xinetd.d' => mockfile.call('xinetd.d'),
@@ -232,6 +233,7 @@ class MockLoader
       # apache_conf
       'find /etc/apache2/ports.conf -maxdepth 1 -type f' => cmd.call('find-apache2-ports-conf'),
       'find /etc/httpd/conf.d/*.conf -maxdepth 1 -type f' => cmd.call('find-httpd-ssl-conf'),
+      'find /etc/httpd/mods-enabled/*.conf -maxdepth 1 -type f' => cmd.call('find-httpd-status-conf'),
       'find /etc/apache2/conf-enabled/*.conf -maxdepth 1 -type f' => cmd.call('find-apache2-conf-enabled'),
       # mount
       "mount | grep -- ' on /'" => cmd.call("mount"),

--- a/test/unit/mock/cmd/find-httpd-status-conf
+++ b/test/unit/mock/cmd/find-httpd-status-conf
@@ -1,0 +1,1 @@
+/etc/httpd/mods-enabled/status.conf

--- a/test/unit/mock/files/httpd.conf
+++ b/test/unit/mock/files/httpd.conf
@@ -16,6 +16,10 @@ Group apache
 #
 Include conf.d/*.conf
 
+# Load config files using an absolute path
+#
+Include /etc/httpd/mods-enabled/*.conf
+
 # First, we configure the "default" to be a very restrictive set of
 # features.
 #

--- a/test/unit/mock/files/status.conf
+++ b/test/unit/mock/files/status.conf
@@ -1,0 +1,1 @@
+ExtendedStatus Off

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -26,6 +26,8 @@ describe 'Inspec::Resources::ApacheConf' do
     _(resource.content).must_be_kind_of String
     _(resource.params('ServerRoot')).must_equal ['"/etc/httpd"']
     _(resource.params('Listen').sort).must_equal ['443', '80']
-  end
 
+    # sourced using an absolute path in httpd.conf
+    _(resource.params('ExtendedStatus')).must_equal ['Off']
+  end
 end


### PR DESCRIPTION
If the path is absolute, just use what was passed, otherwise build an
absolute path using `@conf_dir`.

Fixes #1013
