### PR TITLE
Add FilterTable support to processes resource

### DIFF
--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -4,6 +4,8 @@
 # author: Christoph Hartmann
 # license: All rights reserved
 
+require 'utils/filter'
+
 module Inspec::Resources
   class Processes < Inspec.resource(1)
     name 'processes'
@@ -16,9 +18,7 @@ module Inspec::Resources
       end
     "
 
-    attr_reader :list,
-                :users,
-                :states
+    attr_reader :list
 
     def initialize(grep)
       @grep = grep
@@ -31,16 +31,28 @@ module Inspec::Resources
       @list = all_cmds.find_all do |hm|
         hm[:command] =~ grep
       end
-
-      { users: :user,
-        states: :stat }.each do |var, key|
-        instance_variable_set("@#{var}", @list.map { |l| l[key] }.uniq)
-      end
     end
 
     def to_s
       "Processes #{@grep.class == String ? @grep : @grep.inspect}"
     end
+
+    filter = FilterTable.create
+    filter.add_accessor(:where)
+          .add_accessor(:entries)
+          .add(:labels,   field: 'label')
+          .add(:pids,     field: 'pid')
+          .add(:cpus,     field: 'cpu')
+          .add(:mem,      field: 'mem')
+          .add(:vsz,      field: 'vsz')
+          .add(:rss,      field: 'rss')
+          .add(:tty,      field: 'tty')
+          .add(:states,   field: 'stat')
+          .add(:start,    field: 'start')
+          .add(:time,     field: 'time')
+          .add(:users,    field: 'user')
+          .add(:command,  field: 'command')
+          .connect(self, :list)
 
     private
 


### PR DESCRIPTION
Looking for a quick review before writing tests for the new properties.
Ok with the `.list` deprecation for the commonly used `entries`?