### PR TITLE
add fallback syntax for serverspec tests

### DIFF
--- a/lib/resources/iis_site.rb
+++ b/lib/resources/iis_site.rb
@@ -121,4 +121,27 @@ module Inspec::Resources
       info
     end
   end
+
+  # for compatability with serverspec
+  # this is deprecated syntax and will be removed in future versions
+  class IisSiteServerSpec < IisSite
+    name 'iis_website'
+    desc 'Tests IIS site configuration on windows. Deprecated, use `iis_site` instead.'
+    example "
+      describe iis_website('Default Website') do
+        it{ should exist }
+        it{ should be_running }
+        it{ should be_in_app_pool('Default App Pool') }
+      end
+    "
+
+    def initialize(site_name)
+      super(site_name)
+      warn '[DEPRECATION] `iis_website(site_name)` is deprecated.  Please use `iis_site(site_name)` instead.'
+    end
+
+    def in_app_pool?(app_pool)
+      has_app_pool?(app_pool)
+    end
+  end
 end

--- a/test/integration/default/iis_site_spec.rb
+++ b/test/integration/default/iis_site_spec.rb
@@ -24,3 +24,10 @@ describe iis_site('Default Web Site') do
   it { should have_path('%SystemDrive%\\inetpub\\wwwroot') }
   its('path') { should eq '%SystemDrive%\\inetpub\\wwwroot' }
 end
+
+# test compatability with Serverspec
+describe iis_website('Default Web Site') do
+  it{ should exist }
+  it{ should be_running }
+  it{ should be_in_app_pool('DefaultAppPool') }
+end


### PR DESCRIPTION
This PR adds the ability to run plain Serverspec tests for IIS:

```
describe iis_website('Default Website') do
  it{ should exist }
  it{ should be_running }
  it{ should be_in_app_pool('Default App Pool') }
end
```

See http://serverspec.org/resource_types.html#iis_website