### PR TITLE
Provide target info on shell invocation

### DIFF
--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -42,6 +42,8 @@ module Inspec
       # Add a help menu as the default intro
       Pry.hooks.add_hook(:before_session, 'inspec_intro') do
         intro
+        print_target_info
+        puts
       end
 
       # Track the rules currently registered and what their merge count is.
@@ -94,10 +96,20 @@ module Inspec
       puts
     end
 
+    def print_target_info
+      ctx = @runner.backend
+      puts <<EOF
+You are currently running on:
+
+    OS platform:  #{mark ctx.os[:name] || 'unknown'}
+    OS family:  #{mark ctx.os[:family] || 'unknown'}
+    OS release: #{mark ctx.os[:release] || 'unknown'}
+EOF
+    end
+
     def help(resource = nil)
       if resource.nil?
 
-        ctx = @runner.backend
         puts <<EOF
 
 Available commands:
@@ -110,14 +122,9 @@ Available commands:
 You can use resources in this environment to test the target machine. For example:
 
     command('uname -a').stdout
-    file('/proc/cpuinfo').content => "value",
+    file('/proc/cpuinfo').content => "value"
 
-You are currently running on:
-
-    OS platform:  #{mark ctx.os[:name] || 'unknown'}
-    OS family:  #{mark ctx.os[:family] || 'unknown'}
-    OS release: #{mark ctx.os[:release] || 'unknown'}
-
+#{print_target_info}
 EOF
       elsif resource == 'resources'
         resources

--- a/test/functional/inspec_shell_test.rb
+++ b/test/functional/inspec_shell_test.rb
@@ -127,6 +127,11 @@ describe 'inspec shell tests' do
       out
     end
 
+    it 'displays the target device information for the user without requiring the help command' do
+      out = do_shell('1+1')
+      out.stdout.must_include 'You are currently running on:'
+    end
+
     it 'provides a help command' do
       out = do_shell('help')
       out.stdout.must_include 'Available commands:'


### PR DESCRIPTION
When in inspec shell, you need to type the `help` command to find out info
about your target system. This info would be super helpful right out of the
gate so users have confidence that they're targeting the correct system.

The target info is still available via the `help` command as it always has
been, as well.

/cc @hannah-radish 