### PR TITLE
improve http header handling

### DIFF
--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -13,7 +13,7 @@ An `http` resource block declares the configuration settings to be tested:
     describe http('url', auth: {user: 'user', pass: 'test'}, params: {params}, method: 'method', headers: {headers}, body: body) do
       its('status') { should eq number }
       its('body') { should eq 'body' }
-      its('header') { should eq 'header' }
+      its('headers.name') { should eq 'header' }
     end
 
 where
@@ -47,11 +47,15 @@ The `body` matcher tests body content of http response:
 
 <%= partial "/shared/matcher_eq" %>
 
-### header
+### headers
 
-The `header` matcher tests arbitrary header for the http response:
+The `headers` matcher returns an hash of all http headers:
 
-    its('header') { should eq 'value' }
+    its('headers') { should eq {} }
+
+Individual headers can be tested via:
+
+    its('headers.Content-Type') { should cmp 'text/html' }
 
 ### include
 
@@ -89,6 +93,5 @@ For example, a service is listening on default http port can be tested like this
                   data: '{"data":{"a":"1","b":"five"}}') do
       its('status') { should cmp 200 }
       its('body') { should cmp 'pong' }
-      its('Content-Type') { should cmp 'text/html' }
+      its('headers.Content-Type') { should cmp 'text/html' }
     end
-

--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -4,6 +4,7 @@
 # license: Apache v2
 
 require 'http'
+require 'hashie'
 
 module Inspec::Resources
   class Http < Inspec.resource(1)
@@ -13,7 +14,12 @@ module Inspec::Resources
       describe http('http://localhost:8080/ping', auth: {user: 'user', pass: 'test'}, params: {format: 'html'}) do
         its('status') { should cmp 200 }
         its('body') { should cmp 'pong' }
-        its('Content-Type') { should cmp 'text/html' }
+        its('headers.Content-Type') { should cmp 'text/html' }
+      end
+
+      describe http('http://example.com/ping').headers do
+        its('Content-Length') { should cmp 258 }
+        its('Content-Type') { should cmp 'text/html; charset=UTF-8' }
       end
     "
 
@@ -35,12 +41,12 @@ module Inspec::Resources
       response.to_s
     end
 
-    def method_missing(name)
-      response.headers[name.to_s]
+    def headers
+      Hashie::Mash.new(response.headers.to_h)
     end
 
     def to_s
-      "http #{@method} on #{@url}: #{response}"
+      "http #{@method} on #{@url}"
     end
 
     private

--- a/test/unit/resources/http_test.rb
+++ b/test/unit/resources/http_test.rb
@@ -41,7 +41,7 @@ describe 'Inspec::Resources::Http' do
                              headers: {'content-type' => 'application/json'})
     _(resource.status).must_equal 200
     _(resource.body).must_equal 'headers ok'
-    _(resource.mock).must_equal 'ok'
+    _(resource.headers.Mock).must_equal 'ok'
   end
 
   it 'verify http with params' do


### PR DESCRIPTION
- removes method_missing
- exposes headers as a hash
- improves output of `to_s` method