### PR TITLE
Fail if a remote source content doesn't match lockfile

### DIFF
--- a/lib/fetchers/git.rb
+++ b/lib/fetchers/git.rb
@@ -56,6 +56,10 @@ module Fetchers
       @repo_directory
     end
 
+    def cache_key
+      resolved_ref
+    end
+
     def archive_path
       @repo_directory
     end

--- a/lib/fetchers/local.rb
+++ b/lib/fetchers/local.rb
@@ -55,8 +55,19 @@ module Fetchers
       @target
     end
 
+    def cache_key
+      archive_shasum.to_s
+    end
+
+    def archive_shasum
+      return nil if File.directory?(@target)
+      @archive_shasum ||= Digest::SHA256.hexdigest File.read(@target)
+    end
+
     def resolved_source
-      { path: @target }
+      h = { path: @target }
+      h[:shasum] = archive_shasum if archive_shasum
+      h
     end
   end
 end

--- a/lib/fetchers/local.rb
+++ b/lib/fetchers/local.rb
@@ -56,17 +56,17 @@ module Fetchers
     end
 
     def cache_key
-      archive_shasum.to_s
+      sha256.to_s
     end
 
-    def archive_shasum
+    def sha256
       return nil if File.directory?(@target)
       @archive_shasum ||= Digest::SHA256.hexdigest File.read(@target)
     end
 
     def resolved_source
       h = { path: @target }
-      h[:shasum] = archive_shasum if archive_shasum
+      h[:sha256] = sha256 if sha256
       h
     end
   end

--- a/lib/fetchers/mock.rb
+++ b/lib/fetchers/mock.rb
@@ -27,5 +27,9 @@ module Fetchers
     def resolved_source
       { mock_fetcher: true }
     end
+
+    def cache_key
+      ''
+    end
   end
 end

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -3,6 +3,7 @@
 # author: Christoph Hartmann
 
 require 'uri'
+require 'digest'
 require 'tempfile'
 require 'open-uri'
 
@@ -81,34 +82,61 @@ module Fetchers
     end
 
     def fetch(path)
-      Inspec::Log.debug("Fetching URL: #{@target}")
-      @archive_path = download_archive(path)
+      @archive_path ||= download_archive(path)
+    end
+
+    def shasum
+      content = if @archive_path
+                  File.read(@archive_path)
+                else
+                  remote_archive_content
+                end
+      Digest::SHA256.hexdigest content
     end
 
     def resolved_source
-      { url: @target }
+      @resolved_source ||= { url: @target, shasum: shasum }
+    end
+
+    def cache_key
+      shasum
+    end
+
+    def to_s
+      @target
     end
 
     private
 
-    # download url into archive using opts,
-    # returns File object and content-type from HTTP headers
-    def download_archive(path)
+    def open_target
+      Inspec::Log.debug("Fetching URL: #{@target}")
       http_opts = {}
       http_opts['ssl_verify_mode'.to_sym] = OpenSSL::SSL::VERIFY_NONE if @insecure
       http_opts['Authorization'] = "Bearer #{@token}" if @token
+      open(@target, http_opts)
+    end
 
-      remote = open(@target, http_opts)
+    def remote_archive_content
+      open_target.read
+    end
 
+    def file_type_from_remote(remote)
       content_type = remote.meta['content-type']
-      file_type = MIME_TYPES[content_type] ||
-                  throw(RuntimeError, 'Failed to resolve URL target, its '\
-                  "metadata did not match ZIP or TAR: #{content_type}")
+      file_type = MIME_TYPES[content_type]
 
-      # fall back to tar
       if file_type.nil?
-        fail "Could not determine file type for content type #{content_type}."
+        Inspec::Log.warn("Unrecognized content type: #{content_type}. Assuming tar.gz")
+        file_type = '.tar.gz'
       end
+
+      file_type
+    end
+
+    # download url into archive using opts,
+    # returns File object and content-type from HTTP headers
+    def download_archive(path)
+      remote = open_target
+      file_type = file_type_from_remote(remote)
       final_path = "#{path}#{file_type}"
       # download content
       archive = Tempfile.new(['inspec-dl-', file_type])

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -85,21 +85,21 @@ module Fetchers
       @archive_path ||= download_archive(path)
     end
 
