### PR TITLE
Add additional example for matching crontab commands

### DIFF
--- a/docs/resources/crontab.md.erb
+++ b/docs/resources/crontab.md.erb
@@ -60,3 +60,9 @@ The following examples show how to use this InSpec audit resource.
     describe crontab.where({'hour' => '*', 'minute' => '*'}) do
       its('entries.length') { should cmp '0' }
     end
+
+### Test that the logged-in user's crontab contains a single command that matches a mattern
+
+    describe crontab.where { command =~ /a partial command string/ } do
+      its('entries.length') { should cmp 1 }
+    end

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -21,6 +21,10 @@ module Inspec::Resources
       describe crontab.where({'hour' => '*', 'minute' => '*'}) do
         its('entries.length') { should cmp '0' }
       end
+
+      describe crontab.where { command =~ /a partial command string/ } do
+        its('entries.length') { should cmp 1 }
+      end
     "
 
     attr_reader :params


### PR DESCRIPTION
As raised in #1526, adding an additional example showing how
a user can use the `where` accessor to find commands matching
a pattern and write a test using the results.

Fixes #1526 
