### PR TITLE
adding by_user permissions support for windows

### DIFF
--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -29,6 +29,7 @@ module Inspec::Resources
         it { should be_file }
         it { should be_readable }
         it { should be_writable }
+        it { should be_executable.by_user('root') }
         it { should be_owned_by 'root' }
         its('mode') { should cmp '0644' }
       end

--- a/test/cookbooks/os_prepare/recipes/file.rb
+++ b/test/cookbooks/os_prepare/recipes/file.rb
@@ -40,7 +40,30 @@ if node['platform_family'] != 'windows'
 
 else
 
-  directory 'C:\Test Directory'
-  file 'C:\Test Directory\test file.txt'
+  user 'TestUser' do
+    password 'p@ssw0rd'
+  end
+
+  directory 'C:\Test Directory' do
+    rights :read, 'Administrators'
+    rights :read_execute, 'Administrators'
+    rights :write, 'Administrators'
+    rights :modify, 'Administrators'
+    rights :full_control, 'Administrators', :applies_to_children => true
+    deny_rights :read, 'TestUser'
+    deny_rights :write, 'TestUser'
+    deny_rights :read_execute, 'TestUser'
+  end
+
+  file 'C:\Test Directory\test file.txt' do
+    rights :read, 'Administrators'
+    rights :read_execute, 'Administrators'
+    rights :write, 'Administrators'
+    rights :modify, 'Administrators'
+    rights :full_control, 'Administrators'
+    deny_rights :read, 'TestUser'
+    deny_rights :write, 'TestUser'
+    deny_rights :read_execute, 'TestUser'
+  end
 
 end

--- a/test/integration/default/file_spec.rb
+++ b/test/integration/default/file_spec.rb
@@ -4,7 +4,11 @@ if ENV['DOCKER']
   return
 end
 