-    def shasum
-      content = if @archive_path
-                  File.read(@archive_path)
-                else
-                  remote_archive_content
-                end
-      Digest::SHA256.hexdigest content
+    def sha256
+      c = if @archive_path
+            File.read(@archive_path)
+          else
+            content
+          end
+      Digest::SHA256.hexdigest c
     end
 
     def resolved_source
-      @resolved_source ||= { url: @target, shasum: shasum }
+      @resolved_source ||= { url: @target, sha256: sha256 }
     end
 
     def cache_key
-      shasum
+      sha256
     end
 
     def to_s
@@ -116,7 +116,7 @@ module Fetchers
       open(@target, http_opts)
     end
 
-    def remote_archive_content
+    def content
       open_target.read
     end
 

--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -74,21 +74,11 @@ module Inspec
         h['dependencies'] = dependencies.map(&:to_hash)
       end
 
-      h['content_hash'] = content_hash if content_hash
       h
     end
 
     def lock_deps(dep_array)
       @dependencies = dep_array
-    end
-
-    def content_hash
-      @content_hash ||= begin
-                          archive_path = @vendor_index.archive_entry_for(fetcher.cache_key) || fetcher.archive_path
-                          if archive_path && File.file?(archive_path)
-                            Digest::SHA256.hexdigest File.read(archive_path)
-                          end
-                        end
     end
 
     def fetcher

--- a/lib/inspec/dependencies/vendor_index.rb
+++ b/lib/inspec/dependencies/vendor_index.rb
@@ -50,6 +50,7 @@ module Inspec
     # @return [Boolean]
     #
     def exists?(key)
+      return false if key.nil? || key.empty?
       path = base_path_for(key)
       File.directory?(path) || File.exist?("#{path}.tar.gz") || File.exist?("#{path}.zip")
     end

--- a/lib/inspec/fetcher.rb
+++ b/lib/inspec/fetcher.rb
@@ -16,7 +16,7 @@ module Inspec
       end
     end
 
-    NON_FETCHER_KEYS = [:name, :version_constraint, :cwd, :backend, :cache].freeze
+    NON_FETCHER_KEYS = [:name, :version_constraint, :cwd, :backend, :cache, :shasum].freeze
     def fetcher_specified?(target)
       # Only set a default for Hash-based (i.e. from
       # inspec.yml/inspec.lock) targets

--- a/lib/inspec/fetcher.rb
+++ b/lib/inspec/fetcher.rb
@@ -16,7 +16,7 @@ module Inspec
       end
     end
 
-    NON_FETCHER_KEYS = [:name, :version_constraint, :cwd, :backend, :cache, :shasum].freeze
+    NON_FETCHER_KEYS = [:name, :version_constraint, :cwd, :backend, :cache, :sha256].freeze
     def fetcher_specified?(target)
       # Only set a default for Hash-based (i.e. from
       # inspec.yml/inspec.lock) targets

--- a/lib/inspec/plugins/fetcher.rb
+++ b/lib/inspec/plugins/fetcher.rb
@@ -57,6 +57,13 @@ module Inspec
       end
 
       #
+      # The unique key based on the content of the remote archive.
+      #
+      def cache_key
+        fail "Fetcher #{self} does not implement `cache_key()`. This is required for terminal fetchers."
+      end
+
+      #
       # relative_target is provided to keep compatibility with 3rd
       # party plugins.
       #
@@ -68,18 +75,6 @@ module Inspec
       def relative_target
         file_provider = Inspec::FileProvider.for_path(archive_path)
         file_provider.relative_provider
-      end
-
-      #
-      # A string based on the components of the resolved source,
-      # suitable for constructing per-source file names.
-      #
-      def cache_key
-        key = ''
-        resolved_source.each do |k, v|
-          key << "#{k}:#{v}"
-        end
-        Digest::SHA256.hexdigest key
       end
     end
   end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -33,7 +33,7 @@ module Inspec
       end
 
       cache_key = if target.is_a?(Hash)
-                    target[:shasum] || target[:ref] || fetcher.cache_key
+                    target[:sha256] || target[:ref] || fetcher.cache_key
                   else
                     fetcher.cache_key
                   end
@@ -43,13 +43,13 @@ module Inspec
         cache.prefered_entry_for(cache_key)
       else
         fetcher.fetch(cache.base_path_for(fetcher.cache_key))
