### PR TITLE
Remove check and json logging for now

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -33,7 +33,6 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   def json(target)
     diagnose
     o = opts.dup
-    configure_logger(o)
     o[:ignore_supports] = true
     o[:backend] = Inspec::Backend.create(target: 'mock://')
 
@@ -60,7 +59,6 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   def check(path) # rubocop:disable Metrics/AbcSize
     diagnose
     o = opts.dup
-    configure_logger(o)
     o[:ignore_supports] = true # we check for integrity only
     o[:backend] = Inspec::Backend.create(target: 'mock://')
 

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -78,33 +78,34 @@ describe 'example inheritance profile' do
     out = inspec('vendor ' + meta_path + ' --overwrite')
 
     # execute json command
-    out = inspec('json ' + meta_path + ' -l debug --output ' + dst.path)
+    # we need to activate the logger with `-l debug`, but that needs to redirect its output to STDERR
+    out = inspec('json ' + meta_path + ' --output ' + dst.path)
     out.exit_status.must_equal 0
     hm = JSON.load(File.read(dst.path))
     hm['name'].must_equal 'meta-profile'
     hm['controls'].length.must_equal 79
 
-    copies = out.stdout.scan(/Copy .* to cache directory/).length
-    copies.must_equal 3
-
-    length = out.stdout.scan(/Dependency does not exist in the cache/).length
-    length.must_equal 1
-
-    length = out.stdout.scan(/Fetching URL:/).length
-    length.must_equal 0
+    # copies = out.stdout.scan(/Copy .* to cache directory/).length
+    # copies.must_equal 3
+    #
+    # length = out.stdout.scan(/Dependency does not exist in the cache/).length
+    # length.must_equal 1
+    #
+    # length = out.stdout.scan(/Fetching URL:/).length
+    # length.must_equal 0
 
     # execute check command
     out = inspec('check ' + meta_path + ' -l debug')
     out.exit_status.must_equal 0
 
-    copies = out.stdout.scan(/Copy .* to cache directory/).length
-    copies.must_equal 3
-
-    length = out.stdout.scan(/Dependency does not exist in the cache/).length
-    length.must_equal 1
-
-    length = out.stdout.scan(/Fetching URL:/).length
-    length.must_equal 0
+    # copies = out.stdout.scan(/Copy .* to cache directory/).length
+    # copies.must_equal 3
+    #
+    # length = out.stdout.scan(/Dependency does not exist in the cache/).length
+    # length.must_equal 1
+    #
+    # length = out.stdout.scan(/Fetching URL:/).length
+    # length.must_equal 0
   end
 
   it 'can vendor profile dependencies from the profile path' do


### PR DESCRIPTION
Introduced as part of https://github.com/chef/inspec/pull/1321/files, but causing issues when stdout is parsed as json.

Will need to revisit in another ticket the default logs location(STDOUT or STDERR) 