### PR TITLE
Website: Fix docs nav functionality and optimize for mobile

### DIFF
--- a/www/source/javascripts/nav.js
+++ b/www/source/javascripts/nav.js
@@ -3,9 +3,10 @@ const $navLinks = $('.main-nav--links');
 const $navToggle = $('.main-nav--toggle');
 const navBreakpoint = 730; // this should match $nav-breakpoint in _nav.scss
 const $mainContent = $('#main-content');
+const $mainNav = $('#main-nav');
 
 $(document).ready(function() {
-  $mainContent.css('min-height', $('#main-nav').outerHeight() - $('#main-nav-ctas').outerHeight());
+  $mainContent.css('min-height', $mainNav.outerHeight() - $('#main-nav-ctas').outerHeight());
 });
 
 $navToggle.click(function() {
@@ -25,9 +26,9 @@ const footerOffsetTop = $("#main-footer").offset().top;
 var navOffsetBottom;
 
 function toggleFixedNavPosition() {
-  navOffsetBottom = $("#main-nav").outerHeight() + $(window).scrollTop();
+  navOffsetBottom = $mainNav.outerHeight() + $(window).scrollTop();
 
-  $("#main-nav").toggleClass("is-fixed-bottom", footerOffsetTop < navOffsetBottom)
+  $mainNav.toggleClass("is-fixed-bottom", footerOffsetTop < navOffsetBottom)
 }
 
 toggleFixedNavPosition();

--- a/www/source/javascripts/nav.js
+++ b/www/source/javascripts/nav.js
@@ -2,6 +2,11 @@
 const $navLinks = $('.main-nav--links');
 const $navToggle = $('.main-nav--toggle');
 const navBreakpoint = 730; // this should match $nav-breakpoint in _nav.scss
+const $mainContent = $('#main-content');
+
+$(document).ready(function() {
+  $mainContent.css('min-height', $('#main-nav').outerHeight() - $('#main-nav-ctas').outerHeight());
+});
 
 $navToggle.click(function() {
   $(this).toggleClass('is-active');
@@ -13,4 +18,20 @@ $(window).resize(function() {
     $navToggle.removeClass('is-active');
     $navLinks.attr("style", "");
   }
+});
+
+// toggles fixed nav position when the window is too short
+const footerOffsetTop = $("#main-footer").offset().top;
+var navOffsetBottom;
+
+function toggleFixedNavPosition() {
+  navOffsetBottom = $("#main-nav").outerHeight() + $(window).scrollTop();
+
+  $("#main-nav").toggleClass("is-fixed-bottom", footerOffsetTop < navOffsetBottom)
+}
+
+toggleFixedNavPosition();
+
+$(window).scroll(function() {
+  toggleFixedNavPosition();
 });

--- a/www/source/layouts/_nav.slim
+++ b/www/source/layouts/_nav.slim
@@ -9,7 +9,8 @@ nav#main-nav class="sidebar-layout-#{locals[:sidebar_layout]}"
       a.button.transparent.try-demo href="#" Try the Demo
       a.button.secondary href="https://downloads.chef.io/inspec" Download
     - if locals[:sidebar_layout] == 'docs'
-      = partial "layouts/sidebar"
+      li.main-nav--sidebar
+        = partial "layouts/sidebar"
     - else
       li.main-nav--link
         a href="/"

--- a/www/source/layouts/_sidebar.slim
+++ b/www/source/layouts/_sidebar.slim
@@ -1,19 +1,16 @@
-.container__has-sidebar
-  .row
-    .main-sidebar
-        - if locals[:sidebar_layout] == 'docs'
-          form.main-sidebar--search action="/docs/search/" method="get"
-            input type="text" placeholder="Search Documentation" name="q"
-        ul.main-sidebar--links
-          - sidebar_data(sidebar_layout).each do |item|
-            li.main-sidebar--link
-              h6 = item.title
-              ul.main-sidebar--list.no-bullet
-                - item.links.each do |item_link|
-                  li.main-sidebar--list--item class=link_classes(current_resource.url, item_link)
-                    = link_to item_link.title, item_link.link
-                    - if print_sub_links?(current_resource.url, item_link)
-                      ul.main-sidebar--list--item--dropdown.no-bullet
-                        - item_link.sub_links.each do |sub_link|
-                          li.main-sidebar--list--item  class=link_classes(current_resource.url, sub_link)
-                            = link_to sub_link.title, sub_link.link
+- if locals[:sidebar_layout] == 'docs'
+  form.main-sidebar--search action="/docs/search/" method="get"
+    input type="text" placeholder="Search Documentation" name="q"
+ul.main-sidebar--links
+  - sidebar_data(sidebar_layout).each do |item|
+    li.main-sidebar--link
+      h6 = item.title
+      ul.main-sidebar--list.no-bullet
+        - item.links.each do |item_link|
+          li.main-sidebar--list--item class=link_classes(current_resource.url, item_link)
+            = link_to item_link.title, item_link.link
+            - if print_sub_links?(current_resource.url, item_link)
+              ul.main-sidebar--list--item--dropdown.no-bullet
+                - item_link.sub_links.each do |sub_link|
+                  li.main-sidebar--list--item  class=link_classes(current_resource.url, sub_link)
+                    = link_to sub_link.title, sub_link.link

--- a/www/source/stylesheets/_layout.scss
+++ b/www/source/stylesheets/_layout.scss
@@ -1,4 +1,5 @@
 body {
+  position: relative;
   font-family: $main-font;
   color: $body-text;
 }

--- a/www/source/stylesheets/_nav.scss
+++ b/www/source/stylesheets/_nav.scss
@@ -28,6 +28,11 @@ $nav-breakpoint: 730px;
     position: fixed;
     z-index: 100;
     width: $side-nav-width;
+
+    &.is-fixed-bottom {
+      bottom: 137px;
+      position: absolute;
+    }
   }
 }
 
@@ -92,6 +97,11 @@ $nav-breakpoint: 730px;
 
   @include nav-small {
     display: none;
+  }
+
+  .sidebar-layout-docs & {
+    max-height: calc(100vh - 64px);
+    overflow-y: scroll;
   }
 }
 

