### PR TITLE
Use parenthesis when passing regular expressions

### DIFF
--- a/lib/inspec/objects/test.rb
+++ b/lib/inspec/objects/test.rb
@@ -66,8 +66,14 @@ module Inspec
       res, xtra = describe_chain
       itsy = xtra.nil? ? 'it' : 'its(' + xtra.to_s.inspect + ')'
       naughty = @negated ? '_not' : ''
-      xpect = defined?(@expectation) ? expectation.inspect+' ' : ''
-      format("%sdescribe %s do\n  %s { should%s %s %s}\nend",
+      xpect = defined?(@expectation) ? expectation.inspect : ''
+      if matcher == 'match'
+        # without this, xpect values like / \/zones\// will not be parsed properly
+        xpect = "(#{xpect})"
+      elsif xpect != ''
+        xpect = ' ' + xpect
+      end
+      format("%sdescribe %s do\n  %s { should%s %s%s }\nend",
              vars, res, itsy, naughty, matcher, xpect)
     end
 


### PR DESCRIPTION
Before this change,  some regular expressions would generate a control that's cannot be parses later on for check/exec: 

```
$ be bin/inspec scap convert --profile 'Level 1' /tmp/CIS_Oracle_Solaris_11.2_Benchmark_v1.1.0_one_rule.xml
control "xccdf_org.cisecurity.benchmarks_rule_9.23_Find_Un-owned_Files_and_Directories" do
  title "Find Un-owned Files and Directories"
  desc  "Sometimes when administrators delete users from the password file they neglect to remove all files owned by those users from the system."
  impact 1.0
  describe bash("find / \\( -fstype nfs -o -fstype cachefs -o -fstype autofs -o -fstype ctfs -o -fstype mntfs -o -fstype objfs -o -fstype proc \\) -prune -o \\( -nouser -o -nogroup \\) -ls") do
    its("stdout") { should match / \/zones\// }
  end
end
```

Check error:

```
bundle exec inspec check cis/cis-oraclesolaris11.2-level1 --profiles-path .
/home/travis/build/chef/compliance-profiles/vendor/bundle/ruby/1.9.1/gems/inspec-0.35.0/lib/inspec/profile_context.rb:123:in `instance_eval': cis/cis-oraclesolaris11.2-level1/controls/translated-controls.rb:1145: syntax error, unexpected $undefined (SyntaxError)
    its("stdout") { should match / \/zones\// }
                                    ^
    from /home/travis/build/chef/compliance-profiles/vendor/bundle/ruby/1.9.1/gems/inspec-0.35.0/lib/inspec/profile_context.rb:123:in `load_with_context'
    from /home/travis/build/chef/compliance-profiles/vendor/bundle/ruby/1.9.1/gems/inspec-0.35.0/lib/inspec/profile_context.rb:107:in `load_control_file'
```

---

This PR changes how the regex is parsed to the matcher:

```
$ be bin/inspec scap convert --profile 'Level 1' /tmp/CIS_Oracle_Solaris_11.2_Benchmark_v1.1.0_one_rule.xml
control "xccdf_org.cisecurity.benchmarks_rule_9.23_Find_Un-owned_Files_and_Directories" do
  title "Find Un-owned Files and Directories"
  desc  "Sometimes when administrators delete users from the password file they neglect to remove all files owned by those users from the system."
  impact 1.0
  describe bash("find / \\( -fstype nfs -o -fstype cachefs -o -fstype autofs -o -fstype ctfs -o -fstype mntfs -o -fstype objfs -o -fstype proc \\) -prune -o \\( -nouser -o -nogroup \\) -ls") do
    its("stdout") { should match(/ \/zones\//) }
  end
end
```
