### PR TITLE
Updated redhat family name in example

### DIFF
--- a/docs/resources/os.md.erb
+++ b/docs/resources/os.md.erb
@@ -56,7 +56,7 @@ The `os` audit resource includes a collection of helpers that enable more granul
 * `debian?`
 * `hpux?`
 * `linux?` (including Alpine Linux, Amazon Linux, ArchLinux, CoreOS, Exherbo, Fedora, Gentoo, and Slackware)
-* `redhat?`
+* `redhat?` (including CentOS)
 * `solaris?` (including Nexenta Core, OmniOS, Open Indiana, Solaris Open, and SmartOS)
 * `suse?`
 * `unix?`
@@ -103,7 +103,7 @@ Use `os[:family]` to enable more granular testing of platforms, platform names, 
 * `:debian`
 * `:hpux`
 * `:linux`. For platforms that are part of the Linux family: `:alpine`, `:amazon`, `:arch`, `:coreos`, `:exherbo`, `:fedora`, `:gentoo`, and `:slackware`.
-* `:redhat`
+* `:redhat`. For platforms that are part of the Redhat family: `:centos`.
 * `:solaris`. For platforms that are part of the Solaris family: `:nexentacore`, `:omnios`, `:openindiana`, `:opensolaris`, and `:smartos`.
 * `:suse`
 * `:unix`
@@ -115,7 +115,7 @@ For example, both of the following tests should have the same result:
       describe port(69) do
         its('processes') { should include 'in.tftpd' }
       end
-    elsif os[:family] == 'rhel'
+    elsif os[:family] == 'redhat'
       describe port(69) do
         its('processes') { should include 'xinetd' }
       end
@@ -125,7 +125,7 @@ For example, both of the following tests should have the same result:
       describe port(69) do
         its('processes') { should include 'in.tftpd' }
       end
-    elsif os[:rhel]
+    elsif os[:redhat]
       describe port(69) do
         its('processes') { should include 'xinetd' }
       end

--- a/docs/resources/os.md.erb
+++ b/docs/resources/os.md.erb
@@ -56,7 +56,7 @@ The `os` audit resource includes a collection of helpers that enable more granul
 * `debian?`
 * `hpux?`
 * `linux?` (including Alpine Linux, Amazon Linux, ArchLinux, CoreOS, Exherbo, Fedora, Gentoo, and Slackware)
-* `redhat?` (including CentOS)
+* `redhat?`
 * `solaris?` (including Nexenta Core, OmniOS, Open Indiana, Solaris Open, and SmartOS)
 * `suse?`
 * `unix?`
@@ -103,7 +103,7 @@ Use `os[:family]` to enable more granular testing of platforms, platform names, 
 * `:debian`
 * `:hpux`
 * `:linux`. For platforms that are part of the Linux family: `:alpine`, `:amazon`, `:arch`, `:coreos`, `:exherbo`, `:fedora`, `:gentoo`, and `:slackware`.
-* `:redhat`. For platforms that are part of the Redhat family: `:centos`.
+* `:redhat`
 * `:solaris`. For platforms that are part of the Solaris family: `:nexentacore`, `:omnios`, `:openindiana`, `:opensolaris`, and `:smartos`.
 * `:suse`
 * `:unix`
@@ -115,7 +115,7 @@ For example, both of the following tests should have the same result:
       describe port(69) do
         its('processes') { should include 'in.tftpd' }
       end
-    elsif os[:family] == 'redhat'
+    elsif os[:family] == 'rhel'
       describe port(69) do
         its('processes') { should include 'xinetd' }
       end
@@ -125,7 +125,7 @@ For example, both of the following tests should have the same result:
       describe port(69) do
         its('processes') { should include 'in.tftpd' }
       end