-if os[:name] == 'freebsd'
+if os[:family] == 'windows'
+  filedata = {
+    user: os_env('COMPUTERNAME').content + '\TestUser'
+  }
+elsif os[:name] == 'freebsd'
   filedata = {
     user: 'root',
     group: 'wheel',
@@ -177,14 +181,26 @@ if os.windows?
     its('path') { should cmp "C:\\Windows" }
   end
 
-  describe file('C:\\Test Directory\\test file.txt') do
+  describe file('C:/Test Directory/test file.txt') do
     it { should exist }
     it { should be_file }
+    it { should be_readable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should be_writable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should be_executable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should_not be_readable.by_user(filedata[:user]) }
+    it { should_not be_writable.by_user(filedata[:user]) }
+    it { should_not be_executable.by_user(filedata[:user]) }
   end
 
-  describe file('C:\\Test Directory') do
+  describe file('C:/Test Directory') do
     it { should exist }
     it { should be_directory }
+    it { should be_readable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should be_writable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should be_executable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should_not be_readable.by_user(filedata[:user]) }
+    it { should_not be_writable.by_user(filedata[:user]) }
+    it { should_not be_executable.by_user(filedata[:user]) }
   end
 
   describe file("C:/Program Files (x86)/Windows NT/Accessories/wordpad.exe") do

--- a/test/unit/resources/file_test.rb
+++ b/test/unit/resources/file_test.rb
@@ -5,198 +5,62 @@
 require 'helper'
 require 'inspec/resource'
 
-def shared_file_permission_tests(method_under_test)
-  it 'returns false if the file does not exist' do
-    resource.stubs(:exist?).returns(false)
-    resource.send(method_under_test, nil, nil).must_equal(false)
-  end
-
-  it 'returns the value of #file_permission_granted?' do
-    resource.stubs(:exist?).returns(true)
-    resource.stubs(:file_permission_granted?).returns('test_result')
-    resource.send(method_under_test, nil, nil).must_equal('test_result')
-  end
-end
-
 describe Inspec::Resources::FileResource do
-  let(:resource) { load_resource('file', '/fakepath/fakefile') }
-
-  describe '#readable?' do
-    shared_file_permission_tests(:readable?)
+  let(:file) { stub(unix_mode_mask: 000, mode: 000) }
+  it 'responds on Ubuntu' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('file', '/fakepath/fakefile')
+    resource.stubs(:exist?).returns(true)
+    resource.stubs(:mounted?).returns(true)
+    resource.stubs(:source_path).returns('/fakepath/fakefile')
+    resource.stubs(:file).returns(file)
+    resource.stubs(:content).returns('content')
+    resource.stubs(:mode).returns(000)
+    resource.stubs(:suid).returns(true)
+    resource.stubs(:sgid).returns(true)
+    resource.stubs(:sticky).returns(true)
+    resource.stubs(:file_permission_granted?).with('read', 'by_usergroup', 'by_specific_user').returns('test_result')
+    resource.stubs(:file_permission_granted?).with('write', 'by_usergroup', 'by_specific_user').returns('test_result')
+    resource.stubs(:file_permission_granted?).with('execute', 'by_usergroup', 'by_specific_user').returns('test_result')
+    _(resource.content).must_equal 'content'
+    _(resource.exist?).must_equal true
+    _(resource.mounted?).must_equal true
+    _(resource.to_s).must_equal 'File /fakepath/fakefile'
+    _(resource.readable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.writable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.executable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.suid).must_equal true
+    _(resource.sgid).must_equal true
+    _(resource.sticky).must_equal true
   end
-
-  describe '#writable?' do
-    shared_file_permission_tests(:writable?)
+  it 'responds on Windows' do
+    resource = MockLoader.new(:windows).load_resource('file', 'C:/fakepath/fakefile')
+    resource.stubs(:exist?).returns(true)
+    resource.stubs(:mounted?).returns(true)
+    resource.stubs(:content).returns('content')
+    resource.stubs(:file_permission_granted?).with('read', 'by_usergroup', 'by_specific_user').returns('test_result')
+    resource.stubs(:file_permission_granted?).with('write', 'by_usergroup', 'by_specific_user').returns('test_result')
+    resource.stubs(:file_permission_granted?).with('execute', 'by_usergroup', 'by_specific_user').returns('test_result')
+    _(resource.content).must_equal 'content'
+    _(resource.exist?).must_equal true
+    _(resource.mounted?).must_equal true
+    _(resource.readable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.writable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.executable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
   end
-
-  describe '#executable?' do
-    shared_file_permission_tests(:executable?)
+  it 'does not support check by mask on Windows' do
+    resource = MockLoader.new(:windows).load_resource('file', 'C:/fakepath/fakefile')
+    resource.stubs(:exist?).returns(true)
+    proc { resource.send('readable?', 'by_usergroup', nil) }.must_raise(RuntimeError)
+    proc { resource.send('writable?', 'by_usergroup', nil) }.must_raise(RuntimeError)
+    proc { resource.send('executable?', 'by_usergroup', nil) }.must_raise(RuntimeError)
   end
-
-  describe '#basename' do
-    it 'returns the basename' do
-      resource.stubs(:basename).returns('fakefile')
-      resource.basename.must_equal('fakefile')
-    end
-  end
-
-  describe '#to_s' do
-    it 'returns a properly formatted string' do
-      resource.to_s.must_equal('File /fakepath/fakefile')
-    end
-  end
-
-  describe '#file_permission_granted?' do
-    describe 'when not on a unix OS' do
-      it 'raises an exception' do
-        MockLoader.mock_os(resource, :windows)
-        proc { resource.send(:file_permission_granted?, 'flag', nil, nil) }.must_raise(RuntimeError)
-      end
-    end
-
-    describe 'when on a unix OS' do
-      before do
-        MockLoader.mock_os(resource, :centos7)
-      end
-
-      describe 'when no user is provided' do
-        it 'checks file permission by mask' do
-          resource.expects(:check_file_permission_by_mask).with('usergroup', 'flag')
-          resource.send(:file_permission_granted?, 'flag', 'usergroup', nil)
-        end
-      end
-
-      describe 'when a user is provided' do
-        it 'checks file permission by user' do
-          resource.expects(:check_file_permission_by_user).with('user', 'flag')
-          resource.send(:file_permission_granted?, 'flag', nil, 'user')
-        end
-      end
-    end
-  end
-
-  describe '#check_file_permission_by_mask' do
-    describe 'when no mask is returned' do
-      let(:file) { stub(unix_mode_mask: nil) }
-
-      it 'raises an exception' do
-        file = stub(unix_mode_mask: nil)
-        resource.stubs(:file).returns(file)
-        proc { resource.send(:check_file_permission_by_mask, 'usergroup', 'flag') }.must_raise(RuntimeError)
-      end
-    end
-
-    describe 'when a mask is returned' do
-      describe 'when the bitwise AND returns a non-zero' do
-        let(:file) { stub(unix_mode_mask: 292, mode: 420) }
-        it 'returns true' do
-          resource.stubs(:file).returns(file)
-          resource.send(:check_file_permission_by_mask, 'usergroup', 'flag').must_equal(true)
-        end
-      end
-
-      describe 'when the bitwise AND returns zero' do
-        let(:file) { stub(unix_mode_mask: 73, mode: 420) }
-        it 'returns false' do
-          resource.stubs(:file).returns(file)
-          resource.send(:check_file_permission_by_mask, 'usergroup', 'flag').must_equal(false)
-        end
-      end
-    end
-  end
-
-  describe 'check_file_permission_by_user' do
-    describe 'when on linux' do
-      before do
-        MockLoader.mock_os(resource, :centos7)
-      end
-
-      it 'executes a properly formatted command' do
-        MockLoader.mock_command(resource,
-          'su -s /bin/sh -c "test -flag /fakepath/fakefile" user',
-          exit_status: 0)
-        resource.send(:check_file_permission_by_user, 'user', 'flag')
-      end
-
-      it 'returns true when the cmd exits 0' do
-        MockLoader.mock_command(resource, 'su -s /bin/sh -c "test -flag /fakepath/fakefile" user', exit_status: 0)
-        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(true)
-      end
-
-      it 'returns false when the cmd exits non-zero' do
-        MockLoader.mock_command(resource, 'su -s /bin/sh -c "test -flag /fakepath/fakefile" user', exit_status: 1)
-        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(false)
-      end
-    end
-
-    describe 'when on freebsd' do
-      before do
-        MockLoader.mock_os(resource, :freebsd10)
-      end
-
-      it 'executes a properly formatted command' do
-        MockLoader.mock_command(resource, 'sudo -u user test -flag /fakepath/fakefile', exit_status: 0)
-        resource.send(:check_file_permission_by_user, 'user', 'flag')
-      end
-
-      it 'returns true when the cmd exits 0' do
-        MockLoader.mock_command(resource, 'sudo -u user test -flag /fakepath/fakefile', exit_status: 0)
-        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(true)
-      end
-
-      it 'returns false when the cmd exits non-zero' do
-        MockLoader.mock_command(resource, 'sudo -u user test -flag /fakepath/fakefile', exit_status: 1)
-        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(false)
-      end
-    end
-
-    describe 'when on hpux' do
-      before do
-        MockLoader.mock_os(resource, :hpux)
-      end
-
-      it 'executes a properly formatted command' do
-        MockLoader.mock_command(resource, "su user -c \"test -flag /fakepath/fakefile\"", exit_status: 0)
-        resource.send(:check_file_permission_by_user, 'user', 'flag')
-      end
-
-      it 'returns true when the cmd exits 0' do
-        MockLoader.mock_command(resource, "su user -c \"test -flag /fakepath/fakefile\"", exit_status: 0)
-        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(true)
-      end
-
-      it 'returns false when the cmd exits non-zero' do
-        MockLoader.mock_command(resource, "su user -c \"test -flag /fakepath/fakefile\"", exit_status: 1)
-        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal(false)
-      end
-    end
-
-    describe 'when not on linux or freebsd' do
-      before do
-        MockLoader.mock_os(resource, :undefined)
-      end
-
-      it 'returns an error string' do
-        resource.send(:check_file_permission_by_user, 'user', 'flag').must_equal('The `file` resource does not support `by_user` on your OS.')
-      end
-    end
-  end
-
-  describe '#usergroup_for' do
-    it 'returns "other" if "others" is provided' do
-      resource.send(:usergroup_for, 'others', nil).must_equal('other')
-    end
-
-    it 'returns "all" if no usergroup or user is specified' do
-      resource.send(:usergroup_for, nil, nil).must_equal('all')
-    end
-
-    it 'returns nil if the usergroup is nil and a user is specified' do
-      resource.send(:usergroup_for, nil, 'user').must_equal(nil)
-    end
-
-    it 'returns the passed-in usergroup if usergroup is not nil and user is nil' do
-      resource.send(:usergroup_for, 'mygroup', nil).must_equal('mygroup')
-    end
+  it 'responds with errors on unsupported OS' do
+    resource = MockLoader.new(:unsupported).load_resource('file', 'C:/fakepath/fakefile')
+    resource.stubs(:exist?).returns(true)
+    _(resource.exist?).must_equal true
+    _(resource.readable?('by_usergroup', 'by_specific_user')).must_equal '`readable?` is not supported on your OS yet.'
+    _(resource.writable?('by_usergroup', 'by_specific_user')).must_equal '`writable?` is not supported on your OS yet.'
+    _(resource.executable?('by_usergroup', 'by_specific_user')).must_equal '`executable?` is not supported on your OS yet.'
+    proc { resource.send(:contain, nil) }.must_raise(RuntimeError)
   end
 end


### PR DESCRIPTION
This is a first stab at adding mvp support for checking read/write/execute file permissions, for a specific user.

```
  # verifies if a specific user has access to a file
    describe file("C:/users/vagrant/setup.bat") do
      it { should exist }
      it { should_not be_readable.by_user('vagrant-2012-r2\jdoe') }
      it { should be_readable.by_user('vagrant-2012-r2\vagrant') }
      it { should_not be_executable.by_user('vagrant-2012-r2\jdoe') }
      it { should be_executable.by_user('vagrant-2012-r2\vagrant') }
      it { should_not be_writable.by_user('vagrant-2012-r2\jdoe') }
      it { should be_writable.by_user('vagrant-2012-r2\vagrant') }
      it { should be_readable }
      it { should be_writeable }
      it { should be_executable }
    end
```

The above results in the following when `vagrant-2012-r2\jdoe` was denied access to the file:

<img width="557" alt="screen shot 2016-10-11 at 9 59 33 pm" src="https://cloud.githubusercontent.com/assets/1991696/19294842/2a65b346-8ffe-11e6-9868-0c2d44b74660.png">

I believe it addresses #783 

It will fail unit tests since they will have to be refactored.  If this passes muster I'll refactor the tests.

Signed-off-by: Jeremy J. Miller jm@chef.io
