### PR TITLE
Provide better error message when inspec.yml is invalid

### DIFF
--- a/test/unit/mock/profiles/profile-with-bad-metadata/controls/example.rb
+++ b/test/unit/mock/profiles/profile-with-bad-metadata/controls/example.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+# license: All rights reserved
+
+title 'sample section'
+
+# you can also use plain tests
+describe file('/tmp') do
+  it { should be_directory }
+end
+
+# you add controls here
+control 'tmp-1.0' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/profile-with-bad-metadata/inspec.yml
+++ b/test/unit/mock/profiles/profile-with-bad-metadata/inspec.yml
@@ -1,0 +1,11 @@
+name: profile-with-bad-metadata
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile
+and this is
+bad metadata because
+we didn't start a multi-line string
+version: 0.1.0

--- a/test/unit/source_readers/inspec_test.rb
+++ b/test/unit/source_readers/inspec_test.rb
@@ -35,4 +35,15 @@ describe SourceReaders::InspecReader do
       _(res.libraries.values[0]).must_match(/^# Library resource$/)
     end
   end
+
+  describe 'with an invalid inspec.yml' do
+    let(:mock_file) { MockLoader.profile_tgz('profile-with-bad-metadata') }
+    let(:target) { Inspec::FileProvider.for_path(mock_file) }
+    let(:res) { Inspec::SourceReader.resolve(target) }
+
+    it 'raises an exception' do
+      err = proc { _(res.metadata) }.must_raise RuntimeError
+      err.message.must_match(/Unable to parse inspec\.yml: line \d+/)
+    end
+  end
 end


### PR DESCRIPTION
Currently, if the inspec.yml for a profile is invalid (such as including
an improperly-defined multi-line string), InSpec will throw an exception
from the YAML parser that does not given a clear indication that the
issue was encountered while parsing the inspec.yml file.

This change introduces a better exception message to clue the user into
where the problem actually lies.

Fixes #1549.
