### PR TITLE
map url to https for compliance plugin

### DIFF
--- a/lib/bundles/inspec-compliance/http.rb
+++ b/lib/bundles/inspec-compliance/http.rb
@@ -10,6 +10,7 @@ module Compliance
   class HTTP
     # generic get requires
     def self.get(url, headers = nil, insecure)
+      url = "https://#{url}" if URI.parse(url).scheme.nil?
       uri = URI.parse(url)
       req = Net::HTTP::Get.new(uri.path)
       if !headers.nil?


### PR DESCRIPTION
As submitted by @billmeyer , Thank you!

This solves an issue where entering the hostname without the schema would result in the following error:

```
/pub/git/inspec/lib/bundles/inspec-compliance/http.rb:70:in `send_request': Unable to parse URI: hostname/compliance/profiles/username (RuntimeError)
	from /pub/git/inspec/lib/bundles/inspec-compliance/http.rb:20:in `get'
	from /pub/git/inspec/lib/bundles/inspec-compliance/api.rb:16:in `profiles'
	from /pub/git/inspec/lib/bundles/inspec-compliance/cli.rb:94:in `profiles'
	from /usr/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /usr/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /usr/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /usr/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:115:in `invoke'
	from /usr/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor.rb:242:in `block in subcommand'
	from /usr/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /usr/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /usr/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /usr/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from bin/inspec:12:in `<main>'

```

Map the schema to https by default.