### PR TITLE
'execution' is spelled correctly

### DIFF
--- a/docs/resources/sshd_config.md.erb
+++ b/docs/resources/sshd_config.md.erb
@@ -4,7 +4,7 @@ title: About the sshd_config Resource
 
 # sshd_config
 
-Use the `sshd_config` InSpec audit resource to test configuration data for the OpenSSH daemon located at `/etc/ssh/sshd_config` on Linux and Unix platforms. sshd---the OpenSSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command executation, and data exchanges.
+Use the `sshd_config` InSpec audit resource to test configuration data for the OpenSSH daemon located at `/etc/ssh/sshd_config` on Linux and Unix platforms. sshd---the OpenSSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command execution, and data exchanges.
 
 ## Syntax
 

--- a/lib/resources/ssh_conf.rb
+++ b/lib/resources/ssh_conf.rb
@@ -9,7 +9,7 @@ require 'utils/simpleconfig'
 module Inspec::Resources
   class SshConf < Inspec.resource(1)
     name 'ssh_config'
-    desc 'Use the sshd_config InSpec audit resource to test configuration data for the Open SSH daemon located at /etc/ssh/sshd_config on Linux and UNIX platforms. sshd---the Open SSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command executation, and data exchanges.'
+    desc 'Use the sshd_config InSpec audit resource to test configuration data for the Open SSH daemon located at /etc/ssh/sshd_config on Linux and UNIX platforms. sshd---the Open SSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command execution, and data exchanges.'
     example "
       describe sshd_config do
         its('Protocol') { should eq '2' }


### PR DESCRIPTION
Fixes a minor typo. The correct spelling is 'execution', not
'executation'

Signed-off-by: Nathen Harvey <nharvey@chef.io>