### PR TITLE
Include code description in the output of failed controls

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -411,7 +411,11 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
       test_color = @colors[test_status]
       indicator = @indicators[x[:status]]
       indicator = @indicators['empty'] if indicator.nil?
-      msg = x[:message] || x[:skip_message] || x[:code_desc]
+      if x[:message]
+        msg = x[:code_desc] + "\n" + x[:message]
+      else
+        msg = x[:skip_message] || x[:code_desc]
+      end
       print_line(
         color:      test_color,
         indicator:  @indicators['small'] + indicator,

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -160,7 +160,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  tmp-1.0: Create /tmp directory (1 failed)\e[0m"
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  should not be directory"
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  undefined method `should_nota'"
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  expected `File /tmp.directory?` to return false, got true\e[0m"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  should not be directory\n     expected `File /tmp.directory?` to return false, got true\e[0m"
     end
   end
 
@@ -171,7 +171,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  tmp-1.0: Create /tmp directory (1 failed)\e[0m"
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  should not be directory"
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  undefined method `should_nota'"
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  expected `File /tmp.directory?` to return false, got true\e[0m"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  should not be directory\n     expected `File /tmp.directory?` to return false, got true\e[0m"
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✔  profiled-1: Create /tmp directory (profile d)"
     end
   end


### PR DESCRIPTION
Fixes https://github.com/chef/inspec/issues/1093

Using the example profile in issue #1093, this is the output based on inspec master:

``` ruby
$ be inspec exec /tmp/t.rb -t ssh://root@ap-cc6.opschef.tv --password 'xxx'

Target:  ssh://root@ap-cc6.opschef.tv:22

  ✖  test-kernel_parameter-999: verify certain settings in sysctl (1 failed)
     ✖  expected: >= 18419238472
          got:    128
     ✔  Kernel Parameter net.core.somaxconn value should be > 100

Profile Summary: 0 successful, 1 failures, 0 skipped
```

and this is the output after the code change in this PR:

``` ruby
$ be inspec exec /tmp/t.rb -t ssh://root@ap-cc6.opschef.tv --password 'xxx'

Target:  ssh://root@ap-cc6.opschef.tv:22

  ✖  test-kernel_parameter-999: verify certain settings in sysctl (1 failed)
     ✖  Kernel Parameter net.core.somaxconn value should be >= 18419238472
     expected: >= 18419238472
          got:    128
     ✔  Kernel Parameter net.core.somaxconn value should be > 100


Profile Summary: 0 successful, 1 failures, 0 skipped
```
