### PR TITLE
Doc fix for SourceReaders::InspecReader

### DIFF
--- a/lib/source_readers/inspec.rb
+++ b/lib/source_readers/inspec.rb
@@ -27,7 +27,7 @@ module SourceReaders
 
     # This create a new instance of an InSpec profile source reader
     #
-    # @param [SourceReader] target
+    # @param [FileProvider] target An instance of a FileProvider object that can list files and read them
     # @param [String] metadata_source eg. inspec.yml or metadata.rb
     def initialize(target, metadata_source)
       @target = target


### PR DESCRIPTION
The inline docs for SourceReaders::InspecReader#new state that it takes
a SourceReader object for the target... but we're trying to create the
SourceReader object! It actually takes a FileProvider object that is
capabile of listing files for the given profile and reading them.