### PR TITLE
Generate default profile names, fix bug when using multiple flat profiles

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -82,7 +82,7 @@ module Inspec
 
     # rubocop:disable Metrics/AbcSize
     def initialize(source_reader, options = {})
-      @target = options.delete(:target)
+      @target = options[:target]
       @logger = options[:logger] || Logger.new(nil)
       @locked_dependencies = options[:dependencies]
       @controls = options[:controls] || []
@@ -94,7 +94,7 @@ module Inspec
       @source_reader = source_reader
       @tests_collected = false
       @libraries_loaded = false
-      Metadata.finalize(@source_reader.metadata, @profile_id)
+      Metadata.finalize(@source_reader.metadata, @profile_id, options)
       @runner_context =
         options[:profile_context] ||
         Inspec::ProfileContext.for_profile(self, @backend, @attr_values)

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -217,7 +217,17 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
   end
 
   def profile_contains_example?(profile, example)
-    profile[:name] == example[:profile_id]
+    profile_name = profile[:name]
+    example_profile_id = example[:profile_id]
+
+    # if either the profile name is nil or the profile in the given example
+    # is nil, assume the profile doesn't contain the example and default
+    # to creating a new profile. Otherwise, for profiles that have no
+    # metadata, this may incorrectly match a profile that does not contain
+    # this example, leading to Ruby exceptions.
+    return false if profile_name.nil? || example_profile_id.nil?
+
+    profile_name == example_profile_id
   end
 
   def move_example_into_control(example, control)
@@ -458,7 +468,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
       output.puts "Profile: #{profile[:title]} (#{profile[:name] || 'unknown'})"
     end
 
-    output.puts 'Version: ' + (profile[:version] || 'unknown')
+    output.puts 'Version: ' + (profile[:version] || '(not specified)')
     print_target
     profile[:already_printed] = true
   end

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -29,7 +29,7 @@ describe 'inspec exec' do
     out.stdout.must_equal "
 
 Profile: yumyum profile
