### PR TITLE
Updating .gitignore for Habitat and direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ habitat/VERSION
 habitat/results
 /.ruby-gemset
 /.ruby-version
+/.direnv
+/.envrc
+results/
 
 www/source/index.html.slim
 


### PR DESCRIPTION
For direnv users, excluding the .direnv and .envrc entries will
help avoid any unnecessary local environment settings from getting
committed.

Excluding the results directory will avoid any Habitat artifacts
from getting unnecessarily committed.