### PR TITLE
extending cmp to support better version ops

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -252,6 +252,13 @@ RSpec::Matchers.define :cmp do |first_expected|
     %w{true false}.include?(value.downcase)
   end
 
+  def version?(value)
+    Gem::Version.new(value)
+    true
+  rescue ArgumentError => _ex
+    false
+  end
+
   # expects that the values have been checked with boolean?
   def to_boolean(value)
     value.casecmp('true') == 0
@@ -261,6 +268,8 @@ RSpec::Matchers.define :cmp do |first_expected|
     # if actual and expected are strings
     if expected.is_a?(String) && actual.is_a?(String)
       return actual.casecmp(expected) == 0 if op == :==
+      return Gem::Version.new(actual).method(op).call(Gem::Version.new(expected)) if
+        version?(expected) && version?(actual)
     elsif expected.is_a?(Regexp) && (actual.is_a?(String) || actual.is_a?(Integer))
       return !actual.to_s.match(expected).nil?
     elsif expected.is_a?(String) && integer?(expected) && actual.is_a?(Integer)

--- a/test/integration/default/cmp_matcher_spec.rb
+++ b/test/integration/default/cmp_matcher_spec.rb
@@ -71,6 +71,24 @@ if os.linux?
     it { should_not cmp >= 13 }
   end
 
+  # versions
+  describe '2.4.12' do
+    it { should cmp == '2.4.12' }
+    it { should cmp >= '2.4.5' }
+    it { should cmp >= '2.4.2' }
+    it { should cmp <= '2.4.20' }
+    it { should cmp <= '3.0' }
+    it { should cmp < '2.4.22' }
+    it { should cmp < '3.5' }
+    it { should cmp < '3.5.1' }
+    it { should cmp > '1' }
+    it { should cmp > '1.0' }
+    it { should cmp > '1.0.1' }
+    it { should cmp > '2.4.1' }
+    it { should cmp > '2.4.1.2' }
+    it { should cmp > '2.4.0.1-alpha' }
+  end
+
   # Don't compare octal to number
   describe '07' do
     it { should_not cmp 7 }


### PR DESCRIPTION
This change hopes to extend the functionality of `cmp` matcher to allow for better comparisons when checking version strings.  It adds `Gem::Version` as a type for operand comparison.

Signed-off-by: Jeremy J. Miller <jm@chef.io>