### PR TITLE
Don't gpg-sign commits during tests

### DIFF
--- a/test/functional/gitfetcher_test.rb
+++ b/test/functional/gitfetcher_test.rb
@@ -17,8 +17,8 @@ describe 'profiles with git-based dependencies' do
     Dir.chdir(@git_dep_dir) do
       CMD.run_command("git init")
       CMD.run_command("git add .")
-      CMD.run_command("git commit -m 'initial commit'")
-      CMD.run_command("git commit -m 'another commit' --allow-empty")
+      CMD.run_command("git commit -m 'initial commit' --no-gpg-sign")
+      CMD.run_command("git commit -m 'another commit' --allow-empty --no-gpg-sign")
       CMD.run_command("git tag antag")
     end
 


### PR DESCRIPTION
If you have gpg singing globally enabled, the tests would ask you for
your gpg pin.  This is not fun.

Signed-off-by: Steven Danna steve@chef.io
