### PR TITLE
update supermarket profile search to use new type param

### DIFF
--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -11,11 +11,11 @@ module Supermarket
 
     # displays a list of profiles
     def self.profiles(supermarket_url = SUPERMARKET_URL)
-      url = "#{supermarket_url}/api/v1/tools"
-      _success, data = get(url, { start: 0, items: 100, order: 'recently_added' })
+      url = "#{supermarket_url}/api/v1/tools-search"
+      _success, data = get(url, { type: 'compliance_profile', items: 100, order: 'recently_added' })
       if !data.nil?
         profiles = JSON.parse(data)
-        profiles['items'].select { |p| p['tool_type'] == 'compliance_profile' }.map { |x|
+        profiles['items'].map { |x|
           m = %r{^#{supermarket_url}/api/v1/tools/(?<slug>[\w-]+)(/)?$}.match(x['tool'])
           x['slug'] = m[:slug]
           x


### PR DESCRIPTION
Reverts the work-around that pulls down the latest 100 tools
and filters for type == 'compliance_profile' in the client.

Go back to using tool-search with the new type parameter.

Omit start:0 because that's the default.

Keep the number of items returned at 100, which is more than the
default 10.

Closes #1255