### PR TITLE
allow Automate profile dependencies

### DIFF
--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -80,7 +80,11 @@ EOF
     private
 
     def compliance_profile_name
-      m = %r{^#{@config['server']}/owners/(?<owner>[^/]+)/compliance/(?<id>[^/]+)/tar$}.match(@target)
+      m = if @config['server_type'] == 'automate'
+            %r{^#{@config['server']}/(?<owner>[^/]+)/(?<id>[^/]+)/tar$}
+          else
+            %r{^#{@config['server']}/owners/(?<owner>[^/]+)/compliance/(?<id>[^/]+)/tar$}
+          end.match(@target)
       "#{m[:owner]}/#{m[:id]}"
     end
   end


### PR DESCRIPTION
This fixes https://github.com/chef/inspec/issues/1632

The change allows for compliance profiles identified via `compliance: owner_name/profile_name` in inspec.yml when the profile is in Automate, not Compliance server.  Prior to this change, during the vendoring step, the `compliance_profile_name` method was only matching for Compliance server URL path, which differs from Automate's URL path slightly so the result was a `lib/bundles/inspec-compliance/target.rb:84:in `compliance_profile_name': undefined method `[]' for nil:NilClass (NoMethodError)` error.

`@target` |  value
--- | --- 
Compliance Server |  https://SERVER-FQDN/api/owners/OWNER_NAME/compliance/PROFILE_NAME/tar
Automate Server |  https://SERVER-FQDN/compliance/profiles/OWNER_NAME/PROFILE_NAME/tar

Tested and validated it works for both vendoring/uploading a meta-profile to Compliance Server AND Automate.

Signed-off-by: Jeremy J. Miller <jm@chef.io>