-        if target.respond_to?(:key?) && target.key?(:shasum)
-          if fetcher.resolved_source[:shasum] != target[:shasum]
+        if target.respond_to?(:key?) && target.key?(:sha256)
+          if fetcher.resolved_source[:sha256] != target[:sha256]
             fail <<EOF
 The remote source #{fetcher} no longer has the requested content:
 
-Request Content Hash: #{target[:shasum]}
- Actual Content Hash: #{fetcher.resolved_source[:shasum]}
+Request Content Hash: #{target[:sha256]}
+ Actual Content Hash: #{fetcher.resolved_source[:sha256]}
 
 For URL, supermarket, compliance, and other sources that do not
 provide versioned artifacts, this likely means that the remote source

--- a/test/unit/fetchers/fetchers_test.rb
+++ b/test/unit/fetchers/fetchers_test.rb
@@ -13,6 +13,13 @@ describe Inspec::Fetcher do
   end
 
   describe "without a source specified" do
+    let(:mock_open) {
+      m = Minitest::Mock.new
+      m.expect :meta, {'content-type' => 'application/gzip'}
+      m.expect :read, "fake content"
+      m
+    }
+
     before do
       Supermarket::API.expects(:exist?).returns(true)
       Supermarket::API.expects(:find).returns({'tool_source_url' => "http://mock-url" })
@@ -20,8 +27,9 @@ describe Inspec::Fetcher do
 
     it "defaults to supermarket if only a name is given" do
       res = Inspec::Fetcher.resolve({:name => "mock/test-profile"})
+      res.expects(:open).returns(mock_open)
       res.must_be_kind_of Fetchers::Url
-      res.resolved_source.must_equal({url: "http://mock-url"})
+      res.resolved_source[:url].must_equal("http://mock-url")
     end
 
     it "ignores keys that might have come along for the ride" do

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -38,7 +38,7 @@ describe Fetchers::Url do
       res = fetcher.resolve(url)
       res.expects(:open).returns(mock_open)
       _(res).must_be_kind_of Fetchers::Url
-      _(res.resolved_source).must_equal({url: 'http://chef.io/some.tar.gz', shasum: expected_shasum})
+      _(res.resolved_source).must_equal({url: 'http://chef.io/some.tar.gz', sha256: expected_shasum})
     end
 
     it 'handles a https url' do
@@ -46,7 +46,7 @@ describe Fetchers::Url do
       res = fetcher.resolve(url)
       res.expects(:open).returns(mock_open)
       _(res).must_be_kind_of Fetchers::Url
-      _(res.resolved_source).must_equal({url: 'https://chef.io/some.tar.gz', shasum: expected_shasum})
+      _(res.resolved_source).must_equal({url: 'https://chef.io/some.tar.gz', sha256: expected_shasum})
 
     end
 
@@ -68,7 +68,7 @@ describe Fetchers::Url do
         res = fetcher.resolve(github)
         res.expects(:open).returns(mock_open)
         _(res).wont_be_nil
-        _(res.resolved_source).must_equal({url: 'https://github.com/chef/inspec/archive/master.tar.gz', shasum: expected_shasum})
+        _(res.resolved_source).must_equal({url: 'https://github.com/chef/inspec/archive/master.tar.gz', sha256: expected_shasum})
       end
     end
 
@@ -77,7 +77,7 @@ describe Fetchers::Url do
       res = fetcher.resolve(github)
       res.expects(:open).returns(mock_open)
       _(res).wont_be_nil
-      _(res.resolved_source).must_equal({url: 'https://github.com/hardening-io/tests-os-hardening/archive/2.0.tar.gz', shasum: expected_shasum})
+      _(res.resolved_source).must_equal({url: 'https://github.com/hardening-io/tests-os-hardening/archive/2.0.tar.gz', sha256: expected_shasum})
     end
 
     it "resolves a github commit url" do
@@ -86,7 +86,7 @@ describe Fetchers::Url do
       res.expects(:open).returns(mock_open)
       _(res).wont_be_nil
       _(res.resolved_source).must_equal({url: 'https://github.com/hardening-io/tests-os-hardening/archive/48bd4388ddffde68badd83aefa654e7af3231876.tar.gz',
-                                         shasum: expected_shasum})
+                                         sha256: expected_shasum})
     end
   end
 

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -12,7 +12,7 @@ describe Fetchers::Url do
   end
 
   describe 'testing different urls' do
