### PR TITLE
Provide inspec.lock for archives as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ omnibus/.cache
 omnibus/pkg
 test/**/*.lock
 examples/**/*.lock
+examples/meta-profile/vendor/
 habitat/VERSION
 habitat/results
 /.ruby-gemset

--- a/lib/inspec/dependencies/lockfile.rb
+++ b/lib/inspec/dependencies/lockfile.rb
@@ -15,12 +15,17 @@ module Inspec
       new(lockfile_content)
     end
 
-    def self.from_file(path)
-      parsed_content = YAML.load(File.read(path))
+    def self.from_content(content)
+      parsed_content = YAML.load(content)
       version = parsed_content['lockfile_version']
       fail "No lockfile_version set in #{path}!" if version.nil?
       validate_lockfile_version!(version.to_i)
       new(parsed_content)
+    end
+
+    def self.from_file(path)
+      content = File.read(path)
+      from_content(content)
     end
 
     def self.validate_lockfile_version!(version)

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -206,7 +206,7 @@ module Inspec
       res
     end
 
-    # Check if the profile is internall well-structured. The logger will be
+    # Check if the profile is internally well-structured. The logger will be
     # used to print information on errors and warnings which are found.
     #
     # @return [Boolean] true if no errors were found, false otherwise
@@ -343,7 +343,7 @@ module Inspec
     end
 
     def lockfile_exists?
-      File.exist?(lockfile_path)
+      @source_reader.target.files.include?('inspec.lock')
     end
 
     def lockfile_path
@@ -361,7 +361,7 @@ module Inspec
 
     def lockfile
       @lockfile ||= if lockfile_exists?
-                      Inspec::Lockfile.from_file(lockfile_path)
+                      Inspec::Lockfile.from_content(@source_reader.target.read('inspec.lock'))
                     else
                       generate_lockfile
                     end


### PR DESCRIPTION
Fixes https://github.com/chef/inspec/issues/1322 by providing the loading the inspec.lock from both unpacked and archived profiles.