### PR TITLE
derive xinetd protocol from socket_type when not defined in the config file

### DIFF
--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -92,8 +92,23 @@ module Inspec::Resources
       params
     end
 
+    # Method used to derive the default protocol used from the socket_type
+    def default_protocol(type)
+      case type
+      when 'stream'
+        'tcp'
+      when 'dgram'
+        'udp'
+      else
+        'unknown'
+      end
+    end
+
     def service_lines
-      @services ||= params['services'].values.flatten.map(&:params)
+      @services ||= params['services'].values.flatten.map { |service|
+        service.params['protocol'] ||= default_protocol(service.params['socket_type'])
+        service.params
+      }
     end
   end
 end

--- a/test/unit/resources/xinetd_test.rb
+++ b/test/unit/resources/xinetd_test.rb
@@ -34,10 +34,22 @@ describe 'Inspec::Resources::XinetdConf' do
       _(one.ids).must_equal %w{chargen-dgram}
     end
 
-    it 'get all protocols' do
+    it 'get all protocols for echo' do
       one = resource.services('echo')
       _(one.protocols).must_equal %w{tcp udp}
       _(one.ids).must_equal %w{echo-stream echo-dgram}
+    end
+
+    it 'get all protocols for chargen, including derived from socket_type' do
+      one = resource.services('chargen')
+      _(one.protocols).must_equal %w{tcp udp}
+      _(one.ids).must_equal %w{chargen-stream chargen-dgram}
+    end
+
+    it 'params has only the protocols parsed from the config files' do
+      one = resource.params['services']['chargen'].map{|x| x.params['protocol']}
+      # in this example(CentOS), protocol is not defined in the config
+      _(one).must_equal [nil, nil]
     end
 
     it 'can filter by protocols' do


### PR DESCRIPTION
> SocketType will sometimes implicitly indicate which ProtocolType will be used within an AddressFamily. For example when the SocketType is Dgram, the ProtocolType is always Udp.When the SocketType is Stream, the ProtocolType is always Tcp.

https://msdn.microsoft.com/en-us/library/system.net.sockets.sockettype(v=vs.110).aspx

From my research, the most common `socket_type` values are `stream`(TCP) and `dgram`(UDP). There's no implicit protocol for `raw` and `seqpacket`.
