### PR TITLE
moving the nokogiri reference into the gemspec file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
 end
 
 gem 'ffi', '>= 1.9.14'
-gem 'nokogiri', '~> 1.6'
 
 group :test do
   gem 'bundler', '~> 1.5'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-log'
   spec.add_dependency 'sslshake', '~> 1'
   spec.add_dependency 'parallel', '~> 1.9'
-  spec.add_dependency 'rspec_junit_formatter', '~> 0.2.3'
+  spec.add_dependency 'nokogiri', '~> 1.6'
   spec.add_dependency 'faraday', '>=0.9.0'
   spec.add_dependency 'toml', '~> 0.1'
 end

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -5,7 +5,6 @@
 
 require 'rspec/core'
 require 'rspec/core/formatters/json_formatter'
-require 'rspec_junit_formatter'
 
 # Vanilla RSpec JSON formatter with a slight extension to show example IDs.
 # TODO: Remove these lines when RSpec includes the ID natively


### PR DESCRIPTION
fixes #1562 by moving the nokogiri reference to the gemspec file instead of the gem file. also removes the stale dependency on the rspec junit formatter.