### PR TITLE
WIP: allow subclass of standard inspec resource

### DIFF
--- a/lib/inspec/library_eval_context.rb
+++ b/lib/inspec/library_eval_context.rb
@@ -35,6 +35,7 @@ module Inspec
 
       c3 = Class.new do
         include Inspec::DSL::RequireOverride
+        include Inspec::Resources
         def initialize(require_loader) # rubocop:disable Lint/NestedMethodDefinition
           @require_loader = require_loader
         end

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -122,6 +122,8 @@ module Inspec
       autoloads.each do |path|
         next unless path.end_with?('.rb')
         load_library_file(*@require_loader.load(path)) unless @require_loader.loaded?(path)
+        # merge in any new custom resources defined in libraries
+        @resource_registry.merge!(Inspec::Resource.registry)
       end
       reload_dsl
     end

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -58,6 +58,7 @@ module Inspec
     end
 
     def reload_dsl
+      @resource_registry.merge!(Inspec::Resource.new_registry)
       @control_eval_context = nil
     end
 
@@ -145,8 +146,6 @@ module Inspec
       else
         context.instance_eval(content, source || 'unknown', line || 1)
       end
-      # merge in new resources from global context
-      self.resource_registry.merge!(Inspec::Resource.new_registry)
     end
 
     def unregister_rule(id)

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -93,9 +93,8 @@ module Inspec
       found
     end
 
-    def add_resources(context, registry = nil)
-      @resource_registry.merge!(registry || context.resource_registry)
-      return if registry
+    def add_resources(context)
+      @resource_registry.merge!(context.resource_registry)
       control_eval_context.add_resources(context)
       @lib_subcontexts << context
       reload_dsl
@@ -123,7 +122,6 @@ module Inspec
       autoloads.each do |path|
         next unless path.end_with?('.rb')
         load_library_file(*@require_loader.load(path)) unless @require_loader.loaded?(path)
-        add_resources(@library_eval_context, Inspec::Resource.registry)
       end
       reload_dsl
     end
@@ -147,6 +145,8 @@ module Inspec
       else
         context.instance_eval(content, source || 'unknown', line || 1)
       end
+      # merge in new resources from global context
+      self.resource_registry.merge!(Inspec::Resource.new_registry)
     end
 
     def unregister_rule(id)

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -93,8 +93,9 @@ module Inspec
       found
     end
 
-    def add_resources(context)
-      @resource_registry.merge!(context.resource_registry)
+    def add_resources(context, registry = nil)
+      @resource_registry.merge!(registry || context.resource_registry)
+      return if registry
       control_eval_context.add_resources(context)
       @lib_subcontexts << context
       reload_dsl
@@ -122,8 +123,7 @@ module Inspec
       autoloads.each do |path|
         next unless path.end_with?('.rb')
         load_library_file(*@require_loader.load(path)) unless @require_loader.loaded?(path)
-        # merge in any new custom resources defined in libraries
-        @resource_registry.merge!(Inspec::Resource.registry)
+        add_resources(@library_eval_context, Inspec::Resource.registry)
       end
       reload_dsl
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -127,6 +127,8 @@ class MockLoader
       '/etc/xinetd.d/chargen-stream' => mockfile.call('xinetd.d_chargen-stream'),
       '/etc/xinetd.d/chargen-dgram' => mockfile.call('xinetd.d_chargen-dgram'),
       '/etc/sysctl.conf' => mockfile.call('sysctl.conf'),
+      '/tmp/gordon_config.json' => mockfile.call('gordon_config.json'),
+      '/tmp/gordon_config.yaml' => mockfile.call('gordon_config.yaml')
     }
 
     # create all mock commands

--- a/test/unit/mock/files/gordon_config.json
+++ b/test/unit/mock/files/gordon_config.json
@@ -1,0 +1,7 @@
+{
+  "gordon_config": {
+    "Lives": 3,
+    "MaxSpeed": 200,
+    "Transmission": "manual"
+  }
+}

--- a/test/unit/mock/profiles/dependencies/profile_y/controls/example.rb
+++ b/test/unit/mock/profiles/dependencies/profile_y/controls/example.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+# license: All rights reserved
+
+title 'sample section'
+include_controls 'profile_z'
+
+# you add controls here
+control 'profilez-1' do                     # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end
+
+control 'profilez-2' do
+  title 'Verify gordon_config version'
+  desc 'An optional description...'
+  describe gordon_config do
+    its('version') { should eq('1.0') }
+    its('MaxSpeed') { should eq(200) }
+  end
+end

