### PR TITLE
Avoid spurious downloads during dependency management

### DIFF
--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -1,0 +1,67 @@
+# encoding: utf-8
+require 'inspec/fetcher'
+require 'forwardable'
+
+module Inspec
+  class CachedFetcher
+    extend Forwardable
+
+    attr_reader :cache, :target, :fetcher
+    def initialize(target, cache)
+      @target = target
+      @fetcher = Inspec::Fetcher.resolve(target)
+
+      if @fetcher.nil?
+        fail("Could not fetch inspec profile in #{target.inspect}.")
+      end
+
+      @cache = cache
+    end
+
+    def resolved_source
+      fetch
+      @fetcher.resolved_source
+    end
+
+    def cache_key
+      k = if target.is_a?(Hash)
+            target[:sha256] || target[:ref]
+          end
+
+      if k.nil?
+        fetcher.cache_key
+      else
+        k
+      end
+    end
+
+    def fetch
+      if cache.exists?(cache_key)
+        Inspec::Log.debug "Using cached dependency for #{target}"
+        [cache.prefered_entry_for(cache_key), false]
+      else
+        Inspec::Log.debug "Dependency does not exist in the cache #{target}"
+        fetcher.fetch(cache.base_path_for(fetcher.cache_key))
+        assert_cache_sanity!
+        [fetcher.archive_path, fetcher.writable?]
+      end
+    end
+
+    def assert_cache_sanity!
+      if target.respond_to?(:key?) && target.key?(:sha256)
+        if fetcher.resolved_source[:sha256] != target[:sha256]
+          fail <<EOF
+The remote source #{fetcher} no longer has the requested content:
+
+Request Content Hash: #{target[:sha256]}
+ Actual Content Hash: #{fetcher.resolved_source[:sha256]}
+
+For URL, supermarket, compliance, and other sources that do not
+provide versioned artifacts, this likely means that the remote source
+has changed since your lockfile was generated.
+EOF
+        end
+      end
+    end
+  end
+end

--- a/lib/inspec/plugins/fetcher.rb
+++ b/lib/inspec/plugins/fetcher.rb
@@ -24,6 +24,8 @@ module Inspec
         Inspec::Fetcher
       end
 
+      attr_accessor :target
+
       def writable?
         false
       end


### PR DESCRIPTION
Before, a URL based source might be downloaded multiple times during the
dependency fetching and lockfile creation. This commit tries to avoid
this by:

1) Memoizing data about the archive to avoid re-fetching the archive

2) Adding a CachedFetcher wrapper around the fetcher class to help
ensure that callers always consult the cache before fetching.

Signed-off-by: Steven Danna steve@chef.io
