### PR TITLE
Remove wildcard from windows package detection

### DIFF
--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -204,7 +204,7 @@ module Inspec::Resources
       # Find the package
       cmd = inspec.command <<-EOF.gsub(/^\s*/, '')
         Get-ItemProperty (@("#{search_paths.join('", "')}") | Where-Object { Test-Path $_ }) |
-        Where-Object { $_.DisplayName -like "#{package_name}*" -or $_.PSChildName -like "#{package_name}" } |
+        Where-Object { $_.DisplayName -like "#{package_name}" -or $_.PSChildName -like "#{package_name}" } |
         Select-Object -Property DisplayName,DisplayVersion | ConvertTo-Json
       EOF
 


### PR DESCRIPTION
This allows stricter checks on windows software, and keeps it in line with the package resource on other platforms
