### PR TITLE
Always write lockfiles for local top-level profiles 

### DIFF
--- a/lib/fetchers/local.rb
+++ b/lib/fetchers/local.rb
@@ -55,6 +55,10 @@ module Fetchers
       @target
     end
 
+    def writable?
+      File.directory?(@target)
+    end
+
     def cache_key
       sha256.to_s
     end

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -60,8 +60,8 @@ module Inspec
         desc: 'Load attributes file (experimental)'
       option :cache, type: :string,
         desc: 'Use the given path for caching dependencies. (default: ~/.inspec/cache)'
-      option :no_write_lockfile, type: :boolean, default: false,
-        desc: 'Do not write out a lockfile based on this execution'
+      option :create_lockfile, type: :boolean, default: true,
+        desc: 'Write out a lockfile based on this execution (unless one already exists)'
     end
 
     private

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -60,6 +60,8 @@ module Inspec
         desc: 'Load attributes file (experimental)'
       option :cache, type: :string,
         desc: 'Use the given path for caching dependencies. (default: ~/.inspec/cache)'
+      option :no_write_lockfile, type: :boolean, default: false,
+        desc: 'Do not write out a lockfile based on this execution'
     end
 
     private

--- a/lib/inspec/plugins/fetcher.rb
+++ b/lib/inspec/plugins/fetcher.rb
@@ -24,6 +24,10 @@ module Inspec
         Inspec::Fetcher
       end
 
+      def writable?
+        false
+      end
+
       #
       # The path to the archive on disk.  This can be passed to a
       # FileProvider to get access to the files in the fetched

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -42,7 +42,7 @@ module Inspec
       @target_profiles = []
       @controls = @conf[:controls] || []
       @ignore_supports = @conf[:ignore_supports]
-      @no_write_lockfile = @conf[:no_write_lockfile]
+      @create_lockfile = @conf[:create_lockfile]
       @cache = Inspec::Cache.new(@conf[:cache])
       @test_collector = @conf.delete(:test_collector) || begin
         require 'inspec/runner_rspec'
@@ -78,7 +78,7 @@ module Inspec
 
       @target_profiles.each do |profile|
         @test_collector.add_profile(profile)
-        write_lockfile(profile) unless @no_write_lockfile
+        write_lockfile(profile) if @create_lockfile
         profile.locked_dependencies
         profile.load_libraries
         @attributes |= profile.runner_context.attributes
@@ -102,7 +102,7 @@ module Inspec
       if profile.lockfile_exists?
         Inspec::Log.debug "Using existing lockfile #{profile.lockfile_path}"
       else
-        Inspec::Log.debug "Writing lockfile: #{profile.lockfile_path}"
+        Inspec::Log.debug "Creating lockfile: #{profile.lockfile_path}"
         lockfile = profile.generate_lockfile
         File.write(profile.lockfile_path, lockfile.to_yaml)
       end

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -42,6 +42,7 @@ module Inspec
       @target_profiles = []
       @controls = @conf[:controls] || []
       @ignore_supports = @conf[:ignore_supports]
+      @no_write_lockfile = @conf[:no_write_lockfile]
       @cache = Inspec::Cache.new(@conf[:cache])
       @test_collector = @conf.delete(:test_collector) || begin
         require 'inspec/runner_rspec'
@@ -77,6 +78,7 @@ module Inspec
 
       @target_profiles.each do |profile|
         @test_collector.add_profile(profile)
+        write_lockfile(profile) unless @no_write_lockfile
         profile.locked_dependencies
         profile.load_libraries
         @attributes |= profile.runner_context.attributes
@@ -92,6 +94,18 @@ module Inspec
       Inspec::Log.debug "Starting run with targets: #{@target_profiles.map(&:to_s)}"
       load
       run_tests(with)
+    end
+
+    def write_lockfile(profile)
+      return false if !profile.writable?
+
+      if profile.lockfile_exists?
+        Inspec::Log.debug "Using existing lockfile #{profile.lockfile_path}"
+      else
+        Inspec::Log.debug "Writing lockfile: #{profile.lockfile_path}"
+        lockfile = profile.generate_lockfile
+        File.write(profile.lockfile_path, lockfile.to_yaml)
+      end
     end
 
     def run_tests(with = nil)

--- a/test/functional/gitfetcher_test.rb
+++ b/test/functional/gitfetcher_test.rb
@@ -37,7 +37,7 @@ EOF
   end
 
   it 'executes a profile with a git based dependency' do
