### PR TITLE
Contain matcher maps to include matcher with warning

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -216,10 +216,11 @@ RSpec::Matchers.define :have_rule do |rule|
   end
 end
 
-# unsupported
-RSpec::Matchers.define :contain do |_rule|
-  match do |_resource|
-    fail "[UNSUPPORTED] `contain` matcher. Please use the following syntax `its('content') { should include('value') }`."
+# deprecated
+RSpec::Matchers.define :contain do |rule|
+  match do |resource|
+    warn "[DEPRECATION] `contain` matcher. Please use the following syntax `its('content') { should include('value') }`."
+    expect(resource).to include(rule)
   end
 end
 

--- a/test/integration/default/file_spec.rb
+++ b/test/integration/default/file_spec.rb
@@ -102,6 +102,8 @@ if os.unix?
 
     its('content') { should eq 'hello world' }
     its('content') { should match('world') }
+    its('content') { should contain('hello') }
+    its('content') { should include('hello') }
     its('size') { should eq 11 }
     its('md5sum') { should eq '5eb63bbbe01eeed093cb22bb8f5acdc3' }
     its('sha256sum') { should eq 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9' }


### PR DESCRIPTION
to allow easier migration from serverspec, where contain
matcher is used often

Signed-off-by: Artem Sidorenko <artem@posteo.de>