### PR TITLE
Make minor grammar/style changes to `inspec.io`

### DIFF
--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -26,7 +26,7 @@ header.blue-gradient.margin-top-offset
       | code
       span.code-attribute
         |  do it
-      |  {should be_inspec} 
+      |  { should be_inspec }
       span.code-attribute
         | end
 
@@ -100,20 +100,20 @@ header.blue-gradient.margin-top-offset
           i.fa.fa-angle-right.t-dk
           |  Add context to your tests
         p.t-white
-          | Supports many fields like descriptions, tags, and impact.
+          | Utilize many fields like descriptions, tags, and impact.
 
         h3.t-white 
 
           i.fa.fa-angle-right.t-dk
           |  Apply to all systems
         p.t-white
-          | Combine profiles and customize them with overlays. Pick controls and define exceptions as code.
+          | Analyze everything using the same codified profiles and controls.
       /! code
       .large-6.medium-6.columns
         .code-example.shadow.relative-top.margin-under
           code.code-demo
             span.code-attribute control
-            | 'sshd-21'
+            |  'sshd-21'
             br/
             span.code-token.indent   title
             |  'Set SSH Protocol to 2'
@@ -122,20 +122,20 @@ header.blue-gradient.margin-top-offset
             |  'A detailed description'
             br/
             span.code-token.indent   impact
-            |  1.0 #this is critical
+            |  1.0 # This is critical
             br/
             span.code-token.indent   ref
             |  'compliance guide, section 2.1'
             br/
             br/
-            span.code-attribute describe
+            span.code-attribute.indent   describe
 
             |  sshd_config 
 
             span.code-attribute do
             br/
-            span.code-attribute.indent  its
-            |  ('Protocol') {should cmp 2}
+            span.code-attribute.indent &nbsp;&nbsp;its
+            | ('Protocol') { should cmp 2 }
             br/
             span.code-attribute.indent end
             br/
@@ -155,52 +155,52 @@ header.blue-gradient.margin-top-offset
         h3.t-white 
           i.fa.fa-angle-right.t-dk
           |  Test the desired state
-        p.t-white Match your infrastructure to your expectations.
+        p.t-white Verify your infrastructure matches your expectations.
         h3.t-white 
 
           i.fa.fa-angle-right.t-dk
           |  Use simple and expressive code
         p.t-white
-          | These tests are easy to understand by anyone, reducing friction.
+          | Reduce friction by writing tests that are easy to understand by anyone.
 
         h3.t-white 
 
           i.fa.fa-angle-right.t-dk
           |  Test any system anywhere
         p.t-white
-          | Runs locally and remotely. Supports all major operating systems and configurations.
+          | Run tests locally or remotely on all major operating systems and configurations.
 
         h3.t-white 
 
           i.fa.fa-angle-right.t-dk
           |  Extensible
         p.t-white
-          | Easily create custom resources and share them.
+          | Create custom resources with ease and share them.
         /! code
       .large-6.medium-6.columns
         .code-example.shadow.relative-top.margin-under
           code.code-demo
             span.code-attribute describe
 
-            |  file('/etc/myap.conf') 
+            |  file('/etc/myapp.conf')
 
             span.code-attribute  do
             br/
             span.code-attribute.indent  it
-            |  {should exist}
+            |  { should exist }
             br/
             span.code-attribute.indent  its
-            |  ('mode') {should cmp '0644'}
+            | ('mode') { should cmp 0644 }
             br/
-            span.code-attribute   end
+            span.code-attribute end
             br/
             br/
-            span.code-attribute  describe
+            span.code-attribute describe
             |  myapp.conf
             span.code-attribute  do
             br/
             span.code-attribute.indent  its
-            |  ('port') {should cmp 8080}
+            | ('port') { should cmp 8080 }
             br/
             span.code-attribute   end
             br/
@@ -210,7 +210,7 @@ header.blue-gradient.margin-top-offset
             span.code-attribute  do
             br/
             span.code-attribute.indent  it
-            |  {should be_listening}
+            |  { should be_listening }
             br/
             span.code-attribute   end
           a.btn.strict-right.t-white.try-demo.mobile-hide Try the Demo


### PR DESCRIPTION
This performs the following style changes to `inspec.io`:

## Code example changes

  - Changes `myap.conf` to `myapp.conf`
  - Corrects spacing between `control` and `'sshd-21'`
  - Corrects spacing between `its` and `( )` in multiple places
  - Fixes indentation in `control 'sshd-21'` example
  - Fixes `#this is critical` comment to match Ruby style guide
  - Adds spaces around `{}` to match Ruby style guide
  - Normalizes data types for `cmp` (Example: `'8080' becomes 8080`)
  - Removes leading space before `describe file('/etc/myapp.conf')`

## Text changes

> Match your infrastructure to your expectations.

becomes

> Verify your infrastructure matches your expectations.

---

Rewords the following repeated block under `Apply to all systems`:

> Combine profiles and customize them with overlays. 
> Pick controls and define exceptions as code

becomes

> Analyze everything using the same codified profiles and controls.


## Sentence Normalization
Normalizes the following messages to use the same "verb first" sentence structure:

> Supports many fields like descriptions, tags, and impact.

becomes

> Utilize many fields like descriptions, tags, and impact.

---

> These tests are easy to understand by anyone, reducing friction.

becomes

> Reduce friction by writing tests that are easy to understand by anyone.

---

> Runs locally and remotely. Supports all major operating systems and configurations.

becomes

> Run tests locally or remotely on all major operating systems and configurations.

---

> Easily create custom resources and share them.

becomes

> Create custom resources with ease and share them.