### PR TITLE
Ignore lockfiles in example profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Puppetfile.lock
 profile.tar.gz
 omnibus/.cache
 omnibus/pkg
+test/**/*.lock
+examples/**/*.lock


### PR DESCRIPTION
These get generated if you run the tests manually sometimes and clutter
up git-status.

Signed-off-by: Steven Danna steve@chef.io
