### PR TITLE
Ignore the simulator gemfile group

### DIFF
--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -41,7 +41,7 @@ build do
 
   # We bundle install to ensure the versions of gems we are going to
   # appbundle-lock to are definitely installed
-  bundle 'install --without test integration tools maintenance', env: env
+  bundle 'install --without test integration tools maintenance simulator', env: env
 
   gem "build #{name}.gemspec", env: env
   gem "install #{name}-*.gem --no-document", env: env


### PR DESCRIPTION
The gems in the simulator group are only needed for the www/tutorial,
and we are currently having issues building the native extensions for
the charlock_holmes gem.

Signed-off-by: Adam Leff <adam@leff.co>