### PR TITLE
inspec simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,3 @@ Puppetfile.lock
 profile.tar.gz
 omnibus/.cache
 omnibus/pkg
-www/tutorial/typings
-www/tutorial/node_modules
-www/tutorial/**/*.js.map
-www/tutorial/dist

--- a/www/tutorial/tutorial_files/inspec-mock/Gemfile
+++ b/www/tutorial/tutorial_files/inspec-mock/Gemfile
@@ -1,0 +1,3 @@
+# encoding: utf-8
+source 'https://rubygems.org'
+gemspec

--- a/www/tutorial/tutorial_files/inspec-mock/bin/inspec
+++ b/www/tutorial/tutorial_files/inspec-mock/bin/inspec
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+
+# This mocks all InSpec backends. To use it, run
+# `bundle install`
+# `bundle exec ruby bin/inspec`
+# `bundle exec ruby bin/inspec exec path/to/profile -t docker://123456`
+# `bundle exec ruby bin/inspec exec path/to/profile -t winrm://user:password@host:22`
+# `bundle exec ruby bin/inspec exec path/to/profile -t ssh://user@host:22 -i testkey`\
+
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
+# load InSpec
+require 'inspec'
+require 'inspec/cli'
+
+# Load Train and monkey-patch the backends
+require 'train'
+require 'train/transports/local'
+
+module Train::Transports
+  class SSH < Local
+    name 'ssh'
+
+    def connection(_ = nil)
+      @connection ||= MockConnection.new(@options)
+    end
+
+    class MockConnection < Connection
+      def uri
+        "ssh://#{@options[:user]}@#{@options[:host]}:#{@options[:port]}"
+      end
+    end
+  end
+
+  class WinRM < Local
+    name 'winrm'
+
+    def connection(_ = nil)
+      @connection ||= MockConnection.new(@options)
+    end
+
+    class MockConnection < Connection
+      def uri
+        "winrm://#{@options[:user]}@#{@options[:host]}:#{@options[:port]}"
+      end
+    end
+  end
+
+  class Docker < Local
+    name 'docker'
+
+    def connection(_ = nil)
+      @connection ||= MockConnection.new(@options)
+    end
+
+    class MockConnection < Connection
+      def uri
+        "docker://#{@options[:host]}"
+      end
+    end
+  end
+end
+
+# Call InSpec CLI
+Inspec::InspecCLI.start(ARGV)

--- a/www/tutorial/tutorial_files/inspec-mock/inspec-mock.gemspec
+++ b/www/tutorial/tutorial_files/inspec-mock/inspec-mock.gemspec
@@ -1,0 +1,18 @@
+# coding: utf-8
+Gem::Specification.new do |spec|
+  spec.name          = 'inspec-mock'
+  spec.version       = '0.1.0'
+  spec.authors       = ['Chef Software, Inc']
+  spec.summary       = 'Mock for InSpec.'
+  spec.files = %w{
+    inspec-mock.gemspec Gemfile
+  } + Dir.glob(
+    '{bin,lib}/**/*', File::FNM_DOTMATCH
+  ).reject { |f| File.directory?(f) }
+
+  spec.executables   = %w{ inspec }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'inspec'
+end


### PR DESCRIPTION
To implement the InSpec tutorial, we want to simulate all different backends. This implements a mock for different backends, that can be used to generate files for the tutorial:

```
bundle exec ruby bin/inspec
bundle exec ruby bin/inspec exec path/to/profile -t docker://123456
bundle exec ruby bin/inspec exec path/to/profile -t winrm://user:password@host:22
bundle exec ruby bin/inspec exec path/to/profile -t ssh://user@host:22 -i testkey
```

cc @vjeffrey 
