### PR TITLE
Functional JUnit reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ habitat/results
 www/source/index.html.slim
 
 www/source/index.html.slim
+
+meta-profile-0.2.0.tar.gz
+profile-1.0.0.tar.gz

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
 end
 
 gem 'ffi', '>= 1.9.14'
-gem 'rspec_junit_formatter', '~> 0.2.3'
+gem 'nokogiri', '~> 1.6'
 
 group :test do
   gem 'bundler', '~> 1.5'
@@ -19,7 +19,6 @@ group :test do
   gem 'concurrent-ruby', '~> 0.9'
   gem 'mocha', '~> 1.1'
   gem 'ruby-progressbar', '~> 1.8'
-  gem 'nokogiri', '~> 1.6'
   gem 'webmock', '~> 2.3.2'
 end
 

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -790,7 +790,7 @@ class InspecRspecJUnit < InspecRspecJson
   end
 
   def build_result_xml(xml, control, result)
-    test_class = control[:title].nil? ? 'Anonymnous' : control[:id]
+    test_class = control[:title].nil? ? 'Anonymous' : control[:id]
     xml.testcase(name: result[:code_desc], class: test_class, time: result[:run_time]) do
       if result[:status] == 'failed'
         xml.failure(message: result[:message])

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -794,6 +794,8 @@ class InspecRspecJUnit < InspecRspecJson
     xml.testcase(name: result[:code_desc], class: test_class, time: result[:run_time]) do
       if result[:status] == 'failed'
         xml.failure(message: result[:message])
+      elsif result[:status] == 'skipped'
+        xml.skipped
       end
     end
   end

--- a/test/functional/inspec_exec_junit_test.rb
+++ b/test/functional/inspec_exec_junit_test.rb
@@ -32,12 +32,7 @@ describe 'inspec exec with junit formatter' do
       end
     end
     describe 'the test suite' do
-      let(:suite) { doc.xpath("//testsuite").first}
-
-      it 'has a single properties element with no children' do
-        suite.xpath("//properties").length.must_equal 1
-        suite.xpath("//properties").children.length.must_equal 0
-      end
+      let(:suite) { doc.xpath("//testsuites/testsuite").first}
 
       it 'must have 5 testcase children' do
         suite.xpath("//testcase").length.must_equal 5
@@ -48,11 +43,7 @@ describe 'inspec exec with junit formatter' do
       end
 
       it 'has the failures attribute with 0 total tests' do
-        suite["failures"].must_equal "0"
-      end
-
-      it 'has the errors attribute with 0 total tests' do
-        suite["errors"].must_equal "0"
+        suite["failed"].must_equal "0"
       end
 
       it 'has 2 elements named "File /tmp should be directory"' do
@@ -60,7 +51,7 @@ describe 'inspec exec with junit formatter' do
       end
 
       describe 'the testcase named "gordon_config Can\'t find file ..."' do
-        let(:gordon_yml_tests) { suite.xpath("//testcase[@classname='lib.inspec.runner']") }
+        let(:gordon_yml_tests) { suite.xpath("//testcase[@class='gordon-1.0' and @name='gordon_config']") }
         let(:first_gordon_test) {gordon_yml_tests.first}
 
         it 'should be unique' do


### PR DESCRIPTION
resolves #1438 by removing the gem based junit reporter and manually rolling up JUnit formatted XML based on the JSON reporter's @output_hash.

Some minor ancillary changes:

- The testsuite is no longer expected to have an errors count
- nokogiri gem elevated to a core dependency 