### PR TITLE
Support vendored profiles in Habitat-packaged profiles

### DIFF
--- a/lib/bundles/inspec-habitat/profile.rb
+++ b/lib/bundles/inspec-habitat/profile.rb
@@ -37,6 +37,8 @@ module Habitat
       validate_habitat_installed
       validate_habitat_origin
       create_profile_object
+      verify_profile
+      vendor_profile_dependencies
       copy_profile_to_work_dir
       create_plan
       create_run_hook
@@ -79,7 +81,19 @@ module Habitat
     private
 
     def create_profile_object
-      @profile = Inspec::Profile.for_target(path, backend: Inspec::Backend.create(target: 'mock://'))
+      @profile = Inspec::Profile.for_target(
+        path,
+        cache: Inspec::Cache.new(cache_path.to_s),
+        backend: Inspec::Backend.create(target: 'mock://'),
+      )
+    end
+
+    def cache_path
+      File.join(path, 'vendor')
+    end
+
+    def inspec_lockfile
+      File.join(path, 'inspec.lock')
     end
 
     def verify_profile
@@ -90,6 +104,20 @@ module Habitat
       end
 
       Habitat::Log.info('Profile is valid.')
+    end
+
+    def vendor_profile_dependencies
+      if File.exist?(inspec_lockfile) && Dir.exist?(cache_path)
+        Habitat::Log.info("Profile's dependencies are already vendored, skipping vendor process.")
+      else
+        Habitat::Log.info("Vendoring the profile's dependencies...")
+        FileUtils.rm_rf(cache_path)
+        File.delete(inspec_lockfile) if File.exist?(inspec_lockfile)
+        File.write(inspec_lockfile, profile.generate_lockfile.to_yaml)
+
+        # refresh the profile object since the profile now has new files
+        create_profile_object
+      end
     end
 
     def validate_habitat_installed

--- a/lib/fetchers/git.rb
+++ b/lib/fetchers/git.rb
@@ -24,7 +24,7 @@ module Fetchers
   # you got to this file during debugging, you may want to look at the
   # omnibus source for hints.
   #
-  class Git < Inspec.fetcher(1)
+  class Git < Inspec.fetcher(1) # rubocop:disable ClassLength
     name 'git'
     priority 200
 
@@ -44,6 +44,8 @@ module Fetchers
 
     def fetch(dir)
       @repo_directory = dir
+      FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
+
       if cloned?
         checkout
       else

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -153,7 +153,9 @@ module Fetchers
     def download_archive(path)
       download_archive_to_temp
       final_path = "#{path}#{@archive_type}"
+      FileUtils.mkdir_p(File.dirname(final_path))
       FileUtils.mv(temp_archive_path, final_path)
+      FileUtils.chmod(0644, final_path)
       Inspec::Log.debug("Fetched archive moved to: #{final_path}")
       @temp_archive_path = nil
       final_path

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -155,7 +155,6 @@ module Fetchers
       final_path = "#{path}#{@archive_type}"
       FileUtils.mkdir_p(File.dirname(final_path))
       FileUtils.mv(temp_archive_path, final_path)
-      FileUtils.chmod(0644, final_path)
       Inspec::Log.debug("Fetched archive moved to: #{final_path}")
       @temp_archive_path = nil
       final_path

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -157,7 +157,7 @@ module Inspec
       end
 
       profile_vendor.vendor!
-      puts "Profile dependencies successfully vendored to #{profile_vendor.cache_path}"
+      puts "Dependencies for profile #{profile_path} successfully vendored to #{profile_vendor.cache_path}"
     rescue StandardError => e
       pretty_handle_exception(e)
     end

