### PR TITLE
Fix and document registry issues

### DIFF
--- a/docs/resources/registry_key.md.erb
+++ b/docs/resources/registry_key.md.erb
@@ -48,6 +48,19 @@ or may be enclosed in a double-quoted string with an extra backslash as an escap
     "HKCU\\SOFTWARE\\path\\to\\key\\Themes"
 
 
+<p class="warning">
+Please make sure that you use backslashes instead of forward slashes. Forward slashes will not work for registry keys.
+</p>
+
+    # The following will not work:
+    # describe registry_key('HKLM/SOFTWARE/Microsoft/NET Framework Setup/NDP/v4/Full/1033') do
+    #   its('Release') { should eq 378675 }
+    # end
+    # You should use:
+    describe registry_key('HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\1033') do
+      its('Release') { should eq 378675 }
+    end
+
 ## Matchers
 
 This InSpec audit resource has the following matchers:
@@ -125,6 +138,17 @@ The `have_value` matcher tests if a value exists for a registry key:
 The `name` matcher tests the value for the specified registry setting:
 
     its('name') { should eq 'value' }
+
+
+<p class="warning">
+Any name with a dot will not work as expected: <code>its('explorer.exe') { should eq 'test' }</code>. This issue is tracked in <a href="https://github.com/chef/inspec/issues/1281">https://github.com/chef/inspec/issues/1281</a>
+</p>
+
+    # instead of:
+    # its('explorer.exe') { should eq 'test' }
+    # use the following solution:
+    it { should have_property_value('explorer.exe', :string, 'test') }
+
 
 ## Examples
 

--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -168,7 +168,7 @@ module Inspec::Resources
         $properties
       }
       $path = '#{path}'
-      InSpec-GetRegistryKey($path) | ConvertTo-Json
+      InSpec-GetRegistryKey($path) | ConvertTo-Json -Compress
       EOH
 
       cmd = inspec.powershell(script)

--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -66,7 +66,10 @@ module Inspec::Resources
         # generate registry_key if we do not have a regular expression
         @options[:path] = @options[:hive]
         # add optional key path
-        @options[:path] += '\\' + @options[:key] if @options[:key]
+        if @options[:key]
+          @options[:path] += '\\' if !@options[:key].start_with?('\\')
+          @options[:path] += @options[:key]
+        end
         @options[:name] ||= @options[:path]
       else
         @options[:name] = name

--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -63,18 +63,15 @@ module Inspec::Resources
       @options = {}
       if reg_key && reg_key.is_a?(Hash)
         @options = @options.merge!(reg_key)
+
         # generate registry_key if we do not have a regular expression
-        @options[:path] = @options[:hive]
-        # add optional key path
-        if @options[:key]
-          @options[:path] += '\\' if !@options[:key].start_with?('\\')
-          @options[:path] += @options[:key]
-        end
+        @options[:path] = generate_registry_key_path_from_options
         @options[:name] ||= @options[:path]
       else
         @options[:name] = name
         @options[:path] = reg_key
       end
+
       return skip_resource 'The `registry_key` resource is not supported on your OS yet.' if !inspec.os.windows?
     end
 
@@ -257,6 +254,20 @@ module Inspec::Resources
       options[:type_expandstring] = 2
 
       options[symbol]
+    end
+
+    def generate_registry_key_path_from_options
+      path = @options[:hive]
+      path += format_key_from_options
+
+      path
+    end
+
+    def format_key_from_options
+      key = @options[:key]
+      return '' unless key
+
+      key.start_with?('\\') ? key : "\\#{key}"
     end
   end
 

--- a/test/cookbooks/os_prepare/recipes/default.rb
+++ b/test/cookbooks/os_prepare/recipes/default.rb
@@ -28,7 +28,7 @@ include_recipe('os_prepare::json_yaml_csv_ini')
 include_recipe('os_prepare::apt')
 
 # application configuration
-if node['osprepare']['application']
+if node['osprepare']['application'] && node['platform_family'] != 'windows'
   include_recipe('os_prepare::postgres')
   include_recipe('os_prepare::auditctl') unless node['osprepare']['docker']
   include_recipe('os_prepare::apache')

--- a/test/cookbooks/os_prepare/recipes/registry_key.rb
+++ b/test/cookbooks/os_prepare/recipes/registry_key.rb
@@ -31,6 +31,14 @@ if node['platform_family'] == 'windows'
       :name => 'multistring value',
       :type => :multi_string,
       :data => ['test', 'multi','string','data']