-    out = inspec("exec #{@profile_dir}")
+    out = inspec("exec #{@profile_dir} --no-write-lockfile")
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
   end

--- a/test/functional/gitfetcher_test.rb
+++ b/test/functional/gitfetcher_test.rb
@@ -37,7 +37,7 @@ EOF
   end
 
   it 'executes a profile with a git based dependency' do
-    out = inspec("exec #{@profile_dir} --no-write-lockfile")
+    out = inspec("exec #{@profile_dir} --no-create-lockfile")
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
   end

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -8,21 +8,21 @@ describe 'inspec exec with json formatter' do
   include FunctionalHelper
 
   it 'can execute a simple file with the json formatter' do
-    out = inspec('exec ' + example_control + ' --format json')
+    out = inspec('exec --no-write-lockfile ' + example_control + ' --format json')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     JSON.load(out.stdout).must_be_kind_of Hash
   end
 
   it 'can execute the profile with the json formatter' do
-    out = inspec('exec ' + example_profile + ' --format json')
+    out = inspec('exec --no-write-lockfile ' + example_profile + ' --format json')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     JSON.load(out.stdout).must_be_kind_of Hash
   end
 
   describe 'execute a profile with json formatting' do
-    let(:json) { JSON.load(inspec('exec ' + example_profile + ' --format json').stdout) }
+    let(:json) { JSON.load(inspec('exec --no-write-lockfile ' + example_profile + ' --format json').stdout) }
     let(:profile) { json['profiles'][0] }
     let(:controls) { profile['controls'] }
     let(:ex1) { controls.find { |x| x['id'] == 'tmp-1.0' } }
@@ -115,7 +115,7 @@ describe 'inspec exec with json formatter' do
   end
 
   describe 'with a profile that is not supported on this OS/platform' do
-    let(:out) { inspec('exec ' + File.join(profile_path, 'skippy-profile-os') + ' --format json') }
+    let(:out) { inspec('exec --no-write-lockfile' + File.join(profile_path, 'skippy-profile-os') + ' --format json') }
     let(:json) { JSON.load(out.stdout) }
 
     # TODO: failure handling in json formatters...

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -8,21 +8,21 @@ describe 'inspec exec with json formatter' do
   include FunctionalHelper
 
   it 'can execute a simple file with the json formatter' do
-    out = inspec('exec --no-write-lockfile ' + example_control + ' --format json')
+    out = inspec('exec ' + example_control + ' --format json --no-create-lockfile')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     JSON.load(out.stdout).must_be_kind_of Hash
   end
 
   it 'can execute the profile with the json formatter' do
-    out = inspec('exec --no-write-lockfile ' + example_profile + ' --format json')
+    out = inspec('exec ' + example_profile + ' --format json --no-create-lockfile')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     JSON.load(out.stdout).must_be_kind_of Hash
   end
 
   describe 'execute a profile with json formatting' do
-    let(:json) { JSON.load(inspec('exec --no-write-lockfile ' + example_profile + ' --format json').stdout) }
+    let(:json) { JSON.load(inspec('exec ' + example_profile + ' --format json --no-create-lockfile').stdout) }
     let(:profile) { json['profiles'][0] }
     let(:controls) { profile['controls'] }
     let(:ex1) { controls.find { |x| x['id'] == 'tmp-1.0' } }
@@ -115,7 +115,7 @@ describe 'inspec exec with json formatter' do
   end
 
   describe 'with a profile that is not supported on this OS/platform' do
-    let(:out) { inspec('exec --no-write-lockfile' + File.join(profile_path, 'skippy-profile-os') + ' --format json') }
+    let(:out) { inspec('exec ' + File.join(profile_path, 'skippy-profile-os') + ' --format json --no-create-lockfile') }
     let(:json) { JSON.load(out.stdout) }
 
     # TODO: failure handling in json formatters...

--- a/test/functional/inspec_exec_jsonmin_test.rb
+++ b/test/functional/inspec_exec_jsonmin_test.rb
@@ -8,21 +8,21 @@ describe 'inspec exec' do
   include FunctionalHelper
 
   it 'can execute the profile with the mini json formatter' do
-    out = inspec('exec --no-write-lockfile ' + example_profile + ' --format json-min')
+    out = inspec('exec ' + example_profile + ' --format json-min --no-create-lockfile')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     JSON.load(out.stdout).must_be_kind_of Hash
   end
 
   it 'can execute a simple file with the mini json formatter' do
