### PR TITLE
Vendor profile when uploading to chef-compliance

### DIFF
--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -128,6 +128,8 @@ module Compliance
         exit 1
       end
 
+      Inspec::Profile.vendor(path, options) if File.directory?(path)
+
       o = options.dup
       configure_logger(o)
       # check the profile, we only allow to upload valid profiles
@@ -172,7 +174,6 @@ module Compliance
       # if it is a directory, tar it to tmp directory
       if File.directory?(path)
         archive_path = Dir::Tmpname.create([profile_name, '.tar.gz']) {}
-        # archive_path = file.path
         puts "Generate temporary profile archive at #{archive_path}"
         profile.archive({ output: archive_path, ignore_errors: false, overwrite: true })
       else

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -128,7 +128,7 @@ module Compliance
         exit 1
       end
 
-      Inspec::Profile.vendor(path, options) if File.directory?(path)
+      vendor_deps(path, options) if File.directory?(path)
 
       o = options.dup
       configure_logger(o)

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -146,6 +146,35 @@ module Inspec
       end
     end
 
+    def vendor_deps(path, opts)
+      path.nil? ? path = Pathname.new(Dir.pwd) : path = Pathname.new(path)
+      cache_path = path.join('vendor')
+      inspec_lock = path.join('inspec.lock')
+
+      if (cache_path.exist? || inspec_lock.exist?) && !opts[:overwrite]
+        puts 'Profile is already vendored. Use --overwrite.'
+        return false
+      end
+
+      # remove existing
+      FileUtils.rm_rf(cache_path) if cache_path.exist?
+      File.delete(inspec_lock) if inspec_lock.exist?
+
+      puts "Vendor dependencies of #{path} into #{cache_path}"
+      opts[:logger] = Logger.new(STDOUT)
+      opts[:logger].level = get_log_level(opts.log_level)
+      opts[:cache] = Inspec::Cache.new(cache_path.to_s)
+      opts[:backend] = Inspec::Backend.create(target: 'mock://')
+      configure_logger(opts)
+
+      # vendor dependencies and generate lockfile
+      profile = Inspec::Profile.for_target(path.to_s, opts)
+      lockfile = profile.generate_lockfile
+      File.write(inspec_lock, lockfile.to_yaml)
+    rescue StandardError => e
+      pretty_handle_exception(e)
+    end
+
     def configure_logger(o)
       #
       # TODO(ssd): This is a big gross, but this configures the

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -109,33 +109,14 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   desc 'vendor PATH', 'Download all dependencies and generate a lockfile in a `vendor` directory'
   option :overwrite, type: :boolean, default: false,
     desc: 'Overwrite existing vendored dependencies and lockfile.'
-  def vendor(path = nil) # rubocop:disable Metrics/AbcSize
+  def vendor(path = nil)
     o = opts.dup
-
-    path.nil? ? path = Pathname.new(Dir.pwd) : path = Pathname.new(path)
-    cache_path = path.join('vendor')
-    inspec_lock = path.join('inspec.lock')
-
-    if (cache_path.exist? || inspec_lock.exist?) && !opts[:overwrite]
-      puts 'Profile is already vendored. Use --overwrite.'
-      return false
-    end
-
-    # remove existing
-    FileUtils.rm_rf(cache_path) if cache_path.exist?
-    File.delete(inspec_lock) if inspec_lock.exist?
-
-    puts "Vendor dependencies of #{path} into #{cache_path}"
     o[:logger] = Logger.new(STDOUT)
     o[:logger].level = get_log_level(o.log_level)
-    o[:cache] = Inspec::Cache.new(cache_path.to_s)
-    o[:backend] = Inspec::Backend.create(target: 'mock://')
     configure_logger(o)
 
-    # vendor dependencies and generate lockfile
-    profile = Inspec::Profile.for_target(path.to_s, o)
-    lockfile = profile.generate_lockfile
-    File.write(inspec_lock, lockfile.to_yaml)
+    Inspec::Profile.vendor(path, o)
+
   rescue StandardError => e
     pretty_handle_exception(e)
   end

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -111,14 +111,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
     desc: 'Overwrite existing vendored dependencies and lockfile.'
   def vendor(path = nil)
     o = opts.dup
-    o[:logger] = Logger.new(STDOUT)
-    o[:logger].level = get_log_level(o.log_level)
-    configure_logger(o)
-
-    Inspec::Profile.vendor(path, o)
-
-  rescue StandardError => e
-    pretty_handle_exception(e)
+    vendor_deps(path, o)
   end
 
   desc 'archive PATH', 'archive a profile to tar.gz (default) or zip'

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -48,32 +48,6 @@ module Inspec
       end
     end
 
-    def self.vendor(path, opts)
-      puts 'Vendoring profile.'
-
-      path.nil? ? path = Pathname.new(Dir.pwd) : path = Pathname.new(path)
-      cache_path = path.join('vendor')
-      inspec_lock = path.join('inspec.lock')
-
-      if (cache_path.exist? || inspec_lock.exist?) && !opts[:overwrite]
-        puts 'Profile is already vendored. Use --overwrite.'
-        return false
-      end
-
-      # remove existing
-      FileUtils.rm_rf(cache_path) if cache_path.exist?
-      File.delete(inspec_lock) if inspec_lock.exist?
-
-      puts "Vendor dependencies of #{path} into #{cache_path}"
-      opts[:cache] = Inspec::Cache.new(cache_path.to_s)
-      opts[:backend] = Inspec::Backend.create(target: 'mock://')
-
-      # vendor dependencies and generate lockfile
-      profile = Inspec::Profile.for_target(path.to_s, opts)
-      lockfile = profile.generate_lockfile
-      File.write(inspec_lock, lockfile.to_yaml)
-    end
-
     def self.for_path(path, opts)
       file_provider = FileProvider.for_path(path)
       rp = file_provider.relative_provider

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -48,6 +48,32 @@ module Inspec
       end
     end
 
+    def self.vendor(path, opts)
+      puts 'Vendoring profile.'
+
+      path.nil? ? path = Pathname.new(Dir.pwd) : path = Pathname.new(path)
+      cache_path = path.join('vendor')
+      inspec_lock = path.join('inspec.lock')
+
+      if (cache_path.exist? || inspec_lock.exist?) && !opts[:overwrite]
+        puts 'Profile is already vendored. Use --overwrite.'
+        return false
+      end
+
+      # remove existing
+      FileUtils.rm_rf(cache_path) if cache_path.exist?
+      File.delete(inspec_lock) if inspec_lock.exist?
+
+      puts "Vendor dependencies of #{path} into #{cache_path}"
+      opts[:cache] = Inspec::Cache.new(cache_path.to_s)
+      opts[:backend] = Inspec::Backend.create(target: 'mock://')
+
+      # vendor dependencies and generate lockfile
+      profile = Inspec::Profile.for_target(path.to_s, opts)
+      lockfile = profile.generate_lockfile
+      File.write(inspec_lock, lockfile.to_yaml)
+    end
+
     def self.for_path(path, opts)
       file_provider = FileProvider.for_path(path)
       rp = file_provider.relative_provider


### PR DESCRIPTION
moved the vendoring logic to profile so it can be called from the cli (`inspec vendor PATH`) and from `inspec compliance upload PATH` 
fixes #1294