### PR TITLE
burtlo/cleaner cli formatter

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -107,7 +107,7 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
 
   # Called by the runner during example collection.
   def add_profile(profile)
-    profiles.push(profile)
+    @profiles.push(profile)
   end
 
   def stop(notification)
@@ -123,8 +123,6 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
   end
 
   private
-
-  attr_reader :profiles
 
   def all_unique_controls
     Array(@all_controls).uniq
@@ -205,7 +203,7 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
   end
 
   def profiles_info
-    @profiles_info ||= profiles.map(&:info!).map(&:dup)
+    @profiles_info ||= @profiles.map(&:info!).map(&:dup)
   end
 
   def example2control(example)

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -101,12 +101,9 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
   def initialize(*args)
     super(*args)
     @profiles = []
-    # Will be valid after "start" state is reached.
     @profiles_info = nil
     @backend = nil
   end
-
-  attr_reader :profiles
 
   # Called by the runner during example collection.
   def add_profile(profile)
@@ -125,6 +122,14 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
     end
   end
 
+  private
+
+  attr_reader :profiles
+
+  def all_unique_controls
+    Array(@all_controls).uniq
+  end
+
   def profile_summary
     failed = 0
     skipped = 0
@@ -132,8 +137,6 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
     critical = 0
     major = 0
     minor = 0
-
-    all_unique_controls = Array(@all_controls).uniq
 
     all_unique_controls.each do |control|
       next if control[:id].start_with? '(generated from '
@@ -173,7 +176,7 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
     skipped = 0
     passed = 0
 
-    Array(@all_controls).uniq.each do |control|
+    all_unique_controls.each do |control|
       next unless control[:results]
       control[:results].each do |result|
         if result[:status] == 'failed'
@@ -189,10 +192,8 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
     { 'total' => total, 'failed' => failed, 'skipped' => skipped, 'passed' => passed }
   end
 
-  private
-
   def examples
-    @examples ||= @output_hash.delete(:controls)
+    @output_hash[:controls]
   end
 
   def examples_without_controls

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -586,7 +586,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
   # This class wraps a control hash object to provide a useful inteface for
   # maintaining the associated profile, ids, results, title, etc.
   #
-  class Control
+  class Control # rubocop:disable Metrics/ClassLength
     include Comparable
 
     STATUS_TYPES = {
@@ -608,8 +608,6 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     attr_reader :control, :profile
 
     alias as_hash control
-
-    attr_reader :skips, :fails, :passes
 
     def id
       control[:id]
@@ -683,11 +681,8 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
             !skips.empty? ? "#{skips.uniq.length} skipped" : nil,
           ].compact.join(' ')
         end
-      if suffix == ''
-        title
-      else
-        title + ' (' + suffix + ')'
-      end
+
+      suffix == '' ? title : title + ' (' + suffix + ')'
     end
 
     # We are interested in comparing controls against other controls. It is
@@ -708,9 +703,9 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
 
     private
 
-    def summary_calculation_needed?
-      @summary_calculation_needed
-    end
+    attr_reader :summary_calculation_needed, :skips, :fails, :passes
+
+    alias summary_calculation_needed? summary_calculation_needed
 
     def summary_calculation_is_needed
       @summary_calculation_needed = true
@@ -751,7 +746,6 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
         'minor'
       end
     end
-
   end
 end
 

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -543,6 +543,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     end
   end
 
+  # Prints target information; called from print_current_profile
   def print_target
     return if @backend.nil?
     connection = @backend.backend
@@ -550,6 +551,8 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     output.puts('Target:  ' + connection.uri + "\n\n")
   end
 
+  # Prints blank info is no current_control is defined
+  # Called from print_current_profile and close
   def print_profiles_info(current_control)
     @profiles_info.each do |profile|
       next if profile[:already_printed]

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -80,7 +80,12 @@ module Inspec
         @test_collector.add_profile(profile)
         write_lockfile(profile) if @create_lockfile
         profile.locked_dependencies
-        profile.load_libraries
+        profile_context = profile.load_libraries
+
+        profile_context.dependencies.list.values.each do |requirement|
+          @test_collector.add_profile(requirement.profile)
+        end
+
         @attributes |= profile.runner_context.attributes
         all_controls += profile.collect_tests
       end

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -197,7 +197,7 @@ Test Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;2
     let(:out) { inspec('exec ' + simple_inheritance) }
 
     it 'should print the profile information and then the test results' do
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "local://\n\n\n\e[38;5;9m  ×  tmp-1.0: Create /tmp directory (1 failed)\e[0m\n\e[38;5;9m     ×  File /tmp should not be directory\n"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "\e[38;5;9m  ×  tmp-1.0: Create /tmp directory (1 failed)\e[0m\n\e[38;5;41m     ✔  File /tmp should be directory\e[0m\n\e[38;5;9m     ×  File /tmp should not be directory\n"
     end
   end
 


### PR DESCRIPTION
 Updates RSpec CLI Formater to print profiles correctly

The profiles will display  the controls with their results and then display the examples not associated with any control but within the profile.

```
Profile: InSpec Profile (bananas_in_pajamas)
Version: 0.1.0
Target:  local://

  ✖  ssh (b in p): A human-readable title (1 failed)
     ✔  File sandia/bananas_in_pajamas should exist
     ✖  System Package ssh should be installed
     expected that `System Package ssh` is installed
  ✔  Not Running a Web Server (b in p): A human-readable title
     ✔  File /tmp should be directory
     ✔  System Package httpd should not be installed
     ✔  Service httpd should not be running
  ✔  sftp (b in p): A human-readable title
     ✔  System Package sftp should not be installed

  File file_in_profile_between_controls
     ✖  should exist
     expected File file_in_profile_between_controls to exist
     ✔  should not be owned by "root"
  File file_in_profile_outside_of_control
     ✔  should not exist

Profile: Broken Arrow Profile (broken_arrow)
Version: 1.0.0
Target:  local://

  ✖  CHEF FILES (broken_arrow): Chef files are important to have in place (expected File broken_arrow to exist)
     ✖  File broken_arrow should exist
     expected File broken_arrow to exist

  Service broken_arrow
     ✔  should not be running

Profile: InSpec Profile (my_blank)
Version: 0.1.0
Target:  local://


  File profile_with_a_control_no_examples
     ✔  should not exist

Target:  local://

  ✖  Control (no profile): Hello World (expected nil to match "Hello World")
     ✖  File control_outside.txt content should match "Hello World"
     expected nil to match "Hello World"


Profile Summary: 4 successful, 4 failures, 0 skipped
Test Summary: 17 successful, 6 failures, 0 skipped
```