### PR TITLE
Use include instead of match in the error message

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -219,7 +219,7 @@ end
 # unsupported
 RSpec::Matchers.define :contain do |_rule|
   match do |_resource|
-    fail "[UNSUPPORTED] `contain` matcher. Please use the following syntax `its('content') { should match('value') }`."
+    fail "[UNSUPPORTED] `contain` matcher. Please use the following syntax `its('content') { should include('value') }`."
   end
 end
 


### PR DESCRIPTION
as include behaves like contain (exact matching instead of regexp)

[Related comment](https://github.com/chef/inspec/pull/214#issuecomment-154132333)

Are they any reasons why contain is not mapped to include with a warning? 
It might simplify the migration from serverspec, where deprecated contain matcher is used quite often
