### PR TITLE
ensure metadata release entry is a string

### DIFF
--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -68,6 +68,7 @@ module Inspec
                     os.method(family_check).call
                   )
 
+      # ensure we do have a string if we have a non-nil value eg. 16.06
       release_ok = release.nil? || os[:release] == release
 
       # we want to make sure that all matchers are true
@@ -143,7 +144,9 @@ module Inspec
 
     def self.finalize_supports_elem(elem, logger)
       case x = elem
-      when Hash then x
+      when Hash
+        x[:release] = x[:release].to_s if x[:release]
+        x
       when Array
         logger.warn(
           'Failed to read supports entry that is an array. Please use '\
@@ -162,7 +165,7 @@ module Inspec
 
     def self.finalize_supports(supports, logger)
       case x = supports
-      when Hash   then [x]
+      when Hash   then [finalize_supports_elem(x, logger)]
       when Array  then x.map { |e| finalize_supports_elem(e, logger) }.compact
       when nil    then []
       else

--- a/test/unit/profiles/metadata_test.rb
+++ b/test/unit/profiles/metadata_test.rb
@@ -43,6 +43,18 @@ describe 'metadata with supported operating systems' do
       res.params[:supports].must_equal([{ os: 'ubuntu' }])
     end
 
+    it 'makes sure the supports release field is a string' do
+      res = Inspec::Metadata.from_yaml('mock',
+        "---\nsupports:\n  - release: 12.02", nil)
+      res.params[:supports].must_equal([{ release: '12.02' }])
+    end
+
+    it 'makes sure the supports release field is nil if not configured' do
+      res = Inspec::Metadata.from_yaml('mock',
+        "---\nsupports:\n  - release: ", nil)
+      res.params[:supports].must_equal([{ release: nil }])
+    end
+
     it 'load a profile with empty supports clause' do
       m = supports_meta(nil)
       m.supports_transport?(backend).must_equal true
@@ -97,6 +109,11 @@ describe 'metadata with supported operating systems' do
     it 'rejects a profile which supports ubuntu 12.04' do
       m = supports_meta({ 'os-name' => 'ubuntu', 'release' => '12.04' })
       m.supports_transport?(backend).must_equal false
+    end
+
+    it 'loads a profile which supports ubuntu float 14.04 as parsed by yml' do
+      m = supports_meta({ 'os-name' => 'ubuntu', 'release' => 14.04 })
+      m.supports_transport?(backend).must_equal true
     end
 
     it 'reject unsupported os' do


### PR DESCRIPTION
As reported by Shone Jacob in https://chefcommunity.slack.com/archives/inspec/p1479483621000703 InSpec is not handling the version numbers from Ubuntu properly.

```
$ inspec exec ...
Please report a bug if this causes problems.
This OS/platform (ubuntu) is not supported by this profile.
This is the ubuntu version:
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 16.04.1 LTS
Release:    16.04
Codename:   xenial
```

inspec.yml:

```
supports:
 - os-name: ubuntu
   release: 16.04
```

Internally, YAML parses `16.04` as a number instead as string. This PR fixes that behavior and ensurs that versions always compared as strings.