### PR TITLE
Skip packages resource for unsupported OS

### DIFF
--- a/lib/resources/users.rb
+++ b/lib/resources/users.rb
@@ -57,7 +57,7 @@ module Inspec::Resources
     name 'users'
     desc 'Use the users InSpec audit resource to test local user profiles. Users can be filtered by groups to which they belong, the frequency of required password changes, the directory paths to home and shell.'
     example "
-      describe users.where(uid: 0).entries do
+      describe users.where { uid == 0 }.entries do
         it { should eq ['root'] }
         its('uids') { should eq [1234] }
         its('gids') { should eq [1234] }

--- a/test/unit/resources/packages_test.rb
+++ b/test/unit/resources/packages_test.rb
@@ -43,11 +43,9 @@ describe 'Inspec::Resources::Packages' do
   end
 
 
-  it 'fails on non debian platforms' do
-    proc {
-      resource = MockLoader.new(:centos6).load_resource('packages', 'bash')
-      resource.send(:entries, nil)
-    }.must_raise(RuntimeError)
+  it 'skips on non debian platforms' do
+    resource = MockLoader.new(:centos6).load_resource('packages', [:a, :b])
+    _(resource.resource_skipped).must_equal 'The packages resource is not yet supported on OS centos'
   end
 
   it 'fails if the packages name is not a string or regexp' do


### PR DESCRIPTION
`raise "packages resource is not yet supported on #{os.name}"` was being hit when `inspec check` was executed on a non debian OS.

The test will be skipped on unsupported OSes if written like this:
```ruby
  describe packages(/bash/) do
    its("names") { should be_empty }
  end
```

But succeed when written like this, hence the `warn` in `filtered_packages`:
```ruby
  describe packages(/bash/).names do
    it { should be_empty }
  end
```

More about this limitation here: https://github.com/chef/inspec/issues/1205#issuecomment-252236255