### PR TITLE
Fix omnibus build after new JUnit formatter

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -12,7 +12,7 @@ source 'https://rubygems.org'
 
 # Use entries from chef's Gemfile
 gem 'omnibus', github: 'chef/omnibus', branch: 'sersut/ff-ksubrama/gcc_investigate'
-gem 'omnibus-software', github: 'chef/omnibus-software', branch: 'shain/ruby_windows_monster'
+gem 'omnibus-software', github: 'chef/omnibus-software'
 gem 'license_scout', github: 'chef/license_scout'
 
 # This development group is installed by default when you run `bundle install`,

--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -37,6 +37,8 @@ end
 build_version Inspec::VERSION
 build_iteration 1
 
+override 'ruby', version: '2.3.1'
+
 dependency 'preparation'
 
 dependency 'inspec'

--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -20,8 +20,10 @@ require_relative '../../../lib/inspec/version.rb'
 name 'inspec'
 
 dependency 'ruby'
-dependency 'rb-readline'
+dependency 'rubygems'
 dependency 'bundler'
+dependency 'rb-readline'
+dependency 'nokogiri'
 dependency 'appbundler'
 
 license :project_license


### PR DESCRIPTION
The new JUnit formatter requires nokogiri, so we need
to build nokogiri via omnibus to ensure liblzma, etc.
is built as part of the omnibus package instead of
`gem` picking up a system liblzma, such as on Mac OS X.

Also bumping ruby to 2.3.1 to match ChefDK.

Signed-off-by: Adam Leff <adam@leff.co>