### PR TITLE
Process transitive dependencies from lock file

### DIFF
--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -22,7 +22,7 @@ module Inspec
                 entry[:resolved_source].merge(backend: backend))
 
       locked_deps = []
-      Array(entry['dependencies']).each do |dep_entry|
+      Array(entry[:dependencies]).each do |dep_entry|
         locked_deps << Inspec::Requirement.from_lock_entry(dep_entry, cwd, vendor_index, backend)
       end
       req.lock_deps(locked_deps)

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -173,6 +173,15 @@ Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m
     end
   end
 
+  describe "with a 2-level dependency tree" do
+    it 'correctly runs tests from the whole tree' do
+      out = inspec('exec ' + File.join(profile_path, 'dependencies', 'inheritance'))
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m6 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
+    end
+  end
+
   describe 'when using profiles on the supermarket' do
     it 'can run supermarket profiles directly from the command line' do
       out = inspec("exec supermarket://nathenharvey/tmp-compliance-profile")


### PR DESCRIPTION
This is a regression introduced by the changes from string to symbol
keys in v0.34.0. It seems that our test cookbook that had a nested
dependency example wasn't actually wired up to run.

This adds a basic functional test and corrects the typo.

Signed-off-by: Steven Danna steve@chef.io