-    out = inspec('exec --no-write-lockfile ' + example_control + ' --format json-min')
+    out = inspec('exec ' + example_control + ' --format json-min --no-create-lockfile')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     JSON.load(out.stdout).must_be_kind_of Hash
   end
 
   describe 'execute a profile with mini json formatting' do
-    let(:json) { JSON.load(inspec('exec --no-write-lockfile ' + example_profile + ' --format json-min').stdout) }
+    let(:json) { JSON.load(inspec('exec ' + example_profile + ' --format json-min --no-create-lockfile').stdout) }
     let(:controls) { json['controls'] }
     let(:ex1) { controls.find{|x| x['id'] == 'tmp-1.0'} }
     let(:ex2) { controls.find{|x| x['id'] =~ /generated/} }

--- a/test/functional/inspec_exec_jsonmin_test.rb
+++ b/test/functional/inspec_exec_jsonmin_test.rb
@@ -8,21 +8,21 @@ describe 'inspec exec' do
   include FunctionalHelper
 
   it 'can execute the profile with the mini json formatter' do
-    out = inspec('exec ' + example_profile + ' --format json-min')
+    out = inspec('exec --no-write-lockfile ' + example_profile + ' --format json-min')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     JSON.load(out.stdout).must_be_kind_of Hash
   end
 
   it 'can execute a simple file with the mini json formatter' do
-    out = inspec('exec ' + example_control + ' --format json-min')
+    out = inspec('exec --no-write-lockfile ' + example_control + ' --format json-min')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     JSON.load(out.stdout).must_be_kind_of Hash
   end
 
   describe 'execute a profile with mini json formatting' do
-    let(:json) { JSON.load(inspec('exec ' + example_profile + ' --format json-min').stdout) }
+    let(:json) { JSON.load(inspec('exec --no-write-lockfile ' + example_profile + ' --format json-min').stdout) }
     let(:controls) { json['controls'] }
     let(:ex1) { controls.find{|x| x['id'] == 'tmp-1.0'} }
     let(:ex2) { controls.find{|x| x['id'] =~ /generated/} }

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -8,7 +8,7 @@ describe 'inspec exec' do
   include FunctionalHelper
 
   it 'can execute the profile' do
-    out = inspec('exec --no-write-lockfile ' + example_profile)
+    out = inspec('exec ' + example_profile  + ' --no-create-lockfile')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     stdout = out.stdout.force_encoding(Encoding::UTF_8)
@@ -23,7 +23,7 @@ describe 'inspec exec' do
   end
 
   it 'executes a minimum metadata-only profile' do
-    out = inspec('exec --no-write-lockfile ' + File.join(profile_path, 'simple-metadata'))
+    out = inspec('exec ' + File.join(profile_path, 'simple-metadata') + ' --no-create-lockfile')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     out.stdout.must_equal "
@@ -39,7 +39,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   it 'executes a metadata-only profile' do
-    out = inspec('exec --no-write-lockfile ' + File.join(profile_path, 'complete-metadata'))
+    out = inspec('exec ' + File.join(profile_path, 'complete-metadata') + ' --no-create-lockfile')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     out.stdout.must_equal "
@@ -55,14 +55,14 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   it "executes a profile and reads attributes" do
-    out = inspec("exec --no-write-lockfile #{File.join(examples_path, 'profile-attribute')} --attrs #{File.join(examples_path, "profile-attribute.yml")}")
+    out = inspec("exec #{File.join(examples_path, 'profile-attribute')} --no-create-lockfile --attrs #{File.join(examples_path, "profile-attribute.yml")}")
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m"
   end
 
   it 'executes a specs-only profile' do
-    out = inspec('exec --no-write-lockfile ' + File.join(profile_path, 'spec_only'))
+    out = inspec('exec ' + File.join(profile_path, 'spec_only') + ' --no-create-lockfile')
     out.stderr.must_equal ''
     out.exit_status.must_equal 1
     out.stdout.force_encoding(Encoding::UTF_8).must_include "Target:  local://"
@@ -76,14 +76,14 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   it 'executes only specified controls' do
-    out = inspec('exec --no-write-lockfile ' + example_profile + ' --controls tmp-1.0')
+    out = inspec('exec ' + example_profile + ' --no-create-lockfile --controls tmp-1.0')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     out.stdout.must_include "\nProfile Summary: \e[32m1 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
   end
 
   it 'can execute a simple file with the default formatter' do
