### PR TITLE
Remove errant puts in inspec habitat CLI command

### DIFF
--- a/lib/bundles/inspec-habitat/cli.rb
+++ b/lib/bundles/inspec-habitat/cli.rb
@@ -11,7 +11,6 @@ module Habitat
     option :output_dir, type: :string, required: false,
       desc: 'Directory in which to save the generated Habitat artifact. Default: current directory'
     def create(path)
-      puts options
       Habitat::Profile.create(path, options)
     end
 


### PR DESCRIPTION
Left a `puts` behind during some testing that made its way into
a PR. Removing it!