--- a/lib/inspec/profile_vendor.rb
+++ b/lib/inspec/profile_vendor.rb
@@ -1,0 +1,66 @@
+# encoding: utf-8
+# author: Adam Leff
+
+require 'inspec/profile'
+
+module Inspec
+  class ProfileVendor
+    attr_reader :profile_path
+
+    def initialize(path)
+      @profile_path = Pathname.new(path)
+    end
+
+    def vendor!
+      vendor_dependencies
+    end
+
+    # The URL fetcher uses a Tempfile to retrieve the vendored
+    # profile, which creates a file that is only readable by
+    # the current user. In most circumstances, this is likely OK.
+    # However, in environments like a Habitat package, these files
+    # need to be readable by all users or the Habitat Supervisor
+    # may not be able to start InSpec correctly.
+    #
+    # This method makes sure all vendored files are mode 644 for this
+    # use case. This method is not called by default - the caller
+    # vendoring the profile must make the decision as to whether this
+    # is necessary.
+    def make_readable
+      Dir.glob("#{cache_path}/**/*") do |e|
+        FileUtils.chmod(0644, e) if File.file?(e)
+      end
+    end
+
+    def cache_path
+      profile_path.join('vendor')
+    end
+
+    def lockfile
+      profile_path.join('inspec.lock')
+    end
+
+    private
+
+    def profile
+      @profile ||= Inspec::Profile.for_target(profile_path.to_s, profile_opts)
+    end
+
+    def profile_opts
+      {
+        cache: Inspec::Cache.new(cache_path.to_s),
+        backend: Inspec::Backend.create(target: 'mock://'),
+      }
+    end
+
+    def vendor_dependencies
+      delete_vendored_data
+      File.write(lockfile, profile.generate_lockfile.to_yaml)
+    end
+
+    def delete_vendored_data
+      FileUtils.rm_rf(cache_path) if cache_path.exist?
+      File.delete(lockfile) if lockfile.exist?
+    end
+  end
+end

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -9,7 +9,7 @@ describe 'example inheritance profile' do
 
   it 'can vendor profile dependencies' do
     out = inspec('vendor ' + inheritance_path + ' --overwrite')
-    out.stdout.force_encoding(Encoding::UTF_8).must_include "Vendor dependencies of #{inheritance_path} into #{inheritance_path}/vendor"
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Dependencies for profile #{inheritance_path} successfully vendored to #{inheritance_path}/vendor"
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
 
@@ -29,7 +29,7 @@ describe 'example inheritance profile' do
 
     # vendor all dependencies
     out = inspec('vendor --overwrite', "cd #{inheritance_path} &&")
-    out.stdout.force_encoding(Encoding::UTF_8).must_include "Vendor dependencies of #{inheritance_path} into #{inheritance_path}/vendor"
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Dependencies for profile #{inheritance_path} successfully vendored to #{inheritance_path}/vendor"
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
 
@@ -110,7 +110,7 @@ describe 'example inheritance profile' do
 
   it 'can vendor profile dependencies from the profile path' do
     out = inspec('vendor --overwrite', "cd #{inheritance_path} &&")
-    out.stdout.force_encoding(Encoding::UTF_8).must_include "Vendor dependencies of #{inheritance_path} into #{inheritance_path}/vendor"
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Dependencies for profile #{inheritance_path} successfully vendored to #{inheritance_path}/vendor"
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
 


### PR DESCRIPTION
This change adds support in Habitat-packaged profiles for
profiles that depend on other profiles. When `inspec habitat
profile create` or `inspec habitat profile upload` is run,
it will see if the profile's dependencies have been vendored
yet, and if not, it will vendor them before creating the
habitat artifact.

For the git and URL fetchers, more explicit creation of the
target directories for the vendored profiles is done. This
is implicitly done via normal CLI interactions a user may
go through, but in our case, we want to ensure those directories
are there before the fetchers try to write out content.

By adding this support, we also fix a bug experienced in Habitat
where a profile that was packaged before an `inspec exec` was run
for the profile would cause a failure in Habitat. This is caused
by `inspec exec` doing a vendor of the dependencies if necessary
and generating the inspec.lock file. In Habitat, the package dir
is not writable by the hab user and InSpec would fail to run due
to an inability to write out an inspec.lock.