### PR TITLE
Show actual value for cmp octal comparisons in string to match expected

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -305,12 +305,12 @@ RSpec::Matchers.define :cmp do |first_expected|
   end
 
   failure_message do |actual|
-    actual = '0' + actual.to_s(8) if octal?(@expected)
+    actual = ('0' + actual.to_s(8)).inspect if octal?(@expected)
     "\n" + format_expectation(false) + "\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
   end
 
   failure_message_when_negated do |actual|
-    actual = '0' + actual.to_s(8) if octal?(@expected)
+    actual = ('0' + actual.to_s(8)).inspect if octal?(@expected)
     "\n" + format_expectation(true) + "\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
   end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -176,6 +176,8 @@ Test Summary: \e[32m2 successful\e[0m, \e[31m0 failures\e[0m, \e[37m0 skipped\e[
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  7 should cmp >= 9\n"
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✖  7 should not cmp == /^\\d$/\n"
       out.stdout.force_encoding(Encoding::UTF_8).must_include "✔  7 should cmp == \"7\""
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "  expected: \"01147\"
+          got: \"01777\"\n"
     end
   end
 

--- a/test/unit/mock/profiles/failures/controls/failures.rb
+++ b/test/unit/mock/profiles/failures/controls/failures.rb
@@ -29,6 +29,7 @@ end
 describe file('/tmp') do
   it { should_not be_directory }
   it { should be_directory }
+  its('mode') { should cmp '01147' }
 end
 
 # control, first and second fail, third passes


### PR DESCRIPTION
Before the change in this PR:

``` ruby
     ✖  File /tmp/sixhundred.txt mode should cmp == "0700"

     expected: "0700"
          got: 0600
```

After the change:

``` ruby
     ✖  File /tmp/sixhundred.txt mode should cmp == "0700"

     expected: "0700"
          got: "0600"
```
