### PR TITLE
Fix require_controls DSL method

### DIFF
--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -53,12 +53,15 @@ EOF
   end
 
   def self.filter_included_controls(context, profile, &block)
-    include_ctx = profile.runner_context
+    mock = Inspec::Backend.create({ backend: 'mock' })
+    include_ctx = Inspec::ProfileContext.for_profile(profile, mock, {})
     include_ctx.load(block) if block_given?
     # remove all rules that were not registered
-    context.rules.keys.each do |id|
-      unless include_ctx.rules[id]
-        context.rules[id] = nil
+    context.all_rules.each do |r|
+      id = Inspec::Rule.rule_id(r)
+      fid = Inspec::Rule.profile_id(r) + '/' + id
+      unless include_ctx.rules[id] || include_ctx.rules[fid]
+        context.remove_rule(fid)
       end
     end
   end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -388,6 +388,7 @@ module Inspec
       params[:groups] = groups = {}
       prefix = @source_reader.target.prefix || ''
       tests.each do |rule|
+        next if rule.nil?
         f = load_rule_filepath(prefix, rule)
         load_rule(rule, f, controls, groups)
       end

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -67,6 +67,13 @@ module Inspec
       @conf['profile'].supports_os?
     end
 
+    def remove_rule(id)
+      @rules[id] = nil if @rules.key?(id)
+      @control_subcontexts.each do |c|
+        c.remove_rule(id)
+      end
+    end
+
     def all_controls
       ret = @rules.values
       ret += @control_subcontexts.map(&:all_rules).flatten

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -86,7 +86,7 @@ module Inspec
       end
 
       all_controls.each do |rule|
-        register_rule(rule)
+        register_rule(rule) unless rule.nil?
       end
     end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -197,6 +197,15 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
     end
   end
 
+  describe 'with require_controls' do
+    it 'does not run rules you did not include' do
+      out = inspec('exec ' + File.join(profile_path, 'dependencies', 'require_controls_test') + ' --no-create-lockfile')
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[32m1 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[0m\n"
+    end
+  end
+
   describe "with a 2-level dependency tree" do
     it 'correctly runs tests from the whole tree' do
       out = inspec('exec ' + File.join(profile_path, 'dependencies', 'inheritance') + ' --no-create-lockfile')

--- a/test/unit/mock/profiles/dependencies/require_controls_test/controls/example.rb
+++ b/test/unit/mock/profiles/dependencies/require_controls_test/controls/example.rb
@@ -1,0 +1,6 @@
+# encoding: utf-8
+
+require_controls 'profile_a'
+require_controls 'profile_b' do
+  control 'profileb-2'
+end

--- a/test/unit/mock/profiles/dependencies/require_controls_test/inspec.yml
+++ b/test/unit/mock/profiles/dependencies/require_controls_test/inspec.yml
@@ -1,0 +1,12 @@
+name: require_controls_test
+title: InSpec example inheritance
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
+copyright_email: support@chef.io
+license: Apache 2 license
+version: 1.0.0
+depends:
+  - name: profile_a
+    path: ../profile_a
+  - name: profile_b
+    path: ../profile_b


### PR DESCRIPTION
Previous, require_controls was including all controls from the named
profile, despite the documented behavior being that it only includes
controls explicitly pulled in by the user.  The cause was two-fold:

1) A previous refactor meant that we weren't removing the rule from the
correct context, and

2) We weren't descending down the dependency tree when filtering rules.

This commit fixes the require_controls DSL method and adds a test to
help prevent future regressions.

Signed-off-by: Steven Danna steve@chef.io
