### PR TITLE
revert style changes temporarily

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -253,7 +253,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     'critical' => 3,
   }.freeze
 
-COLORS = {
+  COLORS = {
     'critical' => "\033[31;1m",
     'major'    => "\033[31m",
     'minor'    => "\033[33m",
@@ -264,14 +264,13 @@ COLORS = {
   }.freeze
 
   INDICATORS = {
-    'critical' => '  ×  ',
-    'major'    => '  ∅  ',
-    'minor'    => '  ⊚  ',
-    'failed'   => '  ×  ',
-    'skipped'  => '  ↺  ',
+    'critical' => '  ✖  ',
+    'major'    => '  ✖  ',
+    'minor'    => '  ✖  ',
+    'failed'   => '  ✖  ',
+    'skipped'  => '  ○  ',
     'passed'   => '  ✔  ',
     'unknown'  => '  ?  ',
-    'helpr'    => '  ✣  ',
     'empty'    => '     ',
     'small'    => '   ',
   }.freeze


### PR DESCRIPTION
with this commit: https://github.com/chef/inspec/commit/ff165834a50d0b64124e5912b2787e01d13620be

and the following commit: 
https://github.com/chef/inspec/commit/1338c39e1cf1709e55bf0c5a49a10c7222a748b0

some changes were made to the styles in rspec_json_formatter, but tests were not updated to reflect these changes.  

This commit fixes the failures on master.

The plan is to re-introduce those changes in separate prs where the tests are also addressed to ensure everything is passing. cc @hannah-radish  