### PR TITLE
Fix Habitat plan for nokogiri support

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -10,6 +10,8 @@ pkg_license=('Apache-2.0')
 pkg_source=false
 pkg_deps=(
   core/coreutils
+  core/libxml2
+  core/libxslt
   core/ruby
   core/net-tools
 )
@@ -44,8 +46,23 @@ GEMFILE
 }
 
 do_build() {
-  export BUNDLE_SILENCE_ROOT_WARNING=1 GEM_PATH
-  GEM_PATH="$(pkg_path_for core/bundler)"
+  local _bundler_dir
+  local _libxml2_dir
+  local _libxslt_dir
+
+  _bundler_dir="$(pkg_path_for bundler)"
+  _libxml2_dir="$(pkg_path_for libxml2)"
+  _libxslt_dir="$(pkg_path_for libxslt)"
+
+  export GEM_HOME=${pkg_path}/vendor/bundle
+  export GEM_PATH=${_bundler_dir}:${GEM_HOME}
+  export BUNDLE_SILENCE_ROOT_WARNING=1
+
+  # don't let bundler split up the nokogiri config string (it breaks
+  # the build), so specify it as an env var instead
+  export NOKOGIRI_CONFIG="--use-system-libraries --with-zlib-dir=${_zlib_dir} --with-xslt-dir=${_libxslt_dir} --with-xml2-include=${_libxml2_dir}/include/libxml2 --with-xml2-lib=${_libxml2_dir}/lib"
+  bundle config build.nokogiri "${NOKOGIRI_CONFIG}"
+
   bundle install --jobs "$(nproc)" --retry 5 --standalone \
     --path "$pkg_prefix/bundle" \
     --binstubs "$pkg_prefix/bin"


### PR DESCRIPTION
Nokogiri is failing to build in the habitat artifact due to the lack
of libxml2 and libxslt. This brings them in as dependencies and also
properly configures bundler to use them.

Signed-off-by: Adam Leff <adam@leff.co>