--- a/www/source/stylesheets/_sidebar.scss
+++ b/www/source/stylesheets/_sidebar.scss
@@ -1,6 +1,26 @@
-.main-sidebar ul {
+.sidebar-layout-docs {
+  .main-nav--links {
+    border-top: none;
+  }
+
+  .main-nav--link-ctas {
+    border-bottom: none;
+    margin-bottom: 3px;
+  }
+}
+
+.main-nav--sidebar {
+  padding: 0 $side-nav-padding-small;
+
+  @include nav-large {
+    padding: 0 $side-nav-padding-large;
+  }
+}
+
+.main-sidebar--links {
   list-style: none;
   margin-left: 0.5rem;
+
   ul {
     margin-left: 0;
     margin-bottom: 1rem;
@@ -9,7 +29,6 @@
 
 .main-sidebar--link h6 {
   font-weight: 500;
-
 }
 
 .main-sidebar--list--item {
@@ -63,10 +82,4 @@
     height: 27px;
     min-width: 54px;
   }
-}
-
-// FIXME: this is used to remove the top border line of the search
-// see https://github.com/chef/inspec/issues/1114#issuecomment-249525984
-.sidebar-layout-docs > .main-nav--links {
-  border-top: none;
 }


### PR DESCRIPTION
A few minor styling fixes for the docs nav for mobile, refactoring
the markup to remove unneeded parent elements, and fixing a
bug where the nav overlapped with the footer if the window was
too short.

![inspec-docs-nav](https://cloud.githubusercontent.com/assets/7217000/18849696/0446c626-83e9-11e6-8830-35409be06845.gif)
