### PR TITLE
Add OSX support for host resource

### DIFF
--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -145,7 +145,7 @@ module Inspec::Resources
   # @see http://blogs.technet.com/b/josebda/archive/2015/04/18/windows-powershell-equivalents-for-common-networking-commands-ipconfig-ping-nslookup.aspx
   # @see http://blogs.technet.com/b/heyscriptingguy/archive/2014/03/19/creating-a-port-scanner-with-windows-powershell.aspx
   class WindowsHostProvider < HostProvider
-    def ping(hostname, port = nil, proto = nil)
+    def ping(hostname, port = nil, _proto = nil)
       # ICMP: Test-NetConnection www.microsoft.com
       # TCP and port: Test-NetConnection -ComputerName www.microsoft.com -RemotePort 80
       request = "Test-NetConnection -ComputerName #{hostname}"

--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -43,6 +43,8 @@ module Inspec::Resources
       @port = params[:port]   || nil
       @proto = params[:proto] || nil
 
+      return skip_resource 'The UDP protocol for the `host` resource is not supported yet.' if @proto == 'udp'
+
       @host_provider = nil
       if inspec.os.linux?
         @host_provider = LinuxHostProvider.new(inspec)
@@ -97,7 +99,6 @@ module Inspec::Resources
 
   class DarwinHostProvider < HostProvider
     def ping(hostname, port = nil, proto = nil)
-      return nil if proto == 'udp' # Copying windows behaivor
       if proto == 'tcp'
         resp = inspec.command("nc -vz -G 1 #{hostname} #{port}")
       else
@@ -145,9 +146,6 @@ module Inspec::Resources
   # @see http://blogs.technet.com/b/heyscriptingguy/archive/2014/03/19/creating-a-port-scanner-with-windows-powershell.aspx
   class WindowsHostProvider < HostProvider
     def ping(hostname, port = nil, proto = nil)
-      # TODO: abort if we cannot run it via udp
-      return nil if proto == 'udp'
-
       # ICMP: Test-NetConnection www.microsoft.com
       # TCP and port: Test-NetConnection -ComputerName www.microsoft.com -RemotePort 80
       request = "Test-NetConnection -ComputerName #{hostname}"

--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -96,10 +96,10 @@ module Inspec::Resources
   end
 
   class DarwinHostProvider < HostProvider
-    def ping(hostname, _port = nil, _proto = nil)
-      return nil if _proto == 'udp' # Copying windows behaivor
-      if _proto == 'tcp'
-        resp = inspec.command("nc -vz -G 1 #{hostname} #{_port}")
+    def ping(hostname, port = nil, proto = nil)
+      return nil if proto == 'udp' # Copying windows behaivor
+      if proto == 'tcp'
+        resp = inspec.command("nc -vz -G 1 #{hostname} #{port}")
       else
         resp = inspec.command("ping -W 1 -c 1 #{hostname}")
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -244,6 +244,9 @@ class MockLoader
       # host for Linux
       'getent hosts example.com' => cmd.call('getent-hosts-example.com'),
       'ping -w 1 -c 1 example.com' => cmd.call('ping-example.com'),
+      # host for Darwin
+      'host -t AAAA example.com' => cmd.call('host-AAAA-example.com'),
+      'ping -W 1 -c 1 example.com' => cmd.call('ping-example.com'),
       # apt
       "find /etc/apt/ -name *.list -exec sh -c 'cat {} || echo -n' \\;" => cmd.call('etc-apt'),
       # iptables

--- a/test/unit/mock/cmd/host-AAAA-example.com
+++ b/test/unit/mock/cmd/host-AAAA-example.com
@@ -1,0 +1,1 @@
+example.com has IPv6 address 2606:2800:220:1:248:1893:25c8:1946

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -21,6 +21,13 @@ describe 'Inspec::Resources::Host' do
     _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
   end
 
+  it 'check host on darwin' do
+    resource = MockLoader.new(:osx104).load_resource('host', 'example.com')
+    _(resource.resolvable?).must_equal true
+    _(resource.reachable?).must_equal true
+    _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
+  end
+
   it 'check host on windows' do
     resource = MockLoader.new(:windows).load_resource('host', 'microsoft.com')
     _(resource.resolvable?).must_equal true


### PR DESCRIPTION
- Ping on OSX uses -W instead of -w
- Can use nc for testing TCP connections. There is also a UDP mode for this but doesn't seem to work (and would be unreliable anyways) so following the behavior on windows here.