### PR TITLE
JSON resource's error message is missing filename when file is not found

### DIFF
--- a/lib/resources/json.rb
+++ b/lib/resources/json.rb
@@ -44,13 +44,13 @@ module Inspec::Resources
 
         # check if file is available
         if !@file.file?
-          skip_resource "Can't find file \"#{@conf_path}\""
+          skip_resource "Can't find file \"#{@path}\""
           return @params = {}
         end
 
         # check if file is readable
         if @file_content.empty? && @file.size > 0
-          skip_resource "Can't read file \"#{@conf_path}\""
+          skip_resource "Can't read file \"#{@path}\""
           return @params = {}
         end
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -114,6 +114,7 @@ class MockLoader
       'kitchen.yml' => mockfile.call('kitchen.yml'),
       'example.csv' => mockfile.call('example.csv'),
       'policyfile.lock.json' => mockfile.call('policyfile.lock.json'),
+      'nonexistent.json' => mockfile.call('nonexistent.json'),
       '/sys/class/net/br0/bridge' => mockdir.call(true),
       'rootwrap.conf' => mockfile.call('rootwrap.conf'),
       '/etc/apache2/apache2.conf' => mockfile.call('apache2.conf'),

--- a/test/unit/resources/json_test.rb
+++ b/test/unit/resources/json_test.rb
@@ -33,4 +33,11 @@ describe 'Inspec::Resources::JSON' do
       _(resource.send(:'x.y.z')).must_be_nil
     end
   end
+  describe 'when loading a nonexistent file' do
+    let (:resource) { load_resource('json', 'nonexistent.json') }
+
+    it 'produces an error' do
+      _(resource.resource_skipped).must_equal 'Can\'t find file "nonexistent.json"'
+    end
+  end
 end


### PR DESCRIPTION
fixes #1358
Signed-off-by: Makoto Nozaki <makoto.nozaki@twosigma.com>
