### PR TITLE
Use Chefstyle rather than generic Rubocop

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,6 @@
-# encoding: utf-8
-source 'https://supermarket.chef.io'
+source "https://supermarket.chef.io"
 
-cookbook 'apt'
-cookbook 'os_prepare', path: './test/cookbooks/os_prepare'
-cookbook 'runit', github: 'hw-cookbooks/runit'
-cookbook 'ssh-hardening', git: 'https://github.com/dev-sec/chef-ssh-hardening.git'
+cookbook "apt"
+cookbook "os_prepare", path: "./test/cookbooks/os_prepare"
+cookbook "runit", github: "hw-cookbooks/runit"
+cookbook "ssh-hardening", git: "https://github.com/dev-sec/chef-ssh-hardening.git"

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'bundler', '~> 1.5'
   gem 'minitest', '~> 5.5'
   gem 'rake', '~> 10'
-  gem 'rubocop', '~> 0.39'
+  gem 'chefstyle' 
   gem 'simplecov', '~> 0.10'
   gem 'concurrent-ruby', '~> 0.9'
   gem 'mocha', '~> 1.1'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'bundler', '~> 1.5'
   gem 'minitest', '~> 5.5'
   gem 'rake', '~> 10'
-  gem 'rubocop', '~> 0.36.0'
+  gem 'rubocop', '~> 0.39'
   gem 'simplecov', '~> 0.10'
   gem 'concurrent-ruby', '~> 0.9'
   gem 'mocha', '~> 1.1'

--- a/Rakefile
+++ b/Rakefile
@@ -5,14 +5,15 @@ require 'bundler'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rubocop/rake_task'
+require "chefstyle"
 require_relative 'tasks/docs'
 require_relative 'tasks/maintainers'
 require_relative 'tasks/www'
 
 # Rubocop
-desc 'Run Rubocop lint checks'
-task :rubocop do
-  RuboCop::RakeTask.new
+desc "Run Chef Ruby style checks"
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = ["--display-cop-names"]
 end
 
 # lint the project

--- a/bin/inspec
+++ b/bin/inspec
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
 # Copyright 2015 Dominik Richter. All rights reserved.
 # author: Dominik Richter
 # author: Christoph Hartmann
@@ -7,6 +6,6 @@
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
-require_relative '../lib/inspec'
-require_relative '../lib/inspec/cli'
+require_relative "../lib/inspec"
+require_relative "../lib/inspec/cli"
 Inspec::InspecCLI.start(ARGV)

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -1,42 +1,41 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'inspec/version'
+require "inspec/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'inspec'
+  spec.name          = "inspec"
   spec.version       = Inspec::VERSION
-  spec.authors       = ['Dominik Richter']
-  spec.email         = ['dominik.richter@gmail.com']
-  spec.summary       = 'Infrastructure and compliance testing.'
-  spec.description   = 'InSpec provides a framework for creating end-to-end infrastructure tests. You can use it for integration or even compliance testing. Create fully portable test profiles and use them in your workflow to ensure stability and security. Integrate InSpec in your change lifecycle for local testing, CI/CD, and deployment verification.'
-  spec.homepage      = 'https://github.com/chef/inspec'
-  spec.license       = 'Apache-2.0'
+  spec.authors       = ["Dominik Richter"]
+  spec.email         = ["dominik.richter@gmail.com"]
+  spec.summary       = "Infrastructure and compliance testing."
+  spec.description   = "InSpec provides a framework for creating end-to-end infrastructure tests. You can use it for integration or even compliance testing. Create fully portable test profiles and use them in your workflow to ensure stability and security. Integrate InSpec in your change lifecycle for local testing, CI/CD, and deployment verification."
+  spec.homepage      = "https://github.com/chef/inspec"
+  spec.license       = "Apache-2.0"
 
   spec.files = %w{
     README.md Rakefile MAINTAINERS.toml MAINTAINERS.md LICENSE inspec.gemspec
     Gemfile CHANGELOG.md .rubocop.yml
   } + Dir.glob(
-    '{bin,docs,examples,lib}/**/*', File::FNM_DOTMATCH
+    "{bin,docs,examples,lib}/**/*", File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }
 
   spec.executables   = %w{ inspec }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
-  spec.add_dependency 'train', '>=0.22.0', '<1.0'
-  spec.add_dependency 'thor', '~> 0.19'
-  spec.add_dependency 'json', '>= 1.8', '< 3.0'
-  spec.add_dependency 'rainbow', '~> 2'
-  spec.add_dependency 'method_source', '~> 0.8'
-  spec.add_dependency 'rubyzip', '~> 1.1'
-  spec.add_dependency 'rspec', '~> 3'
-  spec.add_dependency 'rspec-its', '~> 1.2'
-  spec.add_dependency 'pry', '~> 0'
-  spec.add_dependency 'hashie', '~> 3.4'
-  spec.add_dependency 'mixlib-log'
-  spec.add_dependency 'sslshake', '~> 1'
-  spec.add_dependency 'parallel', '~> 1.9'
-  spec.add_dependency 'rspec_junit_formatter', '~> 0.2.3'
-  spec.add_dependency 'faraday', '>=0.9.0'
+  spec.add_dependency "train", ">=0.22.0", "<1.0"
+  spec.add_dependency "thor", "~> 0.19"
+  spec.add_dependency "json", ">= 1.8", "< 3.0"
+  spec.add_dependency "rainbow", "~> 2"
+  spec.add_dependency "method_source", "~> 0.8"
+  spec.add_dependency "rubyzip", "~> 1.1"
+  spec.add_dependency "rspec", "~> 3"
+  spec.add_dependency "rspec-its", "~> 1.2"
+  spec.add_dependency "pry", "~> 0"
+  spec.add_dependency "hashie", "~> 3.4"
+  spec.add_dependency "mixlib-log"
+  spec.add_dependency "sslshake", "~> 1"
+  spec.add_dependency "parallel", "~> 1.9"
+  spec.add_dependency "rspec_junit_formatter", "~> 0.2.3"
+  spec.add_dependency "faraday", ">=0.9.0"
 end

--- a/lib/bundles/inspec-artifact.rb
+++ b/lib/bundles/inspec-artifact.rb
@@ -1,7 +1,6 @@
-# encoding: utf-8
 # author: Dave Parfitt
 
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
-require 'inspec-artifact/cli'
+require "inspec-artifact/cli"

--- a/lib/bundles/inspec-compliance.rb
+++ b/lib/bundles/inspec-compliance.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -6,11 +5,11 @@ libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
 module Compliance
-  autoload :Configuration, 'inspec-compliance/configuration'
-  autoload :HTTP, 'inspec-compliance/http'
-  autoload :Support, 'inspec-compliance/support'
-  autoload :API, 'inspec-compliance/api'
+  autoload :Configuration, "inspec-compliance/configuration"
+  autoload :HTTP, "inspec-compliance/http"
+  autoload :Support, "inspec-compliance/support"
+  autoload :API, "inspec-compliance/api"
 end
 
-require 'inspec-compliance/cli'
-require 'inspec-compliance/target'
+require "inspec-compliance/cli"
+require "inspec-compliance/target"

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -1,9 +1,8 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'net/http'
-require 'uri'
+require "net/http"
+require "uri"
 
 module Compliance
   # API Implementation does not hold any state by itself,
@@ -11,19 +10,19 @@ module Compliance
   class API # rubocop:disable Metrics/ClassLength
     # return all compliance profiles available for the user
     def self.profiles(config)
-      config['server_type'] == 'automate' ? url = "#{config['server']}/#{config['user']}" : url = "#{config['server']}/user/compliance"
+      config["server_type"] == "automate" ? url = "#{config['server']}/#{config['user']}" : url = "#{config['server']}/user/compliance"
       headers = get_headers(config)
-      response = Compliance::HTTP.get(url, headers, config['insecure'])
+      response = Compliance::HTTP.get(url, headers, config["insecure"])
       data = response.body
       response_code = response.code
       case response_code
-      when '200'
-        msg = 'success'
+      when "200"
+        msg = "success"
         profiles = JSON.parse(data)
         # iterate over profiles
-        if config['server_type'] == 'automate'
+        if config["server_type"] == "automate"
           mapped_profiles = profiles.map do |owner, ps|
-            { org: ps['owner_id'], name: owner }
+            { org: ps["owner_id"], name: owner }
           end.flatten
         else
           mapped_profiles = profiles.map do |owner, ps|
@@ -33,8 +32,8 @@ module Compliance
           end.flatten
         end
         return msg, mapped_profiles
-      when '401'
-        msg = '401 Unauthorized. Please check your token.'
+      when "401"
+        msg = "401 Unauthorized. Please check your token."
         return msg, []
       else
         msg = "An unexpected error occurred (HTTP #{response_code}): #{response.message}"
@@ -52,7 +51,7 @@ Server configuration information is missing.
 Please login using `inspec compliance login https://compliance.test --user admin --insecure --token 'PASTE TOKEN HERE' `
 "
       else
-        response = Compliance::HTTP.get(url+'/version', nil, insecure)
+        response = Compliance::HTTP.get(url+"/version", nil, insecure)
         data = response.body
       end
       if !data.nil?
@@ -75,9 +74,9 @@ Please login using `inspec compliance login https://compliance.test --user admin
 
     def self.upload(config, owner, profile_name, archive_path)
       # upload the tar to Chef Compliance
-      config['server_type'] == 'automate' ? url = "#{config['server']}/#{config['user']}" : url = "#{config['server']}/owners/#{owner}/compliance/#{profile_name}/tar"
+      config["server_type"] == "automate" ? url = "#{config['server']}/#{config['user']}" : url = "#{config['server']}/owners/#{owner}/compliance/#{profile_name}/tar"
       headers = get_headers(config)
-      res = Compliance::HTTP.post_file(url, headers, archive_path, config['insecure'])
+      res = Compliance::HTTP.post_file(url, headers, archive_path, config["insecure"])
       [res.is_a?(Net::HTTPSuccess), res.body]
     end
 
@@ -89,11 +88,11 @@ Please login using `inspec compliance login https://compliance.test --user admin
       access_token = nil
       response = Compliance::HTTP.send_request(uri, req, insecure)
       data = response.body
-      if response.code == '200'
+      if response.code == "200"
         begin
           tokendata = JSON.parse(data)
-          access_token = tokendata['access_token']
-          msg = 'Successfully fetched API access token'
+          access_token = tokendata["access_token"]
+          msg = "Successfully fetched API access token"
           success = true
         rescue JSON::ParserError => e
           success = false
@@ -116,9 +115,9 @@ Please login using `inspec compliance login https://compliance.test --user admin
       access_token = nil
       response = Compliance::HTTP.send_request(uri, req, insecure)
       data = response.body
-      if response.code == '200'
+      if response.code == "200"
         access_token = data
-        msg = 'Successfully fetched an API access token valid for 12 hours'
+        msg = "Successfully fetched an API access token valid for 12 hours"
         success = true
       else
         success = false
@@ -131,31 +130,31 @@ Please login using `inspec compliance login https://compliance.test --user admin
 
     def self.get_headers(config)
       token = get_token(config)
-      if config['server_type'] == 'automate'
-        headers = { 'chef-delivery-enterprise' => config['automate']['ent'] }
-        if config['automate']['token_type'] == 'dctoken'
-          headers['x-data-collector-token'] = token
+      if config["server_type"] == "automate"
+        headers = { "chef-delivery-enterprise" => config["automate"]["ent"] }
+        if config["automate"]["token_type"] == "dctoken"
+          headers["x-data-collector-token"] = token
         else
-          headers['chef-delivery-user'] = config['user']
-          headers['chef-delivery-token'] = token
+          headers["chef-delivery-user"] = config["user"]
+          headers["chef-delivery-token"] = token
         end
       else
-        headers = { 'Authorization' => "Bearer #{token}" }
+        headers = { "Authorization" => "Bearer #{token}" }
       end
       headers
     end
 
     def self.get_token(config)
-      return config['token'] unless config['refresh_token']
-      _success, _msg, token = get_token_via_refresh_token(config['server'], config['refresh_token'], config['insecure'])
+      return config["token"] unless config["refresh_token"]
+      _success, _msg, token = get_token_via_refresh_token(config["server"], config["refresh_token"], config["insecure"])
       token
     end
 
     def self.target_url(config, profile)
-      if config['server_type'] == 'automate'
+      if config["server_type"] == "automate"
         target = "#{config['server']}/#{profile}/tar"
       else
-        owner, id = profile.split('/')
+        owner, id = profile.split("/")
         target = "#{config['server']}/owners/#{owner}/compliance/#{id}/tar"
       end
       target

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -1,13 +1,12 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'thor'
-require 'erb'
+require "thor"
+require "erb"
 
 module Compliance
   class ComplianceCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
-    namespace 'compliance'
+    namespace "compliance"
 
     # TODO: find another solution, once https://github.com/erikhuda/thor/issues/261 is fixed
     def self.banner(command, _namespace = nil, _subcommand = false)
@@ -18,63 +17,63 @@ module Compliance
       namespace
     end
 
-    desc "login SERVER --insecure --user='USER' --token='TOKEN'", 'Log in to a Chef Compliance SERVER'
+    desc "login SERVER --insecure --user='USER' --token='TOKEN'", "Log in to a Chef Compliance SERVER"
     option :insecure, aliases: :k, type: :boolean,
       desc: 'Explicitly allows InSpec to perform "insecure" SSL connections and transfers'
     option :user, type: :string, required: false,
-      desc: 'Chef Compliance Username'
+      desc: "Chef Compliance Username"
     option :password, type: :string, required: false,
-      desc: 'Chef Compliance Password'
-    option :apipath, type: :string, default: '/api',
-      desc: 'Set the path to the API, defaults to /api'
+      desc: "Chef Compliance Password"
+    option :apipath, type: :string, default: "/api",
+      desc: "Set the path to the API, defaults to /api"
     option :token, type: :string, required: false,
-      desc: 'Chef Compliance access token'
+      desc: "Chef Compliance access token"
     option :refresh_token, type: :string, required: false,
-      desc: 'Chef Compliance refresh token'
+      desc: "Chef Compliance refresh token"
     def login(server) # rubocop:disable Metrics/AbcSize
       # show warning if the Compliance Server does not support
 
-      options['server'] = server
-      url = options['server'] + options['apipath']
+      options["server"] = server
+      url = options["server"] + options["apipath"]
 
-      if !options['user'].nil? && !options['password'].nil?
+      if !options["user"].nil? && !options["password"].nil?
         # username / password
-        _success, msg = login_username_password(url, options['user'], options['password'], options['insecure'])
-      elsif !options['user'].nil? && !options['token'].nil?
+        _success, msg = login_username_password(url, options["user"], options["password"], options["insecure"])
+      elsif !options["user"].nil? && !options["token"].nil?
         # access token
-        _success, msg = store_access_token(url, options['user'], options['token'], options['insecure'])
-      elsif !options['refresh_token'].nil? && !options['user'].nil?
+        _success, msg = store_access_token(url, options["user"], options["token"], options["insecure"])
+      elsif !options["refresh_token"].nil? && !options["user"].nil?
         # refresh token
-        _success, msg = store_refresh_token(url, options['refresh_token'], true, options['user'], options['insecure'])
+        _success, msg = store_refresh_token(url, options["refresh_token"], true, options["user"], options["insecure"])
         # TODO: we should login with the refreshtoken here
-      elsif !options['refresh_token'].nil?
+      elsif !options["refresh_token"].nil?
         _success, msg = login_refreshtoken(url, options)
       else
-        puts 'Please run `inspec compliance login SERVER` with options --token or --refresh_token, --user, and --insecure or --not-insecure'
+        puts "Please run `inspec compliance login SERVER` with options --token or --refresh_token, --user, and --insecure or --not-insecure"
         exit 1
       end
 
-      puts '', msg
+      puts "", msg
     end
 
-    desc "login_automate SERVER --user='USER' --ent='ENT' --dctoken or --usertoken='TOKEN'", 'Log in to an Automate SERVER'
+    desc "login_automate SERVER --user='USER' --ent='ENT' --dctoken or --usertoken='TOKEN'", "Log in to an Automate SERVER"
     option :dctoken, type: :string,
-      desc: 'Data Collector token'
+      desc: "Data Collector token"
     option :usertoken, type: :string,
-      desc: 'Automate user token'
+      desc: "Automate user token"
     option :user, type: :string,
-      desc: 'Automate username'
+      desc: "Automate username"
     option :ent, type: :string,
-      desc: 'Enterprise for Chef Automate reporting'
+      desc: "Enterprise for Chef Automate reporting"
     option :insecure, aliases: :k, type: :boolean,
       desc: 'Explicitly allows InSpec to perform "insecure" SSL connections and transfers'
     def login_automate(server) # rubocop:disable Metrics/AbcSize
-      options['server'] = server
-      url = options['server'] + '/compliance/profiles'
+      options["server"] = server
+      url = options["server"] + "/compliance/profiles"
 
-      if url && !options['user'].nil? && !options['ent'].nil?
-        if !options['dctoken'].nil? || !options['usertoken'].nil?
-          msg = login_automate_config(url, options['user'], options['dctoken'], options['usertoken'], options['ent'], options['insecure'])
+      if url && !options["user"].nil? && !options["ent"].nil?
+        if !options["dctoken"].nil? || !options["usertoken"].nil?
+          msg = login_automate_config(url, options["user"], options["dctoken"], options["usertoken"], options["ent"], options["insecure"])
         else
           puts "Please specify a token using --dctoken='DATA_COLLECTOR_TOKEN' or usertoken='AUTOMATE_TOKEN' "
           exit 1
@@ -83,10 +82,10 @@ module Compliance
         puts "Please login to your automate instance using 'inspec compliance login_automate SERVER --user AUTOMATE_USER --ent AUTOMATE_ENT --dctoken DC_TOKEN or --usertoken USER_TOKEN' "
         exit 1
       end
-      puts '', msg
+      puts "", msg
     end
 
-    desc 'profiles', 'list all available profiles in Chef Compliance'
+    desc "profiles", "list all available profiles in Chef Compliance"
     def profiles
       config = Compliance::Configuration.new
       return if !loggedin(config)
@@ -94,31 +93,31 @@ module Compliance
       msg, profiles = Compliance::API.profiles(config)
       if !profiles.empty?
         # iterate over profiles
-        headline('Available profiles:')
+        headline("Available profiles:")
         profiles.each { |profile|
           li("#{profile[:org]}/#{profile[:name]}")
         }
       else
-        puts msg, 'Could not find any profiles'
+        puts msg, "Could not find any profiles"
         exit 1
       end
     end
 
-    desc 'exec PROFILE', 'executes a Chef Compliance profile'
+    desc "exec PROFILE", "executes a Chef Compliance profile"
     exec_options
     def exec(*tests)
       config = Compliance::Configuration.new
       return if !loggedin(config)
       # iterate over tests and add compliance scheme
-      tests = tests.map { |t| 'compliance://' + t }
+      tests = tests.map { |t| "compliance://" + t }
       # execute profile from inspec exec implementation
       diagnose
       run_tests(tests, opts)
     end
 
-    desc 'download PROFILE', 'downloads a profile from Chef Compliance'
+    desc "download PROFILE", "downloads a profile from Chef Compliance"
     option :name, type: :string,
-      desc: 'Name of the archive filename (file type will be added)'
+      desc: "Name of the archive filename (file type will be added)"
     def download(profile_name)
       o = options.dup
       configure_logger(o)
@@ -136,7 +135,7 @@ module Compliance
         )
 
         # we provide a name, the fetcher adds the extension
-        _owner, id = profile_name.split('/')
+        _owner, id = profile_name.split("/")
         file_name = fetcher.fetch(o.name || id)
         puts "Profile stored to #{file_name}"
       else
@@ -145,9 +144,9 @@ module Compliance
       end
     end
 
-    desc 'upload PATH', 'uploads a local profile to Chef Compliance'
+    desc "upload PATH", "uploads a local profile to Chef Compliance"
     option :overwrite, type: :boolean, default: false,
-      desc: 'Overwrite existing profile on Chef Compliance.'
+      desc: "Overwrite existing profile on Chef Compliance."
     def upload(path) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, PerceivedComplexity, Metrics/CyclomaticComplexity
       config = Compliance::Configuration.new
       return if !loggedin(config)
@@ -173,25 +172,25 @@ module Compliance
 
       result = profile.check
       unless result[:summary][:valid]
-        error.call('Profile check failed. Please fix the profile before upload.')
+        error.call("Profile check failed. Please fix the profile before upload.")
       else
-        puts('Profile is valid')
+        puts("Profile is valid")
       end
 
       # determine user information
-      if (config['token'].nil? && config['refresh_token'].nil?) || config['user'].nil?
-        error.call('Please login via `inspec compliance login`')
+      if (config["token"].nil? && config["refresh_token"].nil?) || config["user"].nil?
+        error.call("Please login via `inspec compliance login`")
       end
 
       # owner
-      owner = config['user']
+      owner = config["user"]
       # read profile name from inspec.yml
       profile_name = profile.params[:name]
 
       # check that the profile is not uploaded already,
       # confirm upload to the user (overwrite with --force)
-      if Compliance::API.exist?(config, "#{owner}/#{profile_name}") && !options['overwrite']
-        error.call('Profile exists on the server, use --overwrite')
+      if Compliance::API.exist?(config, "#{owner}/#{profile_name}") && !options["overwrite"]
+        error.call("Profile exists on the server, use --overwrite")
       end
 
       # abort if we found an error
@@ -202,7 +201,7 @@ module Compliance
 
       # if it is a directory, tar it to tmp directory
       if File.directory?(path)
-        archive_path = Dir::Tmpname.create([profile_name, '.tar.gz']) {}
+        archive_path = Dir::Tmpname.create([profile_name, ".tar.gz"]) {}
         puts "Generate temporary profile archive at #{archive_path}"
         profile.archive({ output: archive_path, ignore_errors: false, overwrite: true })
       else
@@ -212,49 +211,49 @@ module Compliance
       puts "Start upload to #{owner}/#{profile_name}"
       pname = ERB::Util.url_encode(profile_name)
 
-      config['server_type'] == 'automate' ? upload_msg = 'Uploading to Chef Automate' : upload_msg = 'Uploading to Chef Compliance'
+      config["server_type"] == "automate" ? upload_msg = "Uploading to Chef Automate" : upload_msg = "Uploading to Chef Compliance"
       puts upload_msg
       success, msg = Compliance::API.upload(config, owner, pname, archive_path)
 
       if success
-        puts 'Successfully uploaded profile'
+        puts "Successfully uploaded profile"
       else
-        puts 'Error during profile upload:'
+        puts "Error during profile upload:"
         puts msg
         exit 1
       end
     end
 
-    desc 'version', 'displays the version of the Chef Compliance server'
+    desc "version", "displays the version of the Chef Compliance server"
     def version
       config = Compliance::Configuration.new
-      if config['server_type'] == 'automate'
-        puts 'Version not available when logged in with Automate.'
+      if config["server_type"] == "automate"
+        puts "Version not available when logged in with Automate."
       else
-        info = Compliance::API.version(config['server'], config['insecure'])
-        if !info.nil? && info['version']
+        info = Compliance::API.version(config["server"], config["insecure"])
+        if !info.nil? && info["version"]
           puts "Chef Compliance version: #{info['version']}"
         else
-          puts 'Could not determine server version.'
+          puts "Could not determine server version."
           exit 1
         end
       end
     end
 
-    desc 'logout', 'user logout from Chef Compliance'
+    desc "logout", "user logout from Chef Compliance"
     def logout
       config = Compliance::Configuration.new
-      unless config.supported?(:oidc) || config['token'].nil? || config['server_type'] == 'automate'
+      unless config.supported?(:oidc) || config["token"].nil? || config["server_type"] == "automate"
         config = Compliance::Configuration.new
         url = "#{config['server']}/logout"
-        Compliance::API.post(url, config['token'], config['insecure'], !config.supported?(:oidc))
+        Compliance::API.post(url, config["token"], config["insecure"], !config.supported?(:oidc))
       end
       success = config.destroy
 
       if success
-        puts 'Successfully logged out'
+        puts "Successfully logged out"
       else
-        puts 'Could not log out'
+        puts "Could not log out"
       end
     end
 
@@ -262,38 +261,38 @@ module Compliance
 
     def login_automate_config(url, user, dctoken, usertoken, ent, insecure) # rubocop:disable Metrics/ParameterLists
       config = Compliance::Configuration.new
-      config['user'] = user
-      config['server'] = url
-      config['automate'] = {}
-      config['automate']['ent'] = ent
-      config['server_type'] = 'automate'
-      config['insecure'] = insecure
+      config["user"] = user
+      config["server"] = url
+      config["automate"] = {}
+      config["automate"]["ent"] = ent
+      config["server_type"] = "automate"
+      config["insecure"] = insecure
 
       # determine token method being used
       if !dctoken.nil?
-        config['token'] = dctoken
-        token_type = 'dctoken'
-        token_msg = 'data collector token'
+        config["token"] = dctoken
+        token_type = "dctoken"
+        token_msg = "data collector token"
       else
-        config['token'] = usertoken
-        token_type = 'usertoken'
-        token_msg = 'automate user token'
+        config["token"] = usertoken
+        token_type = "usertoken"
+        token_msg = "automate user token"
       end
 
-      config['automate']['token_type'] = token_type
+      config["automate"]["token_type"] = token_type
       config.store
       msg = "Stored configuration for Chef Automate: '#{url}' with user: '#{user}', ent: '#{ent}' and your #{token_msg}"
       msg
     end
 
     def login_refreshtoken(url, options)
-      success, msg, _access_token = Compliance::API.get_token_via_refresh_token(url, options['refresh_token'], options['insecure'])
+      success, msg, _access_token = Compliance::API.get_token_via_refresh_token(url, options["refresh_token"], options["insecure"])
       if success
         config = Compliance::Configuration.new
-        config['server'] = url
-        config['insecure'] = options['insecure']
-        config['version'] = Compliance::API.version(url, options['insecure'])
-        config['server_type'] = 'compliance'
+        config["server"] = url
+        config["insecure"] = options["insecure"]
+        config["version"] = Compliance::API.version(url, options["insecure"])
+        config["server_type"] = "compliance"
         config.store
       end
 
@@ -304,12 +303,12 @@ module Compliance
       config = Compliance::Configuration.new
       success, msg, api_token = Compliance::API.get_token_via_password(url, username, password, insecure)
       if success
-        config['server'] = url
-        config['user'] = username
-        config['token'] = api_token
-        config['insecure'] = insecure
-        config['version'] = Compliance::API.version(url, insecure)
-        config['server_type'] = 'compliance'
+        config["server"] = url
+        config["user"] = username
+        config["token"] = api_token
+        config["insecure"] = insecure
+        config["version"] = Compliance::API.version(url, insecure)
+        config["server_type"] = "compliance"
         config.store
         success = true
       end
@@ -319,34 +318,34 @@ module Compliance
     # saves a user access token (limited time)
     def store_access_token(url, user, token, insecure)
       config = Compliance::Configuration.new
-      config['server'] = url
-      config['insecure'] = insecure
-      config['user'] = user
-      config['token'] = token
-      config['version'] = Compliance::API.version(url, insecure)
+      config["server"] = url
+      config["insecure"] = insecure
+      config["user"] = user
+      config["token"] = token
+      config["version"] = Compliance::API.version(url, insecure)
       config.store
 
-      [true, 'API access token stored']
+      [true, "API access token stored"]
     end
 
     # saves a refresh token supplied by the user
     def store_refresh_token(url, refresh_token, verify, user, insecure)
       config = Compliance::Configuration.new
-      config['server'] = url
-      config['refresh_token'] = refresh_token
-      config['user'] = user
-      config['insecure'] = insecure
-      config['version'] = Compliance::API.version(url, insecure)
+      config["server"] = url
+      config["refresh_token"] = refresh_token
+      config["user"] = user
+      config["insecure"] = insecure
+      config["version"] = Compliance::API.version(url, insecure)
 
       if !verify
         config.store
         success = true
-        msg = 'API refresh token stored'
+        msg = "API refresh token stored"
       else
         success, msg, _access_token= Compliance::API.get_token_via_refresh_token(url, refresh_token, insecure)
         if success
           config.store
-          msg = 'API access token verified'
+          msg = "API access token verified"
         end
       end
 
@@ -354,12 +353,12 @@ module Compliance
     end
 
     def loggedin(config)
-      serverknown = !config['server'].nil?
-      puts 'You need to login first with `inspec compliance login` or `inspec compliance login_automate`' if !serverknown
+      serverknown = !config["server"].nil?
+      puts "You need to login first with `inspec compliance login` or `inspec compliance login_automate`" if !serverknown
       serverknown
     end
   end
 
   # register the subcommand to Inspec CLI registry
-  Inspec::Plugins::CLI.add_subcommand(ComplianceCLI, 'compliance', 'compliance SUBCOMMAND ...', 'Chef Compliance commands', {})
+  Inspec::Plugins::CLI.add_subcommand(ComplianceCLI, "compliance", "compliance SUBCOMMAND ...", "Chef Compliance commands", {})
 end

--- a/lib/bundles/inspec-compliance/configuration.rb
+++ b/lib/bundles/inspec-compliance/configuration.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -6,13 +5,13 @@ module Compliance
   # stores configuration on local filesystem
   class Configuration
     def initialize
-      @config_path = File.join(Dir.home, '.inspec', 'compliance')
+      @config_path = File.join(Dir.home, ".inspec", "compliance")
       # ensure the directory is available
       unless File.directory?(@config_path)
         FileUtils.mkdir_p(@config_path)
       end
       # set config file path
-      @config_file = File.join(@config_path, '/config.json')
+      @config_file = File.join(@config_path, "/config.json")
       @config = {}
 
       # load the data
@@ -39,7 +38,7 @@ module Compliance
 
     # stores a hash to json
     def store
-      File.open(@config_file, 'w') do |f|
+      File.open(@config_file, "w") do |f|
         f.chmod(0600)
         f.write(@config.to_json)
       end
@@ -59,13 +58,13 @@ module Compliance
       sup = version_with_support(feature)
 
       # we do not know the version, therefore we do not know if its possible to use the feature
-      return if self['version'].nil? || self['version']['version'].nil?
+      return if self["version"].nil? || self["version"]["version"].nil?
 
       if sup.is_a?(Array)
-        Gem::Version.new(self['version']['version']) >= sup[0] &&
-          Gem::Version.new(self['version']['version']) < sup[1]
+        Gem::Version.new(self["version"]["version"]) >= sup[0] &&
+          Gem::Version.new(self["version"]["version"]) < sup[1]
       else
-        Gem::Version.new(self['version']['version']) >= sup
+        Gem::Version.new(self["version"]["version"]) >= sup
       end
     end
 
@@ -73,7 +72,7 @@ module Compliance
     def legacy_check!(feature)
       if !supported?(feature)
         puts "This feature (#{feature}) is not available for legacy installations."
-        puts 'Please upgrade to a recent version of Chef Compliance.'
+        puts "Please upgrade to a recent version of Chef Compliance."
         exit 1
       end
     end
@@ -86,9 +85,9 @@ module Compliance
     def version_with_support(feature)
       case feature.to_sym
       when :oidc
-        Gem::Version.new('0.16.19')
+        Gem::Version.new("0.16.19")
       else
-        Gem::Version.new('0.0.0')
+        Gem::Version.new("0.0.0")
       end
     end
   end

--- a/lib/bundles/inspec-compliance/http.rb
+++ b/lib/bundles/inspec-compliance/http.rb
@@ -1,9 +1,8 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'net/http'
-require 'uri'
+require "net/http"
+require "uri"
 
 module Compliance
   # implements a simple http abstraction on top of Net::HTTP
@@ -26,9 +25,9 @@ module Compliance
       uri = URI.parse(url)
       req = Net::HTTP::Post.new(uri.path)
       if basic_auth
-        req.basic_auth token, ''
+        req.basic_auth token, ""
       else
-        req['Authorization'] = "Bearer #{token}"
+        req["Authorization"] = "Bearer #{token}"
       end
       req.form_data={}
 
@@ -38,11 +37,11 @@ module Compliance
     # post a file
     def self.post_file(url, headers, file_path, insecure)
       uri = URI.parse(url)
-      fail "Unable to parse URL: #{url}" if uri.nil? || uri.host.nil?
+      raise "Unable to parse URL: #{url}" if uri.nil? || uri.host.nil?
       http = Net::HTTP.new(uri.host, uri.port)
 
       # set connection flags
-      http.use_ssl = (uri.scheme == 'https')
+      http.use_ssl = (uri.scheme == "https")
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE if insecure
 
       req = Net::HTTP::Post.new(uri.path)
@@ -50,12 +49,12 @@ module Compliance
         req.add_field(key, value)
       end
 
-      req.body_stream=File.open(file_path, 'rb')
-      req.add_field('Content-Length', File.size(file_path))
-      req.add_field('Content-Type', 'application/x-gtar')
+      req.body_stream=File.open(file_path, "rb")
+      req.add_field("Content-Length", File.size(file_path))
+      req.add_field("Content-Type", "application/x-gtar")
 
-      boundary = 'INSPEC-PROFILE-UPLOAD'
-      req.add_field('session', boundary)
+      boundary = "INSPEC-PROFILE-UPLOAD"
+      req.add_field("session", boundary)
       res=http.request(req)
       res
     end
@@ -63,21 +62,21 @@ module Compliance
     # sends a http requests
     def self.send_request(uri, req, insecure)
       opts = {
-        use_ssl: uri.scheme == 'https',
+        use_ssl: uri.scheme == "https",
       }
       opts[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if insecure
 
-      fail "Unable to parse URI: #{uri}" if uri.nil? || uri.host.nil?
+      raise "Unable to parse URI: #{uri}" if uri.nil? || uri.host.nil?
       res = Net::HTTP.start(uri.host, uri.port, opts) { |http|
         http.request(req)
       }
       res
 
     rescue OpenSSL::SSL::SSLError => e
-      raise e unless e.message.include? 'certificate verify failed'
+      raise e unless e.message.include? "certificate verify failed"
 
       puts "Error: Failed to connect to #{uri}."
-      puts 'If the server uses a self-signed certificate, please re-run the login command with the --insecure option.'
+      puts "If the server uses a self-signed certificate, please re-run the login command with the --insecure option."
       exit 1
     end
   end

--- a/lib/bundles/inspec-compliance/support.rb
+++ b/lib/bundles/inspec-compliance/support.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -12,9 +11,9 @@ module Compliance
     def self.version_with_support(feature)
       case feature.to_sym
       when :oidc # open id connect authentication
-        Gem::Version.new('0.16.19')
+        Gem::Version.new("0.16.19")
       else
-        Gem::Version.new('0.0.0')
+        Gem::Version.new("0.0.0")
       end
     end
 

--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -1,20 +1,19 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'uri'
-require 'inspec/fetcher'
-require 'inspec/errors'
+require "uri"
+require "inspec/fetcher"
+require "inspec/errors"
 
 # InSpec Target Helper for Chef Compliance
 # reuses UrlHelper, but it knows the target server and the access token already
 # similar to `inspec exec http://localhost:2134/owners/%base%/compliance/%ssh%/tar --user %token%`
 module Compliance
   class Fetcher < Fetchers::Url
-    name 'compliance'
+    name "compliance"
     priority 500
     def self.resolve(target) # rubocop:disable PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize
-      uri = if target.is_a?(String) && URI(target).scheme == 'compliance'
+      uri = if target.is_a?(String) && URI(target).scheme == "compliance"
               URI(target)
             elsif target.respond_to?(:key?) && target.key?(:compliance)
               URI("compliance://#{target[:compliance]}")
@@ -29,15 +28,15 @@ module Compliance
       else
         # check if we have a compliance token
         config = Compliance::Configuration.new
-        if config['token'].nil? && config['refresh_token'].nil?
-          if config['server_type'] == 'automate'
-            server = 'automate'
-            msg = 'inspec compliance login_automate https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --usertoken USERTOKEN'
+        if config["token"].nil? && config["refresh_token"].nil?
+          if config["server_type"] == "automate"
+            server = "automate"
+            msg = "inspec compliance login_automate https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --usertoken USERTOKEN"
           else
-            server = 'compliance'
+            server = "compliance"
             msg = "inspec compliance login https://your_compliance_server --user admin --insecure --token 'PASTE TOKEN HERE' "
           end
-          fail Inspec::FetcherFailure, <<EOF
+          raise Inspec::FetcherFailure, <<EOF
 
 Cannot fetch #{uri} because your #{server} token has not been
 configured.
@@ -51,12 +50,12 @@ EOF
         # verifies that the target e.g base/ssh exists
         profile = uri.host + uri.path
         if !Compliance::API.exist?(config, profile)
-          fail Inspec::FetcherFailure, "The compliance profile #{profile} was not found on the configured compliance server"
+          raise Inspec::FetcherFailure, "The compliance profile #{profile} was not found on the configured compliance server"
         end
         profile_fetch_url = Compliance::API.target_url(config, profile)
       end
       # We need to pass the token to the fetcher
-      config['token'] = Compliance::API.get_token(config)
+      config["token"] = Compliance::API.get_token(config)
 
       new(profile_fetch_url, config)
     rescue URI::Error => _e
@@ -74,7 +73,7 @@ EOF
     end
 
     def to_s
-      'Chef Compliance Profile Loader'
+      "Chef Compliance Profile Loader"
     end
 
     private

--- a/lib/bundles/inspec-compliance/test/integration/default/cli.rb
+++ b/lib/bundles/inspec-compliance/test/integration/default/cli.rb
@@ -1,93 +1,91 @@
-# encoding: utf-8
-
 # options
-inspec_bin = 'BUNDLE_GEMFILE=/inspec/Gemfile bundle exec inspec'
-api_url = 'https://0.0.0.0'
-profile = '/inspec/examples/profile'
+inspec_bin = "BUNDLE_GEMFILE=/inspec/Gemfile bundle exec inspec"
+api_url = "https://0.0.0.0"
+profile = "/inspec/examples/profile"
 
-user = command('whoami').stdout.strip
-pwd = command('pwd').stdout.strip
+user = command("whoami").stdout.strip
+pwd = command("pwd").stdout.strip
 puts "Run test as #{user} in path #{pwd}"
 
 # TODO: determine tokens automatically, define in kitchen yml
-access_token = ENV['COMPLIANCE_ACCESSTOKEN']
-refresh_token = ENV['COMPLIANCE_REFRESHTOKEN']
+access_token = ENV["COMPLIANCE_ACCESSTOKEN"]
+refresh_token = ENV["COMPLIANCE_REFRESHTOKEN"]
 
 %w{refresh_token access_token}.each do |type|
   case type
-  when 'access_token'
+  when "access_token"
     token_options = "--token '#{access_token}'"
-  when 'refresh_token'
+  when "refresh_token"
     token_options = "--refresh_token '#{refresh_token}'"
   end
 
   # verifies that the help command works
   describe command("#{inspec_bin} compliance help") do
-    its('stdout') { should include 'inspec compliance help [COMMAND]' }
-    its('stderr') { should eq '' }
-    its('exit_status') { should eq 0 }
+    its("stdout") { should include "inspec compliance help [COMMAND]" }
+    its("stderr") { should eq "" }
+    its("exit_status") { should eq 0 }
   end
 
   # version command fails gracefully when server not configured
   describe command("#{inspec_bin} compliance version") do
-    its('stdout') { should include 'Server configuration information is missing' }
-    its('stderr') { should eq '' }
-    its('exit_status') { should eq 1 }
+    its("stdout") { should include "Server configuration information is missing" }
+    its("stderr") { should eq "" }
+    its("exit_status") { should eq 1 }
   end
 
   # submitting a wrong token should have an exit of 0
   describe command("#{inspec_bin} compliance login #{api_url} --insecure --user 'admin' --token 'wrong-token'") do
-    its('stdout') { should include 'token stored' }
+    its("stdout") { should include "token stored" }
   end
 
   # compliance login --help should give an accurate message for login
   describe command("#{inspec_bin} compliance login --help") do
-    its('stdout') { should include "inspec compliance login SERVER --insecure --user='USER' --token='TOKEN'" }
-    its('exit_status') { should eq 0 }
+    its("stdout") { should include "inspec compliance login SERVER --insecure --user='USER' --token='TOKEN'" }
+    its("exit_status") { should eq 0 }
   end
 
   # profiles command fails gracefully when token/server info is incorrect
   describe command("#{inspec_bin} compliance profiles") do
-    its('stdout') { should include '401 Unauthorized. Please check your token' }
-    its('stderr') { should eq '' }
-    its('exit_status') { should eq 1 }
+    its("stdout") { should include "401 Unauthorized. Please check your token" }
+    its("stderr") { should eq "" }
+    its("exit_status") { should eq 1 }
   end
 
   # login via access token token
   describe command("#{inspec_bin} compliance login #{api_url} --insecure --user 'admin' #{token_options}") do
-    its('stdout') { should include 'token', 'stored' }
-    its('stdout') { should_not include 'Your server supports --user and --password only' }
-    its('stderr') { should eq '' }
-    its('exit_status') { should eq 0 }
+    its("stdout") { should include "token", "stored" }
+    its("stdout") { should_not include "Your server supports --user and --password only" }
+    its("stderr") { should eq "" }
+    its("exit_status") { should eq 0 }
   end
 
   # see available resources
   describe command("#{inspec_bin} compliance profiles") do
-    its('stdout') { should include 'base/ssh' }
-    its('stderr') { should eq '' }
-    its('exit_status') { should eq 0 }
+    its("stdout") { should include "base/ssh" }
+    its("stderr") { should eq "" }
+    its("exit_status") { should eq 0 }
   end
 
   # upload a compliance profile
   describe command("#{inspec_bin} compliance upload #{profile} --overwrite") do
-    its('stdout') { should include 'Profile is valid' }
-    its('stdout') { should include 'Successfully uploaded profile' }
-    its('stdout') { should_not include 'error(s)' }
-    its('stderr') { should eq '' }
-    its('exit_status') { should eq 0 }
+    its("stdout") { should include "Profile is valid" }
+    its("stdout") { should include "Successfully uploaded profile" }
+    its("stdout") { should_not include "error(s)" }
+    its("stderr") { should eq "" }
+    its("exit_status") { should eq 0 }
   end
 
   # returns the version of the server
   describe command("#{inspec_bin} compliance version") do
-    its('stdout') { should include 'Chef Compliance version:' }
-    its('stderr') { should eq '' }
-    its('exit_status') { should eq 0 }
+    its("stdout") { should include "Chef Compliance version:" }
+    its("stderr") { should eq "" }
+    its("exit_status") { should eq 0 }
   end
 
   # logout
   describe command("#{inspec_bin} compliance logout") do
-    its('stdout') { should include 'Successfully logged out' }
-    its('stderr') { should eq '' }
-    its('exit_status') { should eq 0 }
+    its("stdout") { should include "Successfully logged out" }
+    its("stderr") { should eq "" }
+    its("exit_status") { should eq 0 }
   end
 end

--- a/lib/bundles/inspec-init.rb
+++ b/lib/bundles/inspec-init.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
-require 'inspec-init/cli'
+require "inspec-init/cli"

--- a/lib/bundles/inspec-init/cli.rb
+++ b/lib/bundles/inspec-init/cli.rb
@@ -1,11 +1,10 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 
-require 'pathname'
+require "pathname"
 
 module Init
   class CLI < Inspec::BaseCLI
-    namespace 'init'
+    namespace "init"
 
     # TODO: find another solution, once https://github.com/erikhuda/thor/issues/261 is fixed
     def self.banner(command, _namespace = nil, _subcommand = false)
@@ -17,14 +16,14 @@ module Init
     end
 
     # read template directoy
-    template_dir = File.join(File.dirname(__FILE__), 'templates')
-    Dir.glob(File.join(template_dir, '*')) do |template|
+    template_dir = File.join(File.dirname(__FILE__), "templates")
+    Dir.glob(File.join(template_dir, "*")) do |template|
       relative = Pathname.new(template).relative_path_from(Pathname.new(template_dir))
 
       # register command for the template
       desc "#{relative} NAME", "Create a new #{relative}"
       option :overwrite, type: :boolean, default: false,
-         desc: 'Overwrites existing directory'
+         desc: "Overwrites existing directory"
       define_method relative.to_s.to_sym do |name|
         generator(relative.to_s, { name: name }, options)
       end
@@ -39,15 +38,15 @@ module Init
       # path of this script
       dir = File.dirname(__FILE__)
       # look for template directory
-      base_dir = File.join(dir, 'templates', type)
+      base_dir = File.join(dir, "templates", type)
       # prepare glob for all subdirectories and files
-      template = File.join(base_dir, '**', '{*,.*}')
+      template = File.join(base_dir, "**", "{*,.*}")
       # generate target path
       target = Pathname.new(Dir.pwd).join(attributes[:name])
       puts "Create new #{type} at #{mark_text(target)}"
 
       # check that the directory does not exist
-      if File.exist?(target) && !options['overwrite']
+      if File.exist?(target) && !options["overwrite"]
         error "#{mark_text(target)} exists already, use --overwrite"
         exit 1
       end
@@ -93,5 +92,5 @@ module Init
   end
 
   # register the subcommand to Inspec CLI registry
-  Inspec::Plugins::CLI.add_subcommand(Init::CLI, 'init', 'init TEMPLATE ...', 'Scaffolds a new project', {})
+  Inspec::Plugins::CLI.add_subcommand(Init::CLI, "init", "init TEMPLATE ...", "Scaffolds a new project", {})
 end

--- a/lib/bundles/inspec-supermarket.rb
+++ b/lib/bundles/inspec-supermarket.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -6,8 +5,8 @@ libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
 module Supermarket
-  autoload :API, 'inspec-supermarket/api'
+  autoload :API, "inspec-supermarket/api"
 end
 
-require 'inspec-supermarket/cli'
-require 'inspec-supermarket/target'
+require "inspec-supermarket/cli"
+require "inspec-supermarket/target"

--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -1,23 +1,22 @@
-# encoding: utf-8
 # frozen_string_literal: true
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'net/http'
+require "net/http"
 
 module Supermarket
   class API
-    SUPERMARKET_URL = 'https://supermarket.chef.io'.freeze
+    SUPERMARKET_URL = "https://supermarket.chef.io".freeze
 
     # displays a list of profiles
     def self.profiles(supermarket_url = SUPERMARKET_URL)
       url = "#{supermarket_url}/api/v1/tools-search"
-      _success, data = get(url, { type: 'compliance_profile', items: 100 })
+      _success, data = get(url, { type: "compliance_profile", items: 100 })
       if !data.nil?
         profiles = JSON.parse(data)
-        profiles['items'].map { |x|
-          m = %r{^#{supermarket_url}/api/v1/tools/(?<slug>[\w-]+)(/)?$}.match(x['tool'])
-          x['slug'] = m[:slug]
+        profiles["items"].map { |x|
+          m = %r{^#{supermarket_url}/api/v1/tools/(?<slug>[\w-]+)(/)?$}.match(x["tool"])
+          x["slug"] = m[:slug]
           x
         }
       else
@@ -47,7 +46,7 @@ module Supermarket
     def self.same?(profile, supermarket_tool, supermarket_url = SUPERMARKET_URL)
       tool_owner, tool_name = profile_name(profile)
       tool = "#{supermarket_url}/api/v1/tools/#{tool_name}"
-      supermarket_tool['tool_owner'] == tool_owner && supermarket_tool['tool'] == tool
+      supermarket_tool["tool_owner"] == tool_owner && supermarket_tool["tool"] == tool
     end
 
     def self.find(profile, supermarket_url)
@@ -73,7 +72,7 @@ module Supermarket
 
     def self.send_request(uri, req)
       # send request
-      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') {|http|
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") { |http|
         http.request(req)
       }
       [res.is_a?(Net::HTTPSuccess), res.body]

--- a/lib/bundles/inspec-supermarket/cli.rb
+++ b/lib/bundles/inspec-supermarket/cli.rb
@@ -1,10 +1,9 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
 module Supermarket
   class SupermarketCLI < Inspec::BaseCLI
-    namespace 'supermarket'
+    namespace "supermarket"
 
     # TODO: find another solution, once https://github.com/erikhuda/thor/issues/261 is fixed
     def self.banner(command, _namespace = nil, _subcommand = false)
@@ -15,29 +14,29 @@ module Supermarket
       namespace
     end
 
-    desc 'profiles', 'list all available profiles in Chef Supermarket'
+    desc "profiles", "list all available profiles in Chef Supermarket"
     def profiles
       # display profiles in format user/profile
       supermarket_profiles = Supermarket::API.profiles
 
-      headline('Available profiles:')
+      headline("Available profiles:")
       supermarket_profiles.each { |p|
         li("#{p['tool_name']} #{mark_text(p['tool_owner'] + '/' + p['slug'])}")
       }
     end
 
-    desc 'exec PROFILE', 'execute a Supermarket profile'
+    desc "exec PROFILE", "execute a Supermarket profile"
     exec_options
     def exec(*tests)
       # iterate over tests and add compliance scheme
-      tests = tests.map { |t| 'supermarket://' + t }
+      tests = tests.map { |t| "supermarket://" + t }
 
       # execute profile from inspec exec implementation
       diagnose
       run_tests(tests, opts)
     end
 
-    desc 'info PROFILE', 'display Supermarket profile details'
+    desc "info PROFILE", "display Supermarket profile details"
     def info(profile)
       # check that the profile is available
       supermarket_profiles = Supermarket::API.profiles
@@ -61,5 +60,5 @@ module Supermarket
   end
 
   # register the subcommand to Inspec CLI registry
-  Inspec::Plugins::CLI.add_subcommand(SupermarketCLI, 'supermarket', 'supermarket SUBCOMMAND ...', 'Supermarket commands', {})
+  Inspec::Plugins::CLI.add_subcommand(SupermarketCLI, "supermarket", "supermarket SUBCOMMAND ...", "Supermarket commands", {})
 end

--- a/lib/bundles/inspec-supermarket/target.rb
+++ b/lib/bundles/inspec-supermarket/target.rb
@@ -1,19 +1,18 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'uri'
-require 'inspec/fetcher'
-require 'fetchers/url'
+require "uri"
+require "inspec/fetcher"
+require "fetchers/url"
 
 # InSpec Target Helper for Supermarket
 module Supermarket
   class Fetcher < Inspec.fetcher(1)
-    name 'supermarket'
+    name "supermarket"
     priority 500
 
     def self.resolve(target, opts = {})
-      supermarket_uri, supermarket_server = if target.is_a?(String) && URI(target).scheme == 'supermarket'
+      supermarket_uri, supermarket_server = if target.is_a?(String) && URI(target).scheme == "supermarket"
                                               [target, Supermarket::API::SUPERMARKET_URL]
                                             elsif target.respond_to?(:key?) && target.key?(:supermarket)
                                               supermarket_server = target[:supermarket_url] || Supermarket::API::SUPERMARKET_URL
@@ -22,13 +21,13 @@ module Supermarket
       return nil unless supermarket_uri
       return nil unless Supermarket::API.exist?(supermarket_uri, supermarket_server)
       tool_info = Supermarket::API.find(supermarket_uri, supermarket_server)
-      resolve_next(tool_info['tool_source_url'], opts)
+      resolve_next(tool_info["tool_source_url"], opts)
     rescue URI::Error
       nil
     end
 
     def to_s
-      'Chef Compliance Profile Loader'
+      "Chef Compliance Profile Loader"
     end
   end
 end

--- a/lib/fetchers/git.rb
+++ b/lib/fetchers/git.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
-require 'tmpdir'
-require 'fileutils'
-require 'mixlib/shellout'
-require 'inspec/log'
+require "tmpdir"
+require "fileutils"
+require "mixlib/shellout"
+require "inspec/log"
 
 module Fetchers
   #
@@ -25,7 +24,7 @@ module Fetchers
   # omnibus source for hints.
   #
   class Git < Inspec.fetcher(1)
-    name 'git'
+    name "git"
     priority 200
 
     def self.resolve(target, opts = {})
@@ -78,7 +77,7 @@ module Fetchers
                         elsif @tag
                           resolve_ref(@tag)
                         else
-                          resolve_ref('master')
+                          resolve_ref("master")
                         end
     end
 
@@ -86,7 +85,7 @@ module Fetchers
       cmd = shellout("git ls-remote \"#{@remote_url}\" \"#{ref_name}*\"")
       ref = parse_ls_remote(cmd.stdout, ref_name)
       if !ref
-        fail "Unable to resolve #{ref_name} to a specific git commit for #{@remote_url}"
+        raise "Unable to resolve #{ref_name} to a specific git commit for #{@remote_url}"
       end
       ref
     end
@@ -127,7 +126,7 @@ module Fetchers
     end
 
     def cloned?
-      File.directory?(File.join(@repo_directory, '.git'))
+      File.directory?(File.join(@repo_directory, ".git"))
     end
 
     def clone(dir = @repo_directory)
@@ -146,7 +145,7 @@ module Fetchers
       cmd.error!
       cmd.status
     rescue Errno::ENOENT
-      raise 'To use git sources, you must have git installed.'
+      raise "To use git sources, you must have git installed."
     end
 
     def shellout(cmd, opts = {})
@@ -154,12 +153,12 @@ module Fetchers
       cmd = Mixlib::ShellOut.new(cmd, opts)
       cmd.run_command
       Inspec::Log.debug("External command: completed with exit status: #{cmd.exitstatus}")
-      Inspec::Log.debug('External command: STDOUT BEGIN')
+      Inspec::Log.debug("External command: STDOUT BEGIN")
       Inspec::Log.debug(cmd.stdout)
-      Inspec::Log.debug('External command: STDOUT END')
-      Inspec::Log.debug('External command: STDERR BEGIN')
+      Inspec::Log.debug("External command: STDOUT END")
+      Inspec::Log.debug("External command: STDERR BEGIN")
       Inspec::Log.debug(cmd.stderr)
-      Inspec::Log.debug('External command: STDERR END')
+      Inspec::Log.debug("External command: STDERR END")
       cmd
     end
   end

--- a/lib/fetchers/local.rb
+++ b/lib/fetchers/local.rb
@@ -1,10 +1,9 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
 module Fetchers
   class Local < Inspec.fetcher(1)
-    name 'local'
+    name "local"
     priority 0
 
     def self.resolve(target)
@@ -31,11 +30,11 @@ module Fetchers
 
     def self.resolve_from_string(target)
       # Support "urls" in the form of file://
-      if target.start_with?('file://')
-        target = target.gsub(%r{^file://}, '')
+      if target.start_with?("file://")
+        target = target.gsub(%r{^file://}, "")
       else
         # support for windows paths
-        target = target.tr('\\', '/')
+        target = target.tr('\\', "/")
       end
 
       if File.exist?(target)

--- a/lib/fetchers/mock.rb
+++ b/lib/fetchers/mock.rb
@@ -1,10 +1,9 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
 module Fetchers
   class Mock < Inspec.fetcher(1)
-    name 'mock'
+    name "mock"
     priority 0
 
     def self.resolve(target)
@@ -29,7 +28,7 @@ module Fetchers
     end
 
     def cache_key
-      ''
+      ""
     end
   end
 end

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -1,22 +1,21 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'uri'
-require 'digest'
-require 'tempfile'
-require 'open-uri'
+require "uri"
+require "digest"
+require "tempfile"
+require "open-uri"
 
 module Fetchers
   class Url < Inspec.fetcher(1) # rubocop:disable Metrics/ClassLength
     MIME_TYPES = {
-      'application/x-zip-compressed' => '.zip',
-      'application/zip' => '.zip',
-      'application/x-gzip' => '.tar.gz',
-      'application/gzip' => '.tar.gz',
+      "application/x-zip-compressed" => ".zip",
+      "application/zip" => ".zip",
+      "application/x-gzip" => ".tar.gz",
+      "application/gzip" => ".tar.gz",
     }.freeze
 
-    name 'url'
+    name "url"
     priority 200
 
     def self.resolve(target, opts = {})
@@ -76,8 +75,8 @@ module Fetchers
 
     def initialize(url, opts)
       @target = url
-      @insecure = opts['insecure']
-      @token = opts['token']
+      @insecure = opts["insecure"]
+      @token = opts["token"]
       @config = opts
     end
 
@@ -105,12 +104,12 @@ module Fetchers
     end
 
     def file_type_from_remote(remote)
-      content_type = remote.meta['content-type']
+      content_type = remote.meta["content-type"]
       file_type = MIME_TYPES[content_type]
 
       if file_type.nil?
         Inspec::Log.warn("Unrecognized content type: #{content_type}. Assuming tar.gz")
-        file_type = '.tar.gz'
+        file_type = ".tar.gz"
       end
 
       file_type
@@ -125,23 +124,23 @@ module Fetchers
       return @temp_archive_path if ! @temp_archive_path.nil?
       Inspec::Log.debug("Fetching URL: #{@target}")
       http_opts = {}
-      http_opts['ssl_verify_mode'.to_sym] = OpenSSL::SSL::VERIFY_NONE if @insecure
+      http_opts["ssl_verify_mode".to_sym] = OpenSSL::SSL::VERIFY_NONE if @insecure
       if @config
-        if @config['server_type'] == 'automate'
-          http_opts['chef-delivery-enterprise'] = @config['automate']['ent']
-          if @config['automate']['token_type'] == 'dctoken'
-            http_opts['x-data-collector-token'] = @config['token']
+        if @config["server_type"] == "automate"
+          http_opts["chef-delivery-enterprise"] = @config["automate"]["ent"]
+          if @config["automate"]["token_type"] == "dctoken"
+            http_opts["x-data-collector-token"] = @config["token"]
           else
-            http_opts['chef-delivery-user'] = @config['user']
-            http_opts['chef-delivery-token'] = @config['token']
+            http_opts["chef-delivery-user"] = @config["user"]
+            http_opts["chef-delivery-token"] = @config["token"]
           end
         elsif @token
-          http_opts['Authorization'] = "Bearer #{@token}"
+          http_opts["Authorization"] = "Bearer #{@token}"
         end
       end
       remote = open(@target, http_opts)
       @archive_type = file_type_from_remote(remote) # side effect :(
-      archive = Tempfile.new(['inspec-dl-', @archive_type])
+      archive = Tempfile.new(["inspec-dl-", @archive_type])
       archive.binmode
       archive.write(remote.read)
       archive.rewind

--- a/lib/inspec.rb
+++ b/lib/inspec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Dominik Richter
 # license: All rights reserved
 # author: Dominik Richter
@@ -7,17 +6,17 @@
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
-require 'inspec/version'
-require 'inspec/profile'
-require 'inspec/rspec_json_formatter'
-require 'inspec/rule'
-require 'matchers/matchers'
-require 'inspec/runner'
-require 'inspec/shell'
+require "inspec/version"
+require "inspec/profile"
+require "inspec/rspec_json_formatter"
+require "inspec/rule"
+require "matchers/matchers"
+require "inspec/runner"
+require "inspec/shell"
 
 # all utils that may be required by plugins
-require 'inspec/base_cli'
-require 'inspec/fetcher'
-require 'inspec/source_reader'
-require 'inspec/resource'
-require 'inspec/plugins'
+require "inspec/base_cli"
+require "inspec/fetcher"
+require "inspec/source_reader"
+require "inspec/resource"
+require "inspec/plugins"

--- a/lib/inspec/archive/tar.rb
+++ b/lib/inspec/archive/tar.rb
@@ -1,13 +1,12 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'rubygems/package'
+require "rubygems/package"
 
 module Inspec::Archive
   class TarArchiveGenerator
     def archive(base_dir, files, archive)
-      File.open(archive, 'wb') do |file|
+      File.open(archive, "wb") do |file|
         Zlib::GzipWriter.wrap(file) do |gz|
           Gem::Package::TarWriter.new(gz) do |tar|
             files.each do |input_filename|

--- a/lib/inspec/archive/zip.rb
+++ b/lib/inspec/archive/zip.rb
@@ -1,10 +1,9 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'rubygems'
-require 'zip'
-require 'pathname'
+require "rubygems"
+require "zip"
+require "pathname"
 
 module Inspec::Archive
   class ZipArchiveGenerator

--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -1,10 +1,9 @@
-# encoding: utf-8
 # copyright: 2015, Dominik Richter
 # license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'train'
+require "train"
 
 module Inspec
   module Backend
@@ -17,12 +16,12 @@ module Inspec
       name = Train.validate_backend(conf)
       transport = Train.create(name, conf)
       if transport.nil?
-        fail "Can't find transport backend '#{name}'."
+        raise "Can't find transport backend '#{name}'."
       end
 
       connection = transport.connection
       if connection.nil?
-        fail "Can't connect to transport backend '#{name}'."
+        raise "Can't connect to transport backend '#{name}'."
       end
 
       cls = Class.new do

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -1,71 +1,70 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'thor'
-require 'inspec/log'
+require "thor"
+require "inspec/log"
 
 module Inspec
   class BaseCLI < Thor # rubocop:disable Metrics/ClassLength
     def self.target_options
       option :target, aliases: :t, type: :string,
-        desc: 'Simple targeting option using URIs, e.g. ssh://user:pass@host:port'
+        desc: "Simple targeting option using URIs, e.g. ssh://user:pass@host:port"
       option :backend, aliases: :b, type: :string,
-        desc: 'Choose a backend: local, ssh, winrm, docker.'
+        desc: "Choose a backend: local, ssh, winrm, docker."
       option :host, type: :string,
-        desc: 'Specify a remote host which is tested.'
+        desc: "Specify a remote host which is tested."
       option :port, aliases: :p, type: :numeric,
-        desc: 'Specify the login port for a remote scan.'
+        desc: "Specify the login port for a remote scan."
       option :user, type: :string,
-        desc: 'The login user for a remote scan.'
+        desc: "The login user for a remote scan."
       option :password, type: :string,
-        desc: 'Login password for a remote scan, if required.'
+        desc: "Login password for a remote scan, if required."
       option :key_files, aliases: :i, type: :array,
-        desc: 'Login key or certificate file for a remote scan.'
+        desc: "Login key or certificate file for a remote scan."
       option :path, type: :string,
-        desc: 'Login path to use when connecting to the target (WinRM).'
+        desc: "Login path to use when connecting to the target (WinRM)."
       option :sudo, type: :boolean,
-        desc: 'Run scans with sudo. Only activates on Unix and non-root user.'
+        desc: "Run scans with sudo. Only activates on Unix and non-root user."
       option :sudo_password, type: :string,
-        desc: 'Specify a sudo password, if it is required.'
+        desc: "Specify a sudo password, if it is required."
       option :sudo_options, type: :string,
-        desc: 'Additional sudo options for a remote scan.'
+        desc: "Additional sudo options for a remote scan."
       option :sudo_command, type: :string,
-        desc: 'Alternate command for sudo.'
+        desc: "Alternate command for sudo."
       option :shell, type: :boolean,
-        desc: 'Run scans in a subshell. Only activates on Unix.'
+        desc: "Run scans in a subshell. Only activates on Unix."
       option :shell_options, type: :string,
-        desc: 'Additional shell options.'
+        desc: "Additional shell options."
       option :shell_command, type: :string,
-        desc: 'Specify a particular shell to use.'
+        desc: "Specify a particular shell to use."
       option :ssl, type: :boolean,
-        desc: 'Use SSL for transport layer encryption (WinRM).'
+        desc: "Use SSL for transport layer encryption (WinRM)."
       option :self_signed, type: :boolean,
-        desc: 'Allow remote scans with self-signed certificates (WinRM).'
+        desc: "Allow remote scans with self-signed certificates (WinRM)."
       option :json_config, type: :string,
-        desc: 'Read configuration from JSON file (`-` reads from stdin).'
+        desc: "Read configuration from JSON file (`-` reads from stdin)."
     end
 
     def self.profile_options
       option :profiles_path, type: :string,
-        desc: 'Folder which contains referenced profiles.'
+        desc: "Folder which contains referenced profiles."
     end
 
     def self.exec_options
       target_options
       profile_options
       option :controls, type: :array,
-        desc: 'A list of controls to run. Ignore all other tests.'
+        desc: "A list of controls to run. Ignore all other tests."
       option :format, type: :string,
-        desc: 'Which formatter to use: cli, progress, documentation, json, json-min, junit'
+        desc: "Which formatter to use: cli, progress, documentation, json, json-min, junit"
       option :color, type: :boolean, default: true,
-        desc: 'Use colors in output.'
+        desc: "Use colors in output."
       option :attrs, type: :array,
-        desc: 'Load attributes file (experimental)'
+        desc: "Load attributes file (experimental)"
       option :cache, type: :string,
-        desc: 'Use the given path for caching dependencies. (default: ~/.inspec/cache)'
+        desc: "Use the given path for caching dependencies. (default: ~/.inspec/cache)"
       option :create_lockfile, type: :boolean, default: true,
-        desc: 'Write out a lockfile based on this execution (unless one already exists)'
+        desc: "Write out a lockfile based on this execution (unless one already exists)"
     end
 
     private
@@ -73,7 +72,7 @@ module Inspec
     # helper method to run tests
     def run_tests(targets, opts)
       o = opts.dup
-      log_device = opts['format'] == 'json' ? nil : STDOUT
+      log_device = opts["format"] == "json" ? nil : STDOUT
       o[:logger] = Logger.new(log_device)
       o[:logger].level = get_log_level(o.log_level)
 
@@ -86,14 +85,14 @@ module Inspec
     end
 
     def diagnose
-      return unless opts['diagnose']
+      return unless opts["diagnose"]
       puts "InSpec version: #{Inspec::VERSION}"
       puts "Train version: #{Train::VERSION}"
-      puts 'Command line configuration:'
+      puts "Command line configuration:"
       pp options
-      puts 'JSON configuration file:'
+      puts "JSON configuration file:"
       pp options_json
-      puts 'Merged configuration:'
+      puts "Merged configuration:"
       pp opts
       puts
     end
@@ -104,13 +103,13 @@ module Inspec
     end
 
     def options_json
-      conffile = options['json_config']
+      conffile = options["json_config"]
       @json ||= conffile ? read_config(conffile) : {}
     end
 
     def read_config(file)
-      if file == '-'
-        puts 'WARN: reading JSON config from standard input' if STDIN.tty?
+      if file == "-"
+        puts "WARN: reading JSON config from standard input" if STDIN.tty?
         config = STDIN.read
       else
         config = File.read(file)
@@ -130,7 +129,7 @@ module Inspec
       if valid.include?(level)
         l = level
       else
-        l = 'info'
+        l = "info"
       end
 
       Logger.const_get(l.upcase)
@@ -148,11 +147,11 @@ module Inspec
 
     def vendor_deps(path, opts)
       path.nil? ? path = Pathname.new(Dir.pwd) : path = Pathname.new(path)
-      cache_path = path.join('vendor')
-      inspec_lock = path.join('inspec.lock')
+      cache_path = path.join("vendor")
+      inspec_lock = path.join("inspec.lock")
 
       if (cache_path.exist? || inspec_lock.exist?) && !opts[:overwrite]
-        puts 'Profile is already vendored. Use --overwrite.'
+        puts "Profile is already vendored. Use --overwrite."
         return false
       end
 
@@ -164,7 +163,7 @@ module Inspec
       opts[:logger] = Logger.new(STDOUT)
       opts[:logger].level = get_log_level(opts.log_level)
       opts[:cache] = Inspec::Cache.new(cache_path.to_s)
-      opts[:backend] = Inspec::Backend.create(target: 'mock://')
+      opts[:backend] = Inspec::Backend.create(target: "mock://")
       configure_logger(opts)
 
       # vendor dependencies and generate lockfile
@@ -183,7 +182,7 @@ module Inspec
       #
       loc = if o.log_location
               o.log_location
-            elsif %w{json json-min}.include?(o['format'])
+            elsif %w{json json-min}.include?(o["format"])
               STDERR
             else
               STDOUT
@@ -194,7 +193,7 @@ module Inspec
 
       o[:logger] = Logger.new(STDOUT)
       # output json if we have activated the json formatter
-      if opts['log-format'] == 'json'
+      if opts["log-format"] == "json"
         o[:logger].formatter = Logger::JSONFormatter.new
       end
       o[:logger].level = get_log_level(o.log_level)

--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -1,6 +1,5 @@
-# encoding: utf-8
-require 'inspec/fetcher'
-require 'forwardable'
+require "inspec/fetcher"
+require "forwardable"
 
 module Inspec
   class CachedFetcher
@@ -12,7 +11,7 @@ module Inspec
       @fetcher = Inspec::Fetcher.resolve(target)
 
       if @fetcher.nil?
-        fail("Could not fetch inspec profile in #{target.inspect}.")
+        raise("Could not fetch inspec profile in #{target.inspect}.")
       end
 
       @cache = cache
@@ -50,7 +49,7 @@ module Inspec
     def assert_cache_sanity!
       if target.respond_to?(:key?) && target.key?(:sha256)
         if fetcher.resolved_source[:sha256] != target[:sha256]
-          fail <<EOF
+          raise <<EOF
 The remote source #{fetcher} no longer has the requested content:
 
 Request Content Hash: #{target[:sha256]}

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
-require 'inspec/dsl'
-require 'inspec/dsl_shared'
+require "inspec/dsl"
+require "inspec/dsl_shared"
 
 module Inspec
   #
@@ -20,7 +19,7 @@ module Inspec
     # @param [ResourcesDSL] resources_dsl which has all resources to attach
     # @return [RuleContext] the inner context of rules
     def self.rule_context(resources_dsl)
-      require 'rspec/core/dsl'
+      require "rspec/core/dsl"
       Class.new(Inspec::Rule) do
         include RSpec::Core::DSL
         with_resource_dsl resources_dsl
@@ -143,7 +142,7 @@ module Inspec
 
         def block_location(block, alternate_caller)
           if block.nil?
-            alternate_caller[/^(.+:\d+):in .+$/, 1] || 'unknown'
+            alternate_caller[/^(.+:\d+):in .+$/, 1] || "unknown"
           else
             path, line = block.source_location
             "#{File.basename(path)}:#{line}"

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -1,6 +1,5 @@
-# encoding: utf-8
-require 'digest'
-require 'fileutils'
+require "digest"
+require "fileutils"
 
 module Inspec
   #
@@ -19,7 +18,7 @@ module Inspec
   class Cache
     attr_reader :path
     def initialize(path = nil)
-      @path = path || File.join(Dir.home, '.inspec', 'cache')
+      @path = path || File.join(Dir.home, ".inspec", "cache")
       FileUtils.mkdir_p(@path) unless File.directory?(@path)
     end
 

--- a/lib/inspec/dependencies/dependency_set.rb
+++ b/lib/inspec/dependencies/dependency_set.rb
@@ -1,6 +1,5 @@
-# encoding: utf-8
-require 'inspec/dependencies/requirement'
-require 'inspec/dependencies/resolver'
+require "inspec/dependencies/requirement"
+require "inspec/dependencies/resolver"
 
 module Inspec
   #

--- a/lib/inspec/dependencies/lockfile.rb
+++ b/lib/inspec/dependencies/lockfile.rb
@@ -1,5 +1,4 @@
-# encoding: utf-8
-require 'yaml'
+require "yaml"
 
 module Inspec
   class Lockfile
@@ -9,16 +8,16 @@ module Inspec
 
     def self.from_dependency_set(dep_set)
       lockfile_content = {
-        'lockfile_version' => CURRENT_LOCKFILE_VERSION,
-        'depends' => dep_set.to_array,
+        "lockfile_version" => CURRENT_LOCKFILE_VERSION,
+        "depends" => dep_set.to_array,
       }
       new(lockfile_content)
     end
 
     def self.from_content(content)
       parsed_content = YAML.load(content)
-      version = parsed_content['lockfile_version']
-      fail "No lockfile_version set in #{path}!" if version.nil?
+      version = parsed_content["lockfile_version"]
+      raise "No lockfile_version set in #{path}!" if version.nil?
       validate_lockfile_version!(version.to_i)
       new(parsed_content)
     end
@@ -30,7 +29,7 @@ module Inspec
 
     def self.validate_lockfile_version!(version)
       if version < MINIMUM_SUPPORTED_VERSION
-        fail <<EOF
+        raise <<EOF
 This lockfile specifies a lockfile_version of #{version} which is
 lower than the minimum supported version #{MINIMUM_SUPPORTED_VERSION}.
 
@@ -39,7 +38,7 @@ Please create a new lockfile for this project by running:
     inspec vendor
 EOF
       elsif version > CURRENT_LOCKFILE_VERSION
-        fail <<EOF
+        raise <<EOF
 This lockfile claims to be version #{version} which is greater than
 the most recent lockfile version(#{CURRENT_LOCKFILE_VERSION}).
 
@@ -51,15 +50,15 @@ EOF
 
     attr_reader :version, :deps
     def initialize(lockfile_content_hash)
-      version = lockfile_content_hash['lockfile_version']
+      version = lockfile_content_hash["lockfile_version"]
       @version = version.to_i
       parse_content_hash(lockfile_content_hash)
     end
 
     def to_yaml
       {
-        'lockfile_version' => CURRENT_LOCKFILE_VERSION,
-        'depends' => @deps.map { |i| stringify_keys(i) },
+        "lockfile_version" => CURRENT_LOCKFILE_VERSION,
+        "depends" => @deps.map { |i| stringify_keys(i) },
       }.to_yaml
     end
 
@@ -80,13 +79,13 @@ EOF
       else
         # If we've gotten here, there is likely a mistake in the
         # lockfile version validation in the constructor.
-        fail "No lockfile parser for version #{version}"
+        raise "No lockfile parser for version #{version}"
       end
     end
 
     def parse_content_hash_1(lockfile_content_hash)
-      @deps = if lockfile_content_hash['depends']
-                lockfile_content_hash['depends'].map { |i| symbolize_keys(i) }
+      @deps = if lockfile_content_hash["depends"]
+                lockfile_content_hash["depends"].map { |i| symbolize_keys(i) }
               end
     end
 

--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -1,7 +1,6 @@
-# encoding: utf-8
-require 'inspec/cached_fetcher'
-require 'inspec/dependencies/dependency_set'
-require 'digest'
+require "inspec/cached_fetcher"
+require "inspec/dependencies/dependency_set"
+require "digest"
 
 module Inspec
   #
@@ -10,7 +9,7 @@ module Inspec
   #
   class Requirement
     def self.from_metadata(dep, cache, opts)
-      fail 'Cannot load empty dependency.' if dep.nil? || dep.empty?
+      raise "Cannot load empty dependency." if dep.nil? || dep.empty?
       new(dep[:name], dep[:version], cache, opts[:cwd], opts.merge(dep))
     end
 
@@ -65,13 +64,13 @@ module Inspec
 
     def to_hash
       h = {
-        'name' => name,
-        'resolved_source' => resolved_source,
-        'version_constraints' => required_version.to_s,
+        "name" => name,
+        "resolved_source" => resolved_source,
+        "version_constraints" => required_version.to_s,
       }
 
       if !dependencies.empty?
-        h['dependencies'] = dependencies.map(&:to_hash)
+        h["dependencies"] = dependencies.map(&:to_hash)
       end
 
       h

--- a/lib/inspec/dependencies/resolver.rb
+++ b/lib/inspec/dependencies/resolver.rb
@@ -1,7 +1,6 @@
-# encoding: utf-8
 # author: Steven Danna <steve@chef.io>
-require 'inspec/log'
-require 'inspec/errors'
+require "inspec/log"
+require "inspec/errors"
 
 module Inspec
   #
@@ -26,7 +25,7 @@ module Inspec
     def self.resolve(dependencies, cache, working_dir, backend)
       reqs = dependencies.map do |dep|
         req = Inspec::Requirement.from_metadata(dep, cache, cwd: working_dir, backend: backend)
-        req || fail("Cannot initialize dependency: #{req}")
+        req || raise("Cannot initialize dependency: #{req}")
       end
       new.resolve(reqs)
     end
@@ -36,18 +35,18 @@ module Inspec
       deps.each do |dep|
         if seen_items_local.include?(dep.name)
           problem_cookbook = if top_level
-                               'the inspec.yml for this profile.'
+                               "the inspec.yml for this profile."
                              else
                                "the dependency information for #{path_string.split(' ').last}"
                              end
-          fail Inspec::DuplicateDep, "The dependency #{dep.name} is listed twice in #{problem_cookbook}"
+          raise Inspec::DuplicateDep, "The dependency #{dep.name} is listed twice in #{problem_cookbook}"
         else
           seen_items_local << dep.name
         end
       end
     end
 
-    def resolve(deps, top_level = true, seen_items = {}, path_string = '') # rubocop:disable Metrics/AbcSize
+    def resolve(deps, top_level = true, seen_items = {}, path_string = "") # rubocop:disable Metrics/AbcSize
       graph = {}
       if top_level
         Inspec::Log.debug("Starting traversal of dependencies #{deps.map(&:to_s)}")
@@ -65,13 +64,13 @@ module Inspec
                           end
 
         if new_seen_items.key?(dep.resolved_source)
-          fail Inspec::CyclicDependencyError, "Dependency #{dep} would cause a dependency cycle (#{new_path_string})"
+          raise Inspec::CyclicDependencyError, "Dependency #{dep} would cause a dependency cycle (#{new_path_string})"
         else
           new_seen_items[dep.resolved_source] = true
         end
 
         if !dep.source_satisfies_spec?
-          fail Inspec::UnsatisfiedVersionSpecification, "The profile #{dep.name} from #{dep.resolved_source} has a version #{dep.source_version} which doesn't match #{dep.required_version}"
+          raise Inspec::UnsatisfiedVersionSpecification, "The profile #{dep.name} from #{dep.resolved_source} has a version #{dep.source_version} which doesn't match #{dep.required_version}"
         end
 
         Inspec::Log.debug("Adding dependency #{dep.name} (#{dep.resolved_source})")
@@ -81,7 +80,7 @@ module Inspec
         end
       end
 
-      Inspec::Log.debug('Dependency traversal complete.') if top_level
+      Inspec::Log.debug("Dependency traversal complete.") if top_level
       graph
     end
   end

--- a/lib/inspec/describe.rb
+++ b/lib/inspec/describe.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
@@ -17,11 +16,11 @@ module Inspec
     def one(&block)
       return unless block_given?
       instance_eval(&block)
-      @action.call('describe.one', @checks, nil)
+      @action.call("describe.one", @checks, nil)
     end
 
     def describe(*args, &block)
-      @checks.push(['describe', args, block])
+      @checks.push(["describe", args, block])
     end
   end
 end

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # copyright: 2015, Dominik Richter
 # author: Dominik Richter
 # author: Christoph Hartmann
-require 'inspec/log'
+require "inspec/log"
 
 module Inspec::DSL
   def require_controls(id, &block)
@@ -19,7 +18,7 @@ module Inspec::DSL
   alias include_rules include_controls
 
   def require_resource(options = {})
-    fail 'You must specify a specific resource name when calling require_resource()' if options[:resource].nil?
+    raise "You must specify a specific resource name when calling require_resource()" if options[:resource].nil?
 
     from_profile = options[:profile] || profile_name
     target_name = options[:as] || options[:resource]
@@ -33,7 +32,7 @@ module Inspec::DSL
 
     dep_entry = dependencies.list[profile_id]
     if dep_entry.nil?
-      fail <<EOF
+      raise <<EOF
 Cannot load #{profile_id} since it is not listed as a dependency
 of #{bind_context.profile_name}.
 
@@ -53,13 +52,13 @@ EOF
   end
 
   def self.filter_included_controls(context, profile, &block)
-    mock = Inspec::Backend.create({ backend: 'mock' })
+    mock = Inspec::Backend.create({ backend: "mock" })
     include_ctx = Inspec::ProfileContext.for_profile(profile, mock, {})
     include_ctx.load(block) if block_given?
     # remove all rules that were not registered
     context.all_rules.each do |r|
       id = Inspec::Rule.rule_id(r)
-      fid = Inspec::Rule.profile_id(r) + '/' + id
+      fid = Inspec::Rule.profile_id(r) + "/" + id
       unless include_ctx.rules[id] || include_ctx.rules[fid]
         context.remove_rule(fid)
       end

--- a/lib/inspec/dsl_shared.rb
+++ b/lib/inspec/dsl_shared.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module Inspec
   #
   # Contains methods we would like in multiple DSL
@@ -10,7 +9,7 @@ module Inspec
       alias __ruby_require require
 
       def require(path)
-        rbpath = path + '.rb'
+        rbpath = path + ".rb"
         return __ruby_require(path) if !@require_loader.exists?(rbpath)
         return false if @require_loader.loaded?(rbpath)
 

--- a/lib/inspec/env_printer.rb
+++ b/lib/inspec/env_printer.rb
@@ -1,7 +1,6 @@
-# encoding: utf-8
-require 'inspec/shell_detector'
-require 'erb'
-require 'shellwords'
+require "inspec/shell_detector"
+require "erb"
+require "shellwords"
 
 module Inspec
   class EnvPrinter
@@ -28,7 +27,7 @@ module Inspec
     private
 
     def print_completion_for_shell
-      erb = ERB.new(File.read(completion_template_path), nil, '-')
+      erb = ERB.new(File.read(completion_template_path), nil, "-")
       puts erb.result(TemplateContext.new(@command_class).get_bindings)
     end
 
@@ -41,7 +40,7 @@ module Inspec
     end
 
     def completion_dir
-      File.join(File.dirname(__FILE__), 'completions')
+      File.join(File.dirname(__FILE__), "completions")
     end
 
     def completion_template_path
@@ -49,7 +48,7 @@ module Inspec
     end
 
     def shells_with_completions
-      Dir.glob("#{completion_dir}/*.sh.erb").map { |f| File.basename(f, '.sh.erb') }
+      Dir.glob("#{completion_dir}/*.sh.erb").map { |f| File.basename(f, ".sh.erb") }
     end
 
     def print_usage_guidance
@@ -83,7 +82,7 @@ EOF
 
     def exit_no_shell
       if @detected
-        $stderr.puts '# Unable to automatically detect shell and no shell was provided.'
+        $stderr.puts "# Unable to automatically detect shell and no shell was provided."
       end
       $stderr.puts <<EOF
 #

--- a/lib/inspec/errors.rb
+++ b/lib/inspec/errors.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/inspec/expect.rb
+++ b/lib/inspec/expect.rb
@@ -1,9 +1,8 @@
-# encoding: utf-8
 # copyright: 2016, Chef Software Inc.
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'rspec/expectations'
+require "rspec/expectations"
 
 module Inspec
   class Expect
@@ -25,11 +24,11 @@ module Inspec
     def example_group
       that = self
 
-      opts = { 'caller' => calls[0][3] }
+      opts = { "caller" => calls[0][3] }
       if !calls[0][3].nil? && !calls[0][3].empty? &&
-         (m = calls[0][3][0].match(/^([^:]*):(\d+):/))
-        opts['file_path'] = m[0]
-        opts['line_number'] = m[1]
+          (m = calls[0][3][0].match(/^([^:]*):(\d+):/))
+        opts["file_path"] = m[0]
+        opts["line_number"] = m[1]
       end
 
       RSpec::Core::ExampleGroup.describe(that.value, opts) do

--- a/lib/inspec/fetcher.rb
+++ b/lib/inspec/fetcher.rb
@@ -1,9 +1,8 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'inspec/plugins'
-require 'utils/plugin_registry'
+require "inspec/plugins"
+require "utils/plugin_registry"
 
 module Inspec
   class FetcherRegistry < PluginRegistry
@@ -34,12 +33,12 @@ module Inspec
 
   def self.fetcher(version)
     if version != 1
-      fail 'Only fetcher version 1 is supported!'
+      raise "Only fetcher version 1 is supported!"
     end
     Inspec::Plugins::Fetcher
   end
 end
 
-require 'fetchers/local'
-require 'fetchers/url'
-require 'fetchers/git'
+require "fetchers/local"
+require "fetchers/url"
+require "fetchers/git"

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -1,7 +1,6 @@
-# encoding: utf-8
-require 'rubygems/package'
-require 'zlib'
-require 'zip'
+require "rubygems/package"
+require "zlib"
+require "zip"
 
 module Inspec
   class FileProvider
@@ -10,14 +9,14 @@ module Inspec
         MockProvider.new(path)
       elsif File.directory?(path)
         DirProvider.new(path)
-      elsif File.exist?(path) && path.end_with?('.tar.gz', 'tgz')
+      elsif File.exist?(path) && path.end_with?(".tar.gz", "tgz")
         TarProvider.new(path)
-      elsif File.exist?(path) && path.end_with?('.zip')
+      elsif File.exist?(path) && path.end_with?(".zip")
         ZipProvider.new(path)
       elsif File.exist?(path)
         DirProvider.new(path)
       else
-        fail "No file provider for the provided path: #{path}"
+        raise "No file provider for the provided path: #{path}"
       end
     end
 
@@ -25,11 +24,11 @@ module Inspec
     end
 
     def read(_file)
-      fail "#{self} does not implement `read(...)`. This is required."
+      raise "#{self} does not implement `read(...)`. This is required."
     end
 
     def files
-      fail "Fetcher #{self} does not implement `files()`. This is required."
+      raise "Fetcher #{self} does not implement `files()`. This is required."
     end
 
     def relative_provider
@@ -55,7 +54,7 @@ module Inspec
       @files = if File.file?(path)
                  [path]
                else
-                 Dir[File.join(path, '**', '*')]
+                 Dir[File.join(path, "**", "*")]
                end
       @path = path
     end
@@ -76,7 +75,7 @@ module Inspec
       @files = []
       ::Zip::InputStream.open(@path) do |io|
         while (entry = io.get_next_entry)
-          @files.push(entry.name.sub(%r{/+$}, ''))
+          @files.push(entry.name.sub(%r{/+$}, ""))
         end
       end
     end
@@ -136,8 +135,8 @@ module Inspec
 
   class RelativeFileProvider
     BLACKLIST_FILES = [
-      '/pax_global_header',
-      'pax_global_header',
+      "/pax_global_header",
+      "pax_global_header",
     ].freeze
 
     attr_reader :files
@@ -148,7 +147,7 @@ module Inspec
       @parent = parent_provider
       @prefix = get_prefix(parent.files)
       if @prefix.nil?
-        fail "Could not determine path prefix for #{parent}"
+        raise "Could not determine path prefix for #{parent}"
       end
       @files = parent.files.find_all { |x| x.start_with?(prefix) && x != prefix }
                      .map { |x| x[prefix.length..-1] }
@@ -166,7 +165,7 @@ module Inspec
     private
 
     def get_prefix(fs)
-      return '' if fs.empty?
+      return "" if fs.empty?
 
       # filter backlisted files
       fs -= BLACKLIST_FILES
@@ -195,12 +194,12 @@ module Inspec
     end
 
     def get_files_prefix(fs)
-      return '' if fs.empty?
+      return "" if fs.empty?
 
       file = fs[0]
       bn = File.basename(file)
       # no more prefixes
-      return '' if bn == file
+      return "" if bn == file
 
       i = file.rindex(bn)
       pre = file[0..i-1]
@@ -211,8 +210,8 @@ module Inspec
       new_pre = get_prefix(rest)
       return new_pre if pre.start_with? new_pre
       # edge case: completely different prefixes; retry prefix detection
-      a = File.dirname(pre + 'a')
-      b = File.dirname(new_pre + 'b')
+      a = File.dirname(pre + "a")
+      b = File.dirname(new_pre + "b")
       get_prefix([a, b])
     end
   end

--- a/lib/inspec/library_eval_context.rb
+++ b/lib/inspec/library_eval_context.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # author: Steven Danna
 # author: Victoria Jeffrey
-require 'inspec/plugins/resource'
-require 'inspec/dsl_shared'
+require "inspec/plugins/resource"
+require "inspec/dsl_shared"
 
 module Inspec
   #

--- a/lib/inspec/log.rb
+++ b/lib/inspec/log.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'mixlib/log'
+require "mixlib/log"
 
 module Inspec
   class Log

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -1,11 +1,10 @@
-# encoding: utf-8
 # Copyright 2015 Dominik Richter. All rights reserved.
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'logger'
-require 'rubygems/version'
-require 'rubygems/requirement'
+require "logger"
+require "rubygems/version"
+require "rubygems/requirement"
 
 module Inspec
   # Extract metadata.rb information
@@ -58,15 +57,15 @@ module Inspec
 
       # os name is both saved in :family and :name, so check both
       name_ok = name.nil? ||
-                os[:name] == name || os[:family] == name
+        os[:name] == name || os[:family] == name
 
-      family_check = family.to_s + '?'
+      family_check = family.to_s + "?"
       family_ok = family.nil? || os[:family] == family ||
-                  (
-                    os.respond_to?(family_check) &&
-                    # this call will return true if the family matches
-                    os.method(family_check).call
-                  )
+        (
+          os.respond_to?(family_check) &&
+          # this call will return true if the family matches
+          os.method(family_check).call
+        )
 
       # ensure we do have a string if we have a non-nil value eg. 16.06
       release_ok = release.nil? || os[:release] == release
@@ -135,7 +134,7 @@ module Inspec
       return obj.map { |i| symbolize_keys(i) } if obj.is_a?(Array)
       return obj unless obj.is_a?(Hash)
 
-      obj.each_with_object({}) {|(k, v), h|
+      obj.each_with_object({}) { |(k, v), h|
         v = symbolize_keys(v) if v.is_a?(Hash)
         v = symbolize_keys(v) if v.is_a?(Array)
         h[k.to_sym] = v
@@ -149,8 +148,8 @@ module Inspec
         x
       when Array
         logger.warn(
-          'Failed to read supports entry that is an array. Please use '\
-          'the `supports: {os-family: xyz}` syntax.',
+          "Failed to read supports entry that is an array. Please use "\
+          "the `supports: {os-family: xyz}` syntax.",
         )
         nil
       when nil then nil
@@ -180,8 +179,8 @@ module Inspec
     def self.finalize(metadata, profile_id, logger = nil)
       return nil if metadata.nil?
       param = metadata.params || {}
-      param['name'] = profile_id.to_s unless profile_id.to_s.empty?
-      param['version'] = param['version'].to_s unless param['version'].nil?
+      param["name"] = profile_id.to_s unless profile_id.to_s.empty?
+      param["version"] = param["version"].to_s unless param["version"].nil?
       metadata.params = symbolize_keys(param)
       metadata.params[:supports] = finalize_supports(metadata.params[:supports], logger)
 
@@ -204,9 +203,9 @@ module Inspec
       # NOTE there doesn't have to exist an actual file, it may come from an
       # archive (i.e., contents)
       case File.basename(ref)
-      when 'inspec.yml'
+      when "inspec.yml"
         from_yaml(ref, contents, profile_id, logger)
-      when 'metadata.rb'
+      when "metadata.rb"
         from_ruby(ref, contents, profile_id, logger)
       else
         logger ||= Logger.new(nil)

--- a/lib/inspec/objects.rb
+++ b/lib/inspec/objects.rb
@@ -1,12 +1,10 @@
-# encoding: utf-8
-
 module Inspec
-  autoload :Attribute, 'inspec/objects/attribute'
-  autoload :Control, 'inspec/objects/control'
-  autoload :EachLoop, 'inspec/objects/each_loop'
-  autoload :List, 'inspec/objects/list'
-  autoload :OrTest, 'inspec/objects/or_test'
-  autoload :RubyHelper, 'inspec/objects/ruby_helper'
-  autoload :Test, 'inspec/objects/test'
-  autoload :Value, 'inspec/objects/value'
+  autoload :Attribute, "inspec/objects/attribute"
+  autoload :Control, "inspec/objects/control"
+  autoload :EachLoop, "inspec/objects/each_loop"
+  autoload :List, "inspec/objects/list"
+  autoload :OrTest, "inspec/objects/or_test"
+  autoload :RubyHelper, "inspec/objects/ruby_helper"
+  autoload :Test, "inspec/objects/test"
+  autoload :Value, "inspec/objects/value"
 end

--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -1,5 +1,3 @@
-# encoding:utf-8
-
 module Inspec
   class Attribute
     attr_accessor :name
@@ -30,7 +28,7 @@ module Inspec
     end
 
     def ruby_var_identifier
-      'attr_' + @name.downcase.strip.gsub(/\s+/, '-').gsub(/[^\w-]/, '')
+      "attr_" + @name.downcase.strip.gsub(/\s+/, "-").gsub(/[^\w-]/, "")
     end
 
     def to_hash
@@ -45,7 +43,7 @@ module Inspec
       res.push "  title: '#{title}'," unless title.to_s.empty?
       res.push "  default: '#{default}'," unless default.to_s.empty?
       res.push "  description: '#{description}'," unless description.to_s.empty?
-      res.push '})'
+      res.push "})"
       res.join("\n")
     end
 

--- a/lib/inspec/objects/control.rb
+++ b/lib/inspec/objects/control.rb
@@ -1,5 +1,3 @@
-# encoding:utf-8
-
 module Inspec
   class Control
     attr_accessor :id, :title, :desc, :impact, :tests
@@ -21,14 +19,14 @@ module Inspec
       res.push "  desc  #{desc.inspect}" unless desc.to_s.empty?
       res.push "  impact #{impact}" unless impact.nil?
       tests.each { |t| res.push(indent(t.to_ruby, 2)) }
-      res.push 'end'
+      res.push "end"
       res.join("\n")
     end
 
     private
 
     def indent(txt, d)
-      dt = ' '*d
+      dt = " "*d
       dt + txt.gsub("\n", "\n"+dt)
     end
   end

--- a/lib/inspec/objects/each_loop.rb
+++ b/lib/inspec/objects/each_loop.rb
@@ -1,5 +1,3 @@
-# encoding:utf-8
-
 module Inspec
   class EachLoop < List
     attr_reader :variables
@@ -12,7 +10,7 @@ module Inspec
 
     def add_test(t = nil)
       t ||= Test.new
-      t.qualifier[0] = ['entry']
+      t.qualifier[0] = ["entry"]
       @tests.push(t)
       t
     end

--- a/lib/inspec/objects/list.rb
+++ b/lib/inspec/objects/list.rb
@@ -1,14 +1,12 @@
-# encoding:utf-8
-
 module Inspec
   class List < Value
     def map
-      fail 'Inspec::List.map needs to be called with a block' unless block_given?
+      raise "Inspec::List.map needs to be called with a block" unless block_given?
       t = List.new
-      t.qualifier = [['x']]
+      t.qualifier = [["x"]]
       yield(t)
-      return if t.qualifier == [['x']]
-      @qualifier.push(['map', "{ |x| #{t.to_ruby} }"])
+      return if t.qualifier == [["x"]]
+      @qualifier.push(["map", "{ |x| #{t.to_ruby} }"])
       self
     end
   end

--- a/lib/inspec/objects/or_test.rb
+++ b/lib/inspec/objects/or_test.rb
@@ -1,5 +1,3 @@
-# encoding:utf-8
-
 module Inspec
   class OrTest
     attr_reader :tests

--- a/lib/inspec/objects/ruby_helper.rb
+++ b/lib/inspec/objects/ruby_helper.rb
@@ -1,14 +1,12 @@
-# encoding: utf-8
-
 module Inspec
   module RubyHelper
     def ruby_qualifier(q)
       if q.length <= 1
         q[0]
-      elsif q[0] == 'map' && q.length == 2
-        q[0] + ' ' + q[1]
+      elsif q[0] == "map" && q.length == 2
+        q[0] + " " + q[1]
       else
-        q[0] + '(' + q[1..-1].map(&:inspect).join(', ') + ')'
+        q[0] + "(" + q[1..-1].map(&:inspect).join(", ") + ")"
       end
     end
   end

--- a/lib/inspec/objects/test.rb
+++ b/lib/inspec/objects/test.rb
@@ -1,5 +1,3 @@
-# encoding:utf-8
-
 module Inspec
   class Test
     attr_accessor :qualifier, :matcher, :expectation, :skip, :negated, :variables
@@ -43,17 +41,17 @@ module Inspec
       return nil if @qualifier.empty?
 
       resource = (@qualifier.length > 1) ? @qualifier[0..-2] : [@qualifier[0]]
-      res = resource.map { |q| ruby_qualifier(q) }.join('.')
+      res = resource.map { |q| ruby_qualifier(q) }.join(".")
       xres = nil
 
       if @qualifier.length > 1
         last = @qualifier[-1]
-        last_call = last.is_a?(Array) ? last[0].to_s : ''
-        if last.length == 1 && last_call !~ /^to_.$/ && !last_call.include?('[') && !last_call.empty?
+        last_call = last.is_a?(Array) ? last[0].to_s : ""
+        if last.length == 1 && last_call !~ /^to_.$/ && !last_call.include?("[") && !last_call.empty?
           # this will go in its()
           xres = last_call
         else
-          res += '.' + ruby_qualifier(last) unless last_call.empty?
+          res += "." + ruby_qualifier(last) unless last_call.empty?
         end
       end
 
@@ -64,14 +62,14 @@ module Inspec
       vars = variables.map(&:to_ruby).join("\n")
       vars += "\n" unless vars.empty?
       res, xtra = describe_chain
-      itsy = xtra.nil? ? 'it' : 'its(' + xtra.to_s.inspect + ')'
-      naughty = @negated ? '_not' : ''
-      xpect = defined?(@expectation) ? expectation.inspect : ''
+      itsy = xtra.nil? ? "it" : "its(" + xtra.to_s.inspect + ")"
+      naughty = @negated ? "_not" : ""
+      xpect = defined?(@expectation) ? expectation.inspect : ""
       if @expectation.class == Regexp
         # without this, xpect values like / \/zones\// will not be parsed properly
         xpect = "(#{xpect})"
-      elsif xpect != ''
-        xpect = ' ' + xpect
+      elsif xpect != ""
+        xpect = " " + xpect
       end
       format("%sdescribe %s do\n  %s { should%s %s%s }\nend",
              vars, res, itsy, naughty, matcher, xpect)

--- a/lib/inspec/objects/value.rb
+++ b/lib/inspec/objects/value.rb
@@ -1,5 +1,3 @@
-# encoding:utf-8
-
 module Inspec
   class Value
     include ::Inspec::RubyHelper
@@ -14,12 +12,12 @@ module Inspec
     end
 
     def to_ruby
-      res = @variable.nil? ? '' : "#{@variable} = "
-      res + @qualifier.map { |x| ruby_qualifier(x) }.join('.')
+      res = @variable.nil? ? "" : "#{@variable} = "
+      res + @qualifier.map { |x| ruby_qualifier(x) }.join(".")
     end
 
     def name_variable(cache = [])
-      @variable = Array('a'..'z').find { |x| !cache.include?(x) }
+      @variable = Array("a".."z").find { |x| !cache.include?(x) }
       cache.push(@variable)
       @variable
     end

--- a/lib/inspec/plugins.rb
+++ b/lib/inspec/plugins.rb
@@ -1,17 +1,16 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'forwardable'
+require "forwardable"
 
 module Inspec
   # Resource Plugins
   module Plugins
-    autoload :Resource, 'inspec/plugins/resource'
-    autoload :CLI, 'inspec/plugins/cli'
-    autoload :Fetcher, 'inspec/plugins/fetcher'
-    autoload :SourceReader, 'inspec/plugins/source_reader'
-    autoload :Secret, 'inspec/plugins/secret'
+    autoload :Resource, "inspec/plugins/resource"
+    autoload :CLI, "inspec/plugins/cli"
+    autoload :Fetcher, "inspec/plugins/fetcher"
+    autoload :SourceReader, "inspec/plugins/source_reader"
+    autoload :Secret, "inspec/plugins/secret"
   end
 
   # PLEASE NOTE: The Plugin system is an internal mechanism for connecting
@@ -28,30 +27,30 @@ module Inspec
       @paths = []
 
       # load plugins in the same gem installation
-      lib_home = File.expand_path(File.join(__FILE__, '..', '..', '..', '..'))
-      @paths += Dir[lib_home+'/inspec-*-*/lib/inspec-*rb']
+      lib_home = File.expand_path(File.join(__FILE__, "..", "..", "..", ".."))
+      @paths += Dir[lib_home+"/inspec-*-*/lib/inspec-*rb"]
 
       # traverse out of inspec-vX.Y.Z/lib/inspec/plugins.rb
-      @home = home || File.join(Dir.home, '.inspec', 'plugins')
-      @paths += Dir[File.join(@home, '**{,/*/**}', '*.gemspec')]
+      @home = home || File.join(Dir.home, ".inspec", "plugins")
+      @paths += Dir[File.join(@home, "**{,/*/**}", "*.gemspec")]
                 .map { |x| File.dirname(x) }
-                .map { |x| Dir[File.join(x, 'lib', 'inspec-*.rb')] }
+                .map { |x| Dir[File.join(x, "lib", "inspec-*.rb")] }
                 .flatten
 
       # load bundled plugins
       bundled_dir = File.expand_path(File.dirname(__FILE__))
-      @paths += Dir[File.join(bundled_dir, '..', 'bundles', 'inspec-*.rb')].flatten
+      @paths += Dir[File.join(bundled_dir, "..", "bundles", "inspec-*.rb")].flatten
 
       # map paths to names
       @registry = Hash[@paths.map { |x|
-        [File.basename(x, '.rb'), x]
+        [File.basename(x, ".rb"), x]
       }]
     end
 
     def load(name)
       path = @registry[name]
       if path.nil?
-        fail "Couldn't find plugin #{name}. Searching in #{@home}"
+        raise "Couldn't find plugin #{name}. Searching in #{@home}"
       end
       # puts "Loading plugin #{name} from #{path}"
       require path

--- a/lib/inspec/plugins/cli.rb
+++ b/lib/inspec/plugins/cli.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 

--- a/lib/inspec/plugins/fetcher.rb
+++ b/lib/inspec/plugins/fetcher.rb
@@ -1,9 +1,8 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
-require 'utils/plugin_registry'
-require 'inspec/file_provider'
-require 'digest'
+require "utils/plugin_registry"
+require "inspec/file_provider"
+require "digest"
 
 module Inspec
   module Plugins
@@ -36,7 +35,7 @@ module Inspec
       # profile.
       #
       def archive_path
-        fail "Fetcher #{self} does not implement `archive_path()`. This is required."
+        raise "Fetcher #{self} does not implement `archive_path()`. This is required."
       end
 
       #
@@ -49,7 +48,7 @@ module Inspec
       # /foo/bar/baz.zip
       #
       def fetch(_path)
-        fail "Fetcher #{self} does not implement `fetch()`. This is required."
+        raise "Fetcher #{self} does not implement `fetch()`. This is required."
       end
 
       #
@@ -59,14 +58,14 @@ module Inspec
       # tag will be resolved to an exact revision.
       #
       def resolved_source
-        fail "Fetcher #{self} does not implement `resolved_source()`. This is required for terminal fetchers."
+        raise "Fetcher #{self} does not implement `resolved_source()`. This is required for terminal fetchers."
       end
 
       #
       # The unique key based on the content of the remote archive.
       #
       def cache_key
-        fail "Fetcher #{self} does not implement `cache_key()`. This is required for terminal fetchers."
+        raise "Fetcher #{self} does not implement `cache_key()`. This is required for terminal fetchers."
       end
 
       #

--- a/lib/inspec/plugins/resource.rb
+++ b/lib/inspec/plugins/resource.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/inspec/plugins/secret.rb
+++ b/lib/inspec/plugins/secret.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'utils/plugin_registry'
+require "utils/plugin_registry"
 
 module Inspec
   module Plugins

--- a/lib/inspec/plugins/source_reader.rb
+++ b/lib/inspec/plugins/source_reader.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'utils/plugin_registry'
+require "utils/plugin_registry"
 
 module Inspec
   module Plugins
@@ -15,7 +14,7 @@ module Inspec
       #
       # @return [Inspec::Metadata] profile metadata
       def metadata
-        fail "SourceReader #{self} does not implement `metadata()`. This method is required"
+        raise "SourceReader #{self} does not implement `metadata()`. This method is required"
       end
 
       # Retrieve this profile's tests
@@ -26,14 +25,14 @@ module Inspec
       #
       # @return [Hash] Collection with references pointing to test contents
       def tests
-        fail "SourceReader #{self} does not implement `tests()`. This method is required"
+        raise "SourceReader #{self} does not implement `tests()`. This method is required"
       end
 
       # Retrieve this profile's libraries
       #
       # @return [Hash] Collection with references pointing to library contents
       def libraries
-        fail "SourceReader #{self} does not implement `libraries()`. This method is required"
+        raise "SourceReader #{self} does not implement `libraries()`. This method is required"
       end
     end
   end

--- a/lib/inspec/polyfill.rb
+++ b/lib/inspec/polyfill.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2016, Chef Software Inc.
 # author: Dominik Richter
 # author: Christoph Hartmann

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -1,28 +1,27 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
-require 'inspec/log'
-require 'inspec/rule'
-require 'inspec/resource'
-require 'inspec/library_eval_context'
-require 'inspec/control_eval_context'
-require 'inspec/require_loader'
-require 'securerandom'
-require 'inspec/objects/attribute'
+require "inspec/log"
+require "inspec/rule"
+require "inspec/resource"
+require "inspec/library_eval_context"
+require "inspec/control_eval_context"
+require "inspec/require_loader"
+require "securerandom"
+require "inspec/objects/attribute"
 
 module Inspec
   class ProfileContext # rubocop:disable Metrics/ClassLength
     def self.for_profile(profile, backend, attributes)
-      new(profile.name, backend, { 'profile' => profile,
-                                   'attributes' => attributes })
+      new(profile.name, backend, { "profile" => profile,
+                                   "attributes" => attributes })
     end
 
     attr_reader :attributes, :profile_id, :resource_registry, :backend
     attr_accessor :rules
     def initialize(profile_id, backend, conf)
       if backend.nil?
-        fail 'ProfileContext is initiated with a backend == nil. ' \
-             'This is a backend error which must be fixed upstream.'
+        raise "ProfileContext is initiated with a backend == nil. " \
+             "This is a backend error which must be fixed upstream."
       end
       @profile_id = profile_id
       @backend = backend
@@ -39,10 +38,10 @@ module Inspec
     end
 
     def dependencies
-      if @conf['profile'].nil?
+      if @conf["profile"].nil?
         {}
       else
-        @conf['profile'].locked_dependencies
+        @conf["profile"].locked_dependencies
       end
     end
 
@@ -62,9 +61,9 @@ module Inspec
     end
 
     def profile_supports_os?
-      return true if @conf['profile'].nil?
+      return true if @conf["profile"].nil?
 
-      @conf['profile'].supports_os?
+      @conf["profile"].supports_os?
     end
 
     def remove_rule(id)
@@ -105,14 +104,14 @@ module Inspec
     end
 
     def load_libraries(libs)
-      lib_prefix = 'libraries' + File::SEPARATOR
+      lib_prefix = "libraries" + File::SEPARATOR
       autoloads = []
 
       libs.each do |content, source, line|
         path = source
         if source.start_with?(lib_prefix)
-          path = source.sub(lib_prefix, '')
-          autoloads.push(path) if File.dirname(path) == '.'
+          path = source.sub(lib_prefix, "")
+          autoloads.push(path) if File.dirname(path) == "."
         end
 
         @require_loader.add(path, content, source, line)
@@ -120,7 +119,7 @@ module Inspec
 
       # load all files directly that are flat inside the libraries folder
       autoloads.each do |path|
-        next unless path.end_with?('.rb')
+        next unless path.end_with?(".rb")
         load_library_file(*@require_loader.load(path)) unless @require_loader.loaded?(path)
       end
       reload_dsl
@@ -143,7 +142,7 @@ module Inspec
       elsif source.nil? && line.nil?
         context.instance_eval(content)
       else
-        context.instance_eval(content, source || 'unknown', line || 1)
+        context.instance_eval(content, source || "unknown", line || 1)
       end
     end
 
@@ -156,9 +155,9 @@ module Inspec
     def register_rule(r)
       # get the full ID
       file = if @current_load.nil?
-               'unknown'
+               "unknown"
              else
-               @current_load[:file] || 'unknown'
+               @current_load[:file] || "unknown"
              end
       r.instance_variable_set(:@__file, file)
       r.instance_variable_set(:@__group_title, current_load[:title])
@@ -177,7 +176,7 @@ module Inspec
       # we need to return an attribute object, to allow dermination of default values
       attr = Attribute.new(name, options)
       # read value from given gived values
-      attr.value(@conf['attributes'][attr.name]) unless @conf['attributes'].nil?
+      attr.value(@conf["attributes"][attr.name]) unless @conf["attributes"].nil?
       @attributes.push(attr)
       attr.value
     end
@@ -190,7 +189,7 @@ module Inspec
 
     def full_id(pid, rid)
       return rid.to_s if pid.to_s.empty?
-      pid.to_s + '/' + rid.to_s
+      pid.to_s + "/" + rid.to_s
     end
   end
 end

--- a/lib/inspec/require_loader.rb
+++ b/lib/inspec/require_loader.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -1,9 +1,8 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
-require 'inspec/plugins'
+require "inspec/plugins"
 
 module Inspec
   class ProfileNotFound < StandardError; end
@@ -39,7 +38,7 @@ module Inspec
                             profile_context.subcontext_by_name(profile_name)
                           end
 
-          fail ProfileNotFound, "Cannot find profile named: #{profile_name}" if inner_context.nil?
+          raise ProfileNotFound, "Cannot find profile named: #{profile_name}" if inner_context.nil?
           inner_context.resource_registry[resource_name]
         end
 
@@ -64,76 +63,76 @@ module Inspec
 
   def self.validate_resource_dsl_version!(version)
     if version != 1
-      fail 'Only resource version 1 is supported!'
+      raise "Only resource version 1 is supported!"
     end
   end
 end
 
-require 'resources/apache'
-require 'resources/apache_conf'
-require 'resources/apt'
-require 'resources/audit_policy'
-require 'resources/auditd_conf'
-require 'resources/auditd_rules'
-require 'resources/bash'
-require 'resources/bond'
-require 'resources/bridge'
-require 'resources/command'
-require 'resources/directory'
-require 'resources/etc_group'
-require 'resources/file'
-require 'resources/gem'
-require 'resources/groups'
-require 'resources/grub_conf'
-require 'resources/host'
-require 'resources/http'
-require 'resources/iis_site'
-require 'resources/inetd_conf'
-require 'resources/interface'
-require 'resources/iptables'
-require 'resources/json'
-require 'resources/kernel_module'
-require 'resources/kernel_parameter'
-require 'resources/limits_conf'
-require 'resources/login_def'
-require 'resources/mount'
-require 'resources/mssql_session'
-require 'resources/mysql'
-require 'resources/mysql_conf'
-require 'resources/mysql_session'
-require 'resources/npm'
-require 'resources/ntp_conf'
-require 'resources/oneget'
-require 'resources/os'
-require 'resources/os_env'
-require 'resources/package'
-require 'resources/packages'
-require 'resources/parse_config'
-require 'resources/passwd'
-require 'resources/pip'
-require 'resources/port'
-require 'resources/postgres'
-require 'resources/postgres_conf'
-require 'resources/postgres_session'
-require 'resources/powershell'
-require 'resources/processes'
-require 'resources/registry_key'
-require 'resources/security_policy'
-require 'resources/service'
-require 'resources/shadow'
-require 'resources/ssl'
-require 'resources/ssh_conf'
-require 'resources/sys_info'
-require 'resources/users'
-require 'resources/vbscript'
-require 'resources/windows_feature'
-require 'resources/windows_task'
-require 'resources/xinetd'
-require 'resources/wmi'
-require 'resources/yum'
+require "resources/apache"
+require "resources/apache_conf"
+require "resources/apt"
+require "resources/audit_policy"
+require "resources/auditd_conf"
+require "resources/auditd_rules"
+require "resources/bash"
+require "resources/bond"
+require "resources/bridge"
+require "resources/command"
+require "resources/directory"
+require "resources/etc_group"
+require "resources/file"
+require "resources/gem"
+require "resources/groups"
+require "resources/grub_conf"
+require "resources/host"
+require "resources/http"
+require "resources/iis_site"
+require "resources/inetd_conf"
+require "resources/interface"
+require "resources/iptables"
+require "resources/json"
+require "resources/kernel_module"
+require "resources/kernel_parameter"
+require "resources/limits_conf"
+require "resources/login_def"
+require "resources/mount"
+require "resources/mssql_session"
+require "resources/mysql"
+require "resources/mysql_conf"
+require "resources/mysql_session"
+require "resources/npm"
+require "resources/ntp_conf"
+require "resources/oneget"
+require "resources/os"
+require "resources/os_env"
+require "resources/package"
+require "resources/packages"
+require "resources/parse_config"
+require "resources/passwd"
+require "resources/pip"
+require "resources/port"
+require "resources/postgres"
+require "resources/postgres_conf"
+require "resources/postgres_session"
+require "resources/powershell"
+require "resources/processes"
+require "resources/registry_key"
+require "resources/security_policy"
+require "resources/service"
+require "resources/shadow"
+require "resources/ssl"
+require "resources/ssh_conf"
+require "resources/sys_info"
+require "resources/users"
+require "resources/vbscript"
+require "resources/windows_feature"
+require "resources/windows_task"
+require "resources/xinetd"
+require "resources/wmi"
+require "resources/yum"
 
 # file formats, depend on json implementation
-require 'resources/json'
-require 'resources/yaml'
-require 'resources/csv'
-require 'resources/ini'
+require "resources/json"
+require "resources/yaml"
+require "resources/csv"
+require "resources/ini"

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -1,11 +1,10 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 # author: John Kerry
 
-require 'rspec/core'
-require 'rspec/core/formatters/json_formatter'
-require 'rspec_junit_formatter'
+require "rspec/core"
+require "rspec/core/formatters/json_formatter"
+require "rspec_junit_formatter"
 
 # Vanilla RSpec JSON formatter with a slight extension to show example IDs.
 # TODO: Remove these lines when RSpec includes the ID natively
@@ -84,8 +83,8 @@ class InspecRspecMiniJson < RSpec::Core::Formatters::JsonFormatter
       res[:profile_id] = pid
     end
 
-    if res[:status] == 'pending'
-      res[:status] = 'skipped'
+    if res[:status] == "pending"
+      res[:status] = "skipped"
       res[:skip_message] = example.metadata[:description]
       res[:resource] = example.metadata[:described_class].to_s
     end
@@ -137,9 +136,9 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
     minor = 0
 
     all_unique_controls.each do |control|
-      next if control[:id].start_with? '(generated from '
+      next if control[:id].start_with? "(generated from "
       next unless control[:results]
-      if control[:results].any? { |r| r[:status] == 'failed' }
+      if control[:results].any? { |r| r[:status] == "failed" }
         failed += 1
         if control[:impact] >= 0.7
           critical += 1
@@ -148,7 +147,7 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
         else
           minor += 1
         end
-      elsif control[:results].any? { |r| r[:status] == 'skipped' }
+      elsif control[:results].any? { |r| r[:status] == "skipped" }
         skipped += 1
       else
         passed += 1
@@ -157,15 +156,15 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
 
     total = failed + passed + skipped
 
-    { 'total' => total,
-      'failed' => {
-        'total' => failed,
-        'critical' => critical,
-        'major' => major,
-        'minor' => minor,
+    { "total" => total,
+      "failed" => {
+        "total" => failed,
+        "critical" => critical,
+        "major" => major,
+        "minor" => minor,
       },
-      'skipped' => skipped,
-      'passed' => passed }
+      "skipped" => skipped,
+      "passed" => passed }
   end
 
   def tests_summary
@@ -177,9 +176,9 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
     all_unique_controls.each do |control|
       next unless control[:results]
       control[:results].each do |result|
-        if result[:status] == 'failed'
+        if result[:status] == "failed"
           failed += 1
-        elsif result[:status] == 'skipped'
+        elsif result[:status] == "skipped"
           skipped += 1
         else
           passed += 1
@@ -187,7 +186,7 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
       end
     end
 
-    { 'total' => total, 'failed' => failed, 'skipped' => skipped, 'passed' => passed }
+    { "total" => total, "failed" => failed, "skipped" => skipped, "passed" => passed }
   end
 
   def examples
@@ -239,25 +238,25 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
   RSpec::Core::Formatters.register self, :close
 
   COLORS = {
-    'critical' => "\033[38;5;9m",
-    'major'    => "\033[38;5;208m",
-    'minor'    => "\033[0;36m",
-    'failed'   => "\033[38;5;9m",
-    'passed'   => "\033[38;5;41m",
-    'skipped'  => "\033[38;5;247m",
-    'reset'    => "\033[0m",
+    "critical" => "\033[38;5;9m",
+    "major"    => "\033[38;5;208m",
+    "minor"    => "\033[0;36m",
+    "failed"   => "\033[38;5;9m",
+    "passed"   => "\033[38;5;41m",
+    "skipped"  => "\033[38;5;247m",
+    "reset"    => "\033[0m",
   }.freeze
 
   INDICATORS = {
-    'critical' => '  ×  ',
-    'major'    => '  ∅  ',
-    'minor'    => '  ⊚  ',
-    'failed'   => '  ×  ',
-    'skipped'  => '  ↺  ',
-    'passed'   => '  ✔  ',
-    'unknown'  => '  ?  ',
-    'empty'    => '     ',
-    'small'    => '   ',
+    "critical" => "  ×  ",
+    "major"    => "  ∅  ",
+    "minor"    => "  ⊚  ",
+    "failed"   => "  ×  ",
+    "skipped"  => "  ↺  ",
+    "passed"   => "  ✔  ",
+    "unknown"  => "  ?  ",
+    "empty"    => "     ",
+    "small"    => "   ",
   }.freeze
 
   MULTI_TEST_CONTROL_SUMMARY_MAX_LEN = 60
@@ -304,7 +303,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     # to change to know we are done with a profile.
 
     if switching_to_new_profile?(control.profile)
-      output.puts ''
+      output.puts ""
       print_anonymous_examples_associated_with_last_profile
       clear_anonymous_examples_associated_with_last_profile
     end
@@ -333,7 +332,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     # when the profile has no controls or examples it will not have been printed.
     # then we want to ensure we print all the profiles
     print_last_control_with_examples unless last_control_is_anonymous?
-    output.puts ''
+    output.puts ""
     print_anonymous_examples_associated_with_last_profile
     print_profiles_without_examples
     print_profile_summary
@@ -403,7 +402,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     Array(anonymous_examples_within_this_profile).uniq.each do |control|
       print_anonymous_control(control)
     end
-    output.puts '' unless Array(anonymous_examples_within_this_profile).empty?
+    output.puts "" unless Array(anonymous_examples_within_this_profile).empty?
   end
 
   #
@@ -444,7 +443,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
   #
   def print_profile(profile)
     return if profile.nil? || profile[:already_printed]
-    output.puts ''
+    output.puts ""
 
     if profile[:name].nil?
       print_target
@@ -458,7 +457,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
       output.puts "Profile: #{profile[:title]} (#{profile[:name] || 'unknown'})"
     end
 
-    output.puts 'Version: ' + (profile[:version] || 'unknown')
+    output.puts "Version: " + (profile[:version] || "unknown")
     print_target
     profile[:already_printed] = true
   end
@@ -467,10 +466,10 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     profiles_info.reject { |p| p[:already_printed] }.each do |profile|
       print_profile(profile)
       print_line(
-        color: '', indicator: INDICATORS['empty'], id: '', profile: '',
-        summary: 'No tests executed.'
+        color: "", indicator: INDICATORS["empty"], id: "", profile: "",
+        summary: "No tests executed."
       )
-      output.puts ''
+      output.puts ""
     end
   end
 
@@ -481,7 +480,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     return if @backend.nil?
     connection = @backend.backend
     return unless connection.respond_to?(:uri)
-    output.puts('Target:  ' + connection.uri + "\n\n")
+    output.puts("Target:  " + connection.uri + "\n\n")
   end
 
   #
@@ -489,9 +488,9 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
   #
   def print_control(control)
     print_line(
-      color:      COLORS[control.summary_indicator] || '',
-      indicator:  INDICATORS[control.summary_indicator] || INDICATORS['unknown'],
-      summary:    format_lines(control.summary, INDICATORS['empty']),
+      color:      COLORS[control.summary_indicator] || "",
+      indicator:  INDICATORS[control.summary_indicator] || INDICATORS["unknown"],
+      summary:    format_lines(control.summary, INDICATORS["empty"]),
       id:         "#{control.id}: ",
       profile:    control.profile_id,
     )
@@ -501,7 +500,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     test_status = result[:status_type]
     test_color = COLORS[test_status]
     indicator = INDICATORS[result[:status]]
-    indicator = INDICATORS['empty'] if indicator.nil?
+    indicator = INDICATORS["empty"] if indicator.nil?
     if result[:message]
       msg = result[:code_desc] + "\n" + result[:message]
     else
@@ -509,33 +508,33 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     end
     print_line(
       color:      test_color,
-      indicator:  INDICATORS['small'] + indicator,
-      summary:    format_lines(msg, INDICATORS['empty']),
+      indicator:  INDICATORS["small"] + indicator,
+      summary:    format_lines(msg, INDICATORS["empty"]),
       id: nil, profile: nil
     )
   end
 
   def print_anonymous_control(control)
     control_result = control[:results]
-    title = control_result[0][:code_desc].split[0..1].join(' ')
-    puts '  ' + title
+    title = control_result[0][:code_desc].split[0..1].join(" ")
+    puts "  " + title
     # iterate over all describe blocks in anonoymous control block
     control_result.each do |test|
-      control_id = ''
+      control_id = ""
       # display exceptions
       unless test[:exception].nil?
         test_result = test[:message]
       else
         # determine title
-        test_result = test[:skip_message] || test[:code_desc].split[2..-1].join(' ')
+        test_result = test[:skip_message] || test[:code_desc].split[2..-1].join(" ")
         # show error message
         test_result += "\n" + test[:message] unless test[:message].nil?
       end
       status_indicator = test[:status_type]
       print_line(
-        color:      COLORS[status_indicator] || '',
-        indicator:  INDICATORS['small'] + INDICATORS[status_indicator] || INDICATORS['unknown'],
-        summary:    format_lines(test_result, INDICATORS['empty']),
+        color:      COLORS[status_indicator] || "",
+        indicator:  INDICATORS["small"] + INDICATORS[status_indicator] || INDICATORS["unknown"],
+        summary:    format_lines(test_result, INDICATORS["empty"]),
         id:         control_id,
         profile:    control[:profile_id],
       )
@@ -545,30 +544,30 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
   def print_profile_summary
     summary = profile_summary
 
-    s = format('Profile Summary: %s%d successful%s, %s%d failures%s, %s%d skipped%s',
-               COLORS['passed'], summary['passed'], COLORS['reset'],
-               COLORS['failed'], summary['failed']['total'], COLORS['reset'],
-               COLORS['skipped'], summary['skipped'], COLORS['reset'])
-    output.puts(s) if summary['total'] > 0
+    s = format("Profile Summary: %s%d successful%s, %s%d failures%s, %s%d skipped%s",
+               COLORS["passed"], summary["passed"], COLORS["reset"],
+               COLORS["failed"], summary["failed"]["total"], COLORS["reset"],
+               COLORS["skipped"], summary["skipped"], COLORS["reset"])
+    output.puts(s) if summary["total"] > 0
   end
 
   def print_tests_summary
     summary = tests_summary
 
-    s = format('Test Summary: %s%d successful%s, %s%d failures%s, %s%d skipped%s',
-               COLORS['passed'], summary['passed'], COLORS['reset'],
-               COLORS['failed'], summary['failed'], COLORS['reset'],
-               COLORS['skipped'], summary['skipped'], COLORS['reset'])
+    s = format("Test Summary: %s%d successful%s, %s%d failures%s, %s%d skipped%s",
+               COLORS["passed"], summary["passed"], COLORS["reset"],
+               COLORS["failed"], summary["failed"], COLORS["reset"],
+               COLORS["skipped"], summary["skipped"], COLORS["reset"])
     output.puts(s)
   end
 
   # Formats the line (called from print_line)
   def format_line(fields)
-    format = '%color%indicator%id%summary'
+    format = "%color%indicator%id%summary"
     format.gsub(/%\w+/) do |x|
       term = x[1..-1]
       fields.key?(term.to_sym) ? fields[term.to_sym].to_s : x
-    end + COLORS['reset']
+    end + COLORS["reset"]
   end
 
   # Prints line; used to print results
@@ -589,13 +588,13 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     include Comparable
 
     STATUS_TYPES = {
-      'unknown'  => -3,
-      'passed'   => -2,
-      'skipped'  => -1,
-      'minor'    => 1,
-      'major'    => 2,
-      'failed'   => 2.5,
-      'critical' => 3,
+      "unknown"  => -3,
+      "passed"   => -2,
+      "skipped"  => -1,
+      "minor"    => 1,
+      "major"    => 2,
+      "failed"   => 2.5,
+      "critical" => 3,
     }.freeze
 
     def initialize(control, profile)
@@ -613,7 +612,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     end
 
     def anonymous?
-      control[:id].to_s.start_with? '(generated from '
+      control[:id].to_s.start_with? "(generated from "
     end
 
     def profile_id
@@ -655,13 +654,13 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
       elsif examples.empty?
         # Empty control block - if it's anonymous, there's nothing we can do.
         # Is this case even possible?
-        'Empty anonymous control'
+        "Empty anonymous control"
       else
         # Multiple tests - but no title. Do our best and generate some form of
         # identifier or label or name.
-        title = (examples.map { |example| example[:code_desc] }).join('; ')
+        title = (examples.map { |example| example[:code_desc] }).join("; ")
         max_len = MULTI_TEST_CONTROL_SUMMARY_MAX_LEN
-        title = title[0..(max_len-1)] + '...' if title.length > max_len
+        title = title[0..(max_len-1)] + "..." if title.length > max_len
         title
       end
     end
@@ -678,10 +677,10 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
           [
             !fails.empty? ? "#{fails.uniq.length} failed" : nil,
             !skips.empty? ? "#{skips.uniq.length} skipped" : nil,
-          ].compact.join(' ')
+          ].compact.join(" ")
         end
 
-      suffix == '' ? title : title + ' (' + suffix + ')'
+      suffix == "" ? title : title + " (" + suffix + ")"
     end
 
     # We are interested in comparing controls against other controls. It is
@@ -715,7 +714,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     end
 
     def calculate_summary!
-      @summary_status = STATUS_TYPES['unknown']
+      @summary_status = STATUS_TYPES["unknown"]
       @skips = []
       @fails = []
       @passes = []
@@ -727,8 +726,8 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
       example_status = STATUS_TYPES[example[:status_type]]
       @summary_status = example_status if example_status > @summary_status
       fails.push(example) if example_status > 0
-      passes.push(example) if example_status == STATUS_TYPES['passed']
-      skips.push(example) if example_status == STATUS_TYPES['skipped']
+      passes.push(example) if example_status == STATUS_TYPES["passed"]
+      skips.push(example) if example_status == STATUS_TYPES["skipped"]
     end
 
     # Determines 'status_type' (critical, major, minor) of control given
@@ -736,13 +735,13 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     # Called from format_example, sets the 'status_type' for each 'example'
     def status_type(example)
       status = example[:status]
-      return status if status != 'failed' || control[:impact].nil?
+      return status if status != "failed" || control[:impact].nil?
       if control[:impact] >= 0.7
-        'critical'
+        "critical"
       elsif control[:impact] >= 0.4
-        'major'
+        "major"
       else
-        'minor'
+        "minor"
       end
     end
   end

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -1,12 +1,11 @@
-# encoding: utf-8
 # copyright: 2015, Dominik Richter
 # license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'method_source'
-require 'inspec/describe'
-require 'inspec/expect'
+require "method_source"
+require "inspec/describe"
+require "inspec/expect"
 
 module Inspec
   class Rule # rubocop:disable Metrics/ClassLength
@@ -124,13 +123,13 @@ module Inspec
           include dsl
         end.new(method(:__add_check))
       else
-        __add_check('describe', values, with_dsl(block))
+        __add_check("describe", values, with_dsl(block))
       end
     end
 
     def expect(value, &block)
       target = Inspec::Expect.new(value, &with_dsl(block))
-      __add_check('expect', [value], target)
+      __add_check("expect", [value], target)
       target
     end
 
@@ -165,13 +164,13 @@ module Inspec
     def self.prepare_checks(rule)
       msg = skip_status(rule)
       return checks(rule) unless msg
-      msg = 'Skipped control due to only_if condition.' if msg == true
+      msg = "Skipped control due to only_if condition." if msg == true
 
       # TODO: we use os as the carrier here, but should consider
       # a separate resource to do skipping
       resource = rule.os
       resource.skip_resource(msg)
-      [['describe', [resource], nil]]
+      [["describe", [resource], nil]]
     end
 
     def self.merge(dst, src)
@@ -237,18 +236,18 @@ module Inspec
     # @param [String] text string which needs to be unindented
     # @return [String] input with indentation removed
     def unindent(text)
-      return '' if text.nil?
+      return "" if text.nil?
       text.strip.split("\n").map(&:strip)
           .map { |x| x.empty? ? "\n" : x }
-          .join(' ')
+          .join(" ")
     end
 
     # get the rule's source code
     def __get_block_source(&block)
-      return '' unless block_given?
+      return "" unless block_given?
       block.source.to_s
     rescue MethodSource::SourceNotFoundError
-      ''
+      ""
     end
 
     # get the source location of the block

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -1,17 +1,16 @@
-# encoding: utf-8
 # copyright: 2015, Dominik Richter
 # license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'forwardable'
-require 'uri'
-require 'inspec/backend'
-require 'inspec/profile_context'
-require 'inspec/profile'
-require 'inspec/metadata'
-require 'inspec/secrets'
-require 'inspec/dependencies/cache'
+require "forwardable"
+require "uri"
+require "inspec/backend"
+require "inspec/profile_context"
+require "inspec/profile"
+require "inspec/metadata"
+require "inspec/secrets"
+require "inspec/dependencies/cache"
 # spec requirements
 
 module Inspec
@@ -45,7 +44,7 @@ module Inspec
       @create_lockfile = @conf[:create_lockfile]
       @cache = Inspec::Cache.new(@conf[:cache])
       @test_collector = @conf.delete(:test_collector) || begin
-        require 'inspec/runner_rspec'
+        require "inspec/runner_rspec"
         RunnerRspec.new(@conf)
       end
 
@@ -166,7 +165,7 @@ module Inspec
                                            backend: @backend,
                                            controls: @controls,
                                            attributes: @conf[:attributes])
-      fail "Could not resolve #{target} to valid input." if profile.nil?
+      raise "Could not resolve #{target} to valid input." if profile.nil?
       @target_profiles << profile if supports_profile?(profile)
     end
 
@@ -174,13 +173,13 @@ module Inspec
       return true if @ignore_supports
 
       if !profile.supports_runtime?
-        fail 'This profile requires InSpec version '\
+        raise "This profile requires InSpec version "\
              "#{profile.metadata.inspec_requirement}. You are running "\
              "InSpec v#{Inspec::VERSION}.\n"
       end
 
       if !profile.supports_os?
-        fail "This OS/platform (#{@backend.os[:name]}) is not supported by this profile."
+        raise "This OS/platform (#{@backend.os[:name]}) is not supported by this profile."
       end
 
       true
@@ -204,8 +203,8 @@ module Inspec
     end
 
     def eval_with_virtual_profile(command)
-      require 'fetchers/mock'
-      add_target({ 'inspec.yml' => 'name: inspec-shell' })
+      require "fetchers/mock"
+      add_target({ "inspec.yml" => "name: inspec-shell" })
       our_profile = @target_profiles.first
       ctx = our_profile.runner_context
       ctx.load(command)
@@ -217,8 +216,8 @@ module Inspec
       return {} if block.nil? || !block.respond_to?(:source_location)
       opts = {}
       file_path, line = block.source_location
-      opts['file_path'] = file_path
-      opts['line_number'] = line
+      opts["file_path"] = file_path
+      opts["line_number"] = line
       opts
     end
 
@@ -226,19 +225,19 @@ module Inspec
       opts = block_source_info(block)
 
       if !arg.empty? &&
-         arg[0].respond_to?(:resource_skipped) &&
-         !arg[0].resource_skipped.nil?
+          arg[0].respond_to?(:resource_skipped) &&
+          !arg[0].resource_skipped.nil?
         return @test_collector.example_group(*arg, opts) do
           it arg[0].resource_skipped
         end
       else
         # add the resource
         case method_name
-        when 'describe'
+        when "describe"
           return @test_collector.example_group(*arg, opts, &block)
-        when 'expect'
+        when "expect"
           return block.example_group
-        when 'describe.one'
+        when "describe.one"
           tests = arg.map do |x|
             @test_collector.example_group(x[1][0], block_source_info(x[2]), &x[2])
           end
@@ -249,7 +248,7 @@ module Inspec
           # otherwise return all working tests
           return ok_tests
         else
-          fail "A rule was registered with #{method_name.inspect}, "\
+          raise "A rule was registered with #{method_name.inspect}, "\
                "which isn't understood and cannot be processed."
         end
       end

--- a/lib/inspec/runner_mock.rb
+++ b/lib/inspec/runner_mock.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
@@ -35,7 +34,7 @@ module Inspec
     end
 
     def run(_with = nil)
-      puts 'uhm.... nothing or something... dunno, ask your admin'
+      puts "uhm.... nothing or something... dunno, ask your admin"
     end
   end
 end

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -1,10 +1,9 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'rspec/core'
-require 'rspec/its'
-require 'inspec/rspec_json_formatter'
+require "rspec/core"
+require "rspec/its"
+require "inspec/rspec_json_formatter"
 
 # There be dragons!! Or borgs, or something...
 # This file and all its contents cannot be unit-tested. both test-suits
@@ -99,28 +98,28 @@ module Inspec
     private
 
     FORMATTERS = {
-      'json-min' => 'InspecRspecMiniJson',
-      'json' => 'InspecRspecJson',
-      'json-rspec' => 'InspecRspecVanilla',
-      'cli' => 'InspecRspecCli',
-      'junit' => 'InspecRspecJUnit',
+      "json-min" => "InspecRspecMiniJson",
+      "json" => "InspecRspecJson",
+      "json-rspec" => "InspecRspecVanilla",
+      "cli" => "InspecRspecCli",
+      "junit" => "InspecRspecJUnit",
     }.freeze
 
     # Configure the output formatter and stream to be used with RSpec.
     #
     # @return [nil]
     def configure_output
-      if !@conf['output'] || @conf['output'] == '-'
+      if !@conf["output"] || @conf["output"] == "-"
         RSpec.configuration.output_stream = $stdout
       else
-        RSpec.configuration.output_stream = @conf['output']
+        RSpec.configuration.output_stream = @conf["output"]
       end
 
-      format = FORMATTERS[@conf['format']] || @conf['format'] || FORMATTERS['cli']
+      format = FORMATTERS[@conf["format"]] || @conf["format"] || FORMATTERS["cli"]
       @formatter = RSpec.configuration.add_formatter(format)
-      RSpec.configuration.color = @conf['color']
+      RSpec.configuration.color = @conf["color"]
 
-      setup_reporting if @conf['report']
+      setup_reporting if @conf["report"]
     end
 
     def setup_reporting

--- a/lib/inspec/secrets.rb
+++ b/lib/inspec/secrets.rb
@@ -1,19 +1,18 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'inspec/plugins'
-require 'utils/plugin_registry'
+require "inspec/plugins"
+require "utils/plugin_registry"
 
 module Inspec
   SecretsBackend = PluginRegistry.new
 
   def self.secrets(version)
     if version != 1
-      fail 'Only secrets version 1 is supported!'
+      raise "Only secrets version 1 is supported!"
     end
     Inspec::Plugins::Secret
   end
 end
 
-require 'inspec/secrets/yaml'
+require "inspec/secrets/yaml"

--- a/lib/inspec/secrets/yaml.rb
+++ b/lib/inspec/secrets/yaml.rb
@@ -1,15 +1,13 @@
-# encoding: utf-8
-
-require 'yaml'
+require "yaml"
 
 module Secrets
   class YAML < Inspec.secrets(1)
-    name 'yaml'
+    name "yaml"
 
     attr_reader :attributes
 
     def self.resolve(target)
-      unless target.is_a?(String) && File.file?(target) && target.end_with?('.yml')
+      unless target.is_a?(String) && File.file?(target) && target.end_with?(".yml")
         return nil
       end
       new(target)

--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -1,9 +1,8 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'rspec/core/formatters/base_text_formatter'
-require 'pry'
+require "rspec/core/formatters/base_text_formatter"
+require "pry"
 
 module Inspec
   # A pry based shell for inspec. Given a runner (with a configured backend and
@@ -20,7 +19,7 @@ module Inspec
       # context creates to evaluate each individual test file. We want to
       # pretend like we are constantly appending to the same file and want
       # to capture the local variable context from inside said class.
-      @ctx_binding = @runner.eval_with_virtual_profile('binding')
+      @ctx_binding = @runner.eval_with_virtual_profile("binding")
       configure_pry
       @ctx_binding.pry
     end
@@ -31,27 +30,27 @@ module Inspec
       that = self
 
       # Add the help command
-      Pry::Commands.block_command 'help', 'Show examples' do |resource|
+      Pry::Commands.block_command "help", "Show examples" do |resource|
         that.help(resource)
       end
 
       # configure pry shell prompt
-      Pry.config.prompt_name = 'inspec'
+      Pry.config.prompt_name = "inspec"
       Pry.prompt = [proc { "#{readline_ignore("\e[0;32m")}#{Pry.config.prompt_name}> #{readline_ignore("\e[0m")}" }]
 
       # Add a help menu as the default intro
-      Pry.hooks.add_hook(:before_session, 'inspec_intro') do
+      Pry.hooks.add_hook(:before_session, "inspec_intro") do
         intro
       end
 
       # Track the rules currently registered and what their merge count is.
-      Pry.hooks.add_hook(:before_eval, 'inspec_before_eval') do
+      Pry.hooks.add_hook(:before_eval, "inspec_before_eval") do
         @runner.reset
       end
 
       # After pry has evaluated a commanding within the binding context of a
       # test file, register all the rules it discovered.
-      Pry.hooks.add_hook(:after_eval, 'inspec_after_eval') do
+      Pry.hooks.add_hook(:after_eval, "inspec_after_eval") do
         @runner.load
         @runner.run_tests if !@runner.all_rules.empty?
       end
@@ -89,7 +88,7 @@ module Inspec
     end
 
     def intro
-      puts 'Welcome to the interactive InSpec Shell'
+      puts "Welcome to the interactive InSpec Shell"
       puts "To find out how to use it, type: #{mark 'help'}"
       puts
     end
@@ -119,7 +118,7 @@ You are currently running on:
     OS release: #{mark ctx.os[:release] || 'unknown'}
 
 EOF
-      elsif resource == 'resources'
+      elsif resource == "resources"
         resources
       elsif !Inspec::Resource.registry[resource].nil?
         puts <<EOF
@@ -138,13 +137,13 @@ https://github.com/chef/inspec/blob/master/docs/resources.rst##{resource}
 
 EOF
       else
-        puts 'Only the following resources are available:'
+        puts "Only the following resources are available:"
         resources
       end
     end
 
     def resources
-      puts Inspec::Resource.registry.keys.join(' ')
+      puts Inspec::Resource.registry.keys.join(" ")
     end
   end
 end

--- a/lib/inspec/shell_detector.rb
+++ b/lib/inspec/shell_detector.rb
@@ -1,6 +1,5 @@
-# encoding: utf-8
-require 'etc'
-require 'rbconfig'
+require "etc"
+require "rbconfig"
 
 module Inspec
   #
@@ -36,7 +35,7 @@ module Inspec
 
     def detect
       # Most of our detection code assumes a unix-like environment
-      return nil if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+      return nil if RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
 
       shellpath = detect_by_ppid
 
@@ -57,7 +56,7 @@ module Inspec
 
     def detect_by_ppid
       ppid = Process.ppid
-      if Dir.exist?('/proc')
+      if Dir.exist?("/proc")
         File.readlink("/proc/#{ppid}/exe")
       else
         `ps -cp #{ppid} -o command=`.chomp
@@ -65,7 +64,7 @@ module Inspec
     end
 
     def detect_by_env
-      ENV['SHELL']
+      ENV["SHELL"]
     end
 
     def detect_by_getpwuid
@@ -76,7 +75,7 @@ module Inspec
     # Strip any leading path elements
     #
     def shellname(shellpath)
-      shellpath.split('/').last
+      shellpath.split("/").last
     end
 
     #

--- a/lib/inspec/source_reader.rb
+++ b/lib/inspec/source_reader.rb
@@ -1,9 +1,8 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'inspec/plugins'
-require 'utils/plugin_registry'
+require "inspec/plugins"
+require "utils/plugin_registry"
 
 module Inspec
   # Pre-checking of target resolution. Make sure that SourceReader plugins
@@ -19,11 +18,11 @@ module Inspec
 
   def self.source_reader(version)
     if version != 1
-      fail 'Only source readers version 1 is supported!'
+      raise "Only source readers version 1 is supported!"
     end
     Inspec::Plugins::SourceReader
   end
 end
 
-require 'source_readers/inspec'
-require 'source_readers/flat'
+require "source_readers/inspec"
+require "source_readers/flat"

--- a/lib/inspec/version.rb
+++ b/lib/inspec/version.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # frozen_string_literal: true
 # author: Dominik Richter
 # author: Christoph Hartmann
 
 module Inspec
-  VERSION = '1.13.0'.freeze
+  VERSION = "1.13.0".freeze
 end

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
@@ -18,7 +17,7 @@ RSpec::Matchers.define :be_readable do
   end
 
   description do
-    res = 'be readable'
+    res = "be readable"
     res += " by #{@by}" unless @by.nil?
     res += " by user #{@by_user}" unless @by_user.nil?
     res
@@ -39,7 +38,7 @@ RSpec::Matchers.define :be_writable do
   end
 
   description do
-    res = 'be writable'
+    res = "be writable"
     res += " by #{@by}" unless @by.nil?
     res += " by user #{@by_user}" unless @by_user.nil?
     res
@@ -60,7 +59,7 @@ RSpec::Matchers.define :be_executable do
   end
 
   description do
-    res = 'be executable'
+    res = "be executable"
     res += " by #{@by}" unless @by.nil?
     res += " by user #{@by_user}" unless @by_user.nil?
     res
@@ -78,7 +77,7 @@ end
 # verifies that no entry in an array contains a value
 RSpec::Matchers.define :contain_match do |regex|
   match do |arr|
-    warn '[DEPRECATION] `contain_match` is deprecated and will be removed for InSpec 1.0. See https://github.com/chef/inspec/issues/738 for more details'
+    warn "[DEPRECATION] `contain_match` is deprecated and will be removed for InSpec 1.0. See https://github.com/chef/inspec/issues/738 for more details"
     arr.inject { |result, i|
       result = i.match(regex)
       result || i.match(/$/)
@@ -88,7 +87,7 @@ end
 
 RSpec::Matchers.define :contain_duplicates do
   match do |arr|
-    warn '[DEPRECATION] `contain_duplicates` is deprecated and will be removed for InSpec 1.0. See https://github.com/chef/inspec/issues/738 for more details'
+    warn "[DEPRECATION] `contain_duplicates` is deprecated and will be removed for InSpec 1.0. See https://github.com/chef/inspec/issues/738 for more details"
     dup = arr.select { |element| arr.count(element) > 1 }
     !dup.uniq.empty?
   end
@@ -105,7 +104,7 @@ RSpec::Matchers.define :be_installed do
   end
 
   chain :by do
-    fail "[UNSUPPORTED] Please use the new resources 'gem', 'npm' or 'pip'."
+    raise "[UNSUPPORTED] Please use the new resources 'gem', 'npm' or 'pip'."
   end
 
   chain :with_version do |version|
@@ -121,7 +120,7 @@ RSpec::Matchers.define :be_enabled do
   end
 
   chain :with_level do |_level|
-    fail '[UNSUPPORTED] with level is not supported'
+    raise "[UNSUPPORTED] with level is not supported"
   end
 
   failure_message do |service|
@@ -137,7 +136,7 @@ RSpec::Matchers.define :be_running do
   end
 
   chain :under do |_under|
-    fail '[UNSUPPORTED] under is not supported'
+    raise "[UNSUPPORTED] under is not supported"
   end
 
   failure_message do |service|
@@ -178,7 +177,7 @@ RSpec::Matchers.define :be_reachable do
   end
 
   chain :with do |_attr|
-    fail '[UNSUPPORTED] `with` is not supported in combination with `be_reachable`'
+    raise "[UNSUPPORTED] `with` is not supported in combination with `be_reachable`"
   end
 
   failure_message do |host|
@@ -193,7 +192,7 @@ RSpec::Matchers.define :be_resolvable do
   end
 
   chain :by do |_type|
-    fail "[UNSUPPORTED] `by` is not supported in combination with `be_resolvable`. Please use the following syntax `host('example.com', port: 53, proto: 'udp')`."
+    raise "[UNSUPPORTED] `by` is not supported in combination with `be_resolvable`. Please use the following syntax `host('example.com', port: 53, proto: 'udp')`."
   end
 
   failure_message do |host|
@@ -208,11 +207,11 @@ RSpec::Matchers.define :have_rule do |rule|
   end
 
   chain :with_table do |_table|
-    fail "[UNSUPPORTED] `with_table` is not supported in combination with `have_rule`. Please use the following syntax `iptables(table:'mangle', chain: 'input')`."
+    raise "[UNSUPPORTED] `with_table` is not supported in combination with `have_rule`. Please use the following syntax `iptables(table:'mangle', chain: 'input')`."
   end
 
   chain :with_chain do |_chain|
-    fail "[UNSUPPORTED] `with_table` is not supported in combination with `with_chain`. Please use the following syntax `iptables(table:'mangle', chain: 'input')`."
+    raise "[UNSUPPORTED] `with_table` is not supported in combination with `with_chain`. Please use the following syntax `iptables(table:'mangle', chain: 'input')`."
   end
 end
 
@@ -261,7 +260,7 @@ RSpec::Matchers.define :cmp do |first_expected|
 
   # expects that the values have been checked with boolean?
   def to_boolean(value)
-    value.casecmp('true') == 0
+    value.casecmp("true") == 0
   end
 
   def try_match(actual, op, expected) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
@@ -309,18 +308,18 @@ RSpec::Matchers.define :cmp do |first_expected|
   end
 
   def format_expectation(negate)
-    return 'expected: '+@expected.inspect if @operation == :== && !negate
-    negate_str = negate ? 'not ' : ''
+    return "expected: "+@expected.inspect if @operation == :== && !negate
+    negate_str = negate ? "not " : ""
     "expected it #{negate_str}to be #{@operation} #{@expected.inspect}"
   end
 
   failure_message do |actual|
-    actual = ('0' + actual.to_s(8)).inspect if octal?(@expected)
+    actual = ("0" + actual.to_s(8)).inspect if octal?(@expected)
     "\n" + format_expectation(false) + "\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
   end
 
   failure_message_when_negated do |actual|
-    actual = ('0' + actual.to_s(8)).inspect if octal?(@expected)
+    actual = ("0" + actual.to_s(8)).inspect if octal?(@expected)
     "\n" + format_expectation(true) + "\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
   end
 

--- a/lib/resources/apache.rb
+++ b/lib/resources/apache.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
@@ -6,25 +5,25 @@
 
 module Inspec::Resources
   class Apache < Inspec.resource(1)
-    name 'apache'
+    name "apache"
 
     attr_reader :service, :conf_dir, :conf_path, :user
     def initialize
       if inspec.os.debian?
-        @service = 'apache2'
-        @conf_dir = '/etc/apache2/'
-        @conf_path = File.join @conf_dir, 'apache2.conf'
-        @user = 'www-data'
+        @service = "apache2"
+        @conf_dir = "/etc/apache2/"
+        @conf_path = File.join @conf_dir, "apache2.conf"
+        @user = "www-data"
       else
-        @service = 'httpd'
-        @conf_dir = '/etc/httpd/'
-        @conf_path = File.join @conf_dir, '/conf/httpd.conf'
-        @user = 'apache'
+        @service = "httpd"
+        @conf_dir = "/etc/httpd/"
+        @conf_path = File.join @conf_dir, "/conf/httpd.conf"
+        @user = "apache"
       end
     end
 
     def to_s
-      'Apache Environment'
+      "Apache Environment"
     end
   end
 end

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -1,16 +1,15 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
 # license: All rights reserved
 
-require 'utils/simpleconfig'
-require 'utils/find_files'
+require "utils/simpleconfig"
+require "utils/find_files"
 
 module Inspec::Resources
   class ApacheConf < Inspec.resource(1)
-    name 'apache_conf'
-    desc 'Use the apache_conf InSpec audit resource to test the configuration settings for Apache. This file is typically located under /etc/apache2 on the Debian and Ubuntu platforms and under /etc/httpd on the Fedora, CentOS, Red Hat Enterprise Linux, and Arch Linux platforms. The configuration settings may vary significantly from platform to platform.'
+    name "apache_conf"
+    desc "Use the apache_conf InSpec audit resource to test the configuration settings for Apache. This file is typically located under /etc/apache2 on the Debian and Ubuntu platforms and under /etc/httpd on the Fedora, CentOS, Red Hat Enterprise Linux, and Arch Linux platforms. The configuration settings may vary significantly from platform to platform."
     example "
       describe apache_conf do
         its('setting_name') { should eq 'value' }
@@ -50,7 +49,7 @@ module Inspec::Resources
     end
 
     def filter_comments(data)
-      content = ''
+      content = ""
       data.each_line do |line|
         if !line.match(/^\s*#/)
           content << line
@@ -60,7 +59,7 @@ module Inspec::Resources
     end
 
     def read_content
-      @content = ''
+      @content = ""
       @params = {}
 
       # skip if the main configuration file doesn't exist
@@ -100,13 +99,13 @@ module Inspec::Resources
 
     def include_files(params)
       # see if there is more config files to include
-      include_files = params['Include'] || []
-      include_files_optional = params['IncludeOptional'] || []
+      include_files = params["Include"] || []
+      include_files_optional = params["IncludeOptional"] || []
 
       includes = []
       (include_files + include_files_optional).each do |f|
         id    = Pathname.new(f).absolute? ? f : File.join(@conf_dir, f)
-        files = find_files(id, depth: 1, type: 'file')
+        files = find_files(id, depth: 1, type: "file")
 
         includes.push(files) if files
       end

--- a/lib/resources/apt.rb
+++ b/lib/resources/apt.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -26,12 +25,12 @@
 # apt-get install software-properties-common
 # add-apt-repository ppa:ubuntu-wine/ppa
 
-require 'uri'
+require "uri"
 
 module Inspec::Resources
   class AptRepository < Inspec.resource(1)
-    name 'apt'
-    desc 'Use the apt InSpec audit resource to verify Apt repositories on the Debian and Ubuntu platforms, and also PPA repositories on the Ubuntu platform.'
+    name "apt"
+    desc "Use the apt InSpec audit resource to verify Apt repositories on the Debian and Ubuntu platforms, and also PPA repositories on the Ubuntu platform."
     example "
       describe apt('nginx/stable') do
         it { should exist }
@@ -46,7 +45,7 @@ module Inspec::Resources
         @deb_url = determine_ppa_url(ppa_name)
       else
         # this resource is only supported on ubuntu and debian
-        skip_resource 'The `apt` resource is not supported on your OS yet.'
+        skip_resource "The `apt` resource is not supported on your OS yet."
       end
     end
 
@@ -68,7 +67,7 @@ module Inspec::Resources
     private
 
     def find_repo
-      read_debs.select { |repo| repo[:url] == @deb_url && repo[:type] == 'deb' }
+      read_debs.select { |repo| repo[:url] == @deb_url && repo[:type] == "deb" }
     end
 
     HTTP_URL_RE = /\A#{URI::DEFAULT_PARSER.make_regexp(%w{http https})}\z/
@@ -85,7 +84,7 @@ module Inspec::Resources
         active = true
 
         # detect if the repo is commented out
-        line = raw_line.gsub(/^(#\s*)*/, '')
+        line = raw_line.gsub(/^(#\s*)*/, "")
         active = false if raw_line != line
 
         # eg.: deb http://archive.ubuntu.com/ubuntu/ wily main restricted
@@ -100,10 +99,10 @@ module Inspec::Resources
           type: parse_repo[1],
           url: parse_repo[2],
           distro: parse_repo[3],
-          components: parse_repo[4].chomp.split(' '),
+          components: parse_repo[4].chomp.split(" "),
           active: active,
         }
-        next unless ['deb', 'deb-src'].include? repo[:type]
+        next unless ["deb", "deb-src"].include? repo[:type]
 
         lines.push(repo)
       end
@@ -117,21 +116,21 @@ module Inspec::Resources
       # otherwise start generating the ppa url
 
       # special care if the name stats with :
-      ppa_url = ppa_url.split(':')[1] if ppa_url.start_with?('ppa:')
+      ppa_url = ppa_url.split(":")[1] if ppa_url.start_with?("ppa:")
 
       # parse ppa owner and repo
-      ppa_owner, ppa_repo = ppa_url.split('/')
-      ppa_repo = 'ppa' if ppa_repo.nil?
+      ppa_owner, ppa_repo = ppa_url.split("/")
+      ppa_repo = "ppa" if ppa_repo.nil?
 
       # construct new ppa url and return it
-      format('http://ppa.launchpad.net/%s/%s/ubuntu', ppa_owner, ppa_repo)
+      format("http://ppa.launchpad.net/%s/%s/ubuntu", ppa_owner, ppa_repo)
     end
   end
 
   # for compatability with serverspec
   # this is deprecated syntax and will be removed in future versions
   class PpaRepository < AptRepository
-    name 'ppa'
+    name "ppa"
 
     def exists?
       deprecated
@@ -144,7 +143,7 @@ module Inspec::Resources
     end
 
     def deprecated
-      warn '[DEPRECATION] `ppa(reponame)` is deprecated.  Please use `apt(reponame)` instead.'
+      warn "[DEPRECATION] `ppa(reponame)` is deprecated.  Please use `apt(reponame)` instead."
     end
   end
 end

--- a/lib/resources/audit_policy.rb
+++ b/lib/resources/audit_policy.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
@@ -26,8 +25,8 @@
 
 module Inspec::Resources
   class AuditPolicy < Inspec.resource(1)
-    name 'audit_policy'
-    desc 'Use the audit_policy InSpec audit resource to test auditing policies on the Microsoft Windows platform. An auditing policy is a category of security-related events to be audited. Auditing is disabled by default and may be enabled for categories like account management, logon events, policy changes, process tracking, privilege use, system events, or object access. For each auditing category property that is enabled, the auditing level may be set to No Auditing, Not Specified, Success, Success and Failure, or Failure.'
+    name "audit_policy"
+    desc "Use the audit_policy InSpec audit resource to test auditing policies on the Microsoft Windows platform. An auditing policy is a category of security-related events to be audited. Auditing is disabled by default and may be enabled for categories like account management, logon events, policy changes, process tracking, privilege use, system events, or object access. For each auditing category property that is enabled, the auditing level may be set to No Auditing, Not Specified, Success, Success and Failure, or Failure."
     example "
       describe audit_policy do
         its('parameter') { should eq 'value' }
@@ -44,7 +43,7 @@ module Inspec::Resources
 
       # find line
       target = nil
-      result.each_line {|s|
+      result.each_line { |s|
         target = s.strip if s =~ /\b.*#{key}.*\b/
       }
 
@@ -52,14 +51,14 @@ module Inspec::Resources
       values = nil
       unless target.nil?
         # split csv values and return value
-        values = target.split(',')[4]
+        values = target.split(",")[4]
       end
 
       values
     end
 
     def to_s
-      'Audit Policy'
+      "Audit Policy"
     end
   end
 end

--- a/lib/resources/auditd_conf.rb
+++ b/lib/resources/auditd_conf.rb
@@ -1,14 +1,13 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
 # license: All rights reserved
 
-require 'utils/simpleconfig'
+require "utils/simpleconfig"
 
 module Inspec::Resources
   class AuditDaemonConf < Inspec.resource(1)
-    name 'auditd_conf'
+    name "auditd_conf"
     desc "Use the auditd_conf InSpec audit resource to test the configuration settings for the audit daemon. This file is typically located under /etc/audit/auditd.conf' on UNIX and Linux platforms."
     example "
       describe auditd_conf do
@@ -17,7 +16,7 @@ module Inspec::Resources
     "
 
     def initialize(path = nil)
-      @conf_path = path || '/etc/audit/auditd.conf'
+      @conf_path = path || "/etc/audit/auditd.conf"
     end
 
     def method_missing(name)
@@ -25,7 +24,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'Audit Daemon Config'
+      "Audit Daemon Config"
     end
 
     private

--- a/lib/resources/auditd_rules.rb
+++ b/lib/resources/auditd_rules.rb
@@ -1,11 +1,10 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
 # license: All rights reserved
 
-require 'forwardable'
-require 'utils/filter_array'
+require "forwardable"
+require "utils/filter_array"
 
 module Inspec::Resources
   class AuditdRulesLegacy
@@ -30,10 +29,10 @@ module Inspec::Resources
         assignment_re: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
         multiple_values: false,
       }
-      @status_content ||= inspec.command('/sbin/auditctl -s').stdout.chomp
+      @status_content ||= inspec.command("/sbin/auditctl -s").stdout.chomp
       @status_params = SimpleConfig.new(@status_content, @status_opts).params
 
-      status = @status_params['AUDIT_STATUS']
+      status = @status_params["AUDIT_STATUS"]
       return nil if status.nil?
 
       items = Hash[status.scan(/([^=]+)=(\w*)\s*/)]
@@ -41,7 +40,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'Audit Daemon Rules (for auditd version < 2.3)'
+      "Audit Daemon Rules (for auditd version < 2.3)"
     end
   end
 
@@ -50,8 +49,8 @@ module Inspec::Resources
     extend Forwardable
     attr_accessor :rules, :lines
 
-    name 'auditd_rules'
-    desc 'Use the auditd_rules InSpec audit resource to test the rules for logging that exist on the system. The audit.rules file is typically located under /etc/audit/ and contains the list of rules that define what is captured in log files.'
+    name "auditd_rules"
+    desc "Use the auditd_rules InSpec audit resource to test the rules for logging that exist on the system. The audit.rules file is typically located under /etc/audit/ and contains the list of rules that define what is captured in log files."
     example "
       # syntax for auditd < 2.3
       describe auditd_rules do
@@ -76,12 +75,12 @@ module Inspec::Resources
     "
 
     def initialize
-      @content = inspec.command('/sbin/auditctl -l').stdout.chomp
+      @content = inspec.command("/sbin/auditctl -l").stdout.chomp
 
       if @content =~ /^LIST_RULES:/
         # do not warn on centos 5
-        unless inspec.os[:name] == 'centos' && inspec.os[:release].to_i == 5
-          warn '[WARN] this version of auditd is outdated. Updating it allows for using more precise matchers.'
+        unless inspec.os[:name] == "centos" && inspec.os[:release].to_i == 5
+          warn "[WARN] this version of auditd is outdated. Updating it allows for using more precise matchers."
         end
         @legacy = AuditdRulesLegacy.new(@content)
       else
@@ -93,13 +92,13 @@ module Inspec::Resources
     # rubocop:disable Style/MethodName
     def LIST_RULES
       return @legacy.LIST_RULES if @legacy
-      fail 'Using legacy auditd_rules LIST_RULES interface with non-legacy audit package. Please use the new syntax.'
+      raise "Using legacy auditd_rules LIST_RULES interface with non-legacy audit package. Please use the new syntax."
     end
 
     def status(name = nil)
       return @legacy.status(name) if @legacy
 
-      @status_content ||= inspec.command('/sbin/auditctl -s').stdout.chomp
+      @status_content ||= inspec.command("/sbin/auditctl -s").stdout.chomp
       @status_params ||= Hash[@status_content.scan(/^([^ ]+) (.*)$/)]
 
       return @status_params[name] if name
@@ -148,7 +147,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'Audit Daemon Rules'
+      "Audit Daemon Rules"
     end
 
     private
@@ -168,7 +167,7 @@ module Inspec::Resources
     end
 
     def get_syscalls(line)
-      line.scan(/-S ([^ ]+) /).flatten.first.split(',')
+      line.scan(/-S ([^ ]+) /).flatten.first.split(",")
     end
 
     def get_action_list(line)
@@ -191,11 +190,11 @@ module Inspec::Resources
     end
 
     def get_fields(line)
-      fields = line.gsub(/-[aS] [^ ]+ /, '').split('-F ').map { |l| l.split(' ') }.flatten
+      fields = line.gsub(/-[aS] [^ ]+ /, "").split("-F ").map { |l| l.split(" ") }.flatten
 
       opts = {}
       fields.find_all { |x| x.match(/[a-z]+=.*/) }.each do |kv|
-        k, v = kv.split('=')
+        k, v = kv.split("=")
         opts[k.to_sym] = v
       end
 

--- a/lib/resources/bash.rb
+++ b/lib/resources/bash.rb
@@ -1,14 +1,13 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'utils/command_wrapper'
-require 'resources/command'
+require "utils/command_wrapper"
+require "resources/command"
 
 module Inspec::Resources
   class Bash < Cmd
-    name 'bash'
-    desc 'Run a command or script in BASH.'
+    name "bash"
+    desc "Run a command or script in BASH."
     example "
       describe bash('ls -al /') do
         its('stdout') { should match /bin/ }
@@ -25,7 +24,7 @@ module Inspec::Resources
 
     def initialize(command, options = {})
       @raw_command = command
-      options[:shell] = 'bash' if options.is_a?(Hash)
+      options[:shell] = "bash" if options.is_a?(Hash)
       super(CommandWrapper.wrap(command, options))
     end
 

--- a/lib/resources/bond.rb
+++ b/lib/resources/bond.rb
@@ -1,12 +1,11 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'resources/file'
+require "resources/file"
 
 module Inspec::Resources
   class Bond < FileResource
-    name 'bond'
+    name "bond"
     desc 'Use the bond InSpec audit resource to test a logical, bonded network interface (i.e. "two or more network interfaces aggregated into a single, logical network interface"). On Linux platforms, any value in the /proc/net/bonding directory may be tested.'
     example "
       describe bond('bond0') do
@@ -51,11 +50,11 @@ module Inspec::Resources
     end
 
     def has_interface?(interface)
-      params['Slave Interface'].include?(interface)
+      params["Slave Interface"].include?(interface)
     end
 
     def interfaces
-      params['Slave Interface']
+      params["Slave Interface"]
     end
 
     def to_s

--- a/lib/resources/bridge.rb
+++ b/lib/resources/bridge.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -10,8 +9,8 @@
 
 module Inspec::Resources
   class Bridge < Inspec.resource(1)
-    name 'bridge'
-    desc 'Use the bridge InSpec audit resource to test basic network bridge properties, such as name, if an interface is defined, and the associations for any defined interface.'
+    name "bridge"
+    desc "Use the bridge InSpec audit resource to test basic network bridge properties, such as name, if an interface is defined, and the associations for any defined interface."
     example "
       describe bridge 'br0' do
         it { should exist }
@@ -28,7 +27,7 @@ module Inspec::Resources
       elsif inspec.os.windows?
         @bridge_provider = WindowsBridge.new(inspec)
       else
-        return skip_resource 'The `bridge` resource is not supported on your OS yet.'
+        return skip_resource "The `bridge` resource is not supported on your OS yet."
       end
     end
 
@@ -37,7 +36,7 @@ module Inspec::Resources
     end
 
     def has_interface?(interface)
-      return skip_resource 'The `bridge` resource does not provide interface detection for Windows yet' if inspec.os.windows?
+      return skip_resource "The `bridge` resource does not provide interface detection for Windows yet" if inspec.os.windows?
       bridge_info.nil? ? false : bridge_info[:interfaces].include?(interface)
     end
 
@@ -93,7 +92,7 @@ module Inspec::Resources
   class WindowsBridge < BridgeDetection
     def bridge_info(bridge_name)
       # find all bridge adapters
-      cmd = inspec.command('Get-NetAdapterBinding -ComponentID ms_bridge | Get-NetAdapter | Select-Object -Property Name, InterfaceDescription | ConvertTo-Json')
+      cmd = inspec.command("Get-NetAdapterBinding -ComponentID ms_bridge | Get-NetAdapter | Select-Object -Property Name, InterfaceDescription | ConvertTo-Json")
 
       # filter network interface
       begin
@@ -109,7 +108,7 @@ module Inspec::Resources
       bridges = bridges.each_with_object([]) do |adapter, adapter_collection|
         # map object
         info = {
-          name: adapter['Name'],
+          name: adapter["Name"],
           interfaces: nil,
         }
         adapter_collection.push(info) if info[:name].casecmp(bridge_name) == 0

--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
@@ -6,8 +5,8 @@
 
 module Inspec::Resources
   class Cmd < Inspec.resource(1)
-    name 'command'
-    desc 'Use the command InSpec audit resource to test an arbitrary command that is run on the system.'
+    name "command"
+    desc "Use the command InSpec audit resource to test an arbitrary command that is run on the system."
     example "
       describe command('ls -al /') do
         its('stdout') { should match /bin/ }
@@ -45,7 +44,7 @@ module Inspec::Resources
 
     def exist?
       # silent for mock resources
-      return false if inspec.os[:name].to_s == 'unknown'
+      return false if inspec.os[:name].to_s == "unknown"
 
       if inspec.os.linux?
         res = inspec.backend.run_command("bash -c 'type \"#{@command}\"'")

--- a/lib/resources/csv.rb
+++ b/lib/resources/csv.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -7,8 +6,8 @@
 # @see http://technicalpickles.com/posts/parsing-csv-with-ruby
 module Inspec::Resources
   class CsvConfig < JsonConfig
-    name 'csv'
-    desc 'Use the csv InSpec audit resource to test configuration data in a CSV file.'
+    name "csv"
+    desc "Use the csv InSpec audit resource to test configuration data in a CSV file."
     example "
       describe csv('example.csv') do
         its('name') { should eq(['John', 'Alice']) }
@@ -17,7 +16,7 @@ module Inspec::Resources
 
     # override file load and parse hash from csv
     def parse(content)
-      require 'csv'
+      require "csv"
       # convert empty field to nil
       CSV::Converters[:blank_to_nil] = lambda do |field|
         field && field.empty? ? nil : field

--- a/lib/resources/directory.rb
+++ b/lib/resources/directory.rb
@@ -1,13 +1,12 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'resources/file'
+require "resources/file"
 
 module Inspec::Resources
   class Directory < FileResource
-    name 'directory'
-    desc 'Use the directory InSpec audit resource to test if the file type is a directory. This is equivalent to using the file InSpec audit resource and the be_directory matcher, but provides a simpler and more direct way to test directories. All of the matchers available to file may be used with directory.'
+    name "directory"
+    desc "Use the directory InSpec audit resource to test if the file type is a directory. This is equivalent to using the file InSpec audit resource and the be_directory matcher, but provides a simpler and more direct way to test directories. All of the matchers available to file may be used with directory."
     example "
       describe directory('path') do
         it { should be_directory }

--- a/lib/resources/etc_group.rb
+++ b/lib/resources/etc_group.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
@@ -21,16 +20,16 @@
 #   its('users') { should include 'my_user' }
 # end
 
-require 'utils/convert'
-require 'utils/parser'
+require "utils/convert"
+require "utils/parser"
 
 module Inspec::Resources
   class EtcGroup < Inspec.resource(1)
     include Converter
     include CommentParser
 
-    name 'etc_group'
-    desc 'Use the etc_group InSpec audit resource to test groups that are defined on Linux and UNIX platforms. The /etc/group file stores details about each group---group name, password, group identifier, along with a comma-separate list of users that belong to the group.'
+    name "etc_group"
+    desc "Use the etc_group InSpec audit resource to test groups that are defined on Linux and UNIX platforms. The /etc/group file stores details about each group---group name, password, group identifier, along with a comma-separate list of users that belong to the group."
     example "
       describe etc_group do
         its('gids') { should_not contain_duplicates }
@@ -41,22 +40,22 @@ module Inspec::Resources
 
     attr_accessor :gid, :entries
     def initialize(path = nil)
-      @path = path || '/etc/group'
+      @path = path || "/etc/group"
       @entries = parse_group(@path)
 
       # skip resource if it is not supported on current OS
-      return skip_resource 'The `etc_group` resource is not supported on your OS.' \
+      return skip_resource "The `etc_group` resource is not supported on your OS." \
       unless inspec.os.unix?
     end
 
     def groups(filter = nil)
       entries = filter || @entries
-      entries.map { |x| x['name'] } if !entries.nil?
+      entries.map { |x| x["name"] } if !entries.nil?
     end
 
     def gids(filter = nil)
       entries = filter || @entries
-      entries.map { |x| x['gid'] } if !entries.nil?
+      entries.map { |x| x["gid"] } if !entries.nil?
     end
 
     def users(filter = nil)
@@ -64,7 +63,7 @@ module Inspec::Resources
       return nil if entries.nil?
       # filter the user entry
       res = entries.map { |x|
-        x['members'].split(',') if !x.nil? && !x['members'].nil?
+        x["members"].split(",") if !x.nil? && !x["members"].nil?
       }.flatten
       # filter nil elements
       res.reject { |x| x.nil? || x.empty? }
@@ -73,13 +72,13 @@ module Inspec::Resources
     def where(conditions = {})
       return if conditions.empty?
       fields = {
-        name: 'name',
-        group_name: 'name',
-        password: 'password',
-        gid: 'gid',
-        group_id: 'gid',
-        users: 'members',
-        members: 'members',
+        name: "name",
+        group_name: "name",
+        password: "password",
+        gid: "gid",
+        group_id: "gid",
+        users: "members",
+        members: "members",
       }
       res = entries
 
@@ -93,7 +92,7 @@ module Inspec::Resources
     end
 
     def to_s
-      '/etc/group'
+      "/etc/group"
     end
 
     private
@@ -113,19 +112,19 @@ module Inspec::Resources
 
     def parse_group_line(line)
       opts = {
-        comment_char: '#',
+        comment_char: "#",
         standalone_comments: false,
       }
       line, _idx_nl = parse_comment_line(line, opts)
-      x = line.split(':')
+      x = line.split(":")
       # abort if we have an empty or comment line
       return nil if x.size == 0
       # map data
       {
-        'name' => x.at(0), # Name of the group.
-        'password' => x.at(1), # Group's encrypted password.
-        'gid' => convert_to_i(x.at(2)), # The group's decimal ID.
-        'members' => x.at(3), # Group members.
+        "name" => x.at(0), # Name of the group.
+        "password" => x.at(1), # Group's encrypted password.
+        "gid" => convert_to_i(x.at(2)), # The group's decimal ID.
+        "members" => x.at(3), # Group members.
       }
     end
   end

--- a/lib/resources/gem.rb
+++ b/lib/resources/gem.rb
@@ -1,11 +1,10 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
 module Inspec::Resources
   class GemPackage < Inspec.resource(1)
-    name 'gem'
-    desc 'Use the gem InSpec audit resource to test if a global gem package is installed.'
+    name "gem"
+    desc "Use the gem InSpec audit resource to test if a global gem package is installed."
     example "
       describe gem('rubocop') do
         it { should be_installed }
@@ -23,14 +22,14 @@ module Inspec::Resources
       cmd = inspec.command("gem list --local -a -q \^#{@package_name}\$")
       @info = {
         installed: cmd.exit_status == 0,
-        type: 'gem',
+        type: "gem",
       }
       return @info unless @info[:installed]
 
       # extract package name and version
       # parses data like winrm (1.3.4, 1.3.3)
       params = /^\s*([^\(]*?)\s*\((.*?)\)\s*$/.match(cmd.stdout.chomp)
-      versions = params[2].split(',')
+      versions = params[2].split(",")
       @info[:name] = params[1]
       @info[:version] = versions[0]
       @info

--- a/lib/resources/groups.rb
+++ b/lib/resources/groups.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'utils/filter'
+require "utils/filter"
 
 module Inspec::Resources
   # This file contains two resources, the `group` and `groups` resource.
@@ -24,8 +23,8 @@ module Inspec::Resources
   class Groups < Inspec.resource(1)
     include GroupManagementSelector
 
-    name 'groups'
-    desc 'Use the group InSpec audit resource to test groups on the system. Groups can be filtered.'
+    name "groups"
+    desc "Use the group InSpec audit resource to test groups on the system. Groups can be filtered."
     example "
       describe groups.where { name == 'root'} do
         its('names') { should eq ['root'] }
@@ -41,20 +40,20 @@ module Inspec::Resources
     def initialize
       # select group manager
       @group_provider = select_group_manager(inspec.os)
-      return skip_resource 'The `groups` resource is not supported on your OS yet.' if @group_provider.nil?
+      return skip_resource "The `groups` resource is not supported on your OS yet." if @group_provider.nil?
     end
 
     filter = FilterTable.create
     filter.add_accessor(:where)
           .add_accessor(:entries)
-          .add(:names,     field: 'name')
-          .add(:gids,      field: 'gid')
-          .add(:domains,   field: 'domain')
+          .add(:names,     field: "name")
+          .add(:gids,      field: "gid")
+          .add(:domains,   field: "domain")
           .add(:exists?) { |x| !x.entries.empty? }
     filter.connect(self, :collect_group_details)
 
     def to_s
-      'Groups'
+      "Groups"
     end
 
     private
@@ -79,8 +78,8 @@ module Inspec::Resources
   class Group < Inspec.resource(1)
     include GroupManagementSelector
 
-    name 'group'
-    desc 'Use the group InSpec audit resource to test groups on the system.'
+    name "group"
+    desc "Use the group InSpec audit resource to test groups on the system."
     example "
       describe group('root') do
         it { should exist }
@@ -94,7 +93,7 @@ module Inspec::Resources
 
       # select group manager
       @group_provider = select_group_manager(inspec.os)
-      return skip_resource 'The `group` resource is not supported on your OS yet.' if @group_provider.nil?
+      return skip_resource "The `group` resource is not supported on your OS yet." if @group_provider.nil?
     end
 
     # verifies if a group exists
@@ -110,7 +109,7 @@ module Inspec::Resources
       elsif gids.size == 1
         gids.entries[0]
       else
-        fail 'found more than one group with the same name, please use `groups` resource'
+        raise "found more than one group with the same name, please use `groups` resource"
       end
     end
 
@@ -144,7 +143,7 @@ module Inspec::Resources
     end
 
     def groups
-      fail 'group provider must implement the `groups` method'
+      raise "group provider must implement the `groups` method"
     end
   end
 

--- a/lib/resources/grub_conf.rb
+++ b/lib/resources/grub_conf.rb
@@ -1,12 +1,11 @@
-# encoding: utf-8
 # author: Thomas Cate
 # license: All rights reserved
 
-require 'utils/simpleconfig'
+require "utils/simpleconfig"
 
 class GrubConfig < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
-  name 'grub_conf'
-  desc 'Use the grub_conf InSpec audit resource to test the boot config of Linux systems that use Grub.'
+  name "grub_conf"
+  desc "Use the grub_conf InSpec audit resource to test the boot config of Linux systems that use Grub."
   example "
     describe grub_conf('/etc/grub.conf',  'default') do
       its('kernel') { should include '/vmlinuz-2.6.32-573.7.1.el6.x86_64' }
@@ -25,35 +24,35 @@ class GrubConfig < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
 
   def initialize(path = nil, kernel = nil)
     config_for_platform(path)
-    @kernel = kernel || 'default'
+    @kernel = kernel || "default"
   rescue UnknownGrubConfig
-    return skip_resource 'The `grub_config` resource is not supported on your OS yet.'
+    return skip_resource "The `grub_config` resource is not supported on your OS yet."
   end
 
   def config_for_platform(path)
     os = inspec.os
-    if os.redhat? || os[:name] == 'fedora'
+    if os.redhat? || os[:name] == "fedora"
       config_for_redhatish(path)
     elsif os.debian?
-      @conf_path = path || '/boot/grub/grub.cfg'
-      @defaults_path = '/etc/default/grub'
-      @version = 'grub2'
-    elsif os[:name] == 'amazon' # rubocop:disable Style/GuardClause
-      @conf_path = path || '/etc/grub.conf'
-      @version = 'legacy'
+      @conf_path = path || "/boot/grub/grub.cfg"
+      @defaults_path = "/etc/default/grub"
+      @version = "grub2"
+    elsif os[:name] == "amazon" # rubocop:disable Style/GuardClause
+      @conf_path = path || "/etc/grub.conf"
+      @version = "legacy"
     else
-      fail UnknownGrubConfig
+      raise UnknownGrubConfig
     end
   end
 
   def config_for_redhatish(path)
     if inspec.os[:release].to_f < 7
-      @conf_path = path || '/etc/grub.conf'
-      @version = 'legacy'
+      @conf_path = path || "/etc/grub.conf"
+      @version = "legacy"
     else
-      @conf_path = path || '/boot/grub/grub.cfg'
-      @defaults_path = '/etc/default/grub'
-      @version = 'grub2'
+      @conf_path = path || "/boot/grub/grub.cfg"
+      @defaults_path = "/etc/default/grub"
+      @version = "grub2"
     end
   end
 
@@ -62,7 +61,7 @@ class GrubConfig < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
   end
 
   def to_s
-    'Grub Config'
+    "Grub Config"
   end
 
   private
@@ -76,23 +75,23 @@ class GrubConfig < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     menu_entry = 0
     lines = content.split("\n")
     kernel_opts = {}
-    kernel_opts['insmod'] = []
+    kernel_opts["insmod"] = []
     lines.each_with_index do |file_line, index|
       next unless file_line =~ /(^|\s)menuentry\s.*/
       lines.drop(index+1).each do |kernel_line|
         next if kernel_line =~ /(^|\s)(menu|}).*/
-        if menu_entry == conf['GRUB_DEFAULT'].to_i && @kernel == 'default'
+        if menu_entry == conf["GRUB_DEFAULT"].to_i && @kernel == "default"
           if kernel_line =~ /(^|\s)initrd.*/
-            kernel_opts['initrd'] = kernel_line.split(' ')[1]
+            kernel_opts["initrd"] = kernel_line.split(" ")[1]
           end
           if kernel_line =~ /(^|\s)linux.*/
-            kernel_opts['kernel'] = kernel_line.split
+            kernel_opts["kernel"] = kernel_line.split
           end
           if kernel_line =~ /(^|\s)set root=.*/
-            kernel_opts['root'] = kernel_line.split('=')[1].tr('\'', '')
+            kernel_opts["root"] = kernel_line.split("=")[1].tr('\'', "")
           end
           if kernel_line =~ /(^|\s)insmod.*/
-            kernel_opts['insmod'].push(kernel_line.split(' ')[1])
+            kernel_opts["insmod"].push(kernel_line.split(" ")[1])
           end
         else
           menu_entry += 1
@@ -114,14 +113,14 @@ class GrubConfig < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     kernel_opts = {}
     lines.each_with_index do |file_line, index|
       next unless file_line =~ /^title.*/
-      current_kernel = file_line.split(' ', 2)[1]
+      current_kernel = file_line.split(" ", 2)[1]
       lines.drop(index+1).each do |kernel_line|
         if kernel_line =~ /^\s.*/
-          option_type = kernel_line.split(' ')[0]
-          line_options = kernel_line.split(' ').drop(1)
-          if (menu_entry == conf['default'].to_i && @kernel == 'default') || current_kernel == @kernel
-            if option_type == 'kernel'
-              kernel_opts['kernel'] = line_options
+          option_type = kernel_line.split(" ")[0]
+          line_options = kernel_line.split(" ").drop(1)
+          if (menu_entry == conf["default"].to_i && @kernel == "default") || current_kernel == @kernel
+            if option_type == "kernel"
+              kernel_opts["kernel"] = line_options
             else
               kernel_opts[option_type] = line_options[0]
             end
@@ -158,7 +157,7 @@ class GrubConfig < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
 
     content = read_file(@conf_path)
 
-    if @version == 'legacy'
+    if @version == "legacy"
       # parse the file
       conf = SimpleConfig.new(
         content,
@@ -174,7 +173,7 @@ class GrubConfig < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       @params = conf.merge(kernel_opts)
     end
 
-    if @version == 'grub2'
+    if @version == "grub2"
       # read defaults
       defaults = read_file(@defaults_path)
 

--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -26,8 +25,8 @@
 
 module Inspec::Resources
   class Host < Inspec.resource(1)
-    name 'host'
-    desc 'Use the host InSpec audit resource to test the name used to refer to a specific host and its availability, including the Internet protocols and ports over which that host name should be available.'
+    name "host"
+    desc "Use the host InSpec audit resource to test the name used to refer to a specific host and its availability, including the Internet protocols and ports over which that host name should be available."
     example "
       describe host('example.com') do
         it { should be_reachable }
@@ -49,7 +48,7 @@ module Inspec::Resources
       elsif inspec.os.windows?
         @host_provider = WindowsHostProvider.new(inspec)
       else
-        return skip_resource 'The `host` resource is not supported on your OS yet.'
+        return skip_resource "The `host` resource is not supported on your OS yet."
       end
     end
 
@@ -60,7 +59,7 @@ module Inspec::Resources
     end
 
     def reachable?(port = nil, proto = nil, timeout = nil)
-      fail "Use `host` resource with host('#{@hostname}', port: #{port}, proto: '#{proto}') parameters." if !port.nil? || !proto.nil? || !timeout.nil?
+      raise "Use `host` resource with host('#{@hostname}', port: #{port}, proto: '#{proto}') parameters." if !port.nil? || !proto.nil? || !timeout.nil?
       ping.nil? ? false : ping
     end
 
@@ -120,13 +119,13 @@ module Inspec::Resources
   class WindowsHostProvider < HostProvider
     def ping(hostname, port = nil, proto = nil)
       # TODO: abort if we cannot run it via udp
-      return nil if proto == 'udp'
+      return nil if proto == "udp"
 
       # ICMP: Test-NetConnection www.microsoft.com
       # TCP and port: Test-NetConnection -ComputerName www.microsoft.com -RemotePort 80
       request = "Test-NetConnection -ComputerName #{hostname}"
       request += " -RemotePort #{port}" unless port.nil?
-      request += '| Select-Object -Property ComputerName, TcpTestSucceeded, PingSucceeded | ConvertTo-Json'
+      request += "| Select-Object -Property ComputerName, TcpTestSucceeded, PingSucceeded | ConvertTo-Json"
       cmd = inspec.command(request)
 
       begin
@@ -137,9 +136,9 @@ module Inspec::Resources
 
       # Logic being if you provided a port you wanted to check it was open
       if port.nil?
-        ping['PingSucceeded']
+        ping["PingSucceeded"]
       else
-        ping['TcpTestSucceeded']
+        ping["TcpTestSucceeded"]
       end
     end
 
@@ -152,7 +151,7 @@ module Inspec::Resources
       end
 
       resolv = [resolv] unless resolv.is_a?(Array)
-      resolv.map { |entry| entry['IPAddress'] }
+      resolv.map { |entry| entry["IPAddress"] }
     end
   end
 end

--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -1,16 +1,15 @@
-# encoding: utf-8
 # copyright: 2017, Criteo
 # copyright: 2017, Chef Software Inc
 # author: Guilhem Lettron, Christoph Hartmann
 # license: Apache v2
 
-require 'faraday'
-require 'hashie'
+require "faraday"
+require "hashie"
 
 module Inspec::Resources
   class Http < Inspec.resource(1)
-    name 'http'
-    desc 'Use the http InSpec audit resource to test http call.'
+    name "http"
+    desc "Use the http InSpec audit resource to test http call."
     example "
       describe http('http://localhost:8080/ping', auth: {user: 'user', pass: 'test'}, params: {format: 'html'}) do
         its('status') { should cmp 200 }
@@ -25,7 +24,7 @@ module Inspec::Resources
     "
 
     # rubocop:disable ParameterLists
-    def initialize(url, method: 'GET', params: nil, auth: {}, headers: {}, data: nil)
+    def initialize(url, method: "GET", params: nil, auth: {}, headers: {}, data: nil)
       @url = url
       @method = method
       @params = params

--- a/lib/resources/iis_site.rb
+++ b/lib/resources/iis_site.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 # check for site in IIS
 # Usage:
@@ -15,8 +14,8 @@
 
 module Inspec::Resources
   class IisSite < Inspec.resource(1)
-    name 'iis_site'
-    desc 'Tests IIS site configuration on windows. Supported in server 2012+ only'
+    name "iis_site"
+    desc "Tests IIS site configuration on windows. Supported in server 2012+ only"
     example "
       describe iis_site('Default Web Site') do
         it { should exist }
@@ -35,7 +34,7 @@ module Inspec::Resources
       @site_provider = SiteProvider.new(inspec)
 
       # verify that this resource is only supported on Windows
-      return skip_resource 'The `iis_site` resource is not supported on your OS.' if inspec.os[:family] != 'windows'
+      return skip_resource "The `iis_site` resource is not supported on your OS." if inspec.os[:family] != "windows"
     end
 
     def app_pool
@@ -59,7 +58,7 @@ module Inspec::Resources
     end
 
     def running?
-      iis_site.nil? ? false : (iis_site[:state] == 'Started')
+      iis_site.nil? ? false : (iis_site[:state] == "Started")
     end
 
     def has_app_pool?(app_pool)
@@ -102,20 +101,20 @@ module Inspec::Resources
         return nil
       end
 
-      bindings_array = site['bindings']['Collection'].map { |k, _str|
-        k['protocol'] <<
-          ' ' <<
-          k['bindingInformation'] <<
-          (k['protocol'] == 'https' ? ' sslFlags=' << flags : '')
+      bindings_array = site["bindings"]["Collection"].map { |k, _str|
+        k["protocol"] <<
+          " " <<
+          k["bindingInformation"] <<
+          (k["protocol"] == "https" ? " sslFlags=" << flags : "")
       }
 
       # map our values to a hash table
       info = {
-        name: site['name'],
-        state: site['state'],
-        path: site['physicalPath'],
+        name: site["name"],
+        state: site["state"],
+        path: site["physicalPath"],
         bindings: bindings_array,
-        app_pool: site['applicationPool'],
+        app_pool: site["applicationPool"],
       }
 
       info
@@ -125,8 +124,8 @@ module Inspec::Resources
   # for compatability with serverspec
   # this is deprecated syntax and will be removed in future versions
   class IisSiteServerSpec < IisSite
-    name 'iis_website'
-    desc 'Tests IIS site configuration on windows. Deprecated, use `iis_site` instead.'
+    name "iis_website"
+    desc "Tests IIS site configuration on windows. Deprecated, use `iis_site` instead."
     example "
       describe iis_website('Default Website') do
         it{ should exist }
@@ -137,7 +136,7 @@ module Inspec::Resources
 
     def initialize(site_name)
       super(site_name)
-      warn '[DEPRECATION] `iis_website(site_name)` is deprecated.  Please use `iis_site(site_name)` instead.'
+      warn "[DEPRECATION] `iis_website(site_name)` is deprecated.  Please use `iis_site(site_name)` instead."
     end
 
     def in_app_pool?(app_pool)

--- a/lib/resources/inetd_conf.rb
+++ b/lib/resources/inetd_conf.rb
@@ -1,15 +1,14 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
 # license: All rights reserved
 
-require 'utils/simpleconfig'
+require "utils/simpleconfig"
 
 module Inspec::Resources
   class InetdConf < Inspec.resource(1)
-    name 'inetd_conf'
-    desc 'Use the inetd_conf InSpec audit resource to test if a service is enabled in the inetd.conf file on Linux and UNIX platforms. inetd---the Internet service daemon---listens on dedicated ports, and then loads the appropriate program based on a request. The inetd.conf file is typically located at /etc/inetd.conf and contains a list of Internet services associated to the ports on which that service will listen. Only enabled services may handle a request; only services that are required by the system should be enabled.'
+    name "inetd_conf"
+    desc "Use the inetd_conf InSpec audit resource to test if a service is enabled in the inetd.conf file on Linux and UNIX platforms. inetd---the Internet service daemon---listens on dedicated ports, and then loads the appropriate program based on a request. The inetd.conf file is typically located at /etc/inetd.conf and contains a list of Internet services associated to the ports on which that service will listen. Only enabled services may handle a request; only services that are required by the system should be enabled."
     example "
       describe inetd_conf do
         its('shell') { should eq nil }
@@ -19,13 +18,13 @@ module Inspec::Resources
     "
 
     def initialize(path = nil)
-      @conf_path = path || '/etc/inetd.conf'
+      @conf_path = path || "/etc/inetd.conf"
     end
 
     # overwrite exec to ensure it works with its
     # TODO: this needs to be fixed in RSpec
     def exec
-      read_params['exec']
+      read_params["exec"]
     end
 
     def method_missing(name)
@@ -58,7 +57,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'inetd.conf'
+      "inetd.conf"
     end
   end
 end

--- a/lib/resources/ini.rb
+++ b/lib/resources/ini.rb
@@ -1,13 +1,12 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'utils/simpleconfig'
+require "utils/simpleconfig"
 
 module Inspec::Resources
   class IniConfig < JsonConfig
-    name 'ini'
-    desc 'Use the ini InSpec audit resource to test data in a INI file.'
+    name "ini"
+    desc "Use the ini InSpec audit resource to test data in a INI file."
     example "
       descibe ini do
         its('auth_protocol') { should eq 'https' }

--- a/lib/resources/interface.rb
+++ b/lib/resources/interface.rb
@@ -1,13 +1,12 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'utils/convert'
+require "utils/convert"
 
 module Inspec::Resources
   class NetworkInterface < Inspec.resource(1)
-    name 'interface'
-    desc 'Use the interface InSpec audit resource to test basic network adapter properties, such as name, status, state, address, and link speed (in MB/sec).'
+    name "interface"
+    desc "Use the interface InSpec audit resource to test basic network adapter properties, such as name, status, state, address, and link speed (in MB/sec)."
     example "
       describe interface('eth0') do
         it { should exist }
@@ -24,7 +23,7 @@ module Inspec::Resources
       elsif inspec.os.windows?
         @interface_provider = WindowsInterface.new(inspec)
       else
-        return skip_resource 'The `interface` resource is not supported on your OS yet.'
+        return skip_resource "The `interface` resource is not supported on your OS yet."
       end
     end
 
@@ -75,15 +74,15 @@ module Inspec::Resources
 
       # parse state
       state = false
-      if params.key?('operstate')
-        operstate, _value = params['operstate'].first
-        state = operstate == 'up'
+      if params.key?("operstate")
+        operstate, _value = params["operstate"].first
+        state = operstate == "up"
       end
 
       # parse speed
       speed = nil
-      if params.key?('speed')
-        speed, _value = params['speed'].first
+      if params.key?("speed")
+        speed, _value = params["speed"].first
         speed = convert_to_i(speed)
       end
 
@@ -98,7 +97,7 @@ module Inspec::Resources
   class WindowsInterface < InterfaceInfo
     def interface_info(iface)
       # gather all network interfaces
-      cmd = inspec.command('Get-NetAdapter | Select-Object -Property Name, InterfaceDescription, Status, State, MacAddress, LinkSpeed, ReceiveLinkSpeed, TransmitLinkSpeed, Virtual | ConvertTo-Json')
+      cmd = inspec.command("Get-NetAdapter | Select-Object -Property Name, InterfaceDescription, Status, State, MacAddress, LinkSpeed, ReceiveLinkSpeed, TransmitLinkSpeed, Virtual | ConvertTo-Json")
 
       # filter network interface
       begin
@@ -114,9 +113,9 @@ module Inspec::Resources
       adapters = net_adapter.each_with_object([]) do |adapter, adapter_collection|
         # map object
         info = {
-          name: adapter['Name'],
-          up: adapter['State'] == 2,
-          speed: adapter['ReceiveLinkSpeed'] / 1000,
+          name: adapter["Name"],
+          up: adapter["State"] == 2,
+          speed: adapter["ReceiveLinkSpeed"] / 1000,
         }
         adapter_collection.push(info) if info[:name].casecmp(iface) == 0
       end

--- a/lib/resources/iptables.rb
+++ b/lib/resources/iptables.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -23,8 +22,8 @@
 # @see https://www.frozentux.net/iptables-tutorial/iptables-tutorial.html
 module Inspec::Resources
   class IpTables < Inspec.resource(1)
-    name 'iptables'
-    desc 'Use the iptables InSpec audit resource to test rules that are defined in iptables, which maintains tables of IP packet filtering rules. There may be more than one table. Each table contains one (or more) chains (both built-in and custom). A chain is a list of rules that match packets. When the rule matches, the rule defines what target to assign to the packet.'
+    name "iptables"
+    desc "Use the iptables InSpec audit resource to test rules that are defined in iptables, which maintains tables of IP packet filtering rules. There may be more than one table. Each table contains one (or more) chains (both built-in and custom). A chain is a list of rules that match packets. When the rule matches, the rule defines what target to assign to the packet."
     example "
       describe iptables do
         it { should have_rule('-P INPUT ACCEPT') }
@@ -40,7 +39,7 @@ module Inspec::Resources
 
       # ensures, all calls are aborted for non-supported os
       @iptables_cache = []
-      skip_resource 'The `iptables` resource is not supported on your OS yet.'
+      skip_resource "The `iptables` resource is not supported on your OS yet."
     end
 
     def has_rule?(rule = nil, _table = nil, _chain = nil)
@@ -54,7 +53,7 @@ module Inspec::Resources
 
       # construct iptables command to read all rules
       table_cmd = "-t #{@table}" if @table
-      iptables_cmd = format('iptables %s -S %s', table_cmd, @chain).strip
+      iptables_cmd = format("iptables %s -S %s", table_cmd, @chain).strip
 
       cmd = inspec.command(iptables_cmd)
       return [] if cmd.exit_status.to_i != 0
@@ -64,7 +63,7 @@ module Inspec::Resources
     end
 
     def to_s
-      format('Iptables %s %s', @table && "table: #{@table}", @chain && "chain: #{@chain}").strip
+      format("Iptables %s %s", @table && "table: #{@table}", @chain && "chain: #{@chain}").strip
     end
   end
 end

--- a/lib/resources/json.rb
+++ b/lib/resources/json.rb
@@ -1,13 +1,12 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'utils/object_traversal'
+require "utils/object_traversal"
 
 module Inspec::Resources
   class JsonConfig < Inspec.resource(1)
-    name 'json'
-    desc 'Use the json InSpec audit resource to test data in a JSON file.'
+    name "json"
+    desc "Use the json InSpec audit resource to test data in a JSON file."
     example "
       describe json('policyfile.lock.json') do
         its(['cookbook_locks','omnibus','version']) { should eq('2.2.0') }
@@ -59,7 +58,7 @@ module Inspec::Resources
     end
 
     def parse(content)
-      require 'json'
+      require "json"
       JSON.parse(content)
     end
 
@@ -81,7 +80,7 @@ module Inspec::Resources
 
     def to_s
       if @opts.is_a?(Hash) && @opts.key?(:content)
-        'Json content'
+        "Json content"
       else
         "Json #{@path}"
       end

--- a/lib/resources/kernel_module.rb
+++ b/lib/resources/kernel_module.rb
@@ -1,12 +1,11 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 # license: All rights reserved
 
 module Inspec::Resources
   class KernelModule < Inspec.resource(1)
-    name 'kernel_module'
-    desc 'Use the kernel_module InSpec audit resource to test kernel modules on Linux platforms. These parameters are located under /lib/modules. Any submodule may be tested using this resource.'
+    name "kernel_module"
+    desc "Use the kernel_module InSpec audit resource to test kernel modules on Linux platforms. These parameters are located under /lib/modules. Any submodule may be tested using this resource."
     example "
       describe kernel_module('bridge') do
         it { should be_loaded }
@@ -17,27 +16,27 @@ module Inspec::Resources
       @module = modulename
 
       # this resource is only supported on Linux
-      return skip_resource 'The `kernel_parameter` resource is not supported on your OS.' if !inspec.os.linux?
+      return skip_resource "The `kernel_parameter` resource is not supported on your OS." if !inspec.os.linux?
     end
 
     def loaded?
       # default lsmod command
-      lsmod_cmd = 'lsmod'
+      lsmod_cmd = "lsmod"
       # special care for CentOS 5 and sudo
-      lsmod_cmd = '/sbin/lsmod' if inspec.os[:name] == 'centos' && inspec.os[:release].to_i == 5
+      lsmod_cmd = "/sbin/lsmod" if inspec.os[:name] == "centos" && inspec.os[:release].to_i == 5
 
       # get list of all modules
       cmd = inspec.command(lsmod_cmd)
       return false if cmd.exit_status != 0
 
       # check if module is loaded
-      re = Regexp.new('^'+Regexp.quote(@module)+'\s')
+      re = Regexp.new("^"+Regexp.quote(@module)+'\s')
       found = cmd.stdout.match(re)
       !found.nil?
     end
 
     def version
-      if inspec.os[:name] == 'centos' && inspec.os[:release].to_i == 5
+      if inspec.os[:name] == "centos" && inspec.os[:release].to_i == 5
         modinfo_cmd = "/sbin/modinfo -F version #{@module}"
       else
         modinfo_cmd = "modinfo -F version #{@module}"

--- a/lib/resources/kernel_parameter.rb
+++ b/lib/resources/kernel_parameter.rb
@@ -1,11 +1,10 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # license: All rights reserved
 
 module Inspec::Resources
   class KernelParameter < Inspec.resource(1)
-    name 'kernel_parameter'
-    desc 'Use the kernel_parameter InSpec audit resource to test kernel parameters on Linux platforms.'
+    name "kernel_parameter"
+    desc "Use the kernel_parameter InSpec audit resource to test kernel parameters on Linux platforms."
     example "
       describe kernel_parameter('net.ipv4.conf.all.forwarding') do
         its('value') { should eq 0 }
@@ -16,7 +15,7 @@ module Inspec::Resources
       @parameter = parameter
 
       # this resource is only supported on Linux
-      return skip_resource 'The `kernel_parameter` resource is not supported on your OS.' if !inspec.os.linux?
+      return skip_resource "The `kernel_parameter` resource is not supported on your OS." if !inspec.os.linux?
     end
 
     def value
@@ -37,7 +36,7 @@ module Inspec::Resources
   # for compatability with serverspec
   # this is deprecated syntax and will be removed in future versions
   class LinuxKernelParameter < KernelParameter
-    name 'linux_kernel_parameter'
+    name "linux_kernel_parameter"
 
     def initialize(parameter)
       super(parameter)
@@ -49,7 +48,7 @@ module Inspec::Resources
     end
 
     def deprecated
-      warn '[DEPRECATION] `linux_kernel_parameter(parameter)` is deprecated.  Please use `kernel_parameter(parameter)` instead.'
+      warn "[DEPRECATION] `linux_kernel_parameter(parameter)` is deprecated.  Please use `kernel_parameter(parameter)` instead."
     end
 
     def to_s

--- a/lib/resources/limits_conf.rb
+++ b/lib/resources/limits_conf.rb
@@ -1,15 +1,14 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
 # license: All rights reserved
 
-require 'utils/simpleconfig'
+require "utils/simpleconfig"
 
 module Inspec::Resources
   class LimitsConf < Inspec.resource(1)
-    name 'limits_conf'
-    desc 'Use the limits_conf InSpec audit resource to test configuration settings in the /etc/security/limits.conf file. The limits.conf defines limits for processes (by user and/or group names) and helps ensure that the system on which those processes are running remains stable. Each process may be assigned a hard or soft limit.'
+    name "limits_conf"
+    desc "Use the limits_conf InSpec audit resource to test configuration settings in the /etc/security/limits.conf file. The limits.conf defines limits for processes (by user and/or group names) and helps ensure that the system on which those processes are running remains stable. Each process may be assigned a hard or soft limit."
     example "
       describe limits_conf do
         its('*') { should include ['hard','core','0'] }
@@ -17,7 +16,7 @@ module Inspec::Resources
     "
 
     def initialize(path = nil)
-      @conf_path = path || '/etc/security/limits.conf'
+      @conf_path = path || "/etc/security/limits.conf"
     end
 
     def method_missing(name)
@@ -51,7 +50,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'limits.conf'
+      "limits.conf"
     end
   end
 end

--- a/lib/resources/login_def.rb
+++ b/lib/resources/login_def.rb
@@ -1,10 +1,9 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
 # license: All rights reserved
 
-require 'utils/simpleconfig'
+require "utils/simpleconfig"
 
 # Usage:
 #
@@ -20,8 +19,8 @@ require 'utils/simpleconfig'
 
 module Inspec::Resources
   class LoginDef < Inspec.resource(1)
-    name 'login_defs'
-    desc 'Use the login_defs InSpec audit resource to test configuration settings in the /etc/login.defs file. The logins.defs file defines site-specific configuration for the shadow password suite on Linux and UNIX platforms, such as password expiration ranges, minimum/maximum values for automatic selection of user and group identifiers, or the method with which passwords are encrypted.'
+    name "login_defs"
+    desc "Use the login_defs InSpec audit resource to test configuration settings in the /etc/login.defs file. The logins.defs file defines site-specific configuration for the shadow password suite on Linux and UNIX platforms, such as password expiration ranges, minimum/maximum values for automatic selection of user and group identifiers, or the method with which passwords are encrypted."
     example "
       describe login_defs do
         its('ENCRYPT_METHOD') { should eq 'SHA512' }
@@ -29,7 +28,7 @@ module Inspec::Resources
     "
 
     def initialize(path = nil)
-      @conf_path = path || '/etc/login.defs'
+      @conf_path = path || "/etc/login.defs"
     end
 
     def method_missing(name)
@@ -62,7 +61,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'login.defs'
+      "login.defs"
     end
   end
 end

--- a/lib/resources/mount.rb
+++ b/lib/resources/mount.rb
@@ -1,13 +1,12 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'utils/simpleconfig'
+require "utils/simpleconfig"
 
 module Inspec::Resources
   class Mount < Inspec.resource(1)
-    name 'mount'
-    desc 'Use the mount InSpec audit resource to test if mount points.'
+    name "mount"
+    desc "Use the mount InSpec audit resource to test if mount points."
     example "
       describe mount('/') do
         it { should be_mounted }
@@ -24,7 +23,7 @@ module Inspec::Resources
 
     def initialize(path)
       @path = path
-      return skip_resource 'The `mount` resource is not supported on your OS yet.' if !inspec.os.linux?
+      return skip_resource "The `mount` resource is not supported on your OS yet." if !inspec.os.linux?
       @file = inspec.backend.file(@path)
     end
 

--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -1,11 +1,10 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
 module Inspec::Resources
   class MssqlSession < Inspec.resource(1)
-    name 'mssql_session'
-    desc 'Use the mssql_session InSpec audit resource to test SQL commands run against a MS Sql Server database.'
+    name "mssql_session"
+    desc "Use the mssql_session InSpec audit resource to test SQL commands run against a MS Sql Server database."
     example "
       sql = mssql_session('myuser','mypassword')
       describe sql.query('select * from sys.databases where name like \'*test*\') do
@@ -16,18 +15,18 @@ module Inspec::Resources
     def initialize(user = nil, pass = nil)
       @user = user
       @pass = pass
-      skip_resource('user and pass are required for MSSQL tests') if @user.nil? or @pass.nil?
+      skip_resource("user and pass are required for MSSQL tests") if @user.nil? or @pass.nil?
     end
 
     def query(q)
-      escaped_query = q.gsub(/\\/, '\\\\').gsub(/"/, '\\"').gsub(/\$/, '\\$').gsub(/\@/, '`@')
+      escaped_query = q.gsub(/\\/, '\\\\').gsub(/"/, '\\"').gsub(/\$/, '\\$').gsub(/\@/, "`@")
       cmd = inspec.command("sqlcmd -U #{@user} -P #{@pass} -Q \"#{escaped_query}\"")
 
       cmd
     end
 
     def to_s
-      'MSSQL'
+      "MSSQL"
     end
   end
 end

--- a/lib/resources/mysql.rb
+++ b/lib/resources/mysql.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
@@ -6,17 +5,17 @@
 
 module Inspec::Resources
   class Mysql < Inspec.resource(1)
-    name 'mysql'
+    name "mysql"
 
     attr_reader :package, :service, :conf_dir, :conf_path, :data_dir, :log_dir, :log_path, :log_group, :log_dir_group
     def initialize
       # set OS-dependent filenames and paths
       case inspec.os[:family]
-      when 'debian'
+      when "debian"
         init_ubuntu
-      when 'redhat', 'fedora'
+      when "redhat", "fedora"
         init_redhat
-      when 'arch'
+      when "arch"
         init_arch
       else
         # TODO: could not detect
@@ -25,59 +24,59 @@ module Inspec::Resources
     end
 
     def init_ubuntu
-      @package = 'mysql-server'
-      @service = 'mysql'
-      @conf_path = '/etc/mysql/my.cnf'
-      @conf_dir = '/etc/mysql/'
-      @data_dir = '/var/lib/mysql/'
-      @log_dir = '/var/log/'
-      @log_path = '/var/log/mysql.log'
-      @log_group = 'adm'
+      @package = "mysql-server"
+      @service = "mysql"
+      @conf_path = "/etc/mysql/my.cnf"
+      @conf_dir = "/etc/mysql/"
+      @data_dir = "/var/lib/mysql/"
+      @log_dir = "/var/log/"
+      @log_path = "/var/log/mysql.log"
+      @log_group = "adm"
       case inspec.os[:release]
-      when '14.04'
-        @log_dir_group = 'syslog'
+      when "14.04"
+        @log_dir_group = "syslog"
       else
-        @log_dir_group = 'root'
+        @log_dir_group = "root"
       end
     end
 
     def init_redhat
-      @package = 'mysql-server'
-      @service = 'mysqld'
-      @conf_path = '/etc/my.cnf'
-      @conf_dir = '/etc/'
-      @data_dir = '/var/lib/mysql/'
-      @log_dir = '/var/log/'
-      @log_path = '/var/log/mysqld.log'
-      @log_group = 'mysql'
-      @log_dir_group = 'root'
+      @package = "mysql-server"
+      @service = "mysqld"
+      @conf_path = "/etc/my.cnf"
+      @conf_dir = "/etc/"
+      @data_dir = "/var/lib/mysql/"
+      @log_dir = "/var/log/"
+      @log_path = "/var/log/mysqld.log"
+      @log_group = "mysql"
+      @log_dir_group = "root"
     end
 
     def init_arch
-      @package = 'mariadb'
-      @service = 'mysql'
-      @conf_path = '/etc/mysql/my.cnf'
-      @conf_dir = '/etc/mysql/'
-      @data_dir = '/var/lib/mysql/'
-      @log_dir = '/var/log/'
-      @log_path = '/var/log/mysql.log'
-      @log_group = 'mysql'
-      @log_dir_group = 'root'
+      @package = "mariadb"
+      @service = "mysql"
+      @conf_path = "/etc/mysql/my.cnf"
+      @conf_dir = "/etc/mysql/"
+      @data_dir = "/var/lib/mysql/"
+      @log_dir = "/var/log/"
+      @log_path = "/var/log/mysql.log"
+      @log_group = "mysql"
+      @log_dir_group = "root"
     end
 
     def init_default
-      @service = 'mysqld'
-      @conf_path = '/etc/my.cnf'
-      @conf_dir = '/etc/'
-      @data_dir = '/var/lib/mysql/'
-      @log_dir = '/var/log/'
-      @log_path = '/var/log/mysqld.log'
-      @log_group = 'mysql'
-      @log_dir_group = 'root'
+      @service = "mysqld"
+      @conf_path = "/etc/my.cnf"
+      @conf_dir = "/etc/"
+      @data_dir = "/var/lib/mysql/"
+      @log_dir = "/var/log/"
+      @log_path = "/var/log/mysqld.log"
+      @log_group = "mysql"
+      @log_dir_group = "root"
     end
 
     def to_s
-      'MySQL'
+      "MySQL"
     end
   end
 end

--- a/lib/resources/mysql_conf.rb
+++ b/lib/resources/mysql_conf.rb
@@ -1,12 +1,11 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # license: All rights reserved
 
-require 'utils/simpleconfig'
-require 'utils/find_files'
-require 'utils/hash'
-require 'resources/mysql'
+require "utils/simpleconfig"
+require "utils/find_files"
+require "utils/hash"
+require "resources/mysql"
 
 module Inspec::Resources
   class MysqlConfEntry
@@ -28,8 +27,8 @@ module Inspec::Resources
   end
 
   class MysqlConf < Inspec.resource(1)
-    name 'mysql_conf'
-    desc 'Use the mysql_conf InSpec audit resource to test the contents of the configuration file for MySQL, typically located at /etc/mysql/my.cnf or /etc/my.cnf.'
+    name "mysql_conf"
+    desc "Use the mysql_conf InSpec audit resource to test the contents of the configuration file for MySQL, typically located at /etc/mysql/my.cnf or /etc/my.cnf."
     example "
       describe mysql_conf('path') do
         its('setting') { should eq 'value' }
@@ -65,7 +64,7 @@ module Inspec::Resources
     end
 
     def read_content
-      @content = ''
+      @content = ""
       @params = {}
 
       # skip if the main configuration file doesn't exist
@@ -103,13 +102,13 @@ module Inspec::Resources
       dirs = conf.scan(/^!includedir\s+(.*)\s*/).flatten.compact.map { |x| abs_path(reldir, x) }
       dirs.map do |dir|
         # @TODO: non local glob
-        files += find_files(dir, depth: 1, type: 'file')
+        files += find_files(dir, depth: 1, type: "file")
       end
       files
     end
 
     def abs_path(dir, f)
-      return f if f.start_with? '/'
+      return f if f.start_with? "/"
       File.join(dir, f)
     end
 
@@ -118,7 +117,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'MySQL Configuration'
+      "MySQL Configuration"
     end
   end
 end

--- a/lib/resources/mysql_session.rb
+++ b/lib/resources/mysql_session.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
@@ -6,8 +5,8 @@
 
 module Inspec::Resources
   class MysqlSession < Inspec.resource(1)
-    name 'mysql_session'
-    desc 'Use the mysql_session InSpec audit resource to test SQL commands run against a MySQL database.'
+    name "mysql_session"
+    desc "Use the mysql_session InSpec audit resource to test SQL commands run against a MySQL database."
     example "
       sql = mysql_session('my_user','password')
       describe sql.query('show databases like \'test\';') do
@@ -22,7 +21,7 @@ module Inspec::Resources
       skip_resource("Can't run MySQL SQL checks without authentication") if @user.nil? or @pass.nil?
     end
 
-    def query(q, db = '')
+    def query(q, db = "")
       # TODO: simple escape, must be handled by a library
       # that does this securely
       escaped_query = q.gsub(/\\/, '\\\\').gsub(/"/, '\\"').gsub(/\$/, '\\$')
@@ -31,7 +30,7 @@ module Inspec::Resources
       cmd = inspec.command("mysql -u#{@user} -p#{@pass} #{db} -s -e \"#{escaped_query}\"")
       out = cmd.stdout + "\n" + cmd.stderr
       if out =~ /Can't connect to .* MySQL server/ or
-         out.downcase =~ /^error/
+          out.downcase =~ /^error/
         # skip this test if the server can't run the query
         skip_resource("Can't connect to MySQL instance for SQL checks.")
       end
@@ -41,14 +40,14 @@ module Inspec::Resources
     end
 
     def to_s
-      'MySQL Session'
+      "MySQL Session"
     end
 
     private
 
     def init_fallback
       # support debian mysql administration login
-      debian = inspec.command('test -f /etc/mysql/debian.cnf && cat /etc/mysql/debian.cnf').stdout
+      debian = inspec.command("test -f /etc/mysql/debian.cnf && cat /etc/mysql/debian.cnf").stdout
       return if debian.empty?
 
       user = debian.match(/^\s*user\s*=\s*([^ ]*)\s*$/)

--- a/lib/resources/npm.rb
+++ b/lib/resources/npm.rb
@@ -1,11 +1,10 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
 module Inspec::Resources
   class NpmPackage < Inspec.resource(1)
-    name 'npm'
-    desc 'Use the npm InSpec audit resource to test if a global npm package is installed. npm is the the package manager for Nodejs packages, such as bower and StatsD.'
+    name "npm"
+    desc "Use the npm InSpec audit resource to test if a global npm package is installed. npm is the the package manager for Nodejs packages, such as bower and StatsD."
     example "
       describe npm('bower') do
         it { should be_installed }
@@ -23,13 +22,13 @@ module Inspec::Resources
       cmd = inspec.command("npm ls -g --json #{@package_name}")
       @info = {
         name: @package_name,
-        type: 'npm',
+        type: "npm",
         installed: cmd.exit_status == 0,
       }
       return @info unless @info[:installed]
 
       pkgs = JSON.parse(cmd.stdout)
-      @info[:version] = pkgs['dependencies'][@package_name]['version']
+      @info[:version] = pkgs["dependencies"][@package_name]["version"]
       @info
     end
 

--- a/lib/resources/ntp_conf.rb
+++ b/lib/resources/ntp_conf.rb
@@ -1,15 +1,14 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
 # license: All rights reserved
 
-require 'utils/simpleconfig'
+require "utils/simpleconfig"
 
 module Inspec::Resources
   class NtpConf < Inspec.resource(1)
-    name 'ntp_conf'
-    desc 'Use the ntp_conf InSpec audit resource to test the synchronization settings defined in the ntp.conf file. This file is typically located at /etc/ntp.conf.'
+    name "ntp_conf"
+    desc "Use the ntp_conf InSpec audit resource to test the synchronization settings defined in the ntp.conf file. This file is typically located at /etc/ntp.conf."
     example "
       describe ntp_conf do
         its('server') { should_not eq nil }
@@ -18,7 +17,7 @@ module Inspec::Resources
     "
 
     def initialize(path = nil)
-      @conf_path = path || '/etc/ntp.conf'
+      @conf_path = path || "/etc/ntp.conf"
     end
 
     def method_missing(name)
@@ -29,7 +28,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'ntp.conf'
+      "ntp.conf"
     end
 
     private

--- a/lib/resources/oneget.rb
+++ b/lib/resources/oneget.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -11,8 +10,8 @@
 # end
 module Inspec::Resources
   class OneGetPackage < Inspec.resource(1)
-    name 'oneget'
-    desc 'Use the oneget InSpec audit resource to test if the named package and/or package version is installed on the system. This resource uses OneGet, which is part of the Windows Management Framework 5.0 and Windows 10. This resource uses the Get-Package cmdlet to return all of the package names in the OneGet repository.'
+    name "oneget"
+    desc "Use the oneget InSpec audit resource to test if the named package and/or package version is installed on the system. This resource uses OneGet, which is part of the Windows Management Framework 5.0 and Windows 10. This resource uses the Get-Package cmdlet to return all of the package names in the OneGet repository."
     example "
       describe oneget('zoomit') do
         it { should be_installed }
@@ -24,14 +23,14 @@ module Inspec::Resources
       @package_name = package_name
 
       # verify that this resource is only supported on Windows
-      return skip_resource 'The `oneget` resource is not supported on your OS.' if !inspec.os.windows?
+      return skip_resource "The `oneget` resource is not supported on your OS." if !inspec.os.windows?
     end
 
     def info
       return @info if defined?(@info)
 
       @info = {}
-      @info[:type] = 'oneget'
+      @info[:type] = "oneget"
       @info[:installed] = false
 
       cmd = inspec.command("Get-Package -Name '#{@package_name}' | ConvertTo-Json")
@@ -52,8 +51,8 @@ module Inspec::Resources
         return @info
       end
 
-      @info[:name] = pkgs['Name'] if pkgs.key?('Name')
-      @info[:version] = pkgs['Version'] if pkgs.key?('Version')
+      @info[:name] = pkgs["Name"] if pkgs.key?("Name")
+      @info[:version] = pkgs["Version"] if pkgs.key?("Version")
       @info
     end
 

--- a/lib/resources/os.rb
+++ b/lib/resources/os.rb
@@ -1,11 +1,10 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
 module Inspec::Resources
   class OSResource < Inspec.resource(1)
-    name 'os'
-    desc 'Use the os InSpec audit resource to test the platform on which the system is running.'
+    name "os"
+    desc "Use the os InSpec audit resource to test the platform on which the system is running."
     example "
       describe os[:family] do
         it { should eq 'redhat' }
@@ -52,7 +51,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'Operating System Detection'
+      "Operating System Detection"
     end
   end
 end

--- a/lib/resources/os_env.rb
+++ b/lib/resources/os_env.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
@@ -11,12 +10,12 @@
 #   its('split') { should_not include('.') }
 # end
 
-require 'utils/simpleconfig'
+require "utils/simpleconfig"
 
 module Inspec::Resources
   class OsEnv < Inspec.resource(1)
-    name 'os_env'
-    desc 'Use the os_env InSpec audit resource to test the environment variables for the platform on which the system is running.'
+    name "os_env"
+    desc "Use the os_env InSpec audit resource to test the environment variables for the platform on which the system is running."
     example "
       describe os_env('VARIABLE') do
         its('matcher') { should eq 1 }
@@ -33,7 +32,7 @@ module Inspec::Resources
     def split
       # we can't take advantage of `File::PATH_SEPARATOR` as code is
       # evaluated on the host machine
-      path_separator = inspec.os.windows? ? ';' : ':'
+      path_separator = inspec.os.windows? ? ";" : ":"
       # -1 is required to catch cases like dir1::dir2:
       # where we have a trailing :
       @content.nil? ? [] : @content.split(path_separator, -1)
@@ -41,7 +40,7 @@ module Inspec::Resources
 
     def to_s
       if @osenv.nil?
-        'Environment variables'
+        "Environment variables"
       else
         "Environment variable #{@osenv}"
       end
@@ -53,7 +52,7 @@ module Inspec::Resources
       command = if inspec.os.windows?
                   "${Env:#{env}}"
                 else
-                  'env'
+                  "env"
                 end
 
       out = inspec.command(command)

--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -10,8 +9,8 @@
 # end
 module Inspec::Resources
   class Package < Inspec.resource(1)
-    name 'package'
-    desc 'Use the package InSpec audit resource to test if the named package and/or package version is installed on the system.'
+    name "package"
+    desc "Use the package InSpec audit resource to test if the named package and/or package version is installed on the system."
     example "
       describe package('nginx') do
         it { should be_installed }
@@ -31,20 +30,20 @@ module Inspec::Resources
         @pkgman = Deb.new(inspec)
       elsif %w{redhat suse amazon fedora}.include?(os[:family])
         @pkgman = Rpm.new(inspec)
-      elsif ['arch'].include?(os[:family])
+      elsif ["arch"].include?(os[:family])
         @pkgman = Pacman.new(inspec)
-      elsif ['darwin'].include?(os[:family])
+      elsif ["darwin"].include?(os[:family])
         @pkgman = Brew.new(inspec)
       elsif inspec.os.windows?
         @pkgman = WindowsPkg.new(inspec)
-      elsif ['aix'].include?(os[:family])
+      elsif ["aix"].include?(os[:family])
         @pkgman = BffPkg.new(inspec)
       elsif os.solaris?
         @pkgman = SolarisPkg.new(inspec)
-      elsif ['hpux'].include?(os[:family])
+      elsif ["hpux"].include?(os[:family])
         @pkgman = HpuxPkg.new(inspec)
       else
-        return skip_resource 'The `package` resource is not supported on your OS yet.'
+        return skip_resource "The `package` resource is not supported on your OS yet."
       end
     end
 
@@ -94,10 +93,10 @@ module Inspec::Resources
       # If the package is removed and not purged, Status is "deinstall ok config-files" with exit_status 0
       # If the package is purged cmd fails with non-zero exit status
       {
-        name: params['Package'],
-        installed: params['Status'].split(' ').first == 'install',
-        version: params['Version'],
-        type: 'deb',
+        name: params["Package"],
+        installed: params["Status"].split(" ").first == "install",
+        version: params["Version"],
+        type: "deb",
       }
     end
   end
@@ -115,22 +114,22 @@ module Inspec::Resources
         multiple_values: false,
       ).params
       # On some (all?) systems, the linebreak before the vendor line is missing
-      if params['Version'] =~ /\s*Vendor:/
-        v = params['Version'].split(' ')[0]
+      if params["Version"] =~ /\s*Vendor:/
+        v = params["Version"].split(" ")[0]
       else
-        v = params['Version']
+        v = params["Version"]
       end
       # On some (all?) systems, the linebreak before the build line is missing
-      if params['Release'] =~ /\s*Build Date:/
-        r = params['Release'].split(' ')[0]
+      if params["Release"] =~ /\s*Build Date:/
+        r = params["Release"].split(" ")[0]
       else
-        r = params['Release']
+        r = params["Release"]
       end
       {
-        name: params['Name'],
+        name: params["Name"],
         installed: true,
         version: "#{v}-#{r}",
-        type: 'rpm',
+        type: "rpm",
       }
     end
   end
@@ -143,10 +142,10 @@ module Inspec::Resources
       # parse data
       pkg = JSON.parse(cmd.stdout)[0]
       {
-        name: pkg['name'],
+        name: pkg["name"],
         installed: true,
-        version: pkg['installed'][0]['version'],
-        type: 'brew',
+        version: pkg["installed"][0]["version"],
+        type: "brew",
       }
     rescue JSON::ParserError => _e
       return nil
@@ -166,10 +165,10 @@ module Inspec::Resources
       ).params
 
       {
-        name: params['Name'],
+        name: params["Name"],
         installed: true,
-        version: params['Version'],
-        type: 'pacman',
+        version: params["Version"],
+        type: "pacman",
       }
     end
   end
@@ -178,12 +177,12 @@ module Inspec::Resources
     def info(package_name)
       cmd = inspec.command("swlist -l product | grep #{package_name}")
       return nil if cmd.exit_status.to_i != 0
-      pkg = cmd.stdout.strip.split(' ')
+      pkg = cmd.stdout.strip.split(" ")
       {
         name: pkg[0],
         installed: true,
         version: pkg[1],
-        type: 'pkg',
+        type: "pkg",
       }
     end
   end
@@ -198,13 +197,13 @@ module Inspec::Resources
       ]
 
       # add 64 bit search paths
-      if inspec.os.arch == 'x86_64'
+      if inspec.os.arch == "x86_64"
         search_paths << 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
         search_paths << 'HKCU:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
       end
 
       # Find the package
-      cmd = inspec.command <<-EOF.gsub(/^\s*/, '')
+      cmd = inspec.command <<-EOF.gsub(/^\s*/, "")
         Get-ItemProperty (@("#{search_paths.join('", "')}") | Where-Object { Test-Path $_ }) |
         Where-Object { $_.DisplayName -like "#{package_name}" -or $_.PSChildName -like "#{package_name}" } |
         Select-Object -Property DisplayName,DisplayVersion | ConvertTo-Json
@@ -220,10 +219,10 @@ module Inspec::Resources
       package = package[0] if package.is_a?(Array)
 
       {
-        name: package['DisplayName'],
+        name: package["DisplayName"],
         installed: true,
-        version: package['DisplayVersion'],
-        type: 'windows',
+        version: package["DisplayVersion"],
+        type: "windows",
       }
     end
   end
@@ -234,12 +233,12 @@ module Inspec::Resources
       cmd = inspec.command("lslpp -cL #{package_name}")
       return nil if cmd.exit_status.to_i != 0
 
-      bff_pkg = cmd.stdout.split("\n").last.split(':')
+      bff_pkg = cmd.stdout.split("\n").last.split(":")
       {
         name:      bff_pkg[1],
         installed: true,
         version:   bff_pkg[2],
-        type:      'bff',
+        type:      "bff",
       }
     end
   end
@@ -266,12 +265,12 @@ module Inspec::Resources
       ).params
 
       # parse 11.10.0,REV=2006.05.18.01.46
-      v = params['VERSION'].split(',')
+      v = params["VERSION"].split(",")
       {
-        name: params['PKGINST'],
+        name: params["PKGINST"],
         installed: true,
-        version: v[0] + '-' + v[1].split('=')[1],
-        type: 'pkg',
+        version: v[0] + "-" + v[1].split("=")[1],
+        type: "pkg",
       }
     end
 
@@ -287,11 +286,11 @@ module Inspec::Resources
       ).params
 
       {
-        name: params['Name'],
+        name: params["Name"],
         installed: true,
         # 0.5.11-0.175.3.1.0.5.0
         version: "#{params['Version']}-#{params['Branch']}",
-        type: 'pkg',
+        type: "pkg",
       }
     end
   end

--- a/lib/resources/packages.rb
+++ b/lib/resources/packages.rb
@@ -1,15 +1,14 @@
-# encoding: utf-8
 # copyright: 2017, Chef Software, Inc. <legal@chef.io>
 # author: Joshua Timberman
 # author: Alex Pop
 # license: All rights reserved
 
-require 'utils/filter'
+require "utils/filter"
 
 module Inspec::Resources
   class Packages < Inspec.resource(1)
-    name 'packages'
-    desc 'Use the packages InSpec audit resource to test properties for multiple packages installed on the system'
+    name "packages"
+    desc "Use the packages InSpec audit resource to test properties for multiple packages installed on the system"
     example "
       describe packages(/xserver-xorg.*/) do
         its('entries') { should be_empty }
@@ -37,9 +36,9 @@ module Inspec::Resources
     filter = FilterTable.create
     filter.add_accessor(:where)
           .add_accessor(:entries)
-          .add(:statuses,  field: 'status', style: :simple)
-          .add(:names,     field: 'name')
-          .add(:versions,  field: 'version')
+          .add(:statuses,  field: "status", style: :simple)
+          .add(:names,     field: "name")
+          .add(:versions,  field: "version")
           .connect(self, :filtered_packages)
 
     private
@@ -50,7 +49,7 @@ module Inspec::Resources
       elsif p.class == Regexp
         p
       else
-        fail 'invalid name argument to packages resource, please use a "string" or /regexp/'
+        raise 'invalid name argument to packages resource, please use a "string" or /regexp/'
       end
     end
 
@@ -64,7 +63,7 @@ module Inspec::Resources
       if os.debian?
         command = "dpkg-query -W -f='${db:Status-Abbrev} ${Package} ${Version}\\n'"
       else
-        fail "packages resource is not yet supported on #{os.name}"
+        raise "packages resource is not yet supported on #{os.name}"
       end
       build_package_list(command)
     end
@@ -77,8 +76,8 @@ module Inspec::Resources
       return [] if all.nil?
       all.map do |m|
         a = m.split
-        a[0] = 'installed' if a[0] =~ /^.i/
-        a[2] = a[2].split(':').last
+        a[0] = "installed" if a[0] =~ /^.i/
+        a[2] = a[2].split(":").last
         Package.new(*a)
       end
     end

--- a/lib/resources/parse_config.rb
+++ b/lib/resources/parse_config.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
@@ -15,8 +14,8 @@
 
 module Inspec::Resources
   class PConfig < Inspec.resource(1)
-    name 'parse_config'
-    desc 'Use the parse_config InSpec audit resource to test arbitrary configuration files.'
+    name "parse_config"
+    desc "Use the parse_config InSpec audit resource to test arbitrary configuration files."
     example "
       output = command('some-command').stdout
       describe parse_config(output, { data_config_option: value } ) do
@@ -97,8 +96,8 @@ module Inspec::Resources
   end
 
   class PConfigFile < PConfig
-    name 'parse_config_file'
-    desc 'Use the parse_config_file InSpec audit resource to test arbitrary configuration files. It works identiacal to parse_config. Instead of using a command output, this resource works with files.'
+    name "parse_config_file"
+    desc "Use the parse_config_file InSpec audit resource to test arbitrary configuration files. It works identiacal to parse_config. Instead of using a command output, this resource works with files."
     example "
       describe parse_config_file('/path/to/file') do
         its('setting') { should eq 1 }

--- a/lib/resources/passwd.rb
+++ b/lib/resources/passwd.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
@@ -13,13 +12,13 @@
 # - home directory
 # - command
 
-require 'utils/parser'
-require 'utils/filter'
+require "utils/parser"
+require "utils/filter"
 
 module Inspec::Resources
   class Passwd < Inspec.resource(1)
-    name 'passwd'
-    desc 'Use the passwd InSpec audit resource to test the contents of /etc/passwd, which contains the following information for users that may log into the system and/or as users that own running processes.'
+    name "passwd"
+    desc "Use the passwd InSpec audit resource to test the contents of /etc/passwd, which contains the following information for users that may log into the system and/or as users that own running processes."
     example "
       describe passwd do
         its('users') { should_not include 'forbidden_user' }
@@ -44,7 +43,7 @@ module Inspec::Resources
 
     def initialize(path = nil, opts = nil)
       opts ||= {}
-      @path = path || '/etc/passwd'
+      @path = path || "/etc/passwd"
       @content = opts[:content] || inspec.file(@path).content
       @lines = @content.to_s.split("\n")
       @params = parse_passwd(@content)
@@ -53,45 +52,45 @@ module Inspec::Resources
     filter = FilterTable.create
     filter.add_accessor(:where)
           .add_accessor(:entries)
-          .add(:users,     field: 'user')
-          .add(:passwords, field: 'password')
-          .add(:uids,      field: 'uid')
-          .add(:gids,      field: 'gid')
-          .add(:descs,     field: 'desc')
-          .add(:homes,     field: 'home')
-          .add(:shells,    field: 'shell')
+          .add(:users,     field: "user")
+          .add(:passwords, field: "password")
+          .add(:uids,      field: "uid")
+          .add(:gids,      field: "gid")
+          .add(:descs,     field: "desc")
+          .add(:homes,     field: "home")
+          .add(:shells,    field: "shell")
 
     filter.add(:count) { |t, _|
-      warn '[DEPRECATION] `passwd.count` is deprecated. Please use `passwd.entries.length` instead. It will be removed in version 1.0.0.'
+      warn "[DEPRECATION] `passwd.count` is deprecated. Please use `passwd.entries.length` instead. It will be removed in version 1.0.0."
       t.entries.length
     }
 
     filter.add(:usernames) { |t, x|
-      warn '[DEPRECATION] `passwd.usernames` is deprecated. Please use `passwd.users` instead. It will be removed in version 1.0.0.'
+      warn "[DEPRECATION] `passwd.usernames` is deprecated. Please use `passwd.users` instead. It will be removed in version 1.0.0."
       t.users(x)
     }
 
     filter.add(:username) { |t, x|
-      warn '[DEPRECATION] `passwd.username` is deprecated. Please use `passwd.users` instead. It will be removed in version 1.0.0.'
+      warn "[DEPRECATION] `passwd.username` is deprecated. Please use `passwd.users` instead. It will be removed in version 1.0.0."
       t.users(x)[0]
     }
 
     # rebuild the passwd line from raw content
     filter.add(:content) { |t, _|
       t.entries.map do |e|
-        [e.user, e.password, e.uid, e.gid, e.desc, e.home, e.shell].join(':')
+        [e.user, e.password, e.uid, e.gid, e.desc, e.home, e.shell].join(":")
       end.join("\n")
     }
 
     def uid(x)
-      warn '[DEPRECATION] `passwd.uid(arg)` is deprecated. Please use `passwd.uids(arg)` instead. It will be removed in version 1.0.0.'
+      warn "[DEPRECATION] `passwd.uid(arg)` is deprecated. Please use `passwd.uids(arg)` instead. It will be removed in version 1.0.0."
       uids(x)
     end
 
     filter.connect(self, :params)
 
     def to_s
-      '/etc/passwd'
+      "/etc/passwd"
     end
   end
 end

--- a/lib/resources/pip.rb
+++ b/lib/resources/pip.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -9,8 +8,8 @@
 #
 module Inspec::Resources
   class PipPackage < Inspec.resource(1)
-    name 'pip'
-    desc 'Use the pip InSpec audit resource to test packages that are installed using the pip installer.'
+    name "pip"
+    desc "Use the pip InSpec audit resource to test packages that are installed using the pip installer."
     example "
       describe pip('Jinja2') do
         it { should be_installed }
@@ -25,7 +24,7 @@ module Inspec::Resources
       return @info if defined?(@info)
 
       @info = {}
-      @info[:type] = 'pip'
+      @info[:type] = "pip"
       cmd = inspec.command("#{pip_cmd} show #{@package_name}")
       return @info if cmd.exit_status != 0
 
@@ -34,8 +33,8 @@ module Inspec::Resources
         assignment_re: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
         multiple_values: false,
       ).params
-      @info[:name] = params['Name']
-      @info[:version] = params['Version']
+      @info[:name] = params["Name"]
+      @info[:version] = params["Version"]
       @info[:installed] = true
       @info
     end
@@ -59,23 +58,23 @@ module Inspec::Resources
       # to find the binary on Windows
       if inspec.os.windows?
         # we need to detect the pip command on Windows
-        cmd = inspec.command('New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Pip -Value (Invoke-Command -ScriptBlock {where.exe pip}) -PassThru | Add-Member -MemberType NoteProperty -Name Python -Value (Invoke-Command -ScriptBlock {where.exe python}) -PassThru | ConvertTo-Json')
+        cmd = inspec.command("New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Pip -Value (Invoke-Command -ScriptBlock {where.exe pip}) -PassThru | Add-Member -MemberType NoteProperty -Name Python -Value (Invoke-Command -ScriptBlock {where.exe python}) -PassThru | ConvertTo-Json")
         begin
           paths = JSON.parse(cmd.stdout)
           # use pip if it on system path
-          pipcmd = paths['Pip']
+          pipcmd = paths["Pip"]
           # calculate path on windows
-          if defined?(paths['Python']) && pipcmd.nil?
-            pipdir = paths['Python'].split('\\')
+          if defined?(paths["Python"]) && pipcmd.nil?
+            pipdir = paths["Python"].split('\\')
             # remove python.exe
             pipdir.pop
-            pipcmd = pipdir.push('Scripts').push('pip.exe').join('/')
+            pipcmd = pipdir.push("Scripts").push("pip.exe").join("/")
           end
         rescue JSON::ParserError => _e
           return nil
         end
       end
-      pipcmd || 'pip'
+      pipcmd || "pip"
     end
   end
 end

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -1,15 +1,14 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'utils/parser'
-require 'utils/filter'
+require "utils/parser"
+require "utils/filter"
 
 # TODO: currently we return local ip only
 # TODO: improve handling of same port on multiple interfaces
 module Inspec::Resources
   class Port < Inspec.resource(1)
-    name 'port'
+    name "port"
     desc "Use the port InSpec audit resource to test basic port properties, such as port, process, if it's listening."
     example "
       describe port(80) do
@@ -34,17 +33,17 @@ module Inspec::Resources
 
       @cache = nil
       @port_manager = port_manager_for_os
-      return skip_resource 'The `port` resource is not supported on your OS yet.' if @port_manager.nil?
+      return skip_resource "The `port` resource is not supported on your OS yet." if @port_manager.nil?
     end
 
     filter = FilterTable.create
     filter.add_accessor(:where)
           .add_accessor(:entries)
-          .add(:ports,     field: 'port', style: :simple)
-          .add(:addresses, field: 'address', style: :simple)
-          .add(:protocols, field: 'protocol', style: :simple)
-          .add(:processes, field: 'process', style: :simple)
-          .add(:pids,      field: 'pid', style: :simple)
+          .add(:ports,     field: "port", style: :simple)
+          .add(:addresses, field: "address", style: :simple)
+          .add(:protocols, field: "protocol", style: :simple)
+          .add(:processes, field: "process", style: :simple)
+          .add(:pids,      field: "pid", style: :simple)
           .add(:listening?) { |x| x.entries.length > 0 }
     filter.connect(self, :info)
 
@@ -65,7 +64,7 @@ module Inspec::Resources
         LsofPorts.new(inspec)
       elsif os.windows?
         WindowsPorts.new(inspec)
-      elsif ['freebsd'].include?(os[:family])
+      elsif ["freebsd"].include?(os[:family])
         FreeBsdPorts.new(inspec)
       elsif os.solaris?
         SolarisPorts.new(inspec)
@@ -80,8 +79,8 @@ module Inspec::Resources
       return @cache = [] if @port_manager.nil?
       # query ports
       cache = @port_manager.info || []
-      cache.select! { |x| x['port'] == @port } unless @port.nil?
-      cache.select! { |x| x['address'] == @ip } unless @ip.nil?
+      cache.select! { |x| x["port"] == @port } unless @port.nil?
+      cache.select! { |x| x["address"] == @ip } unless @ip.nil?
       @cache = cache
     end
   end
@@ -118,7 +117,7 @@ module Inspec::Resources
     private
 
     def powershell_info
-      cmd = inspec.command('Get-NetTCPConnection -state Listen | Select-Object -Property State, Caption, Description, LocalAddress, LocalPort, RemoteAddress, RemotePort, DisplayName, Status | ConvertTo-Json')
+      cmd = inspec.command("Get-NetTCPConnection -state Listen | Select-Object -Property State, Caption, Description, LocalAddress, LocalPort, RemoteAddress, RemotePort, DisplayName, Status | ConvertTo-Json")
       return nil if cmd.exit_status != 0
 
       entries = JSON.parse(cmd.stdout)
@@ -126,9 +125,9 @@ module Inspec::Resources
 
       entries.map { |x|
         {
-          'port'     => x['LocalPort'],
-          'address'  => x['LocalAddress'],
-          'protocol' => 'tcp',
+          "port"     => x["LocalPort"],
+          "address"  => x["LocalAddress"],
+          "protocol" => "tcp",
         }
       }
     rescue JSON::ParserError => _e
@@ -143,14 +142,14 @@ module Inspec::Resources
       lines = cmd.stdout.scan(/^>\s*(tcp\S*|udp\S*)\s+(\S+):(\d+)\s+(\S+)\s+(\S*)\s+(\d+)\s+(.+)/i)
       lines.map do |line|
         pid = line[5].to_i
-        process = line[6].delete('[').delete(']').strip
-        process = 'System' if process == 'Can not obtain ownership information' && pid == 4
+        process = line[6].delete("[").delete("]").strip
+        process = "System" if process == "Can not obtain ownership information" && pid == 4
         {
-          'port'     => line[2].to_i,
-          'address'  => line[1].delete('[').delete(']'),
-          'protocol' => line[0].downcase,
-          'pid'      => pid,
-          'process'  => process,
+          "port"     => line[2].to_i,
+          "address"  => line[1].delete("[").delete("]"),
+          "protocol" => line[0].downcase,
+          "pid"      => pid,
+          "process"  => process,
         }
       end
     end
@@ -161,7 +160,7 @@ module Inspec::Resources
     attr_reader :lsof
 
     def initialize(inspec, lsofpath = nil)
-      @lsof = lsofpath || 'lsof'
+      @lsof = lsofpath || "lsof"
       super(inspec)
     end
 
@@ -169,7 +168,7 @@ module Inspec::Resources
       ports = []
 
       # check that lsof is available, otherwise fail
-      fail 'Please ensure `lsof` is available on the machine.' if !inspec.command(@lsof.to_s).exist?
+      raise "Please ensure `lsof` is available on the machine." if !inspec.command(@lsof.to_s).exist?
 
       # -F p=pid, c=command, P=protocol name, t=type, n=internet addresses
       # see 'OUTPUT FOR OTHER PROGRAMS' in LSOF(8)
@@ -178,15 +177,15 @@ module Inspec::Resources
 
       # map to desired return struct
       lsof_parser(lsof_cmd).each do |process, port_ids|
-        pid, cmd = process.split(':')
+        pid, cmd = process.split(":")
         port_ids.each do |port_str|
           # should not break on ipv6 addresses
-          ipv, proto, port, host = port_str.split(':', 4)
-          ports.push({ 'port'     => port.to_i,
-                       'address'  => host,
-                       'protocol' => ipv == 'ipv6' ? proto + '6' : proto,
-                       'process'  => cmd,
-                       'pid'      => pid.to_i })
+          ipv, proto, port, host = port_str.split(":", 4)
+          ports.push({ "port"     => port.to_i,
+                       "address"  => host,
+                       "protocol" => ipv == "ipv6" ? proto + "6" : proto,
+                       "process"  => cmd,
+                       "pid"      => pid.to_i })
         end
       end
 
@@ -215,17 +214,17 @@ module Inspec::Resources
         line.chomp!
         key = line.slice!(0)
         case key
-        when 'p'
+        when "p"
           proc_id = line
           port_id = nil
-        when 'c'
-          proc_id += ':' + line
-        when 't'
+        when "c"
+          proc_id += ":" + line
+        when "t"
           port_id = line.downcase
-        when 'P'
-          port_id += ':' + line.downcase
-        when 'n'
-          src, dst = line.split('->')
+        when "P"
+          port_id += ":" + line.downcase
+        when "n"
+          src, dst = line.split("->")
 
           # skip active comm streams
           next if dst
@@ -233,13 +232,13 @@ module Inspec::Resources
           host, port = /^(\S+):(\d+|\*)$/.match(src)[1, 2]
 
           # skip channels from port 0 - what does this mean?
-          next if port == '*'
+          next if port == "*"
 
           # create new array stub if !exist?
           procs[proc_id] = [] unless procs.key?(proc_id)
 
           # change address '*' to zero
-          host = (port_id =~ /^ipv6:/) ? '[::]' : '0.0.0.0' if host == '*'
+          host = (port_id =~ /^ipv6:/) ? "[::]" : "0.0.0.0" if host == "*"
           # entrust URI to scrub the host and port
           begin
             uri = URI("addr://#{host}:#{port}")
@@ -251,7 +250,7 @@ module Inspec::Resources
 
           # e.g. 'ipv4:tcp:22:127.0.0.1'
           #                             strip ipv6 squares for inspec
-          port_id += ':' + port + ':' + host.gsub(/^\[|\]$/, '')
+          port_id += ":" + port + ":" + host.gsub(/^\[|\]$/, "")
 
           # lsof will give us another port unless it's done
           procs[proc_id] << port_id
@@ -265,7 +264,7 @@ module Inspec::Resources
   # extract port information from netstat
   class LinuxPorts < PortsInfo
     def info
-      cmd = inspec.command('netstat -tulpen')
+      cmd = inspec.command("netstat -tulpen")
       return nil if cmd.exit_status.to_i != 0
 
       ports = []
@@ -274,24 +273,24 @@ module Inspec::Resources
         port_info = parse_netstat_line(line)
 
         # only push protocols we are interested in
-        next unless %w{tcp tcp6 udp udp6}.include?(port_info['protocol'])
+        next unless %w{tcp tcp6 udp udp6}.include?(port_info["protocol"])
         ports.push(port_info)
       end
       ports
     end
 
     def parse_net_address(net_addr, protocol)
-      if protocol.eql?('tcp6') || protocol.eql?('udp6')
+      if protocol.eql?("tcp6") || protocol.eql?("udp6")
         # prep for URI parsing, parse ip6 port
         ip6 = /^(\S+):(\d+)$/.match(net_addr)
         ip6addr = ip6[1]
-        ip6addr = '::' if ip6addr =~ /^:::$/
+        ip6addr = "::" if ip6addr =~ /^:::$/
         # build uri
         ip_addr = URI("addr://[#{ip6addr}]:#{ip6[2]}")
         # replace []
         host = ip_addr.host[1..ip_addr.host.size-2]
       else
-        ip_addr = URI('addr://'+net_addr)
+        ip_addr = URI("addr://"+net_addr)
         host = ip_addr.host
       end
 
@@ -313,23 +312,23 @@ module Inspec::Resources
       protocol = parsed[1].downcase
 
       # detect protocol if not provided
-      protocol += '6' if parsed[4].count(':') > 1 && %w{tcp udp}.include?(protocol)
+      protocol += "6" if parsed[4].count(":") > 1 && %w{tcp udp}.include?(protocol)
 
       # extract host and port information
       host, port = parse_net_address(parsed[4], protocol)
 
       # extract PID
-      process = parsed[9].split('/')
+      process = parsed[9].split("/")
       pid = process[0]
       pid = pid.to_i if pid =~ /^\d+$/
       process = process[1]
 
       {
-        'port'     => port,
-        'address'  => host,
-        'protocol' => protocol,
-        'process'  => process,
-        'pid'      => pid,
+        "port"     => port,
+        "address"  => host,
+        "protocol" => protocol,
+        "process"  => process,
+        "pid"      => pid,
       }
     end
   end
@@ -337,7 +336,7 @@ module Inspec::Resources
   # extracts information from sockstat
   class FreeBsdPorts < PortsInfo
     def info
-      cmd = inspec.command('sockstat -46l')
+      cmd = inspec.command("sockstat -46l")
       return nil if cmd.exit_status.to_i != 0
 
       ports = []
@@ -346,7 +345,7 @@ module Inspec::Resources
         port_info = parse_sockstat_line(line)
 
         # push data, if not headerfile
-        next unless %w{tcp tcp6 udp udp6}.include?(port_info['protocol'])
+        next unless %w{tcp tcp6 udp udp6}.include?(port_info["protocol"])
         ports.push(port_info)
       end
       ports
@@ -354,16 +353,16 @@ module Inspec::Resources
 
     def parse_net_address(net_addr, protocol)
       case protocol
-      when 'tcp4', 'udp4', 'tcp', 'udp'
+      when "tcp4", "udp4", "tcp", "udp"
         # replace * with 0.0.0.0
-        net_addr = net_addr.gsub(/^\*:/, '0.0.0.0:') if net_addr =~ /^*:(\d+)$/
-        ip_addr = URI('addr://'+net_addr)
+        net_addr = net_addr.gsub(/^\*:/, "0.0.0.0:") if net_addr =~ /^*:(\d+)$/
+        ip_addr = URI("addr://"+net_addr)
         host = ip_addr.host
         port = ip_addr.port
-      when 'tcp6', 'udp6'
-        return [] if net_addr == '*:*' # abort for now
+      when "tcp6", "udp6"
+        return [] if net_addr == "*:*" # abort for now
         # replace * with 0:0:0:0:0:0:0:0
-        net_addr = net_addr.gsub(/^\*:/, '0:0:0:0:0:0:0:0:') if net_addr =~ /^*:(\d+)$/
+        net_addr = net_addr.gsub(/^\*:/, "0:0:0:0:0:0:0:0:") if net_addr =~ /^*:(\d+)$/
         # extract port
         ip6 = /^(\S+):(\d+)$/.match(net_addr)
         ip6addr = ip6[1]
@@ -396,15 +395,15 @@ module Inspec::Resources
       pid = pid.to_i if pid =~ /^\d+$/
 
       # map tcp4 and udp4
-      protocol = 'tcp' if protocol.eql?('tcp4')
-      protocol = 'udp' if protocol.eql?('udp4')
+      protocol = "tcp" if protocol.eql?("tcp4")
+      protocol = "udp" if protocol.eql?("udp4")
 
       {
-        'port'     => port,
-        'address'  => host,
-        'protocol' => protocol,
-        'process'  => process,
-        'pid'      => pid,
+        "port"     => port,
+        "address"  => host,
+        "protocol" => protocol,
+        "process"  => process,
+        "pid"      => pid,
       }
     end
   end
@@ -414,7 +413,7 @@ module Inspec::Resources
 
     def info
       # extract all port info
-      cmd = inspec.command('netstat -an -f inet -f inet6')
+      cmd = inspec.command("netstat -an -f inet -f inet6")
       return nil if cmd.exit_status.to_i != 0
 
       # parse the content
@@ -422,22 +421,22 @@ module Inspec::Resources
 
       # filter all ports, where we `listen`
       listen = netstat_ports.select { |val|
-        !val['state'].nil? && 'listen'.casecmp(val['state']) == 0
+        !val["state"].nil? && "listen".casecmp(val["state"]) == 0
       }
 
       # map the data
       ports = listen.map { |val|
-        protocol = val['protocol']
-        local_addr = val['local-address']
+        protocol = val["protocol"]
+        local_addr = val["local-address"]
 
         # solaris uses 127.0.0.1.57455 instead 127.0.0.1:57455, lets convert the
         # the last . to :
-        local_addr[local_addr.rindex('.')] = ':'
+        local_addr[local_addr.rindex(".")] = ":"
         host, port = parse_net_address(local_addr, protocol)
         {
-          'port'     => port,
-          'address'  => host,
-          'protocol' => protocol,
+          "port"     => port,
+          "address"  => host,
+          "protocol" => protocol,
         }
       }
       ports
@@ -448,20 +447,20 @@ module Inspec::Resources
   class HpuxPorts < FreeBsdPorts
     def info
       ## Can't use 'netstat -an -f inet -f inet6' as the latter -f option overrides the former one and return only inet ports
-      cmd1 = inspec.command('netstat -an -f inet')
+      cmd1 = inspec.command("netstat -an -f inet")
       return nil if cmd1.exit_status.to_i != 0
-      cmd2 = inspec.command('netstat -an -f inet6')
+      cmd2 = inspec.command("netstat -an -f inet6")
       return nil if cmd2.exit_status.to_i != 0
       cmd = cmd1.stdout + cmd2.stdout
       ports = []
       # parse all lines
       cmd.each_line do |line|
         port_info = parse_netstat_line(line)
-        next unless %w{tcp tcp6 udp udp6}.include?(port_info['protocol'])
+        next unless %w{tcp tcp6 udp udp6}.include?(port_info["protocol"])
         ports.push(port_info)
       end
       # select all ports, where we `listen`
-      ports.select { |val| val if 'listen'.casecmp(val['state']) == 0 }
+      ports.select { |val| val if "listen".casecmp(val["state"]) == 0 }
     end
 
     def parse_netstat_line(line)
@@ -471,17 +470,17 @@ module Inspec::Resources
 
       return {} if parsed.nil? || line.match(/^proto/i) || line.match(/^active/i)
       protocol = parsed[1].downcase
-      state = parsed[6].nil?? ' ' : parsed[6].downcase
+      state = parsed[6].nil?? " " : parsed[6].downcase
       local_addr = parsed[4]
-      local_addr[local_addr.rindex('.')] = ':'
+      local_addr[local_addr.rindex(".")] = ":"
       # extract host and port information
       host, port = parse_net_address(local_addr, protocol)
       # map data
       {
-        'port'     => port,
-        'address'  => host,
-        'protocol' => protocol,
-        'state'    => state,
+        "port"     => port,
+        "address"  => host,
+        "protocol" => protocol,
+        "state"    => state,
       }
     end
   end

--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
@@ -6,7 +5,7 @@
 
 module Inspec::Resources
   class Postgres < Inspec.resource(1)
-    name 'postgres'
+    name "postgres"
 
     attr_reader :service, :data_dir, :conf_dir, :conf_path
     def initialize
@@ -18,7 +17,7 @@ module Inspec::Resources
         # Debian allows multiple versions of postgresql to be
         # installed as well as multiple "clusters" to be configured.
         #
-        version = version_from_dir('/etc/postgresql')
+        version = version_from_dir("/etc/postgresql")
         cluster = cluster_from_dir("/etc/postgresql/#{version}")
         @conf_dir = "/etc/postgresql/#{version}/#{cluster}"
         @data_dir = "/var/lib/postgresql/#{version}/#{cluster}"
@@ -33,22 +32,22 @@ module Inspec::Resources
         # warning in version_from_dir. We should determine which case
         # is more common and only warn in the less common case.
         #
-        version = if inspec.directory('/var/lib/pgsql/data').exist?
-                    warn 'Found /var/lib/pgsql/data. Assuming postgresql install uses un-versioned directories.'
+        version = if inspec.directory("/var/lib/pgsql/data").exist?
+                    warn "Found /var/lib/pgsql/data. Assuming postgresql install uses un-versioned directories."
                     nil
                   else
-                    version_from_dir('/var/lib/pgsql/')
+                    version_from_dir("/var/lib/pgsql/")
                   end
 
-        @data_dir = File.join('/var/lib/pgsql/', version.to_s, 'data')
-      elsif os[:name] == 'arch'
+        @data_dir = File.join("/var/lib/pgsql/", version.to_s, "data")
+      elsif os[:name] == "arch"
         #
         # https://wiki.archlinux.org/index.php/PostgreSQL
         #
         # The archlinux wiki points to /var/lib/postgresql/data as the
         # main data directory.
         #
-        @data_dir = '/var/lib/postgres/data'
+        @data_dir = "/var/lib/postgres/data"
       else
         #
         # According to https://www.postgresql.org/docs/9.5/static/creating-cluster.html
@@ -56,17 +55,17 @@ module Inspec::Resources
         # > There is no default, although locations such as
         # > /usr/local/pgsql/data or /var/lib/pgsql/data are popular.
         #
-        @data_dir = '/var/lib/pgsql/data'
+        @data_dir = "/var/lib/pgsql/data"
       end
 
-      @service = 'postgresql'
+      @service = "postgresql"
       @conf_dir ||= @data_dir
       verify_dirs
-      @conf_path = File.join @conf_dir, 'postgresql.conf'
+      @conf_path = File.join @conf_dir, "postgresql.conf"
     end
 
     def to_s
-      'PostgreSQL'
+      "PostgreSQL"
     end
 
     private
@@ -100,17 +99,17 @@ module Inspec::Resources
     end
 
     def dir_to_version(dir)
-      dir.chomp.split('/').last
+      dir.chomp.split("/").last
     end
 
     def cluster_from_dir(dir)
       # Main is the default cluster name on debian use it if it
       # exists.
       if inspec.directory("#{dir}/main").exist?
-        'main'
+        "main"
       else
         dirs = inspec.command("ls -d #{dir}/*/").stdout.lines
-        first = dirs.first.chomp.split('/').last
+        first = dirs.first.chomp.split("/").last
         if dirs.count > 1
           warn "Multiple postgresql clusters configured or incorrect base dir #{dir}"
           warn "Using the first directory found: #{first}"

--- a/lib/resources/postgres_conf.rb
+++ b/lib/resources/postgres_conf.rb
@@ -1,17 +1,16 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
 # license: All rights reserved
 
-require 'utils/simpleconfig'
-require 'utils/find_files'
-require 'resources/postgres'
+require "utils/simpleconfig"
+require "utils/find_files"
+require "resources/postgres"
 
 module Inspec::Resources
   class PostgresConf < Inspec.resource(1)
-    name 'postgres_conf'
-    desc 'Use the postgres_conf InSpec audit resource to test the contents of the configuration file for PostgreSQL, typically located at /etc/postgresql/<version>/main/postgresql.conf or /var/lib/postgres/data/postgresql.conf, depending on the platform.'
+    name "postgres_conf"
+    desc "Use the postgres_conf InSpec audit resource to test the contents of the configuration file for PostgreSQL, typically located at /etc/postgresql/<version>/main/postgresql.conf or /var/lib/postgres/data/postgresql.conf, depending on the platform."
     example "
       describe postgres_conf do
         its('max_connections') { should eq '5' }
@@ -51,13 +50,13 @@ module Inspec::Resources
     end
 
     def to_s
-      'PostgreSQL Configuration'
+      "PostgreSQL Configuration"
     end
 
     private
 
     def read_content
-      @content = ''
+      @content = ""
       @params = {}
 
       # skip if the main configuration file doesn't exist
@@ -91,12 +90,12 @@ module Inspec::Resources
     end
 
     def include_files(params)
-      include_files = params['include'] || []
-      include_files += params['include_if_exists'] || []
-      dirs = params['include_dir'] || []
+      include_files = params["include"] || []
+      include_files += params["include_if_exists"] || []
+      dirs = params["include_dir"] || []
       dirs.each do |dir|
-        dir = File.join(@conf_dir, dir) if dir[0] != '/'
-        include_files += find_files(dir, depth: 1, type: 'file')
+        dir = File.join(@conf_dir, dir) if dir[0] != "/"
+        include_files += find_files(dir, depth: 1, type: "file")
       end
       include_files
     end

--- a/lib/resources/postgres_session.rb
+++ b/lib/resources/postgres_session.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
@@ -23,8 +22,8 @@ module Inspec::Resources
   end
 
   class PostgresSession < Inspec.resource(1)
-    name 'postgres_session'
-    desc 'Use the postgres_session InSpec audit resource to test SQL commands run against a PostgreSQL database.'
+    name "postgres_session"
+    desc "Use the postgres_session InSpec audit resource to test SQL commands run against a PostgreSQL database."
     example "
       sql = postgres_session('username', 'password')
 
@@ -34,12 +33,12 @@ module Inspec::Resources
     "
 
     def initialize(user, pass)
-      @user = user || 'postgres'
+      @user = user || "postgres"
       @pass = pass
     end
 
     def query(query, db = [])
-      dbs = db.map { |x| "-d #{x}" }.join(' ')
+      dbs = db.map { |x| "-d #{x}" }.join(" ")
       # TODO: simple escape, must be handled by a library
       # that does this securely
       escaped_query = query.gsub(/\\/, '\\\\').gsub(/"/, '\\"').gsub(/\$/, '\\$')
@@ -47,16 +46,16 @@ module Inspec::Resources
       cmd = inspec.command("PGPASSWORD='#{@pass}' psql -U #{@user} #{dbs} -h localhost -c \"#{escaped_query}\"")
       out = cmd.stdout + "\n" + cmd.stderr
       if cmd.exit_status != 0 or
-         out =~ /could not connect to .*/ or
-         out.downcase =~ /^error/
+          out =~ /could not connect to .*/ or
+          out.downcase =~ /^error/
         # skip this test if the server can't run the query
         skip_resource "Can't read run query #{query.inspect} on postgres_session: #{out}"
       else
         # remove the whole header (i.e. up to the first ^-----+------+------$)
         # remove the tail
         lines = cmd.stdout
-                   .sub(/(.*\n)+([-]+[+])*[-]+\n/, '')
-                   .sub(/\n[^\n]*\n\n$/, '')
+                   .sub(/(.*\n)+([-]+[+])*[-]+\n/, "")
+                   .sub(/\n[^\n]*\n\n$/, "")
         Lines.new(lines.strip, "PostgreSQL query: #{query}")
       end
     end

--- a/lib/resources/powershell.rb
+++ b/lib/resources/powershell.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
@@ -6,8 +5,8 @@
 
 module Inspec::Resources
   class PowershellScript < Cmd
-    name 'powershell'
-    desc 'Use the powershell InSpec audit resource to test a Windows PowerShell script on the Microsoft Windows platform.'
+    name "powershell"
+    desc "Use the powershell InSpec audit resource to test a Windows PowerShell script on the Microsoft Windows platform."
     example "
       script = <<-EOH
         # you powershell script
@@ -20,7 +19,7 @@ module Inspec::Resources
 
     def initialize(script)
       unless inspec.os.windows?
-        return skip_resource 'The `script` resource is not supported on your OS yet.'
+        return skip_resource "The `script` resource is not supported on your OS yet."
       end
       # since WinRM 2.0 and the default use of powershell for local execution in
       # train, we do not need to wrap the script here anymore
@@ -38,13 +37,13 @@ module Inspec::Resources
     end
 
     def to_s
-      'Powershell'
+      "Powershell"
     end
   end
 
   # this is deprecated syntax and will be removed in future versions
   class LegacyPowershellScript < PowershellScript
-    name 'script'
+    name "script"
 
     def initialize(script)
       deprecated
@@ -52,7 +51,7 @@ module Inspec::Resources
     end
 
     def deprecated
-      warn '[DEPRECATION] `script(script)` is deprecated.  Please use `powershell(script)` instead.'
+      warn "[DEPRECATION] `script(script)` is deprecated.  Please use `powershell(script)` instead."
     end
   end
 end

--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -1,15 +1,14 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
 # license: All rights reserved
 
-require 'utils/filter'
+require "utils/filter"
 
 module Inspec::Resources
   class Processes < Inspec.resource(1)
-    name 'processes'
-    desc 'Use the processes InSpec audit resource to test properties for programs that are running on the system.'
+    name "processes"
+    desc "Use the processes InSpec audit resource to test properties for programs that are running on the system."
     example "
       describe processes('mysqld') do
         its('entries.length') { should eq 1 }
@@ -25,8 +24,8 @@ module Inspec::Resources
       @grep = grep
       # turn into a regexp if it isn't one yet
       if grep.class == String
-        grep = '(/[^/]*)*' + grep if grep[0] != '/'
-        grep = Regexp.new('^' + grep + '(\s|$)')
+        grep = "(/[^/]*)*" + grep if grep[0] != "/"
+        grep = Regexp.new("^" + grep + '(\s|$)')
       end
       all_cmds = ps_axo
       @list = all_cmds.find_all do |hm|
@@ -39,25 +38,25 @@ module Inspec::Resources
     end
 
     def list
-      warn '[DEPRECATION] `processes.list` is deprecated. Please use `processes.entries` instead. It will be removed in version 2.0.0.'
+      warn "[DEPRECATION] `processes.list` is deprecated. Please use `processes.entries` instead. It will be removed in version 2.0.0."
       @list
     end
 
     filter = FilterTable.create
     filter.add_accessor(:where)
           .add_accessor(:entries)
-          .add(:labels,   field: 'label')
-          .add(:pids,     field: 'pid')
-          .add(:cpus,     field: 'cpu')
-          .add(:mem,      field: 'mem')
-          .add(:vsz,      field: 'vsz')
-          .add(:rss,      field: 'rss')
-          .add(:tty,      field: 'tty')
-          .add(:states,   field: 'stat')
-          .add(:start,    field: 'start')
-          .add(:time,     field: 'time')
-          .add(:users,    field: 'user')
-          .add(:commands, field: 'command')
+          .add(:labels,   field: "label")
+          .add(:pids,     field: "pid")
+          .add(:cpus,     field: "cpu")
+          .add(:mem,      field: "mem")
+          .add(:vsz,      field: "vsz")
+          .add(:rss,      field: "rss")
+          .add(:tty,      field: "tty")
+          .add(:states,   field: "stat")
+          .add(:start,    field: "start")
+          .add(:time,     field: "time")
+          .add(:users,    field: "user")
+          .add(:commands, field: "command")
           .connect(self, :filtered_processes)
 
     private
@@ -70,10 +69,10 @@ module Inspec::Resources
       os = inspec.os
 
       if os.linux?
-        command = 'ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command'
+        command = "ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command"
         regex = /^([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+(\w{3} \d{2}|\d{2}:\d{2}:\d{2})\s+([^ ]+)\s+([^ ]+)\s+(.*)$/
       else
-        command = 'ps axo pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user,command'
+        command = "ps axo pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user,command"
         regex = /^\s*([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+(.*)$/
       end
       build_process_list(command, regex, os)

--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -1,9 +1,8 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # license: All rights reserved
 
-require 'json'
+require "json"
 
 # Three constructor methods are available:
 # 1. resistry_key(path'):
@@ -49,8 +48,8 @@ require 'json'
 
 module Inspec::Resources
   class RegistryKey < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
-    name 'registry_key'
-    desc 'Use the registry_key InSpec audit resource to test key values in the Microsoft Windows registry.'
+    name "registry_key"
+    desc "Use the registry_key InSpec audit resource to test key values in the Microsoft Windows registry."
     example "
       describe registry_key('path\to\key') do
         its('name') { should eq 'value' }
@@ -72,7 +71,7 @@ module Inspec::Resources
         @options[:name] = name
         @options[:path] = reg_key
       end
-      return skip_resource 'The `registry_key` resource is not supported on your OS yet.' if !inspec.os.windows?
+      return skip_resource "The `registry_key` resource is not supported on your OS yet." if !inspec.os.windows?
     end
 
     def exists?
@@ -81,7 +80,7 @@ module Inspec::Resources
 
     def has_value?(value)
       val = registry_key(@options[:path])
-      !val.nil? && registry_property_value(val, '(default)') == value ? true : false
+      !val.nil? && registry_property_value(val, "(default)") == value ? true : false
     end
 
     def has_property?(property_name, property_type = nil)
@@ -132,13 +131,13 @@ module Inspec::Resources
     def registry_property_value(regkey, property)
       return nil if !registry_property_exists(regkey, property)
       # always ensure the key is lower case
-      regkey[prep_prop(property)]['value']
+      regkey[prep_prop(property)]["value"]
     end
 
     def registry_property_type(regkey, property)
       return nil if !registry_property_exists(regkey, property)
       # always ensure the key is lower case
-      regkey[prep_prop(property)]['type']
+      regkey[prep_prop(property)]["type"]
     end
 
     def registry_key(path)
@@ -188,7 +187,7 @@ module Inspec::Resources
       @registry_cache
     end
 
-    def children_keys(path, filter = '')
+    def children_keys(path, filter = "")
       return @children_cache if defined?(@children_cache)
       filter = filter.source if filter.is_a? ::Regexp
       script = <<-EOH
@@ -260,7 +259,7 @@ module Inspec::Resources
   # for compatability with serverspec
   # this is deprecated syntax and will be removed in future versions
   class WindowsRegistryKey < RegistryKey
-    name 'windows_registry_key'
+    name "windows_registry_key"
 
     def initialize(name)
       deprecated

--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 #
@@ -13,63 +12,63 @@
 # All local GPO parameters can be examined via Registry, but not all security
 # parameters. Therefore we need a combination of Registry and secedit output
 
-require 'hashie'
+require "hashie"
 
 module Inspec::Resources
   # known and supported MS privilege rights
   # @see https://technet.microsoft.com/en-us/library/dd277311.aspx
   # @see https://msdn.microsoft.com/en-us/library/windows/desktop/bb530716(v=vs.85).aspx
   MS_PRIVILEGES_RIGHTS = [
-    'SeNetworkLogonRight',
-    'SeBackupPrivilege',
-    'SeChangeNotifyPrivilege',
-    'SeSystemtimePrivilege',
-    'SeCreatePagefilePrivilege',
-    'SeDebugPrivilege',
-    'SeRemoteShutdownPrivilege',
-    'SeAuditPrivilege',
-    'SeIncreaseQuotaPrivilege',
-    'SeIncreaseBasePriorityPrivilege',
-    'SeLoadDriverPrivilege',
-    'SeBatchLogonRight',
-    'SeServiceLogonRight',
-    'SeInteractiveLogonRight',
-    'SeSecurityPrivilege',
-    'SeSystemEnvironmentPrivilege',
-    'SeProfileSingleProcessPrivilege',
-    'SeSystemProfilePrivilege',
-    'SeAssignPrimaryTokenPrivilege',
-    'SeRestorePrivilege',
-    'SeShutdownPrivilege',
-    'SeTakeOwnershipPrivilege',
-    'SeUndockPrivilege',
-    'SeManageVolumePrivilege',
-    'SeRemoteInteractiveLogonRight',
-    'SeImpersonatePrivilege',
-    'SeCreateGlobalPrivilege',
-    'SeIncreaseWorking',
-    'SeTimeZonePrivilege',
-    'SeCreateSymbolicLinkPrivilege',
-    'SeDenyNetworkLogonRight', # Deny access to this computer from the network
-    'SeDenyInteractiveLogonRight', # Deny logon locally
-    'SeDenyBatchLogonRight', # Deny logon as a batch job
-    'SeDenyServiceLogonRight', # Deny logon as a service
-    'SeTcbPrivilege',
-    'SeMachineAccountPrivilege',
-    'SeCreateTokenPrivilege',
-    'SeCreatePermanentPrivilege',
-    'SeEnableDelegationPrivilege',
-    'SeLockMemoryPrivilege',
-    'SeSyncAgentPrivilege',
-    'SeUnsolicitedInputPrivilege',
-    'SeTrustedCredManAccessPrivilege',
-    'SeRelabelPrivilege', # the privilege to change a Windows integrity label (new to Windows Vista)
-    'SeDenyRemoteInteractiveLogonRight', # Deny logon through Terminal Services
+    "SeNetworkLogonRight",
+    "SeBackupPrivilege",
+    "SeChangeNotifyPrivilege",
+    "SeSystemtimePrivilege",
+    "SeCreatePagefilePrivilege",
+    "SeDebugPrivilege",
+    "SeRemoteShutdownPrivilege",
+    "SeAuditPrivilege",
+    "SeIncreaseQuotaPrivilege",
+    "SeIncreaseBasePriorityPrivilege",
+    "SeLoadDriverPrivilege",
+    "SeBatchLogonRight",
+    "SeServiceLogonRight",
+    "SeInteractiveLogonRight",
+    "SeSecurityPrivilege",
+    "SeSystemEnvironmentPrivilege",
+    "SeProfileSingleProcessPrivilege",
+    "SeSystemProfilePrivilege",
+    "SeAssignPrimaryTokenPrivilege",
+    "SeRestorePrivilege",
+    "SeShutdownPrivilege",
+    "SeTakeOwnershipPrivilege",
+    "SeUndockPrivilege",
+    "SeManageVolumePrivilege",
+    "SeRemoteInteractiveLogonRight",
+    "SeImpersonatePrivilege",
+    "SeCreateGlobalPrivilege",
+    "SeIncreaseWorking",
+    "SeTimeZonePrivilege",
+    "SeCreateSymbolicLinkPrivilege",
+    "SeDenyNetworkLogonRight", # Deny access to this computer from the network
+    "SeDenyInteractiveLogonRight", # Deny logon locally
+    "SeDenyBatchLogonRight", # Deny logon as a batch job
+    "SeDenyServiceLogonRight", # Deny logon as a service
+    "SeTcbPrivilege",
+    "SeMachineAccountPrivilege",
+    "SeCreateTokenPrivilege",
+    "SeCreatePermanentPrivilege",
+    "SeEnableDelegationPrivilege",
+    "SeLockMemoryPrivilege",
+    "SeSyncAgentPrivilege",
+    "SeUnsolicitedInputPrivilege",
+    "SeTrustedCredManAccessPrivilege",
+    "SeRelabelPrivilege", # the privilege to change a Windows integrity label (new to Windows Vista)
+    "SeDenyRemoteInteractiveLogonRight", # Deny logon through Terminal Services
   ].freeze
 
   class SecurityPolicy < Inspec.resource(1)
-    name 'security_policy'
-    desc 'Use the security_policy InSpec audit resource to test security policies on the Microsoft Windows platform.'
+    name "security_policy"
+    desc "Use the security_policy InSpec audit resource to test security policies on the Microsoft Windows platform."
     example "
       describe security_policy do
         its('SeNetworkLogonRight') { should include 'S-1-5-11' }
@@ -100,7 +99,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'Security Policy'
+      "Security Policy"
     end
 
     private
@@ -109,11 +108,11 @@ module Inspec::Resources
       return @content if defined?(@content)
 
       # export the security policy
-      cmd = inspec.command('secedit /export /cfg win_secpol.cfg')
+      cmd = inspec.command("secedit /export /cfg win_secpol.cfg")
       return nil if cmd.exit_status.to_i != 0
 
       # store file content
-      cmd = inspec.command('Get-Content win_secpol.cfg')
+      cmd = inspec.command("Get-Content win_secpol.cfg")
       return skip_resource "Can't read security policy" if cmd.exit_status.to_i != 0
       @content = cmd.stdout
 
@@ -123,7 +122,7 @@ module Inspec::Resources
       @content
     ensure
       # delete temp file
-      inspec.command('Remove-Item win_secpol.cfg').exit_status.to_i
+      inspec.command("Remove-Item win_secpol.cfg").exit_status.to_i
     end
 
     def read_params
@@ -144,8 +143,8 @@ module Inspec::Resources
         val.to_i
       # special handling for SID array
       elsif val =~ /^\*\S/
-        val.split(',').map { |v|
-          v.sub('*S', 'S')
+        val.split(",").map { |v|
+          v.sub("*S", "S")
         }
       # special handling for string values with "
       elsif !(m = /^\"(.*)\"$/.match(val)).nil?

--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -1,9 +1,8 @@
-# encoding: utf-8
 # copyright: 2016, Chef Software Inc.
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'forwardable'
+require "forwardable"
 
 # The file format consists of
 # - user
@@ -17,10 +16,10 @@ require 'forwardable'
 
 module Inspec::Resources
   class Shadow < Inspec.resource(1)
-    name 'shadow'
-    desc 'Use the shadow InSpec resource to test the contents of /etc/shadow, '\
-         'which contains the following information for users that may log into '\
-         'the system and/or as users that own running processes.'
+    name "shadow"
+    desc "Use the shadow InSpec resource to test the contents of /etc/shadow, "\
+         "which contains the following information for users that may log into "\
+         "the system and/or as users that own running processes."
     example "
       describe shadow do
         its('users') { should_not include 'forbidden_user' }
@@ -37,19 +36,19 @@ module Inspec::Resources
     attr_reader :content
     attr_reader :lines
 
-    def initialize(path = '/etc/shadow', opts = nil)
+    def initialize(path = "/etc/shadow", opts = nil)
       opts ||= {}
-      @path = path || '/etc/shadow'
+      @path = path || "/etc/shadow"
       @content = opts[:content] || inspec.file(@path).content
       @lines = @content.to_s.split("\n")
-      @filters = opts[:filters] || ''
+      @filters = opts[:filters] || ""
       @params = @lines.map { |l| parse_shadow_line(l) }
     end
 
     def filter(hm = {})
       return self if hm.nil? || hm.empty?
       res = @params
-      filters = ''
+      filters = ""
       hm.each do |attr, condition|
         condition = condition.to_s if condition.is_a? Integer
         filters += " #{attr} = #{condition.inspect}"
@@ -62,7 +61,7 @@ module Inspec::Resources
           end
         end
       end
-      content = res.map { |x| x.values.join(':') }.join("\n")
+      content = res.map { |x| x.values.join(":") }.join("\n")
       Shadow.new(@path, content: content, filters: @filters + filters)
     end
 
@@ -75,39 +74,39 @@ module Inspec::Resources
     end
 
     def users(name = nil)
-      name.nil? ? map_data('user') : filter(user: name)
+      name.nil? ? map_data("user") : filter(user: name)
     end
 
     def passwords(password = nil)
-      password.nil? ? map_data('password') : filter(password: password)
+      password.nil? ? map_data("password") : filter(password: password)
     end
 
     def last_changes(filter_by = nil)
-      filter_by.nil? ? map_data('last_change') : filter(last_change: filter_by)
+      filter_by.nil? ? map_data("last_change") : filter(last_change: filter_by)
     end
 
     def min_days(filter_by = nil)
-      filter_by.nil? ? map_data('min_days') : filter(min_days: filter_by)
+      filter_by.nil? ? map_data("min_days") : filter(min_days: filter_by)
     end
 
     def max_days(filter_by = nil)
-      filter_by.nil? ? map_data('max_days') : filter(max_days: filter_by)
+      filter_by.nil? ? map_data("max_days") : filter(max_days: filter_by)
     end
 
     def warn_days(filter_by = nil)
-      filter_by.nil? ? map_data('warn_days') : filter(warn_days: filter_by)
+      filter_by.nil? ? map_data("warn_days") : filter(warn_days: filter_by)
     end
 
     def inactive_days(filter_by = nil)
-      filter_by.nil? ? map_data('inactive_days') : filter(inactive_days: filter_by)
+      filter_by.nil? ? map_data("inactive_days") : filter(inactive_days: filter_by)
     end
 
     def expiry_dates(filter_by = nil)
-      filter_by.nil? ? map_data('expiry_date') : filter(expiry_date: filter_by)
+      filter_by.nil? ? map_data("expiry_date") : filter(expiry_date: filter_by)
     end
 
     def to_s
-      f = @filters.empty? ? '' : ' with'+@filters
+      f = @filters.empty? ? "" : " with"+@filters
       "/etc/shadow#{f}"
     end
 
@@ -124,17 +123,17 @@ module Inspec::Resources
     # @param [String] line a line of /etc/shadow
     # @return [Hash] Map of entries in this line
     def parse_shadow_line(line)
-      x = line.split(':')
+      x = line.split(":")
       {
-        'user'          => x.at(0),
-        'password'      => x.at(1),
-        'last_change'   => x.at(2),
-        'min_days'      => x.at(3),
-        'max_days'      => x.at(4),
-        'warn_days'     => x.at(5),
-        'inactive_days' => x.at(6),
-        'expiry_date'   => x.at(7),
-        'reserved'      => x.at(8),
+        "user"          => x.at(0),
+        "password"      => x.at(1),
+        "last_change"   => x.at(2),
+        "min_days"      => x.at(3),
+        "max_days"      => x.at(4),
+        "warn_days"     => x.at(5),
+        "inactive_days" => x.at(6),
+        "expiry_date"   => x.at(7),
+        "reserved"      => x.at(8),
       }
     end
   end

--- a/lib/resources/ssh_conf.rb
+++ b/lib/resources/ssh_conf.rb
@@ -1,15 +1,14 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
 # license: All rights reserved
 
-require 'utils/simpleconfig'
+require "utils/simpleconfig"
 
 module Inspec::Resources
   class SshConf < Inspec.resource(1)
-    name 'ssh_config'
-    desc 'Use the sshd_config InSpec audit resource to test configuration data for the Open SSH daemon located at /etc/ssh/sshd_config on Linux and UNIX platforms. sshd---the Open SSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command execution, and data exchanges.'
+    name "ssh_config"
+    desc "Use the sshd_config InSpec audit resource to test configuration data for the Open SSH daemon located at /etc/ssh/sshd_config on Linux and UNIX platforms. sshd---the Open SSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command execution, and data exchanges."
     example "
       describe sshd_config do
         its('Protocol') { should eq '2' }
@@ -17,8 +16,8 @@ module Inspec::Resources
     "
 
     def initialize(conf_path = nil, type = nil)
-      @conf_path = conf_path || '/etc/ssh/ssh_config'
-      typename = (@conf_path.include?('sshd') ? 'Server' : 'Client')
+      @conf_path = conf_path || "/etc/ssh/ssh_config"
+      typename = (@conf_path.include?("sshd") ? "Server" : "Client")
       @type = type || "SSH #{typename} configuration #{conf_path}"
     end
 
@@ -49,7 +48,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'SSH Configuration'
+      "SSH Configuration"
     end
 
     private
@@ -82,10 +81,10 @@ module Inspec::Resources
   end
 
   class SshdConf < SshConf
-    name 'sshd_config'
+    name "sshd_config"
 
     def initialize(path = nil)
-      super(path || '/etc/ssh/sshd_config')
+      super(path || "/etc/ssh/sshd_config")
     end
   end
 end

--- a/lib/resources/ssl.rb
+++ b/lib/resources/ssl.rb
@@ -1,17 +1,16 @@
-# encoding: utf-8
 # copyright: 2015, Chef Software Inc.
 # license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'sslshake'
-require 'utils/filter'
-require 'uri'
-require 'parallel'
+require "sslshake"
+require "utils/filter"
+require "uri"
+require "parallel"
 
 # Custom resource based on the InSpec resource DSL
 class SSL < Inspec.resource(1)
-  name 'ssl'
+  name "ssl"
 
   desc "
     SSL test resource
@@ -34,11 +33,11 @@ class SSL < Inspec.resource(1)
   "
 
   VERSIONS = [
-    'ssl2',
-    'ssl3',
-    'tls1.0',
-    'tls1.1',
-    'tls1.2',
+    "ssl2",
+    "ssl3",
+    "tls1.0",
+    "tls1.1",
+    "tls1.2",
   ].freeze
 
   attr_reader :host, :port, :timeout, :retries
@@ -47,12 +46,12 @@ class SSL < Inspec.resource(1)
     @host = opts[:host]
     if @host.nil?
       # Transports like SSH and WinRM will provide a hostname
-      if inspec.backend.respond_to?('hostname')
+      if inspec.backend.respond_to?("hostname")
         @host = inspec.backend.hostname
-      elsif inspec.backend.class.to_s == 'Train::Transports::Local::Connection'
-        @host = 'localhost'
+      elsif inspec.backend.class.to_s == "Train::Transports::Local::Connection"
+        @host = "localhost"
       else
-        fail 'Cannot determine host for SSL test. Please specify it or use a different target.'
+        raise "Cannot determine host for SSL test. Please specify it or use a different target."
       end
     end
     @port = opts[:port] || 443
@@ -63,9 +62,9 @@ class SSL < Inspec.resource(1)
   filter = FilterTable.create
   filter.add_accessor(:where)
         .add_accessor(:entries)
-        .add(:ciphers, field: 'cipher')
-        .add(:protocols, field: 'protocol')
-        .add(:enabled?) { |x| x.handshake.values.any? { |i| i['success'] } }
+        .add(:ciphers, field: "cipher")
+        .add(:protocols, field: "protocol")
+        .add(:enabled?) { |x| x.handshake.values.any? { |i| i["success"] } }
         .add(:handshake) { |x|
           groups = x.entries.group_by(&:protocol)
           res = Parallel.map(groups, in_threads: 8) do |proto, e|
@@ -85,14 +84,14 @@ class SSL < Inspec.resource(1)
 
   def scan_config
     [
-      { 'protocol' => 'ssl2', 'ciphers' => SSLShake::SSLv2::CIPHERS.keys },
-      { 'protocol' => 'ssl3', 'ciphers' => SSLShake::TLS::SSL3_CIPHERS.keys },
-      { 'protocol' => 'tls1.0', 'ciphers' => SSLShake::TLS::TLS10_CIPHERS.keys },
-      { 'protocol' => 'tls1.1', 'ciphers' => SSLShake::TLS::TLS10_CIPHERS.keys },
-      { 'protocol' => 'tls1.2', 'ciphers' => SSLShake::TLS::TLS_CIPHERS.keys },
+      { "protocol" => "ssl2", "ciphers" => SSLShake::SSLv2::CIPHERS.keys },
+      { "protocol" => "ssl3", "ciphers" => SSLShake::TLS::SSL3_CIPHERS.keys },
+      { "protocol" => "tls1.0", "ciphers" => SSLShake::TLS::TLS10_CIPHERS.keys },
+      { "protocol" => "tls1.1", "ciphers" => SSLShake::TLS::TLS10_CIPHERS.keys },
+      { "protocol" => "tls1.2", "ciphers" => SSLShake::TLS::TLS_CIPHERS.keys },
     ].map do |line|
-      line['ciphers'].map do |cipher|
-        { 'protocol' => line['protocol'], 'cipher' => cipher }
+      line["ciphers"].map do |cipher|
+        { "protocol" => line["protocol"], "cipher" => cipher }
       end
     end.flatten
   end

--- a/lib/resources/sys_info.rb
+++ b/lib/resources/sys_info.rb
@@ -1,10 +1,9 @@
-# encoding: utf-8
 module Inspec::Resources
   # this resource returns additional system informatio
   class System < Inspec.resource(1)
-    name 'sys_info'
+    name "sys_info"
 
-    desc 'Use the user InSpec system resource to test for operating system properties.'
+    desc "Use the user InSpec system resource to test for operating system properties."
     example "
       describe sys_info do
         its('hostname') { should eq 'example.com' }
@@ -15,11 +14,11 @@ module Inspec::Resources
     def hostname
       os = inspec.os
       if os.linux?
-        inspec.command('hostname').stdout.chomp
+        inspec.command("hostname").stdout.chomp
       elsif os.windows?
-        inspec.powershell('$env:computername').stdout.chomp
+        inspec.powershell("$env:computername").stdout.chomp
       else
-        skip_resource 'The `sys_info.hostname` resource is not supported on your OS yet.'
+        skip_resource "The `sys_info.hostname` resource is not supported on your OS yet."
       end
     end
   end

--- a/lib/resources/users.rb
+++ b/lib/resources/users.rb
@@ -1,10 +1,9 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'utils/parser'
-require 'utils/convert'
-require 'utils/filter'
+require "utils/parser"
+require "utils/convert"
+require "utils/filter"
 
 module Inspec::Resources
   # This file contains two resources, the `user` and `users` resource.
@@ -19,15 +18,15 @@ module Inspec::Resources
         LinuxUser.new(inspec)
       elsif os.windows?
         WindowsUser.new(inspec)
-      elsif ['darwin'].include?(os[:family])
+      elsif ["darwin"].include?(os[:family])
         DarwinUser.new(inspec)
-      elsif ['freebsd'].include?(os[:family])
+      elsif ["freebsd"].include?(os[:family])
         FreeBSDUser.new(inspec)
-      elsif ['aix'].include?(os[:family])
+      elsif ["aix"].include?(os[:family])
         AixUser.new(inspec)
       elsif os.solaris?
         SolarisUser.new(inspec)
-      elsif ['hpux'].include?(os[:family])
+      elsif ["hpux"].include?(os[:family])
         HpuxUser.new(inspec)
       end
     end
@@ -54,8 +53,8 @@ module Inspec::Resources
   class Users < Inspec.resource(1)
     include UserManagementSelector
 
-    name 'users'
-    desc 'Use the users InSpec audit resource to test local user profiles. Users can be filtered by groups to which they belong, the frequency of required password changes, the directory paths to home and shell.'
+    name "users"
+    desc "Use the users InSpec audit resource to test local user profiles. Users can be filtered by groups to which they belong, the frequency of required password changes, the directory paths to home and shell."
     example "
       describe users.where(uid: 0).entries do
         it { should eq ['root'] }
@@ -66,7 +65,7 @@ module Inspec::Resources
     def initialize
       # select user provider
       @user_provider = select_user_manager(inspec.os)
-      return skip_resource 'The `users` resource is not supported on your OS yet.' if @user_provider.nil?
+      return skip_resource "The `users` resource is not supported on your OS yet." if @user_provider.nil?
     end
 
     filter = FilterTable.create
@@ -89,7 +88,7 @@ module Inspec::Resources
     filter.connect(self, :collect_user_details)
 
     def to_s
-      'Users'
+      "Users"
     end
 
     private
@@ -139,8 +138,8 @@ module Inspec::Resources
   # end
   class User < Inspec.resource(1)
     include UserManagementSelector
-    name 'user'
-    desc 'Use the user InSpec audit resource to test user profiles, including the groups to which they belong, the frequency of required password changes, the directory paths to home and shell.'
+    name "user"
+    desc "Use the user InSpec audit resource to test user profiles, including the groups to which they belong, the frequency of required password changes, the directory paths to home and shell."
     example "
       describe user('root') do
         it { should exist }
@@ -152,7 +151,7 @@ module Inspec::Resources
       @username = username
       # select user provider
       @user_provider = select_user_manager(inspec.os)
-      return skip_resource 'The `user` resource is not supported on your OS yet.' if @user_provider.nil?
+      return skip_resource "The `user` resource is not supported on your OS yet." if @user_provider.nil?
     end
 
     def exists?
@@ -213,36 +212,36 @@ module Inspec::Resources
 
     # implement 'mindays' method to be compatible with serverspec
     def minimum_days_between_password_change
-      deprecated('minimum_days_between_password_change', "Please use: its('mindays')")
+      deprecated("minimum_days_between_password_change", "Please use: its('mindays')")
       mindays
     end
 
     # implement 'maxdays' method to be compatible with serverspec
     def maximum_days_between_password_change
-      deprecated('maximum_days_between_password_change', "Please use: its('maxdays')")
+      deprecated("maximum_days_between_password_change", "Please use: its('maxdays')")
       maxdays
     end
 
     # implements rspec has matcher, to be compatible with serverspec
     # @see: https://github.com/rspec/rspec-expectations/blob/master/lib/rspec/matchers/built_in/has.rb
     def has_uid?(compare_uid)
-      deprecated('has_uid?')
+      deprecated("has_uid?")
       uid == compare_uid
     end
 
     def has_home_directory?(compare_home)
-      deprecated('has_home_directory?', "Please use: its('home')")
+      deprecated("has_home_directory?", "Please use: its('home')")
       home == compare_home
     end
 
     def has_login_shell?(compare_shell)
-      deprecated('has_login_shell?', "Please use: its('shell')")
+      deprecated("has_login_shell?", "Please use: its('shell')")
       shell == compare_shell
     end
 
     def has_authorized_key?(_compare_key)
-      deprecated('has_authorized_key?')
-      fail NotImplementedError
+      deprecated("has_authorized_key?")
+      raise NotImplementedError
     end
 
     def deprecated(name, alternative = nil)
@@ -292,7 +291,7 @@ module Inspec::Resources
     #   groups: '',
     # }
     def identity(_username)
-      fail 'user provider must implement the `identity` method'
+      raise "user provider must implement the `identity` method"
     end
 
     # returns optional information about a user, eg shell
@@ -313,7 +312,7 @@ module Inspec::Resources
 
     # returns an array with users
     def list_users
-      fail 'user provider must implement the `list_users` method'
+      raise "user provider must implement the `list_users` method"
     end
 
     # retuns all aspects of the user as one hash
@@ -341,7 +340,7 @@ module Inspec::Resources
     attr_reader :inspec, :id_cmd, :list_users_cmd
     def initialize(inspec)
       @inspec = inspec
-      @id_cmd ||= 'id'
+      @id_cmd ||= "id"
       @list_users_cmd ||= 'cut -d: -f1 /etc/passwd | grep -v "^#"'
       super
     end
@@ -357,7 +356,7 @@ module Inspec::Resources
     def parse_value(line)
       SimpleConfig.new(
         line,
-        line_separator: ',',
+        line_separator: ",",
         assignment_re: /^\s*([^\(]*?)\s*\(\s*(.*?)\)*$/,
         group_re: nil,
         multiple_values: false,
@@ -378,11 +377,11 @@ module Inspec::Resources
       ).params
 
       {
-        uid: convert_to_i(parse_value(params['uid']).keys[0]),
-        username: parse_value(params['uid']).values[0],
-        gid: convert_to_i(parse_value(params['gid']).keys[0]),
-        groupname: parse_value(params['gid']).values[0],
-        groups: parse_value(params['groups']).values,
+        uid: convert_to_i(parse_value(params["uid"]).keys[0]),
+        username: parse_value(params["uid"]).values[0],
+        gid: convert_to_i(parse_value(params["gid"]).keys[0]),
+        groupname: parse_value(params["gid"]).values[0],
+        groups: parse_value(params["groups"]).values,
       }
     end
 
@@ -408,8 +407,8 @@ module Inspec::Resources
       # returns: root:x:0:0:root:/root:/bin/bash
       passwd = parse_passwd_line(cmd.stdout.chomp)
       {
-        home: passwd['home'],
-        shell: passwd['shell'],
+        home: passwd["home"],
+        shell: passwd["shell"],
       }
     end
 
@@ -425,9 +424,9 @@ module Inspec::Resources
       ).params
 
       {
-        mindays: convert_to_i(params['Minimum number of days between password change']),
-        maxdays: convert_to_i(params['Maximum number of days between password change']),
-        warndays: convert_to_i(params['Number of days of warning before password expires']),
+        mindays: convert_to_i(params["Minimum number of days between password change"]),
+        maxdays: convert_to_i(params["Maximum number of days between password change"]),
+        warndays: convert_to_i(params["Number of days of warning before password expires"]),
       }
     end
   end
@@ -435,7 +434,7 @@ module Inspec::Resources
   class SolarisUser < LinuxUser
     def initialize(inspec)
       @inspec = inspec
-      @id_cmd ||= 'id -a'
+      @id_cmd ||= "id -a"
       super
     end
   end
@@ -460,7 +459,7 @@ module Inspec::Resources
       lsuser = inspec.command("lsuser -C -a home shell #{username}")
       return nil if lsuser.exit_status != 0
 
-      user = lsuser.stdout.chomp.split("\n").last.split(':')
+      user = lsuser.stdout.chomp.split("\n").last.split(":")
       {
         home:  user[1],
         shell: user[2],
@@ -473,7 +472,7 @@ module Inspec::Resources
       )
       return nil if cmd.exit_status != 0
 
-      user_sec = cmd.stdout.chomp.split("\n").last.split(':')
+      user_sec = cmd.stdout.chomp.split("\n").last.split(":")
 
       {
         mindays:  user_sec[1].to_i * 7,
@@ -487,7 +486,7 @@ module Inspec::Resources
     def meta_info(username)
       hpuxuser = inspec.command("logins -x -l #{username}")
       return nil if hpuxuser.exit_status != 0
-      user = hpuxuser.stdout.chomp.split(' ')
+      user = hpuxuser.stdout.chomp.split(" ")
       {
         home: user[4],
         shell: user[5],
@@ -502,7 +501,7 @@ module Inspec::Resources
   # @see http://superuser.com/questions/592921/mac-osx-users-vs-dscl-command-to-list-user
   class DarwinUser < UnixUser
     def initialize(inspec)
-      @list_users_cmd ||= 'dscl . list /Users'
+      @list_users_cmd ||= "dscl . list /Users"
       super
     end
 
@@ -518,8 +517,8 @@ module Inspec::Resources
       ).params
 
       {
-        home: params['NFSHomeDirectory'],
-        shell: params['UserShell'],
+        home: params["NFSHomeDirectory"],
+        shell: params["UserShell"],
       }
     end
   end
@@ -541,8 +540,8 @@ module Inspec::Resources
       # returns: root:*:0:0:Charlie &:/root:/bin/csh
       passwd = parse_passwd_line(cmd.stdout.chomp)
       {
-        home: passwd['home'],
-        shell: passwd['shell'],
+        home: passwd["home"],
+        shell: passwd["shell"],
       }
     end
   end

--- a/lib/resources/vbscript.rb
+++ b/lib/resources/vbscript.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'securerandom'
+require "securerandom"
 
 module Inspec::Resources
   # This resource allows users to run vbscript on windows machines. We decided
@@ -22,8 +21,8 @@ module Inspec::Resources
   # after we executed it
   # @see https://msdn.microsoft.com/en-us/library/aa364991.aspx
   class VBScript < PowershellScript
-    name 'vbscript'
-    desc ''
+    name "vbscript"
+    desc ""
     example "
       script = <<-EOH
         # you vbscript
@@ -35,7 +34,7 @@ module Inspec::Resources
     "
 
     def initialize(vbscript)
-      return skip_resource 'The `vbscript` resource is not supported on your OS yet.' unless inspec.os.windows?
+      return skip_resource "The `vbscript` resource is not supported on your OS yet." unless inspec.os.windows?
       @seperator = SecureRandom.uuid
       cmd = <<-EOH
 $vbscript = @"
@@ -55,14 +54,14 @@ EOH
     end
 
     def to_s
-      'Windows VBScript'
+      "Windows VBScript"
     end
 
     private
 
     def parse_stdout
       res = inspec.backend.run_command(@command)
-      parsed_result = res.stdout.gsub(/#{@seperator}\r\n$/, '')
+      parsed_result = res.stdout.gsub(/#{@seperator}\r\n$/, "")
       res.stdout = parsed_result
       res
     end

--- a/lib/resources/windows_feature.rb
+++ b/lib/resources/windows_feature.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -29,8 +28,8 @@
 # }
 module Inspec::Resources
   class WindowsFeature < Inspec.resource(1)
-    name 'windows_feature'
-    desc 'Use the windows_feature InSpec audit resource to test features on Microsoft Windows.'
+    name "windows_feature"
+    desc "Use the windows_feature InSpec audit resource to test features on Microsoft Windows."
     example "
       describe windows_feature('dhcp') do
         it { should be_installed }
@@ -42,7 +41,7 @@ module Inspec::Resources
       @cache = nil
 
       # verify that this resource is only supported on Windows
-      return skip_resource 'The `windows_feature` resource is not supported on your OS.' if !inspec.os.windows?
+      return skip_resource "The `windows_feature` resource is not supported on your OS." if !inspec.os.windows?
     end
 
     # returns true if the package is installed
@@ -58,7 +57,7 @@ module Inspec::Resources
 
       @cache = {
         name: @feature,
-        type: 'windows-feature',
+        type: "windows-feature",
       }
 
       # cannot rely on exit code for now, successful command returns exit code 1
@@ -71,10 +70,10 @@ module Inspec::Resources
       end
 
       @cache = {
-        name: params['Name'],
-        description: params['Description'],
-        installed: params['Installed'],
-        type: 'windows-feature',
+        name: params["Name"],
+        description: params["Description"],
+        installed: params["Installed"],
+        type: "windows-feature",
       }
     end
 

--- a/lib/resources/windows_task.rb
+++ b/lib/resources/windows_task.rb
@@ -1,10 +1,9 @@
-# encoding: utf-8
 # author: Gary Bright @username-is-already-taken2
 # author: Chris Beard @cdbeard2016
 module Inspec::Resources
   class WindowsTasks < Inspec.resource(1)
-    name 'windows_task'
-    desc 'Use the windows_task InSpec audit resource to test task schedules on Microsoft Windows.'
+    name "windows_task"
+    desc "Use the windows_task InSpec audit resource to test task schedules on Microsoft Windows."
     example "
       describe windows_task('\\Microsoft\\Windows\\Time Synchronization\\SynchronizeTime') do
         it { should be_enabled }
@@ -31,7 +30,7 @@ module Inspec::Resources
       @cache = nil
 
       # verify that this resource is only supported on Windows
-      return skip_resource 'The `windows_task` resource is not supported on your OS.' unless inspec.os.windows?
+      return skip_resource "The `windows_task` resource is not supported on your OS." unless inspec.os.windows?
     end
 
     def exists?
@@ -42,12 +41,12 @@ module Inspec::Resources
     # rubocop:disable Style/WordArray
     def enabled?
       return false if info.nil? || info[:state].nil?
-      ['Ready', 'Running'].include?(info[:state])
+      ["Ready", "Running"].include?(info[:state])
     end
 
     def disabled?
       return false if info.nil? || info[:state].nil?
-      info[:scheduled_task_state] == 'Disabled' || info[:state] == 'Disabled'
+      info[:scheduled_task_state] == "Disabled" || info[:state] == "Disabled"
     end
 
     def logon_mode
@@ -88,14 +87,14 @@ module Inspec::Resources
       end
 
       @cache = {
-        uri: params['URI'],
-        state: params['State'],
-        logon_mode: params['Logon Mode'],
-        last_result: params['Last Result'],
-        task_to_run: params['Task To Run'],
-        run_as_user: params['Run As User'],
-        scheduled_task_state: params['Scheduled Task State'],
-        type: 'windows-task',
+        uri: params["URI"],
+        state: params["State"],
+        logon_mode: params["Logon Mode"],
+        last_result: params["Last Result"],
+        task_to_run: params["Task To Run"],
+        run_as_user: params["Run As User"],
+        scheduled_task_state: params["Scheduled Task State"],
+        type: "windows-task",
       }
     end
 

--- a/lib/resources/wmi.rb
+++ b/lib/resources/wmi.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'utils/object_traversal'
+require "utils/object_traversal"
 
 module Inspec::Resources
   # This resource simplifies the access to wmi
@@ -10,8 +9,8 @@ module Inspec::Resources
   # WMIC /NAMESPACE:\\root\rsop\computer PATH RSOP_SecuritySettingNumeric WHERE "KeyName = 'MinimumPasswordAge' And precedence=1" GET Setting
   # We use Get-WmiObject via Powershell to retrieve all values.
   class WMI < Inspec.resource(1)
-    name 'wmi'
-    desc 'request wmi information'
+    name "wmi"
+    desc "request wmi information"
     example "
       describe wmi({
         class: 'RSOP_SecuritySettingNumeric',
@@ -27,7 +26,7 @@ module Inspec::Resources
 
     def initialize(wmiclass = nil, opts = nil)
       # verify that this resource is only supported on Windows
-      return skip_resource 'The `windows_feature` resource is not supported on your OS.' unless inspec.os.windows?
+      return skip_resource "The `windows_feature` resource is not supported on your OS." unless inspec.os.windows?
 
       @options = opts || {}
       # if wmiclass is not a hash, we have to handle deprecation behavior
@@ -66,7 +65,7 @@ module Inspec::Resources
       args = @options.select { |key, _value| [:class, :namespace, :query, :filter].include?(key) }
 
       # convert to Get-WmiObject arguments
-      params = ''
+      params = ""
       args.each { |key, value| params += " -#{key} \"#{value}\"" }
 
       # run wmi command and filter empty wmi

--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -1,14 +1,13 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'utils/parser'
-require 'utils/filter'
+require "utils/parser"
+require "utils/filter"
 
 module Inspec::Resources
   class XinetdConf < Inspec.resource(1)
-    name 'xinetd_conf'
-    desc 'Xinetd services configuration.'
+    name "xinetd_conf"
+    desc "Xinetd services configuration."
     example "
       describe xinetd_conf.services('chargen') do
         its('socket_types') { should include 'dgram' }
@@ -21,7 +20,7 @@ module Inspec::Resources
 
     include XinetdParser
 
-    def initialize(conf_path = '/etc/xinetd.conf')
+    def initialize(conf_path = "/etc/xinetd.conf")
       @conf_path = conf_path
       @contents = {}
     end
@@ -37,14 +36,14 @@ module Inspec::Resources
     filter = FilterTable.create
     filter.add_accessor(:where)
           .add_accessor(:entries)
-          .add(:services,     field: 'service')
-          .add(:ids,          field: 'id')
-          .add(:socket_types, field: 'socket_type')
-          .add(:types,        field: 'type')
-          .add(:protocols,    field: 'protocol')
-          .add(:wait,         field: 'wait')
-          .add(:disabled?) { |x| x.where('disable' => 'no').services.empty? }
-          .add(:enabled?) { |x| x.where('disable' => 'yes').services.empty? }
+          .add(:services,     field: "service")
+          .add(:ids,          field: "id")
+          .add(:socket_types, field: "socket_type")
+          .add(:types,        field: "type")
+          .add(:protocols,    field: "protocol")
+          .add(:wait,         field: "wait")
+          .add(:disabled?) { |x| x.where("disable" => "no").services.empty? }
+          .add(:enabled?) { |x| x.where("disable" => "yes").services.empty? }
           .connect(self, :service_lines)
 
     private
@@ -68,7 +67,7 @@ module Inspec::Resources
       return {} if read_content.nil?
       flat_params = parse_xinetd(read_content)
       # we need to map service data in order to use it with filtertable
-      params = { 'services' => {} }
+      params = { "services" => {} }
 
       # map services that were defined and map it to the service hash
       flat_params.each do |k, v|
@@ -79,13 +78,13 @@ module Inspec::Resources
         # handle service entries
         else
           # store service
-          params['services'][name] = v
+          params["services"][name] = v
 
           # add the service identifier to its parameters
           if v.is_a?(Array)
-            v.each { |service| service.params['service'] = name }
+            v.each { |service| service.params["service"] = name }
           else
-            v.params['service'] = name
+            v.params["service"] = name
           end
         end
       end
@@ -95,18 +94,18 @@ module Inspec::Resources
     # Method used to derive the default protocol used from the socket_type
     def default_protocol(type)
       case type
-      when 'stream'
-        'tcp'
-      when 'dgram'
-        'udp'
+      when "stream"
+        "tcp"
+      when "dgram"
+        "udp"
       else
-        'unknown'
+        "unknown"
       end
     end
 
     def service_lines
-      @services ||= params['services'].values.flatten.map { |service|
-        service.params['protocol'] ||= default_protocol(service.params['socket_type'])
+      @services ||= params["services"].values.flatten.map { |service|
+        service.params["protocol"] ||= default_protocol(service.params["socket_type"])
         service.params
       }
     end

--- a/lib/resources/yaml.rb
+++ b/lib/resources/yaml.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'yaml'
+require "yaml"
 
 # Parses a yaml document
 # Usage:
@@ -11,8 +10,8 @@ require 'yaml'
 # end
 module Inspec::Resources
   class YamlConfig < JsonConfig
-    name 'yaml'
-    desc 'Use the yaml InSpec audit resource to test configuration data in a YAML file.'
+    name "yaml"
+    desc "Use the yaml InSpec audit resource to test configuration data in a YAML file."
     example "
       describe yaml do
         its('name') { should eq 'foo' }

--- a/lib/resources/yum.rb
+++ b/lib/resources/yum.rb
@@ -1,8 +1,7 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'resources/file'
+require "resources/file"
 
 # Usage:
 # describe yum do
@@ -32,8 +31,8 @@ require 'resources/file'
 
 module Inspec::Resources
   class Yum < Inspec.resource(1)
-    name 'yum'
-    desc 'Use the yum InSpec audit resource to test packages in the Yum repository.'
+    name "yum"
+    desc "Use the yum InSpec audit resource to test packages in the Yum repository."
     example "
       describe yum.repo('name') do
         it { should exist }
@@ -51,7 +50,7 @@ module Inspec::Resources
       return @cache if defined?(@cache)
       # parse the repository data from yum
       # we cannot use -C, because this is not reliable and may lead to errors
-      @command_result = inspec.command('yum -v repolist all')
+      @command_result = inspec.command("yum -v repolist all")
       @content = @command_result.stdout
       @cache = []
       repo = {}
@@ -75,7 +74,7 @@ module Inspec::Resources
     end
 
     def repos
-      repositories.map { |repo| repo['id'] }
+      repositories.map { |repo| repo["id"] }
     end
 
     def repo(repo)
@@ -88,7 +87,7 @@ module Inspec::Resources
     end
 
     def to_s
-      'Yum Repository'
+      "Yum Repository"
     end
 
     private
@@ -101,7 +100,7 @@ module Inspec::Resources
     # Optimize the key value
     def repo_key(key)
       return key if key.nil?
-      key.gsub('Repo-', '').downcase
+      key.gsub("Repo-", "").downcase
     end
   end
 
@@ -120,7 +119,7 @@ module Inspec::Resources
 
     def info
       return @cache if defined?(@cache)
-      selection = @yum.repositories.select { |e| e['id'] == @reponame || shortname(e['id']) == @reponame }
+      selection = @yum.repositories.select { |e| e["id"] == @reponame || shortname(e["id"]) == @reponame }
       @cache = selection[0] if !selection.nil? && selection.length == 1
       @cache
     end
@@ -132,7 +131,7 @@ module Inspec::Resources
     def enabled?
       repo = info
       return false if repo.nil?
-      info['status'] == 'enabled'
+      info["status"] == "enabled"
     end
 
     def to_s
@@ -143,7 +142,7 @@ module Inspec::Resources
   # for compatability with serverspec
   # this is deprecated syntax and will be removed in future versions
   class YumRepoLegacy < Yum
-    name 'yumrepo'
+    name "yumrepo"
 
     def initialize(name)
       super()
@@ -161,7 +160,7 @@ module Inspec::Resources
     end
 
     def deprecated
-      warn '[DEPRECATION] `yumrepo(reponame)` is deprecated.  Please use `yum.repo(reponame)` instead.'
+      warn "[DEPRECATION] `yumrepo(reponame)` is deprecated.  Please use `yum.repo(reponame)` instead."
     end
   end
 end

--- a/lib/source_readers/flat.rb
+++ b/lib/source_readers/flat.rb
@@ -1,20 +1,19 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'inspec/fetcher'
-require 'inspec/metadata'
+require "inspec/fetcher"
+require "inspec/metadata"
 
 module SourceReaders
   class Flat < Inspec.source_reader(1)
-    name 'flat'
+    name "flat"
     priority 5
 
     def self.resolve(target)
       # TODO: eventually remove the metadata.rb exception here
       # when we have fully phased out metadata.rb in 1.0
       files = target.files.find_all { |x|
-        x.end_with?('.rb') && !x.include?('/') && x != 'metadata.rb'
+        x.end_with?(".rb") && !x.include?("/") && x != "metadata.rb"
       }
       return nil if files.empty?
       new(target, files)

--- a/lib/source_readers/inspec.rb
+++ b/lib/source_readers/inspec.rb
@@ -1,24 +1,23 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'inspec/fetcher'
-require 'inspec/metadata'
+require "inspec/fetcher"
+require "inspec/metadata"
 
 module SourceReaders
   class InspecReader < Inspec.source_reader(1)
-    name 'inspec'
+    name "inspec"
     priority 10
 
     def self.resolve(target)
-      return new(target, 'inspec.yml') if target.files.include?('inspec.yml')
+      return new(target, "inspec.yml") if target.files.include?("inspec.yml")
       # TODO: deprecated for 1.0.0 release
-      if target.files.include?('metadata.rb') &&
-         (
-           target.files.include?('controls') ||
-           target.files.include?('test')
-         )
-        return new(target, 'metadata.rb')
+      if target.files.include?("metadata.rb") &&
+          (
+            target.files.include?("controls") ||
+            target.files.include?("test")
+          )
+        return new(target, "metadata.rb")
       end
       nil
     end
@@ -44,14 +43,14 @@ module SourceReaders
 
     def load_tests
       tests = @target.files.find_all do |path|
-        path.start_with?('controls') && path.end_with?('.rb')
+        path.start_with?("controls") && path.end_with?(".rb")
       end
       Hash[tests.map { |x| [x, @target.read(x)] }]
     end
 
     def load_libs
       tests = @target.files.find_all do |path|
-        path.start_with?('libraries') && path.end_with?('.rb')
+        path.start_with?("libraries") && path.end_with?(".rb")
       end
       Hash[tests.map { |x| [x, @target.read(x)] }]
     end

--- a/lib/utils/command_wrapper.rb
+++ b/lib/utils/command_wrapper.rb
@@ -1,32 +1,31 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'shellwords'
+require "shellwords"
 
 class CommandWrapper
   UNIX_SHELLS = %w{sh bash zsh}.freeze
 
   def self.wrap(cmd, options)
     unless options.is_a?(Hash)
-      fail 'All options for the command wrapper must be provided as a hash. '\
+      raise "All options for the command wrapper must be provided as a hash. "\
         "You entered: #{options.inspect}. Please consult the documentation."
     end
 
     wrap = options[:wrap]
     if !wrap.nil? && !wrap.is_a?(Proc)
-      fail "Called command wrapper with wrap: #{wrap.inspect}. It must be called with a Proc."
+      raise "Called command wrapper with wrap: #{wrap.inspect}. It must be called with a Proc."
     elsif !wrap.nil?
       return wrap.call(cmd)
     end
 
     shell = options[:shell]
     unless UNIX_SHELLS.include?(shell)
-      fail "Don't know how to wrap commands for shell: #{shell.inspect}."
+      raise "Don't know how to wrap commands for shell: #{shell.inspect}."
     end
 
     path = options[:path] || shell
-    args = options[:args] || '-c'
-    path.to_s + ' ' + args + ' ' + Shellwords.escape(cmd)
+    args = options[:args] || "-c"
+    path.to_s + " " + args + " " + Shellwords.escape(cmd)
   end
 end

--- a/lib/utils/convert.rb
+++ b/lib/utils/convert.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Stephan Renatus
 # author: Christoph Hartmann
@@ -27,15 +26,15 @@ module FilterTable
 
     def self.to_ruby(trace)
       chain = trace.instance_variable_get(:@chain)
-      return '' if chain.empty?
-      ' ' + chain.map do |el|
+      return "" if chain.empty?
+      " " + chain.map do |el|
         m = el[0][0]
         args = el[0].drop(1)
         nxt = to_ruby(el[1])
         next m.to_s + nxt if args.empty?
-        next m.to_s + ' ' + args[0].inspect + nxt if args.length == 1
-        m.to_s + '(' + args.map(&:inspect).join(', ') + ')' + nxt
-      end.join(' ')
+        next m.to_s + " " + args[0].inspect + nxt if args.length == 1
+        m.to_s + "(" + args.map(&:inspect).join(", ") + ")" + nxt
+      end.join(" ")
     end
   end
 
@@ -52,7 +51,7 @@ module FilterTable
       return self if !conditions.is_a?(Hash)
       return self if conditions.empty? && !block_given?
 
-      filters = ''
+      filters = ""
       table = @params
       conditions.each do |field, condition|
         filters += " #{field} == #{condition.inspect}"
@@ -60,7 +59,7 @@ module FilterTable
       end
 
       if block_given?
-        table = table.find_all { |e| new_entry(e, '').instance_eval(&block) }
+        table = table.find_all { |e| new_entry(e, "").instance_eval(&block) }
         src = Trace.new
         src.instance_eval(&block)
         filters += Trace.to_ruby(src)
@@ -70,13 +69,13 @@ module FilterTable
     end
 
     def new_entry(*_)
-      fail "#{self.class} must not be used on its own. It must be inherited "\
-           'and the #new_entry method must be implemented. This is an internal '\
-           'error and should not happen.'
+      raise "#{self.class} must not be used on its own. It must be inherited "\
+           "and the #new_entry method must be implemented. This is an internal "\
+           "error and should not happen."
     end
 
     def entries
-      f = @resource.to_s + @filters.to_s + ' one entry'
+      f = @resource.to_s + @filters.to_s + " one entry"
       @params.map do |line|
         new_entry(line, f)
       end
@@ -162,7 +161,7 @@ module FilterTable
           define_method x[0], &x[1]
         end
 
-        define_method :new_entry do |hashmap, filter = ''|
+        define_method :new_entry do |hashmap, filter = ""|
           return entry_struct.new if hashmap.nil?
           res = entry_struct.new(*struct_fields.map { |x| hashmap[x] })
           res.__filter = filter
@@ -174,7 +173,7 @@ module FilterTable
       accessors = @accessors + @connectors.keys
       accessors.each do |method_name|
         resource.send(:define_method, method_name.to_sym) do |*args, &block|
-          filter = table.new(self, method(table_accessor).call, ' with')
+          filter = table.new(self, method(table_accessor).call, " with")
           filter.method(method_name.to_sym).call(*args, &block)
         end
       end

--- a/lib/utils/filter_array.rb
+++ b/lib/utils/filter_array.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Chef Software, Inc.
 # license: All rights reserved
 # author: Stephan Renatus

--- a/lib/utils/find_files.rb
+++ b/lib/utils/find_files.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # license: All rights reserved
 # author: Dominik Richter
@@ -6,14 +5,14 @@
 
 module FindFiles
   TYPES = {
-    block: 'b',
-    character: 'c',
-    directory: 'd',
-    pipe: 'p',
-    file: 'f',
-    link: 'l',
-    socket: 's',
-    door: 'D',
+    block: "b",
+    character: "c",
+    directory: "d",
+    pipe: "p",
+    file: "f",
+    link: "l",
+    socket: "s",
+    door: "D",
   }.freeze
 
   # ignores errors

--- a/lib/utils/hash.rb
+++ b/lib/utils/hash.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
@@ -21,7 +20,7 @@ class ::Hash
     inject({}) do |acc, (key, value)|
       index = prefix.to_s + key.to_s
       if value.is_a?(Hash)
-        acc.merge(value.smash(index + '-'))
+        acc.merge(value.smash(index + "-"))
       else
         acc.merge(index => value)
       end

--- a/lib/utils/json_log.rb
+++ b/lib/utils/json_log.rb
@@ -1,17 +1,16 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 
-require 'json'
+require "json"
 
 # a simple streaming json logger
 class Logger::JSONFormatter < Logger::Formatter
   def call(severity, time, progname, msg)
     puts JSON.generate(
       {
-        'progname'=> progname,
-        'severity'=> severity,
-        'time'=> time,
-        'msg'=> msg,
-      },)
+        "progname"=> progname,
+        "severity"=> severity,
+        "time"=> time,
+        "msg"=> msg,
+      })
   end
 end

--- a/lib/utils/latest_version.rb
+++ b/lib/utils/latest_version.rb
@@ -1,19 +1,18 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 
-require 'json'
-require 'net/http'
+require "json"
+require "net/http"
 
 class LatestInSpecVersion
   # fetches the latest version from rubygems server
   def latest
-    uri = URI('https://rubygems.org/api/v1/gems/inspec.json')
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') {|http|
+    uri = URI("https://rubygems.org/api/v1/gems/inspec.json")
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") { |http|
       http.read_timeout = 0.5
       http.get(uri.path)
     }
     inspec_info = JSON.parse(res.body)
-    inspec_info['version']
+    inspec_info["version"]
   rescue Exception # rubocop:disable Lint/RescueException
     nil
   end

--- a/lib/utils/modulator.rb
+++ b/lib/utils/modulator.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 module Modulator

--- a/lib/utils/object_traversal.rb
+++ b/lib/utils/object_traversal.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 module ObjectTraverser

--- a/lib/utils/parser.rb
+++ b/lib/utils/parser.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
 
@@ -9,7 +8,7 @@ module PasswdParser
   # @return [Array] Collection of passwd entries
   def parse_passwd(content)
     content.to_s.split("\n").map do |line|
-      next if line[0] == '#'
+      next if line[0] == "#"
       parse_passwd_line(line)
     end.compact
   end
@@ -19,15 +18,15 @@ module PasswdParser
   # @param [String] line a line of /etc/passwd
   # @return [Hash] Map of entries in this line
   def parse_passwd_line(line)
-    x = line.split(':')
+    x = line.split(":")
     {
-      'user' => x.at(0),
-      'password' => x.at(1),
-      'uid' => x.at(2),
-      'gid' => x.at(3),
-      'desc' => x.at(4),
-      'home' => x.at(5),
-      'shell' => x.at(6),
+      "user" => x.at(0),
+      "password" => x.at(1),
+      "uid" => x.at(2),
+      "gid" => x.at(3),
+      "desc" => x.at(4),
+      "home" => x.at(5),
+      "shell" => x.at(6),
     }
   end
 end
@@ -44,7 +43,7 @@ module CommentParser
     idx_comment = raw.index(opts[:comment_char])
     idx_nl = raw.length if idx_nl.nil?
     idx_comment = idx_nl + 1 if idx_comment.nil?
-    line = ''
+    line = ""
 
     # is a comment inside this line
     if idx_comment < idx_nl && idx_comment != 0
@@ -74,12 +73,12 @@ module MountParser
 
     if compatibility == false
       # parse options as array
-      mount_options[:options] = mount[5].gsub(/\(|\)/, '').split(',')
+      mount_options[:options] = mount[5].gsub(/\(|\)/, "").split(",")
     else
       # parse options as serverspec uses it, tbis is deprecated
       mount_options[:options] = {}
-      mount[5].gsub(/\(|\)/, '').split(',').each do |option|
-        name, val = option.split('=')
+      mount[5].gsub(/\(|\)/, "").split(",").each do |option|
+        name, val = option.split("=")
         if val.nil?
           val = true
         elsif val =~ /^\d+$/
@@ -112,11 +111,11 @@ module SolarisNetstatParser
       # find header, its delimiter
       if line =~ /TCP:|UDP:|SCTP:/
         # get protocol
-        protocol = line.split(':')[0].chomp.strip.downcase
+        protocol = line.split(":")[0].chomp.strip.downcase
 
         # determine version tcp, tcp6, udp, udp6
-        proto_version = line.split(':')[1].chomp.strip
-        protocol += '6' if proto_version == 'IPv6'
+        proto_version = line.split(":")[1].chomp.strip
+        protocol += "6" if proto_version == "IPv6"
 
         # reset names cache
         column_widths = nil
@@ -136,9 +135,9 @@ module SolarisNetstatParser
 
         # parse the header names
         # TODO: names should be optional
-        names = split_columns(column_widths, cache_name_line).to_a.map { |v| v.chomp.strip.downcase.tr(' ', '-').gsub(/[^\w-]/, '_') }
+        names = split_columns(column_widths, cache_name_line).to_a.map { |v| v.chomp.strip.downcase.tr(" ", "-").gsub(/[^\w-]/, "_") }
         info = {
-          'protocol' => protocol.downcase,
+          "protocol" => protocol.downcase,
         }
 
         # generate hash for each line and use the names as keys
@@ -201,22 +200,22 @@ module XinetdParser
     until rest.empty?
       # extract content line
       nl = rest.index("\n") || (rest.length-1)
-      comment = rest.index('#') || (rest.length-1)
+      comment = rest.index("#") || (rest.length-1)
       dst_idx = (comment < nl) ? comment : nl
-      inner_line = (dst_idx == 0) ? '' : rest[0..dst_idx-1].strip
+      inner_line = (dst_idx == 0) ? "" : rest[0..dst_idx-1].strip
       # update unparsed content
       rest = rest[nl+1..-1]
       next if inner_line.empty?
 
-      if inner_line == '}'
-        if cur_group == 'defaults'
+      if inner_line == "}"
+        if cur_group == "defaults"
           res[cur_group] = SimpleConfig.new(simple_conf.join("\n"))
         else
           res[cur_group] ||= []
           res[cur_group].push(SimpleConfig.new(simple_conf.join("\n")))
         end
         cur_group = nil
-      elsif rest.lstrip[0] == '{'
+      elsif rest.lstrip[0] == "{"
         cur_group = inner_line
         simple_conf = []
         rest = rest[rest.index("\n")+1..-1]

--- a/lib/utils/plugin_registry.rb
+++ b/lib/utils/plugin_registry.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
 
@@ -39,7 +38,7 @@ class PluginRegistry
     #
     # @return [PluginRegistry] plugin registry for this plugin
     def self.plugin_registry
-      fail "Plugin #{self} does not implement `self.plugin_registry()`. This method is required"
+      raise "Plugin #{self} does not implement `self.plugin_registry()`. This method is required"
     end
 
     # Register a new plugin by name
@@ -47,7 +46,7 @@ class PluginRegistry
     # @param [String] the unique name of this plugin
     # @return [nil] disregard
     def self.name(name)
-      fail "Trying to register #{self} with name == nil" if name.nil?
+      raise "Trying to register #{self} with name == nil" if name.nil?
       @name = name
       plugin_registry.registry[name] = self
     end
@@ -72,7 +71,7 @@ class PluginRegistry
     # @param [String] target to try to resolve
     # @return [Plugin] instance if it can be resolved, nil otherwise
     def self.resolve(_target)
-      fail "Plugin #{self} does not implement `self.resolve(target)`. This method is required"
+      raise "Plugin #{self} does not implement `self.resolve(target)`. This method is required"
     end
 
     # When a plugin's resolve doesn't lead to the final state, it can

--- a/lib/utils/simpleconfig.rb
+++ b/lib/utils/simpleconfig.rb
@@ -1,10 +1,9 @@
-# encoding: utf-8
 # copyright: 2015, Dominik Richter
 # license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 
-require 'utils/parser'
+require "utils/parser"
 
 class SimpleConfig
   include CommentParser
@@ -81,7 +80,7 @@ class SimpleConfig
     if opts[:multiple_values]
       @vals[line.strip] ||= []
     else
-      @vals[line.strip] = ''
+      @vals[line.strip] = ""
     end
   end
 
@@ -92,7 +91,7 @@ class SimpleConfig
       parse_implicit_assignment_line(line, opts)
 
     # return whatever is left
-    rest[(idx_nl + 1)..-1] || ''
+    rest[(idx_nl + 1)..-1] || ""
   end
 
   def is_empty_line(l)
@@ -101,9 +100,9 @@ class SimpleConfig
 
   def default_options
     {
-      quotes: '',
+      quotes: "",
       multiline: false,
-      comment_char: '#',
+      comment_char: "#",
       line_separator: nil, # uses this char to seperate lines before parsing
       assignment_re: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/,
       group_re: /\[([^\]]+)\]\s*$/,

--- a/omnibus/Berksfile
+++ b/omnibus/Berksfile
@@ -1,13 +1,12 @@
-# encoding: utf-8
-source 'https://supermarket.chef.io'
+source "https://supermarket.chef.io"
 
-cookbook 'omnibus'
+cookbook "omnibus"
 
 # Uncomment to use the latest version of the Omnibus cookbook from GitHub
 # cookbook 'omnibus', github: 'opscode-cookbooks/omnibus'
 
 group :integration do
-  cookbook 'apt',      '~> 2.8'
-  cookbook 'freebsd',  '~> 0.3'
-  cookbook 'yum-epel', '~> 0.6'
+  cookbook "apt",      "~> 2.8"
+  cookbook "freebsd",  "~> 0.3"
+  cookbook "yum-epel", "~> 0.6"
 end

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,5 +1,4 @@
-# encoding: utf-8
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Install omnibus
 # Sadly due to an ongoing msys2 issue, producing windows builds requires
@@ -11,9 +10,9 @@ source 'https://rubygems.org'
 # gem 'omnibus-software', github: 'chef/omnibus-software', branch: 'ksubrama/ruby23'
 
 # Use entries from chef's Gemfile
-gem 'omnibus', github: 'chef/omnibus', branch: 'sersut/ff-ksubrama/gcc_investigate'
-gem 'omnibus-software', github: 'chef/omnibus-software', branch: 'shain/ruby_windows_monster'
-gem 'license_scout', github: 'chef/license_scout'
+gem "omnibus", github: "chef/omnibus", branch: "sersut/ff-ksubrama/gcc_investigate"
+gem "omnibus-software", github: "chef/omnibus-software", branch: "shain/ruby_windows_monster"
+gem "license_scout", github: "chef/license_scout"
 
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need
@@ -21,10 +20,10 @@ gem 'license_scout', github: 'chef/license_scout'
 # by running `bundle install --without development` to speed up build times.
 group :development do
   # Use Berkshelf for resolving cookbook dependencies
-  gem 'berkshelf', '~> 4.3'
+  gem "berkshelf", "~> 4.3"
 
   # Use Test Kitchen with Vagrant for converging the build environment
-  gem 'test-kitchen',    '~> 1.9'
-  gem 'kitchen-vagrant', '~> 0.19'
-  gem 'winrm-fs', '~> 0.4'
+  gem "test-kitchen",    "~> 1.9"
+  gem "kitchen-vagrant", "~> 0.19"
+  gem "winrm-fs", "~> 0.4"
 end

--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright:: Copyright 2016, Chef Software Inc.
 # License:: Apache License, Version 2.0
@@ -16,15 +15,15 @@
 # limitations under the License.
 #
 
-require_relative '../../../lib/inspec/version.rb'
+require_relative "../../../lib/inspec/version.rb"
 
-name 'inspec'
-friendly_name 'InSpec'
-maintainer 'Chef Software, Inc <maintainers@chef.io>'
-homepage 'https://github.com/chef/inspec'
+name "inspec"
+friendly_name "InSpec"
+maintainer "Chef Software, Inc <maintainers@chef.io>"
+homepage "https://github.com/chef/inspec"
 
-license 'Apache-2.0'
-license_file '../LICENSE'
+license "Apache-2.0"
+license_file "../LICENSE"
 
 # Defaults to C:/opscode/inspec on Windows
 # and /opt/inspec on all other platforms.
@@ -37,35 +36,35 @@ end
 build_version Inspec::VERSION
 build_iteration 1
 
-dependency 'preparation'
+dependency "preparation"
 
-dependency 'inspec'
+dependency "inspec"
 
 # Mark all directories world readable.
-dependency 'gem-permissions'
+dependency "gem-permissions"
 # Redirect all gem bat files and rb files to point to embedded ruby.
-dependency 'shebang-cleanup'
+dependency "shebang-cleanup"
 # Ensure our SSL cert files are accessible to ruby.
-dependency 'openssl-customization'
+dependency "openssl-customization"
 # Remove all .dll.a and .a files needed for static linkage.
-dependency 'clean-static-libs'
+dependency "clean-static-libs"
 
 package :rpm do
-  signing_passphrase ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']
+  signing_passphrase ENV["OMNIBUS_RPM_SIGNING_PASSPHRASE"]
 end
 
 package :pkg do
-  identifier 'com.getchef.pkg.inspec'
-  signing_identity 'Developer ID Installer: Chef Software, Inc. (EU3VF8YLX2)'
+  identifier "com.getchef.pkg.inspec"
+  signing_identity "Developer ID Installer: Chef Software, Inc. (EU3VF8YLX2)"
 end
 compress :dmg
 
 package :msi do
   fast_msi true
-  upgrade_code 'DFCD452F-31E5-4236-ACD1-253F4720250B'
-  wix_light_extension 'WixUtilExtension'
-  signing_identity 'F74E1A68005E8A9C465C3D2FF7B41F3988F0EA09', machine_store: true
+  upgrade_code "DFCD452F-31E5-4236-ACD1-253F4720250B"
+  wix_light_extension "WixUtilExtension"
+  signing_identity "F74E1A68005E8A9C465C3D2FF7B41F3988F0EA09", machine_store: true
 end
 
-exclude '**/.git'
-exclude '**/bundler/git'
+exclude "**/.git"
+exclude "**/bundler/git"

--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright:: Copyright 2016, Chef Software Inc.
 # License:: Apache License, Version 2.0
@@ -15,21 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require_relative '../../../lib/inspec/version.rb'
+require_relative "../../../lib/inspec/version.rb"
 
-name 'inspec'
+name "inspec"
 
-dependency 'ruby'
-dependency 'rb-readline'
-dependency 'bundler'
-dependency 'appbundler'
+dependency "ruby"
+dependency "rb-readline"
+dependency "bundler"
+dependency "appbundler"
 
 license :project_license
 
 default_version "v#{Inspec::VERSION}"
 
 source path: "#{Omnibus::Config.project_root}/../",
-       options: { exclude: ['omnibus'] }
+       options: { exclude: ["omnibus"] }
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
@@ -39,10 +38,10 @@ build do
 
   # We bundle install to ensure the versions of gems we are going to
   # appbundle-lock to are definitely installed
-  bundle 'install --without test integration tools maintenance', env: env
+  bundle "install --without test integration tools maintenance", env: env
 
   gem "build #{name}.gemspec", env: env
   gem "install #{name}-*.gem --no-document", env: env
 
-  appbundle 'inspec', env: env
+  appbundle "inspec", env: env
 end

--- a/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
+++ b/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright:: Copyright (c) 2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
@@ -22,13 +21,13 @@
 #
 # This is required to make Chef tools use https URLs out of the box.
 
-unless ENV.key?('SSL_CERT_FILE')
+unless ENV.key?("SSL_CERT_FILE")
   base_dirs = File.dirname(__FILE__).split(File::SEPARATOR)
 
   (base_dirs.length - 1).downto(0) do |i|
-    candidate_ca_bundle = File.join(base_dirs[0..i] + ['ssl/certs/cacert.pem'])
+    candidate_ca_bundle = File.join(base_dirs[0..i] + ["ssl/certs/cacert.pem"])
     if File.exist?(candidate_ca_bundle)
-      ENV['SSL_CERT_FILE'] = candidate_ca_bundle
+      ENV["SSL_CERT_FILE"] = candidate_ca_bundle
       break
     end
   end

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # This file is used to configure the inspec project. It contains
 # some minimal configuration examples for working with Omnibus. For a full list
@@ -35,7 +34,7 @@ use_s3_caching true
 # s3_access_key  ENV['AWS_ACCESS_KEY_ID']
 # s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
 # s3_bucket      ENV['AWS_S3_BUCKET']
-s3_bucket      'opscode-omnibus-cache'
+s3_bucket      "opscode-omnibus-cache"
 
 # Customize compiler bits
 # ------------------------------
@@ -46,13 +45,13 @@ s3_bucket      'opscode-omnibus-cache'
 
 # Load additional software
 # ------------------------------
-software_gems ['omnibus-software']
+software_gems ["omnibus-software"]
 # local_software_dirs ['/path/to/local/software']
 
 # Windows architecture defaults
 # ------------------------------
-arch = if %w{x86 x64}.include?((ENV['OMNIBUS_WINDOWS_ARCH'] || '').downcase)
-         ENV['OMNIBUS_WINDOWS_ARCH'].downcase.to_sym
+arch = if %w{x86 x64}.include?((ENV["OMNIBUS_WINDOWS_ARCH"] || "").downcase)
+         ENV["OMNIBUS_WINDOWS_ARCH"].downcase.to_sym
        else
          :x86
        end

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # Copyright:: Copyright (c) 2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
@@ -15,9 +14,9 @@
 # limitations under the License.
 #
 
-require 'erb'
-require 'ruby-progressbar'
-require 'fileutils'
+require "erb"
+require "ruby-progressbar"
+require "fileutils"
 
 class Markdown
   class << self
@@ -57,7 +56,7 @@ class Markdown
     end
 
     def suffix
-      '.md'
+      ".md"
     end
 
     def meta(opts)
@@ -108,11 +107,11 @@ class RST
     end
 
     def suffix
-      '.rst'
+      ".rst"
     end
 
     def meta(_o)
-      '' # ignore for now
+      "" # ignore for now
     end
   end
 end
@@ -128,33 +127,33 @@ class ResourceDocs
   end
 
   def partial(x)
-    render(x + '.md.erb')
+    render(x + ".md.erb")
   end
 
   private
 
   def render_path(path)
     abs = File.join(@root, path)
-    fail "Can't find file to render in #{abs}" unless File.file?(abs)
+    raise "Can't find file to render in #{abs}" unless File.file?(abs)
 
     ERB.new(File.read(abs)).result(binding)
   end
 end
 
 namespace :docs do
-  desc 'Create cli docs'
+  desc "Create cli docs"
   task :cli do
     # formatter for the output file
     f = Markdown
     # list of subcommands we ignore; these are e.g. plugins
     skip_commands = %w{scap}
 
-    res = f.meta(title: 'About the InSpec CLI')
-    res << f.h1('InSpec CLI')
-    res << f.p('Use the InSpec CLI to run tests and audits against targets '\
-               'using local, SSH, WinRM, or Docker connections.')
+    res = f.meta(title: "About the InSpec CLI")
+    res << f.h1("InSpec CLI")
+    res << f.p("Use the InSpec CLI to run tests and audits against targets "\
+               "using local, SSH, WinRM, or Docker connections.")
 
-    require 'inspec/cli'
+    require "inspec/cli"
     cmds = Inspec::InspecCLI.all_commands
     cmds.keys.sort.each do |key|
       next if skip_commands.include? key
@@ -163,22 +162,22 @@ namespace :docs do
       res << f.h2(cmd.usage.split.first)
       res << f.p(cmd.description.capitalize)
 
-      res << f.h3('Syntax')
-      res << f.p('This subcommand has the following syntax:')
-      res << f.code("$ inspec #{cmd.usage}", 'bash')
+      res << f.h3("Syntax")
+      res << f.p("This subcommand has the following syntax:")
+      res << f.code("$ inspec #{cmd.usage}", "bash")
 
       opts = cmd.options.select { |_, o| !o.hide }
       unless opts.empty?
-        res << f.h3('Options') + f.p('This subcommand has additional options:')
+        res << f.h3("Options") + f.p("This subcommand has additional options:")
 
-        list = ''
+        list = ""
         opts.keys.sort.each do |option|
           opt = cmd.options[option]
           # TODO: remove when UX of help is reworked 1.0
-          usage = opt.usage.split(', ')
-                     .map { |x| x.tr('[]', '') }
-                     .map { |x| x.start_with?('-') ? x : '-'+x }
-                     .map { |x| '``' + x + '``' }
+          usage = opt.usage.split(", ")
+                     .map { |x| x.tr("[]", "") }
+                     .map { |x| x.start_with?("-") ? x : "-"+x }
+                     .map { |x| "``" + x + "``" }
           list << f.li("#{usage.join(', ')}  \n#{opt.description}")
         end.join
         res << f.ul(list)
@@ -188,27 +187,27 @@ namespace :docs do
       res << "\n\n" if f == RST
     end
 
-    dst = 'docs/cli' + f.suffix
+    dst = "docs/cli" + f.suffix
     File.write(dst, res)
     puts "Documentation generated in #{dst.inspect}"
   end
 
-  desc 'Create resources docs'
+  desc "Create resources docs"
   task :resources, [:clean] do
-    src = 'docs'
-    dst = 'www/source/docs/reference/resources'
+    src = "docs"
+    dst = "www/source/docs/reference/resources"
     FileUtils.mkdir_p(dst)
 
     docs = ResourceDocs.new(src)
-    resources = Dir[File.join(src, 'resources/*.md.erb')]
-                .map { |x| x.sub(/^#{src}/, '') }
+    resources = Dir[File.join(src, "resources/*.md.erb")]
+                .map { |x| x.sub(/^#{src}/, "") }
     puts "Found #{src.length} resource docs"
     puts "Rendering docs to #{dst}/"
 
-    progressbar = ProgressBar.create(total: resources.length, title: 'Rendering')
+    progressbar = ProgressBar.create(total: resources.length, title: "Rendering")
     resources.each do |file|
-      progressbar.log('          '+file)
-      dst_name = File.basename(file).sub(/\.md\.erb$/, '.html.md')
+      progressbar.log("          "+file)
+      dst_name = File.basename(file).sub(/\.md\.erb$/, ".html.md")
       res = docs.render(file)
       File.write(File.join(dst, dst_name), res)
       progressbar.increment
@@ -216,38 +215,38 @@ namespace :docs do
     progressbar.finish
 
     f = Markdown
-    res = f.meta(title: 'InSpec Resources Reference')
-    res << f.h1('InSpec Resources Reference')
-    res << f.p('The following InSpec audit resources are available:')
-    list = ''
+    res = f.meta(title: "InSpec Resources Reference")
+    res << f.h1("InSpec Resources Reference")
+    res << f.p("The following InSpec audit resources are available:")
+    list = ""
     resources.each do |file|
-      name = File.basename(file).sub(/\.md\.erb$/, '')
-      list << f.li(f.a(name.sub('_', '\\_'), 'resources/' + name + '.html'))
+      name = File.basename(file).sub(/\.md\.erb$/, "")
+      list << f.li(f.a(name.sub("_", '\\_'), "resources/" + name + ".html"))
     end
     res << f.ul(list)
-    dst = File.join(src, 'resources.md')
+    dst = File.join(src, "resources.md")
     puts "Create #{dst}"
     File.write(dst, res)
   end
 
-  desc 'Clean all rendered docs from www/'
+  desc "Clean all rendered docs from www/"
   task :clean do
-    dst = 'www/source/docs/reference'
+    dst = "www/source/docs/reference"
     puts "Clean up #{dst}"
     FileUtils.rm_rf(dst) if File.exist?(dst)
     FileUtils.mkdir_p(dst)
   end
 
-  desc 'Copy fixed doc files'
+  desc "Copy fixed doc files"
   task copy: [:clean, :resources] do
-    src = 'docs'
-    dst = 'www/source/docs/reference'
-    files = Dir[File.join(src, '*.md')]
+    src = "docs"
+    dst = "www/source/docs/reference"
+    files = Dir[File.join(src, "*.md")]
 
-    progressbar = ProgressBar.create(total: files.length, title: 'Copying')
+    progressbar = ProgressBar.create(total: files.length, title: "Copying")
     files.each do |path|
-      name = File.basename(path).sub(/\.md$/, '.html.md')
-      progressbar.log('          '+File.join(dst, name))
+      name = File.basename(path).sub(/\.md$/, ".html.md")
+      progressbar.log("          "+File.join(dst, name))
       FileUtils.cp(path, File.join(dst, name))
       progressbar.increment
     end
@@ -264,10 +263,10 @@ def run_tasks_in_namespace(ns)
   end
 end
 
-desc 'Create all docs in docs/ from source code'
+desc "Create all docs in docs/ from source code"
 task :docs do
   run_tasks_in_namespace :docs
-  Verify.file('www/source/docs/reference/README.html.md')
-  Verify.file('www/source/docs/reference/cli.html.md')
-  Verify.file('www/source/docs/reference/resources.html.md')
+  Verify.file("www/source/docs/reference/README.html.md")
+  Verify.file("www/source/docs/reference/cli.html.md")
+  Verify.file("www/source/docs/reference/resources.html.md")
 end

--- a/tasks/maintainers.rb
+++ b/tasks/maintainers.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # Copyright:: Copyright (c) 2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
@@ -15,40 +14,40 @@
 # limitations under the License.
 #
 
-require 'rake'
+require "rake"
 
-SOURCE = File.join(File.dirname(__FILE__), '..', 'MAINTAINERS.toml')
-TARGET = File.join(File.dirname(__FILE__), '..', 'MAINTAINERS.md')
+SOURCE = File.join(File.dirname(__FILE__), "..", "MAINTAINERS.toml")
+TARGET = File.join(File.dirname(__FILE__), "..", "MAINTAINERS.md")
 
 # The list of repositories that teams should own
-REPOSITORIES = ['chef/inspec'].freeze
+REPOSITORIES = ["chef/inspec"].freeze
 
 begin
-  require 'tomlrb'
-  require 'octokit'
-  require 'pp'
+  require "tomlrb"
+  require "octokit"
+  require "pp"
 
   namespace :maintainers do
     task default: :generate
 
-    desc 'Generate MarkDown version of MAINTAINERS file'
+    desc "Generate MarkDown version of MAINTAINERS file"
     task :generate do
       maintainers = Tomlrb.load_file SOURCE
       out = "<!-- This is a generated file. Please do not edit directly -->\n\n"
       out << "<!-- Modify MAINTAINERS.toml and run `rake maintainers:generate` to regenerate. -->\n\n"
-      out << '# ' + maintainers['Preamble']['title'] + "\n\n"
-      out << maintainers['Preamble']['text'] + "\n"
-      out << components(maintainers['people'], maintainers['Org']['Components'])
-      File.open(TARGET, 'w') { |fn|
+      out << "# " + maintainers["Preamble"]["title"] + "\n\n"
+      out << maintainers["Preamble"]["text"] + "\n"
+      out << components(maintainers["people"], maintainers["Org"]["Components"])
+      File.open(TARGET, "w") { |fn|
         fn.write out
       }
     end
 
-    desc 'Synchronize GitHub teams'
+    desc "Synchronize GitHub teams"
     task :synchronize do
       Octokit.auto_paginate = true
       github_teams
-      prepare_teams(source['Org']['Components'].dup)
+      prepare_teams(source["Org"]["Components"].dup)
       sync_teams!
     end
   end
@@ -62,20 +61,20 @@ begin
   end
 
   def teams
-    @teams ||= { 'inspec-maintainers' => { 'title' => 'Maintainers of the InSpec toolset' } }
+    @teams ||= { "inspec-maintainers" => { "title" => "Maintainers of the InSpec toolset" } }
   end
 
   def add_members(team, name)
-    teams['inspec-maintainers']['members'] ||= []
-    teams['inspec-maintainers']['members'] << name
+    teams["inspec-maintainers"]["members"] ||= []
+    teams["inspec-maintainers"]["members"] << name
     teams[team] ||= {}
-    teams[team]['members'] ||= []
-    teams[team]['members'] << name
+    teams[team]["members"] ||= []
+    teams[team]["members"] << name
   end
 
   def set_team_title(team, title)
     teams[team] ||= {}
-    teams[team]['title'] = title
+    teams[team]["title"] = title
   end
 
   def gh_teams
@@ -85,13 +84,13 @@ begin
   # we have to resolve team names to ids. While we're at it, we can get the privacy
   # setting, so we know whether we need to update it
   def github_teams
-    github.org_teams('chef').each do |team|
-      gh_teams[team[:slug]] = { 'id' => team[:id], 'privacy' => team[:privacy] }
+    github.org_teams("chef").each do |team|
+      gh_teams[team[:slug]] = { "id" => team[:id], "privacy" => team[:privacy] }
     end
   end
 
   def get_github_team(team)
-    github.team_members(gh_teams[team]['id']).map do |member|
+    github.team_members(gh_teams[team]["id"]).map do |member|
       member[:login]
     end.sort.uniq.map(&:downcase)
   rescue
@@ -100,10 +99,10 @@ begin
 
   def create_team(team)
     puts "creating new github team: #{team} with title: #{teams[team]['title']} "
-    t = github.create_team('chef', name: team, description: teams[team]['title'],
-                       privacy: 'closed', repo_names: REPOSITORIES,
-                       accept: 'application/vnd.github.ironman-preview+json')
-    gh_teams[team] = { 'id' => t[:id], 'privacy' => t[:privacy] }
+    t = github.create_team("chef", name: team, description: teams[team]["title"],
+                       privacy: "closed", repo_names: REPOSITORIES,
+                       accept: "application/vnd.github.ironman-preview+json")
+    gh_teams[team] = { "id" => t[:id], "privacy" => t[:privacy] }
   end
 
   def compare_teams(current, desired)
@@ -114,11 +113,11 @@ begin
 
   def prepare_teams(cmp)
     %w{text paths}.each { |k| cmp.delete(k) }
-    if cmp.key?('team')
-      team = cmp.delete('team')
-      add_members(team, cmp.delete('lieutenant')) if cmp.key?('lieutenant')
-      add_members(team, cmp.delete('maintainers')) if cmp.key?('maintainers')
-      set_team_title(team, cmp.delete('title'))
+    if cmp.key?("team")
+      team = cmp.delete("team")
+      add_members(team, cmp.delete("lieutenant")) if cmp.key?("lieutenant")
+      add_members(team, cmp.delete("maintainers")) if cmp.key?("maintainers")
+      set_team_title(team, cmp.delete("title"))
     else
       %w{maintainers lieutenant title}.each { |k| cmp.delete(k) }
     end
@@ -145,42 +144,42 @@ begin
   def add_team_members(team, additions)
     additions.each do |member|
       puts "Adding #{member} to #{team}"
-      github.add_team_membership(gh_teams[team]['id'], member, role: 'member',
-                                 accept: 'application/vnd.github.ironman-preview+json')
+      github.add_team_membership(gh_teams[team]["id"], member, role: "member",
+                                 accept: "application/vnd.github.ironman-preview+json")
     end
   end
 
   def remove_team_members(team, deletions)
     deletions.each do |member|
       puts "Removing #{member} from #{team}"
-      github.remove_team_membership(gh_teams[team]['id'], member,
-                                    accept: 'application/vnd.github.ironman-preview+json')
+      github.remove_team_membership(gh_teams[team]["id"], member,
+                                    accept: "application/vnd.github.ironman-preview+json")
     end
   end
 
   def sync_teams!
     teams.each do |name, details|
       current = get_github_team(name)
-      desired = details['members'].flatten.sort.uniq.map(&:downcase)
+      desired = details["members"].flatten.sort.uniq.map(&:downcase)
       additions, deletions = compare_teams(current, desired)
       update_team(name, additions, deletions)
     end
   end
 
   def get_person(person)
-    source['people'][person]
+    source["people"][person]
   end
 
   def components(list, cmp)
-    out = '## ' + cmp.delete('title') + "\n\n"
-    out << cmp.delete('text') + "\n" if cmp.key?('text')
-    out << "To mention the team, use @chef/#{cmp.delete('team')}\n\n" if cmp.key?('team')
-    if cmp.key?('lieutenant')
+    out = "## " + cmp.delete("title") + "\n\n"
+    out << cmp.delete("text") + "\n" if cmp.key?("text")
+    out << "To mention the team, use @chef/#{cmp.delete('team')}\n\n" if cmp.key?("team")
+    if cmp.key?("lieutenant")
       out << "### Lieutenant\n\n"
-      out << person(list, cmp.delete('lieutenant')) + "\n\n"
+      out << person(list, cmp.delete("lieutenant")) + "\n\n"
     end
-    out << maintainers(list, cmp.delete('maintainers')) + "\n" if cmp.key?('maintainers')
-    cmp.delete('paths')
+    out << maintainers(list, cmp.delete("maintainers")) + "\n" if cmp.key?("maintainers")
+    cmp.delete("paths")
     cmp.each { |_k, v| out << components(list, v) }
     out
   end
@@ -195,16 +194,16 @@ begin
 
   # rubocop:disable Metrics/AbcSize
   def person(list, person)
-    out = if list[person].key?('GitHub')
+    out = if list[person].key?("GitHub")
             "* [#{list[person]['Name']}](https://github.com/#{list[person]['GitHub']})"
           else
             "* #{list[person]['Name']}"
           end
-    out << "\n  * IRC - #{list[person]['IRC']}" if list[person].key?('IRC')
-    out << "\n  * [@#{list[person]['Twitter']}](https://twitter.com/#{list[person]['Twitter']})" if list[person].key?('Twitter')
-    out << "\n  * [#{list[person]['email']}](mailto:#{list[person]['email']})" if list[person].key?('email')
-    out << "\n  * #{list[person]['phone']}" if list[person].key?('phone')
-    out << "\n  * [ServerFault](#{list[person]['ServerFault']})" if list[person].key?('ServerFault')
+    out << "\n  * IRC - #{list[person]['IRC']}" if list[person].key?("IRC")
+    out << "\n  * [@#{list[person]['Twitter']}](https://twitter.com/#{list[person]['Twitter']})" if list[person].key?("Twitter")
+    out << "\n  * [#{list[person]['email']}](mailto:#{list[person]['email']})" if list[person].key?("email")
+    out << "\n  * #{list[person]['phone']}" if list[person].key?("phone")
+    out << "\n  * [ServerFault](#{list[person]['ServerFault']})" if list[person].key?("ServerFault")
     out
   end
   # rubocop:enable all

--- a/tasks/shared.rb
+++ b/tasks/shared.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # Copyright:: Copyright (c) 2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
@@ -28,7 +27,7 @@ end
 module Verify
   def self.file(path)
     return print("\033[32m.\033[0m") if File.file?(path)
-    fail "Failed to build this step. Looking for file in #{path} but it doesn't exist."
+    raise "Failed to build this step. Looking for file in #{path} but it doesn't exist."
   end
 
   def self.ok

--- a/tasks/www.rb
+++ b/tasks/www.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # Copyright:: Copyright (c) 2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
@@ -15,105 +14,105 @@
 # limitations under the License.
 #
 
-require_relative 'shared.rb'
+require_relative "shared.rb"
 
 namespace :www do
-  desc 'Builds the tutorial contents'
+  desc "Builds the tutorial contents"
   task :tutorial do
-    Log.section 'Build the online tutorial in www/tutorial/'
-    sh('cd www/tutorial/ && npm install')
-    sh('cd www/tutorial/ && gulp build')
-    Verify.file('www/tutorial/dist/index.html')
-    Verify.file('www/tutorial/dist/css/inspec_tutorial.css')
-    Verify.file('www/tutorial/dist/scripts/inspec_tutorial.js')
-    Verify.file('www/tutorial/dist/dist/inspec_tutorial.js')
+    Log.section "Build the online tutorial in www/tutorial/"
+    sh("cd www/tutorial/ && npm install")
+    sh("cd www/tutorial/ && gulp build")
+    Verify.file("www/tutorial/dist/index.html")
+    Verify.file("www/tutorial/dist/css/inspec_tutorial.css")
+    Verify.file("www/tutorial/dist/scripts/inspec_tutorial.js")
+    Verify.file("www/tutorial/dist/dist/inspec_tutorial.js")
   end
 
-  desc 'Builds the middleman site'
+  desc "Builds the middleman site"
   task :site do
-    Log.section 'Build middleman project in www/'
+    Log.section "Build middleman project in www/"
     Bundler.with_clean_env {
-      sh('cd www/ && bundle install && bundle exec middleman build')
+      sh("cd www/ && bundle install && bundle exec middleman build")
     }
-    Verify.file('www/build/index.html')
-    Verify.file('www/build/javascripts/all.js')
-    Verify.file('www/build/stylesheets/site.css')
+    Verify.file("www/build/index.html")
+    Verify.file("www/build/javascripts/all.js")
+    Verify.file("www/build/stylesheets/site.css")
   end
 
-  desc 'Assemble the website site from middleman and the tutorial'
+  desc "Assemble the website site from middleman and the tutorial"
   task :assemble do
-    Log.section 'Copy only tutorial into middleman build directory'
-    sh('rsync -a --exclude=index.html www/tutorial/dist/* www/build/')
+    Log.section "Copy only tutorial into middleman build directory"
+    sh("rsync -a --exclude=index.html www/tutorial/dist/* www/build/")
   end
 
-  desc 'Builds the full site locally'
-  task build: ['www:tutorial', 'www:site', 'www:assemble']
+  desc "Builds the full site locally"
+  task build: ["www:tutorial", "www:site", "www:assemble"]
 
   task :clean do
-    dst = 'www/build'
+    dst = "www/build"
     FileUtils.rm_rf(dst) if File.directory?(dst)
   end
 
-  desc 'Releases the site to gh-pages'
+  desc "Releases the site to gh-pages"
   task :release do
     # This folder contains the built files
-    dst = 'www/build'
-    unless File.directory?(dst) && File.file?(File.join(dst, 'index.html'))
-      puts 'It looks like you have not built the site yet. Calling rake www:build'
-      Rake::Task['www:build'].invoke
+    dst = "www/build"
+    unless File.directory?(dst) && File.file?(File.join(dst, "index.html"))
+      puts "It looks like you have not built the site yet. Calling rake www:build"
+      Rake::Task["www:build"].invoke
     end
 
-    unless File.directory?(dst) && File.file?(File.join(dst, 'index.html'))
-      fail 'It looks like the site was not build. Aborting.'
+    unless File.directory?(dst) && File.file?(File.join(dst, "index.html"))
+      raise "It looks like the site was not build. Aborting."
     end
 
     # check if git exists
-    sh('command -v git >/dev/null 2>&1') ||
-      fail("It looks like `git` isn't installed. It is required to run this build task.")
+    sh("command -v git >/dev/null 2>&1") ||
+      raise("It looks like `git` isn't installed. It is required to run this build task.")
 
-    unless sh('git diff-index --quiet HEAD --')
-      fail 'Please make sure you have no uncommitted changes in this repository.'
+    unless sh("git diff-index --quiet HEAD --")
+      raise "Please make sure you have no uncommitted changes in this repository."
     end
 
-    File.write('www/build/CNAME', 'inspec.io')
-    file_count = Dir['www/build/*'].length
-    file_size = `du -hs www/build`.sub(/\s+.*$/m, '')
+    File.write("www/build/CNAME", "inspec.io")
+    file_count = Dir["www/build/*"].length
+    file_size = `du -hs www/build`.sub(/\s+.*$/m, "")
 
-    if system('git rev-parse --verify gh-pages')
-      Log.info 'Remove local gh-pages branch'
-      sh('git branch -D gh-pages')
+    if system("git rev-parse --verify gh-pages")
+      Log.info "Remove local gh-pages branch"
+      sh("git branch -D gh-pages")
     end
 
     current_branch = `git rev-parse --abbrev-ref HEAD`.strip
     if current_branch.empty?
-      fail 'Cannot determine current branch to go back to! Aborting.'
+      raise "Cannot determine current branch to go back to! Aborting."
     end
 
-    Log.info 'Create empty gh-pages branch'
-    sh('git checkout --orphan gh-pages')
+    Log.info "Create empty gh-pages branch"
+    sh("git checkout --orphan gh-pages")
 
-    Log.info 'Clear out all local git files!'
-    sh('git rm -rf .')
+    Log.info "Clear out all local git files!"
+    sh("git rm -rf .")
 
     Log.info "Add the built files in #{dst}"
     sh("git add #{dst}")
 
-    Log.info 'Remove all other files in this empty branch'
-    sh('git clean -df')
+    Log.info "Remove all other files in this empty branch"
+    sh("git clean -df")
 
-    Log.info 'Move the site to the root directory'
+    Log.info "Move the site to the root directory"
     sh("git mv #{File.join(dst, '*')} .")
 
-    Log.info 'Commit to gh-pages'
+    Log.info "Commit to gh-pages"
     sh("git commit -m 'website update'")
 
-    require 'inquirer'
+    require "inquirer"
     if Ask.confirm("Ready to go, I have #{file_count} files at #{file_size}. "\
-                   'Do you want to push this live?', default: false)
-      Log.info 'push to origin, this may take a moment'
-      sh('git push -u origin --force-with-lease gh-pages')
+                   "Do you want to push this live?", default: false)
+      Log.info "push to origin, this may take a moment"
+      sh("git push -u origin --force-with-lease gh-pages")
     else
-      puts 'Aborted.'
+      puts "Aborted."
     end
 
     sh("git checkout #{current_branch}")
@@ -121,8 +120,8 @@ namespace :www do
 end
 
 task :www do
-  Rake::Task['www:clean'].invoke
-  Rake::Task['docs'].invoke
-  Rake::Task['www:build'].invoke
-  Rake::Task['www:release'].invoke
+  Rake::Task["www:clean"].invoke
+  Rake::Task["docs"].invoke
+  Rake::Task["www:build"].invoke
+  Rake::Task["www:release"].invoke
 end

--- a/www/Gemfile
+++ b/www/Gemfile
@@ -1,21 +1,20 @@
-# encoding: utf-8
 # If you do not have OpenSSL installed, update
 # the following line to use 'http://' instead
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'slim', '>= 3.0'
+gem "slim", ">= 3.0"
 
 # For faster file watcher updates on Windows:
-gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
+gem "wdm", "~> 0.1.0", platforms: [:mswin, :mingw]
 
 # windows does not come with time zone data
-gem 'tzinfo-data', platforms: [:mswin, :mingw]
+gem "tzinfo-data", platforms: [:mswin, :mingw]
 
 # Middleman Gems
-gem 'middleman-sprockets', '>= 4.0.0'
-gem 'middleman-compass', '>= 4.0.0'
-gem 'middleman', '>= 4.0.0'
-gem 'middleman-livereload'
-gem 'middleman-autoprefixer'
-gem 'middleman-syntax'
-gem 'redcarpet'
+gem "middleman-sprockets", ">= 4.0.0"
+gem "middleman-compass", ">= 4.0.0"
+gem "middleman", ">= 4.0.0"
+gem "middleman-livereload"
+gem "middleman-autoprefixer"
+gem "middleman-syntax"
+gem "redcarpet"

--- a/www/config.rb
+++ b/www/config.rb
@@ -1,5 +1,4 @@
-# encoding: utf-8
-require 'slim'
+require "slim"
 
 ###
 # Page options, layouts, aliases and proxies
@@ -8,12 +7,12 @@ require 'slim'
 # Per-page layout changes:
 #
 # With no layout
-page '/*.xml', layout: false
-page '/*.json', layout: false
-page '/*.txt', layout: false
+page "/*.xml", layout: false
+page "/*.json", layout: false
+page "/*.txt", layout: false
 
 # With alternative layout: we send the sidebar request to the default layout
-page 'docs/*', layout: :docs, locals: { sidebar_layout: 'docs' }
+page "docs/*", layout: :docs, locals: { sidebar_layout: "docs" }
 
 # Proxy pages (http://middlemanapp.com/basics/dynamic-pages/)
 # proxy '/this-page-has-no-template.html', '/template-file.html', locals: {
@@ -29,7 +28,7 @@ configure :development do
 end
 
 # Methods defined in the helpers block are available in templates
-require 'lib/sidebar_helpers'
+require "lib/sidebar_helpers"
 helpers SidebarHelpers
 
 # Methods defined in the helpers block are available in templates

--- a/www/config.ru
+++ b/www/config.ru
@@ -1,12 +1,11 @@
-# encoding: utf-8
-require 'middleman-core/load_paths'
+require "middleman-core/load_paths"
 ::Middleman.setup_load_paths
 
-require 'middleman-core'
-require 'middleman-core/rack'
+require "middleman-core"
+require "middleman-core/rack"
 
-require 'fileutils'
-FileUtils.mkdir('log') unless File.exist?('log')
+require "fileutils"
+FileUtils.mkdir("log") unless File.exist?("log")
 ::Middleman::Logger.singleton("log/#{ENV['RACK_ENV']}.log")
 
 app = ::Middleman::Application.new

--- a/www/lib/sidebar_helpers.rb
+++ b/www/lib/sidebar_helpers.rb
@@ -1,18 +1,17 @@
-# encoding: utf-8
 # helper methods for source/layouts/sidebar.slim
 module SidebarHelpers
   SIDEBAR_LAYOUTS = %w{docs}.freeze
 
   def sidebar_data(sidebar_layout)
     unless SIDEBAR_LAYOUTS.include?(sidebar_layout)
-      fail "'#{sidebar_layout}' is not a valid sidebar layout type."
+      raise "'#{sidebar_layout}' is not a valid sidebar layout type."
     end
 
     data.public_send(:"#{sidebar_layout}_sidebar").sidebar_links.dup
   end
 
   def link_classes(current_url, item_link)
-    't-purple' if same_link?(current_url, item_link.link)
+    "t-purple" if same_link?(current_url, item_link.link)
   end
 
   def print_sub_links?(current_url, item_link)
@@ -27,7 +26,7 @@ module SidebarHelpers
   end
 
   def strip_trailing_slash(str)
-    str.end_with?('/') ? str[0..-2] : str
+    str.end_with?("/") ? str[0..-2] : str
   end
 
   def active_child?(current_url, item_link)

--- a/www/tutorial/scripts/build_simulator_runtime.rb
+++ b/www/tutorial/scripts/build_simulator_runtime.rb
@@ -1,53 +1,52 @@
-# encoding: utf-8
-require 'train'
-require 'docker-api'
-require 'fileutils'
-require 'json'
+require "train"
+require "docker-api"
+require "fileutils"
+require "json"
 
-simulator = 'inspec-simulator'
+simulator = "inspec-simulator"
 
-backend = Train.create('local')
+backend = Train.create("local")
 conn = backend.connection
 
 def build_inspec(backend)
-  puts '----> build inspec.gem'
+  puts "----> build inspec.gem"
   pwd = File.expand_path(File.dirname(__FILE__))
   cmd = backend.run_command("cd #{pwd}/../../../ && rm -f inspec-*.gem && gem build inspec.gemspec")
   puts cmd.stdout
   # move gem to simulator
-  FileUtils.mv(Dir.glob(pwd+'/../../../inspec-*.gem')[0], pwd + '/simulator/install/inspec.gem')
+  FileUtils.mv(Dir.glob(pwd+"/../../../inspec-*.gem")[0], pwd + "/simulator/install/inspec.gem")
 end
 
 def build_inspec_mock(backend)
-  puts '----> build inspec-mock.gem'
+  puts "----> build inspec-mock.gem"
   pwd = File.expand_path(File.dirname(__FILE__))
   # build gem
   cmd = backend.run_command("cd #{pwd}/inspec-mock && rm -f inspec-mock*.gem && gem build inspec-mock.gemspec")
   puts cmd.stdout
   # move gem to simulator
-  FileUtils.mv(Dir.glob(pwd+'/inspec-mock/inspec-mock*.gem')[0], pwd + '/simulator/install/inspec-mock.gem')
+  FileUtils.mv(Dir.glob(pwd+"/inspec-mock/inspec-mock*.gem")[0], pwd + "/simulator/install/inspec-mock.gem")
 end
 
 def build_simulator(name)
-  puts '----> build simulator container (this may take a minute)'
-  simulator_dir = File.expand_path(File.join(File.dirname(__FILE__), 'simulator'))
+  puts "----> build simulator container (this may take a minute)"
+  simulator_dir = File.expand_path(File.join(File.dirname(__FILE__), "simulator"))
   Docker.options[:read_timeout] = 5 * 60
   image = Docker::Image.build_from_dir(simulator_dir) do |v|
     begin
-      if (log = JSON.parse(v)) && log.key?('stream')
-        puts log['stream']
+      if (log = JSON.parse(v)) && log.key?("stream")
+        puts log["stream"]
       end
     rescue JSON::ParserError => _e
       puts v
     end
   end
-  image.tag('repo' => name, 'tag' => 'latest', force: true)
+  image.tag("repo" => name, "tag" => "latest", force: true)
 end
 
 def copy_examples
-  puts '----> copy examples'
+  puts "----> copy examples"
   pwd = File.expand_path(File.dirname(__FILE__))
-  FileUtils.cp_r(Dir.glob(pwd+'/../../../examples/profile/*'), pwd + '/simulator/filesystem/examples/profile')
+  FileUtils.cp_r(Dir.glob(pwd+"/../../../examples/profile/*"), pwd + "/simulator/filesystem/examples/profile")
 end
 
 # prepare everything for the simulator

--- a/www/tutorial/scripts/inspec-mock/Gemfile
+++ b/www/tutorial/scripts/inspec-mock/Gemfile
@@ -1,3 +1,2 @@
-# encoding: utf-8
-source 'https://rubygems.org'
+source "https://rubygems.org"
 gemspec

--- a/www/tutorial/scripts/inspec-mock/bin/inspec
+++ b/www/tutorial/scripts/inspec-mock/bin/inspec
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
-
 # This mocks all InSpec backends. To use it, run
 # `bundle install`
 # `bundle exec ruby bin/inspec`
@@ -12,16 +10,16 @@ Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
 # load InSpec
-require 'inspec'
-require 'inspec/cli'
+require "inspec"
+require "inspec/cli"
 
 # Load Train and monkey-patch the backends
-require 'train'
-require 'train/transports/local'
+require "train"
+require "train/transports/local"
 
 module Train::Transports
   class SSH < Local
-    name 'ssh'
+    name "ssh"
 
     def connection(_ = nil)
       @connection ||= MockConnection.new(@options)
@@ -35,7 +33,7 @@ module Train::Transports
   end
 
   class WinRM < Local
-    name 'winrm'
+    name "winrm"
 
     def connection(_ = nil)
       @connection ||= MockConnection.new(@options)
@@ -49,7 +47,7 @@ module Train::Transports
   end
 
   class Docker < Local
-    name 'docker'
+    name "docker"
 
     def connection(_ = nil)
       @connection ||= MockConnection.new(@options)

--- a/www/tutorial/scripts/inspec-mock/inspec-mock.gemspec
+++ b/www/tutorial/scripts/inspec-mock/inspec-mock.gemspec
@@ -1,18 +1,17 @@
-# coding: utf-8
 Gem::Specification.new do |spec|
-  spec.name          = 'inspec-mock'
-  spec.version       = '0.1.0'
-  spec.authors       = ['Chef Software, Inc']
-  spec.summary       = 'Mock for InSpec.'
+  spec.name          = "inspec-mock"
+  spec.version       = "0.1.0"
+  spec.authors       = ["Chef Software, Inc"]
+  spec.summary       = "Mock for InSpec."
   spec.files = %w{
     inspec-mock.gemspec Gemfile
   } + Dir.glob(
-    '{bin,lib}/**/*', File::FNM_DOTMATCH
+    "{bin,lib}/**/*", File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }
 
   spec.executables   = %w{ inspec }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
-  spec.add_dependency 'inspec'
+  spec.add_dependency "inspec"
 end

--- a/www/tutorial/scripts/run_simulator_recording.rb
+++ b/www/tutorial/scripts/run_simulator_recording.rb
@@ -1,44 +1,43 @@
-# encoding: utf-8
-require 'train'
-require 'yaml'
-require 'github/markup'
-require 'json'
-require 'shellwords'
-require 'digest'
+require "train"
+require "yaml"
+require "github/markup"
+require "json"
+require "shellwords"
+require "digest"
 
 # global config
-input_dir = File.expand_path(File.join(File.dirname(__FILE__), '../content'))
-output_dir = File.expand_path(File.join(File.dirname(__FILE__), '../app/responses'))
-simulator = 'inspec-simulator'
+input_dir = File.expand_path(File.join(File.dirname(__FILE__), "../content"))
+output_dir = File.expand_path(File.join(File.dirname(__FILE__), "../app/responses"))
+simulator = "inspec-simulator"
 
 # Create key given command
 def create_key(command)
-  formatted_command = command.gsub(/\W/, '_')
-  not_too_long = formatted_command.gsub(/_{2,}/, '_')
+  formatted_command = command.gsub(/\W/, "_")
+  not_too_long = formatted_command.gsub(/_{2,}/, "_")
   # ensure file names do not get to long (for Windows)
   if not_too_long.length > 40
     hash = Digest::MD5.hexdigest not_too_long
     # hard_cut at 40 chars
     not_too_long = not_too_long.slice(0..40)
     # find last underscore and change end with hash
-    not_too_long.gsub!(/_[^_]*$/, '_' + hash)
+    not_too_long.gsub!(/_[^_]*$/, "_" + hash)
   end
-  not_too_long + '.txt'
+  not_too_long + ".txt"
 end
 
 def indent(text)
-  '     ' + text
+  "     " + text
 end
 
 # loads all commands from tutorial.yml
 def load_tutorial_commands(demos)
   # extract commands from instructions
-  raw_commands = demos.map { |x| x['desc'] }.map { |x| x.scan(/```(.*?)```/m) }.flatten.map(&:strip).map { |x| x.split("\n") }
+  raw_commands = demos.map { |x| x["desc"] }.map { |x| x.scan(/```(.*?)```/m) }.flatten.map(&:strip).map { |x| x.split("\n") }
 
   # find out if we have a single command or a multiline shell command
   tutorial_commands = raw_commands.map { |x|
     cmd = x.join("\n")
-    if cmd.include?('describe')
+    if cmd.include?("describe")
       cmd
     else
       x
@@ -47,28 +46,28 @@ def load_tutorial_commands(demos)
 
   # Pull shell commands out so they can be handled
   # This is currently done by checking if the command includes the word inspec :/
-  no_shell_tutorial_commands = tutorial_commands.select { |a| a.include?('inspec') && a != 'inspec shell' }
-  commands = no_shell_tutorial_commands.map {|cmd|
+  no_shell_tutorial_commands = tutorial_commands.select { |a| a.include?("inspec") && a != "inspec shell" }
+  commands = no_shell_tutorial_commands.map { |cmd|
     {
-      'key' => create_key(cmd),
-      'command' => cmd,
-      'simulator_cmd' => cmd,
-      'extra' => false,
-      'shell' => 'sh',
+      "key" => create_key(cmd),
+      "command" => cmd,
+      "simulator_cmd" => cmd,
+      "extra" => false,
+      "shell" => "sh",
     }
   }
 
   # special handling for InSpec shell commands
-  shell_tutorial_commands = tutorial_commands.reject { |a| a.include?('inspec') }
-  commands += shell_tutorial_commands.map {|cmd|
+  shell_tutorial_commands = tutorial_commands.reject { |a| a.include?("inspec") }
+  commands += shell_tutorial_commands.map { |cmd|
     # Add 'echo' and ' | inspec shell' to shell commands to enable inspec shell command functionality
-    simulator_cmd = 'echo ' + Shellwords.escape(cmd) + ' | inspec shell'
+    simulator_cmd = "echo " + Shellwords.escape(cmd) + " | inspec shell"
     {
-      'key' => create_key(simulator_cmd),
-      'command' => cmd,
-      'simulator_cmd' => simulator_cmd,
-      'extra' => false,
-      'shell' => 'inspec',
+      "key" => create_key(simulator_cmd),
+      "command" => cmd,
+      "simulator_cmd" => simulator_cmd,
+      "extra" => false,
+      "shell" => "inspec",
     }
   }
   commands
@@ -76,36 +75,36 @@ end
 
 # load all commands from commands.yml
 def load_extra_commands(extra_commands)
-  extra_commands.map {|cmd|
+  extra_commands.map { |cmd|
     {
-      'key' => create_key(cmd),
-      'command' => cmd,
-      'simulator_cmd' => cmd,
-      'extra' => true,
-      'shell' => 'sh',
+      "key" => create_key(cmd),
+      "command" => cmd,
+      "simulator_cmd" => cmd,
+      "extra" => true,
+      "shell" => "sh",
     }
   }
 end
 
 def generate_webapp_instructions(demos, output_dir)
   # Create instructions.json file
-  instructions_file = File.new(File.join(output_dir, 'instructions.json'), 'w')
-  tutorial_instructions = demos.map { |x| [x['title'], x['desc']] }
-  tutorial_instructions.map! { |set| [set[0], GitHub::Markup.render('instructions.markdown', set[1])] }
+  instructions_file = File.new(File.join(output_dir, "instructions.json"), "w")
+  tutorial_instructions = demos.map { |x| [x["title"], x["desc"]] }
+  tutorial_instructions.map! { |set| [set[0], GitHub::Markup.render("instructions.markdown", set[1])] }
   instructions_file.write(JSON.generate(tutorial_instructions))
   puts indent("Wrote #{instructions_file.path}")
 end
 
 def generate_webapp_commands(commands, output_dir)
   # Create commands.json file
-  commands_file = File.new(File.join(output_dir, 'commands.json'), 'w')
+  commands_file = File.new(File.join(output_dir, "commands.json"), "w")
   commands_file.write(JSON.generate(commands))
   puts indent("Wrote #{commands_file.path}")
 end
 
 def run_command(command, conn, output_dir)
   puts indent("Run `#{command['command']}` on `#{command['shell']}`")
-  cmd = conn.run_command(command['simulator_cmd'])
+  cmd = conn.run_command(command["simulator_cmd"])
   cmd.stdout
 
   # save the result and put it in inspec/www/app/responses with command as filename
@@ -115,16 +114,16 @@ def run_command(command, conn, output_dir)
   welcome = "To find out how to use it, type: [1mhelp[0m\n\n"
   # To find out how to use it, type: [1mhelp[0m
   idx = result.index(welcome)
-  if command['shell'] == 'inspec' && !idx.nil?
+  if command["shell"] == "inspec" && !idx.nil?
     # find welcome message
     index = idx + welcome.length
     # also remove the command before the welcome message
     result = result.slice(index, result.length - index)
   end
 
-  key = command['key']
+  key = command["key"]
   filename = File.join(output_dir, key.to_s)
-  out_file = File.new(filename, 'w')
+  out_file = File.new(filename, "w")
   result.lines.each do |line|
     line_to_write = "#{line.chomp}\r\n"
     out_file.write(line_to_write)
@@ -134,16 +133,16 @@ def run_command(command, conn, output_dir)
 end
 
 def generate_simulation_files(simulator, commands, output_dir)
-  require 'docker'
-  fail "#{simulator} docker image is not available" unless Docker::Image.exist?(simulator)
+  require "docker"
+  raise "#{simulator} docker image is not available" unless Docker::Image.exist?(simulator)
 
   # start container and get id
   Docker.options[:read_timeout] = 3 * 60
-  container = Docker::Container.create('Cmd' => ['/bin/sh'], 'Image' => simulator, 'Tty' => true)
+  container = Docker::Container.create("Cmd" => ["/bin/sh"], "Image" => simulator, "Tty" => true)
   container.start
   puts indent("Run simulation on Container #{container.id}")
   # Create Train connection
-  backend = Train.create('docker', { host: container.id })
+  backend = Train.create("docker", { host: container.id })
   conn = backend.connection
 
   # Loop over sh commands
@@ -157,15 +156,15 @@ def generate_simulation_files(simulator, commands, output_dir)
 end
 
 # start workflow
-puts '---> Load Content'
+puts "---> Load Content"
 # Load tutorial instructions
-demos = YAML.load(File.read(File.join(input_dir, 'tutorial.yml')))['demos']
+demos = YAML.load(File.read(File.join(input_dir, "tutorial.yml")))["demos"]
 commands = load_tutorial_commands(demos)
 
-extra_commands = YAML.load(File.read(File.join(input_dir, 'commands.yml')))['commands']
+extra_commands = YAML.load(File.read(File.join(input_dir, "commands.yml")))["commands"]
 commands += load_extra_commands(extra_commands)
 
-puts '---> Create files for web app'
+puts "---> Create files for web app"
 generate_webapp_instructions(demos, output_dir)
 generate_webapp_commands(commands, output_dir)
 generate_simulation_files(simulator, commands, output_dir)

--- a/www/tutorial/tutorial_files/inspec-mock/Gemfile
+++ b/www/tutorial/tutorial_files/inspec-mock/Gemfile
@@ -1,3 +1,2 @@
-# encoding: utf-8
-source 'https://rubygems.org'
+source "https://rubygems.org"
 gemspec

--- a/www/tutorial/tutorial_files/inspec-mock/bin/inspec
+++ b/www/tutorial/tutorial_files/inspec-mock/bin/inspec
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
-
 # This mocks all InSpec backends. To use it, run
 # `bundle install`
 # `bundle exec ruby bin/inspec`
@@ -12,16 +10,16 @@ Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
 # load InSpec
-require 'inspec'
-require 'inspec/cli'
+require "inspec"
+require "inspec/cli"
 
 # Load Train and monkey-patch the backends
-require 'train'
-require 'train/transports/local'
+require "train"
+require "train/transports/local"
 
 module Train::Transports
   class SSH < Local
-    name 'ssh'
+    name "ssh"
 
     def connection(_ = nil)
       @connection ||= MockConnection.new(@options)
@@ -35,7 +33,7 @@ module Train::Transports
   end
 
   class WinRM < Local
-    name 'winrm'
+    name "winrm"
 
     def connection(_ = nil)
       @connection ||= MockConnection.new(@options)
@@ -49,7 +47,7 @@ module Train::Transports
   end
 
   class Docker < Local
-    name 'docker'
+    name "docker"
 
     def connection(_ = nil)
       @connection ||= MockConnection.new(@options)

--- a/www/tutorial/tutorial_files/inspec-mock/inspec-mock.gemspec
+++ b/www/tutorial/tutorial_files/inspec-mock/inspec-mock.gemspec
@@ -1,18 +1,17 @@
-# coding: utf-8
 Gem::Specification.new do |spec|
-  spec.name          = 'inspec-mock'
-  spec.version       = '0.1.0'
-  spec.authors       = ['Chef Software, Inc']
-  spec.summary       = 'Mock for InSpec.'
+  spec.name          = "inspec-mock"
+  spec.version       = "0.1.0"
+  spec.authors       = ["Chef Software, Inc"]
+  spec.summary       = "Mock for InSpec."
   spec.files = %w{
     inspec-mock.gemspec Gemfile
   } + Dir.glob(
-    '{bin,lib}/**/*', File::FNM_DOTMATCH
+    "{bin,lib}/**/*", File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }
 
   spec.executables   = %w{ inspec }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
-  spec.add_dependency 'inspec'
+  spec.add_dependency "inspec"
 end


### PR DESCRIPTION
To keep consistency in Chef Ruby projects, use chefstyle for linting.

This has the added benefit of preventing rubocop conflicts between inspec and other projects that depend on it. 