### PR TITLE
copy vendored dependencies into cache

### DIFF
--- a/examples/meta-profile/README.md
+++ b/examples/meta-profile/README.md
@@ -4,3 +4,34 @@ The inspec.yml file in this profile shows how one can use dependencies
 from non-local sources such as Git or an HTTP url. This feature can
 be used to build up a environment-wide profile that is based on more
 specific profiles managed by others.
+
+InSpec supports multiple profile locations:
+
+```
+depends:
+  # defaults to supermarket
+  - name: hardening/ssh-hardening  
+  # remote tar or zip file
+  - name: os-hardening
+    url: https://github.com/dev-sec/tests-os-hardening/archive/master.zip
+  # git
+  - git: https://github.com/dev-sec/ssl-benchmark.git
+  - name: windows-patch-benchmark
+    git: https://github.com/chris-rock/windows-patch-benchmark.git
+  # Chef Compliance
+  - name: linux
+    compliance: base/linux
+```
+
+You could use those dependencies in your `exmaple.rb`:
+
+```
+
+include_controls 'hardening/ssh-hardening'
+include_controls 'os-hardening'
+include_controls 'ssl-benchmark'
+include_controls 'linux'
+include_controls 'windows-patch-benchmark'
+```
+
+Further details are described in our [InSpec Docs](http://inspec.io/docs/reference/profiles/)

--- a/examples/meta-profile/controls/example.rb
+++ b/examples/meta-profile/controls/example.rb
@@ -1,8 +1,14 @@
 # encoding: utf-8
 # copyright: 2015, The Authors
 # license: All rights reserved
-include_controls 'ssh-hardening'
-include_controls 'os-hardening'
-include_controls 'ssl-benchmark'
-include_controls 'linux'
+
+# import full profile
+include_controls 'hardening/ssh-hardening'
+
+# select only individual controls
+include_controls 'ssl-benchmark' do
+  control "tls1.2"
+end
+
+# inspec knows that it cannot run Windows tests on Linux
 include_controls 'windows-patch-benchmark'

--- a/examples/meta-profile/inspec.yml
+++ b/examples/meta-profile/inspec.yml
@@ -8,10 +8,6 @@ summary: InSpec Profile that is only consuming dependencies
 version: 0.2.0
 depends:
   - name: hardening/ssh-hardening  # defaults to supermarket
-  - name: os-hardening
-    url: https://github.com/dev-sec/tests-os-hardening/archive/master.zip
   - git: https://github.com/dev-sec/ssl-benchmark.git
   - name: windows-patch-benchmark
     git: https://github.com/chris-rock/windows-patch-benchmark.git
-  - name: linux
-    compliance: base/linux

--- a/lib/source_readers/inspec.rb
+++ b/lib/source_readers/inspec.rb
@@ -25,6 +25,10 @@ module SourceReaders
 
     attr_reader :metadata, :tests, :libraries
 
+    # This create a new instance of an InSpec profile source reader
+    #
+    # @param [SourceReader] target
+    # @param [String] metadata_source eg. inspec.yml or metadata.rb
     def initialize(target, metadata_source)
       @target = target
       @metadata = Inspec::Metadata.from_ref(

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -4,31 +4,59 @@ require 'functional/helper'
 
 describe 'example inheritance profile' do
   include FunctionalHelper
-  let(:path) { File.join(examples_path, 'inheritance') }
+  let(:inheritance_path) { File.join(examples_path, 'inheritance') }
+  let(:meta_path) { File.join(examples_path, 'meta-profile') }
 
   it 'can vendor profile dependencies' do
-    out = inspec('vendor ' + path + ' --overwrite')
-    out.stdout.force_encoding(Encoding::UTF_8).must_include "Vendor dependencies of #{path} into #{path}/vendor"
+    out = inspec('vendor ' + inheritance_path + ' --overwrite')
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Vendor dependencies of #{inheritance_path} into #{inheritance_path}/vendor"
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
 
-    vendor_dir = File.join(path, 'vendor')
+    vendor_dir = File.join(inheritance_path, 'vendor')
     File.exist?(vendor_dir).must_equal true
 
-    lockfile = File.join(path, 'inspec.lock')
+    lockfile = File.join(inheritance_path, 'inspec.lock')
     File.exist?(lockfile).must_equal true
   end
 
   it 'can vendor profile dependencies from the profile path' do
-    out = inspec('vendor --overwrite', "cd #{path} &&")
-    out.stdout.force_encoding(Encoding::UTF_8).must_include "Vendor dependencies of #{path} into #{path}/vendor"
+    out = inspec('vendor --overwrite', "cd #{inheritance_path} &&")
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Vendor dependencies of #{inheritance_path} into #{inheritance_path}/vendor"
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
 
-    vendor_dir = File.join(path, 'vendor')
+    vendor_dir = File.join(inheritance_path, 'vendor')
     File.exist?(vendor_dir).must_equal true
 
-    lockfile = File.join(path, 'inspec.lock')
+    lockfile = File.join(inheritance_path, 'inspec.lock')
     File.exist?(lockfile).must_equal true
+  end
+
+  it 'ensure nothing is loaded from external source if vendored profile is used' do
+    out = inspec('vendor ' + meta_path + ' --overwrite')
+    out.exit_status.must_equal 0
+
+    vendor_dir = File.join(meta_path, 'vendor')
+    File.exist?(vendor_dir).must_equal true
+
+    lockfile = File.join(meta_path, 'inspec.lock')
+    File.exist?(lockfile).must_equal true
+
+    out = inspec('exec ' + meta_path + ' -l debug --no-create-lockfile')
+    out.stdout.force_encoding(Encoding::UTF_8).must_include   'Using cached dependency for {:url=>"https://github.com/dev-sec/tests-ssh-hardening/archive/master.tar.gz", :sha256=>"01414bd307ea2f7d4dc8cd141085ba7ad61d4c3b2606d57b2dae987c1c3954cb"'
+    out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:git=>"https://github.com/dev-sec/ssl-benchmark.git", :ref=>"e17486c864434c818f96ca13edd2c5a420100a45"'
+    out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:git=>"https://github.com/chris-rock/windows-patch-benchmark.git", :ref=>"c183d08eb25638e7f5eac97e521640ea314c8e3d"'
+    out.stdout.force_encoding(Encoding::UTF_8).index('Fetching URL:').must_be_nil
+    out.stdout.force_encoding(Encoding::UTF_8).index('Fetched archive moved to:').must_be_nil
+
+    out.stderr.must_equal ''
+  end
+
+  it 'ensure json command works for vendored profile' do
+    out = inspec('json ' + meta_path + ' --output ' + dst.path)
+    hm = JSON.load(File.read(dst.path))
+    hm['name'].must_equal 'meta-profile'
+    hm['controls'].length.must_equal 79
   end
 end


### PR DESCRIPTION
This implements the second part of #1283. It copies vendored content into the global cache before the profile is executed