### PR TITLE
Adding JUnit formatter support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
 end
 
 gem 'ffi', '>= 1.9.14'
+gem 'rspec_junit_formatter', '~> 0.2.3'
 
 group :test do
   gem 'bundler', '~> 1.5'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-log'
   spec.add_dependency 'sslshake', '~> 1'
   spec.add_dependency 'parallel', '~> 1.9'
+  spec.add_dependency 'rspec_junit_formatter', '~> 0.2.3'
 end

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
+# author: John Kerry
 
 require 'rspec/core'
 require 'rspec/core/formatters/json_formatter'

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -4,6 +4,7 @@
 
 require 'rspec/core'
 require 'rspec/core/formatters/json_formatter'
+require 'rspec_junit_formatter'
 
 # Vanilla RSpec JSON formatter with a slight extension to show example IDs.
 # TODO: Remove these lines when RSpec includes the ID natively
@@ -545,5 +546,16 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     end
 
     data
+  end
+end
+
+class InspecRspecJUnit < RSpecJUnitFormatter
+  RSpec::Core::Formatters.register self, :close
+
+  def initialize(*args)
+    super(*args)
+  end
+
+  def close(_notification)
   end
 end

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -103,6 +103,7 @@ module Inspec
       'json' => 'InspecRspecJson',
       'json-rspec' => 'InspecRspecVanilla',
       'cli' => 'InspecRspecCli',
+      'junit' => 'InspecRspecJUnit',
     }.freeze
 
     # Configure the output formatter and stream to be used with RSpec.

--- a/test/functional/inspec_exec_junit_test.rb
+++ b/test/functional/inspec_exec_junit_test.rb
@@ -4,13 +4,6 @@
 require 'functional/helper'
 require 'nokogiri'
 
-# <testsuite name="rspec" tests="2" failures="0" errors="0" time="0.004459" timestamp="2016-11-20T21:43:51-05:00">
-#   <!-- Randomized with seed 39231 -->
-#   <properties/>
-#   <testcase classname="lib.inspec.rule" name="File /tmp should be directory" file="./lib/inspec/rule.rb" time="0.003060"/>
-#   <testcase classname="lib.inspec.rule" name="File /tmp should be directory" file="./lib/inspec/rule.rb" time="0.000217"/>
-# </testsuite>
-
 describe 'inspec exec with junit formatter' do
   include FunctionalHelper
 
@@ -26,23 +19,9 @@ describe 'inspec exec with junit formatter' do
     out = inspec('exec ' + example_profile + ' --format junit --no-create-lockfile')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
-    puts out.stdout
     doc = Nokogiri::XML(out.stdout)
     doc.errors.length.must_equal 0
   end
-
-# <?xml version="1.0" encoding="UTF-8"?>
-# <testsuite name="rspec" tests="5" failures="0" errors="0" time="0.025467" timestamp="2016-11-20T22:42:53-05:00">
-#   <!-- Randomized with seed 35012 -->
-#   <properties/>
-#   <testcase classname="lib.inspec.rule" name="File /tmp should be directory" file="./lib/inspec/rule.rb" time="0.001841"/>
-#   <testcase classname="lib.inspec.rule" name="File /tmp should be directory" file="./lib/inspec/rule.rb" time="0.000128"/>
-#   <testcase classname="lib.inspec.runner" name="gordon_config Can't find file &quot;/tmp/gordon/config.yaml&quot;" file="./lib/inspec/runner.rb" time="0.000011">
-#     <skipped/>
-#   </testcase>
-#   <testcase classname="examples.profile.controls.gordon" name="File  content should match nil" file="./examples/profile/controls/gordon.rb" time="0.001176"/>
-#   <testcase classname="lib.inspec.rule" name="File /bin/sh should be owned by &quot;root&quot;" file="./lib/inspec/rule.rb" time="0.019848"/>
-# </testsuite>
 
   describe 'execute a profile with junit formatting' do
     let(:doc) { Nokogiri::XML(inspec('exec ' + example_profile + ' --format junit --no-create-lockfile').stdout) }
@@ -60,6 +39,10 @@ describe 'inspec exec with junit formatter' do
         suite.xpath("//properties").children.length.must_equal 0
       end
 
+      it 'must have 5 testcase children' do
+        suite.xpath("//testcase").length.must_equal 5
+      end
+
       it 'has the tests attribute with 5 total tests' do
         suite["tests"].must_equal "5"
       end
@@ -71,5 +54,23 @@ describe 'inspec exec with junit formatter' do
       it 'has the errors attribute with 0 total tests' do
         suite["errors"].must_equal "0"
       end
