### PR TITLE
Loosen addressable version pin

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'parallel', '~> 1.9'
   spec.add_dependency 'faraday', '>=0.9.0'
   spec.add_dependency 'toml', '~> 0.1'
-  spec.add_dependency 'addressable', '~> 2.5'
+  spec.add_dependency 'addressable', '~> 2.4'
 end


### PR DESCRIPTION
The version of addressable that was pinned in the gemspec was
too new and conflicted with some of chef's dependencies. Loosening
it will allow us to include InSpec in the chef omnibus packages.