-    elsif os[:redhat]
+    elsif os[:rhel]
       describe port(69) do
         its('processes') { should include 'xinetd' }
       end

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -143,5 +143,15 @@ Please login using `inspec compliance login https://compliance.test --user admin
       end
       headers
     end
+
+    def self.target_url(config, profile)
+      if config['server_type'] == 'automate'
+        target = "#{config['server']}/#{profile}/tar"
+      else
+        owner, id = profile.split('/')
+        target = "#{config['server']}/owners/#{owner}/compliance/#{id}/tar"
+      end
+      target
+    end
   end
 end

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -116,6 +116,35 @@ module Compliance
       run_tests(tests, opts)
     end
 
+    desc 'download PROFILE', 'downloads a profile from Chef Compliance'
+    option :name, type: :string,
+      desc: 'Name of the archive filename (file type will be added)'
+    def download(profile_name)
+      o = options.dup
+      configure_logger(o)
+
+      config = Compliance::Configuration.new
+      return if !loggedin(config)
+
+      if Compliance::API.exist?(config, profile_name)
+        puts "Downloading `#{profile_name}`"
+
+        fetcher = Compliance::Fetcher.resolve(
+          {
+            compliance: profile_name,
+          },
+        )
+
+        # we provide a name, the fetcher adds the extension
+        _owner, id = profile_name.split('/')
+        file_name = fetcher.fetch(o.name || id)
+        puts "Profile stored to #{file_name}"
+      else
+        puts "Profile #{profile_name} is not available in Chef Compliance."
+        exit 1
+      end
+    end
+
     desc 'upload PATH', 'uploads a local profile to Chef Compliance'
     option :overwrite, type: :boolean, default: false,
       desc: 'Overwrite existing profile on Chef Compliance.'

--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -53,21 +53,11 @@ EOF
         if !Compliance::API.exist?(config, profile)
           fail Inspec::FetcherFailure, "The compliance profile #{profile} was not found on the configured compliance server"
         end
-        profile_fetch_url = target_url(profile, config)
+        profile_fetch_url = Compliance::API.target_url(config, profile)
       end
       new(profile_fetch_url, config)
     rescue URI::Error => _e
       nil
-    end
-
-    def self.target_url(profile, config)
-      if config['server_type'] == 'automate'
-        target = "#{config['server']}/#{profile}/tar"
-      else
-        owner, id = profile.split('/')
-        target = "#{config['server']}/owners/#{owner}/compliance/#{id}/tar"
-      end
-      target
     end
 
     # We want to save compliance: in the lockfile rather than url: to

--- a/lib/resources/postgres_conf.rb
+++ b/lib/resources/postgres_conf.rb
@@ -74,7 +74,10 @@ module Inspec::Resources
         raw_conf = read_file(to_read[0])
         @content += raw_conf
 
-        params = SimpleConfig.new(raw_conf).params
+        opts = {
+          assignment_re: /^\s*([^=]*?)\s*=\s*[']?\s*(.*?)\s*[']?\s*$/,
+        }
+        params = SimpleConfig.new(raw_conf, opts).params
         @params.merge!(params)
 
         to_read = to_read.drop(1)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -128,6 +128,7 @@ class MockLoader
       '/etc/xinetd.d/chargen-stream' => mockfile.call('xinetd.d_chargen-stream'),
       '/etc/xinetd.d/chargen-dgram' => mockfile.call('xinetd.d_chargen-dgram'),
       '/etc/sysctl.conf' => mockfile.call('sysctl.conf'),
+      '/etc/postgresql/9.4/main/postgresql.conf' => mockfile.call('postgresql.conf'),
     }
 
     # create all mock commands

--- a/test/unit/mock/files/postgresql.conf
+++ b/test/unit/mock/files/postgresql.conf
@@ -1,0 +1,7 @@
+# PostgreSQL configuration file
+data_directory = '/var/lib/postgresql/9.4/main'
+datestyle = 'iso, mdy'
+log_connections = on
+doublequote = ''value''
+empty =
+key


### PR DESCRIPTION
Updated redhat family name in examples. 
'rhel' should be 'redhat'