### PR TITLE
cmp code_desc missing operation and expected valid

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -313,6 +313,10 @@ RSpec::Matchers.define :cmp do |first_expected|
     actual = '0' + actual.to_s(8) if octal?(@expected)
     "\n" + format_expectation(true) + "\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
   end
+
+  description do
+    "cmp #{@operation} #{@expected.inspect}"
+  end
 end
 
 # user resource matcher for serverspec compatibility

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -173,6 +173,9 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  should not be directory\n"
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  undefined method `should_nota'"
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  should not be directory\n     expected `File /tmp.directory?` to return false, got true\e[0m"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  7 should cmp >= 9\n"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  7 should not cmp == /^\\d$/\n"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "✔  7 should cmp == \"7\""
     end
   end
 

--- a/test/unit/mock/profiles/failures/controls/failures.rb
+++ b/test/unit/mock/profiles/failures/controls/failures.rb
@@ -30,3 +30,13 @@ describe file('/tmp') do
   it { should_not be_directory }
   it { should be_directory }
 end
+
+# control, first and second fail, third passes
+control 'cmp-1.0' do
+  title 'Using the cmp matcher for numbers'
+  describe 7 do
+    it { should cmp >= 9 }
+    it { should_not cmp /^\d$/ }
+    it { should cmp == '7' }
+  end
+end


### PR DESCRIPTION
Having the following spec file:

``` ruby
describe 6 do
  it { should cmp 6 }
end

describe 7 do
  it { should cmp '7' }
end

describe 8 do
  it { should cmp <= '10' }
end

describe 9 do
  it { should cmp == 9 }
end
```

I get the following exec output with inspec 1.1.0(latest):

``` ruby
$ be inspec exec ~/tmp/cmp.rb
Target:  local://

  6 should
     ✔  cmp 6
  7 should
     ✔  cmp "7"
  8 should
     ✔  cmp
  9 should
     ✔  cmp
```

^ see the missing operator and value for 8 & 9

The code change in this PR produces the following exec output:

``` ruby
$ be inspec exec ~/tmp/cmp.rb
Target:  local://

  6 should
     ✔  cmp == 6
  7 should
     ✔  cmp == "7"
  8 should
     ✔  cmp <= "10"
  9 should
     ✔  cmp == 9
```

8 & 9 have operator and value 🎉 
