### PR TITLE
Adding a Habitat profile artifact creator

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'parallel', '~> 1.9'
   spec.add_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_dependency 'faraday', '>=0.9.0'
+  spec.add_dependency 'toml', '~> 0.1'
 end

--- a/lib/bundles/inspec-habitat.rb
+++ b/lib/bundles/inspec-habitat.rb
@@ -1,0 +1,12 @@
+# encoding: utf-8
+# author: Adam Leff
+
+libdir = File.dirname(__FILE__)
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+
+module Habitat
+  autoload :Log,     'inspec-habitat/log'
+  autoload :Profile, 'inspec-habitat/profile'
+end
+
+require 'inspec-habitat/cli'

--- a/lib/bundles/inspec-habitat/cli.rb
+++ b/lib/bundles/inspec-habitat/cli.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+# author: Adam Leff
+
+require 'thor'
+
+module Habitat
+  class HabitatProfileCLI < Thor
+    namespace 'habitat profile'
+
+    desc 'create PATH', 'Create a Habitat artifact for the profile found at PATH'
+    option :output_dir, type: :string, required: false,
+      desc: 'Directory in which to save the generated Habitat artifact. Default: current directory'
+    def create(path)
+      puts options
+      Habitat::Profile.create(path, options)
+    end
+
+    desc 'upload PATH', 'Create a Habitat artifact for the profile found at PATH, and upload it to a Habitat Depot'
+    def upload(path)
+      Habitat::Profile.upload(path, options)
+    end
+  end
+
+  class HabitatCLI < Inspec::BaseCLI
+    namespace 'habitat'
+
+    desc 'profile', 'Manage InSpec profiles as Habitat artifacts'
+    subcommand 'profile', HabitatProfileCLI
+  end
+
+  Inspec::Plugins::CLI.add_subcommand(HabitatCLI, 'habitat', 'habitat SUBCOMMAND ...', 'Commands for InSpec + Habitat Integration', {})
+end

--- a/lib/bundles/inspec-habitat/log.rb
+++ b/lib/bundles/inspec-habitat/log.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+# author: Adam Leff
+
+require 'mixlib/log'
+
+module Habitat
+  class Log
+    extend Mixlib::Log
+  end
+end

