### PR TITLE
return empty array for known privileges

### DIFF
--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -16,6 +16,57 @@
 require 'hashie'
 
 module Inspec::Resources
+  # known and supported MS privilege rights
+  # @see https://technet.microsoft.com/en-us/library/dd277311.aspx
+  # @see https://msdn.microsoft.com/en-us/library/windows/desktop/bb530716(v=vs.85).aspx
+  MS_PRIVILEGES_RIGHTS = [
+    'SeNetworkLogonRight',
+    'SeBackupPrivilege',
+    'SeChangeNotifyPrivilege',
+    'SeSystemtimePrivilege',
+    'SeCreatePagefilePrivilege',
+    'SeDebugPrivilege',
+    'SeRemoteShutdownPrivilege',
+    'SeAuditPrivilege',
+    'SeIncreaseQuotaPrivilege',
+    'SeIncreaseBasePriorityPrivilege',
+    'SeLoadDriverPrivilege',
+    'SeBatchLogonRight',
+    'SeServiceLogonRight',
+    'SeInteractiveLogonRight',
+    'SeSecurityPrivilege',
+    'SeSystemEnvironmentPrivilege',
+    'SeProfileSingleProcessPrivilege',
+    'SeSystemProfilePrivilege',
+    'SeAssignPrimaryTokenPrivilege',
+    'SeRestorePrivilege',
+    'SeShutdownPrivilege',
+    'SeTakeOwnershipPrivilege',
+    'SeUndockPrivilege',
+    'SeManageVolumePrivilege',
+    'SeRemoteInteractiveLogonRight',
+    'SeImpersonatePrivilege',
+    'SeCreateGlobalPrivilege',
+    'SeIncreaseWorking',
+    'SeTimeZonePrivilege',
+    'SeCreateSymbolicLinkPrivilege',
+    'SeDenyNetworkLogonRight', # Deny access to this computer from the network
+    'SeDenyInteractiveLogonRight', # Deny logon locally
+    'SeDenyBatchLogonRight', # Deny logon as a batch job
+    'SeDenyServiceLogonRight', # Deny logon as a service
+    'SeTcbPrivilege',
+    'SeMachineAccountPrivilege',
+    'SeCreateTokenPrivilege',
+    'SeCreatePermanentPrivilege',
+    'SeEnableDelegationPrivilege',
+    'SeLockMemoryPrivilege',
+    'SeSyncAgentPrivilege',
+    'SeUnsolicitedInputPrivilege',
+    'SeTrustedCredManAccessPrivilege',
+    'SeRelabelPrivilege', # the privilege to change a Windows integrity label (new to Windows Vista)
+    'SeDenyRemoteInteractiveLogonRight', # Deny logon through Terminal Services
+  ].freeze
+
   class SecurityPolicy < Inspec.resource(1)
     name 'security_policy'
     desc 'Use the security_policy InSpec audit resource to test security policies on the Microsoft Windows platform.'
@@ -42,6 +93,9 @@ module Inspec::Resources
       # deep search for hash key
       params.extend Hashie::Extensions::DeepFind
       res = params.deep_find(name.to_s)
+
+      # return an empty array if configuration does not include rights configuration
+      return [] if res.nil? && MS_PRIVILEGES_RIGHTS.include?(name.to_s)
       res
     end
 


### PR DESCRIPTION
This PR prevents cases, where a specific privilege has not been configured. The `include` matcher will throw an error if used on `nil` elements.

```
(users.where { username =~ /.*/}.uids.entries + groups.where { name =~ /.*/}.gids.entries).each do |entry|
    describe security_policy do
      its("SeTcbPrivilege") { should_not include entry }
    end
  end
```

Therefore it turns:

```
inspec> (users.where { username =~ /.*/}.uids.entries + groups.where { name =~ /.*/}.gids.entries).each do |entry|
inspec>   describe security_policy do    
inspec>     its("SeTcbPrivilege") { should_not include entry }      
inspec>   end      
inspec> end    

  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-21-1759981009-4135989804-1844563890-500"
     expected nil not to include "S-1-5-21-1759981009-4135989804-1844563890-500", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-21-1759981009-4135989804-1844563890-501"
     expected nil not to include "S-1-5-21-1759981009-4135989804-1844563890-501", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-21-1759981009-4135989804-1844563890-1001"
     expected nil not to include "S-1-5-21-1759981009-4135989804-1844563890-1001", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-579"
     expected nil not to include "S-1-5-32-579", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-544"
     expected nil not to include "S-1-5-32-544", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-551"
     expected nil not to include "S-1-5-32-551", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-574"
     expected nil not to include "S-1-5-32-574", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-569"
     expected nil not to include "S-1-5-32-569", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-562"
     expected nil not to include "S-1-5-32-562", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-573"
     expected nil not to include "S-1-5-32-573", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-546"
     expected nil not to include "S-1-5-32-546", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-578"
     expected nil not to include "S-1-5-32-578", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-568"
     expected nil not to include "S-1-5-32-568", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-556"
     expected nil not to include "S-1-5-32-556", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-559"
     expected nil not to include "S-1-5-32-559", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-558"
     expected nil not to include "S-1-5-32-558", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-547"
     expected nil not to include "S-1-5-32-547", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-550"
     expected nil not to include "S-1-5-32-550", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-576"
     expected nil not to include "S-1-5-32-576", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-577"
     expected nil not to include "S-1-5-32-577", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-575"
     expected nil not to include "S-1-5-32-575", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-555"
     expected nil not to include "S-1-5-32-555", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-580"
     expected nil not to include "S-1-5-32-580", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-552"
     expected nil not to include "S-1-5-32-552", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-32-545"
     expected nil not to include "S-1-5-32-545", but it does not respond to `include?`
  Security Policy
     ✖  SeTcbPrivilege should not include "S-1-5-21-1759981009-4135989804-1844563890-1000"
     expected nil not to include "S-1-5-21-1759981009-4135989804-1844563890-1000", but it does not respond to `include?`
```

into

```
inspec> (users.where { username =~ /.*/}.uids.entries + groups.where { name =~ /.*/}.gids.entries).each do |entry|
inspec>   describe security_policy do    
inspec>     its("SeTcbPrivilege") { should_not include entry }      
inspec>   end      
inspec> end    

  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-21-1759981009-4135989804-1844563890-500"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-21-1759981009-4135989804-1844563890-501"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-21-1759981009-4135989804-1844563890-1001"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-579"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-544"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-551"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-574"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-569"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-562"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-573"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-546"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-578"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-568"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-556"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-559"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-558"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-547"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-550"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-576"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-577"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-575"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-555"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-580"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-552"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-32-545"
  Security Policy
     ✔  SeTcbPrivilege should not include "S-1-5-21-1759981009-4135989804-1844563890-1000"

```
