### PR TITLE
print name for supermarket profiles

### DIFF
--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -12,7 +12,7 @@ module Supermarket
     # displays a list of profiles
     def self.profiles(supermarket_url = SUPERMARKET_URL)
       url = "#{supermarket_url}/api/v1/tools-search"
-      _success, data = get(url, { type: 'compliance_profile', items: 100, order: 'recently_added' })
+      _success, data = get(url, { type: 'compliance_profile', items: 100 })
       if !data.nil?
         profiles = JSON.parse(data)
         profiles['items'].map { |x|

--- a/lib/bundles/inspec-supermarket/cli.rb
+++ b/lib/bundles/inspec-supermarket/cli.rb
@@ -22,7 +22,7 @@ module Supermarket
 
       headline('Available profiles:')
       supermarket_profiles.each { |p|
-        li("#{p['tool_owner']}/#{p['slug']}")
+        li("#{p['tool_name']} #{mark_text(p['tool_owner'] + '/' + p['slug'])}")
       }
     end
 


### PR DESCRIPTION
This PR improves the readability of `inspec supermarket profiles` command.

Before:
<img width="513" alt="screen shot 2016-12-21 at 12 25 27 pm" src="https://cloud.githubusercontent.com/assets/1178413/21387680/1125120c-c779-11e6-84e0-658692cdb422.png">

After:
<img width="647" alt="screen shot 2016-12-21 at 12 25 36 pm" src="https://cloud.githubusercontent.com/assets/1178413/21387687/146b04f8-c779-11e6-8392-069f7ad3a2a6.png">