+
+      it 'has 2 elements named "File /tmp should be directory"' do
+        suite.xpath("//testcase[@name='File /tmp should be directory']").length.must_equal 2
+      end
+
+      describe 'the testcase named "gordon_config Can\'t find file ..."' do
+        let(:gordon_yml_tests) { suite.xpath("//testcase[@classname='lib.inspec.runner']") }
+        let(:first_gordon_test) {gordon_yml_tests.first}
+
+        it 'should be unique' do
+          gordon_yml_tests.length.must_equal 1
+        end
+
+        it 'should be skipped' do
+          first_gordon_test.xpath("//skipped").length.must_equal 1
+        end
+      end
     end
+  end
 end

--- a/test/functional/inspec_exec_junit_test.rb
+++ b/test/functional/inspec_exec_junit_test.rb
@@ -1,0 +1,75 @@
+# encoding: utf-8
+# author: John Kerry
+
+require 'functional/helper'
+require 'nokogiri'
+
+# <testsuite name="rspec" tests="2" failures="0" errors="0" time="0.004459" timestamp="2016-11-20T21:43:51-05:00">
+#   <!-- Randomized with seed 39231 -->
+#   <properties/>
+#   <testcase classname="lib.inspec.rule" name="File /tmp should be directory" file="./lib/inspec/rule.rb" time="0.003060"/>
+#   <testcase classname="lib.inspec.rule" name="File /tmp should be directory" file="./lib/inspec/rule.rb" time="0.000217"/>
+# </testsuite>
+
+describe 'inspec exec with junit formatter' do
+  include FunctionalHelper
+
+  it 'can execute a simple file with the junit formatter' do
+    out = inspec('exec ' + example_control + ' --format junit --no-create-lockfile')
+    out.stderr.must_equal ''
+    out.exit_status.must_equal 0
+    doc = Nokogiri::XML(out.stdout)
+    doc.errors.length.must_equal 0
+  end
+
+  it 'can execute the profile with the junit formatter' do
+    out = inspec('exec ' + example_profile + ' --format junit --no-create-lockfile')
+    out.stderr.must_equal ''
+    out.exit_status.must_equal 0
+    puts out.stdout
+    doc = Nokogiri::XML(out.stdout)
+    doc.errors.length.must_equal 0
+  end
+
+# <?xml version="1.0" encoding="UTF-8"?>
+# <testsuite name="rspec" tests="5" failures="0" errors="0" time="0.025467" timestamp="2016-11-20T22:42:53-05:00">
+#   <!-- Randomized with seed 35012 -->
+#   <properties/>
+#   <testcase classname="lib.inspec.rule" name="File /tmp should be directory" file="./lib/inspec/rule.rb" time="0.001841"/>
+#   <testcase classname="lib.inspec.rule" name="File /tmp should be directory" file="./lib/inspec/rule.rb" time="0.000128"/>
+#   <testcase classname="lib.inspec.runner" name="gordon_config Can't find file &quot;/tmp/gordon/config.yaml&quot;" file="./lib/inspec/runner.rb" time="0.000011">
+#     <skipped/>
+#   </testcase>
+#   <testcase classname="examples.profile.controls.gordon" name="File  content should match nil" file="./examples/profile/controls/gordon.rb" time="0.001176"/>
+#   <testcase classname="lib.inspec.rule" name="File /bin/sh should be owned by &quot;root&quot;" file="./lib/inspec/rule.rb" time="0.019848"/>
+# </testsuite>
+
+  describe 'execute a profile with junit formatting' do
+    let(:doc) { Nokogiri::XML(inspec('exec ' + example_profile + ' --format junit --no-create-lockfile').stdout) }
+
+    describe 'the document' do
+      it 'has only one testsuite' do
+        doc.xpath("//testsuite").length.must_equal 1
+      end
+    end
+    describe 'the test suite' do
+      let(:suite) { doc.xpath("//testsuite").first}
+
+      it 'has a single properties element with no children' do
+        suite.xpath("//properties").length.must_equal 1
+        suite.xpath("//properties").children.length.must_equal 0
+      end
+
+      it 'has the tests attribute with 5 total tests' do
+        suite["tests"].must_equal "5"
+      end
+
+      it 'has the failures attribute with 0 total tests' do
+        suite["failures"].must_equal "0"
+      end
+
+      it 'has the errors attribute with 0 total tests' do
+        suite["errors"].must_equal "0"
+      end
+    end
+end


### PR DESCRIPTION
resolves #1301 by adding a simple empty shell class extension to the JUnit rspec formatter provided in the rspec_junit_formatter gem.  A dependency to the latest version of this gem is also included.


Signed-off-by: jkerry <john@kerryhouse.net>