### PR TITLE
Adds junit to the inspec help exec

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -57,7 +57,7 @@ module Inspec
       option :controls, type: :array,
         desc: 'A list of controls to run. Ignore all other tests.'
       option :format, type: :string,
-        desc: 'Which formatter to use: cli, progress, documentation, json, json-min'
+        desc: 'Which formatter to use: cli, progress, documentation, json, json-min, junit'
       option :color, type: :boolean, default: true,
         desc: 'Use colors in output.'
       option :attrs, type: :array,

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -212,7 +212,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   option :command, aliases: :c,
     desc: 'A single command string to run instead of launching the shell'
   option :format, type: :string, default: nil, hide: true,
-    desc: 'Which formatter to use: cli, progress, documentation, json, json-min'
+    desc: 'Which formatter to use: cli, progress, documentation, json, json-min, junit'
   def shell_func
     diagnose
     o = opts.dup

--- a/www/tutorial/app/responses/inspec_help_exec.txt
+++ b/www/tutorial/app/responses/inspec_help_exec.txt
@@ -23,7 +23,7 @@ Options:
   l, [--log-level=LOG_LEVEL]                       # Set the log level: info (default), debug, warn, error
       [--profiles-path=PROFILES_PATH]              # Folder which contains referenced profiles.
       [--controls=one two three]                   # A list of controls to run. Ignore all other tests.
-      [--format=FORMAT]                            # Which formatter to use: cli, progress, documentation, json, json-min
+      [--format=FORMAT]                            # Which formatter to use: cli, progress, documentation, json, json-min, junit
       [--color], [--no-color]                      # Use colors in output.
                                                    # Default: true
       [--attrs=one two three]                      # Load attributes file (experimental)


### PR DESCRIPTION
While rebasing the branch where I was working on the cli formatter I
noticed the addition of junit. However, it was not in the help.

Signed-off-by: Franklin Webber <franklin@chef.io>