### PR TITLE
Set the global message to display again

### DIFF
--- a/www/source/layouts/_global-message.slim
+++ b/www/source/layouts/_global-message.slim
@@ -15,4 +15,4 @@
           | Dismiss
 
 javascript:
-  gm_session_id = 'inspecGlobalMessage1';
+  gm_session_id = 'inspecGlobalMessage2';

--- a/www/source/layouts/_global-message.slim
+++ b/www/source/layouts/_global-message.slim
@@ -6,8 +6,8 @@
     .row
       .columns.small-8.medium-8.medium-push-2.medium-text-center
         a href="https://www.chef.io/webinars/?commid=225819" target="_blank"
-          strong Upcoming Webinar: Compliance as Code with InSpec 1.0 Oct 25 10AM PST
-          |  Register now!
+          strong Watch the Recorded Webcast – Compliance as Code with InSpec 1.0 Oct 25
+          |  View now!
 
       .columns.small-4.medium-2.text-right
         span.dismiss-button


### PR DESCRIPTION
Incrementing the global message id will force the localStorage to reset thus re-enabling display of the global message. In other words, we want people who dismissed the previous message to see this new message.
