### PR TITLE
Require Ruby 2.1

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.1'
+
   spec.add_dependency 'train', '>=0.22.0', '<1.0'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'


### PR DESCRIPTION
InSpec now depends on nokogiri which has a dependency of Ruby 2.1 or
later. If someone tries to `gem install inspec` using Ruby 2.0, it
will fail on the nokogiri dependency rather than InSpec itself.

Additionally, Ruby 2.0 is already EOL.

Fixes #1597