+    },{
+      :name => 'super\/escape',
+      :type => :string,
+      :data => '\/value/\\'
+    },{
+      :name => 'key.with.dot',
+      :type => :string,
+      :data => 'value.with.dot'
     }]
     recursive true
     action :create

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -163,8 +163,7 @@ class MockLoader
       'env' => cmd.call('env'),
       '${Env:PATH}'  => cmd.call('$env-PATH'),
       # registry key test using winrm 2.0
-      '2376c7b3d81de9382303356e1efdea99385effb84788562c3e697032d51bf942' => cmd.call('reg_schedule'),
-      '89b48f91634e7efc40105fc082c5e12693b08c0a7c4a578b1f3a07e34f676c66' => cmd.call('reg_schedule'),
+      'bd15a11a4b07de0224c4d1ab16c49ad78dd6147650c6ef629152c7093a5ac95e' => cmd.call('reg_schedule'),
       'Auditpol /get /subcategory:\'User Account Management\' /r' => cmd.call('auditpol'),
       '/sbin/auditctl -l' => cmd.call('auditctl'),
       '/sbin/auditctl -s' => cmd.call('auditctl-s'),

--- a/test/integration/default/registry_key_spec.rb
+++ b/test/integration/default/registry_key_spec.rb
@@ -111,3 +111,21 @@ control 'regex-test' do
     end
   }
 end
+
+# test key without leading slash
+describe registry_key({
+  hive: 'HKLM',
+  key:  'System\Test',
+}) do
+  it { should exist }
+  it { should have_value('test') }
+end
+
+# test key with leading slash
+describe registry_key({
+  hive: 'HKLM',
+  key:  '\System\Test',
+}) do
+  it { should exist }
+  it { should have_value('test') }
+end

--- a/test/integration/default/registry_key_spec.rb
+++ b/test/integration/default/registry_key_spec.rb
@@ -129,3 +129,14 @@ describe registry_key({
   it { should exist }
   it { should have_value('test') }
 end
+
+describe registry_key('HKLM\System\Test') do
+  it { should exist }
+  its('super\/escape') { should eq '\/value/\\' }
+
+  # its('key.with.dot') { should eq 'value.with.dot' }
+  # does not work due to the . inside the its block
+  # see https://github.com/chef/inspec/issues/1281
+  # use the following solution:
+  it { should have_property_value('key.with.dot', :string, 'value.with.dot') }
+end

--- a/test/unit/resources/registry_key_test.rb
+++ b/test/unit/resources/registry_key_test.rb
@@ -15,4 +15,23 @@ describe 'Inspec::Resources::RegistryKey' do
     resource_without_name = MockLoader.new(:windows).load_resource('registry_key', 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule')
     _(resource_without_name.Start).must_equal 2
   end
+
+  it 'generates a proper path from options' do
+    resource = MockLoader.new(:windows).load_resource(
+      'registry_key',
+      'Test 1',
+      { hive: 'my_hive', key: '\\my_prefixed_key'},
+    )
+    _(resource.send(:generate_registry_key_path_from_options)).must_equal 'my_hive\\my_prefixed_key'
+  end
+
+  it 'generates a proper path from options when the key has no leading slash' do
+    resource = MockLoader.new(:windows).load_resource(
+      'registry_key',
+      'Test 1',
+      { hive: 'my_hive', key: 'key_with_no_slash'},
+    )
+    _(resource.send(:generate_registry_key_path_from_options)).must_equal 'my_hive\\key_with_no_slash'
+  end
+
 end


### PR DESCRIPTION
Powershell 3 has issues with some characters in strings when used in combination with `ConvertTo-Json`:

```
PS C:\Windows\system32> $properties = New-Object -Type PSObject
$properties | Add-Member "super" "\/value/\\"
$properties | ConvertTo-Json
ConvertTo-Json : The converted JSON string is in bad format.
At line:3 char:15
+ $properties | ConvertTo-Json
+               ~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (@{super=\/value/\\}:PSObject) 
    [ConvertTo-Json], InvalidOperationException
    + FullyQualifiedErrorId : JsonStringInBadFormat,Microsoft.PowerShell.Comma 
   nds.ConvertToJsonCommand
```

By using `ConvertTo-Json -Compress`, it just works:
```
PS C:\Windows\system32> $properties = New-Object -Type PSObject
$properties | Add-Member "super" "\/value/\\"
$properties | ConvertTo-Json -Compress
{"super":"\\/value/\\\\"}
``` 

 * Fixes #1131
 * Fixes #1268
 * adds documentation for #1281