### PR TITLE
Headers and list elements that include more than one `_` character we…

### DIFF
--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -29,13 +29,13 @@ This InSpec audit resource has the following matchers:
 
 <%= partial "/shared/matcher_be" %>
 
-### be_block_device
+### be\_block\_device
 
 The `be_block_device` matcher tests if the file exists as a block device, such as `/dev/disk0` or `/dev/disk0s9`:
 
     it { should be_block_device }
 
-### be_character_device
+### be\_character\_device
 
 The `be_character_device` matcher tests if the file exists as a character device (that corresponds to a block device), such as `/dev/rdisk0` or `/dev/rdisk0s9`:
 
@@ -71,7 +71,7 @@ The `be_file` matcher tests if the file exists as a file. This can be useful wit
 
     it { should be_file }
 
-### be_grouped_into
+### be\_grouped\_into
 
 The `be_grouped_into` matcher tests if the file exists as part of the named group:
 
@@ -83,7 +83,7 @@ The `be_immutable` matcher tests if the file is immutable, i.e. "cannot be chang
 
     it { should be_immutable }
 
-### be_linked_to
+### be\_linked\_to
 
 The `be_linked_to` matcher tests if the file is linked to the named target:
 
@@ -95,7 +95,7 @@ The `be_mounted` matcher tests if the file is accessible from the file system:
 
     it { should be_mounted }
 
-### be_owned_by
+### be\_owned\_by
 
 The `be_owned_by` matcher tests if the file is owned by the named user, such as `root`:
 

--- a/docs/resources/iis_site.md.erb
+++ b/docs/resources/iis_site.md.erb
@@ -64,7 +64,7 @@ The `exist` matcher tests if the site exists:
 
     it { should exist }
 
-### have_app_pool
+### have\_app\_pool
 
 The `have_app_pool` matcher tests if the named application pool exists for the site:
 

--- a/docs/resources/parse_config_file.md.erb
+++ b/docs/resources/parse_config_file.md.erb
@@ -2,7 +2,7 @@
 title: About the parse_config_file Resource
 ---
 
-# parse_config_file
+# parse\_config\_file
 
 Use the `parse_config_file` InSpec audit resource to test arbitrary configuration files. It works in the same way as `parse_config`. Instead of using a command output, this resource works with files.
 

--- a/docs/resources/registry_key.md.erb
+++ b/docs/resources/registry_key.md.erb
@@ -101,7 +101,7 @@ The `have_property` matcher tests if a property exists for a registry key:
 
     it { should have_property 'value' }
 
-### have_property_value
+### have\_property\_value
 
 The `have_property_value` matcher tests if a property value exists for a registry key:
 

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -222,7 +222,7 @@ namespace :docs do
     list = ''
     resources.each do |file|
       name = File.basename(file).sub(/\.md\.erb$/, '')
-      list << f.li(f.a(name, 'resources/' + name + '.html'))
+      list << f.li(f.a(name.sub('_', '\\_'), 'resources/' + name + '.html'))
     end
     res << f.ul(list)
     dst = File.join(src, 'resources.md')


### PR DESCRIPTION
Headers and list elements that include more than one `_` character were being rendered incorrectly.  (Perhaps it is only when there are an even number but in any case I only found words with either one or two `_`s.)

The html rendered from markdown would look like:

`<h3>be<em>grouped</em>into</h3>`

When there is only one `_` the html rendered correctly:

`<h3>be_directory</h3>`

This change escapes the `_` when there are multiple.
- New markdown:  `### be\_grouped\_into`
- New html:      `<h3>be_grouped_into</h3>`

resource matchers fixed:
- be_block_device
- be_character_device
- be_grouped_into
- be_linked_to
- be_owned_by
- have_app_pool
- have_property_value

resource fixed:
- parse_config_file

Signed-off-by: Nathen Harvey nharvey@chef.io
