### PR TITLE
Fix processes resource user and command truncation

### DIFF
--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -47,10 +47,10 @@ module Inspec::Resources
       os = inspec.os
 
       if os.linux?
-        command = 'ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,comm,user'
+        command = 'ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command'
         regex = /^([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+(.*)$/
       else
-        command = 'ps axo pid,pcpu,pmem,vsz,rss,tty,stat,start,time,comm,user'
+        command = 'ps axo pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user,command'
         regex = /^\s*([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+(.*)$/
       end
       build_process_list(command, regex, os)
@@ -59,7 +59,7 @@ module Inspec::Resources
     Process = Struct.new(:label, :pid,
                          :cpu, :mem, :vsz,
                          :rss, :tty, :stat,
-                         :start, :time, :command, :user)
+                         :start, :time, :user, :command)
 
     def build_process_list(command, regex, os)
       cmd = inspec.command(command)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -140,8 +140,8 @@ class MockLoader
     }
 
     mock.commands = {
-      'ps aux' => cmd.call('ps-aux'),
-      'ps auxZ' => cmd.call('ps-auxZ'),
+      'ps axo pid,pcpu,pmem,vsz,rss,tty,stat,start,time,comm,user' => cmd.call('ps-axo'),
+      'ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,comm,user' => cmd.call('ps-axoZ'),
       'Get-Content win_secpol.cfg' => cmd.call('secedit-export'),
       'secedit /export /cfg win_secpol.cfg' => cmd.call('success'),
       'Remove-Item win_secpol.cfg' => cmd.call('success'),

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -140,8 +140,8 @@ class MockLoader
     }
 
     mock.commands = {
-      'ps axo pid,pcpu,pmem,vsz,rss,tty,stat,start,time,comm,user' => cmd.call('ps-axo'),
-      'ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,comm,user' => cmd.call('ps-axoZ'),
+      'ps axo pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user,command' => cmd.call('ps-axo'),
+      'ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command' => cmd.call('ps-axoZ'),
       'Get-Content win_secpol.cfg' => cmd.call('secedit-export'),
       'secedit /export /cfg win_secpol.cfg' => cmd.call('success'),
       'Remove-Item win_secpol.cfg' => cmd.call('success'),

--- a/test/unit/mock/cmd/ps-aux
+++ b/test/unit/mock/cmd/ps-aux
@@ -1,5 +1,0 @@
-USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-root         1  0.0  0.0  18084  3228 ?        Ss   14:15   0:00 /bin/bash
-root        13  0.0  0.0  15284  2148 ?        R+   15:08   0:00 ps aux
-noot        19  0.0  0.0  24521  1536 s001     Ss   09:23   0:00 svc
-noot        23  0.0  0.0  25044  1908 s000     S    08:46   0:00 svc

--- a/test/unit/mock/cmd/ps-auxZ
+++ b/test/unit/mock/cmd/ps-auxZ
@@ -1,3 +1,0 @@
-LABEL                            USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-system_u:system_r:kernel_t:s0    root         1  0.0  0.0  19232  1492 ?        Ss   May04   0:01 /sbin/init
-system_u:system_r:kernel_t:s0    root        39  0.0  0.0      0     0 ?        S    May04   0:00 crypto/0

--- a/test/unit/mock/cmd/ps-axo
+++ b/test/unit/mock/cmd/ps-axo
@@ -1,5 +1,4 @@
-PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND   USER
-  1  0.0  0.0  18084  3228 ?        Ss   14:15   0:00 /bin/bash root
- 13  0.0  0.0  15284  2148 ?        R+   15:08   0:00 ps aux    root
- 19  0.0  0.0  24521  1536 s001     Ss   09:23   0:00 svc       noot
- 23  0.0  0.0  25044  1908 s000     S    08:46   0:00 svc       noot
+  PID  %CPU %MEM      VSZ    RSS TTY      STAT STARTED      TIME USER            COMMAND
+  7115   0.3  0.0  2516588   3052 ttys008  U    Fri05PM   0:00.05 root            login -fp apop
+  7116   0.0  0.0  2499948   1292 ttys008  S+   Fri05PM   0:00.97 apop            -bash
+  7853   0.0  0.1  2526272   8804 ttys009  Ss   Fri05PM   0:00.06 apop            /Users/apop/Applications/iTerm.app/Contents/MacOS/iTerm2 --server login -fp apop

--- a/test/unit/mock/cmd/ps-axo
+++ b/test/unit/mock/cmd/ps-axo
@@ -1,0 +1,5 @@
+PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND   USER
+  1  0.0  0.0  18084  3228 ?        Ss   14:15   0:00 /bin/bash root
+ 13  0.0  0.0  15284  2148 ?        R+   15:08   0:00 ps aux    root
+ 19  0.0  0.0  24521  1536 s001     Ss   09:23   0:00 svc       noot
+ 23  0.0  0.0  25044  1908 s000     S    08:46   0:00 svc       noot

--- a/test/unit/mock/cmd/ps-axoZ
+++ b/test/unit/mock/cmd/ps-axoZ
@@ -1,3 +1,4 @@
-LABEL                          PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND    USER
-system_u:system_r:kernel_t:s0    1  0.0  0.0  19232  1492 ?        Ss   May04   0:01 /sbin/init root
-system_u:system_r:kernel_t:s0   39  0.0  0.0      0     0 ?        S    May04   0:00 crypto/0   root
+LABEL                             PID %CPU %MEM    VSZ   RSS TT       STAT  STARTED     TIME USER                             COMMAND
+system_u:system_r:init_t:s0      5127  0.0  0.2 547208  5376 ?        Ss   10:54:22 00:00:00 opscode-pgsql                    postgres: bifrost bifrost 127.0.0.1(43699) idle
+system_u:system_r:init_t:s0      5140  1.9 11.2 2908400 215308 ?      Ssl  10:54:23 00:00:05 opscode                          java -Xmx466M -Xms466M -XX:NewSize=32M -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -Xloggc:/var/log/opscode/opscode-solr4/gclog.log -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCTimeStamps -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+PrintTenuringDistribution -Dsolr.data.dir=/var/opt/opscode/opscode-solr4/data -Dsolr.solr.home=/var/opt/opscode/opscode-solr4/home -Djava.io.tmpdir=/var/opt/opscode/opscode-solr4/ -server -jar /opt/opscode/embedded/service/opscode-solr4/jetty/start.jar
+system_u:system_r:init_t:s0      5169  0.0  0.0   4084   536 ?        S    10:54:23 00:00:00 opscode                          svlogd -tt /var/log/opscode/opscode-solr4

--- a/test/unit/mock/cmd/ps-axoZ
+++ b/test/unit/mock/cmd/ps-axoZ
@@ -1,0 +1,3 @@
+LABEL                          PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND    USER
+system_u:system_r:kernel_t:s0    1  0.0  0.0  19232  1492 ?        Ss   May04   0:01 /sbin/init root
+system_u:system_r:kernel_t:s0   39  0.0  0.0      0     0 ?        S    May04   0:00 crypto/0   root

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -12,62 +12,62 @@ describe 'Inspec::Resources::Processes' do
   end
 
   it 'verify processes resource' do
-    resource = MockLoader.new(:freebsd10).load_resource('processes', '/bin/bash')
-    _(resource.list.length).must_equal 1
+    resource = MockLoader.new(:freebsd10).load_resource('processes', 'login -fp apop')
+    _(resource.list.length).must_equal 2
     _(resource.list[0].to_h).must_equal({
       label: nil,
-      pid: 1,
-      cpu: '0.0',
+      pid: 7115,
+      cpu: '0.3',
       mem: '0.0',
-      vsz: 18084,
-      rss: 3228,
-      tty: '?',
-      stat: 'Ss',
-      start: '14:15',
-      time: '0:00',
-      command: '/bin/bash',
+      vsz: 2516588,
+      rss: 3052,
+      tty: 'ttys008',
+      stat: 'U',
+      start: 'Fri05PM',
+      time: '0:00.05',
       user: 'root',
+      command: 'login -fp apop',
     })
   end
 
   it 'verify processes resource on linux os' do
-    resource = MockLoader.new(:centos6).load_resource('processes', '/sbin/init')
+    resource = MockLoader.new(:centos6).load_resource('processes', 'postgres: bifrost bifrost')
     _(resource.list.length).must_equal 1
     _(resource.list[0].to_h).must_equal({
-      label: 'system_u:system_r:kernel_t:s0',
-      pid: 1,
+      label: 'system_u:system_r:init_t:s0',
+      pid: 5127,
       cpu: '0.0',
-      mem: '0.0',
-      vsz: 19232,
-      rss: 1492,
+      mem: '0.2',
+      vsz: 547208,
+      rss: 5376,
       tty: '?',
       stat: 'Ss',
-      start: 'May04',
-      time: '0:01',
-      command: '/sbin/init',
-      user: 'root',
+      start: '10:54:22',
+      time: '00:00:00',
+      user: 'opscode-pgsql',
+      command: 'postgres: bifrost bifrost 127.0.0.1(43699) idle',
     })
   end
 
   it 'access attributes of a process' do
-    resource = MockLoader.new(:centos6).load_resource('processes', '/sbin/init')
+    resource = MockLoader.new(:centos6).load_resource('processes', 'postgres: bifrost bifrost')
     process = resource.list[0]
-    process.user.must_equal 'root'
-    process[:user].must_equal 'root'
-    process['user'].must_equal 'root'
-    process[-1].must_equal 'root'
-    process[1].must_equal 1
+    process.user.must_equal 'opscode-pgsql'
+    process[:user].must_equal 'opscode-pgsql'
+    process['user'].must_equal 'opscode-pgsql'
+    process[-1].must_equal 'postgres: bifrost bifrost 127.0.0.1(43699) idle'
+    process[1].must_equal 5127
   end
 
   it 'retrieves the users and states as arrays' do
-    resource = MockLoader.new(:freebsd10).load_resource('processes', 'svc')
-    _(resource.users.sort).must_equal ['noot']
-    _(resource.states.sort).must_equal ['S', 'Ss']
+    resource = MockLoader.new(:freebsd10).load_resource('processes', 'login -fp apop')
+    _(resource.users.sort).must_equal ['apop', 'root']
+    _(resource.states.sort).must_equal ['Ss', 'U']
   end
 
   it 'retrieves the users and states as arrays on linux os' do
-    resource = MockLoader.new(:centos6).load_resource('processes', 'crypto/0')
-    _(resource.users.sort).must_equal ['root']
-    _(resource.states.sort).must_equal ['S']
+    resource = MockLoader.new(:centos6).load_resource('processes', 'postgres: bifrost bifrost')
+    _(resource.users.sort).must_equal ['opscode-pgsql']
+    _(resource.states.sort).must_equal ['Ss']
   end
 end

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -16,7 +16,6 @@ describe 'Inspec::Resources::Processes' do
     _(resource.list.length).must_equal 1
     _(resource.list[0].to_h).must_equal({
       label: nil,
-      user: 'root',
       pid: 1,
       cpu: '0.0',
       mem: '0.0',
@@ -27,6 +26,7 @@ describe 'Inspec::Resources::Processes' do
       start: '14:15',
       time: '0:00',
       command: '/bin/bash',
+      user: 'root',
     })
   end
 
@@ -35,7 +35,6 @@ describe 'Inspec::Resources::Processes' do
     _(resource.list.length).must_equal 1
     _(resource.list[0].to_h).must_equal({
       label: 'system_u:system_r:kernel_t:s0',
-      user: 'root',
       pid: 1,
       cpu: '0.0',
       mem: '0.0',
@@ -46,6 +45,7 @@ describe 'Inspec::Resources::Processes' do
       start: 'May04',
       time: '0:01',
       command: '/sbin/init',
+      user: 'root',
     })
   end
 
@@ -55,7 +55,8 @@ describe 'Inspec::Resources::Processes' do
     process.user.must_equal 'root'
     process[:user].must_equal 'root'
     process['user'].must_equal 'root'
-    process[1].must_equal 'root'
+    process[-1].must_equal 'root'
+    process[1].must_equal 1
   end
 
   it 'retrieves the users and states as arrays' do


### PR DESCRIPTION
Fixes https://github.com/chef/inspec/issues/995

Uses code submitted by @Anirudh-Gupta here: https://github.com/chef/inspec/pull/1173

Linux:

``` ruby
inspec> processes('/opt/chef-compliance/embedded/service/core/bin/core run').list
=> [#<struct Inspec::Resources::Processes::Process
  label="system_u:system_r:init_t:s0",
  pid=801,
  cpu="0.0",
  mem="3.7",
  vsz=481740,
  rss=57368,
  tty="?",
  stat="Ssl",
  start="12:43:15",
  time="00:00:02",
  user="chef-compliance",
  command=
   "/opt/chef-compliance/embedded/service/core/bin/core run --mode=setup --oidc --oidc-issuer-url https://ap-cc6.opschef.tv --oidc-client-id JZik-QcuP1LK2lOmL8l1qQwyazeI6XoUhvYnOb7oFz0=@ap-cc6.opschef.tv --oidc-redirect-url https://ap-cc6.opschef.tv/api/callback">]
```

OSX:

``` ruby
inspec> processes('Support/mdworker -s mdworker').list
=> [#<struct Inspec::Resources::Processes::Process
  label=nil,
  pid=92252,
  cpu="0.0",
  mem="0.1",
  vsz=2519384,
  rss=12628,
  tty="??",
  stat="S",
  start="3:03PM",
  time="0:00.03",
  user="_spotlight",
  command=
   "/System/Library/Frameworks/CoreServices.framework/Frameworks/Metadata.framework/Versions/A/Support/mdworker -s mdworker -c MDSImporterWorker -m com.apple.mdworker.shared">]
```
