### PR TITLE
do not load controls from test directory

### DIFF
--- a/lib/source_readers/inspec.rb
+++ b/lib/source_readers/inspec.rb
@@ -44,7 +44,7 @@ module SourceReaders
 
     def load_tests
       tests = @target.files.find_all do |path|
-        path.start_with?('controls', 'test') && path.end_with?('.rb')
+        path.start_with?('controls') && path.end_with?('.rb')
       end
       Hash[tests.map { |x| [x, @target.read(x)] }]
     end


### PR DESCRIPTION
This PR fixes #1326

InSpec still supported loading controls from `test` directory. This was supported in the early versions of InSpec and is not used anymore nor documented. Therefore, going forward we support loading controls from `controls` directory only