### PR TITLE
enable inspec compliance cli support automate

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -8,12 +8,12 @@ require 'uri'
 module Compliance
   # API Implementation does not hold any state by itself,
   # everything will be stored in local Configuration store
-  class API
+  class API # rubocop:disable Metrics/ClassLength
     # return all compliance profiles available for the user
     def self.profiles(config)
-      url = "#{config['server']}/user/compliance"
+      config['automate'][0] ? url = "#{config['server']}/#{config['user']}" : url = "#{config['server']}/user/compliance"
       # TODO, api should not be dependent on .supported?
-      response = Compliance::HTTP.get(url, config['token'], config['insecure'], !config.supported?(:oidc))
+      response = Compliance::HTTP.get(url, config['token'], config['insecure'], config['user'], !config.supported?(:oidc), config['automate'], config['ent'])
       data = response.body
       response_code = response.code
       case response_code
@@ -21,11 +21,17 @@ module Compliance
         msg = 'success'
         profiles = JSON.parse(data)
         # iterate over profiles
-        mapped_profiles = profiles.map do |owner, ps|
-          ps.keys.map do |name|
-            { org: owner, name: name }
-          end
-        end.flatten
+        if config['automate'][0]
+          mapped_profiles = profiles.map do |owner, ps|
+            { org: ps['owner_id'], name: owner }
+          end.flatten
+        else
+          mapped_profiles = profiles.map do |owner, ps|
+            ps.keys.map do |name|
+              { org: owner, name: name }
+            end
+          end.flatten
+        end
         return msg, mapped_profiles
       when '401'
         msg = '401 Unauthorized. Please check your token.'
@@ -69,8 +75,8 @@ Please login using `inspec compliance login https://compliance.test --user admin
 
     def self.upload(config, owner, profile_name, archive_path)
       # upload the tar to Chef Compliance
-      url = "#{config['server']}/owners/#{owner}/compliance/#{profile_name}/tar"
-      res = Compliance::HTTP.post_file(url, config['token'], archive_path, config['insecure'], !config.supported?(:oidc))
+      config['automate'][0] ? url = "#{config['server']}/#{config['user']}" : url = "#{config['server']}/owners/#{owner}/compliance/#{profile_name}/tar"
+      res = Compliance::HTTP.post_file(url, config['token'], config['user'], archive_path, config['insecure'], !config.supported?(:oidc), config['automate'], config['ent'])
       [res.is_a?(Net::HTTPSuccess), res.body]
     end
 

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -11,9 +11,9 @@ module Compliance
   class API # rubocop:disable Metrics/ClassLength
     # return all compliance profiles available for the user
     def self.profiles(config)
-      config['automate'][0] ? url = "#{config['server']}/#{config['user']}" : url = "#{config['server']}/user/compliance"
+      config['server_type'] == 'automate' ? url = "#{config['server']}/#{config['user']}" : url = "#{config['server']}/user/compliance"
       # TODO, api should not be dependent on .supported?
-      response = Compliance::HTTP.get(url, config['token'], config['insecure'], config['user'], !config.supported?(:oidc), config['automate'], config['ent'])
+      response = Compliance::HTTP.get(url, config['token'], config['insecure'], config['user'], !config.supported?(:oidc), config['automate'], config['server_type'])
       data = response.body
       response_code = response.code
       case response_code
@@ -21,7 +21,7 @@ module Compliance
         msg = 'success'
         profiles = JSON.parse(data)
         # iterate over profiles
-        if config['automate'][0]
+        if config['server_type'] == 'automate'
           mapped_profiles = profiles.map do |owner, ps|
             { org: ps['owner_id'], name: owner }
           end.flatten
@@ -75,8 +75,8 @@ Please login using `inspec compliance login https://compliance.test --user admin
 
     def self.upload(config, owner, profile_name, archive_path)
       # upload the tar to Chef Compliance
-      config['automate'][0] ? url = "#{config['server']}/#{config['user']}" : url = "#{config['server']}/owners/#{owner}/compliance/#{profile_name}/tar"
-      res = Compliance::HTTP.post_file(url, config['token'], config['user'], archive_path, config['insecure'], !config.supported?(:oidc), config['automate'], config['ent'])
+      config['server_type'] == 'automate' ? url = "#{config['server']}/#{config['user']}" : url = "#{config['server']}/owners/#{owner}/compliance/#{profile_name}/tar"
+      res = Compliance::HTTP.post_file(url, config['token'], config['user'], archive_path, config['insecure'], !config.supported?(:oidc), config['automate'], config['server_type'])
       [res.is_a?(Net::HTTPSuccess), res.body]
     end
 

--- a/lib/bundles/inspec-compliance/http.rb
+++ b/lib/bundles/inspec-compliance/http.rb
@@ -9,13 +9,21 @@ module Compliance
   # implements a simple http abstraction on top of Net::HTTP
   class HTTP
     # generic get requires
