### PR TITLE
Add Rake to Habitat build Gemfile

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -39,6 +39,7 @@ do_prepare() {
   cat > Gemfile <<GEMFILE
 source 'https://rubygems.org'
 gem '$pkg_name', '= $pkg_version'
+gem 'rake'
 GEMFILE
 }
 


### PR DESCRIPTION
The `rainbow` gem requires `rake` to build native extensions, and rake
is a development dependency for InSpec, not a runtime dependency.

This change adds the `rake` gem to the Habitat build Gemfile so we
can successfully build a Habitat artifact.

Signed-off-by: Adam Leff <adam@leff.co>