### PR TITLE
Add `--cache` option to `inspec exec`

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -58,6 +58,8 @@ module Inspec
         desc: 'Use colors in output.'
       option :attrs, type: :array,
         desc: 'Load attributes file (experimental)'
+      option :cache, type: :string,
+        desc: 'Use the given path for caching dependencies. (default: ~/.inspec/cache)'
     end
 
     private

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -102,8 +102,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   desc 'vendor', 'Download all dependencies and generate a lockfile'
   def vendor(path = nil)
     configure_logger(opts)
-    profile = Inspec::Profile.for_target('./', opts)
-    lockfile = profile.generate_lockfile(path)
+    profile = Inspec::Profile.for_target('./', opts.merge(cache: Inspec::Cache.new(path)))
+    lockfile = profile.generate_lockfile
     File.write('inspec.lock', lockfile.to_yaml)
   end
 

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 
 module Inspec
   #
-  # VendorIndex manages an on-disk cache of inspec profiles.  The
+  # Inspec::Cache manages an on-disk cache of inspec profiles.  The
   # cache can contain:
   #
   #  - .tar.gz profile archives
@@ -16,7 +16,7 @@ module Inspec
   # sources.
   #
   #
-  class VendorIndex
+  class Cache
     attr_reader :path
     def initialize(path = nil)
       @path = path || File.join(Dir.home, '.inspec', 'cache')
@@ -43,7 +43,7 @@ module Inspec
 
     #
     # For a given name and source_url, return true if the
-    # profile exists in the VendorIndex.
+    # profile exists in the Cache.
     #
     # @param [String] name
     # @param [String] source_url
@@ -56,7 +56,7 @@ module Inspec
     end
 
     #
-    # Return the path to given profile in the vendor index.
+    # Return the path to given profile in the cache.
     #
     # The `source_url` parameter should be a URI-like string that
     # fully specifies the source of the exact version we want to pull

--- a/lib/inspec/dependencies/resolver.rb
+++ b/lib/inspec/dependencies/resolver.rb
@@ -23,9 +23,9 @@ module Inspec
   # implementation of the fetcher being used.
   #
   class Resolver
-    def self.resolve(dependencies, vendor_index, working_dir, backend)
+    def self.resolve(dependencies, cache, working_dir, backend)
       reqs = dependencies.map do |dep|
-        req = Inspec::Requirement.from_metadata(dep, vendor_index, cwd: working_dir, backend: backend)
+        req = Inspec::Requirement.from_metadata(dep, cache, cwd: working_dir, backend: backend)
         req || fail("Cannot initialize dependency: #{req}")
       end
       new.resolve(reqs)

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -11,6 +11,7 @@ require 'inspec/profile_context'
 require 'inspec/profile'
 require 'inspec/metadata'
 require 'inspec/secrets'
+require 'inspec/dependencies/cache'
 # spec requirements
 
 module Inspec
@@ -41,7 +42,7 @@ module Inspec
       @target_profiles = []
       @controls = @conf[:controls] || []
       @ignore_supports = @conf[:ignore_supports]
-
+      @cache = Inspec::Cache.new(@conf[:cache])
       @test_collector = @conf.delete(:test_collector) || begin
         require 'inspec/runner_rspec'
         RunnerRspec.new(@conf)
@@ -140,6 +141,7 @@ module Inspec
     #
     def add_target(target, _opts = [])
       profile = Inspec::Profile.for_target(target,
+                                           cache: @cache,
                                            backend: @backend,
                                            controls: @controls,
                                            attributes: @conf[:attributes])


### PR DESCRIPTION
This allows users to run:

  inspec exec ./ --cache PATH

which will use `PATH` as the dir to retrieve and store remote
dependencies.  The hope is that this can eventually be used with
`inspec vendor PATH` to package up a profile for offline use.

Signed-off-by: Steven Danna steve@chef.io
