### PR TITLE
Fixes resources in the docs

### DIFF
--- a/docs/resources/npm.md.erb
+++ b/docs/resources/npm.md.erb
@@ -11,7 +11,7 @@ Use the `npm` InSpec audit resource to test if a global NPM package is installed
 
 A `npm` resource block declares a package and (optionally) a package version:
 
-    describe gem('npm_package_name') do
+    describe npm('npm_package_name') do
       it { should be_installed }
     end
 

--- a/docs/resources/pip.md.erb
+++ b/docs/resources/pip.md.erb
@@ -10,14 +10,14 @@ Use the `pip` InSpec audit resource to test packages that are installed using th
 
 A `pip` resource block declares a package and (optionally) a package version:
 
-    describe pip('Jinja2') do
+    describe pip('package_name') do
       it { should be_installed }
     end
 
 where
 
-* `'Jinja2'` is the name of the package
-* `be_installed` tests to see if the `Jinja2` package is installed
+* `'package_name'` is the name of the package, such as `'Jinja2'`
+* `be_installed` tests to see if the package described above is installed
 
 
 ## Matchers

--- a/docs/resources/powershell.md.erb
+++ b/docs/resources/powershell.md.erb
@@ -14,7 +14,7 @@ A `powershell` resource block declares a Powershell script to be tested, and the
       # a PowerShell script
     EOH
 
-    describe script(script) do
+    describe powershell(script) do
       its('matcher') { should eq 'output' }
     end
 

--- a/docs/resources/vbscript.md.erb
+++ b/docs/resources/vbscript.md.erb
@@ -10,7 +10,7 @@ Use the `vbscript` InSpec audit resource to test a VBScript on the Windows platf
 
 A `vbscript` resource block tests the output of a VBScript on the Windows platform:
 
-    describe vbscript('script_name') do
+    describe vbscript('script contents') do
       its('stdout') { should eq 'output' }
     end
 
@@ -52,18 +52,18 @@ The following examples show how to use this InSpec audit resource.
 
 A VBScript file similar to:
 
-    vbscript = <<-EOH
+    script = <<-EOH
       WScript.Echo "hello"
     EOH
 
 may be tested for multiple lines:
 
-    describe vbscript(vbscript) do
+    describe vbscript(script) do
       its('stdout') { should eq "hello\r\n" }
     end
 
 and tested for whitespace removal from standard output:
 
-    describe vbscript(vbscript) do
+    describe vbscript(script) do
       its('strip') { should eq "hello" }
     end


### PR DESCRIPTION
* Fixes the npm package example to state 'npm' vs 'gem'
* Fixes powershell resource to specify the resource instead of 'script'
* Updates the `vbscript` example to rename script variable to 'script'

> While ruby would allow the local variable and the presence of the InSpec method at the same time I think that it is bad form. Other resource examples also use 'script'.

* Changes pip to show generic example

> Other package like resources show a generic example in the default.