### PR TITLE
Updated compliance api requests to actually use refresh token correctly

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -147,9 +147,7 @@ Please login using `inspec compliance login https://compliance.test --user admin
 
     def self.get_token(config)
       return config['token'] unless config['refresh_token']
-
       _success, _msg, token = get_token_via_refresh_token(config['server'], config['refresh_token'], config['insecure'])
-
       token
     end
 

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -179,7 +179,7 @@ module Compliance
       end
 
       # determine user information
-      if config['token'].nil? || config['user'].nil?
+      if (config['token'].nil? && config['refresh_token'].nil?) || config['user'].nil?
         error.call('Please login via `inspec compliance login`')
       end
 
@@ -287,11 +287,10 @@ module Compliance
     end
 
     def login_refreshtoken(url, options)
-      success, msg, access_token = Compliance::API.get_token_via_refresh_token(url, options['refresh_token'], options['insecure'])
+      success, msg, _access_token = Compliance::API.get_token_via_refresh_token(url, options['refresh_token'], options['insecure'])
       if success
         config = Compliance::Configuration.new
         config['server'] = url
-        config['token'] = access_token
         config['insecure'] = options['insecure']
         config['version'] = Compliance::API.version(url, options['insecure'])
         config['server_type'] = 'compliance'
@@ -344,11 +343,10 @@ module Compliance
         success = true
         msg = 'API refresh token stored'
       else
-        success, msg, access_token = Compliance::API.get_token_via_refresh_token(url, refresh_token, insecure)
+        success, msg = Compliance::API.get_token_via_refresh_token(url, refresh_token, insecure)
         if success
-          config['token'] = access_token
           config.store
-          msg = 'API access token verified and stored'
+          msg = 'API access token verified'
         end
       end
 

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -343,7 +343,7 @@ module Compliance
         success = true
         msg = 'API refresh token stored'
       else
-        success, msg = Compliance::API.get_token_via_refresh_token(url, refresh_token, insecure)
+        success, msg, _access_token= Compliance::API.get_token_via_refresh_token(url, refresh_token, insecure)
         if success
           config.store
           msg = 'API access token verified'

--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -13,7 +13,7 @@ module Compliance
   class Fetcher < Fetchers::Url
     name 'compliance'
     priority 500
-    def self.resolve(target) # rubocop:disable PerceivedComplexity, Metrics/CyclomaticComplexity
+    def self.resolve(target) # rubocop:disable PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize
       uri = if target.is_a?(String) && URI(target).scheme == 'compliance'
               URI(target)
             elsif target.respond_to?(:key?) && target.key?(:compliance)
@@ -29,7 +29,7 @@ module Compliance
       else
         # check if we have a compliance token
         config = Compliance::Configuration.new
-        if config['token'].nil?
+        if config['token'].nil? && config['refresh_token'].nil?
           if config['server_type'] == 'automate'
             server = 'automate'
             msg = 'inspec compliance login_automate https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --usertoken USERTOKEN'
@@ -55,6 +55,9 @@ EOF
         end
         profile_fetch_url = Compliance::API.target_url(config, profile)
       end
+      # We need to pass the token to the fetcher
+      config['token'] = Compliance::API.get_token(config)
+
       new(profile_fetch_url, config)
     rescue URI::Error => _e
       nil


### PR DESCRIPTION
We do not store a token in the config file but rather generate one on each command called.  This also does not cache any tokens but generates them every time.  Not sure if this is ideal or not but this a first pass and needs some work.  Also there are no tests added yet.  At this point just looking for feedback on the approach.  This is to help solve #1414 