### PR TITLE
try to use sysv fallback if is not producing proper output

### DIFF
--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -336,7 +336,7 @@ module Inspec::Resources
       status = inspec.command("#{service_ctl} status #{service_name}")
 
       # fallback for systemv services, those are not handled via `initctl`
-      return SysV.new(inspec).info(service_name) if status.exit_status.to_i != 0
+      return SysV.new(inspec).info(service_name) if status.exit_status.to_i != 0 || status.stdout == ''
 
       # @see: http://upstart.ubuntu.com/cookbook/#job-states
       # grep for running to indicate the service is there


### PR DESCRIPTION
Addresses an error detected by @atomic111 in https://github.com/dev-sec/postgres-baseline/issues/17 where `postgres` resource is not returning values for upstart, since `initctl` is returning an empty string