### PR TITLE
add support for hostname detection on macOS

### DIFF
--- a/lib/resources/sys_info.rb
+++ b/lib/resources/sys_info.rb
@@ -14,7 +14,7 @@ module Inspec::Resources
     # returns the hostname of the local system
     def hostname
       os = inspec.os
-      if os.linux?
+      if os.linux? || os.darwin?
         inspec.command('hostname').stdout.chomp
       elsif os.windows?
         inspec.powershell('$env:computername').stdout.chomp


### PR DESCRIPTION
```
inspec shell
Welcome to the interactive InSpec Shell
To find out how to use it, type: help

You are currently running on:

    OS platform:  mac_os_x
    OS family:  darwin
    OS release: 10.12.4

inspec> sys_info.hostname
=> "remchartmann01"
```