### PR TITLE
improve vendor command

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -105,16 +105,36 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
     pretty_handle_exception(e)
   end
 
-  desc 'vendor', 'Download all dependencies and generate a lockfile'
-  def vendor(path = nil)
+  desc 'vendor PATH', 'Download all dependencies and generate a lockfile in a `vendor` directory'
+  option :overwrite, type: :boolean, default: false,
+    desc: 'Overwrite existing vendored dependencies and lockfile.'
+  def vendor(path = nil) # rubocop:disable Metrics/AbcSize
     o = opts.dup
-    o[:cache] = Inspec::Cache.new(path)
+
+    path.nil? ? path = Pathname.new(Dir.pwd) : path = Pathname.new(path)
+    cache_path = path.join('vendor')
+    inspec_lock = path.join('inspec.lock')
+
+    if (cache_path.exist? || inspec_lock.exist?) && !opts[:overwrite]
+      puts 'Profile is already vendored. Use --overwrite.'
+      return false
+    end
+
+    # remove existing
+    FileUtils.rm_rf(cache_path) if cache_path.exist?
+    File.delete(inspec_lock) if inspec_lock.exist?
+
+    puts "Vendor dependencies of #{path} into #{cache_path}"
+    o[:logger] = Logger.new(STDOUT)
+    o[:logger].level = get_log_level(o.log_level)
+    o[:cache] = Inspec::Cache.new(cache_path.to_s)
     o[:backend] = Inspec::Backend.create(target: 'mock://')
     configure_logger(o)
 
-    profile = Inspec::Profile.for_target('./', o)
+    # vendor dependencies and generate lockfile
+    profile = Inspec::Profile.for_target(path.to_s, o)
     lockfile = profile.generate_lockfile
-    File.write('inspec.lock', lockfile.to_yaml)
+    File.write(inspec_lock, lockfile.to_yaml)
   rescue StandardError => e
     pretty_handle_exception(e)
   end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -22,6 +22,8 @@ module Inspec
     extend Forwardable
 
     def self.resolve_target(target, cache = nil)
+      c = cache || Cache.new
+      Inspec::Log.debug "Resolve #{target} into cache #{c.path}"
       Inspec::CachedFetcher.new(target, cache || Cache.new)
     end
 

--- a/test/functional/helper.rb
+++ b/test/functional/helper.rb
@@ -33,7 +33,7 @@ module FunctionalHelper
     TMP_CACHE[res.path] = res
   }
 
-  def inspec(commandline)
-    CMD.run_command("#{exec_inspec} #{commandline}")
+  def inspec(commandline, prefix = nil)
+    CMD.run_command("#{prefix} #{exec_inspec} #{commandline}")
   end
 end

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+require 'functional/helper'
+
+describe 'example inheritance profile' do
+  include FunctionalHelper
+  let(:path) { File.join(examples_path, 'inheritance') }
+
+  it 'can vendor profile dependencies' do
+    out = inspec('vendor ' + path + ' --overwrite')
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Vendor dependencies of #{path} into #{path}/vendor"
+    out.stderr.must_equal ''
+    out.exit_status.must_equal 0
+
+    vendor_dir = File.join(path, 'vendor')
+    File.exist?(vendor_dir).must_equal true
+
+    lockfile = File.join(path, 'inspec.lock')
+    File.exist?(lockfile).must_equal true
+  end
+
+  it 'can vendor profile dependencies from the profile path' do
+    out = inspec('vendor --overwrite', "cd #{path} &&")
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Vendor dependencies of #{path} into #{path}/vendor"
+    out.stderr.must_equal ''
+    out.exit_status.must_equal 0
+
+    vendor_dir = File.join(path, 'vendor')
+    File.exist?(vendor_dir).must_equal true
+
+    lockfile = File.join(path, 'inspec.lock')
+    File.exist?(lockfile).must_equal true
+  end
+end


### PR DESCRIPTION
This PR makes improves the usability of the `inspec vendor` command.

Case 1:
```
$ cd profile
$ inspec vendor
# This creates a ./vendor and ./inspec.lock
```
Case 2:
```
$ inspec vendor path/to/profile
# This creates a path/to/profile/vendor and path/to/profile/inspec.lock
```