-    def self.get(url, token, insecure, basic_auth = false)
+    def self.get(url, token, insecure, user, basic_auth = false, automate = false, ent = nil) # rubocop:disable Metrics/ParameterLists
       uri = URI.parse(url)
       req = Net::HTTP::Get.new(uri.path)
 
       return send_request(uri, req, insecure) if token.nil?
 
-      if basic_auth
+      if automate[0]
+        req.add_field('chef-delivery-enterprise', ent)
+        if automate[1] == 'dctoken'
+          req.add_field('x-data-collector-token', token)
+        else
+          req.add_field('chef-delivery-user', user)
+          req.add_field('chef-delivery-token', token)
+        end
+      elsif basic_auth
         req.basic_auth(token, '')
       else
         req['Authorization'] = "Bearer #{token}"
@@ -39,7 +47,7 @@ module Compliance
     end
 
     # post a file
-    def self.post_file(url, token, file_path, insecure, basic_auth = false)
+    def self.post_file(url, token, user, file_path, insecure, basic_auth = false, automate = false, ent = nil) # rubocop:disable Metrics/ParameterLists
       uri = URI.parse(url)
       fail "Unable to parse URL: #{url}" if uri.nil? || uri.host.nil?
       http = Net::HTTP.new(uri.host, uri.port)
@@ -49,7 +57,15 @@ module Compliance
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE if insecure
 
       req = Net::HTTP::Post.new(uri.path)
-      if basic_auth
+      if automate[0]
+        req.add_field('chef-delivery-enterprise', ent)
+        if automate[1] == 'dctoken'
+          req.add_field('x-data-collector-token', token)
+        else
+          req.add_field('chef-delivery-user', user)
+          req.add_field('chef-delivery-token', token)
+        end
+      elsif basic_auth
         req.basic_auth token, ''
       else
         req['Authorization'] = "Bearer #{token}"

--- a/lib/bundles/inspec-compliance/http.rb
+++ b/lib/bundles/inspec-compliance/http.rb
@@ -9,15 +9,15 @@ module Compliance
   # implements a simple http abstraction on top of Net::HTTP
   class HTTP
     # generic get requires
-    def self.get(url, token, insecure, user, basic_auth = false, automate = false, ent = nil) # rubocop:disable Metrics/ParameterLists
+    def self.get(url, token, insecure, user, basic_auth = false, automate = nil, server_type) # rubocop:disable Metrics/ParameterLists
       uri = URI.parse(url)
       req = Net::HTTP::Get.new(uri.path)
 
       return send_request(uri, req, insecure) if token.nil?
 
-      if automate[0]
-        req.add_field('chef-delivery-enterprise', ent)
-        if automate[1] == 'dctoken'
+      if server_type == 'automate'
+        req.add_field('chef-delivery-enterprise', automate['ent'])
+        if automate['token_type'] == 'dctoken'
           req.add_field('x-data-collector-token', token)
         else
           req.add_field('chef-delivery-user', user)
@@ -47,7 +47,7 @@ module Compliance
     end
 
     # post a file
-    def self.post_file(url, token, user, file_path, insecure, basic_auth = false, automate = false, ent = nil) # rubocop:disable Metrics/ParameterLists
+    def self.post_file(url, token, user, file_path, insecure, basic_auth = false, automate = nil, server_type) # rubocop:disable Metrics/ParameterLists
       uri = URI.parse(url)
       fail "Unable to parse URL: #{url}" if uri.nil? || uri.host.nil?
       http = Net::HTTP.new(uri.host, uri.port)
@@ -57,9 +57,9 @@ module Compliance
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE if insecure
 
       req = Net::HTTP::Post.new(uri.path)
-      if automate[0]
-        req.add_field('chef-delivery-enterprise', ent)
-        if automate[1] == 'dctoken'
+      if server_type == 'automate'
+        req.add_field('chef-delivery-enterprise', automate['ent'])
+        if automate['token_type'] == 'dctoken'
           req.add_field('x-data-collector-token', token)
         else
           req.add_field('chef-delivery-user', user)

--- a/lib/bundles/inspec-compliance/http.rb
+++ b/lib/bundles/inspec-compliance/http.rb
@@ -9,24 +9,13 @@ module Compliance
   # implements a simple http abstraction on top of Net::HTTP
   class HTTP
     # generic get requires
-    def self.get(url, token, insecure, user, basic_auth = false, automate = nil, server_type) # rubocop:disable Metrics/ParameterLists
+    def self.get(url, headers = nil, insecure)
       uri = URI.parse(url)
       req = Net::HTTP::Get.new(uri.path)
-
-      return send_request(uri, req, insecure) if token.nil?
-
-      if server_type == 'automate'
-        req.add_field('chef-delivery-enterprise', automate['ent'])
-        if automate['token_type'] == 'dctoken'
-          req.add_field('x-data-collector-token', token)
-        else
-          req.add_field('chef-delivery-user', user)
-          req.add_field('chef-delivery-token', token)
+      if !headers.nil?
+        headers.each do |key, value|
+          req.add_field(key, value)
         end
