### PR TITLE
tp/learn links

### DIFF
--- a/docs/dsl_inspec.md
+++ b/docs/dsl_inspec.md
@@ -74,7 +74,7 @@ The following examples show simple compliance tests using a single `control` blo
 
 ## Test System Event Log
 
-The following test shows how to audit machines running Windows 2012 R2 that pwassword complexity is enabled:
+The following test shows how to audit machines running Windows 2012 R2 that password complexity is enabled:
 
 ```ruby
 control 'windows-account-102' do
@@ -89,7 +89,7 @@ end
 
 ## Are PosgtreSQL passwords empty?
 
-The following test shows how to audit machines running PostgerSQL to ensure that passwords are not empty.
+The following test shows how to audit machines running PostgreSQL to ensure that passwords are not empty.
 
 ```ruby
 control 'postgres-7' do
@@ -173,7 +173,7 @@ end
 
 ## Test Windows Registry Keys
 
-The following test shows how to audit machines to ensure Safe DLL Seach Mode is enabled:
+The following test shows how to audit machines to ensure Safe DLL Search Mode is enabled:
 
 ```ruby
 control 'windows-base-101' do

--- a/www/source/tutorials.html.slim
+++ b/www/source/tutorials.html.slim
@@ -50,15 +50,15 @@ title: InSpec - Tutorials
           |  Day 7
           span  - How to Inherit a Profile from Chef Compliance Server
       li
-        a.tutorials--link href="https://learn.chef.io/test-your-infrastructure-code/"
+        a.tutorials--link href="https://learn.chef.io/tutorials/test-your-infrastructure-code/"
           i.fa.fa-link
           span  Test Your Infrastructure Code with Chef
       li
-        a.tutorials--link href="https://learn.chef.io/compliance-assess/"
+        a.tutorials--link href="https://learn.chef.io/tutorials/compliance-assess/"
           i.fa.fa-link
           span  Assess Your Infrastructure with Chef Compliance Scanner
       li
-        a.tutorials--link href="https://learn.chef.io/compliance-remediate/"
+        a.tutorials--link href="https://learn.chef.io/tutorials/compliance-remediate/"
           i.fa.fa-link
           span  Remediate Compliance Failures on your Infrastructure with Chef
     h3.tutorials--subhead Guides For Advanced Topics


### PR DESCRIPTION
- We’re gradually moving the tutorials under /tutorials.
