### PR TITLE
move inquirer to deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache: bundler
 dist: trusty
 services:
 - docker
-bundler_args: "--without integration tools maintenance"
+bundler_args: "--without integration tools maintenance deploy"
 before_install:
 - gem install bundler
 - gem update --system 2.4.5

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ group :test do
   gem 'concurrent-ruby', '~> 0.9'
   gem 'mocha', '~> 1.1'
   gem 'ruby-progressbar', '~> 1.8'
-  gem 'inquirer'
   gem 'nokogiri', '~> 1.6'
 end
 
@@ -59,4 +58,8 @@ group :maintenance do
   # To sync maintainers with github
   gem 'octokit'
   gem 'netrc'
+end
+
+group :deploy do
+  gem 'inquirer'
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - ruby -r rubygems -e "p Gem.path"
 
 build_script:
-  - bundle install --path=vendor/bundle --without integration tools maintenance
+  - bundle install --path=vendor/bundle --without integration tools maintenance deploy
 
 test_script:
   - SET SPEC_OPTS=--format progress

--- a/tasks/www.rb
+++ b/tasks/www.rb
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-require 'inquirer'
 require_relative 'shared.rb'
 
 namespace :www do
@@ -102,6 +101,7 @@ namespace :www do
     Log.info 'Commit to gh-pages'
     system("git commit -m 'website update'")
 
+    require 'inquirer'
     if Ask.confirm("Ready to go, I have #{file_count} files at #{file_size}. "\
                    'Do you want to push this live?', default: false)
       Log.info 'push to origin, this may take a moment'


### PR DESCRIPTION
this will unblock us. at the moment, we're failing out all 1.9.3 tests on appveyor and travis
