### PR TITLE
Relax constraint on rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'bundler', '~> 1.5'
   gem 'minitest', '~> 5.5'
   gem 'rake', '~> 10'
-  gem 'rubocop', '~> 0.36.0'
+  gem 'rubocop', '~> 0.39'
   gem 'simplecov', '~> 0.10'
   gem 'concurrent-ruby', '~> 0.9'
   gem 'mocha', '~> 1.1'


### PR DESCRIPTION
cookstyle requires ~> 0.39

Signed-off-by: Tom Duffield <tom@chef.io>