### PR TITLE
switch to faraday as http backend

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sslshake', '~> 1'
   spec.add_dependency 'parallel', '~> 1.9'
   spec.add_dependency 'rspec_junit_formatter', '~> 0.2.3'
-  spec.add_dependency 'http', '~> 2.1.0'
+  spec.add_dependency 'faraday', '>=0.9.0'
 end

--- a/test/unit/resources/http_test.rb
+++ b/test/unit/resources/http_test.rb
@@ -41,7 +41,7 @@ describe 'Inspec::Resources::Http' do
                              headers: {'content-type' => 'application/json'})
     _(resource.status).must_equal 200
     _(resource.body).must_equal 'headers ok'
-    _(resource.headers.Mock).must_equal 'ok'
+    _(resource.headers.mock).must_equal 'ok'
   end
 
   it 'verify http with params' do


### PR DESCRIPTION
This PR switches to faraday as http backend lib. It has less dependencies and does not require `ruby-dev`.