### PR TITLE
Fix formatting and colors on Windows

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -238,27 +238,60 @@ end
 class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
   RSpec::Core::Formatters.register self, :close
 
-  COLORS = {
-    'critical' => "\033[38;5;9m",
-    'major'    => "\033[38;5;208m",
-    'minor'    => "\033[0;36m",
-    'failed'   => "\033[38;5;9m",
-    'passed'   => "\033[38;5;41m",
-    'skipped'  => "\033[38;5;247m",
-    'reset'    => "\033[0m",
-  }.freeze
+  case RUBY_PLATFORM
+  when /windows|mswin|msys|mingw|cygwin/
 
-  INDICATORS = {
-    'critical' => '  ×  ',
-    'major'    => '  ∅  ',
-    'minor'    => '  ⊚  ',
-    'failed'   => '  ×  ',
-    'skipped'  => '  ↺  ',
-    'passed'   => '  ✔  ',
-    'unknown'  => '  ?  ',
-    'empty'    => '     ',
-    'small'    => '   ',
-  }.freeze
+    # Most currently available Windows terminals have poor support
+    # for ANSI extended colors
+    COLORS = {
+      'critical' => "\033[0;1;31m",
+      'major'    => "\033[0;1;31m",
+      'minor'    => "\033[0;36m",
+      'failed'   => "\033[0;1;31m",
+      'passed'   => "\033[0;1;32m",
+      'skipped'  => "\033[0;37m",
+      'reset'    => "\033[0m",
+    }.freeze
+
+    # Most currently available Windows terminals have poor support
+    # for UTF-8 characters so use these boring indicators
+    INDICATORS = {
+      'critical' => '  [CRIT]  ',
+      'major'    => '  [MAJR]  ',
+      'minor'    => '  [MINR]  ',
+      'failed'   => '  [FAIL]  ',
+      'skipped'  => '  [SKIP]  ',
+      'passed'   => '  [PASS]  ',
+      'unknown'  => '  [UNKN]  ',
+      'empty'    => '     ',
+      'small'    => '   ',
+    }.freeze
+  else
+    # Extended colors for everyone else
+    COLORS = {
+      'critical' => "\033[38;5;9m",
+      'major'    => "\033[38;5;208m",
+      'minor'    => "\033[0;36m",
+      'failed'   => "\033[38;5;9m",
+      'passed'   => "\033[38;5;41m",
+      'skipped'  => "\033[38;5;247m",
+      'reset'    => "\033[0m",
+    }.freeze
+
+    # Groovy UTF-8 characters for everyone else...
+    # ...even though they probably only work on Mac
+    INDICATORS = {
+      'critical' => '  ×  ',
+      'major'    => '  ∅  ',
+      'minor'    => '  ⊚  ',
+      'failed'   => '  ×  ',
+      'skipped'  => '  ↺  ',
+      'passed'   => '  ✔  ',
+      'unknown'  => '  ?  ',
+      'empty'    => '     ',
+      'small'    => '   ',
+    }.freeze
+  end
 
   MULTI_TEST_CONTROL_SUMMARY_MAX_LEN = 60
 


### PR DESCRIPTION
Fixes issue #1508
 
* Windows terminals don't support extended ANSI colours. Use basic + intensity
* Windows terminals don't support UTF-8 well so don't use special characters

Other OS'es get what they had before.

Signed-off-by: Richard Nixon \<richard.nixon@btinternet.com\>