-    let(:mock_file) { MockLoader.profile_path('complete-metadata') }
+
     let(:fetcher) {
       Class.new(Fetchers::Url) do
         attr_reader :target, :archive
@@ -23,18 +23,30 @@ describe Fetchers::Url do
       end
     }
 
+    # We don't use the MockLoader here becuase it produces tarballs
+    # with different sha's on each run
+    let(:expected_shasum) { "98b1ae45059b004178a8eee0c1f6179dcea139c0fd8a69ee47a6f02d97af1f17" }
+    let(:mock_open) {
+      m = Minitest::Mock.new
+      m.expect :meta, {'content-type' => 'application/gzip'}
+      m.expect :read, "fake content"
+      m
+    }
+
     it 'handles a http url' do
       url = 'http://chef.io/some.tar.gz'
       res = fetcher.resolve(url)
+      res.expects(:open).returns(mock_open)
       _(res).must_be_kind_of Fetchers::Url
-      _(res.resolved_source).must_equal({url: 'http://chef.io/some.tar.gz'})
+      _(res.resolved_source).must_equal({url: 'http://chef.io/some.tar.gz', shasum: expected_shasum})
     end
 
     it 'handles a https url' do
       url = 'https://chef.io/some.tar.gz'
       res = fetcher.resolve(url)
+      res.expects(:open).returns(mock_open)
       _(res).must_be_kind_of Fetchers::Url
-      _(res.resolved_source).must_equal({url: 'https://chef.io/some.tar.gz'})
+      _(res.resolved_source).must_equal({url: 'https://chef.io/some.tar.gz', shasum: expected_shasum})
 
     end
 
@@ -54,23 +66,27 @@ describe Fetchers::Url do
        http://www.github.com/chef/inspec.git}.each do |github|
       it "resolves a github url #{github}" do
         res = fetcher.resolve(github)
+        res.expects(:open).returns(mock_open)
         _(res).wont_be_nil
-        _(res.resolved_source).must_equal({url: 'https://github.com/chef/inspec/archive/master.tar.gz'})
+        _(res.resolved_source).must_equal({url: 'https://github.com/chef/inspec/archive/master.tar.gz', shasum: expected_shasum})
       end
     end
 
     it "resolves a github branch url" do
       github = 'https://github.com/hardening-io/tests-os-hardening/tree/2.0'
       res = fetcher.resolve(github)
+      res.expects(:open).returns(mock_open)
       _(res).wont_be_nil
-      _(res.resolved_source).must_equal({url: 'https://github.com/hardening-io/tests-os-hardening/archive/2.0.tar.gz'})
+      _(res.resolved_source).must_equal({url: 'https://github.com/hardening-io/tests-os-hardening/archive/2.0.tar.gz', shasum: expected_shasum})
     end
 
     it "resolves a github commit url" do
       github = 'https://github.com/hardening-io/tests-os-hardening/tree/48bd4388ddffde68badd83aefa654e7af3231876'
       res = fetcher.resolve(github)
+      res.expects(:open).returns(mock_open)
       _(res).wont_be_nil
-      _(res.resolved_source).must_equal({url: 'https://github.com/hardening-io/tests-os-hardening/archive/48bd4388ddffde68badd83aefa654e7af3231876.tar.gz'})
+      _(res.resolved_source).must_equal({url: 'https://github.com/hardening-io/tests-os-hardening/archive/48bd4388ddffde68badd83aefa654e7af3231876.tar.gz',
+                                         shasum: expected_shasum})
     end
   end
 
@@ -96,7 +112,8 @@ describe Fetchers::Url do
     end
 
     it "returns the resolved_source hash" do
-      subject.resolved_source.must_equal({ url: target })
+      subject.expects(:open).returns(mock_open)
+      subject.resolved_source[:url].must_equal(target)
     end
   end
 end


### PR DESCRIPTION
If a URL based source does not match the shasum recorded in the
lockfile, it likely means a new version has been pushed to the remote
source. In this case, we fail to help ensure that when using a lockfile
we always run the same code as when the lockfile was created.

Signed-off-by: Steven Danna steve@chef.io
