### PR TITLE
Fix omnibus configuration

### DIFF
--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -32,21 +32,24 @@
 # Enable S3 asset caching
 # ------------------------------
 use_s3_caching true
-# s3_access_key  ENV['AWS_ACCESS_KEY_ID']
-# s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
-# s3_bucket      ENV['AWS_S3_BUCKET']
+s3_access_key  ENV['AWS_ACCESS_KEY_ID']
+s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
 s3_bucket      'opscode-omnibus-cache'
 
 # Customize compiler bits
 # ------------------------------
 # solaris_compiler 'gcc'
-# build_retries 5
-# fetcher_read_timeout 120
-# fetcher_retries 5
+
+# Configure retries
+# similar settings to chef/chef
+# ------------------------------
+build_retries 3
+fetcher_retries 3
+fetcher_read_timeout 120
 
 # Load additional software
 # ------------------------------
-software_gems ['omnibus-software']
+# software_gems ['omnibus-software']
 # local_software_dirs ['/path/to/local/software']
 
 # Windows architecture defaults


### PR DESCRIPTION
The latest omnibus master expects certain settings to be enabled for
S3 caching to work, and our omnibus.rb wasn't set up properly. Also
aligning some of our settings to chef/chef's settings which we know
to work properly.