### PR TITLE
Remove default parameter in `updateInstructions()`

### DIFF
--- a/www/tutorial/app/app.component.ts
+++ b/www/tutorial/app/app.component.ts
@@ -68,7 +68,7 @@ export class AppComponent implements OnInit {
   }
 
   // called when tutorial commands need to be displayed
-  updateInstructions(step = null) {
+  updateInstructions(step?) {
     // if step is given, we calculate the new index
     let totalSteps = this.instructionsArray.length - 1;
     switch(step) {


### PR DESCRIPTION
Some browsers [do not support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters#Browser_compatibility) the use of default parameters. 

Moving the logic that sets `step` to null if undefined into the function body allows those browsers to render the tutorial correctly.

This fixes #1165 
