### PR TITLE
Added oracle linux to rhel platform section of 'service' resource.

### DIFF
--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -134,9 +134,9 @@ module Inspec::Resources
         else
           SysV.new(inspec, service_ctl || '/usr/sbin/service')
         end
-      elsif %w{redhat fedora centos}.include?(platform)
+      elsif %w{redhat fedora centos oracle}.include?(platform)
         version = os[:release].to_i
-        if (%w{ redhat centos }.include?(platform) && version >= 7) || (platform == 'fedora' && version >= 15)
+        if (%w{ redhat centos oracle }.include?(platform) && version >= 7) || (platform == 'fedora' && version >= 15)
           Systemd.new(inspec, service_ctl)
         else
           SysV.new(inspec, service_ctl || '/sbin/service')


### PR DESCRIPTION
Tests currently skipping over 'service' resource on oracle linux. 

Broken when chef/train was fixed to detect oracle linux correctly.
