### PR TITLE
Fix issue with registry_key example

### DIFF
--- a/docs/resources/registry_key.md.erb
+++ b/docs/resources/registry_key.md.erb
@@ -73,9 +73,8 @@ For example, to get all child items for a registry key:
 The following example shows how find a property that may exist against multiple registry keys, and then test that property for every registry key in which that property is located:
 
     describe registry_key({
-      hive: HKEY_USERS
-    }).children(/^S-1-5-21-[0-9]+-[0-9]+-[0-9]+-[0-9]{3,}\\Software\\Policies\\Microsoft\\Windows\\Installer/).each
-      { |key|
+      hive: 'HKEY_USERS'
+    }).children(/^S-1-5-21-[0-9]+-[0-9]+-[0-9]+-[0-9]{3,}\\Software\\Policies\\Microsoft\\Windows\\Installer/).each { |key|
         describe registry_key(key) do
           its('AlwaysInstallElevated') { should eq 'value' }
         end


### PR DESCRIPTION
There are two issues with this `registry_key` resource example.

1) The hive in the example isn't wrapped in single-quotes. Ruby attempts to evaluate this as an object when it needs to be string data. Surrounding `HKEY_USERS` with single-quotes resolves this issue.

2) The `.each` method expects the beginning of the provided array to be on the same line. Moving `{ |key|` to directly follow `.each` allows the method to properly execute.
