### PR TITLE
Ensure resources are visible inside its blocks

### DIFF
--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -23,7 +23,7 @@ module Inspec
       require 'rspec/core/dsl'
       Class.new(Inspec::Rule) do
         include RSpec::Core::DSL
-        include resources_dsl
+        with_resource_dsl resources_dsl
       end
     end
 

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -122,10 +122,12 @@ module Inspec
       @rules.delete(full_id(@profile_id, id))
     end
 
+    attr_reader :current_load
+
     def register_rule(r)
       # get the full ID
-      r.instance_variable_set(:@__file, @current_load[:file])
-      r.instance_variable_set(:@__group_title, @current_load[:title])
+      r.instance_variable_set(:@__file, current_load[:file])
+      r.instance_variable_set(:@__group_title, current_load[:title])
 
       # add the rule to the registry
       fid = full_id(Inspec::Rule.profile_id(r), Inspec::Rule.rule_id(r))

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -231,21 +231,11 @@ module Inspec
       Inspec::Log.debug "Registering rule #{rule}"
       @rules << rule
       checks = ::Inspec::Rule.prepare_checks(rule)
-      examples = checks.map do |m, a, b|
+      examples = checks.flat_map do |m, a, b|
         get_check_example(m, a, b)
-      end.flatten.compact
+      end.compact
 
-      examples.each do |example|
-        # TODO: Remove this!! It is very dangerous to do this here.
-        # The goal of this is to make the audit DSL available to all
-        # describe blocks. Right now, these blocks are executed outside
-        # the scope of this run, thus not gaining ony of the DSL pieces.
-        # To circumvent this, the full DSL is attached to the example's
-        # scope.
-        dsl = Inspec::Resource.create_dsl(backend)
-        example.send(:include, dsl)
-        @test_collector.add_test(example, rule)
-      end
+      examples.each { |e| @test_collector.add_test(e, rule) }
     end
   end
 end

--- a/test/unit/profiles/control_eval_context_tests.rb
+++ b/test/unit/profiles/control_eval_context_tests.rb
@@ -1,0 +1,54 @@
+# encoding: utf-8
+# author: Steven Danna
+
+require 'helper'
+require 'rspec/core'
+require 'inspec/control_eval_context'
+
+describe Inspec::ControlEvalContext do
+  module FakeDSL
+    def foobar
+      "wombat"
+    end
+  end
+  Inspec::Log.level = :debug
+
+  let(:control_content) { <<EOF
+control 'foo' do
+  describe foobar do
+  end
+end
+
+control 'bar' do
+  describe "wombat" do
+    it { should_equal foobar }
+  end
+end
+EOF
+  }
+
+  let(:resource_dsl) { FakeDSL }
+  let(:backend) { mock() }
+  let(:profile_context) { Inspec::ProfileContext.new('test-profile', backend, {}) }
+  let(:eval_context) do
+    c = Inspec::ControlEvalContext.create(profile_context, resource_dsl)
+    # A lot of mocking here :(
+    c.new(backend, mock(), mock(), mock())
+  end
+
+  it 'accepts a context and a resource_dsl' do
+    Inspec::ControlEvalContext.create(profile_context, resource_dsl)
+  end
+
+  it 'provides rules with access to the given DSL' do
+    profile_context.stubs(:current_load).returns({file: "<test content>"})
+    eval_context.instance_eval(control_content)
+    profile_context.all_rules.each do |rule|
+      # Turn each rule into an example group and run it, none of the example content should raise an
+      # exception
+      Inspec::Rule.prepare_checks(rule).each do |m, a, b|
+        RSpec::Core::ExampleGroup.describe(*a, &b).run
+      end
+    end
+  end
+end


### PR DESCRIPTION
The recent changes to provide isolated views of the available resources
was not extended to Rspec::ExampleGroups. This ensures that
ExampleGroups have access to the same resources as the enclosing
Inspec::Rule.

Signed-off-by: Steven Danna steve@chef.io
