### PR TITLE
inspec check and json to use vendored dependencies

### DIFF
--- a/examples/meta-profile/inspec.yml
+++ b/examples/meta-profile/inspec.yml
@@ -8,6 +8,6 @@ summary: InSpec Profile that is only consuming dependencies
 version: 0.2.0
 depends:
   - name: hardening/ssh-hardening  # defaults to supermarket
-  - git: https://github.com/dev-sec/ssl-benchmark.git
+  - url: https://github.com/dev-sec/ssl-benchmark
   - name: windows-patch-benchmark
-    git: https://github.com/chris-rock/windows-patch-benchmark.git
+    url: https://github.com/chris-rock/windows-patch-benchmark

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -33,8 +33,10 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   def json(target)
     diagnose
     o = opts.dup
+    configure_logger(o)
     o[:ignore_supports] = true
     o[:backend] = Inspec::Backend.create(target: 'mock://')
+    o[:cache] = Inspec::Cache.new(nil)
 
     profile = Inspec::Profile.for_target(target, o)
     dst = o[:output].to_s
@@ -56,12 +58,13 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   desc 'check PATH', 'verify all tests at the specified PATH'
   option :format, type: :string
   profile_options
-  def check(path) # rubocop:disable Metrics/AbcSize
+  def check(path) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     diagnose
     o = opts.dup
-    # configure_logger(o) # we do not need a logger for check yet
+    configure_logger(o)
     o[:ignore_supports] = true # we check for integrity only
     o[:backend] = Inspec::Backend.create(target: 'mock://')
+    o[:cache] = Inspec::Cache.new(nil)
 
     # run check
     profile = Inspec::Profile.for_target(path, o)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -36,7 +36,6 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
     configure_logger(o)
     o[:ignore_supports] = true
     o[:backend] = Inspec::Backend.create(target: 'mock://')
-    o[:cache] = Inspec::Cache.new(nil)
 
     profile = Inspec::Profile.for_target(target, o)
     dst = o[:output].to_s
@@ -58,13 +57,12 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   desc 'check PATH', 'verify all tests at the specified PATH'
   option :format, type: :string
   profile_options
-  def check(path) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def check(path) # rubocop:disable Metrics/AbcSize
     diagnose
     o = opts.dup
     configure_logger(o)
     o[:ignore_supports] = true # we check for integrity only
     o[:backend] = Inspec::Backend.create(target: 'mock://')
-    o[:cache] = Inspec::Cache.new(nil)
 
     # run check
     profile = Inspec::Profile.for_target(path, o)

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -21,10 +21,9 @@ module Inspec
   class Profile # rubocop:disable Metrics/ClassLength
     extend Forwardable
 
-    def self.resolve_target(target, cache = nil)
-      c = cache || Cache.new
-      Inspec::Log.debug "Resolve #{target} into cache #{c.path}"
-      Inspec::CachedFetcher.new(target, cache || Cache.new)
+    def self.resolve_target(target, cache)
+      Inspec::Log.debug "Resolve #{target} into cache #{cache.path}"
+      Inspec::CachedFetcher.new(target, cache)
     end
 
     # Check if the profile contains a vendored cache, move content into global cache
@@ -65,11 +64,13 @@ module Inspec
     end
 
     def self.for_fetcher(fetcher, opts)
+      opts[:cache] = opts[:cache] || Cache.new
       path, writable = fetcher.fetch
       for_path(path, opts.merge(target: fetcher.target, writable: writable))
     end
 
     def self.for_target(target, opts = {})
+      opts[:cache] = opts[:cache] || Cache.new
       fetcher = resolve_target(target, opts[:cache])
       for_fetcher(fetcher, opts)
     end

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -52,9 +52,9 @@ describe 'example inheritance profile' do
     File.exist?(lockfile).must_equal true
 
     out = inspec('exec ' + meta_path + ' -l debug --no-create-lockfile')
-    out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:url=>"https://github.com/dev-sec/tests-ssh-hardening/archive/master.tar.gz", :sha256=>"01414bd307ea2f7d4dc8cd141085ba7ad61d4c3b2606d57b2dae987c1c3954cb"'
-    out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:git=>"https://github.com/dev-sec/ssl-benchmark.git", :ref=>"e17486c864434c818f96ca13edd2c5a420100a45"'
-    out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:git=>"https://github.com/chris-rock/windows-patch-benchmark.git", :ref=>"c183d08eb25638e7f5eac97e521640ea314c8e3d"'
+    out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:url=>"https://github.com/dev-sec/tests-ssh-hardening/archive/master.tar.gz"'
+    out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:url=>"https://github.com/dev-sec/ssl-benchmark/archive/master.tar.gz"'
+    out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:url=>"https://github.com/chris-rock/windows-patch-benchmark/archive/master.tar.gz"'
     out.stdout.force_encoding(Encoding::UTF_8).index('Fetching URL:').must_be_nil
     out.stdout.force_encoding(Encoding::UTF_8).index('Fetched archive moved to:').must_be_nil
 
@@ -66,11 +66,15 @@ describe 'example inheritance profile' do
     out = inspec('vendor ' + meta_path + ' --overwrite')
 
     # clean cache directory
-    FileUtils.rm_r "#{Dir.home}/.inspec/cache"
+    FileUtils.rm_rf "#{Dir.home}/.inspec/cache"
 
     # execute json command
     out = inspec('json ' + meta_path + ' -l debug')
     out.exit_status.must_equal 0
+
+    copies = out.stdout.scan(/Copy .* to cache directory/).length
+    copies.must_equal 3
+
     length = out.stdout.scan(/Dependency does not exist in the cache/).length
     length.must_equal 1
   end
@@ -80,11 +84,15 @@ describe 'example inheritance profile' do
     out = inspec('vendor ' + meta_path + ' --overwrite')
 
     # clean cache directory
-    FileUtils.rm_r "#{Dir.home}/.inspec/cache"
+    FileUtils.rm_rf "#{Dir.home}/.inspec/cache"
 
     # execute check command
     out = inspec('check ' + meta_path + ' -l debug')
     out.exit_status.must_equal 0
+
+    copies = out.stdout.scan(/Copy .* to cache directory/).length
+    copies.must_equal 3
+
     length = out.stdout.scan(/Dependency does not exist in the cache/).length
     length.must_equal 1
   end


### PR DESCRIPTION
Fixes: https://github.com/chef/inspec/issues/1316 by providing a cache directory. Otherwise `copy_deps_into_cache` is not called.