### PR TITLE
Code-block directive is not needed here

### DIFF
--- a/docs/shared/matcher_cmp.md.erb
+++ b/docs/shared/matcher_cmp.md.erb
@@ -28,8 +28,6 @@ vs:
 
 Ignoring case sensitivity:
 
-.. code-block:: ruby
-
    describe some_resource do
      its('setting') { should cmp 'raw' }
      its('setting') { should cmp 'RAW' }


### PR DESCRIPTION
and breaks the layout: http://inspec.io/docs/reference/resources/file/
