### PR TITLE
[www] Add warning to the http resource documentation

### DIFF
--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -6,6 +6,10 @@ title: About the http Resource
 
 Use the `http` InSpec audit resource to test an http endpoint.
 
+<p class="warning">Currently, this resource always executes on the host on which <code>inspec exec</code> is run, even if you use the <code>--target</code> option to remotely scan a different host.<br>
+<br>
+This will be corrected in a future version of InSpec. New InSpec releases are posted in the <a href="https://discourse.chef.io/c/chef-release" target="_blank">Release Announcements Category in Discourse</a>.</p>
+
 ## Syntax
 
 An `http` resource block declares the configuration settings to be tested:

--- a/www/source/stylesheets/_settings.scss
+++ b/www/source/stylesheets/_settings.scss
@@ -12,6 +12,7 @@ $color_purple_shade: rgba(151,110,229,0.4);
 $color_blue_shade: rgba(91, 201, 163, 1);
 $color_blue_shade_2: rgba(58, 142, 206, 1);
 $color_lt_blue: #eaf8f9;
+$color_lt_yellow: #fff7d5;
 
 //fonts
 

--- a/www/source/stylesheets/_typography.scss
+++ b/www/source/stylesheets/_typography.scss
@@ -121,3 +121,10 @@ hr {
 .t-purple > a { //trigger for side bar LI
 	color: $color_purple !important;
 }
+
+.warning {
+    padding: 10px;
+    margin-bottom: 1em;
+    background: $color_lt_yellow;
+    border: 1px solid rgba(255,147,0,0.3);
+}


### PR DESCRIPTION
Currently, the `http` resource only operates on the node on which
`inspec exec` is run, even if the user uses the `--target` flag.
This has caused some confusion in the community.

Until this can be fixed, this change adds a warning to the documentation.