### PR TITLE
Fix gem resource on Windows

### DIFF
--- a/lib/resources/gem.rb
+++ b/lib/resources/gem.rb
@@ -23,7 +23,7 @@ module Inspec::Resources
                       'gem'
                     when :chef
                       if inspec.os.windows?
-                        'c:\opscode\chef\embedded\bin\gem'
+                        'c:\opscode\chef\embedded\bin\gem.bat'
                       else
                         '/opt/chef/embedded/bin/gem'
                       end
@@ -32,6 +32,7 @@ module Inspec::Resources
                     else
                       gem_binary
                     end
+      skip_resource 'Unable to retrieve gem information' if info.empty?
     end
 
     def info
@@ -47,6 +48,8 @@ module Inspec::Resources
       # extract package name and version
       # parses data like winrm (1.3.4, 1.3.3)
       params = /^\s*([^\(]*?)\s*\((.*?)\)\s*$/.match(cmd.stdout.chomp)
+      return {} if params.nil?
+
       versions = params[2].split(',')
       @info[:name] = params[1]
       @info[:version] = versions[0]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -175,7 +175,7 @@ class MockLoader
       'gem list --local -a -q ^rubocop$' => cmd.call('gem-list-local-a-q-rubocop'),
       '/opt/ruby-2.3.1/embedded/bin/gem list --local -a -q ^pry$' => cmd.call('gem-list-local-a-q-pry'),
       '/opt/chef/embedded/bin/gem list --local -a -q ^chef-sugar$' => cmd.call('gem-list-local-a-q-chef-sugar'),
-      'c:\opscode\chef\embedded\bin\gem list --local -a -q ^json$' => cmd.call('gem-list-local-a-q-json'),
+      'c:\opscode\chef\embedded\bin\gem.bat list --local -a -q ^json$' => cmd.call('gem-list-local-a-q-json'),
       '/opt/opscode/embedded/bin/gem list --local -a -q ^knife-backup$' => cmd.call('gem-list-local-a-q-knife-backup'),
       'npm ls -g --json bower' => cmd.call('npm-ls-g--json-bower'),
       'pip show jinja2' => cmd.call('pip-show-jinja2'),

--- a/test/unit/resources/gem_test.rb
+++ b/test/unit/resources/gem_test.rb
@@ -56,7 +56,7 @@ describe 'Inspec::Resources::Gem' do
     }
     _(resource.installed?).must_equal true
     _(resource.info).must_equal pkg
-    _(resource.gem_binary).must_equal 'c:\opscode\chef\embedded\bin\gem'
+    _(resource.gem_binary).must_equal 'c:\opscode\chef\embedded\bin\gem.bat'
   end
 
   it 'verify gem in :chef_server' do


### PR DESCRIPTION
RubyGems on windows comes with a batch file that wraps the `gem` command
so it executes correctly. This change uses that batch file for windows
for our `gem` resource, and also properly handles when we receive no output
from the command.

Fixes #1645