### PR TITLE
ssl resource to use inspec.backend.hostname and require train 0.19.1

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'train', '>=0.19.0', '<1.0'
+  spec.add_dependency 'train', '>=0.19.1', '<1.0'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'rainbow', '~> 2'


### PR DESCRIPTION
Uses this change in train: https://github.com/chef/train/pull/150
