### PR TITLE
Fix xinetd parsing of services from the same file. Expose resource.protocols

### DIFF
--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -41,6 +41,7 @@ module Inspec::Resources
           .add(:ids,          field: 'id')
           .add(:socket_types, field: 'socket_type')
           .add(:types,        field: 'type')
+          .add(:protocols,    field: 'protocol')
           .add(:wait,         field: 'wait')
           .add(:disabled?) { |x| x.where('disable' => 'no').services.empty? }
           .add(:enabled?) { |x| x.where('disable' => 'yes').services.empty? }

--- a/lib/utils/parser.rb
+++ b/lib/utils/parser.rb
@@ -209,7 +209,12 @@ module XinetdParser
       next if inner_line.empty?
 
       if inner_line == '}'
-        res[cur_group] = SimpleConfig.new(simple_conf.join("\n"))
+        if cur_group == 'defaults'
+          res[cur_group] = SimpleConfig.new(simple_conf.join("\n"))
+        else
+          res[cur_group] ||= []
+          res[cur_group].push(SimpleConfig.new(simple_conf.join("\n")))
+        end
         cur_group = nil
       elsif rest.lstrip[0] == '{'
         cur_group = inner_line
@@ -224,7 +229,7 @@ module XinetdParser
         others.each { |ores|
           ores.each { |k, v|
             res[k] ||= []
-            res[k].push(v)
+            res[k].concat(v)
           }
         }
       else

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -128,6 +128,7 @@ class MockLoader
       '/etc/xinetd.d' => mockfile.call('xinetd.d'),
       '/etc/xinetd.d/chargen-stream' => mockfile.call('xinetd.d_chargen-stream'),
       '/etc/xinetd.d/chargen-dgram' => mockfile.call('xinetd.d_chargen-dgram'),
+      '/etc/xinetd.d/echo' => mockfile.call('xinetd.d_echo'),
       '/etc/sysctl.conf' => mockfile.call('sysctl.conf'),
       '/etc/postgresql/9.4/main/postgresql.conf' => mockfile.call('postgresql.conf'),
     }

--- a/test/unit/mock/cmd/find-xinetd.d
+++ b/test/unit/mock/cmd/find-xinetd.d
@@ -1,2 +1,3 @@
 /etc/xinetd.d/chargen-stream
 /etc/xinetd.d/chargen-dgram
+/etc/xinetd.d/echo

--- a/test/unit/mock/files/xinetd.d_chargen-dgram
+++ b/test/unit/mock/files/xinetd.d_chargen-dgram
@@ -4,6 +4,7 @@ service chargen
     # comment
     id		= chargen-dgram
     type		= INTERNAL
-  	wait		= yes
-  	socket_type	= dgram
+    wait		= yes
+    socket_type	= dgram
+    protocol	= udp
 }

--- a/test/unit/mock/files/xinetd.d_chargen-dgram
+++ b/test/unit/mock/files/xinetd.d_chargen-dgram
@@ -6,5 +6,6 @@ service chargen
     type		= INTERNAL
     wait		= yes
     socket_type	= dgram
-    protocol	= udp
+    # How protocol is defined by default in CentOS 6:
+    # protocol	=  socket type is usually enough
 }

--- a/test/unit/mock/files/xinetd.d_chargen-stream
+++ b/test/unit/mock/files/xinetd.d_chargen-stream
@@ -6,5 +6,6 @@ service chargen
     type		= INTERNAL
     wait		= yes
     socket_type	= stream
-    protocol	= tcp
+    # How protocol is defined by default in CentOS 6:
+    # protocol	=  socket type is usually enough
 }

--- a/test/unit/mock/files/xinetd.d_chargen-stream
+++ b/test/unit/mock/files/xinetd.d_chargen-stream
@@ -4,6 +4,7 @@ service chargen
     # disable = no
     id		= chargen-stream
     type		= INTERNAL
-  	wait		= yes
-  	socket_type	= stream
+    wait		= yes
+    socket_type	= stream
+    protocol	= tcp
 }

--- a/test/unit/mock/files/xinetd.d_echo
+++ b/test/unit/mock/files/xinetd.d_echo
@@ -1,0 +1,26 @@
+# default: off
+# description: An xinetd internal service which echo's characters back to
+# clients.
+# This is the tcp version.
+service echo
+{
+	disable		= yes
+	type		= INTERNAL
+	id		= echo-stream
+	socket_type	= stream
+	protocol	= tcp
+	user		= root
+	wait		= no
+}
+
+# This is the udp version.
+service echo
+{
+	disable		= no
+	type		= INTERNAL
+	id		= echo-dgram
+	socket_type	= dgram
+	protocol	= udp
+	user		= root
+	wait		= yes
+}

--- a/test/unit/resources/xinetd_test.rb
+++ b/test/unit/resources/xinetd_test.rb
@@ -17,11 +17,11 @@ describe 'Inspec::Resources::XinetdConf' do
 
   describe 'with services from child configs' do
     it 'has one service name' do
-      _(resource.services.uniq).must_equal %w{chargen}
+      _(resource.services.uniq).must_equal %w{chargen echo}
     end
 
     it 'has multiple service definitions' do
-      _(resource.ids).must_equal %w{chargen-stream chargen-dgram}
+      _(resource.ids).must_equal %w{chargen-stream chargen-dgram echo-stream echo-dgram}
     end
 
     it 'can filter by name' do
@@ -32,6 +32,17 @@ describe 'Inspec::Resources::XinetdConf' do
       one = resource.services('chargen').socket_types('dgram')
       _(one.services.length).must_equal 1
       _(one.ids).must_equal %w{chargen-dgram}
+    end
+
+    it 'get all protocols' do
+      one = resource.services('echo')
+      _(one.protocols).must_equal %w{tcp udp}
+      _(one.ids).must_equal %w{echo-stream echo-dgram}
+    end
+
+    it 'can filter by protocols' do
+      one = resource.services('echo')
+      _(one.protocols(/tcp.*/).ids).must_equal %w{echo-stream}
     end
 
     it 'checks if all are disabled on one disabled service' do


### PR DESCRIPTION
When services are in the same file, with the `tcp` and `udp` protocol configurations, only the second one was being exposed by the resource. This PR fixes that.

It also adds another mocked xinetd file, same way they are by default in Ubuntu:
```bash
[root@vagrant-local-ubuntu1404]# ls /etc/xinetd.d/echo*
/etc/xinetd.d/echo
```

where the existing `chargen` mocked configs follow the split RedHat format:
```bash
[root@ap-cc6 ~]# ls /etc/xinetd.d/echo*
/etc/xinetd.d/echo-dgram  /etc/xinetd.d/echo-stream
```