### PR TITLE
Fixed error in OS docs, added CentOS to redhat family docs.

### DIFF
--- a/docs/resources/os.md.erb
+++ b/docs/resources/os.md.erb
@@ -56,7 +56,7 @@ The `os` audit resource includes a collection of helpers that enable more granul
 * `debian?`
 * `hpux?`
 * `linux?` (including Alpine Linux, Amazon Linux, ArchLinux, CoreOS, Exherbo, Fedora, Gentoo, and Slackware)
-* `redhat?`
+* `redhat?` (including CentOS)
 * `solaris?` (including Nexenta Core, OmniOS, Open Indiana, Solaris Open, and SmartOS)
 * `suse?`
 * `unix?`

--- a/docs/resources/os.md.erb
+++ b/docs/resources/os.md.erb
@@ -103,7 +103,7 @@ Use `os[:family]` to enable more granular testing of platforms, platform names, 
 * `:debian`
 * `:hpux`
 * `:linux`. For platforms that are part of the Linux family: `:alpine`, `:amazon`, `:arch`, `:coreos`, `:exherbo`, `:fedora`, `:gentoo`, and `:slackware`.
-* `:redhat`
+* `:redhat`. For platforms that are part of the Redhat family: `:centos`.
 * `:solaris`. For platforms that are part of the Solaris family: `:nexentacore`, `:omnios`, `:openindiana`, `:opensolaris`, and `:smartos`.
 * `:suse`
 * `:unix`
@@ -115,7 +115,7 @@ For example, both of the following tests should have the same result:
       describe port(69) do
         its('processes') { should include 'in.tftpd' }
       end
-    elsif os[:family] == 'rhel'
+    elsif os[:family] == 'redhat'
       describe port(69) do
         its('processes') { should include 'xinetd' }
       end
@@ -125,7 +125,7 @@ For example, both of the following tests should have the same result:
       describe port(69) do
         its('processes') { should include 'in.tftpd' }
       end
-    elsif os[:rhel]
+    elsif os[:redhat]
       describe port(69) do
         its('processes') { should include 'xinetd' }
       end


### PR DESCRIPTION
Mentioning CentOS as part of the redhat family. Fixed an error in the documents for the OS resource.