### PR TITLE
fix double-log-level

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -44,8 +44,6 @@ module Inspec
         desc: 'Allow remote scans with self-signed certificates (WinRM).'
       option :json_config, type: :string,
         desc: 'Read configuration from JSON file (`-` reads from stdin).'
-      option :log_level, aliases: :l, type: :string,
-        desc: 'Set the log level: info (default), debug, warn, error'
     end
 
     def self.profile_options


### PR DESCRIPTION
Fixes the output of `inspec help exec`

```
$ inspec help exec
Usage:
  inspec exec PATHS

Options:
  t, [--target=TARGET]                             # Simple targeting option using URIs, e.g. ssh://user:pass@host:port
  b, [--backend=BACKEND]                           # Choose a backend: local, ssh, winrm, docker.
      [--host=HOST]                                # Specify a remote host which is tested.
  p, [--port=N]                                    # Specify the login port for a remote scan.
      [--user=USER]                                # The login user for a remote scan.
      [--password=PASSWORD]                        # Login password for a remote scan, if required.
  i, [--key-files=one two three]                   # Login key or certificate file for a remote scan.
      [--path=PATH]                                # Login path to use when connecting to the target (WinRM).
      [--sudo], [--no-sudo]                        # Run scans with sudo. Only activates on Unix and non-root user.
      [--sudo-password=SUDO_PASSWORD]              # Specify a sudo password, if it is required.
      [--sudo-options=SUDO_OPTIONS]                # Additional sudo options for a remote scan.
      [--sudo-command=SUDO_COMMAND]                # Alternate command for sudo.
      [--shell], [--no-shell]                      # Run scans in a subshell. Only activates on Unix.
      [--shell-options=SHELL_OPTIONS]              # Additional shell options.
      [--shell-command=SHELL_COMMAND]              # Specify a particular shell to use.
      [--ssl], [--no-ssl]                          # Use SSL for transport layer encryption (WinRM).
      [--self-signed], [--no-self-signed]          # Allow remote scans with self-signed certificates (WinRM).
      [--json-config=JSON_CONFIG]                  # Read configuration from JSON file (`-` reads from stdin).
  l, [--log-level=LOG_LEVEL]                       # Set the log level: info (default), debug, warn, error
      [--profiles-path=PROFILES_PATH]              # Folder which contains referenced profiles.
      [--controls=one two three]                   # A list of controls to run. Ignore all other tests.
      [--format=FORMAT]                            # Which formatter to use: cli, progress, documentation, json, json-min
      [--color], [--no-color]                      # Use colors in output.
                                                   # Default: true
      [--attrs=one two three]                      # Load attributes file (experimental)
      [--cache=CACHE]                              # Use the given path for caching dependencies. (default: ~/.inspec/cache)
      [--create-lockfile], [--no-create-lockfile]  # Write out a lockfile based on this execution (unless one already exists)
                                                   # Default: true
  l, [--log-level=LOG_LEVEL]                       # Set the log level: info (default), debug, warn, error
      [--log-location=LOG_LOCATION]                # Location to send diagnostic log messages to. (default: STDOUT or STDERR)
      [--diagnose], [--no-diagnose]                # Show diagnostics (versions, configurations)

run all test files at the specified PATH.
```
to
```
$ inspec help exec
Usage:
  inspec exec PATHS

Options:
  t, [--target=TARGET]                             # Simple targeting option using URIs, e.g. ssh://user:pass@host:port
  b, [--backend=BACKEND]                           # Choose a backend: local, ssh, winrm, docker.
      [--host=HOST]                                # Specify a remote host which is tested.
  p, [--port=N]                                    # Specify the login port for a remote scan.
      [--user=USER]                                # The login user for a remote scan.
      [--password=PASSWORD]                        # Login password for a remote scan, if required.
  i, [--key-files=one two three]                   # Login key or certificate file for a remote scan.
      [--path=PATH]                                # Login path to use when connecting to the target (WinRM).
      [--sudo], [--no-sudo]                        # Run scans with sudo. Only activates on Unix and non-root user.
      [--sudo-password=SUDO_PASSWORD]              # Specify a sudo password, if it is required.
      [--sudo-options=SUDO_OPTIONS]                # Additional sudo options for a remote scan.
      [--sudo-command=SUDO_COMMAND]                # Alternate command for sudo.
      [--shell], [--no-shell]                      # Run scans in a subshell. Only activates on Unix.
      [--shell-options=SHELL_OPTIONS]              # Additional shell options.
      [--shell-command=SHELL_COMMAND]              # Specify a particular shell to use.
      [--ssl], [--no-ssl]                          # Use SSL for transport layer encryption (WinRM).
      [--self-signed], [--no-self-signed]          # Allow remote scans with self-signed certificates (WinRM).
      [--json-config=JSON_CONFIG]                  # Read configuration from JSON file (`-` reads from stdin).
      [--profiles-path=PROFILES_PATH]              # Folder which contains referenced profiles.
      [--controls=one two three]                   # A list of controls to run. Ignore all other tests.
      [--format=FORMAT]                            # Which formatter to use: cli, progress, documentation, json, json-min
      [--color], [--no-color]                      # Use colors in output.
                                                   # Default: true
      [--attrs=one two three]                      # Load attributes file (experimental)
      [--cache=CACHE]                              # Use the given path for caching dependencies. (default: ~/.inspec/cache)
      [--create-lockfile], [--no-create-lockfile]  # Write out a lockfile based on this execution (unless one already exists)
                                                   # Default: true
  l, [--log-level=LOG_LEVEL]                       # Set the log level: info (default), debug, warn, error
      [--log-location=LOG_LOCATION]                # Location to send diagnostic log messages to. (default: STDOUT or STDERR)
      [--diagnose], [--no-diagnose]                # Show diagnostics (versions, configurations)

run all test files at the specified PATH.
$
```