### PR TITLE
Accessing nested mappings in a yam file

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ end
 
 ```ruby
 describe yaml('.kitchen.yml') do
-  its('driver.name') { should eq('vagrant') }
+  its(%w(driver name)) { should eq('vagrant') }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ describe sshd_config do
 end
 ```
 
-* Test your `kitchen.yml` file to verify that only Vagrant is configured as the driver.
+* Test your `kitchen.yml` file to verify that only Vagrant is configured as the driver.  The %w() formatting will
+pass rubocop lintng and allow you to access nested mappings.
 
 ```ruby
 describe yaml('.kitchen.yml') do


### PR DESCRIPTION
I spent hours following the example in the documentation.  When trying to access the nested mappings I received the error "unknown method <name of nested key>".  When I read the code from lib/utils/object_traversal.rb I found where keys.shift was used to traverse the object.  So I changed from the dotted notation to an array and voila I accessed the nested mapping and could easily verify my tests.  I use rubocop for linting so it complained about the [] notation.  I updated it to the %w() notation and now pass rubocop linting and my tests were failing correctly but now passing accurately.
