### PR TITLE
Ignore RVM files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ test/**/*.lock
 examples/**/*.lock
 habitat/VERSION
 habitat/results
+/.ruby-gemset
+/.ruby-version


### PR DESCRIPTION
For the case somebody is using RVM for inspec development
with different environments (rubies/gemsets)
