### PR TITLE
WIP: handle error of ssl resource with mock backend

### DIFF
--- a/lib/resources/ssl.rb
+++ b/lib/resources/ssl.rb
@@ -51,8 +51,10 @@ class SSL < Inspec.resource(1)
         @host = inspec.backend.hostname
       elsif inspec.backend.class.to_s == 'Train::Transports::Local::Connection'
         @host = 'localhost'
+      elsif inspec.backend.class.to_s == 'Train::Transports::Mock::Connection'
+        # nothing to do, we are not going to execute anyway
       else
-        fail 'Cannot determine host for SSL test. Please specify it or use a different target.'
+        skip_resource 'Cannot determine host for SSL test. Please specify it or use a different target.'
       end
     end
     @port = opts[:port] || 443


### PR DESCRIPTION
In cases where the ssl resource is used with the mock backend, InSpec crashed:

```
$ inspec archive /Users/chartmann/Development/Demo/acme-inspec-profile
I, [2016-11-10T00:41:05.359571 #70106]  INFO -- : Checking profile in /Users/chartmann/Development/Demo/acme-inspec-profile
I, [2016-11-10T00:41:05.359643 #70106]  INFO -- : Metadata OK.
`command(ssh).exist?` is not suported on your OS: 
/Users/chartmann/Development/inspec/lib/resources/ssl.rb:56:in `initialize': Cannot determine host for SSL test. Please specify it or use a different target. (RuntimeError)
	from /Users/chartmann/Development/inspec/lib/inspec/plugins/resource.rb:48:in `initialize'
	from /Users/chartmann/Development/inspec/lib/inspec/resource.rb:48:in `new'
	from /Users/chartmann/Development/inspec/lib/inspec/resource.rb:48:in `block (3 levels) in create_dsl'
	from /Users/chartmann/Development/Demo/acme-inspec-profile/controls/ssl.rb:34:in `block in load_with_context'
	from /Users/chartmann/Development/inspec/lib/inspec/rule.rb:51:in `instance_eval'
	from /Users/chartmann/Development/inspec/lib/inspec/rule.rb:51:in `initialize'
	from /Users/chartmann/Development/inspec/lib/inspec/control_eval_context.rb:73:in `new'
	from /Users/chartmann/Development/inspec/lib/inspec/control_eval_context.rb:73:in `block (2 levels) in create'
	from /Users/chartmann/Development/Demo/acme-inspec-profile/controls/ssl.rb:31:in `load_with_context'
	from /Users/chartmann/Development/inspec/lib/inspec/profile_context.rb:146:in `instance_eval'
	from /Users/chartmann/Development/inspec/lib/inspec/profile_context.rb:146:in `load_with_context'
	from /Users/chartmann/Development/inspec/lib/inspec/profile_context.rb:130:in `load_control_file'
	from /Users/chartmann/Development/inspec/lib/inspec/profile.rb:143:in `block in collect_tests'
	from /Users/chartmann/Development/inspec/lib/inspec/profile.rb:140:in `each'
	from /Users/chartmann/Development/inspec/lib/inspec/profile.rb:140:in `collect_tests'
	from /Users/chartmann/Development/inspec/lib/inspec/profile.rb:416:in `load_checks_params'
	from /Users/chartmann/Development/inspec/lib/inspec/profile.rb:409:in `load_params'
	from /Users/chartmann/Development/inspec/lib/inspec/profile.rb:133:in `params'
	from /Users/chartmann/Development/inspec/lib/inspec/profile.rb:298:in `controls_count'
	from /Users/chartmann/Development/inspec/lib/inspec/profile.rb:269:in `check'
	from /Users/chartmann/Development/inspec/lib/inspec/cli.rb:163:in `archive'
	from /Users/chartmann/.rvm/rubies/ruby-2.2.1/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /Users/chartmann/.rvm/rubies/ruby-2.2.1/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/chartmann/.rvm/rubies/ruby-2.2.1/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /Users/chartmann/.rvm/rubies/ruby-2.2.1/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /Users/chartmann/Development/inspec/bin/inspec:12:in `<top (required)>'
	from /Users/chartmann/.rvm/rubies/ruby-2.2.1/lib/ruby/gems/2.2.0/bin/inspec:23:in `load'
	from /Users/chartmann/.rvm/rubies/ruby-2.2.1/lib/ruby/gems/2.2.0/bin/inspec:23:in `<main>'
	from /Users/chartmann/.rvm/rubies/ruby-2.2.1/lib/ruby/gems/2.2.0/bin/ruby_executable_hooks:15:in `eval'
	from /Users/chartmann/.rvm/rubies/ruby-2.2.1/lib/ruby/gems/2.2.0/bin/ruby_executable_hooks:15:in `<main>'
```