### PR TITLE
fix processes resource for os's where username is long to avoid truncation

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -138,8 +138,8 @@ class MockLoader
     }
 
     mock.commands = {
-      'ps aux' => cmd.call('ps-aux'),
-      'ps auxZ' => cmd.call('ps-auxZ'),
+      'ps axo pid,pcpu,pmem,vsz,rss,tty,stat,start,time,comm,user' => cmd.call('ps-axo'),
+      'ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,comm,user' => cmd.call('ps-axoZ'),
       'Get-Content win_secpol.cfg' => cmd.call('secedit-export'),
       'secedit /export /cfg win_secpol.cfg' => cmd.call('success'),
       'Remove-Item win_secpol.cfg' => cmd.call('success'),

--- a/test/unit/mock/cmd/ps-aux
+++ b/test/unit/mock/cmd/ps-aux
@@ -1,5 +1,0 @@
-USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-root         1  0.0  0.0  18084  3228 ?        Ss   14:15   0:00 /bin/bash
-root        13  0.0  0.0  15284  2148 ?        R+   15:08   0:00 ps aux
-noot        19  0.0  0.0  24521  1536 s001     Ss   09:23   0:00 svc
-noot        23  0.0  0.0  25044  1908 s000     S    08:46   0:00 svc

--- a/test/unit/mock/cmd/ps-auxZ
+++ b/test/unit/mock/cmd/ps-auxZ
@@ -1,3 +1,0 @@
-LABEL                            USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-system_u:system_r:kernel_t:s0    root         1  0.0  0.0  19232  1492 ?        Ss   May04   0:01 /sbin/init
-system_u:system_r:kernel_t:s0    root        39  0.0  0.0      0     0 ?        S    May04   0:00 crypto/0

--- a/test/unit/mock/cmd/ps-axo
+++ b/test/unit/mock/cmd/ps-axo
@@ -1,0 +1,5 @@
+PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND   USER
+  1  0.0  0.0  18084  3228 ?        Ss   14:15   0:00 /bin/bash root
+ 13  0.0  0.0  15284  2148 ?        R+   15:08   0:00 ps aux    root
+ 19  0.0  0.0  24521  1536 s001     Ss   09:23   0:00 svc       noot
+ 23  0.0  0.0  25044  1908 s000     S    08:46   0:00 svc       noot

--- a/test/unit/mock/cmd/ps-axoZ
+++ b/test/unit/mock/cmd/ps-axoZ
@@ -1,0 +1,3 @@
+LABEL                          PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND    USER
+system_u:system_r:kernel_t:s0    1  0.0  0.0  19232  1492 ?        Ss   May04   0:01 /sbin/init root
+system_u:system_r:kernel_t:s0   39  0.0  0.0      0     0 ?        S    May04   0:00 crypto/0   root

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -16,7 +16,6 @@ describe 'Inspec::Resources::Processes' do
     _(resource.list.length).must_equal 1
     _(resource.list[0].to_h).must_equal({
       label: nil,
-      user: 'root',
       pid: 1,
       cpu: '0.0',
       mem: '0.0',
@@ -27,6 +26,7 @@ describe 'Inspec::Resources::Processes' do
       start: '14:15',
       time: '0:00',
       command: '/bin/bash',
+      user: 'root',
     })
   end
 
@@ -35,7 +35,6 @@ describe 'Inspec::Resources::Processes' do
     _(resource.list.length).must_equal 1
     _(resource.list[0].to_h).must_equal({
       label: 'system_u:system_r:kernel_t:s0',
-      user: 'root',
       pid: 1,
       cpu: '0.0',
       mem: '0.0',
@@ -46,6 +45,7 @@ describe 'Inspec::Resources::Processes' do
       start: 'May04',
       time: '0:01',
       command: '/sbin/init',
+      user: 'root',
     })
   end
 
@@ -55,7 +55,8 @@ describe 'Inspec::Resources::Processes' do
     process.user.must_equal 'root'
     process[:user].must_equal 'root'
     process['user'].must_equal 'root'
-    process[1].must_equal 'root'
+    process[-1].must_equal 'root'
+    process[1].must_equal 1
   end
 
   it 'retrieves the users and states as arrays' do


### PR DESCRIPTION
Proposed fix for #995 
Moves the username at the end of the field list to avoid getting truncated in OS's like Ubuntu. The last field does not get truncated, however long it may be.
