### PR TITLE
Optimize regular expression for postgres config parsing

### DIFF
--- a/lib/resources/postgres_conf.rb
+++ b/lib/resources/postgres_conf.rb
@@ -74,7 +74,10 @@ module Inspec::Resources
         raw_conf = read_file(to_read[0])
         @content += raw_conf
 
-        params = SimpleConfig.new(raw_conf).params
+        opts = {
+          assignment_re: /^\s*([^=]*?)\s*=\s*[']?\s*(.*?)\s*[']?\s*$/,
+        }
+        params = SimpleConfig.new(raw_conf, opts).params
         @params.merge!(params)
 
         to_read = to_read.drop(1)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -128,6 +128,7 @@ class MockLoader
       '/etc/xinetd.d/chargen-stream' => mockfile.call('xinetd.d_chargen-stream'),
       '/etc/xinetd.d/chargen-dgram' => mockfile.call('xinetd.d_chargen-dgram'),
       '/etc/sysctl.conf' => mockfile.call('sysctl.conf'),
+      '/etc/postgresql/9.4/main/postgresql.conf' => mockfile.call('postgresql.conf'),
     }
 
     # create all mock commands

--- a/test/unit/mock/files/postgresql.conf
+++ b/test/unit/mock/files/postgresql.conf
@@ -1,0 +1,7 @@
+# PostgreSQL configuration file
+data_directory = '/var/lib/postgresql/9.4/main'
+datestyle = 'iso, mdy'
+log_connections = on
+doublequote = ''value''
+empty =
+key


### PR DESCRIPTION
This PR optimizes the configuration parsing for PostgreSQL. Assuming we have the following configuration:

```
root@default-apt-ubuntu-1404:~# cat /etc/postgresql/9.4/main/postgresql.conf
# PostgreSQL configuration file
# This file was automatically generated and dropped off by chef!
# Please refer to the PostgreSQL documentation for details on
# configuration settings.

data_directory = '/var/lib/postgresql/9.4/main'
datestyle = 'iso, mdy'
default_text_search_config = 'pg_catalog.english'
external_pid_file = '/var/run/postgresql/9.4-main.pid'
hba_file = '/etc/postgresql/9.4/main/pg_hba.conf'
ident_file = '/etc/postgresql/9.4/main/pg_ident.conf'
listen_addresses = 'localhost'
log_connections = on
log_directory = 'pg_log'
log_disconnections = on
log_duration = on
log_hostname = on
log_line_prefix = '%t %u %d %h'
logging_collector = on
max_connections = 100
password_encryption = on
port = 5432
shared_buffers = '24MB'
ssl = off
ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'
unix_socket_directories = '/var/run/postgresql'
```

we need to parse the following types:
* `logging_collector = on`
* `log_directory = 'pg_log'`

This PR adapts to the regular expression to allow:

```
describe postgres_conf('/etc/postgresql/9.4/main/postgresql.conf') do
    its('logging_collector') { should eq 'on' }
    its('log_directory') { should eq 'pg_log' }
  end
```