### PR TITLE
Force encoding in bin only

### DIFF
--- a/bin/inspec
+++ b/bin/inspec
@@ -4,6 +4,9 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 require_relative '../lib/inspec'
 require_relative '../lib/inspec/cli'
 Inspec::InspecCLI.start(ARGV)

--- a/lib/inspec.rb
+++ b/lib/inspec.rb
@@ -4,9 +4,6 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-Encoding.default_external = Encoding::UTF_8
-Encoding.default_internal = Encoding::UTF_8
-
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 


### PR DESCRIPTION
move force encoding to binary only, so that it does not affect the use of inspec in lib mode.

As reported, InSpec in audit cookbook changed the default encoding for ruby. Therefore the following error occurred: 

```
 * remote_file[/var/chef/cache/webfiles.tar.gz] action create

    ================================================================================
    Error executing action `create` on resource 'remote_file[/var/chef/cache/webfiles.tar.gz]'
    ================================================================================

    Encoding::UndefinedConversionError
    ----------------------------------
    "\x8B" from ASCII-8BIT to UTF-8
```

Moving it to bin, keeps it standard for InSpec when used from shell, but does not enforce it for library modes
