### PR TITLE
Windows Service Check for service enabled state. 

### DIFF
--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -613,7 +613,8 @@ module Inspec::Resources
     def service_enabled?(service)
       !service['WMI'].nil? &&
         !service['WMI']['StartMode'].nil? &&
-        service['WMI']['StartMode'] == 'Auto'
+        (service['WMI']['StartMode'] == 'Auto' ||
+        service['WMI']['StartMode'] == 'Manual')
     end
 
     # detect if service is running


### PR DESCRIPTION
Updated Windows Service check for Enabled state to allow both Auto and Manual to be considered valid states for a service to be enabled.

Reference Issue #1269 
