### PR TITLE
Move simulator gems to www

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,12 +31,6 @@ group :integration do
   gem 'kitchen-dokken'
 end
 
-group :simulator do
-  gem 'github-markup'
-  gem 'redcarpet'
-  gem 'docker-api'
-end
-
 group :tools do
   gem 'pry', '~> 0.10'
   gem 'rb-readline'

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -11,7 +11,7 @@ source 'https://rubygems.org'
 # gem 'omnibus-software', github: 'chef/omnibus-software', branch: 'ksubrama/ruby23'
 
 # Use entries from chef's Gemfile
-gem 'omnibus', github: 'chef/omnibus', branch: 'sersut/ff-ksubrama/gcc_investigate'
+gem 'omnibus', github: 'chef/omnibus'
 gem 'omnibus-software', github: 'chef/omnibus-software'
 gem 'license_scout', github: 'chef/license_scout'
 

--- a/www/Gemfile
+++ b/www/Gemfile
@@ -19,3 +19,9 @@ gem 'middleman-livereload'
 gem 'middleman-autoprefixer'
 gem 'middleman-syntax'
 gem 'redcarpet'
+
+group :simulator do
+  gem 'github-markup'
+  gem 'redcarpet'
+  gem 'docker-api'
+end


### PR DESCRIPTION
The simulator gems are not necessary for building InSpec, only the website.
This is currently causing issues in the Jenkins infrastructure due to
a downstream dependency of github-markup.

Signed-off-by: Adam Leff <adam@leff.co>