### PR TITLE
Fix broken link in README.md

### DIFF
--- a/examples/profile/README.md
+++ b/examples/profile/README.md
@@ -1,6 +1,6 @@
 # Example InSpec Profile
 
-This example shows the implementation of an InSpec [profile](../../docs/profiles.rst).
+This example shows the implementation of an InSpec [profile](../../docs/profiles.md).
 
 ## Verify a profile
 


### PR DESCRIPTION
Link pointed to the right doc but the wrong extension.

Obvious fix.

Signed-off-by: Sean Walberg sean@ertw.com
