### PR TITLE
drop ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,48 +9,47 @@ services:
 - docker
 bundler_args: "--without integration tools maintenance deploy"
 before_install:
-- gem install bundler
-- gem update --system 2.4.5
+- gem update --system
+- gem update bundler
 - gem --version
 matrix:
   include:
-  - rvm: 1.9.3
-  - rvm: 2.1.8
-  - rvm: 2.2.5
-  - rvm: 2.3.1
+  - rvm: 2.1.10
+  - rvm: 2.2.6
+  - rvm: 2.3.3
     script: bundle exec rake $SUITE
     env: SUITE="lint test test:functional"
-  - rvm: 2.3.1
+  - rvm: 2.3.3
     script: bundle exec rake $SUITE
     env: SUITE="test:resources config=test/test.yaml" N=2
-  - rvm: 2.3.1
+  - rvm: 2.3.3
     script: bundle exec rake $SUITE
     env: SUITE="test:resources config=test/test-extra.yaml" N=2
-  - rvm: 2.3.1
+  - rvm: 2.3.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS=default-ubuntu-1204 DOCKER=true
-  - rvm: 2.3.1
+  - rvm: 2.3.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-ubuntu-1604' DOCKER=true
-  - rvm: 2.3.1
+  - rvm: 2.3.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-centos-68' DOCKER=true
-  - rvm: 2.3.1
+  - rvm: 2.3.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-centos-7' DOCKER=true
-  - rvm: 2.3.1
+  - rvm: 2.3.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-debian-8' DOCKER=true
-  - rvm: 2.3.1
+  - rvm: 2.3.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-oracle-72' DOCKER=true
-  - rvm: 2.3.1
+  - rvm: 2.3.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-fedora-24' DOCKER=true

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,6 @@
 source 'https://rubygems.org'
 gemspec
 
-# pin dependency for Ruby 1.9.3 since bundler is not
-# detecting that net-ssh 3 does not work with 1.9.3
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('1.9.3')
-  gem 'net-ssh', '~> 2.9'
-  gem 'tins', '~> 1.6.0'
-end
-
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
   gem 'json', '~> 1.8'
   gem 'rack', '< 2.0'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   bundler_url: https://rubygems.org/downloads/bundler-1.9.9.gem
 
   matrix:
-    - ruby_version: "193"
+    - ruby_version: "21"
     - ruby_version: "22"
     - ruby_version: "23"
 

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -83,7 +83,7 @@ describe 'example inheritance profile' do
     out.exit_status.must_equal 0
     hm = JSON.load(File.read(dst.path))
     hm['name'].must_equal 'meta-profile'
-    hm['controls'].length.must_equal 79
+    hm['controls'].length.must_equal 78
 
     # copies = out.stdout.scan(/Copy .* to cache directory/).length
     # copies.must_equal 3


### PR DESCRIPTION
This PR:
- removes ruby 1.9.3 (its is becoming too difficult to maintain 1.9.3 with pinning all dependencies in Gemfile)
- update functional tests to meet the updated profile
