### PR TITLE
overwrite exec for inetd because respec its is executing `exec`

### DIFF
--- a/lib/resources/inetd_conf.rb
+++ b/lib/resources/inetd_conf.rb
@@ -22,6 +22,12 @@ module Inspec::Resources
       @conf_path = path || '/etc/inetd.conf'
     end
 
+    # overwrite exec to ensure it works with its
+    # TODO: this needs to be fixed in RSpec
+    def exec
+      read_params['exec']
+    end
+
     def method_missing(name)
       read_params[name.to_s]
     end


### PR DESCRIPTION
This PR fixed https://github.com/chef/inspec/issues/1253 until https://github.com/chef/inspec/issues/875 is in place.

```
$ inspec shell -t docker://1de218c4b67c
Welcome to the interactive InSpec Shell
To find out how to use it, type: help

inspec> describe inetd_conf do
inspec> inetd_conf.exec
=> ["stream", "tcp", "nowait", "root", "/usr/sbin/in.rexecd", "in.rexecd"]
inspec> describe inetd_conf do
inspec>   its('exec') { should eq nil }  
inspec> end  

Profile: inspec-shell
Version: unknown



  inetd.conf exec
     ✖  should eq nil

     expected: nil
          got: ["stream", "tcp", "nowait", "root", "/usr/sbin/in.rexecd", "in.rexecd"]

     (compared using ==)


Test Summary: 0 successful, 1 failures, 0 skipped
inspec> 
```
