### PR TITLE
Remove trailing `\\` from iis_site example

### DIFF
--- a/docs/resources/iis_site.md.erb
+++ b/docs/resources/iis_site.md.erb
@@ -131,7 +131,7 @@ The following examples show how to use this InSpec audit resource.
       it { should be_running }
       it { should have_app_pool('DefaultAppPool') }
       it { should have_binding('http *:80:') }
-      it { should have_path('%SystemDrive%\\inetpub\\wwwroot\\') }
+      it { should have_path('%SystemDrive%\\inetpub\\wwwroot') }
     end
 
 ### Test if IIS service is running


### PR DESCRIPTION
See tests [here](https://github.com/chef/inspec/blob/725e0a1bc50008c8ad252bd8d5c833a7af20c606/test/integration/default/iis_site_spec.rb#L24)