### PR TITLE
Changing headings to align with SEO best practices

### DIFF
--- a/docs/resources/apache_conf.md.erb
+++ b/docs/resources/apache_conf.md.erb
@@ -6,7 +6,7 @@ title: About the apache_conf Resource
 
 Use the `apache_conf` InSpec audit resource to test the configuration settings for Apache. This file is typically located under `/etc/apache2` on the Debian and Ubuntu platforms and under `/etc/httpd` on the Fedora, CentOS, RedHat Enterprise Linux, and ArchLinux platforms. The configuration settings may vary significantly from platform to platform.
 
-# Syntax
+## Syntax
 
 An `apache_conf` InSpec audit resource block declares configuration settings that should be tested:
 
@@ -20,7 +20,7 @@ where
 * `('path')` is the non-default path to the Apache configuration file
 * `{ should eq 'value' }` is the value that is expected
 
-# Matchers
+## Matchers
 
 This InSpec audit resource matches any service that is listed in the Apache configuration file:
 
@@ -38,37 +38,37 @@ For example:
     end
 
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test for blocking .htaccess files on CentOS
+### Test for blocking .htaccess files on CentOS
 
     describe apache_conf do
       its('AllowOverride') { should eq 'None' }
     end
 
-## Test ports for SSL
+### Test ports for SSL
 
     describe apache_conf do
       its('Listen') { should eq '443'}

--- a/docs/resources/apt.md.erb
+++ b/docs/resources/apt.md.erb
@@ -6,7 +6,7 @@ title: About the apt Resource
 
 Use the `apt` InSpec audit resource to verify Apt repositories on the Debian and Ubuntu platforms, and also PPA repositories on the Ubuntu platform.
 
-# Syntax
+## Syntax
 
 An `apt` resource block tests the contents of Apt and PPA repositories:
 
@@ -22,61 +22,61 @@ where
 * `exist` and `be_enabled` are a valid matchers for this resource
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_enabled
+### be_enabled
 
 The `be_enabled` matcher tests if a package exists in the repository:
 
     it { should be_enabled }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if a package exists on the system:
 
     it { should exist }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if apt repository exists and is enabled
+### Test if apt repository exists and is enabled
 
     describe apt('http://ppa.launchpad.net/juju/stable/ubuntu') do
       it { should exist }
       it { should be_enabled }
     end
 
-## Verify that a PPA repository exists and is enabled
+### Verify that a PPA repository exists and is enabled
 
     describe apt('ppa:nginx/stable') do
       it { should exist }
       it { should be_enabled }
     end
 
-## Verify that a repository is not present
+### Verify that a repository is not present
 
     describe apt('ubuntu-wine/ppa') do
       it { should_not exist }

--- a/docs/resources/audit_policy.md.erb
+++ b/docs/resources/audit_policy.md.erb
@@ -6,7 +6,7 @@ title: About the audit_policy Resource
 
 Use the `audit_policy` Inspec audit resource to test auditing policies on the Windows platform. An auditing policy is a category of security-related events to be audited. Auditing is disabled by default and may be enabled for categories like account management, logon events, policy changes, process tracking, privilege use, system events, or object access. For each auditing category property that is enabled, the auditing level may be set to `No Auditing`, `Not Specified`, `Success`, `Success and Failure`, or `Failure`.
 
-# Syntax
+## Syntax
 
 An `audit_policy` resource block declares a parameter that belongs to an audit policy category or subcategory:
 
@@ -20,41 +20,41 @@ where
 * `'value'` must be one of `No Auditing`, `Not Specified`, `Success`, `Success and Failure`, or `Failure`
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test that a parameter is not set to "No Auditing"
+### Test that a parameter is not set to "No Auditing"
 
     describe audit_policy do
       its('Other Account Logon Events') { should_not eq 'No Auditing' }
     end
 
-## Test that a parameter is set to "Success"
+### Test that a parameter is set to "Success"
 
     describe audit_policy do
       its('User Account Management') { should eq 'Success' }

--- a/docs/resources/auditd_conf.md.erb
+++ b/docs/resources/auditd_conf.md.erb
@@ -6,7 +6,7 @@ title: About the auditd_conf Resource
 
 Use the `auditd_conf` InSpec audit resource to test the configuration settings for the audit daemon. This file is typically located under `/etc/audit/auditd.conf'` on Unix and Linux platforms.
 
-# Syntax
+## Syntax
 
 A `auditd_conf` resource block declares configuration settings that should be tested:
 
@@ -21,27 +21,27 @@ where
 * `{ should cmp 'value' }` is the value that is expected
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## keyword
+### keyword
 
 This matcher will matche any keyword that is listed in the `auditd.conf` configuration file. Option names and values are case-insensitive:
 
@@ -51,15 +51,15 @@ or:
 
     its('max_log_file') { should cmp 6 }
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test the auditd.conf file
+### Test the auditd.conf file
 
     describe auditd_conf do
       its('log_file') { should cmp '/full/path/to/file' }

--- a/docs/resources/auditd_rules.md.erb
+++ b/docs/resources/auditd_rules.md.erb
@@ -7,7 +7,7 @@ title: About the auditd_rules Resource
 Use the `auditd_rules` InSpec audit resource to test the rules for logging that exist on the system. The `audit.rules` file is typically located under `/etc/audit/` and contains the list of rules that define what is captured in log files. This resource uses `auditctl` to query the run-time `auditd` rules setup, which may be different from `audit.rules`.
 
 
-# Syntax
+## Syntax
 
 An `auditd_rules` resource block declares one (or more) rules to be tested, and then what that rule should do. The syntax depends on the version of `audit`:
 
@@ -62,35 +62,35 @@ or test that individual rules are defined:
 where each test must declare one (or more) rules to be tested.
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if a rule contains a matching element that is identified by a regular expression
+### Test if a rule contains a matching element that is identified by a regular expression
 
 For `audit` >= 2.3:
 
@@ -109,13 +109,13 @@ For `audit` < 2.3:
     end
 
 
-## Query the audit daemon status
+### Query the audit daemon status
 
     describe auditd_rules.status('backlog') do
       it { should cmp 0 }
     end
 
-## Query properties of rules targeting specific syscalls or files
+### Query properties of rules targeting specific syscalls or files
 
     describe auditd_rules.syscall('open').action do
       it { should eq(['always']) }

--- a/docs/resources/bash.md.erb
+++ b/docs/resources/bash.md.erb
@@ -6,7 +6,7 @@ title: About the bash Resource
 
 Use the `bash` InSpec audit resource to test an arbitrary command that is run on the system using a Bash script.
 
-# Syntax
+## Syntax
 
 A `command` resource block declares a command to be run, one (or more) expected outputs, and the location to which that output is sent:
 
@@ -30,55 +30,55 @@ For example:
     end
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if a command may be run on the system:
 
     it { should exist }
 
-## exit_status
+### exit_status
 
 The `exit_status` matcher tests the exit status for the command:
 
     its('exit_status') { should eq 0 }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## stderr
+### stderr
 
 The `stderr` matcher tests results of the command as returned in standard error (stderr):
 
     its('stderr') { should eq '' }
 
-## stdout
+### stdout
 
 The `stdout` matcher tests results of the command as returned in standard output (stdout).
 
     its('stdout') { should match /bin/ }
 
 
-# Examples
+## Examples
 
 None.

--- a/docs/resources/bond.md.erb
+++ b/docs/resources/bond.md.erb
@@ -6,7 +6,7 @@ title: About the bond Resource
 
 Use the `bond` InSpec audit resource to test a logical, bonded network interface (i.e. "two or more network interfaces aggregated into a single, logical network interface"). On Linux platforms, any value in the `/proc/net/bonding` directory may be tested.
 
-# Syntax
+## Syntax
 
 A `bond` resource block declares a bonded network interface, and then specifies the properties of that bonded network interface to be tested:
 
@@ -20,72 +20,72 @@ where
 * `{ should exist }` is a valid matcher for this resource
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## content
+### content
 
 The `content` matcher tests if contents in the file that defines the bonded network interface match the value specified in the test. The values of the `content` matcher are arbitrary:
 
     its('content') { should match('value') }
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if the bonded network interface is available:
 
     it { should exist }
 
-## have_interface
+### have_interface
 
 The `have_interface` matcher tests if the bonded network interface has one (or more) secondary interfaces:
 
     it { should have_interface }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## interfaces
