### PR TITLE
Download InSpec profiles from Chef Compliance

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -143,5 +143,15 @@ Please login using `inspec compliance login https://compliance.test --user admin
       end
       headers
     end
+
+    def self.target_url(config, profile)
+      if config['server_type'] == 'automate'
+        target = "#{config['server']}/#{profile}/tar"
+      else
+        owner, id = profile.split('/')
+        target = "#{config['server']}/owners/#{owner}/compliance/#{id}/tar"
+      end
+      target
+    end
   end
 end

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -116,6 +116,35 @@ module Compliance
       run_tests(tests, opts)
     end
 
+    desc 'download PROFILE', 'downloads a profile from Chef Compliance'
+    option :name, type: :string,
+      desc: 'Name of the archive filename (file type will be added)'
+    def download(profile_name)
+      o = options.dup
+      configure_logger(o)
+
+      config = Compliance::Configuration.new
+      return if !loggedin(config)
+
+      if Compliance::API.exist?(config, profile_name)
+        puts "Downloading `#{profile_name}`"
+
+        fetcher = Compliance::Fetcher.resolve(
+          {
+            compliance: profile_name,
+          },
+        )
+
+        # we provide a name, the fetcher adds the extension
+        _owner, id = profile_name.split('/')
+        file_name = fetcher.fetch(o.name || id)
+        puts "Profile stored to #{file_name}"
+      else
+        puts "Profile #{profile_name} is not available in Chef Compliance."
+        exit 1
+      end
+    end
+
     desc 'upload PATH', 'uploads a local profile to Chef Compliance'
     option :overwrite, type: :boolean, default: false,
       desc: 'Overwrite existing profile on Chef Compliance.'

--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -53,21 +53,11 @@ EOF
         if !Compliance::API.exist?(config, profile)
           fail Inspec::FetcherFailure, "The compliance profile #{profile} was not found on the configured compliance server"
         end
-        profile_fetch_url = target_url(profile, config)
+        profile_fetch_url = Compliance::API.target_url(config, profile)
       end
       new(profile_fetch_url, config)
     rescue URI::Error => _e
       nil
-    end
-
-    def self.target_url(profile, config)
-      if config['server_type'] == 'automate'
-        target = "#{config['server']}/#{profile}/tar"
-      else
-        owner, id = profile.split('/')
-        target = "#{config['server']}/owners/#{owner}/compliance/#{id}/tar"
-      end
-      target
     end
 
     # We want to save compliance: in the lockfile rather than url: to


### PR DESCRIPTION
```
$ inspec compliance download base/linux
Downloading `base/linux`
Profile stored to linux.tar.gz
$ inspec compliance download base/linux2
Profile base/linux2 is not available in Chef Compliance.
$ echo $?
1
```