### PR TITLE
Add support for "inspec -v" showing the version

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -230,6 +230,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
       puts "\nYour version of InSpec is out of date! The latest version is #{latest}."
     end
   end
+  map %w{-v --version} => :version
 
   private
 


### PR DESCRIPTION
The other Chef tooling (chef-client, chef, kitchen, berks, etc.)
support a `-v` flag to display the version. Currently, inspec
errors out with the following error:

```
Could not find command "_v".
```

This adds a Thor map so that `-v` executes the `version` command.