### PR TITLE
Allow users to reference resources from dependencies

### DIFF
--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -92,6 +92,14 @@ module Inspec
           res
         end
 
+        define_method :add_resource do |name, new_res|
+          resources_dsl.module_exec do
+            define_method name.to_sym do |*args|
+              new_res.new(@backend, name.to_s, *args)
+            end
+          end
+        end
+
         define_method :add_resources do |context|
           self.class.class_eval do
             include context.to_resources_dsl

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -18,6 +18,15 @@ module Inspec::DSL
   alias require_rules require_controls
   alias include_rules include_controls
 
+  def require_resource(options = {})
+    fail 'You must specify a specific resource name when calling require_resource()' if options[:resource].nil?
+
+    from_profile = options[:profile] || profile_name
+    target_name = options[:as] || options[:resource]
+    res = resource_class(from_profile, options[:resource])
+    add_resource(target_name, res)
+  end
+
   def self.load_spec_files_for_profile(bind_context, opts, &block)
     dependencies = opts[:dependencies]
     profile_id = opts[:profile_id]

--- a/lib/inspec/plugins/resource.rb
+++ b/lib/inspec/plugins/resource.rb
@@ -72,6 +72,9 @@ module Inspec
       end
 
       # rubocop:enable Lint/NestedMethodDefinition
+      if __resource_registry.key?(name)
+        Inspec::Log.warn("Overwriting resource #{name}. To reference a specific version of #{name} use the resource() method")
+      end
       __resource_registry[name] = cl
     end
   end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -66,6 +66,7 @@ module Inspec
       @backend = options[:backend] || Inspec::Backend.create(options)
       @source_reader = source_reader
       @tests_collected = false
+      @libraries_loaded = false
       Metadata.finalize(@source_reader.metadata, @profile_id)
       @runner_context = options[:profile_context] || Inspec::ProfileContext.for_profile(self,
                                                                                         @backend,
@@ -125,6 +126,8 @@ module Inspec
     end
 
     def load_libraries
+      return @runner_context if @libraries_loaded
+
       locked_dependencies.each do |d|
         c = d.load_libraries
         @runner_context.add_resources(c)
@@ -135,6 +138,7 @@ module Inspec
       end
 
       @runner_context.load_libraries(libs)
+      @libraries_loaded = true
       @runner_context
     end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -176,6 +176,15 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
     end
   end
 
+  describe 'using namespaced resources' do
+    it 'works' do
+      out = inspec('exec ' + File.join(profile_path, 'dependencies', 'resource-namespace'))
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m5 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
+    end
+  end
+
   describe "with a 2-level dependency tree" do
     it 'correctly runs tests from the whole tree' do
       out = inspec('exec ' + File.join(profile_path, 'dependencies', 'inheritance'))

--- a/test/unit/mock/profiles/dependencies/resource-namespace/controls/example.rb
+++ b/test/unit/mock/profiles/dependencies/resource-namespace/controls/example.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+# license: All rights reserved
+require_resource(profile: 'profile_c', resource: 'gordon_config', as: 'gordy_config')
+
+describe gordy_config do
+  its('version') { should eq('1.0') }
+end
+
+control 'whichgordon' do
+  describe gordy_config do
+    its('version') { should eq('1.0') }
+  end
+
+  describe gordon_config do
+    its('version') { should eq('2.0') }
+  end
+
+  describe gordy_config do
+    its('version') { should eq(gordy_config.version) }
+  end
+
+  describe gordon_config do
+    its('version') { should eq(gordon_config.version) }
+  end
+
+end

--- a/test/unit/mock/profiles/dependencies/resource-namespace/inspec.yml
+++ b/test/unit/mock/profiles/dependencies/resource-namespace/inspec.yml
@@ -1,0 +1,13 @@
+name: resource-namespace
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile
+version: 0.1.0
+depends:
+  - name: profile_a
+    path: '../profile_a'
+  - name: profile_d
+    path: '../profile_d'


### PR DESCRIPTION
All resources from deps are added into the control_eval_context used by
the current profile. However, if there is a name conflict, the last
loaded resource wins. The new `require_resource` dsl method allows the
user to do the following:

```
require_resource(profile: 'profile_name',
                 resource: 'other',
                as: 'renamed')

describe renamed do
  ...
end
```

Signed-off-by: Steven Danna steve@chef.io
