### PR TITLE
Provide inspec.yml shortcut syntax

### DIFF
--- a/examples/meta-profile/inspec.yml
+++ b/examples/meta-profile/inspec.yml
@@ -7,12 +7,10 @@ license: Apache 2
 summary: InSpec Profile that is only consuming dependencies
 version: 0.2.0
 depends:
-  - name: ssh-hardening
-    supermarket: hardening/ssh-hardening
+  - name: hardening/ssh-hardening  # defaults to supermarket
   - name: os-hardening
     url: https://github.com/dev-sec/tests-os-hardening/archive/master.zip
-  - name: ssl-benchmark
-    git: https://github.com/dev-sec/ssl-benchmark.git
+  - git: https://github.com/dev-sec/ssl-benchmark.git
   - name: windows-patch-benchmark
     git: https://github.com/chris-rock/windows-patch-benchmark.git
   - name: linux

--- a/lib/inspec/dependencies/resolver.rb
+++ b/lib/inspec/dependencies/resolver.rb
@@ -50,7 +50,7 @@ module Inspec
     def resolve(deps, top_level = true, seen_items = {}, path_string = '') # rubocop:disable Metrics/AbcSize
       graph = {}
       if top_level
-        Inspec::Log.debug("Starting traversal of dependencies #{deps.map(&:name)}")
+        Inspec::Log.debug("Starting traversal of dependencies #{deps.map(&:to_s)}")
       else
         Inspec::Log.debug("Traversing dependency tree of transitive dependency #{deps.map(&:name)}")
       end

--- a/lib/inspec/fetcher.rb
+++ b/lib/inspec/fetcher.rb
@@ -6,7 +6,31 @@ require 'inspec/plugins'
 require 'utils/plugin_registry'
 
 module Inspec
-  Fetcher = PluginRegistry.new
+  class FetcherRegistry < PluginRegistry
+    def resolve(target)
+      if fetcher_specified?(target)
+        super(target)
+      else
+        Inspec::Log.debug("Assuming default supermarket source for #{target}")
+        super(with_default_fetcher(target))
+      end
+    end
+
+    NON_FETCHER_KEYS = [:name, :version_constraint, :cwd, :backend, :cache].freeze
+    def fetcher_specified?(target)
+      # Only set a default for Hash-based (i.e. from
+      # inspec.yml/inspec.lock) targets
+
+      return true if !target.respond_to?(:keys)
+      !(target.keys - NON_FETCHER_KEYS).empty?
+    end
+
+    def with_default_fetcher(target)
+      target.merge({ supermarket: target[:name] })
+    end
+  end
+
+  Fetcher = FetcherRegistry.new
 
   def self.fetcher(version)
     if version != 1

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -77,6 +77,10 @@ module Inspec
       metadata.params[:name]
     end
 
+    def version
+      metadata.params[:version]
+    end
+
     def params
       @params ||= load_params
     end

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -172,4 +172,16 @@ Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✔  profiled-1: Create /tmp directory (profile d)"
     end
   end
+
+  describe 'when using profiles on the supermarket' do
+    it 'can run supermarket profiles directly from the command line' do
+      out = inspec("exec supermarket://nathenharvey/tmp-compliance-profile")
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
+    end
+
+    it 'can run supermarket profiles from inspec.yml' do
+      out = inspec("exec #{File.join(profile_path, 'supermarket-dep')}")
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
+    end
+  end
 end

--- a/test/unit/fetchers/fetchers_test.rb
+++ b/test/unit/fetchers/fetchers_test.rb
@@ -3,11 +3,31 @@
 # author: Christoph Hartmann
 
 require 'helper'
+require 'bundles/inspec-supermarket/target'
+require 'bundles/inspec-supermarket/api'
 
 describe Inspec::Fetcher do
   it 'loads the local fetcher for this file' do
     res = Inspec::Fetcher.resolve(__FILE__)
     res.must_be_kind_of Fetchers::Local
+  end
+
+  describe "without a source specified" do
+    before do
+      Supermarket::API.expects(:exist?).returns(true)
+      Supermarket::API.expects(:find).returns({'tool_source_url' => "http://mock-url" })
+    end
+
+    it "defaults to supermarket if only a name is given" do
+      res = Inspec::Fetcher.resolve({:name => "mock/test-profile"})
+      res.must_be_kind_of Fetchers::Url
+      res.resolved_source.must_equal({url: "http://mock-url"})
+    end
+
+    it "ignores keys that might have come along for the ride" do
+      res = Inspec::Fetcher.resolve({:name => "mock/test-profile", cwd: "/tmp/inspec-test", cache: "ancache", backend: "test-backend"})
+      res.must_be_kind_of Fetchers::Url
+    end
   end
 
   it 'is able to handle Windows paths' do

--- a/test/unit/mock/profiles/supermarket-dep/controls/default.rb
+++ b/test/unit/mock/profiles/supermarket-dep/controls/default.rb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+
+include_controls 'nathenharvey/tmp-compliance-profile'

--- a/test/unit/mock/profiles/supermarket-dep/inspec.yml
+++ b/test/unit/mock/profiles/supermarket-dep/inspec.yml
@@ -1,0 +1,9 @@
+name: supermarket-dep
+title: InSpec example simple inheritance
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
+copyright_email: support@chef.io
+license: Apache 2 license
+version: 1.0.0
+depends:
+  - name: nathenharvey/tmp-compliance-profile


### PR DESCRIPTION
- Allow users to elide the `name` attributes
- Assume a default source of supermarket

Fixes #1048

Signed-off-by: Steven Danna steve@chef.io
