### PR TITLE
Restrict to net-ssh < 4

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'net-ssh', '>= 2.9", "< 4.0'
   spec.add_dependency 'train', '>=0.22.0', '<1.0'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'net-ssh', '>= 2.9", "< 4.0'
+  spec.add_dependency 'net-ssh', '>= 2.9', '< 4.0'
   spec.add_dependency 'train', '>=0.22.0', '<1.0'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'


### PR DESCRIPTION
The current stable version of Chef (12.18.19) restricts net-ssh to 3.2, but Inspec (via train), allows for version 4, which breaks chef-client runs. This change applies the same < 4 restriction.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>