+### interfaces
 
 The `interfaces` matcher tests if the named secondary interfaces are available:
 
     its('interfaces') { should eq ['eth0', 'eth1', ...] }
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## params
+### params
 
 The `params` matcher tests arbitrary parameters for the bonded network interface:
 
     its('params') { should eq 'value' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if eth0 is a secondary interface for bond0
+### Test if eth0 is a secondary interface for bond0
 
     describe bond('bond0') do
       it { should exist }
       it { should have_interface 'eth0' }
     end
 
-## Test parameters for bond0
+### Test parameters for bond0
 
     describe bond('bond0') do
       its('Bonding Mode') { should eq 'IEEE 802.3ad Dynamic link aggregation' }

--- a/docs/resources/bridge.md.erb
+++ b/docs/resources/bridge.md.erb
@@ -9,7 +9,7 @@ Use the `bridge` InSpec audit resource to test basic network bridge properties, 
 * On Linux platforms, any value in the `/sys/class/net/{interface}/bridge` directory may be tested
 * On the Windows platform, the `Get-NetAdapter` cmdlet is associated with the `Get-NetAdapterBinding` cmdlet and returns the `ComponentID ms_bridge` value as a JSON object
 
-# Syntax
+## Syntax
 
 A `bridge` resource block declares the bridge to be tested and what interface it should be associated with:
 
@@ -18,39 +18,39 @@ A `bridge` resource block declares the bridge to be tested and what interface it
       it { should have_interface 'eth0' }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if the network bridge is available:
 
     it { should exist }
 
-## have_interface
+### have_interface
 
 The `have_interface` matcher tests if the named interface is defined for the network bridge:
 
     it { should have_interface 'eth0' }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## interfaces
+### interfaces
 
 The `interfaces` matcher tests if the named interface is present:
 
@@ -58,10 +58,10 @@ The `interfaces` matcher tests if the named interface is present:
     its('interfaces') { should eq 'bar' }
     its('interfaces') { should include('foo') }
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 None.

--- a/docs/resources/bsd_service.md.erb
+++ b/docs/resources/bsd_service.md.erb
@@ -6,7 +6,7 @@ title: About the bsd_service Resource
 
 Use the `bsd_service` InSpec audit resource to test a service using a Berkeley OS-style `init` on the FreeBSD platform.
 
-# Syntax
+## Syntax
 
 A `bsd_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
@@ -29,48 +29,48 @@ The path to the service manager's control may be specified for situations where 
       it { should be_running }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_enabled
+### be_enabled
 
 The `be_enabled` matcher tests if the named service is enabled:
 
     it { should be_enabled }
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
     it { should be_installed }
 
-## be_running
+### be_running
 
 The `be_running` matcher tests if the named service is running:
 
     it { should be_running }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 None.

--- a/docs/resources/command.md.erb
+++ b/docs/resources/command.md.erb
@@ -6,7 +6,7 @@ title: About the command Resource
 
 Use the `command` InSpec audit resource to test an arbitrary command that is run on the system.
 
-# Syntax
+## Syntax
 
 A `command` resource block declares a command to be run, one (or more) expected outputs, and the location to which that output is sent:
 
@@ -22,49 +22,49 @@ where
 * `'output'` tests the output of the command run on the system versus the output value stated in the test
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if a command may be run on the system:
 
     it { should exist }
 
-## exit_status
+### exit_status
 
 The `exit_status` matcher tests the exit status for the command:
 
     its('exit_status') { should eq 123 }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## stderr
+### stderr
 
 The `stderr` matcher tests results of the command as returned in standard error (stderr):
 
     its('stderr') { should eq 'error' }
 
-## stdout
+### stdout
 
 The `stdout` matcher tests results of the command as returned in standard output (stdout). The following example shows matching output using a regular expression:
 
@@ -72,11 +72,11 @@ The `stdout` matcher tests results of the command as returned in standard output
        its('stdout') { should match (/[0-9]/) }
     end
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test for PostgreSQL database running a RC, development, or beta release
+### Test for PostgreSQL database running a RC, development, or beta release
 
     describe command('psql -V') do
       its('stdout') { should eq '/RC/' }
@@ -84,7 +84,7 @@ The following examples show how to use this InSpec audit resource.
       its('stdout') { should_not eq '/BETA/' }
     end
 
-## Test standard output (stdout)
+### Test standard output (stdout)
 
     describe command('echo hello') do
       its('stdout') { should eq 'hello\n' }
@@ -92,7 +92,7 @@ The following examples show how to use this InSpec audit resource.
       its('exit_status') { should eq 0 }
     end
 
-## Test standard error (stderr)
+### Test standard error (stderr)
 
     describe command('>&2 echo error') do
       its('stdout') { should eq '' }
@@ -100,7 +100,7 @@ The following examples show how to use this InSpec audit resource.
       its('exit_status') { should eq 0 }
     end
 
-## Test an exit status code
+### Test an exit status code
 
     describe command('exit 123') do
       its('stdout') { should eq '' }
@@ -108,19 +108,19 @@ The following examples show how to use this InSpec audit resource.
       its('exit_status') { should eq 123 }
     end
 
-## Test if the command shell exists
+### Test if the command shell exists
 
     describe command('/bin/sh').exist? do
       it { should eq true }
     end
 
-## Test for a command that should not exist
+### Test for a command that should not exist
 
     describe command('this is not existing').exist? do
       it { should eq false }
     end
 
-## Verify NTP
+### Verify NTP
 
 The following example shows how to use the `file` audit resource to verify if the `ntp.conf` and `leap-seconds` files are present, and then the `command` resource to verify if NTP is installed and running:
 
@@ -136,7 +136,7 @@ The following example shows how to use the `file` audit resource to verify if th
        its('exit_status') { should eq 0 }
     end
 
-## Verify WiX
+### Verify WiX
 
 Wix includes serveral tools -- such as `candle` (preprocesses and compiles source files into object files), `light` (links and binds object files to an installer database), and `heat` (harvests files from various input formats). The following example uses a whitespace array and the `file` audit resource to verify if these three tools are present:
 
@@ -145,7 +145,7 @@ Wix includes serveral tools -- such as `candle` (preprocesses and compiles sourc
       heat.exe
       light.exe
     ).each do |utility|
-      describe file("C:/wix/#{utility}") do
+      describe file("C:/wix/##{utility}") do
         it { should be_file }
       end
     end

--- a/docs/resources/csv.md.erb
+++ b/docs/resources/csv.md.erb
@@ -6,7 +6,7 @@ title: About the csv Resource
 
 Use the `csv` InSpec audit resource to test configuration data in a CSV file.
 
-# Syntax
+## Syntax
 
 A `csv` resource block declares the configuration data to be tested:
 
@@ -21,41 +21,41 @@ where
 * `should eq 'foo'` tests a value of `name` as read from a CSV file versus the value declared in the test
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## name
+### name
 
 The `name` matcher tests the value of `name` as read from a CSV file versus the value declared in the test:
 
     its('name') { should eq 'foo' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test a CSV file
+### Test a CSV file
 
     describe csv('some_file.csv') do
       its('setting') { should eq 1 }

--- a/docs/resources/directory.md.erb
+++ b/docs/resources/directory.md.erb
@@ -6,7 +6,7 @@ title: About the directory Resource
 
 Use the `directory` InSpec audit resource to test if the file type is a directory. This is equivalent to using the `file` resource and the `be_directory` matcher, but provides a simpler and more direct way to test directories. All of the matchers available to `file` may be used with `directory`.
 
-# Syntax
+## Syntax
 
 A `directory` resource block declares the location of the directory to be tested, and then one (or more) matchers:
 
@@ -14,30 +14,30 @@ A `directory` resource block declares the location of the directory to be tested
       it { should MATCHER 'value' }
     end
 
-# Matchers
+## Matchers
 
 This resource may use any of the matchers available to the `file` resource that may be useful when testing a directory.
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 None.

--- a/docs/resources/etc_group.md.erb
+++ b/docs/resources/etc_group.md.erb
@@ -6,7 +6,7 @@ title: About the etc_group Resource
 
 Use the `etc_group` InSpec audit resource to test groups that are defined on Linux and Unix platforms. The `/etc/group` file stores details about each group---group name, password, group identifier, along with a comma-separate list of users that belong to the group.
 
-# Syntax
+## Syntax
 
 A `etc_group` resource block declares a collection of properties to be tested:
 
@@ -28,49 +28,49 @@ where
 * `.where()` may specify a specific item and value, to which the matchers are compared
 * `'gids'`, `'groups'`, and `'users'` are valid matchers for this resource
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## gids
+### gids
 
 The `gids` matcher tests if the named group identifier is present or if it contains duplicates:
 
     its('gids') { should_not contain_duplicates }
 
-## groups
+### groups
 
 The `groups` matcher tests all groups for the named user:
 
     its('groups') { should include 'my_group' }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## users
+### users
 
 The `users` matcher tests all groups for the named user:
 
     its('users') { should include 'my_user' }
 
-## where
+### where
 
 The `where` matcher allows the test to be focused to one (or more) specific items:
 
@@ -87,29 +87,29 @@ where `item` may be one (or more) of:
 * `members: 'member_name'`
 
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test group identifiers (GIDs) for duplicates
+### Test group identifiers (GIDs) for duplicates
 
     describe etc_group do
       its('gids') { should_not contain_duplicates }
     end
 
-## Test all groups to see if a specific user belongs to one (or more) groups
+### Test all groups to see if a specific user belongs to one (or more) groups
 
     describe etc_group do
       its('groups') { should include 'my_group' }
     end
 
-## Test all groups for a specific user name
+### Test all groups for a specific user name
 
     describe etc_group do
       its('users') { should include 'my_user' }
     end
 
-## Filter a list of groups for a specific user
+### Filter a list of groups for a specific user
 
     describe etc_group.where(name: 'my_group') do
       its('users') { should include 'my_user' }

--- a/docs/resources/etc_passwd.md.erb
+++ b/docs/resources/etc_passwd.md.erb
@@ -18,7 +18,7 @@ These entries are defined as a colon-delimited row in the file, one row per user
 
     root:x:1234:5678:additional_info:/home/dir/:/bin/bash
 
-# Syntax
+## Syntax
 
 A `passwd` resource block declares one (or more) users and associated user information to be tested:
 
@@ -38,40 +38,40 @@ where
 * `filter` may take any of the following arguments: `count` (retrieves the number of entries), `lines` (provides raw `passwd` lines), and `params` (returns an array of maps for all entries)
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## gids
+### gids
 
 The `gids` matcher tests if the group indentifiers in the test match group identifiers in `/etc/passwd`:
 
     its('gids') { should include 1234 }
     its('gids') { should cmp 0 }
 
-## homes
+### homes
 
 The `homes` matcher tests the absolute path to a user's home directory:
 
     its('home') { should eq '/' }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## length
+### length
 
 The `length` matcher tests the length of a password that appears in `/etc/passwd`:
 
@@ -83,11 +83,11 @@ This matcher is best used in conjunction with filters. For example:
        its('length') { should_not be < 16 }
     end
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## passwords
+### passwords
 
 The `passwords` matcher tests if passwords are
 
@@ -100,7 +100,7 @@ For example:
     its('passwords') { should eq ['x'] }
     its('passwords') { should cmp '*' }
 
-## shells
+### shells
 
 The `shells` matcher tests the absolute path of a shell (or command) to which a user has access:
 
@@ -112,7 +112,7 @@ or to find all users with the nologin shell:
       its('users') { should_not include 'my_login_user' }
     end
 
-## uids
+### uids
 
 The `uids` matcher tests if the user indentifiers in the test match user identifiers in `/etc/passwd`:
 
@@ -125,24 +125,24 @@ or:
       its('count') { should eq 1 }
     end
 
-## users
+### users
 
 The `users` matcher tests if the user names in the test match user names in `/etc/passwd`:
 
     its('users') { should eq ['root', 'www-data'] }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test usernames and UIDs
+### Test usernames and UIDs
 
     describe passwd do
       its('users') { should eq ['root', 'www-data'] }
       its('uids') { should eq [0, 33] }
     end
 
-## Select one user and test for multiple occurrences
+### Select one user and test for multiple occurrences
 
     describe passwd.uids(0) do
       its('users') { should cmp 'root' }

--- a/docs/resources/etc_shadow.md.erb
+++ b/docs/resources/etc_shadow.md.erb
@@ -19,7 +19,7 @@ These entries are defined as a colon-delimited row in the file, one row per user
 
     dannos:Gb7crrO5CDF.:10063:0:99999:7:::
 
-# Syntax
+## Syntax
 
 A `shadow` resource block declares one (or more) users and associated user information to be tested:
 
@@ -40,19 +40,19 @@ where
 * `filter` one (or more) arguments, for example: `passwd.users(/name/)` used to define filtering; `filter` may take any of the following arguments: `count` (retrieves the number of entries), `lines` (provides raw `passwd` lines), and `params` (returns an array of maps for all entries)
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## count
+### count
 
 The `count` matcher tests the number of times the named user appears in `/etc/shadow`:
 
@@ -64,49 +64,49 @@ TThis matcher is best used in conjunction with filters. For example:
        its('count') { should eq 1 }
     end
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## expiry_dates
+### expiry_dates
 
 The `expiry_dates` matcher tests the number of days a user account has been disabled:
 
     its('expiry_dates') { should eq '' }
 
-## inactive_days
+### inactive_days
 
 The `inactive_days` matcher tests the number of days a user must be inactive before the user account is disabled:
 
     its('inactive_days') { should eq '' }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## last_changes
+### last_changes
 
 The `last_changes` matcher tests the last time a password was changed:
 
     its('last_changes') { should eq '' }
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## max_days
+### max_days
 
 The `max_days` matcher tests the maximum number of days after which a password must be changed:
 
     its('max_days') { should eq 90 }
 
-## min_days
+### min_days
 
 The `min_days` matcher tests the minimum number of days a password must exist, before it may be changed:
 
     its('min_days') { should eq 0 }
 
-## passwords
+### passwords
 
 The `passwords` matcher tests if passwords are
 
@@ -119,29 +119,29 @@ For example:
     its('passwords') { should eq ['x'] }
     its('passwords') { should cmp '*' }
 
-## users
+### users
 
 The `users` matcher tests if the user name exists `/etc/shadow`:
 
     its('users') { should eq 'root' }
 
-## warn_days
+### warn_days
 
 The `warn_days` matcher tests the number of days a user is warned about an expiring password:
 
     its('warn_days') { should eq 7 }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test for a forbidden user
+### Test for a forbidden user
 
     describe shadow do
       its('users') { should_not include 'forbidden_user' }
     end
 
-## Test that a user appears one time
+### Test that a user appears one time
 
     describe shadow.users('bin') do
       its('passwords') { should cmp 'x' }

--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -6,7 +6,7 @@ title: About the file Resource
 
 Use the `file` InSpec audit resource to test all system file types, including files, directories, symbolic links, named pipes, sockets, character devices, block devices, and doors.
 
-# Syntax
+## Syntax
 
 A `file` resource block declares the location of the file type to be tested, what type that file should be (if required), and then one (or more) matchers:
 
@@ -21,33 +21,33 @@ where
 * `'value'` is the value to be tested
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_block_device
+### be_block_device
 
 The `be_block_device` matcher tests if the file exists as a block device, such as `/dev/disk0` or `/dev/disk0s9`:
 
     it { should be_block_device }
 
-## be_character_device
+### be_character_device
 
 The `be_character_device` matcher tests if the file exists as a character device (that corresponds to a block device), such as `/dev/rdisk0` or `/dev/rdisk0s9`:
 
     it { should be_character_device }
 
-## be_directory
+### be_directory
 
 The `be_directory` matcher tests if the file exists as a directory, such as `/etc/passwd`, `/etc/shadow`, or `/var/log/httpd`:
 
     it { should be_directory }
 
-## be_executable
+### be_executable
 
 The `be_executable` matcher tests if the file exists as an executable:
 
@@ -65,49 +65,49 @@ a user:
 
     it { should be_executable.by_user('user') }
 
-## be_file
+### be_file
 
 The `be_file` matcher tests if the file exists as a file. This can be useful with configuration files like `/etc/passwd` where there typically is not an associated file extension---`passwd.txt`:
 
     it { should be_file }
 
-## be_grouped_into
+### be_grouped_into
 
 The `be_grouped_into` matcher tests if the file exists as part of the named group:
 
     it { should be_grouped_into 'group' }
 
-## be_immutable
+### be_immutable
 
 The `be_immutable` matcher tests if the file is immutable, i.e. "cannot be changed":
 
     it { should be_immutable }
 
-## be_linked_to
+### be_linked_to
 
 The `be_linked_to` matcher tests if the file is linked to the named target:
 
     it { should be_linked_to '/etc/target-file' }
 
-## be_mounted
+### be_mounted
 
 The `be_mounted` matcher tests if the file is accessible from the file system:
 
     it { should be_mounted }
 
-## be_owned_by
+### be_owned_by
 
 The `be_owned_by` matcher tests if the file is owned by the named user, such as `root`:
 
     it { should be_owned_by 'root' }
 
-## be_pipe
+### be_pipe
 
 The `be_pipe` matcher tests if the file exists as first-in, first-out special file (`.fifo`) that is typically used to define a named pipe, such as `/var/log/nginx/access.log.fifo`:
 
     it { should be_pipe }
 
-## be_readable
+### be_readable
 
 The `be_readable` matcher tests if the file is readable:
 
@@ -125,25 +125,25 @@ a user:
 
     it { should be_readable.by_user('user') }
 
-## be_socket
+### be_socket
 
 The `be_socket` matcher tests if the file exists as socket (`.sock`), such as `/var/run/php-fpm.sock`:
 
     it { should be_socket }
 
-## be_symlink
+### be_symlink
 
 The `be_symlink` matcher tests if the file exists as a symbolic, or soft link that contains an absolute or relative path reference to another file:
 
     it { should be_symlink }
 
-## be_version
+### be_version
 
 The `be_version` matcher tests the version of the file:
 
     it { should be_version '1.2.3' }
 
-## be_writable
+### be_writable
 
 The `be_writable` matcher tests if the file is writable:
 
@@ -161,11 +161,11 @@ a user:
 
     it { should be_writable.by_user('user') }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## content
+### content
 
 The `content` matcher tests if contents in the file match the value specified in a regular expression. The values of the `content` matcher are arbitrary and depend on the file type being tested and also the type of information that is expected to be in that file:
 
@@ -179,67 +179,67 @@ The following complete example tests the `pg_hba.conf` file in PostgreSQL for MD
       its('content') { should match(%r{host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5})
     end
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if the named file exists:
 
     it { should exist }
 
-## file_version
+### file_version
 
 The `file_version` matcher tests if the file's version matches the specified value. The difference between a file's "file version" and "product version" is that the file version is the version number of the file itself, whereas the product version is the version number associated with the application from which that file originates:
 
     its('file_version') { should eq '1.2.3' }
 
-## group
+### group
 
 The `group` matcher tests if the group to which a file belongs matches the specified value:
 
     its('group') { should eq 'admins' }
 
-## have_mode
+### have_mode
 
 The `have_mode` matcher tests if a file has a mode assigned to it:
 
     it { should have_mode }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## link_path
+### link_path
 
 The `link_path` matcher tests if the file exists at the specified path:
 
     its('link_path') { should eq '/some/path/to/file' }
 
-## link_target
+### link_target
 
 The `link_target` matcher tests if a file that is linked to this file exists at the specified path:
 
     its('link_target') { should eq '/some/path/to/file' }
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## md5sum
+### md5sum
 
 The `md5sum` matcher tests if the MD5 checksum for a file matches the specified value:
 
     its('md5sum') { should eq '3329x3hf9130gjs9jlasf2305mx91s4j' }
 
-## mode
+### mode
 
 The `mode` matcher tests if the mode assigned to the file matches the specified value:
 
     its('mode') { should cmp '0644' }
 
-## mtime
+### mtime
 
 The `mtime` matcher tests if the file modification time for the file matches the specified value:
 
@@ -252,31 +252,31 @@ or:
       it { should >= Time.now.to_i - 1000}
     end
 
-## owner
+### owner
 
 The `owner` matcher tests if the owner of the file matches the specified value:
 
     its('owner') { should eq 'root' }
 
-## product_version
+### product_version
 
 The `product_version` matcher tests if the file's product version matches the specified value. The difference between a file's "file version" and "product version" is that the file version is the version number of the file itself, whereas the product version is the version number associated with the application from which that file originates:
 
     its('product_version') { should eq 2.3.4 }
 
-## selinux_label
+### selinux_label
 
 The `selinux_label` matcher tests if the SELinux label for a file matches the specified value:
 
     its('selinux_label') { should eq 'system_u:system_r:httpd_t:s0' }
 
-## sha256sum
+### sha256sum
 
 The `sha256sum` matcher tests if the SHA-256 checksum for a file matches the specified value:
 
     its('sha256sum') { should eq 'b837ch38lh19bb8eaopl8jvxwd2e4g58jn9lkho1w3ed9jbkeicalplaad9k0pjn' }
 
-## size
+### size
 
 The `size` matcher tests if a file's size matches, is greater than, or is less than the specified value. For example, equal:
 
@@ -290,7 +290,7 @@ Less than:
 
     its('size') { should < 10240 }
 
-## type
+### type
 
 The `type` matcher tests if the first letter of the file's mode string contains one of the following characters:
 
@@ -311,11 +311,11 @@ or:
 
     its('type') { should eq 'socket' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test the contents of a file for MD5 requirements
+### Test the contents of a file for MD5 requirements
 
     describe file(hba_config_file) do
       its('content') { should match /local\s.*?all\s.*?all\s.*?md5/ }
@@ -323,26 +323,26 @@ The following examples show how to use this InSpec audit resource.
       its('content') { should match %r{/host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5/} }
     end
 
-## Test if a file exists
+### Test if a file exists
 
     describe file('/tmp') do
      it { should exist }
     end
 
-## Test that a file does not exist
+### Test that a file does not exist
 
     describe file('/tmpest') do
      it { should_not exist }
     end
 
-## Test if a path is a directory
+### Test if a path is a directory
 
     describe file('/tmp') do
      its('type') { should eq :directory }
      it { should be_directory }
     end
 
-## Test if a path is a file and not a directory
+### Test if a path is a file and not a directory
 
     describe file('/proc/version') do
       its('type') { should eq 'file' }
@@ -350,7 +350,7 @@ The following examples show how to use this InSpec audit resource.
       it { should_not be_directory }
     end
 
-## Test if a file is a symbolic link
+### Test if a file is a symbolic link
 
     describe file('/dev/stdout') do
       its('type') { should eq 'symlink' }
@@ -359,7 +359,7 @@ The following examples show how to use this InSpec audit resource.
       it { should_not be_directory }
     end
 
-## Test if a file is a character device
+### Test if a file is a character device
 
     describe file('/dev/zero') do
       its('type') { should eq 'character' }
@@ -368,7 +368,7 @@ The following examples show how to use this InSpec audit resource.
       it { should_not be_directory }
     end
 
-## Test if a file is a block device
+### Test if a file is a block device
 
     describe file('/dev/zero') do
       its('type') { should eq 'block' }
@@ -377,51 +377,51 @@ The following examples show how to use this InSpec audit resource.
       it { should_not be_directory }
     end
 
-## Test the mode for a file
+### Test the mode for a file
 
     describe file('/dev') do
      its('mode') { should cmp '00755' }
     end
 
-## Test the owner of a file
+### Test the owner of a file
 
     describe file('/root') do
       its('owner') { should eq 'root' }
     end
 
-## Test if a file is owned by the root user
+### Test if a file is owned by the root user
 
     describe file('/dev') do
       it { should be_owned_by 'root' }
     end
 
-## Test the mtime for a file
+### Test the mtime for a file
 
     describe file('/').mtime.to_i do
       it { should <= Time.now.to_i }
       it { should >= Time.now.to_i - 1000}
     end
 
-## Test that a file's size is between 64 and 10240
+### Test that a file's size is between 64 and 10240
 
     describe file('/') do
       its('size') { should be > 64 }
       its('size') { should be < 10240 }
     end
 
-## Test that a file's size is zero
+### Test that a file's size is zero
 
     describe file('/proc/cpuinfo') do
       its('size') { should be 0 }
     end
 
-## Test that a file is not mounted
+### Test that a file is not mounted
 
     describe file('/proc/cpuinfo') do
       it { should_not be_mounted }
     end
 
-## Test an MD5 checksum
+### Test an MD5 checksum
 
     require 'digest'
     cpuinfo = file('/proc/cpuinfo').content
@@ -432,7 +432,7 @@ The following examples show how to use this InSpec audit resource.
       its('md5sum') { should eq md5sum }
     end
 
-## Test an SHA-256 checksum
+### Test an SHA-256 checksum
 
     require 'digest'
     cpuinfo = file('/proc/cpuinfo').content
@@ -443,7 +443,7 @@ The following examples show how to use this InSpec audit resource.
       its('sha256sum') { should eq sha256sum }
     end
 
-## Verify NTP
+### Verify NTP
 
 The following example shows how to use the `file` audit resource to verify if the `ntp.conf` and `leap-seconds` files are present, and then the `command` resource to verify if NTP is installed and running:
 

--- a/docs/resources/gem.md.erb
+++ b/docs/resources/gem.md.erb
@@ -6,7 +6,7 @@ title: About the gem Resource
 
 Use the `gem` InSpec audit resource to test if a global Gem package is installed.
 
-# Syntax
+## Syntax
 
 A `gem` resource block declares a package and (optionally) a package version:
 
@@ -19,54 +19,54 @@ where
 * `('gem_package_name')` must specify a Gem package, such as `'rubocop'`
 * `be_installed` is a valid matcher for this resource
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named Gem package is installed:
 
     it { should be_installed }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## version
+### version
 
 The `version` matcher tests if the named package version is on the system:
 
     its('version') { should eq '0.33.0' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Verify that a gem package is installed, with a specific version
+### Verify that a gem package is installed, with a specific version
 
     describe gem('rubocop') do
       it { should be_installed }
       its('version') { should eq '0.33.0' }
     end
 
-## Verify that a gem package is not installed
+### Verify that a gem package is not installed
 
     describe gem('rubocop') do
       it { should_not be_installed }

--- a/docs/resources/group.md.erb
+++ b/docs/resources/group.md.erb
@@ -6,7 +6,7 @@ title: About the group Resource
 
 Use the `group` InSpec audit resource to test groups on the system.
 
-# Syntax
+## Syntax
 
 A `group` resource block declares a group, and then the details to be tested, such as if the group is a local group, the group identifier, or if the group exists:
 
@@ -20,53 +20,53 @@ where
 * `'group_name'` must specify the name of a group on the system
 * `exist` and `'gid'` are valid matchers for this resource
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_local
+### be_local
 
 The `be_local` matcher tests if the group is a local group:
 
     it { should be_local }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if the named user exists:
 
     it { should exist }
 
-## gid
+### gid
 
 The `gid` matcher tests the named group identifier:
 
     its('gid') { should eq 1234 }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test the group identifier for the root group
+### Test the group identifier for the root group
 
     describe group('root') do
       it { should exist }

--- a/docs/resources/grub_conf.md.erb
+++ b/docs/resources/grub_conf.md.erb
@@ -6,7 +6,7 @@ title: About the grub_conf Resource
 
 Grub is a boot loader on the Linux platform used to load and then transfer control to an operating system kernel, after which that kernel initializes the rest of the operating system. Use the `grub_conf` InSpec audit resource to test boot loader configuration settings that are defined in the `grub.conf` configuration file.
 
-# Syntax
+## Syntax
 
 A `grub_conf` resource block declares a list of settings in a `grub.conf` file:
 
@@ -29,35 +29,35 @@ where
 * `'value'` is the value that is expected
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test a grub.conf file
+### Test a grub.conf file
 
 A Grub configuration file located at `/etc/grub.conf` is similar to the following:
 
@@ -99,7 +99,7 @@ The following test verifies the `ramdisk_size` for the non-deault kernel:
        its('kernel') { should include 'ramdisk_size=400000' }
      end
 
-## Test a configuration file and boot configuration
+### Test a configuration file and boot configuration
 
     describe grub_conf('/etc/grub.conf',  'default') do
       its('kernel') { should include '/vmlinuz-2.6.32-573.7.1.el6.x86_64' }
@@ -108,7 +108,7 @@ The following test verifies the `ramdisk_size` for the non-deault kernel:
       its('timeout') { should eq '5' }
     end
 
-## Test a specific kernel
+### Test a specific kernel
 
     grub_conf('/etc/grub.conf',  'CentOS (2.6.32-573.12.1.el6.x86_64)') do
       its('kernel') { should include 'audit=1' }

--- a/docs/resources/host.md.erb
+++ b/docs/resources/host.md.erb
@@ -6,7 +6,7 @@ title: About the host Resource
 
 Use the `host` InSpec audit resource to test the name used to refer to a specific host and its availability, including the Internet protocols and ports over which that host name should be available.
 
-# Syntax
+## Syntax
 
 A `host` resource block declares a host name, and then (depending on what is to be tested) a port and/or a protocol:
 
@@ -25,59 +25,59 @@ where
 * `be_reachable` is a valid matcher for this resource
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_reachable
+### be_reachable
 
 The `be_reachable` matcher tests if the host name is available:
 
     it { should be_reachable }
 
-## be_resolvable
+### be_resolvable
 
 The `be_resolvable` matcher tests for host name resolution, i.e. "resolvable to an IP address":
 
     it { should be_resolvable }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## ipaddress
+### ipaddress
 
 The `ipaddress` matcher tests if a host name is resolvable to a specific IP address:
 
     its('ipaddress') { should include '93.184.216.34' }
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Verify host name is reachable over a specific protocol and port number
+### Verify host name is reachable over a specific protocol and port number
 
     describe host('example.com', port: 53, proto: 'udp') do
       it { should be_reachable }
     end
 
-## Verify that a specific IP address can be resolved
+### Verify that a specific IP address can be resolved
 
     describe host('example.com', port: 80, proto: 'tcp') do
       it { should be_resolvable }

--- a/docs/resources/iis_site.md.erb
+++ b/docs/resources/iis_site.md.erb
@@ -6,7 +6,7 @@ title: About the iis_site Resource
 
 Use the `iis_site` InSpec audit resource to test the state of IIS on Windows Server 2012 (and later).
 
-# Syntax
+## Syntax
 
 An `iis_site` resource block declares details about the named site:
 
@@ -36,35 +36,35 @@ For example:
       it { should have_path('C:\\inetpub\\wwwroot') }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_running
+### be_running
 
 The `be_running` matcher tests if the site is running:
 
     it { should be_running }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if the site exists:
 
     it { should exist }
 
-## have_app_pool
+### have_app_pool
 
 The `have_app_pool` matcher tests if the named application pool exists for the site:
 
@@ -74,7 +74,7 @@ For example, testing if a site's application pool inherits the settings of the p
 
     it { should have_app_pool('/') }
 
-## have_binding
+### have_binding
 
 The `have_binding` matcher tests if the specified binding exists for the site:
 
@@ -86,7 +86,7 @@ or:
 
 A site may have multiple bindings; use a `have_binding` matcher for each unique site binding to be tested.
 
-### Binding Attributes
+##### Binding Attributes
 
 The `have_binding` matcher can also test attributes that are defined for a site binding. For example, the `sslFlags` attribute defines if SSL is enabled, and (when enabled) what level of SSL is applied to the site.
 
@@ -106,25 +106,25 @@ Testing a site with 128-bit SSL enabled:
 
     it { should have_binding('https :443:www.contoso.com sslFlags=Ssl128') }
 
-## have_path
+### have_path
 
 The `have_path` matcher tests if the named path is defined for the site:
 
     it { should have_path('C:\\inetpub\\wwwroot') }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test a default IIS site
+### Test a default IIS site
 
     describe iis_site('Default Web Site') do
       it { should exist }
@@ -134,7 +134,7 @@ The following examples show how to use this InSpec audit resource.
       it { should have_path('%SystemDrive%\\inetpub\\wwwroot\\') }
     end
 
-## Test if IIS service is running
+### Test if IIS service is running
 
     describe service('W3SVC') do
       it { should be_installed }

--- a/docs/resources/inetd_conf.md.erb
+++ b/docs/resources/inetd_conf.md.erb
@@ -6,7 +6,7 @@ title: About the inetd_conf Resource
 
 Use the `inetd_conf` InSpec audit resource to test if a service is listed in the `inetd.conf` file on Linux and Unix platforms. inetd---the Internet service daemon---listens on dedicated ports, and then loads the appropriate program based on a request. The `inetd.conf` file is typically located at `/etc/inetd.conf` and contains a list of Internet services associated to the ports on which that service will listen. Only enabled services may handle a request; only services that are required by the system should be enabled.`
 
-# Syntax
+## Syntax
 
 An `inetd_conf` resource block declares the list of services that are enabled in the `inetd.conf` file:
 
@@ -21,7 +21,7 @@ where
 * `should eq 'value'` is the value that is expected
 
 
-# Matchers
+## Matchers
 
 This resource matches any service that is listed in the `inetd.conf` file. You may want to ensure that specific services do not listen via `inetd.conf`:
 
@@ -43,31 +43,31 @@ For example:
       its('exec') { should eq nil }
     end
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Verify that FTP is disabled
+### Verify that FTP is disabled
 
 The contents if the `inetd.conf` file contain the following:
 
@@ -88,7 +88,7 @@ Because both the `ftp` and `telnet` Internet services are commented out (`#`), b
 
 then the same test will return `false` for `ftp` and the entire test will fail.
 
-## Test if telnet is installed
+### Test if telnet is installed
 
     describe package('telnetd') do
       it { should_not be_installed }

--- a/docs/resources/ini.md.erb
+++ b/docs/resources/ini.md.erb
@@ -6,7 +6,7 @@ title: About the ini Resource
 
 Use the `ini` InSpec audit resource to test settings in an INI file.
 
-# Syntax
+## Syntax
 
 An `ini` resource block declares the configuration settings to be tested:
 
@@ -27,35 +27,35 @@ For example:
       its('server') { should eq '192.0.2.62' }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test SMTP settings in a PHP INI file
+### Test SMTP settings in a PHP INI file
 
 For example, a PHP INI file located at contains the following settings:
 

--- a/docs/resources/interface.md.erb
+++ b/docs/resources/interface.md.erb
@@ -9,7 +9,7 @@ Use the `interface` InSpec audit resource to test basic network adapter properti
 * On Linux platforms, `/sys/class/net/#{iface}` is used as source
 * On the Windows platform, the `Get-NetAdapter` cmdlet is used as source
 
-# Syntax
+## Syntax
 
 An `interface` resource block declares network interface properties to be tested:
 
@@ -19,48 +19,48 @@ An `interface` resource block declares network interface properties to be tested
       its('name') { should eq eth0 }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_up
+### be_up
 
 The `be_up` matcher tests if the network interface is available:
 
     it { should be_up }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## name
+### name
 
 The `name` matcher tests if the named network interface exists:
 
     its('name') { should eq eth0 }
 
-## speed
+### speed
 
 The `speed` matcher tests the speed of the network interface, in MB/sec:
 
     its('speed') { should eq 1000 }
 
-# Examples
+## Examples
 
 None.

--- a/docs/resources/iptables.md.erb
+++ b/docs/resources/iptables.md.erb
@@ -6,7 +6,7 @@ title: About the iptables Resource
 
 Use the `iptables` InSpec audit resource to test rules that are defined in `iptables`, which maintains tables of IP packet filtering rules. There may be more than one table. Each table contains one (or more) chains (both built-in and custom). A chain is a list of rules that match packets. When the rule matches, the rule defines what target to assign to the packet.
 
-# Syntax
+## Syntax
 
 A `iptables` resource block declares tests for rules in IP tables:
 
@@ -23,47 +23,47 @@ where
 * `have_rule('RULE')` tests that rule in the iptables file
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## have_rule
+### have_rule
 
 The `have_rule` matcher tests the named rule against the information in the `iptables` file:
 
     it { should have_rule('RULE') }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if the IP table allows a packet through
+### Test if the IP table allows a packet through
 
     describe iptables do
       it { should have_rule('-P INPUT ACCEPT') }
     end
 
-## Test if the IP table allows a packet through, for a specific table and chain
+### Test if the IP table allows a packet through, for a specific table and chain
 
     describe iptables(table:'mangle', chain: 'input') do
       it { should have_rule('-P INPUT ACCEPT') }

--- a/docs/resources/json.md.erb
+++ b/docs/resources/json.md.erb
@@ -6,7 +6,7 @@ title: About the json Resource
 
 Use the `json` InSpec audit resource to test data in a JSON file.
 
-# Syntax
+## Syntax
 
 A `json` resource block declares the data to be tested. Assume the following JSON file:
 
@@ -35,41 +35,41 @@ where
 * `should eq 'foo'` tests a value of `name` as read from a JSON file versus the value declared in the test
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## name
+### name
 
 The `name` matcher tests the value of `name` as read from a JSON file versus the value declared in the test:
 
     its('name') { should eq 'foo' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test a cookbook version in a policyfile.lock.json file
+### Test a cookbook version in a policyfile.lock.json file
 
     describe json('policyfile.lock.json') do
       its(['cookbook_locks', 'omnibus', 'version']) { should eq('2.2.0') }

--- a/docs/resources/kernel_module.md.erb
+++ b/docs/resources/kernel_module.md.erb
@@ -6,7 +6,7 @@ title: About the kernel_module Resource
 
 Use the `kernel_module` InSpec audit resource to test kernel modules on Linux platforms. These parameters are located under `/lib/modules`. Any submodule may be tested using this resource.
 
-# Syntax
+## Syntax
 
 A `kernel_module` resource block declares a module name, and then tests if that module is a loadable kernel module:
 
@@ -19,41 +19,41 @@ where
 * `'module_name'` must specify a kernel module, such as `'bridge'`
 * `{ should be_loaded }` tests if the module is a loadable kernel module
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_loaded
+### be_loaded
 
 The `be_loaded` matcher tests if the module is a loadable kernel module:
 
     it { should be_loaded }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if a module is loaded
+### Test if a module is loaded
 
     describe kernel_module('bridge') do
       it { should be_loaded }

--- a/docs/resources/kernel_parameter.md.erb
+++ b/docs/resources/kernel_parameter.md.erb
@@ -6,7 +6,7 @@ title: About the kernel_parameter Resource
 
 Use the `kernel_parameter` InSpec audit resource to test kernel parameters on Linux platforms.
 
-# Syntax
+## Syntax
 
 A `kernel_parameter` resource block declares a parameter and then a value to be tested:
 
@@ -19,53 +19,53 @@ where
 * `'kernel.parameter'` must specify a kernel parameter, such as `'net.ipv4.conf.all.forwarding'`
 * `{ should eq 0 }` states the value to be tested
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## value
+### value
 
 The `value` matcher tests the value assigned to the named IP address versus the value declared in the test:
 
     its('value') { should eq 0 }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if global forwarding is enabled for an IPv4 address
+### Test if global forwarding is enabled for an IPv4 address
 
     describe kernel_parameter('net.ipv4.conf.all.forwarding') do
       its('value') { should eq 1 }
     end
 
-## Test if global forwarding is disabled for an IPv6 address
+### Test if global forwarding is disabled for an IPv6 address
 
     describe kernel_parameter('net.ipv6.conf.all.forwarding') do
       its('value') { should eq 0 }
     end
 
-## Test if an IPv6 address accepts redirects
+### Test if an IPv6 address accepts redirects
 
     describe kernel_parameter('net.ipv6.conf.interface.accept_redirects') do
       its('value') { should eq 'true' }

--- a/docs/resources/launchd_service.md.erb
+++ b/docs/resources/launchd_service.md.erb
@@ -6,7 +6,7 @@ title: About the launchd_service Resource
 
 Use the ``launchd_service`` InSpec audit resource to test a service using Launchd.
 
-# Syntax
+## Syntax
 
 A ``launchd_service`` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
@@ -29,48 +29,48 @@ The path to the service manager's control may be specified for situations where 
       it { should be_running }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_enabled
+### be_enabled
 
 The `be_enabled` matcher tests if the named service is enabled:
 
     it { should be_enabled }
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
     it { should be_installed }
 
-## be_running
+### be_running
 
 The `be_running` matcher tests if the named service is running:
 
     it { should be_running }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 None.

--- a/docs/resources/limits_conf.md.erb
+++ b/docs/resources/limits_conf.md.erb
@@ -17,7 +17,7 @@ Entries in the `limits.conf` file are similar to:
     ^^^^^^^^^   ^^^^   ^^^^^^   ^^^^^
     domain      type    item    value
 
-# Syntax
+## Syntax
 
 A `limits_conf` resource block declares a domain to be tested, along with associated type, item, and value:
 
@@ -34,19 +34,19 @@ where
 * `'item'` is the item for which limits are defined, such as `core`, `nofile`, `stack`, `nproc`, `priority`, or `maxlogins`
 * `'value'` is the value associated with the `item`
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## domain
+### domain
 
 The `domain` matcher tests the domain in the `limits.conf` file, along with associated type, item, and value:
 
@@ -56,23 +56,23 @@ For example:
 
     its('grantmc') { should include ['hard', 'nofile', '63536'] }
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test limits
+### Test limits
 
     describe limits_conf('path') do
       its('*') { should include ['soft', 'core', '0'], ['hard', 'rss', '10000'] }

--- a/docs/resources/login_def.md.erb
+++ b/docs/resources/login_def.md.erb
@@ -6,7 +6,7 @@ title: About the login_defs Resource
 
 Use the `login_defs` InSpec audit resource to test configuration settings in the `/etc/login.defs` file. The `logins.defs` file defines site-specific configuration for the shadow password suite on Linux and Unix platforms, such as password expiration ranges, minimum/maximum values for automatic selection of user and group identifiers, or the method with which passwords are encrypted.
 
-# Syntax
+## Syntax
 
 A `login_defs` resource block declares the `login.defs` configuration data to be tested:
 
@@ -20,41 +20,41 @@ where
 * `{ should include('foo') }` tests the value of `name` as read from `login.defs` versus the value declared in the test
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## name
+### name
 
 The `name` matcher tests the value of `name` as read from `login.defs` versus the value declared in the test:
 
     its('name') { should eq 'foo' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test password expiration settings
+### Test password expiration settings
 
     describe login_defs do
       its('PASS_MAX_DAYS') { should eq '180' }
@@ -63,13 +63,13 @@ The following examples show how to use this InSpec audit resource.
       its('PASS_WARN_AGE') { should eq '30' }
     end
 
-## Test the encryption method
+### Test the encryption method
 
     describe login_defs do
       its('ENCRYPT_METHOD') { should eq 'SHA512' }
     end
 
-## Test umask setting
+### Test umask setting
 
     describe login_def do
       its('UMASK') { should eq '077' }

--- a/docs/resources/mount.md.erb
+++ b/docs/resources/mount.md.erb
@@ -6,7 +6,7 @@ title: About the mount Resource
 
 Use the `mount` InSpec audit resource to test the mount points on Linux systems.
 
-# Syntax
+## Syntax
 
 An `mount` resource block declares the synchronization settings that should be tested:
 
@@ -21,59 +21,59 @@ where
 * `'value'` is the value to be tested
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_mounted
+### be_mounted
 
 The `be_mounted` matcher tests if the file is accessible from the file system:
 
     it { should be_mounted }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## device
+### device
 
 The `device` matcher tests the device from the `fstab` table:
 
     its('device') { should eq  '/dev/mapper/VolGroup-lv_root' }
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## options
+### options
 
 The `options` matcher tests the mount options for the file system from the `fstab` table:
 
     its('options') { should eq ['rw', 'mode=620'] }
 
-## type
+### type
 
 The `type` matcher tests the file system type:
 
     its('type') { should eq  'ext4' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test a the mount point on '/'
+### Test a the mount point on '/'
 
     describe mount('/') do
       it { should be_mounted }

--- a/docs/resources/mysql_conf.md.erb
+++ b/docs/resources/mysql_conf.md.erb
@@ -6,7 +6,7 @@ title: About the mysql_conf Resource
 
 Use the `mysql_conf` InSpec audit resource to test the contents of the configuration file for MySQL, typically located at `/etc/mysql/my.cnf` or `/etc/my.cnf`.
 
-# Syntax
+## Syntax
 
 A `mysql_conf` resource block declares one (or more) settings in the `my.cnf` file, and then compares the setting in the configuration file to the value stated in the test:
 
@@ -21,31 +21,31 @@ where
 * `should eq 'value'` is the value that is expected
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## setting
+### setting
 
 The `setting` matcher tests specific, named settings in the `my.cnf` file:
 
@@ -53,18 +53,18 @@ The `setting` matcher tests specific, named settings in the `my.cnf` file:
 
 Use a `setting` matcher for each setting to be tested.
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test the maximum number of allowed connections
+### Test the maximum number of allowed connections
 
     describe mysql_conf do
       its('max_connections') { should eq '505' }
       its('max_user_connections') { should eq '500' }
     end
 
-## Test slow query logging**
+### Test slow query logging**
 
     describe mysql_conf do
       its('slow_query_log_file') { should eq 'hostname_slow.log' }
@@ -74,14 +74,14 @@ The following examples show how to use this InSpec audit resource.
       its('min_examined_row_limit') { should eq '100' }
     end
 
-## Test the port and socket on which MySQL listens
+### Test the port and socket on which MySQL listens
 
     describe mysql_conf do
       its('port') { should eq '3306' }
       its('socket') { should eq '/var/run/mysqld/mysql.sock' }
     end
 
-## Test connection and thread variables
+### Test connection and thread variables
 
     describe mysql_conf do
       its('port') { should eq '3306' }
@@ -95,7 +95,7 @@ The following examples show how to use this InSpec audit resource.
       its('thread_cache_size') { should eq '505' }
     end
 
-## Test the safe-user-create parameter
+### Test the safe-user-create parameter
 
     describe mysql_conf.params('mysqld') do
       its('safe-user-create') { should eq('1') }

--- a/docs/resources/mysql_session.md.erb
+++ b/docs/resources/mysql_session.md.erb
@@ -6,7 +6,7 @@ title: About the mysql_session Resource
 
 Use the `mysql_session` InSpec audit resource to test SQL commands run against a MySQL database.
 
-# Syntax
+## Syntax
 
 A `mysql_session` resource block declares the username and password to use for the session, and then the command to be run:
 
@@ -20,41 +20,41 @@ where
 * `query('QUERY')` contains the query to be run
 * `its('output') { should eq('') }` compares the results of the query against the expected result in the test
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## output
+### output
 
 The `output` matcher tests the results of the query:
 
     its('output') { should eq(/^0/) }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test for matching databases
+### Test for matching databases
 
     sql = mysql_session('my_user','password')
 

--- a/docs/resources/npm.md.erb
+++ b/docs/resources/npm.md.erb
@@ -7,7 +7,7 @@ title: About the npm Resource
 Use the `npm` InSpec audit resource to test if a global NPM package is installed. NPM is the the package manager for Node.js packages (https://docs.npmjs.com), such as Bower and StatsD.
 
 
-# Syntax
+## Syntax
 
 A `npm` resource block declares a package and (optionally) a package version:
 
@@ -21,54 +21,54 @@ where
 * `be_installed` is a valid matcher for this resource
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named Gem package and package version (if specified) is installed:
 
     it { should be_installed }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## version
+### version
 
 The `version` matcher tests if the named package version is on the system:
 
     its('version') { should eq '1.2.3' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Verify that bower is installed, with a specific version
+### Verify that bower is installed, with a specific version
 
     describe npm('bower') do
       it { should be_installed }
       its('version') { should eq '1.4.1' }
     end
 
-## Verify that statsd is not installed
+### Verify that statsd is not installed
 
     describe npm('statsd') do
       it { should_not be_installed }

--- a/docs/resources/ntp_conf.md.erb
+++ b/docs/resources/ntp_conf.md.erb
@@ -7,7 +7,7 @@ title: About the ntp_conf Resource
 Use the `ntp_conf` InSpec audit resource to test the synchronization settings defined in the `ntp.conf` file. This file is typically located at `/etc/ntp.conf`.
 
 
-# Syntax
+## Syntax
 
 An `ntp_conf` resource block declares the synchronization settings that should be tested:
 
@@ -22,7 +22,7 @@ where
 * `{ should eq 'value' }` is the value that is expected
 
 
-# Matchers
+## Matchers
 
 This resource matches any service that is listed in the `ntp.conf` file:
 
@@ -40,31 +40,31 @@ For example:
     end
 
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test for clock drift against named servers
+### Test for clock drift against named servers
 
     describe ntp_conf do
       its('driftfile') { should eq '/var/lib/ntp/ntp.drift' }

--- a/docs/resources/oneget.md.erb
+++ b/docs/resources/oneget.md.erb
@@ -6,7 +6,7 @@ title: About the oneget Resource
 
 Use the `oneget` InSpec audit resource to test if the named package and/or package version is installed on the system. This resource uses Oneget, which is `part of the Windows Management Framework 5.0 and Windows 10 <https://github.com/OneGet/oneget>`__. This resource uses the `Get-Package` cmdlet to return all of the package names in the Oneget repository.
 
-# Syntax
+## Syntax
 
 A `oneget` resource block declares a package and (optionally) a package version:
 
@@ -20,47 +20,47 @@ where
 * `be_installed` is a valid matcher for this resource
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named package is installed on the system:
 
     it { should be_installed }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## version
+### version
 
 The `version` matcher tests if the named package version is on the system:
 
     its('version') { should eq '1.2.3' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if VLC is installed
+### Test if VLC is installed
 
     describe oneget('VLC') do
       it { should be_installed }

--- a/docs/resources/os.md.erb
+++ b/docs/resources/os.md.erb
@@ -6,7 +6,7 @@ title: About the os Resource
 
 Use the `os` InSpec audit resource to test the platform on which the system is running.
 
-# Syntax
+## Syntax
 
 An `os` resource block declares the platform to be tested. The platform may specified via matcher or control block name. For example, using a matcher:
 
@@ -22,31 +22,31 @@ or using the block name:
 
 * `'platform_name'` (a string) or `:family_name` (a symbol) is one of `aix`, `bsd`, `darwin`, `debian`, `hpux`, `linux`, `redhat`, `solaris`, `suse`,  `unix`, or `windows`
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# os.family? Helpers
+## os.family? Helpers
 
 The `os` audit resource includes a collection of helpers that enable more granular testing of platforms, platform names, architectures, and releases. Use any of the following platform-specific helpers to test for specific platforms:
 
@@ -94,7 +94,7 @@ Use the following helpers to test for operating system names, releases, and arch
        it { should eq 'foo' }
     end
 
-# os[:family] Symbols
+## os[:family] Symbols
 
 Use `os[:family]` to enable more granular testing of platforms, platform names, architectures, and releases. Use any of the following platform-specific symbols to test for specific platforms:
 
@@ -131,23 +131,23 @@ For example, both of the following tests should have the same result:
       end
     end
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test for RedHat
+### Test for RedHat
 
     describe os[:family] do
       it { should eq 'redhat' }
     end
 
-## Test for Ubuntu
+### Test for Ubuntu
 
     describe os[:family] do
       it { should eq 'debian' }
     end
 
-## Test for Microsoft Windows
+### Test for Microsoft Windows
 
     describe os[:family] do
       it { should eq 'windows' }

--- a/docs/resources/os_env.md.erb
+++ b/docs/resources/os_env.md.erb
@@ -6,7 +6,7 @@ title: About the os_env Resource
 
 Use the `os_env` InSpec audit resource to test the environment variables for the platform on which the system is running.
 
-# Syntax
+## Syntax
 
 A `os_env` resource block declares an environment variable, and then declares its value:
 
@@ -20,37 +20,37 @@ where
 * `matcher` is a valid matcher for this resource
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## content
+### content
 
 The `content` matcher return the value of the environment variable:
 
     its('content') { should eq '/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin' }
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## split
+### split
 
 The `split` splits the content with the `:` deliminator:
 
@@ -64,18 +64,18 @@ Use `-1` to test for cases where there is a trailing colon (`:`), such as `dir1:
 
     its('split') { should include ('-1') }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test the PATH environment variable
+### Test the PATH environment variable
 
     describe os_env('PATH') do
       its('split') { should_not include('') }
       its('split') { should_not include('.') }
     end
 
-## Test Habitat environment variables
+### Test Habitat environment variables
 
 Habitat uses the `os_env` resource to test environment variables. The environment variables are first defined in a whitespace array, after which each environment variable is tested:
 

--- a/docs/resources/package.md.erb
+++ b/docs/resources/package.md.erb
@@ -7,7 +7,7 @@ title: About the package Resource
 Use the `package` InSpec audit resource to test if the named package and/or package version is installed on the system.
 
 
-# Syntax
+## Syntax
 
 A `package` resource block declares a package and (optionally) a package version:
 
@@ -20,60 +20,60 @@ where
 * `('name')` must specify the name of a package, such as `'nginx'`
 * `be_installed` is a valid matcher for this resource
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named package is installed on the system:
 
     it { should be_installed }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## version
+### version
 
 The `version` matcher tests if the named package version is on the system:
 
     its('version') { should eq '1.2.3' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if nginx version 1.9.5 is installed
+### Test if nginx version 1.9.5 is installed
 
     describe package('nginx') do
       it { should be_installed }
       its('version') { should eq 1.9.5 }
     end
 
-## Test that a package is not installed
+### Test that a package is not installed
 
     describe package('some_package') do
       it { should_not be_installed }
     end
 
-## Test if telnet is installed
+### Test if telnet is installed
 
     describe package('telnetd') do
       it { should_not be_installed }
@@ -83,7 +83,7 @@ The following examples show how to use this InSpec audit resource.
       its('telnet') { should eq nil }
     end
 
-## Test if ClamAV (an antivirus engine) is installed and running
+### Test if ClamAV (an antivirus engine) is installed and running
 
     describe package('clamav') do
       it { should be_installed }
@@ -96,7 +96,7 @@ The following examples show how to use this InSpec audit resource.
       it { should_not be_running }
     end
 
-## Verify if Memcached is installed, enabled, and running
+### Verify if Memcached is installed, enabled, and running
 
 Memcached is an in-memory key-value store that helps improve the performance of database-driven websites and can be installed, maintained, and tested using the `memcached` cookbook (maintained by Chef). The following example is from the `memcached` cookbook and shows how to use a combination of the `package`, `service`, and `port` InSpec audit resources to test if Memcached is installed, enabled, and running:
 

--- a/docs/resources/parse_config.md.erb
+++ b/docs/resources/parse_config.md.erb
@@ -6,7 +6,7 @@ title: About the parse_config Resource
 
 Use the `parse_config` InSpec audit resource to test arbitrary configuration files.
 
-# Syntax
+## Syntax
 
 A `parse_config` resource block declares the location of the configuration setting to be tested, and then what value is to be tested. Because this resource relies on arbitrary configuration files, the test itself is often arbitrary and relies on custom Ruby code:
 
@@ -35,11 +35,11 @@ where each test
 * May run a command to `stdout`, and then run the test against that output
 * May use options to define how configuration data is to be parsed
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## assignment_re
+### assignment_re
 
 Use `assignment_re` to test a key value using a regular expression:
 
@@ -49,29 +49,29 @@ may be tested using the following regular expression, which determines assignmen
 
     assignment_re: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## comment_char
+### comment_char
 
 Use `comment_char` to test for comments in a configuration file:
 
     comment_char: '#'
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## key_vals
+### key_vals
 
 Use `key_vals` to test how many values a key contains:
 
@@ -81,11 +81,11 @@ contains three values. To test that value to ensure it only contains one, use:
 
     key_vals: 1
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## multiple_values
+### multiple_values
 
 Use `multiple_values` if the source file uses the same key multiple times. All values will be aggregated in an array:
 
@@ -105,7 +105,7 @@ To use plain key value mapping, use `multiple_values: false`:
     params['key'] = 'b'
     params['key2'] = 'c'
 
-## standalone_comments
+### standalone_comments
 
 Use `standalone_comments` to parse comments as a line, otherwise inline comments are allowed:
 
@@ -117,6 +117,6 @@ Use `standalone_comments: false`, to parse the following:
     'key = value # comment'
     params['key'] = 'value'
 
-# Examples
+## Examples
 
 None.

--- a/docs/resources/parse_config_file.md.erb
+++ b/docs/resources/parse_config_file.md.erb
@@ -6,7 +6,7 @@ title: About the parse_config_file Resource
 
 Use the `parse_config_file` InSpec audit resource to test arbitrary configuration files. It works in the same way as `parse_config`. Instead of using a command output, this resource works with files.
 
-# Syntax
+## Syntax
 
 A `parse_config_file` InSpec audit resource block declares the location of the configuration file to be tested, and then which settings in that file are to be tested.
 
@@ -32,7 +32,7 @@ where each test
 * May run a command to `stdout`, and then run the test against that output
 * May use options to define how configuration data is to be parsed
 
-# Options
+## Options
 
 This resource supports the following options for parsing configuration data. Use them in an `options` block stated outside of (and immediately before) the actual test:
 
@@ -44,11 +44,11 @@ This resource supports the following options for parsing configuration data. Use
       its('setting') { should eq 1 }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## assignment_re
+### assignment_re
 
 Use `assignment_re` to test a key value using a regular expression:
 
@@ -58,29 +58,29 @@ may be tested using the following regular expression, which determines assignmen
 
     assignment_re: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## comment_char
+### comment_char
 
 Use `comment_char` to test for comments in a configuration file:
 
     comment_char: '#'
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## key_vals
+### key_vals
 
 Use `key_vals` to test how many values a key contains:
 
@@ -90,11 +90,11 @@ contains three values. To test that value to ensure it only contains one, use:
 
     key_vals: 1
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## multiple_values
+### multiple_values
 
 Use `multiple_values` if the source file uses the same key multiple times. All values will be aggregated in an array:
 
@@ -114,7 +114,7 @@ To use plain key value mapping, use `multiple_values: false`:
     params['key'] = 'b'
     params['key2'] = 'c'
 
-## standalone_comments
+### standalone_comments
 
 Use `standalone_comments` to parse comments as a line, otherwise inline comments are allowed:
 
@@ -126,17 +126,17 @@ Use `standalone_comments: false`, to parse the following:
     'key = value # comment'
     params['key'] = 'value'
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test a configuration setting
+### Test a configuration setting
 
     describe parse_config_file('/path/to/file.conf') do
      its('PARAM_X') { should eq 'Y' }
     end
 
-## Use options, and then test a configuration setting
+### Use options, and then test a configuration setting
 
     describe parse_config_file('/path/to/file.conf', { multiple_values: true }) do
      its('PARAM_X') { should include 'Y' }

--- a/docs/resources/pip.md.erb
+++ b/docs/resources/pip.md.erb
@@ -6,7 +6,7 @@ title: About the pip Resource
 
 Use the `pip` InSpec audit resource to test packages that are installed using the Python PIP installer.
 
-# Syntax
+## Syntax
 
 A `pip` resource block declares a package and (optionally) a package version:
 
@@ -20,53 +20,53 @@ where
 * `be_installed` tests to see if the `Jinja2` package is installed
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named package is installed on the system:
 
     it { should be_installed }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## version
+### version
 
 The `version` matcher tests if the named package version is on the system:
 
     its('version') { should eq '1.2.3' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if Jinja2 is installed on the system
+### Test if Jinja2 is installed on the system
 
     describe pip('Jinja2') do
       it { should be_installed }
     end
 
-## Test if Jinja2 2.8 is installed on the system
+### Test if Jinja2 2.8 is installed on the system
 
     describe pip('Jinja2') do
       it { should be_installed }

--- a/docs/resources/port.md.erb
+++ b/docs/resources/port.md.erb
@@ -6,7 +6,7 @@ title: About the port Resource
 
 Use the `port` InSpec audit resource to test basic port properties, such as port, process, if it's listening.
 
-# Syntax
+## Syntax
 
 A `port` resource block declares a port, and then depending on what needs to be tested, a process, protocol, process identifier, and its state (is it listening?):
 
@@ -35,55 +35,55 @@ For example, to test if the SSH daemon is available on a Linux machine via the d
       its('addresses') { should include '0.0.0.0' }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## address
+### address
 
 The `addresses` matcher tests if the specified address is associated with a port:
 
     its('addresses') { should include '0.0.0.0' }
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_listening
+### be_listening
 
 The `be_listening` matcher tests if the port is listening for traffic:
 
     it { should be_listening }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## pids
+### pids
 
 The `pids` matcher tests the process identifiers (PIDs):
 
     its('pids') { should eq ['27808'] }
 
-## processes
+### processes
 
 The `processes` matcher tests if the named process is running on the system:
 
     its('processes') { should eq ['syslog'] }
 
-## protocols
+### protocols
 
 The `protocols` matcher tests the Internet protocol: ICMP (`'icmp'`), TCP (`'tcp'` or `'tcp6'`), or UDP (`'udp'` or `'udp6'`):
 
@@ -93,18 +93,18 @@ or for the IPv6 protocol:
 
     its('protocols') { should include 'tcp6' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test port 80, listening with the TCP protocol
+### Test port 80, listening with the TCP protocol
 
     describe port(80) do
       it { should be_listening }
       its('protocols') {should eq ['tcp']}
     end
 
-## Test port 80, on a specific address
+### Test port 80, on a specific address
 
 A specific port address may be checked using either of the following examples:
 
@@ -119,14 +119,14 @@ or:
       it { should be_listening }
     end
 
-## Test port 80, listening with TCP version IPv6 protocol
+### Test port 80, listening with TCP version IPv6 protocol
 
     describe port(80) do
       it { should be_listening }
       its('protocols') {should eq ['tcp6']}
     end
 
-## Test that only secure ports accept requests
+### Test that only secure ports accept requests
 
     describe port(80) do
       it { should_not be_listening }
@@ -137,7 +137,7 @@ or:
       its('protocols') {should eq ['tcp']}
     end
 
-## Verify port 65432 is not listening
+### Verify port 65432 is not listening
 
     describe port(22) do
       it { should be_listening }

--- a/docs/resources/postgres_conf.md.erb
+++ b/docs/resources/postgres_conf.md.erb
@@ -6,7 +6,7 @@ title: About the postgres_conf Resource
 
 Use the `postgres_conf` InSpec audit resource to test the contents of the configuration file for PostgreSQL, typically located at `/etc/postgresql/<version>/main/postgresql.conf` or `/var/lib/postgres/data/postgresql.conf`, depending on the platform.
 
-# Syntax
+## Syntax
 
 A `postgres_conf` resource block declares one (or more) settings in the `postgresql.conf` file, and then compares the setting in the configuration file to the value stated in the test:
 
@@ -20,31 +20,31 @@ where
 * `('path')` is the non-default path to the `postgresql.conf` file (optional)
 * `should eq 'value'` is the value that is expected
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## setting
+### setting
 
 The `setting` matcher tests specific, named settings in the `postgresql.conf` file:
 
@@ -52,17 +52,17 @@ The `setting` matcher tests specific, named settings in the `postgresql.conf` fi
 
 Use a `setting` matcher for each setting to be tested.
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test the maximum number of allowed client connections
+### Test the maximum number of allowed client connections
 
     describe postgres_conf do
       its('max_connections') { should eq '5' }
     end
 
-## Test system logging
+### Test system logging
 
     describe postgres_conf do
       its('logging_collector') { should eq 'on' }
@@ -73,13 +73,13 @@ The following examples show how to use this InSpec audit resource.
       its('log_line_prefix') { should eq '%t %u %d %h' }
     end
 
-## Test the port on which PostgreSQL listens
+### Test the port on which PostgreSQL listens
 
     describe postgres_conf do
       its('port') { should eq '5432' }
     end
 
-## Test the Unix socket settings
+### Test the Unix socket settings
 
     describe postgres_conf do
       its('unix_socket_directories') { should eq '.s.PGSQL.5432' }

--- a/docs/resources/postgres_session.md.erb
+++ b/docs/resources/postgres_session.md.erb
@@ -6,7 +6,7 @@ title: About the postgres_session Resource
 
 Use the `postgres_session` InSpec audit resource to test SQL commands run against a PostgreSQL database.
 
-# Syntax
+## Syntax
 
 A `postgres_session` resource block declares the username and password to use for the session, and then the command to be run:
 
@@ -22,41 +22,41 @@ where
 * `sql.query('')` contains the query to be run
 * `its('output') { should eq('') }` compares the results of the query against the expected result in the test
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## output
+### output
 
 The `output` matcher tests the results of the query:
 
     its('output') { should eq(/^0/) }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test the PostgreSQL shadow password
+### Test the PostgreSQL shadow password
 
     sql = postgres_session('my_user', 'password')
 
@@ -64,7 +64,7 @@ The following examples show how to use this InSpec audit resource.
       its('output') { should eq('') }
     end
 
-## Test for risky database entries
+### Test for risky database entries
 
     describe postgres_session('my_user', 'password').query('SELECT count (*)
                   FROM pg_language

--- a/docs/resources/powershell.md.erb
+++ b/docs/resources/powershell.md.erb
@@ -6,7 +6,7 @@ title: About the powershell Resource
 
 Use the `powershell` InSpec audit resource to test a Powershell script on the Windows platform.
 
-# Syntax
+## Syntax
 
 A `powershell` resource block declares a Powershell script to be tested, and then compares the output of that command to the matcher in the test:
 
@@ -25,53 +25,53 @@ where
 * `'output'` tests the output of the command run on the system versus the output value stated in the test
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exit_status
+### exit_status
 
 The `exit_status` matcher tests the exit status for the command:
 
     its('exit_status') { should eq 123 }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## stderr
+### stderr
 
 The `stderr` matcher tests results of the command as returned in standard error (stderr):
 
     its('stderr') { should eq 'error' }
 
-## stdout
+### stdout
 
 The `stdout` matcher tests results of the command as returned in standard output (stdout):
 
     its('stdout') { should eq '/^1$/' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Get all groups of Administrator user
+### Get all groups of Administrator user
 
     script = <<-EOH
       # find user
@@ -85,7 +85,7 @@ The following examples show how to use this InSpec audit resource.
       its('stdout') { should_not eq '' }
     end
 
-## Write-Output 'hello'
+### Write-Output 'hello'
 
 The following Powershell script:
 

--- a/docs/resources/process.md.erb
+++ b/docs/resources/process.md.erb
@@ -6,7 +6,7 @@ title: About the processes Resource
 
 Use the `processes` InSpec audit resource to test properties for programs that are running on the system.
 
-# Syntax
+## Syntax
 
 A `processes` resource block declares the name of the process to be tested, and then declares one (or more) property/value pairs:
 
@@ -20,53 +20,53 @@ where
 * `property_name` may be used to test user (`its('users')`) and state properties (`its('states')`)
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## property_name
+### property_name
 
 The `property_name` matcher tests the named property for the specified value:
 
     its('property_name') { should eq ['property_value'] }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if the list length for the mysqld process is 1
+### Test if the list length for the mysqld process is 1
 
     describe processes('mysqld') do
       its('list.length') { should eq 1 }
     end
 
-## Test if the init process is owned by the root user
+### Test if the init process is owned by the root user
 
     describe processes('init') do
       its('users') { should eq ['root'] }
     end
 
-## Test if a high-priority process is running
+### Test if a high-priority process is running
 
     describe processes('some_process') do
       its('states') { should eq ['R<'] }

--- a/docs/resources/registry_key.md.erb
+++ b/docs/resources/registry_key.md.erb
@@ -6,7 +6,7 @@ title: About the registry_key Resource
 
 Use the `registry_key` InSpec audit resource to test key values in the Windows registry.
 
-# Syntax
+## Syntax
 
 A `registry_key` resource block declares the item in the Windows registry, the path to a setting under that item, and then one (or more) name/value pairs to be tested.
 
@@ -33,7 +33,7 @@ Or use a Ruby Hash:
     end
 
 
-## Registry Key Path Separators
+### Registry Key Path Separators
 
 A Windows registry key can be used as a string in Ruby code, such as when a registry key is used as the name of a recipe. In Ruby, when a registry key is enclosed in a double-quoted string (`" "`), the same backslash character (`\`) that is used to define the registry key path separator is also used in Ruby to define an escape character. Therefore, the registry key path separators must be escaped when they are enclosed in a double-quoted string. For example, the following registry key:
 
@@ -48,15 +48,15 @@ or may be enclosed in a double-quoted string with an extra backslash as an escap
     "HKCU\\SOFTWARE\\path\\to\\key\\Themes"
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## children
+### children
 
 The `children` matcher return all of the child items of a registry key. A regular expression may be used to filter child items:
 
@@ -81,57 +81,57 @@ The following example shows how find a property that may exist against multiple 
         end
       }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if the registry key is present:
 
     it { should exist }
 
-## have_property
+### have_property
 
 The `have_property` matcher tests if a property exists for a registry key:
 
     it { should have_property 'value' }
 
-## have_property_value
+### have_property_value
 
 The `have_property_value` matcher tests if a property value exists for a registry key:
 
     it { should have_property_value 'value' }
 
-## have_value
+### have_value
 
 The `have_value` matcher tests if a value exists for a registry key:
 
     it { should have_value 'value' }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## name
+### name
 
 The `name` matcher tests the value for the specified registry setting:
 
     its('name') { should eq 'value' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test the start time for the Schedule service
+### Test the start time for the Schedule service
 
     describe registry_key('Task Scheduler','HKEY_LOCAL_MACHINE\...\Schedule') do
       its('Start') { should eq 2 }
@@ -139,7 +139,7 @@ The following examples show how to use this InSpec audit resource.
 
 where `'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule'` is the full path to the setting.
 
-## Use a regular expression in responses
+### Use a regular expression in responses
 
     describe registry_key({
       hive: 'HKEY_LOCAL_MACHINE',

--- a/docs/resources/runit_service.md.erb
+++ b/docs/resources/runit_service.md.erb
@@ -6,7 +6,7 @@ title: About the runit_service Resource
 
 Use the `runit_service` InSpec audit resource to test a service using runit.
 
-# Syntax
+## Syntax
 
 A `runit_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
@@ -29,48 +29,48 @@ The path to the service manager's control may be specified for situations where 
       it { should be_running }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_enabled
+### be_enabled
 
 The `be_enabled` matcher tests if the named service is enabled:
 
     it { should be_enabled }
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
     it { should be_installed }
 
-## be_running
+### be_running
 
 The `be_running` matcher tests if the named service is running:
 
     it { should be_running }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 None.

--- a/docs/resources/security_policy.md.erb
+++ b/docs/resources/security_policy.md.erb
@@ -6,7 +6,7 @@ title: About the security_policy Resource
 
 Use the `security_policy` InSpec audit resource to test security policies on the Windows platform.
 
-# Syntax
+## Syntax
 
 A `security_policy` resource block declares the name of a security policy and the value to be tested:
 
@@ -20,41 +20,41 @@ where
 * `{ should eq 'value' }` tests the value of `policy_name` against the value declared in the test
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## policy_name
+### policy_name
 
 The `policy_name` matcher must be the name of a security policy:
 
     its('SeNetworkLogonRight') { should eq '*S-1-5-11' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Verify that only the Administrators group has remote access
+### Verify that only the Administrators group has remote access
 
     describe security_policy do
       its('SeRemoteInteractiveLogonRight') { should eq '*S-1-5-32-544' }

--- a/docs/resources/service.md.erb
+++ b/docs/resources/service.md.erb
@@ -8,7 +8,7 @@ Use the `service` InSpec audit resource to test if the named service is installe
 
 Under some circumstances, it may be necessary to specify the service manager by using one of the following service manager-specific resources: `bsd_service`, `launchd_service`, `runit_service`, `systemd_service`, `sysv_service`, oe `upstart_service`. These resources are based on the `service` resource.
 
-# Syntax
+## Syntax
 
 A `service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
@@ -24,67 +24,67 @@ where
 * `be_installed`, `be_enabled`, and `be_running` are valid matchers for this resource
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_enabled
+### be_enabled
 
 The `be_enabled` matcher tests if the named service is enabled:
 
     it { should be_enabled }
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
     it { should be_installed }
 
-## be_running
+### be_running
 
 The `be_running` matcher tests if the named service is running:
 
     it { should be_running }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if the postgresql service is both running and enabled
+### Test if the postgresql service is both running and enabled
 
     describe service('postgresql') do
       it { should be_enabled }
       it { should be_running }
     end
 
-## Test if the mysql service is both running and enabled
+### Test if the mysql service is both running and enabled
 
     describe service('mysqld') do
       it { should be_enabled }
       it { should be_running }
     end
 
-## Test if ClamAV (an antivirus engine) is installed and running
+### Test if ClamAV (an antivirus engine) is installed and running
 
     describe package('clamav') do
       it { should be_installed }
@@ -97,7 +97,7 @@ The following examples show how to use this InSpec audit resource.
       it { should_not be_running }
     end
 
-## Test Unix System V run levels
+### Test Unix System V run levels
 
 On targets that are using SystemV services, the existing run levels can also be checked:
 
@@ -109,7 +109,7 @@ On targets that are using SystemV services, the existing run levels can also be 
       it { should be_enabled }
     end
 
-## Override the service manager
+### Override the service manager
 
 Under some circumstances, it may be required to override the logic in place to select the right service manager. For example, to check a service managed by Upstart:
 
@@ -127,7 +127,7 @@ This is also possible with `systemd_service`, `runit_service`, `sysv_service`, `
       it { should be_running }
     end
 
-## Verify that IIS is running
+### Verify that IIS is running
 
     describe service('W3SVC') do
       it { should be_installed }

--- a/docs/resources/ssh_config.md.erb
+++ b/docs/resources/ssh_config.md.erb
@@ -6,7 +6,7 @@ title: About the ssh_config Resource
 
 Use the `ssh_config` InSpec audit resource to test OpenSSH client configuration data located at `/etc/ssh/ssh_config` on Linux and Unix platforms.
 
-# Syntax
+## Syntax
 
 An `ssh_config` resource block declares the client OpenSSH configuration data to be tested:
 
@@ -21,31 +21,31 @@ where
 * `{ should include('foo') }` tests the value of `name` as read from `ssh_config` versus the value declared in the test
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## name
+### name
 
 The `name` matcher tests the value of `name` as read from `ssh_config` versus the value declared in the test:
 
@@ -55,11 +55,11 @@ or:
 
     its('name') { should include('bar') }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test SSH configuration settings
+### Test SSH configuration settings
 
     describe ssh_config do
       its('cipher') { should contain '3des' }
@@ -67,7 +67,7 @@ The following examples show how to use this InSpec audit resource.
       its('hostname') { should include('example.com') }
     end
 
-## Test which variables from the local environment are sent to the server
+### Test which variables from the local environment are sent to the server
 
     only_if do
       command('sshd').exist? or command('ssh').exists?
@@ -77,14 +77,14 @@ The following examples show how to use this InSpec audit resource.
       its('SendEnv') { should include('GORDON_CLIENT') }
     end
 
-## Test owner and group permissions
+### Test owner and group permissions
 
     describe ssh_config do
       its('owner') { should eq 'root' }
       its('mode') { should cmp '0644' }
     end
 
-## Test SSH configuration
+### Test SSH configuration
 
     describe ssh_config do
       its('Host') { should eq '*' }

--- a/docs/resources/sshd_config.md.erb
+++ b/docs/resources/sshd_config.md.erb
@@ -6,7 +6,7 @@ title: About the sshd_config Resource
 
 Use the `sshd_config` InSpec audit resource to test configuration data for the OpenSSH daemon located at `/etc/ssh/sshd_config` on Linux and Unix platforms. sshd---the OpenSSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command executation, and data exchanges.
 
-# Syntax
+## Syntax
 
 An `sshd_config` resource block declares the client OpenSSH configuration data to be tested:
 
@@ -21,31 +21,31 @@ where
 * `{ should include('foo') }` tests the value of `name` as read from `sshd_config` versus the value declared in the test
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## name
+### name
 
 The `name` matcher tests the value of `name` as read from `sshd_config` versus the value declared in the test:
 
@@ -55,35 +55,35 @@ or:
 
     its('name') {should include('bar') }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test which variables may be sent to the server
+### Test which variables may be sent to the server
 
     describe sshd_config do
       its('AcceptEnv') { should include('GORDON_SERVER') }
     end
 
-## Test for IPv6-only addresses
+### Test for IPv6-only addresses
 
     describe sshd_config do
       its('AddressFamily') { should cmp 'inet6' }
     end
 
-## Test the Protocol setting
+### Test the Protocol setting
 
     describe sshd_config do
       its('Protocol') { should cmp 2 }
     end
 
-## Test for approved, strong ciphers
+### Test for approved, strong ciphers
 
     describe sshd_config do
       its('Ciphers') { should cmp('chacha20-poly1305@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr') }
     end
 
-## Test SSH protocols
+### Test SSH protocols
 
     describe sshd_config do
       its('Port') { should cmp  22 }

--- a/docs/resources/ssl.md.erb
+++ b/docs/resources/ssl.md.erb
@@ -6,7 +6,7 @@ title: About the ssl Resource
 
 Use the `ssl` InSpec audit resource to test SSL settings for the named port.
 
-# Syntax
+## Syntax
 
 An `ssl` resource block declares an SSL port, and then other properties of the test like cipher and/or protocol:
 
@@ -26,21 +26,21 @@ where
 * `filter` may take any of the following arguments: `ciphers`, `protocols`, and `handshake`
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_enabled
+### be_enabled
 
 The `be_enabled` matcher tests if SSL is enabled:
 
     it { should be_enabled }
 
-## ciphers
+### ciphers
 
 The `ciphers` matcher tests the named cipher:
 
@@ -52,23 +52,23 @@ or:
       it { should_not be_enabled }
     end
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## protocols
+### protocols
 
 The `protocols` matcher tests the number of times the named user appears in `/etc/shadow`:
 
@@ -80,11 +80,11 @@ or:
       it { should_not be_enabled }
     end
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Run the ssl-benchmark example profile
+### Run the ssl-benchmark example profile
 
 The following shows how to use the `ssl` InSpec audit resource to find all TCP ports on the system, including IPv4 and IPv6. (This is a partial example based on the `ssl_text.rb` file in the `ssl-benchmark` profile on GitHub.)
 

--- a/docs/resources/sys_info.md.erb
+++ b/docs/resources/sys_info.md.erb
@@ -6,7 +6,7 @@ title: About the sys_info Resource
 
 Use the `sys_info` InSpec audit resource to test for operating system properties for the named host, and then returns that info as standard output.
 
-# Syntax
+## Syntax
 
 An `sys_info` resource block declares the hostname to be tested:
 
@@ -14,41 +14,41 @@ An `sys_info` resource block declares the hostname to be tested:
       its('hostname') { should eq 'value' }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## hostname
+### hostname
 
 The `hostname` matcher tests the host for which standard output is returned:
 
     its('hostname') { should eq 'value' }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Get system information for example.com
+### Get system information for example.com
 
     describe sys_info do
       its('hostname') { should eq 'example.com' }

--- a/docs/resources/systemd_service.md.erb
+++ b/docs/resources/systemd_service.md.erb
@@ -6,7 +6,7 @@ title: About the systemd_service Resource
 
 Use the `systemd_service` InSpec audit resource to test a service using SystemD.
 
-# Syntax
+## Syntax
 
 A `systemd_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
@@ -29,48 +29,48 @@ The path to the service manager's control may be specified for situations where 
       it { should be_running }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_enabled
+### be_enabled
 
 The `be_enabled` matcher tests if the named service is enabled:
 
     it { should be_enabled }
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
     it { should be_installed }
 
-## be_running
+### be_running
 
 The `be_running` matcher tests if the named service is running:
 
     it { should be_running }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 None.

--- a/docs/resources/sysv_service.md.erb
+++ b/docs/resources/sysv_service.md.erb
@@ -6,7 +6,7 @@ title: About the sysv_service Resource
 
 Use the `sysv_service` InSpec audit resource to test a service using SystemV.
 
-# Syntax
+## Syntax
 
 A `sysv_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
@@ -29,48 +29,48 @@ The path to the service manager's control may be specified for situations where 
       it { should be_running }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_enabled
+### be_enabled
 
 The `be_enabled` matcher tests if the named service is enabled:
 
     it { should be_enabled }
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
     it { should be_installed }
 
-## be_running
+### be_running
 
 The `be_running` matcher tests if the named service is running:
 
     it { should be_running }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 None.

--- a/docs/resources/upstart_service.md.erb
+++ b/docs/resources/upstart_service.md.erb
@@ -6,7 +6,7 @@ title: About the upstart_service Resource
 
 Use the `upstart_service` InSpec audit resource to test a service using Upstart.
 
-# Syntax
+## Syntax
 
 An `upstart_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
@@ -29,48 +29,48 @@ The path to the service manager's control may be specified for situations where 
       it { should be_running }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_enabled
+### be_enabled
 
 The `be_enabled` matcher tests if the named service is enabled:
 
     it { should be_enabled }
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
     it { should be_installed }
 
-## be_running
+### be_running
 
 The `be_running` matcher tests if the named service is running:
 
     it { should be_running }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 None.

--- a/docs/resources/user.md.erb
+++ b/docs/resources/user.md.erb
@@ -6,7 +6,7 @@ title: About the user Resource
 
 Use the `user` InSpec audit resource to test user profiles for a single, known/expected local user, including the groups to which that user belongs, the frequency of required password changes, and the directory paths to home and shell.
 
-# Syntax
+## Syntax
 
 A `user` resource block declares a user name, and then one (or more) matchers:
 
@@ -29,29 +29,29 @@ where
 * `it { should exist }` tests if the user exists
 * `gid`, `group`, `groups`, `home`, `maxdays`, `mindays`, `shell`, `uid`, and `warndays` are valid matchers for this resource
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if the named user exists:
 
     it { should exist }
 
-## gid
+### gid
 
 The `gid` matcher tests the group identifier:
 
@@ -59,7 +59,7 @@ The `gid` matcher tests the group identifier:
 
 where `1234` represents the user identifier.
 
-## group
+### group
 
 The `group` matcher tests the group to which the user belongs:
 
@@ -67,27 +67,27 @@ The `group` matcher tests the group to which the user belongs:
 
 where `root` represents the group.
 
-## groups
+### groups
 
 The `groups` matcher tests two (or more) groups to which the user belongs:
 
     its('groups') { should eq ['root', 'other']}
 
-## home
+### home
 
 The `home` matcher tests the home directory path for the user:
 
     its('home') { should eq '/root' }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## maxdays
+### maxdays
 
 The `maxdays` matcher tests the maximum number of days between password changes:
 
@@ -95,7 +95,7 @@ The `maxdays` matcher tests the maximum number of days between password changes:
 
 where `99` represents the maximum number of days.
 
-## mindays
+### mindays
 
 The `mindays` matcher tests the minimum number of days between password changes:
 
@@ -103,13 +103,13 @@ The `mindays` matcher tests the minimum number of days between password changes:
 
 where `0` represents the maximum number of days.
 
-## shell
+### shell
 
 The `shell` matcher tests the path to the default shell for the user:
 
     its('shell') { should eq '/bin/bash' }
 
-## uid
+### uid
 
 The `uid` matcher tests the user identifier:
 
@@ -117,7 +117,7 @@ The `uid` matcher tests the user identifier:
 
 where `1234` represents the user identifier.
 
-## warndays
+### warndays
 
 The `warndays` matcher tests the number of days a user is warned before a password must be changed:
 
@@ -125,11 +125,11 @@ The `warndays` matcher tests the number of days a user is warned before a passwo
 
 where `5` represents the number of days a user is warned.
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Verify available users for the MySQL server
+### Verify available users for the MySQL server
 
     describe user('root') do
       it { should exist }
@@ -142,7 +142,7 @@ The following examples show how to use this InSpec audit resource.
      it { should_not exist }
     end
 
-## Test users on multiple platforms
+### Test users on multiple platforms
 
 The `nginx` user is typically `www-data`, but on CentOS it's `nginx`. The following example shows how to test for the `nginx` user with a single test, but accounting for all platforms:
 

--- a/docs/resources/users.md.erb
+++ b/docs/resources/users.md.erb
@@ -6,7 +6,7 @@ title: About the users Resource
 
 Use the `users` InSpec audit resource to look up all local users available on the system, and then test specific properties of those users. This resource does not return information about users that may be located on other systems, such as LDAP or Active Directory.
 
-# Syntax
+## Syntax
 
 A `users` resource block declares a user name, and then one (or more) matchers:
 
@@ -33,29 +33,29 @@ or:
       it { should exist }
     end
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if the named user exists:
 
     it { should exist }
 
-## gid
+### gid
 
 The `gid` matcher tests the group identifier:
 
@@ -63,7 +63,7 @@ The `gid` matcher tests the group identifier:
 
 where `1234` represents the user identifier.
 
-## group
+### group
 
 The `group` matcher tests the group to which the user belongs:
 
@@ -71,27 +71,27 @@ The `group` matcher tests the group to which the user belongs:
 
 where `root` represents the group.
 
-## groups
+### groups
 
 The `groups` matcher tests two (or more) groups to which the user belongs:
 
     its('groups') { should eq ['root', 'other']}
 
-## home
+### home
 
 The `home` matcher tests the home directory path for the user:
 
     its('home') { should eq '/root' }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## maxdays
+### maxdays
 
 The `maxdays` matcher tests the maximum number of days between password changes:
 
@@ -99,7 +99,7 @@ The `maxdays` matcher tests the maximum number of days between password changes:
 
 where `99` represents the maximum number of days.
 
-## mindays
+### mindays
 
 The `mindays` matcher tests the minimum number of days between password changes:
 
@@ -107,13 +107,13 @@ The `mindays` matcher tests the minimum number of days between password changes:
 
 where `0` represents the maximum number of days.
 
-## shell
+### shell
 
 The `shell` matcher tests the path to the default shell for the user:
 
     its('shell') { should eq '/bin/bash' }
 
-## uid
+### uid
 
 The `uid` matcher tests the user identifier:
 
@@ -121,7 +121,7 @@ The `uid` matcher tests the user identifier:
 
 where `1234` represents the user identifier.
 
-## warndays
+### warndays
 
 The `warndays` matcher tests the number of days a user is warned before a password must be changed:
 
@@ -129,11 +129,11 @@ The `warndays` matcher tests the number of days a user is warned before a passwo
 
 where `5` represents the number of days a user is warned.
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Use a regular expression to find users
+### Use a regular expression to find users
 
     describe users.where { uid =~ /S\-1\-5\-21\-\d+\-\d+\-\d+\-500/ } do
       it { should exist }

--- a/docs/resources/vbscript.md.erb
+++ b/docs/resources/vbscript.md.erb
@@ -6,7 +6,7 @@ title: About the vbscript Resource
 
 Use the `vbscript` InSpec audit resource to test a VBScript on the Windows platform.
 
-# Syntax
+## Syntax
 
 A `vbscript` resource block tests the output of a VBScript on the Windows platform:
 
@@ -20,35 +20,35 @@ where
 * `('output')` is the expected output of the VBScript
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test a VBScript
+### Test a VBScript
 
 A VBScript file similar to:
 

--- a/docs/resources/windows_feature.md.erb
+++ b/docs/resources/windows_feature.md.erb
@@ -6,7 +6,7 @@ title: About the windows_feature Resource
 
 Use the `windows_feature` InSpec audit resource to test features on Windows via the `Get-WindowsFeature` cmdlet.
 
-# Syntax
+## Syntax
 
 A `windows_feature` resource block declares the name of the Windows feature, tests if that feature is installed, and then returns information about that feature:
 
@@ -20,41 +20,41 @@ where
 * `be_installed` is a valid matcher for this resource
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_installed
+### be_installed
 
 The `be_installed` matcher tests if the named Windows feature is installed:
 
     it { should be_installed }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test the DHCP Server feature
+### Test the DHCP Server feature
 
     describe windows_feature('DHCP Server') do
       it{ should be_installed }

--- a/docs/resources/wmi.md.erb
+++ b/docs/resources/wmi.md.erb
@@ -6,7 +6,7 @@ title: About the wmi Resource
 
 Use the `wmi` InSpec audit resource to test WMI settings on the Windows platform.
 
-# Syntax
+## Syntax
 
 A `wmi` resource block tests WMI settings on the Windows platform:
 
@@ -47,35 +47,35 @@ and the second uses a filter in the Ruby Hash to first identify WinRM, and then 
     end
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test a password expiration policy
+### Test a password expiration policy
 
     describe wmi({
       class: 'RSOP_SecuritySettingNumeric',
@@ -85,7 +85,7 @@ The following examples show how to use this InSpec audit resource.
        its('Setting') { should eq 1 }
     end
 
-## Test if an anonymous user can query the Local Security Authority (LSA)
+### Test if an anonymous user can query the Local Security Authority (LSA)
 
     describe wmi({
       namespace: 'root\rsop\computer',

--- a/docs/resources/xinetd_conf.md.erb
+++ b/docs/resources/xinetd_conf.md.erb
@@ -6,7 +6,7 @@ title: About the xinetd_conf Resource
 
 Use the `xinetd_conf` InSpec audit resource to test services under `/etc/xinet.d` on Linux and Unix platforms. xinetd---the extended Internet service daemon---listens on all ports, and then loads the appropriate program based on a request. The `xinetd.conf` file is typically located at `/etc/xinetd.conf` and contains a list of Internet services associated to the ports on which that service will listen. Only enabled services may handle a request; only services that are required by the system should be enabled.
 
-# Syntax
+## Syntax
 
 An `xinetd_conf` resource block declares settings found in a `xinetd.conf` file for the named service:
 
@@ -22,29 +22,29 @@ where
 * `should eq 'value'` is the value that is expected
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_enabed
+### be_enabed
 
 The `be_enabled` matcher tests if a service listed under `/etc/xinet.d` is enabled:
 
     it { should be_enabled }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## ids
+### ids
 
 The `ids` matcher tests if the named service is located under `/etc/xinet.d`:
 
@@ -54,21 +54,21 @@ For example:
 
     its('ids') { should include 'chargen-stream chargen-dgram'}
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## services
+### services
 
 The `services` matcher tests if the named service is listed under `/etc/xinet.d`:
 
     its('services') { should include 'service_name' }
 
-## socket_types
+### socket_types
 
 The `socket_types` matcher tests if a service listed under `/etc/xinet.d` is configured to use the named socket type:
 
@@ -86,7 +86,7 @@ For a TCP-based service:
 
     its('socket_types') { should eq 'stream' }
 
-## types
+### types
 
 The `types` matcher tests the service type:
 
@@ -94,7 +94,7 @@ The `types` matcher tests the service type:
 
 where `'TYPE'` is `INTERNAL` (for a service provided by xinetd), `RPC` (for a service based on remote procedure call), or `UNLISTED` (for services not under `/etc/services` or `/etc/rpc`).
 
-## wait
+### wait
 
 The `wait` matcher tests how a service handles incoming connections.
 
@@ -108,11 +108,11 @@ For TCP (`stream`) socket types the `wait` matcher should test for `no`:
     its('socket_types') { should eq 'stream' }
     its('wait') { should eq 'no' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test a socket_type
+### Test a socket_type
 
 The network socket type: `dgram` (a datagram-based service), `raw` (a service that requires direct access to an IP address), `stream` (a stream-based service), or `seqpacket` (a service that requires a sequenced packet).
 
@@ -120,7 +120,7 @@ The network socket type: `dgram` (a datagram-based service), `raw` (a service th
        its('socket_types') { should include 'dgram' }
     end
 
-## Test a service type
+### Test a service type
 
 The type of service: `INTERNAL` (a service provided by xinetd), `RPC` (an RPC-based service), `TCPMUX` (a service that is started on a well-known TPCMUX port), or `UNLISTED` (a service that is not listed in a standard system file location).
 
@@ -128,7 +128,7 @@ The type of service: `INTERNAL` (a service provided by xinetd), `RPC` (an RPC-ba
        its('type') { should include 'RPC' }
     end
 
-## Test the telnet service
+### Test the telnet service
 
 For example, a `telnet` file under `/etc/xinet.d` contains the following settings:
 

--- a/docs/resources/yaml.md.erb
+++ b/docs/resources/yaml.md.erb
@@ -6,7 +6,7 @@ title: About the yaml Resource
 
 Use the `yaml` InSpec audit resource to test configuration data in a Yaml file.
 
-# Syntax
+## Syntax
 
 A `yaml` resource block declares the configuration data to be tested. Assume the following Yaml file:
 
@@ -28,41 +28,41 @@ where
 * `should eq 'foo'` tests a value of `name` as read from a Yaml file versus the value declared in the test
 
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## name
+### name
 
 The `name` matcher tests the value of `name` as read from a Yaml file versus the value declared in the test:
 
     its('name') { should eq 'foo' }
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test a kitchen.yml file driver
+### Test a kitchen.yml file driver
 
     describe yaml('.kitchen.yaml') do
       its('driver.name') { should eq('vagrant') }

--- a/docs/resources/yum.md.erb
+++ b/docs/resources/yum.md.erb
@@ -6,7 +6,7 @@ title: About the yum Resource
 
 Use the `yum` InSpec audit resource to test packages in the Yum repository.
 
-# Syntax
+## Syntax
 
 A `yum` resource block declares a package repo, tests if the package repository is present, and if it that package repository is a valid package source (i.e. "is enabled"):
 
@@ -19,43 +19,43 @@ where
 
 * `repo('name')` is the (optional) name of a package repo, using either a full identifier (`'updates/7/x86_64'`) or a short identifier (`'updates'`)
 
-# Matchers
+## Matchers
 
 This InSpec audit resource has the following matchers:
 
-## be
+### be
 
 <%= partial "/shared/matcher_be" %>
 
-## be_enabled
+### be_enabled
 
 The `be_enabled` matcher tests if the package repository is a valid package source:
 
     it { should be_enabled }
 
-## cmp
+### cmp
 
 <%= partial "/shared/matcher_cmp" %>
 
-## eq
+### eq
 
 <%= partial "/shared/matcher_eq" %>
 
-## exist
+### exist
 
 The `exist` matcher tests if the package repository exists:
 
     it { should exist }
 
-## include
+### include
 
 <%= partial "/shared/matcher_include" %>
 
-## match
+### match
 
 <%= partial "/shared/matcher_match" %>
 
-## repo('name')
+### repo('name')
 
 The `repo('name')` matcher names a specific package repository:
 
@@ -63,13 +63,13 @@ The `repo('name')` matcher names a specific package repository:
       ...
     end
 
-## repos
+### repos
 
 The `repos` matcher tests if a named repo, using either a full identifier (`'updates/7/x86_64'`) or a short identifier (`'updates'`), is included in the Yum repo:
 
     its('repos') { should include 'some_repo' }
 
-## shortname
+### shortname
 
 The `shortname` matcher names a specific package repository's group identifier. For example, if a repository's group name is "Directory Server", the corresponding group idenfier is typically "directory-server":
 
@@ -77,17 +77,17 @@ The `shortname` matcher names a specific package repository's group identifier. 
       its('shortname') { should eq 'directory-server' }
     end
 
-# Examples
+## Examples
 
 The following examples show how to use this InSpec audit resource.
 
-## Test if the yum repo exists
+### Test if the yum repo exists
 
     describe yum do
       its('repos') { should exist }
     end
 
-## Test if the 'base/7/x86_64' repo exists and is enabled
+### Test if the 'base/7/x86_64' repo exists and is enabled
 
     describe yum do
       its('repos') { should include 'base/7/x86_64' }
@@ -95,7 +95,7 @@ The following examples show how to use this InSpec audit resource.
       its('epel') { should be_enabled }
     end
 
-## Test if a specific yum repo exists
+### Test if a specific yum repo exists
 
     describe yum.repo('epel') do
       it { should exist }


### PR DESCRIPTION
Having multiple H1 tags in a doc can hurt SEO for that topic, so all H1s (with the exception of the first one) have been changed to H2s, H2s changed to H3s, and so on.

Signed-off-by: David Wrede dwrede@chef.io
