### PR TITLE
move Inspec Habitat package to chef/inspec.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ omnibus/.cache
 omnibus/pkg
 test/**/*.lock
 examples/**/*.lock
+habitat/VERSION
+habitat/results

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ gem install inspec-*.gem
 
 On Windows, you need to install [Ruby](http://rubyinstaller.org/downloads/) with [Ruby Development Kit](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit) to build dependencies with its native extensions.
 
+### Install via Habitat
+
+Currently, this method of installation only supports Linux. See the [Habitat site](https://www.habitat.sh/) for more information.
+
+Download the `hab` binary from the [Habitat](https://www.habitat.sh/docs/get-habitat/) site. 
+
+```bash
+hab pkg install chef/inspec
+export PATH="$(hab pkg path core/ruby)/bin:$(hab pkg path chef/inspec)/bin:$PATH"
+
+inspec
+```
+
 ### Run InSpec
 
 You should now be able to run:

--- a/Rakefile
+++ b/Rakefile
@@ -167,3 +167,20 @@ task :release_docker do
   puts "--> #{cmd}"
   sh('sh', '-c', cmd)
 end
+
+desc 'Release a new Habitat package'
+task :release_habitat do
+    version = Inspec::VERSION
+    ENV['HAB_ORIGIN'] = "chef"
+    if Dir.exist?("./results") then
+        raise "Please remove the ./results directory"
+    end
+    if ! ENV.has_key?("HAB_AUTH_TOKEN") then
+        raise "Please set the HAB_AUTH_TOKEN environment variable"
+    end
+    cmd = "echo #{version} > ./habitat/VERSION && "\
+          "hab studio build ./habitat && " \
+          "hab pkg upload ./results/*.hart"
+    puts "--> #{cmd}"
+    sh('sh', '-c', cmd)
+end

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,56 @@
+pkg_name=inspec
+pkg_origin=chef
+pkg_version=$(cat "VERSION")
+pkg_description="InSpec is an open-source testing framework for infrastructure
+  with a human- and machine-readable language for specifying compliance,
+  security and policy requirements."
+pkg_upstream_url=https://github.com/chef/inspec
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Apache-2.0')
+pkg_source=false
+pkg_deps=(
+  core/coreutils
+  core/ruby
+  core/net-tools
+)
+pkg_build_deps=(
+  core/bundler
+  core/coreutils
+  core/gcc
+  core/make
+  core/readline
+)
+pkg_bin_dirs=(bin)
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  # Create a Gemfile with what we need
+  cat > Gemfile <<GEMFILE
+source 'https://rubygems.org'
+gem '$pkg_name', '= $pkg_version'
+GEMFILE
+}
+
+do_build() {
+  export BUNDLE_SILENCE_ROOT_WARNING=1 GEM_PATH
+  GEM_PATH="$(pkg_path_for core/bundler)"
+  bundle install --jobs "$(nproc)" --retry 5 --standalone \
+    --path "$pkg_prefix/bundle" \
+    --binstubs "$pkg_prefix/bin"
+}
+
+do_install () {
+  fix_interpreter "$pkg_prefix/bin/*" core/coreutils bin/env
+  cp Gemfile.lock "$pkg_prefix"
+}


### PR DESCRIPTION
NOTE: The existing `core/inspec` package (version 0.27.0) cannot be removed
from the public Habitat depot.

See also: https://github.com/chef/compliance-team/pull/32

see #843 