--- a/lib/bundles/inspec-habitat/profile.rb
+++ b/lib/bundles/inspec-habitat/profile.rb
@@ -1,0 +1,334 @@
+# encoding: utf-8
+# author: Adam Leff
+
+require 'mixlib/shellout'
+require 'toml'
+
+module Habitat
+  class Profile # rubocop:disable Metrics/ClassLength
+    attr_reader :options, :path, :profile
+
+    def self.create(path, options = {})
+      creator = new(path, options)
+      hart_file = creator.create
+      creator.copy(hart_file)
+    ensure
+      creator.delete_work_dir
+    end
+
+    def self.upload(path, options = {})
+      uploader = new(path, options)
+      uploader.upload
+    ensure
+      uploader.delete_work_dir
+    end
+
+    def initialize(path, options = {})
+      @path    = path
+      @options = options
+
+      log_level = options.fetch('log_level', 'info')
+      Habitat::Log.level(log_level.to_sym)
+    end
+
+    def create
+      Habitat::Log.info("Creating a Habitat artifact for profile: #{path}")
+
+      validate_habitat_installed
+      validate_habitat_origin
+      create_profile_object
+      copy_profile_to_work_dir
+      create_plan
+      create_run_hook
+      create_default_config
+
+      # returns the path to the .hart file in the work directory
+      build_hart
+    rescue => e
+      Habitat::Log.debug(e.backtrace.join("\n"))
+      exit_with_error(
+        'Unable to generate Habitat artifact.',
+        "#{e.class} -- #{e.message}",
+      )
+    end
+
+    def copy(hart_file)
+      validate_output_dir
+
+      Habitat::Log.info("Copying artifact to #{output_dir}...")
+      copy_hart(hart_file)
+    end
+
+    def upload
+      validate_habitat_auth_token
+      hart_file = create
+      upload_hart(hart_file)
+    rescue => e
+      Habitat::Log.debug(e.backtrace.join("\n"))
+      exit_with_error(
+        'Unable to upload Habitat artifact.',
+        "#{e.class} -- #{e.message}",
+      )
+    end
+
+    def delete_work_dir
+      Habitat::Log.debug("Deleting work directory #{work_dir}")
+      FileUtils.rm_rf(work_dir) if Dir.exist?(work_dir)
+    end
+
+    private
+
+    def create_profile_object
+      @profile = Inspec::Profile.for_target(path, {})
+    end
+
+    def verify_profile
+      Habitat::Log.info('Checking to see if the profile is valid...')
+
+      unless profile.check[:summary][:valid]
+        exit_with_error('Profile check failed. Please fix the profile before creating a Habitat artifact.')
+      end
+
+      Habitat::Log.info('Profile is valid.')
+    end
+
+    def validate_habitat_installed
+      Habitat::Log.info('Checking to see if Habitat is installed...')
+      cmd = Mixlib::ShellOut.new('hab --version')
+      cmd.run_command
+      if cmd.error?
+        exit_with_error('Unable to run Habitat commands.', cmd.stderr)
+      end
+    end
+
+    def validate_habitat_origin
+      if habitat_origin.nil?
+        exit_with_error(
+          'Unable to determine Habitat origin name.',
+          'Run `hab setup` or set the HAB_ORIGIN environment variable.',
+        )
+      end
+    end
+
+    def validate_habitat_auth_token
+      if habitat_auth_token.nil?
+        exit_with_error(
+          'Unable to determine Habitat auth token for publishing.',
+          'Run `hab setup` or set the HAB_AUTH_TOKEN environment variable.',
+        )
+      end
+    end
+
+    def validate_output_dir
+      exit_with_error("Output directory #{output_dir} is not a directory or does not exist.") unless
+        File.directory?(output_dir)
+    end
+
+    def work_dir
+      return @work_dir if @work_dir
+
+      @work_dir ||= Dir.mktmpdir('inspec-habitat-exporter')
+      Dir.mkdir(File.join(@work_dir, 'src'))
+      Dir.mkdir(File.join(@work_dir, 'habitat'))
+      Dir.mkdir(File.join(@work_dir, 'habitat', 'hooks'))
+      Habitat::Log.debug("Generated work directory #{@work_dir}")
+
+      @work_dir
+    end
+
+    def copy_profile_to_work_dir
+      Habitat::Log.info('Copying profile contents to the work directory...')
+      profile.files.each do |f|
+        src = File.join(profile.root_path, f)
+        dst = File.join(work_dir, 'src', f)
+        if File.directory?(f)
+          Habitat::Log.debug("Creating directory #{dst}")
+          FileUtils.mkdir_p(dst)
+        else
+          Habitat::Log.debug("Copying file #{src} to #{dst}")
+          FileUtils.cp_r(src, dst)
+        end
+      end
+    end
+
+    def create_plan
+      plan_file = File.join(work_dir, 'habitat', 'plan.sh')
+      Habitat::Log.info("Generating Habitat plan at #{plan_file}...")
+      File.write(plan_file, plan_contents)
+    end
+
+    def create_run_hook
+      run_hook_file = File.join(work_dir, 'habitat', 'hooks', 'run')
+      Habitat::Log.info("Generating a Habitat run hook at #{run_hook_file}...")
+      File.write(run_hook_file, run_hook_contents)
+    end
+
+    def create_default_config
+      default_toml = File.join(work_dir, 'habitat', 'default.toml')
+      Habitat::Log.info("Generating Habitat's default.toml configuration...")
+      File.write(default_toml, 'sleep_time = 300')
+    end
+
+    def build_hart
+      Habitat::Log.info('Building our Habitat artifact...')
+
+      env = {
+        'TERM'               => 'vt100',
+        'HAB_ORIGIN'         => habitat_origin,
+        'HAB_NONINTERACTIVE' => 'true',
+      }
+
+      env['RUST_LOG'] = 'debug' if Habitat::Log.level == :debug
+
+      # TODO: Would love to use Mixlib::ShellOut here, but it doesn't
+      # seem to preserve the STDIN tty, and docker gets angry.
+      Dir.chdir(work_dir) do
+        unless system(env, 'hab studio build .')
+          exit_with_error('Unable to build the Habitat artifact.')
+        end
+      end
+
+      hart_files = Dir.glob(File.join(work_dir, 'results', '*.hart'))
+
+      if hart_files.length > 1
+        exit_with_error('More than one Habitat artifact was created which was not expected.')
+      elsif hart_files.empty?
+        exit_with_error('No Habitat artifact was created.')
+      end
+
+      hart_files.first
+    end
+
+    def copy_hart(working_dir_hart)
+      hart_basename = File.basename(working_dir_hart)
+      dst = File.join(output_dir, hart_basename)
+      FileUtils.cp(working_dir_hart, dst)
+
+      dst
+    end
+
+    def upload_hart(hart_file)
+      Habitat::Log.info('Uploading the Habitat artifact to our Depot...')
+
+      env = {
+        'TERM'               => 'vt100',
+        'HAB_AUTH_TOKEN'     => habitat_auth_token,
+        'HAB_NONINTERACTIVE' => 'true',
+      }
+
+      env['HAB_DEPOT_URL'] = ENV['HAB_DEPOT_URL'] if ENV['HAB_DEPOT_URL']
+
+      cmd = Mixlib::ShellOut.new("hab pkg upload #{hart_file}", env: env)
+      cmd.run_command
+      if cmd.error?
+        exit_with_error(
+          'Unable to upload Habitat artifact to the Depot.',
+          cmd.stdout,
+          cmd.stderr,
+        )
+      end
+
+      Habitat::Log.info('Upload complete!')
+    end
+
+    def habitat_origin
+      ENV['HAB_ORIGIN'] || habitat_cli_config['origin']
+    end
+
+    def habitat_auth_token
+      ENV['HAB_AUTH_TOKEN'] || habitat_cli_config['auth_token']
+    end
+
+    def habitat_cli_config
+      return @cli_config if @cli_config
+
+      config_file = File.join(ENV['HOME'], '.hab', 'etc', 'cli.toml')
+      return {} unless File.exist?(config_file)
+
+      @cli_config = TOML.load_file(config_file)
+    end
+
+    def output_dir
+      options[:output_dir] || Dir.pwd
+    end
+
+    def exit_with_error(*errors)
+      errors.each do |error_msg|
+        Habitat::Log.error(error_msg)
+      end
+
+      exit 1
+    end
+
+    def package_name
+      "inspec-profile-#{profile.name}"
+    end
+
+    def plan_contents
+      plan = <<-EOL
+pkg_name=#{package_name}
+pkg_version=#{profile.version}
+pkg_origin=#{habitat_origin}
+pkg_source="nosuchfile.tar.gz"
+pkg_deps=(chef/inspec)
+pkg_build_deps=()
+EOL
+
+      plan += "pkg_license='#{profile.metadata.params[:license]}'\n\n" if profile.metadata.params[:license]
+
+      plan += <<-EOL
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_build() {
+  cp -vr $PLAN_CONTEXT/../src/* $HAB_CACHE_SRC_PATH/$pkg_dirname
+}
+
+do_install() {
+  cp -R . ${pkg_prefix}/dist
+}
+      EOL
+
+      plan
+    end
+
+    def run_hook_contents
+      <<-EOL
+#!/bin/sh
+
+export PATH=${PATH}:$(hab pkg path core/ruby)/bin
+
+PROFILE_IDENT="#{habitat_origin}/#{package_name}"
+SLEEP_TIME={{cfg.sleep_time}}
+
+# InSpec will try to create a .inspec directory, so this needs to be somewhere writable by the hab user
+cd {{pkg.svc_var_path}}
+
+while true; do
+  echo "Executing InSpec for ${PROFILE_IDENT}"
+  hab pkg exec chef/inspec inspec exec $(hab pkg path ${PROFILE_IDENT})/dist --format=cli 2>&1
+  RC=$?
+
+  echo ""
+  if [ "x${RC}" == "x0" ]; then
+    echo "InSpec run completed successfully."
+  else
+    echo "InSpec run did NOT complete successfully."
+  fi
+
+  echo "sleeping for ${SLEEP_TIME} seconds"
+  sleep ${SLEEP_TIME}
+done
+      EOL
+    end
+  end
+end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -318,8 +318,6 @@ module Inspec
 
       # display all files that will be part of the archive
       @logger.debug 'Add the following files to archive:'
-      root_path = @source_reader.target.prefix
-      files = @source_reader.target.files
       files.each { |f| @logger.debug '    ' + f }
 
       if opts[:zip]
@@ -348,6 +346,14 @@ module Inspec
 
     def lockfile_path
       File.join(cwd, 'inspec.lock')
+    end
+
+    def root_path
+      @source_reader.target.prefix
+    end
+
+    def files
+      @source_reader.target.files
     end
 
     #

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,6 +30,8 @@ require 'inspec/runner'
 require 'inspec/runner_mock'
 require 'fetchers/mock'
 
+require_relative '../lib/bundles/inspec-habitat'
+
 require 'train'
 CMD = Train.create('local').connection
 TMP_CACHE = {}

--- a/test/unit/bundles/inspect-habitat/profile_test.rb
+++ b/test/unit/bundles/inspect-habitat/profile_test.rb
@@ -1,0 +1,118 @@
+require 'helper'
+require 'mixlib/log'
+require 'ostruct'
+
+describe Habitat::Profile do
+  let(:profile) do
+    OpenStruct.new(
+      name:    'my_profile',
+      version: '1.2.3',
+      files:   %w(file1 file2)
+    )
+  end
+
+  let(:subject) { Habitat::Profile.new('/path/to/profile', { 'log_level' => 'fatal' }) }
+
+  before do
+    Habitat::Log.level(:fatal)
+  end
+
+  describe '#validate_habitat_installed' do
+    it 'exits if hab --version fails' do
+      cmd = mock
+      cmd.stubs(:error?).returns(true)
+      cmd.stubs(:run_command)
+      cmd.stubs(:stdout)
+      cmd.stubs(:stderr)
+      Mixlib::ShellOut.expects(:new).with('hab --version').returns(cmd)
+      proc { subject.send(:validate_habitat_installed) }.must_raise SystemExit
+    end
+  end
+
+  describe '#validate_habitat_origin' do
+    it 'does not exit if the origin key exists' do
+      subject.expects(:habitat_origin).returns('12345')
+      subject.send(:validate_habitat_origin)
+    end
+
+    it 'exits if no origin key exists' do
+      subject.expects(:habitat_origin).returns(nil)
+      proc { subject.send(:validate_habitat_origin) }.must_raise SystemExit
+    end
+  end
+
+  describe '#validate_habitat_auth_token' do
+    it 'does not exit if the auth_token exists' do
+      subject.expects(:habitat_auth_token).returns('12345')
+      subject.send(:validate_habitat_auth_token)
+    end
+
+    it 'exits if no auth_token exists' do
+      subject.expects(:habitat_auth_token).returns(nil)
+      proc { subject.send(:validate_habitat_auth_token) }.must_raise SystemExit
+    end
+  end
+
+  describe '#build_hart' do
+    before do
+      subject.expects(:work_dir).at_least_once.returns(Dir.tmpdir)
+    end
+
+    it 'exits if the build fails' do
+      subject.expects(:system).returns(false)
+      proc { subject.send(:build_hart) }.must_raise SystemExit
+    end
+
+    it 'exits if more than one hart is created' do
+      subject.expects(:system).returns(true)
+      Dir.expects(:glob).returns(%w(hart1 hart2))
+      proc { subject.send(:build_hart) }.must_raise SystemExit
+    end
+
+    it 'exits if more than no hart is created' do
+      subject.expects(:system).returns(true)
+      Dir.expects(:glob).returns([])
+      proc { subject.send(:build_hart) }.must_raise SystemExit
+    end
+
+    it 'returns the hart filename' do
+      subject.expects(:system).returns(true)
+      Dir.expects(:glob).returns(%w(hart1))
+      subject.send(:build_hart).must_equal('hart1')
+    end
+  end
+
+  describe '#upload_hart' do
+    it 'exits if the upload failed' do
+      env = {
+        'TERM'               => 'vt100',
+        'HAB_AUTH_TOKEN'     => 'my_token',
+        'HAB_NONINTERACTIVE' => 'true',
+      }
+
+      cmd = mock
+      cmd.stubs(:run_command)
+      cmd.stubs(:error?).returns(true)
+      cmd.stubs(:stdout)
+      cmd.stubs(:stderr)
+
+      subject.expects(:habitat_auth_token).returns('my_token')
+      Mixlib::ShellOut.expects(:new).with("hab pkg upload my_hart", env: env).returns(cmd)
+      proc { subject.send(:upload_hart, 'my_hart') }.must_raise SystemExit
+    end
+  end
+
+  describe '#habitat_cli_config' do
+    it 'returns an empty hash if the CLI config does not exist' do
+      File.expects(:exist?).with(File.join(ENV['HOME'], '.hab', 'etc', 'cli.toml')).returns(false)
+      subject.send(:habitat_cli_config).must_equal({})
+    end
+
+    it 'returns parsed TOML from the hab config file' do
+      config_file = File.join(ENV['HOME'], '.hab', 'etc', 'cli.toml')
+      File.expects(:exist?).with(config_file).returns(true)
+      TOML.expects(:load_file).with(config_file).returns(foo: 1)
+      subject.send(:habitat_cli_config).must_equal(foo: 1)
+    end
+  end
+end


### PR DESCRIPTION
Adding a Habitat profile artifact creator

Two new commands have been created:

 * inspec habitat profile create /path/to/profile
 * inspec habitat profile upload /path/to/profile

The `create` command creates a Habitat artifact that contains the contents
of the Habitat profile found at the provided path. This will be used later
in some Habitat + InSpec integrations.

The `upload` command does the same create process but then uploads the
resulting artifact to the Habitat Depot.

Signed-off-by: Adam Leff <adam@leff.co>