### PR TITLE
Yum resource fix for non-existent repos and repo info

### DIFF
--- a/docs/resources/yum.md.erb
+++ b/docs/resources/yum.md.erb
@@ -101,3 +101,11 @@ The following examples show how to use this InSpec audit resource.
       it { should exist }
       it { should be_enabled }
     end
+
+### Test a particular repository configuration, such as its Base URL
+
+    describe yum.repo('mycompany-artifacts') do
+      it { should exist }
+      it { should be_enabled }
+      its('baseurl') { should include 'mycompany.biz' }
+    end

--- a/lib/resources/yum.rb
+++ b/lib/resources/yum.rb
@@ -2,8 +2,6 @@
 # author: Christoph Hartmann
 # author: Dominik Richter
 
-require 'resources/file'
-
 # Usage:
 # describe yum do
 #   its('repos') { should exist }
@@ -22,6 +20,7 @@ require 'resources/file'
 # describe yum.repo('epel') do
 #   it { should exist }
 #   it { should be_enabled }
+#   its('baseurl') { should include 'mycompany.biz' }
 # end
 #
 # deprecated:
@@ -33,7 +32,7 @@ require 'resources/file'
 module Inspec::Resources
   class Yum < Inspec.resource(1)
     name 'yum'
-    desc 'Use the yum InSpec audit resource to test packages in the Yum repository.'
+    desc 'Use the yum InSpec audit resource to test the configuration of Yum repositories.'
     example "
       describe yum.repo('name') do
         it { should exist }
@@ -121,22 +120,25 @@ module Inspec::Resources
     def info
       return @cache if defined?(@cache)
       selection = @yum.repositories.select { |e| e['id'] == @reponame || shortname(e['id']) == @reponame }
-      @cache = selection[0] if !selection.nil? && selection.length == 1
+      @cache = selection.empty? ? {} : selection.first
       @cache
     end
 
     def exist?
-      !info.nil?
+      !info.empty?
     end
 
     def enabled?
-      repo = info
-      return false if repo.nil?
+      return false unless exist?
       info['status'] == 'enabled'
     end
 
+    def method_missing(name)
+      info[name.to_s]
+    end
+
     def to_s
-      "YumRepo #{shortname(info['id'])}"
+      "YumRepo #{@reponame}"
     end
   end
 

--- a/lib/resources/yum.rb
+++ b/lib/resources/yum.rb
@@ -133,8 +133,20 @@ module Inspec::Resources
       info['status'] == 'enabled'
     end
 
-    def method_missing(name)
-      info[name.to_s]
+    # provide a method for each of the repo metadata items we know about
+    [
+      :baseurl,
+      :expire,
+      :filename,
+      :mirrors,
+      :pkgs,
+      :size,
+      :status,
+      :updated,
+    ].each do |key|
+      define_method key do
+        info[key.to_s]
+      end
     end
 
     def to_s

--- a/test/unit/resources/yum_test.rb
+++ b/test/unit/resources/yum_test.rb
@@ -50,15 +50,17 @@ describe 'Inspec::Resources::YumRepo' do
     extras = resource.repo('extras/7/x86_64')
     _(extras.exist?).must_equal true
     _(extras.enabled?).must_equal true
+    _(extras.baseurl).must_include 'informatik'
     # test enabled extra repo with short name
     extras = resource.repo('extras')
     _(extras.exist?).must_equal true
     _(extras.enabled?).must_equal true
+    _(extras.baseurl).must_include 'informatik'
     # test disabled extra-source repo
     extras = resource.repo('base-debuginfo/x86_64')
     _(extras.exist?).must_equal true
     _(extras.enabled?).must_equal false
-    _(extras.to_s).must_equal 'YumRepo base-debuginfo'
+    _(extras.to_s).must_equal 'YumRepo base-debuginfo/x86_64'
   end
 
   it 'test enabled extra repo (serverspec backwards comptability)' do

--- a/test/unit/resources/yum_test.rb
+++ b/test/unit/resources/yum_test.rb
@@ -63,6 +63,19 @@ describe 'Inspec::Resources::YumRepo' do
     _(extras.to_s).must_equal 'YumRepo base-debuginfo/x86_64'
   end
 
+  it 'provides methods for retrieving per-repo information' do
+    resource = MockLoader.new(:centos7).load_resource('yum')
+    repo = resource.repo('base/7/x86_64')
+    _(repo.baseurl).must_equal 'http://ftp.hosteurope.de/mirror/centos.org/7.1.1503/os/x86_64/ (9 more)'
+    _(repo.expire).must_equal '21600 second(s) (last: Sun Sep  6 10:20:46 2015)'
+    _(repo.filename).must_equal '/etc/yum.repos.d/CentOS-Base.repo'
+    _(repo.mirrors).must_equal 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=stock'
+    _(repo.pkgs).must_equal '8652'
+    _(repo.size).must_equal '6.3 G'
+    _(repo.status).must_equal 'enabled'
+    _(repo.updated).must_equal 'Tue Mar 31 22:50:46 2015'
+  end
+
   it 'test enabled extra repo (serverspec backwards comptability)' do
     serverspec = load_resource('yumrepo', 'extras')
     _(serverspec.exists?).must_equal true


### PR DESCRIPTION
If a repo did not exist, running matchers against it (such as `exist`)
were failing due to a bug in `#to_s` when fetching the repo name. The
`info` method would return nil and we'd still try to treat it as a hash.

This change ensures that info is always a hash, possibly empty if the
repo doesn't exist, and uses the repo name provided by the user rather
than shortening it to be consistent with our other resources which don't
manipulate the user input in the formatter.

Also added a method_missing to allow users to interrogate repo options,
such as baseurl or gpgcheck.

Fixes #1553