### PR TITLE
Fix protocols matcher text on ssl resource docs

### DIFF
--- a/docs/resources/ssl.md.erb
+++ b/docs/resources/ssl.md.erb
@@ -70,7 +70,7 @@ or:
 
 ### protocols
 
-The `protocols` matcher tests the number of times the named user appears in `/etc/shadow`:
+The `protocols` matcher tests what protocol versions (SSLv3, TLSv1.1, etc) are enabled:
 
     its('protocols') { should eq 'ssl2' }
 


### PR DESCRIPTION
The `protocols` matcher section on the `ssl` resource
doc page fell victim to some copy/paste. This change
updates the text to the correct description.

Fixes #1620 