-    out = inspec('exec --no-write-lockfile ' + example_control)
+    out = inspec('exec ' + example_control  + ' --no-create-lockfile')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     out.stdout.must_include "\nProfile Summary: \e[32m1 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
@@ -91,7 +91,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'with a profile that is not supported on this OS/platform' do
-    let(:out) { inspec('exec --no-write-lockfile ' + File.join(profile_path, 'skippy-profile-os')) }
+    let(:out) { inspec('exec ' + File.join(profile_path, 'skippy-profile-os') + ' --no-create-lockfile') }
     let(:json) { JSON.load(out.stdout) }
 
     it 'exits with an error' do
@@ -101,7 +101,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'with a profile that is supported on this version of inspec' do
-    let(:out) { inspec('exec --no-write-lockfile ' + File.join(profile_path, 'supported_inspec')) }
+    let(:out) { inspec('exec ' + File.join(profile_path, 'supported_inspec') + ' --no-create-lockfile') }
 
     it 'exits cleanly' do
       out.stderr.must_equal ''
@@ -110,7 +110,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'with a profile that is not supported on this version of inspec' do
-    let(:out) { inspec('exec --no-write-lockfile ' + File.join(profile_path, 'unsupported_inspec')) }
+    let(:out) { inspec('exec ' + File.join(profile_path, 'unsupported_inspec') + ' --no-create-lockfile') }
 
     it 'does not support this profile' do
       out.exit_status.must_equal 1
@@ -119,7 +119,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'with a profile that loads a library and reference' do
-    let(:out) { inspec('exec --no-write-lockfile ' + File.join(profile_path, 'library')) }
+    let(:out) { inspec('exec ' + File.join(profile_path, 'library') + ' --no-create-lockfile') }
 
     it 'executes the profile without error' do
       out.exit_status.must_equal 0
@@ -127,7 +127,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'given a profile with controls and anonymous describe blocks' do
-    let(:out) { inspec('exec --no-write-lockfile ' + example_control) }
+    let(:out) { inspec('exec ' + example_control + ' --no-create-lockfile') }
 
     it 'prints the control results, then the anonymous describe block results' do
       out.stdout.force_encoding(Encoding::UTF_8).must_equal "
@@ -146,7 +146,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'given a profile with an anonymous describe block' do
-    let(:out) { inspec('exec --no-write-lockfile ' + failure_control) }
+    let(:out) { inspec('exec ' + failure_control + ' --no-create-lockfile') }
 
     it 'prints the exception message when a test has a syntax error' do
       out.stdout.must_include "undefined method `should_nota' "
