### PR TITLE
pass options hash sans target key

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -89,7 +89,7 @@ module Inspec
       @writable = options[:writable] || false
       @profile_id = options[:id]
       @cache = options[:cache] || Cache.new
-      @backend = options[:backend] || Inspec::Backend.create(options)
+      @backend = options[:backend] || Inspec::Backend.create(options.select { |k, _| k != 'target' })
       @attr_values = options[:attributes]
       @source_reader = source_reader
       @tests_collected = false


### PR DESCRIPTION
This PR fixes https://github.com/chef/inspec/issues/1631

```
validate_backend': Cannot determine backend from target configuration "meta-profile.tar.gz". Valid example: ssh://192.168.0.1. (Train::UserError)
```

Originally, the `:target` key was deleted from the `options` hash in the `initialize` method of `Inspec::Profile`, before being passed to `Inspec::Backend.create()`  Recently, in the commit below, the `:target` delete method was removed so that the key still existed in the hash:  https://github.com/chef/inspec/commit/d0bc085412fb68890f6d6ac8a042381240385f2c#diff-d1eede4085683a605d9b8892a198f642L85

This change introduced an unintended behavior: when train goes off to validate in the `validate_backend` method, it's raising an error since `:target` is not `nil`: https://github.com/chef/train/blob/master/lib/train.rb#L121-L124

This PR simply reverts the original behavior by passing the `options` hash to `Inspec::Backend.create()` without the `:target` key in it.  With this, the functionality works as before and preserves the desired effect from the commit above.

Signed-off-by: Jeremy J. Miller <jm@chef.io>