-Version: unknown
+Version: (not specified)
 Target:  local://
 
      No tests executed.\e[0m
@@ -142,7 +142,9 @@ Test Summary: \e[38;5;41m0 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;2
     let(:out) { inspec('exec ' + example_control + ' --no-create-lockfile') }
 
     it 'prints the control results, then the anonymous describe block results' do
-      out.stdout.force_encoding(Encoding::UTF_8).must_equal "
+      out.stdout.force_encoding(Encoding::UTF_8).must_match(%r{Profile: tests from .*examples/profile/controls/example.rb})
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "
+Version: (not specified)
 Target:  local://
 
 \e[38;5;41m  \xE2\x9C\x94  tmp-1.0: Create /tmp directory\e[0m

--- a/test/unit/profiles/metadata_test.rb
+++ b/test/unit/profiles/metadata_test.rb
@@ -7,12 +7,13 @@ require 'inspec/metadata'
 
 describe 'metadata with supported operating systems' do
   let(:logger) { Minitest::Mock.new }
+  let(:empty_options) { {} }
 
   def supports_meta(params)
     res = Inspec::Metadata.from_yaml('mock', "---", nil, logger)
     # manually inject supported parameters
     res.params[:supports] = params
-    Inspec::Metadata.finalize(res, 'mock', logger)
+    Inspec::Metadata.finalize(res, 'mock', empty_options, logger)
     res
   end
 
@@ -21,20 +22,42 @@ describe 'metadata with supported operating systems' do
 
     it 'finalizes a loaded metadata via Profile ID' do
       res = Inspec::Metadata.from_yaml('mock', '---', nil)
-      Inspec::Metadata.finalize(res, 'mock')
+      Inspec::Metadata.finalize(res, 'mock', empty_options)
       res.params[:name].must_equal('mock')
     end
 
     it 'finalizes a loaded metadata via Profile ID and overwrites the ID' do
       res = Inspec::Metadata.from_yaml('mock', "---\nname: hello", nil)
-      Inspec::Metadata.finalize(res, 'mock')
+      Inspec::Metadata.finalize(res, 'mock', empty_options)
       res.params[:name].must_equal('mock')
     end
 
     it 'finalizes a loaded metadata by turning strings into symbols' do
       res = Inspec::Metadata.from_yaml('mock', "---\nauthor: world", nil)
-      Inspec::Metadata.finalize(res, 'mock')
+      Inspec::Metadata.finalize(res, 'mock', empty_options)
       res.params[:author].must_equal('world')
+    end
+
+    it 'sets a default name with the original target if there is no name, title, or profile_id' do
+      res = Inspec::Metadata.from_yaml('mock', '---', nil, logger)
+      options = { target: '/path/to/tests' }
+      Inspec::Metadata.finalize(res, nil, options, logger)
+      res.params[:name].must_equal('tests from /path/to/tests')
+    end
+
+    it 'does not overwrite an existing name when name exists and profile_id is nil' do
+      res = Inspec::Metadata.from_yaml('mock', "\nname: my_name", nil)
+      options = { target: '/path/to/tests' }
+      Inspec::Metadata.finalize(res, nil, options, logger)
+      res.params[:name].must_equal('my_name')
+    end
+
+    it 'does not set a default name if a title is provided and profile_id is nil' do
+      res = Inspec::Metadata.from_yaml('mock', "\ntitle: my_title", nil)
+      options = { target: '/path/to/tests' }
+      Inspec::Metadata.finalize(res, nil, options, logger)
+      res.params[:title].must_equal('my_title')
+      res.params[:name].must_be_nil
     end
 
     it 'loads the support field from metadata' do

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -12,8 +12,8 @@ describe Inspec::Profile do
   describe 'with an empty profile' do
     let(:profile) { MockLoader.load_profile('empty-metadata') }
 
-    it 'has no metadata' do
-      profile.params[:name].must_be_nil
+    it 'has a default name containing the original target' do
+      profile.params[:name].must_match(/tests from .*empty-metadata/)
     end
 
     it 'has no controls' do
@@ -24,8 +24,8 @@ describe Inspec::Profile do
   describe 'with an empty profile (legacy mode)' do
     let(:profile) { MockLoader.load_profile('legacy-empty-metadata') }
 
-    it 'has no metadata' do
-      profile.params[:name].must_be_nil
+    it 'has a default name containing the original target' do
+      profile.params[:name].must_match(/tests from .*empty-metadata/)
     end
 
     it 'has no controls' do
@@ -70,7 +70,6 @@ describe Inspec::Profile do
 
       it 'prints loads of warnings' do
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]
-        logger.expect :error, nil, ["Missing profile name in inspec.yml"]
         logger.expect :error, nil, ["Missing profile version in inspec.yml"]
         logger.expect :warn, nil, ["Missing profile title in inspec.yml"]
         logger.expect :warn, nil, ["Missing profile summary in inspec.yml"]
@@ -85,9 +84,9 @@ describe Inspec::Profile do
         # verify hash result
         result[:summary][:valid].must_equal false
         result[:summary][:location].must_equal "#{home}/mock/profiles/#{profile_id}"
-        result[:summary][:profile].must_equal nil
+        result[:summary][:profile].must_match(/tests from .*empty-metadata/)
         result[:summary][:controls].must_equal 0
-        result[:errors].length.must_equal 2
+        result[:errors].length.must_equal 1
         result[:warnings].length.must_equal 5
       end
     end
@@ -97,7 +96,6 @@ describe Inspec::Profile do
 
       it 'prints loads of warnings' do
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]
-        logger.expect :error, nil, ["Missing profile name in metadata.rb"]
         logger.expect :warn, nil, ['The use of `metadata.rb` is deprecated. Use `inspec.yml`.']
         logger.expect :error, nil, ["Missing profile version in metadata.rb"]
         logger.expect :warn, nil, ["Missing profile title in metadata.rb"]
@@ -113,9 +111,9 @@ describe Inspec::Profile do
         # verify hash result
         result[:summary][:valid].must_equal false
         result[:summary][:location].must_equal "#{home}/mock/profiles/#{profile_id}"
-        result[:summary][:profile].must_equal nil
+        result[:summary][:profile].must_match(/tests from .*legacy-empty-metadata/)
         result[:summary][:controls].must_equal 0
-        result[:errors].length.must_equal 2
+        result[:errors].length.must_equal 1
         result[:warnings].length.must_equal 6
       end
     end


### PR DESCRIPTION
When running InSpec with multiple profiles, and two or more of the profiles
are read in using the "Flat" SourceReader (i.e. they are not actual profiles
with a metadata file like inspec.yml, but rather just a folder containing
.rb files with controls and tests in them), InSpec would throw a NilClass
error when building the necessary objects for the formatter.

![broken](https://cloud.githubusercontent.com/assets/3221128/22896304/9a38f06a-f1ed-11e6-9e1d-003fb5fd3027.png)

The cause was in `#profile_contains_example` in the formatter code which
checks to see if the profile name is the same as the profile_id in the given
example. However, if both of those were nil, it would potentially match the
wrong Flat-read profile. By refusing to match if either are nil, we fix the
syntax issue, but the output is confusing:

![fixed but confusing](https://cloud.githubusercontent.com/assets/3221128/22896326/adf4ae50-f1ed-11e6-8bc9-63f17868308e.png)

The tests now run and are outputted, but we erroneously show targets that have no tests run, and the tests from the two profiles are jumbled together. By assigning a default name to a profile that has no title/name, we can clean up the output and provide our user more helpful information about their tests.

![fixed](https://cloud.githubusercontent.com/assets/3221128/22896419/fe6d373a-f1ed-11e6-80ce-d2ce5559c2b3.png)

Fixes #1456.

Signed-off-by: Adam Leff <adam@leff.co>