### PR TITLE
Add ability to get a new token from a refresh token set in the config

### DIFF
--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -57,6 +57,16 @@ module Compliance
       puts '', msg
     end
 
+    desc 'login_refresh', 'Refresh compliance login token from a stored refresh token'
+    def login_refresh
+      config = Compliance::Configuration.new
+      return if !loggedin(config)
+
+      _success, msg = store_refresh_token(config['server'], config['refresh_token'], true, config['user'], config['insecure'])
+
+      puts '', msg
+    end
+
     desc "login_automate SERVER --user='USER' --ent='ENT' --dctoken or --usertoken='TOKEN'", 'Log in to an Automate SERVER'
     option :dctoken, type: :string,
       desc: 'Data Collector token'

--- a/test/functional/inspec_compliance_test.rb
+++ b/test/functional/inspec_compliance_test.rb
@@ -42,6 +42,13 @@ describe 'inspec compliance' do
     out.stdout.must_include 'Please login to your automate instance using'
   end
 
+  it 'refresh login with no config' do
+    out = inspec('compliance login_refresh')
+    out.exit_status.must_equal 0
+    #TODO: inspec should really use stderr for errors
+    out.stdout.must_include 'You need to login first with `inspec compliance login` or `inspec compliance login_automate`'
+  end
+
   it 'inspec compliance profiles without authentication' do
     out = inspec('compliance profile')
     out.stdout.must_include 'You need to login first with `inspec compliance login`'


### PR DESCRIPTION
With this refresh tokens can now be used as intended, instead of logging in again with all the required you can refresh the token on disk with a simple command.

Honestly this is a stopgap instead of fixing the issue which is the token never gets updated if there is an issue with login and a refresh token is added.  This would allow automated systems a way to keep updating their authentication credentials with refresh tokens.