### PR TITLE
Supermarket tools get and filter by tool_type

### DIFF
--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -11,11 +11,11 @@ module Supermarket
 
     # displays a list of profiles
     def self.profiles(supermarket_url = SUPERMARKET_URL)
-      url = "#{supermarket_url}/api/v1/tools-search"
-      _success, data = get(url, { q: 'compliance_profile' })
+      url = "#{supermarket_url}/api/v1/tools"
+      _success, data = get(url, { start: 0, items: 100, order: 'recently_added' })
       if !data.nil?
         profiles = JSON.parse(data)
-        profiles['items'].map { |x|
+        profiles['items'].select { |p| p['tool_type'] == 'compliance_profile' }.map { |x|
           m = %r{^#{supermarket_url}/api/v1/tools/(?<slug>[\w-]+)(/)?$}.match(x['tool'])
           x['slug'] = m[:slug]
           x


### PR DESCRIPTION
With InSpec in master:

``` bash
$ inspec supermarket profiles | grep '^ * ' | wc -l
       8
```

With the change in this PR:

``` bash
$ bundle exec inspec supermarket profiles | grep '^ * ' | wc -l
      11
```

It fixes the [profiles list issue](https://github.com/chef/inspec/issues/1219) by querying the most recent 100(out of 126 at the moment) tools and filtering by tool_type. The API returns max 100 items. 
The oldest compliance profile is number 25 on that list. This gives us a few months until the supermarket search API will have a type filter.
