### PR TITLE
Adding SNI utilization to ssl resource

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pry', '~> 0'
   spec.add_dependency 'hashie', '~> 3.4'
   spec.add_dependency 'mixlib-log'
-  spec.add_dependency 'sslshake', '~> 1'
+  spec.add_dependency 'sslshake', '~> 1.1'
   spec.add_dependency 'parallel', '~> 1.9'
   spec.add_dependency 'faraday', '>=0.9.0'
   spec.add_dependency 'toml', '~> 0.1'

--- a/lib/resources/ssl.rb
+++ b/lib/resources/ssl.rb
@@ -71,7 +71,7 @@ class SSL < Inspec.resource(1)
           res = Parallel.map(groups, in_threads: 8) do |proto, e|
             [proto, SSLShake.hello(x.resource.host, port: x.resource.port,
               protocol: proto, ciphers: e.map(&:cipher),
-              timeout: x.resource.timeout, retries: x.resource.retries)]
+              timeout: x.resource.timeout, retries: x.resource.retries, servername: x.resource.host)]
           end
           Hash[res]
         }


### PR DESCRIPTION
Hi

updated the ssl resource to utilize the new sni feature [1] in the underlying sslshake lib.
its now possible to scan servers serving multiple domains over ssl/tls

[1] https://github.com/arlimus/sslshake/pull/5