--- a/test/unit/mock/profiles/dependencies/profile_y/inspec.yml
+++ b/test/unit/mock/profiles/dependencies/profile_y/inspec.yml
@@ -1,0 +1,11 @@
+name: profile_y
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile
+version: 0.1.0
+depends:
+  - name: profile_z
+    path: ../profile_z

--- a/test/unit/mock/profiles/dependencies/profile_z/controls/example.rb
+++ b/test/unit/mock/profiles/dependencies/profile_z/controls/example.rb
@@ -1,0 +1,9 @@
+# you add controls here
+control 'profilez-1' do                     # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/dependencies/profile_z/inspec.yml
+++ b/test/unit/mock/profiles/dependencies/profile_z/inspec.yml
@@ -1,0 +1,8 @@
+name: profile_z
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile
+version: 0.1.0

--- a/test/unit/mock/profiles/dependencies/profile_z/libraries/gordon_config.rb
+++ b/test/unit/mock/profiles/dependencies/profile_z/libraries/gordon_config.rb
@@ -1,0 +1,19 @@
+class GordonConfig < JsonConfig
+  name 'gordon_config'
+
+  desc "Gordon's resource description ..."
+
+  example "
+    describe gordon_config do
+      its('version') { should eq('1.0') }
+    end
+  "
+
+  def initialize
+    super('/tmp/gordon.json')
+  end
+
+  def version
+    "1.0"
+  end
+end

--- a/test/unit/mock/profiles/dependencies/profile_z/libraries/gordon_config_v2.rb
+++ b/test/unit/mock/profiles/dependencies/profile_z/libraries/gordon_config_v2.rb
@@ -1,0 +1,19 @@
+class GordonConfigv2 < JsonConfig
+  name 'gordon_configv2'
+
+  desc "Gordonv2's resource description ..."
+
+  example "
+    describe gordon_configv2 do
+      its('version') { should eq('2.0') }
+    end
+  "
+
+  def initialize
+    super('/tmp/gordon.json')
+  end
+
+  def version
+    "2.0"
+  end
+end

--- a/test/unit/profiles/control_eval_context_test.rb
+++ b/test/unit/profiles/control_eval_context_test.rb
@@ -57,7 +57,7 @@ EOF
     let(:resource_dsl) { Inspec::Resource.create_dsl(profile_context) }
     let(:inner_context) { Inspec::ProfileContext.new('inner-context', backend, {}) }
     let(:control_content) do <<EOF
-resource('profile_a', 'foobar')
+require_resource(profile: 'profile_a', resource: 'gordon_config', as: 'gordy_config')
 EOF
     end
 
@@ -69,8 +69,8 @@ EOF
 
     it "returns the resource from a subcontext" do
       profile_context.expects(:subcontext_by_name).with('profile_a').returns(inner_context)
-      inner_context.expects(:resource_registry).returns({'foobar' => mock(:new => 'newfoo')})
-      eval_context.instance_eval(control_content).must_equal "newfoo"
+      inner_context.expects(:resource_registry).returns({'gordon_config' => mock()})
+      eval_context.instance_eval(control_content).must_equal :gordy_config
     end
 
   end

--- a/test/unit/profiles/library_eval_context_test.rb
+++ b/test/unit/profiles/library_eval_context_test.rb
@@ -17,6 +17,17 @@ class MyTestResource < Inspec.resource(1)
     '2.0'
   end
 end
+
+class AnotherResource < IniConfig
+  name 'another_resource'
+
+  desc 'Another Resource description'
+  example 'see README'
+
+  def version
+    '2.0'
+  end
+end
 EOF
   }
 
@@ -29,12 +40,12 @@ EOF
 
   it 'adds the resource to our registry' do
     eval_context.instance_eval(resource_content)
-    registry.keys.include?("my_test_resource").must_equal true
+    registry.keys.include?('my_test_resource').must_equal true
   end
 
-  it 'adds nothing to the default registry' do
-    old_default_registry = Inspec::Resource.default_registry.dup
+  it 'adds the global resource to default registry' do
     eval_context.instance_eval(resource_content)
-    old_default_registry.must_equal Inspec::Resource.default_registry
+    Inspec::Resource.new_registry.keys.include?('another_resource').must_equal true
   end
+
 end


### PR DESCRIPTION
This fixes https://github.com/chef/inspec/issues/1300

It allows a subclass of existing resource, for example:
```
# profile/libraries/node.rb
class NodeAttributes < JsonConfig
  name 'node'
  def initialize
    super('/tmp/node.json')
  end
end
```
and standard, brand new resource like this:

```
class GordonConfig < Inspec.resource(1)
  name 'gordon_config'
  ...
end
```
to work.

Signed-off-by: Jeremy J. Miller <jm@chef.io>