@@ -154,7 +154,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'given an inherited profile that has more that one test per control block' do
-    let(:out) { inspec('exec --no-write-lockfile ' + simple_inheritance) }
+    let(:out) { inspec('exec ' + simple_inheritance + ' --no-create-lockfile') }
 
     it 'should print all the results' do
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  tmp-1.0: Create /tmp directory (1 failed)\e[0m"
@@ -165,7 +165,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'when passing in two profiles given an inherited profile that has more that one test per control block' do
-    let(:out) { inspec('exec --no-write-lockfile ' + File.join(profile_path, 'dependencies', 'profile_d') + ' ' + simple_inheritance) }
+    let(:out) { inspec('exec ' + File.join(profile_path, 'dependencies', 'profile_d') + ' ' + simple_inheritance + ' --no-create-lockfile') }
 
     it 'should print all the results' do
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  tmp-1.0: Create /tmp directory (1 failed)\e[0m"
@@ -178,7 +178,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
 
   describe 'using namespaced resources' do
     it 'works' do
-      out = inspec('exec --no-write-lockfile ' + File.join(profile_path, 'dependencies', 'resource-namespace'))
+      out = inspec('exec ' + File.join(profile_path, 'dependencies', 'resource-namespace') + ' --no-create-lockfile')
       out.stderr.must_equal ''
       out.exit_status.must_equal 0
       out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m5 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
@@ -187,7 +187,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
 
   describe "with a 2-level dependency tree" do
     it 'correctly runs tests from the whole tree' do
-      out = inspec('exec --no-write-lockfile ' + File.join(profile_path, 'dependencies', 'inheritance'))
+      out = inspec('exec ' + File.join(profile_path, 'dependencies', 'inheritance') + ' --no-create-lockfile')
       out.stderr.must_equal ''
       out.exit_status.must_equal 0
       out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m6 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
@@ -196,19 +196,19 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
 
   describe 'when using profiles on the supermarket' do
     it 'can run supermarket profiles directly from the command line' do
-      out = inspec("exec --no-write-lockfile supermarket://nathenharvey/tmp-compliance-profile")
+      out = inspec("exec supermarket://nathenharvey/tmp-compliance-profile --no-create-lockfile")
       out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
     end
 
     it 'can run supermarket profiles from inspec.yml' do
-      out = inspec("exec --no-write-lockfile #{File.join(profile_path, 'supermarket-dep')}")
+      out = inspec("exec #{File.join(profile_path, 'supermarket-dep')} --no-create-lockfile")
       out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
     end
   end
 
   describe 'when a dependency does not support our backend platform' do
     it 'skips the controls from that profile' do
-      out = inspec("exec --no-write-lockfile #{File.join(profile_path, 'profile-support-skip')}")
+      out = inspec("exec #{File.join(profile_path, 'profile-support-skip')} --no-create-lockfile")
       out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m2 skipped\e[0m\n"
     end
   end

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -8,7 +8,7 @@ describe 'inspec exec' do
   include FunctionalHelper
 
   it 'can execute the profile' do
-    out = inspec('exec ' + example_profile)
+    out = inspec('exec --no-write-lockfile ' + example_profile)
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     stdout = out.stdout.force_encoding(Encoding::UTF_8)
@@ -23,7 +23,7 @@ describe 'inspec exec' do
   end
 
   it 'executes a minimum metadata-only profile' do
-    out = inspec('exec ' + File.join(profile_path, 'simple-metadata'))
+    out = inspec('exec --no-write-lockfile ' + File.join(profile_path, 'simple-metadata'))
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     out.stdout.must_equal "
@@ -39,7 +39,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   it 'executes a metadata-only profile' do
-    out = inspec('exec ' + File.join(profile_path, 'complete-metadata'))
+    out = inspec('exec --no-write-lockfile ' + File.join(profile_path, 'complete-metadata'))
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     out.stdout.must_equal "
@@ -55,14 +55,14 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   it "executes a profile and reads attributes" do
-    out = inspec("exec #{File.join(examples_path, 'profile-attribute')} --attrs #{File.join(examples_path, "profile-attribute.yml")}")
+    out = inspec("exec --no-write-lockfile #{File.join(examples_path, 'profile-attribute')} --attrs #{File.join(examples_path, "profile-attribute.yml")}")
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m"
   end
 
   it 'executes a specs-only profile' do
-    out = inspec('exec ' + File.join(profile_path, 'spec_only'))
+    out = inspec('exec --no-write-lockfile ' + File.join(profile_path, 'spec_only'))
     out.stderr.must_equal ''
     out.exit_status.must_equal 1
     out.stdout.force_encoding(Encoding::UTF_8).must_include "Target:  local://"
@@ -76,14 +76,14 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   it 'executes only specified controls' do
-    out = inspec('exec ' + example_profile + ' --controls tmp-1.0')
+    out = inspec('exec --no-write-lockfile ' + example_profile + ' --controls tmp-1.0')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     out.stdout.must_include "\nProfile Summary: \e[32m1 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
   end
 
   it 'can execute a simple file with the default formatter' do
-    out = inspec('exec ' + example_control)
+    out = inspec('exec --no-write-lockfile ' + example_control)
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     out.stdout.must_include "\nProfile Summary: \e[32m1 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
@@ -91,7 +91,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'with a profile that is not supported on this OS/platform' do
-    let(:out) { inspec('exec ' + File.join(profile_path, 'skippy-profile-os')) }
+    let(:out) { inspec('exec --no-write-lockfile ' + File.join(profile_path, 'skippy-profile-os')) }
     let(:json) { JSON.load(out.stdout) }
 
     it 'exits with an error' do
@@ -101,7 +101,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'with a profile that is supported on this version of inspec' do
-    let(:out) { inspec('exec ' + File.join(profile_path, 'supported_inspec')) }
+    let(:out) { inspec('exec --no-write-lockfile ' + File.join(profile_path, 'supported_inspec')) }
 
     it 'exits cleanly' do
       out.stderr.must_equal ''
@@ -110,7 +110,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'with a profile that is not supported on this version of inspec' do
-    let(:out) { inspec('exec ' + File.join(profile_path, 'unsupported_inspec')) }
+    let(:out) { inspec('exec --no-write-lockfile ' + File.join(profile_path, 'unsupported_inspec')) }
 
     it 'does not support this profile' do
       out.exit_status.must_equal 1
@@ -119,7 +119,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'with a profile that loads a library and reference' do
-    let(:out) { inspec('exec ' + File.join(profile_path, 'library')) }
+    let(:out) { inspec('exec --no-write-lockfile ' + File.join(profile_path, 'library')) }
 
     it 'executes the profile without error' do
       out.exit_status.must_equal 0
@@ -127,7 +127,7 @@ Test Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'given a profile with controls and anonymous describe blocks' do
-    let(:out) { inspec('exec ' + example_control) }
+    let(:out) { inspec('exec --no-write-lockfile ' + example_control) }
 
     it 'prints the control results, then the anonymous describe block results' do
       out.stdout.force_encoding(Encoding::UTF_8).must_equal "
@@ -146,7 +146,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'given a profile with an anonymous describe block' do
-    let(:out) { inspec('exec ' + failure_control) }
+    let(:out) { inspec('exec --no-write-lockfile ' + failure_control) }
 
     it 'prints the exception message when a test has a syntax error' do
       out.stdout.must_include "undefined method `should_nota' "
@@ -154,7 +154,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'given an inherited profile that has more that one test per control block' do
-    let(:out) { inspec('exec ' + simple_inheritance) }
+    let(:out) { inspec('exec --no-write-lockfile ' + simple_inheritance) }
 
     it 'should print all the results' do
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  tmp-1.0: Create /tmp directory (1 failed)\e[0m"
@@ -165,7 +165,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
   end
 
   describe 'when passing in two profiles given an inherited profile that has more that one test per control block' do
-    let(:out) { inspec('exec ' + File.join(profile_path, 'dependencies', 'profile_d') + ' ' + simple_inheritance) }
+    let(:out) { inspec('exec --no-write-lockfile ' + File.join(profile_path, 'dependencies', 'profile_d') + ' ' + simple_inheritance) }
 
     it 'should print all the results' do
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  tmp-1.0: Create /tmp directory (1 failed)\e[0m"
@@ -178,7 +178,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
 
   describe 'using namespaced resources' do
     it 'works' do
-      out = inspec('exec ' + File.join(profile_path, 'dependencies', 'resource-namespace'))
+      out = inspec('exec --no-write-lockfile ' + File.join(profile_path, 'dependencies', 'resource-namespace'))
       out.stderr.must_equal ''
       out.exit_status.must_equal 0
       out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m5 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
@@ -187,7 +187,7 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
 
   describe "with a 2-level dependency tree" do
     it 'correctly runs tests from the whole tree' do
-      out = inspec('exec ' + File.join(profile_path, 'dependencies', 'inheritance'))
+      out = inspec('exec --no-write-lockfile ' + File.join(profile_path, 'dependencies', 'inheritance'))
       out.stderr.must_equal ''
       out.exit_status.must_equal 0
       out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m6 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
@@ -196,19 +196,19 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
 
   describe 'when using profiles on the supermarket' do
     it 'can run supermarket profiles directly from the command line' do
-      out = inspec("exec supermarket://nathenharvey/tmp-compliance-profile")
+      out = inspec("exec --no-write-lockfile supermarket://nathenharvey/tmp-compliance-profile")
       out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
     end
 
     it 'can run supermarket profiles from inspec.yml' do
-      out = inspec("exec #{File.join(profile_path, 'supermarket-dep')}")
+      out = inspec("exec --no-write-lockfile #{File.join(profile_path, 'supermarket-dep')}")
       out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
     end
   end
 
   describe 'when a dependency does not support our backend platform' do
     it 'skips the controls from that profile' do
-      out = inspec("exec #{File.join(profile_path, 'profile-support-skip')}")
+      out = inspec("exec --no-write-lockfile #{File.join(profile_path, 'profile-support-skip')}")
       out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m0 successful\e[0m, \e[31m0 failures\e[0m, \e[37m2 skipped\e[0m\n"
     end
   end


### PR DESCRIPTION
This commit threads through some state related to whether or not a
profile is "local", that is whether it is a directory on disk.  If it
is, we then write out the lockfile to disk.

Signed-off-by: Steven Danna steve@chef.io
