### PR TITLE
Show process name during inspec output

### DIFF
--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -21,9 +21,10 @@ module Inspec::Resources
                 :states
 
     def initialize(grep)
+      @grep = grep
       # turn into a regexp if it isn't one yet
       if grep.class == String
-        grep = '(/[^/]*)*'+grep if grep[0] != '/'
+        grep = '(/[^/]*)*' + grep if grep[0] != '/'
         grep = Regexp.new('^' + grep + '(\s|$)')
       end
       all_cmds = ps_axo
@@ -38,7 +39,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'Processes'
+      "Processes #{@grep.class == String ? @grep : @grep.inspect}"
     end
 
     private

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -70,4 +70,14 @@ describe 'Inspec::Resources::Processes' do
     _(resource.users.sort).must_equal ['opscode-pgsql']
     _(resource.states.sort).must_equal ['Ss']
   end
+
+  it 'command name matches with output (string)' do
+    resource = MockLoader.new(:centos6).load_resource('processes', 'mysqld')
+    _(resource.to_s).must_equal 'Processes mysqld'
+  end
+
+  it 'command name matches with output (regex)' do
+    resource = MockLoader.new(:centos6).load_resource('processes', /mysqld/)
+    _(resource.to_s).must_equal 'Processes /mysqld/'
+  end
 end


### PR DESCRIPTION
Testing a _process_ resource I got this output:

```
  Processes list.length
     ✔  should eq 1
```

when I expected something like _Processes mysqld_. Using _grep_ variable to verify the output:

```
  Processes mysqld
     ✔  users should cmp == "mysql"
```

or, when we use RegExp:

```
  Processes /mysqld_safe/
     ✔  users should cmp == "root"
```

I also added some unit tests to verify this behavior.