-      elsif basic_auth
-        req.basic_auth(token, '')
-      else
-        req['Authorization'] = "Bearer #{token}"
       end
       send_request(uri, req, insecure)
     end
@@ -47,7 +36,7 @@ module Compliance
     end
 
     # post a file
-    def self.post_file(url, token, user, file_path, insecure, basic_auth = false, automate = nil, server_type) # rubocop:disable Metrics/ParameterLists
+    def self.post_file(url, headers, file_path, insecure)
       uri = URI.parse(url)
       fail "Unable to parse URL: #{url}" if uri.nil? || uri.host.nil?
       http = Net::HTTP.new(uri.host, uri.port)
@@ -57,18 +46,8 @@ module Compliance
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE if insecure
 
       req = Net::HTTP::Post.new(uri.path)
-      if server_type == 'automate'
-        req.add_field('chef-delivery-enterprise', automate['ent'])
-        if automate['token_type'] == 'dctoken'
-          req.add_field('x-data-collector-token', token)
-        else
-          req.add_field('chef-delivery-user', user)
-          req.add_field('chef-delivery-token', token)
-        end
-      elsif basic_auth
-        req.basic_auth token, ''
-      else
-        req['Authorization'] = "Bearer #{token}"
+      headers.each do |key, value|
+        req.add_field(key, value)
       end
 
       req.body_stream=File.open(file_path, 'rb')

--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -25,9 +25,9 @@ module Compliance
       # check if we have a compliance token
       config = Compliance::Configuration.new
       if config['token'].nil?
-        if config['automate'][0]
+        if config['server_type'] == 'automate'
           server = 'automate'
-          msg = 'inspec compliance automate https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --usertoken USERTOKEN'
+          msg = 'inspec compliance login_automate https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --usertoken USERTOKEN'
         else
           server = 'compliance'
           msg = "inspec compliance login https://your_compliance_server --user admin --insecure --token 'PASTE TOKEN HERE' "
@@ -54,7 +54,7 @@ EOF
     end
 
     def self.target_url(profile, config)
-      if config['automate'][0]
+      if config['server_type'] == 'automate'
         target = "#{config['server']}/#{profile}/tar"
       else
         owner, id = profile.split('/')

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -127,18 +127,18 @@ module Fetchers
       http_opts = {}
       http_opts['ssl_verify_mode'.to_sym] = OpenSSL::SSL::VERIFY_NONE if @insecure
       if @config
-        if @config['automate']
-          automate = true
-          http_opts['chef-delivery-enterprise'] = @config['ent']
-          if @config['automate'][1] == 'dctoken'
+        if @config['server_type'] == 'automate'
+          http_opts['chef-delivery-enterprise'] = @config['automate']['ent']
+          if @config['automate']['token_type'] == 'dctoken'
             http_opts['x-data-collector-token'] = @config['token']
           else
             http_opts['chef-delivery-user'] = @config['user']
             http_opts['chef-delivery-token'] = @config['token']
           end
+        elsif @token
+          http_opts['Authorization'] = "Bearer #{@token}"
         end
       end
-      http_opts['Authorization'] = "Bearer #{@token}" if @token && automate.nil?
       remote = open(@target, http_opts)
       @archive_type = file_type_from_remote(remote) # side effect :(
       archive = Tempfile.new(['inspec-dl-', @archive_type])

--- a/test/functional/inspec_compliance_test.rb
+++ b/test/functional/inspec_compliance_test.rb
@@ -35,6 +35,13 @@ describe 'inspec compliance' do
     out.stdout.must_include 'Please run `inspec compliance login SERVER` with options'
   end
 
+  it 'automate with missing parameters' do
+    out = inspec('compliance login_automate http://example.com')
+    out.exit_status.must_equal 1
+    #TODO: inspec should really use stderr for errors
+    out.stdout.must_include 'Please login to your automate instance using'
+  end
+
   it 'inspec compliance profiles without authentication' do
     out = inspec('compliance profile')
     out.stdout.must_include 'You need to login first with `inspec compliance login`'


### PR DESCRIPTION
fixes https://github.com/chef/inspec/issues/1295

`b inspec compliance login_automate http://delivery --user admin --dctoken $DC_TOKEN --ent $AUTOMATE_ENT `

`b inspec compliance login_automate http://delivery --user $AUTOMATE_USER --usertoken $AUTOMATE_TOKEN --ent $AUTOMATE_ENT `

`b inspec compliance profiles`

`b inspec compliance upload ~/linux.tar.gz`

`b inspec compliance logout` <-- just destroys config when automate

`b inspec compliance version` <-- returns msg saying that's not available with automate

`b inspec compliance exec admin/linux`