### PR TITLE
harmonize compliance profiles view with supermarket views

### DIFF
--- a/lib/bundles/inspec-compliance/README.md
+++ b/lib/bundles/inspec-compliance/README.md
@@ -9,8 +9,9 @@ This extensions offers the following features:
 To use the CLI, this InSpec add-on adds the following commands:
 
  * `$ inspec compliance login` - authentication of the API token against Chef Compliance
+ * `$ inspec compliance login_automate` - authentication of the API token against Chef Automate
  * `$ inspec compliance profiles` - list all available Chef Compliance profiles
- * `$ inspec compliance exec profile` - runs a Chef Compliance profile
+ * `$ inspec exec compliance://profile` - runs a Chef Compliance profile
  * `$ inspec compliance upload path/to/local/profile` - uploads a local profile to Chef Compliance
  * `$ inspec compliance logout` - logout of Chef Compliance
 
@@ -19,7 +20,36 @@ Compliance profiles can be executed in two mays:
 - via compliance exec: `inspec compliance exec profile`
 - via compliance scheme: `inspec exec compliance://profile`
 
+
 ## Usage
+
+### Command options
+
+```
+$ inspec compliance
+Commands:
+  inspec compliance download PROFILE  # downloads a profile from Chef Compliance
+  inspec compliance exec PROFILE      # executes a Chef Compliance profile
+  inspec compliance help [COMMAND]    # Describe subcommands or one specific subcommand
+  inspec compliance login SERVER      # Log in to a Chef Compliance SERVER
+  inspec compliance login_automate SERVER   # Log in to an Automate SERVER
+  inspec compliance logout            # user logout from Chef Compliance
+  inspec compliance profiles          # list all available profiles in Chef Compliance
+  inspec compliance upload PATH       # uploads a local profile to Chef Compliance
+  inspec compliance version           # displays the version of the Chef Compliance server
+```
+
+### Login with Chef Automate
+
+You need a Chef Automate server up and running. Compliance features need to [be activated](https://docs.chef.io/install_chef_automate.html#compliance), too.
+
+Now, you need a user token. You can retrieve that via [UI](https://docs.chef.io/api_delivery.html) or [CLI](https://docs.chef.io/ctl_delivery.html#delivery-token).
+
+```
+inspec compliance login_automate https://automate.compliance.test --insecure --user 'admin' --ent 'brewinc' --usertoken 'zuop..._KzE'
+```
+
+### Login with Chef Compliance
 
 Before you start using the compliance plugin, you need a running [Chef Compliance](https://www.chef.io/compliance/) server. Please login and gather the access token:
 
@@ -28,24 +58,17 @@ Before you start using the compliance plugin, you need a running [Chef Complianc
 You can choose the access token (`--token`) or the refresh token (`--refresh_token`)
 
 ```
-$ inspec compliance
-Commands:
-  inspec compliance exec PROFILE    # executes a Chef Compliance profile
-  inspec compliance help [COMMAND]  # Describe subcommands or one specific subcommand
-  inspec compliance login SERVER    # Log in to a Chef Compliance SERVER
-  inspec compliance logout          # user logout from Chef Compliance
-  inspec compliance profiles        # list all available profiles in Chef Compliance
-  inspec compliance upload PATH     # uploads a local profile to Chef Compliance
-  inspec compliance version         # displays the version of the Chef Compliance server
-
 # login to chef compliance server
 $ inspec compliance login https://compliance.test --user admin --insecure --token '...'
 
 # display the chef compliance server version
 $ inspec compliance version
 Chef Compliance version: 1.0.11
+```
 
-# list available profiles via Chef Compliance
+### List available profiles via Chef Compliance / Automate
+
+```
 $ inspec compliance profiles
 Available profiles:
 -------------------
@@ -65,8 +88,11 @@ Available profiles:
  * cis/cis-ubuntu12.04lts-level2
  * cis/cis-ubuntu14.04lts-level1
  * cis/cis-ubuntu14.04lts-level2
+```
 
-# upload a profile to chef Compliance
+### Upload a profile to Chef Compliance / Automate
+
+```
 $ inspec compliance version
 Chef Compliance version: 1.0.11
 ➜  inspec git:(chris-rock/cc-error-not-loggedin) ✗ b inspec compliance upload examples/profile
@@ -103,8 +129,11 @@ Available profiles:
  * cis/cis-ubuntu12.04lts-level2
  * cis/cis-ubuntu14.04lts-level1
  * cis/cis-ubuntu14.04lts-level2
+```
 
-# run a profile from Chef Compliance locally
+### Run a profile from Chef Compliance / Automate on Workstation
+
+```
 $ inspec exec compliance://admin/profile
 .*...
 
@@ -119,7 +148,7 @@ Finished in 0.02862 seconds (files took 0.62628 seconds to load)
 5 examples, 0 failures, 1 pending
 ```
 
-# Logout from Chef Compliance
+### To Logout from Chef Compliance
 
 ```
 $ inspec compliance logout

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -22,16 +22,14 @@ module Compliance
         profiles = JSON.parse(data)
         # iterate over profiles
         if config['server_type'] == 'automate'
-          mapped_profiles = profiles.map do |owner, ps|
-            { org: ps['owner_id'], name: owner }
-          end.flatten
+          mapped_profiles = profiles.values.to_a.flatten
         else
-          mapped_profiles = profiles.map do |owner, ps|
-            ps.keys.map do |name|
-              { org: owner, name: name }
-            end
-          end.flatten
+          mapped_profiles = []
+          profiles.values.each { |org|
+            mapped_profiles += org.values
+          }
         end
+
         return msg, mapped_profiles
       when '401'
         msg = '401 Unauthorized. Please check your token.'
@@ -66,7 +64,7 @@ Please login using `inspec compliance login https://compliance.test --user admin
     def self.exist?(config, profile)
       _msg, profiles = Compliance::API.profiles(config)
       if !profiles.empty?
-        index = profiles.index { |p| "#{p[:org]}/#{p[:name]}" == profile }
+        index = profiles.index { |p| "#{p['owner_id']}/#{p['name']}" == profile }
         !index.nil? && index >= 0
       else
         false

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -57,7 +57,14 @@ module Compliance
       puts '', msg
     end
 
-    desc "login_automate SERVER --user='USER' --ent='ENT' --dctoken or --usertoken='TOKEN'", 'Log in to an Automate SERVER'
+    desc "login_automate SERVER --insecure --user='USER' --ent='ENT' --usertoken='TOKEN'", 'Log in to an Automate SERVER'
+    long_desc <<-LONGDESC
+      `login_automate` allows you to use InSpec with Chef Automate
+
+      You need to a user-token for communication with Chef Automate. More
+      information about token retrieval for Automate is available at:
+      https://docs.chef.io/api_delivery.html
+    LONGDESC
     option :dctoken, type: :string,
       desc: 'Data Collector token'
     option :usertoken, type: :string,
@@ -72,31 +79,32 @@ module Compliance
       options['server'] = server
       url = options['server'] + '/compliance/profiles'
 
-      if url && !options['user'].nil? && !options['ent'].nil?
-        if !options['dctoken'].nil? || !options['usertoken'].nil?
-          msg = login_automate_config(url, options['user'], options['dctoken'], options['usertoken'], options['ent'], options['insecure'])
-        else
-          puts "Please specify a token using --dctoken='DATA_COLLECTOR_TOKEN' or --usertoken='AUTOMATE_TOKEN' "
-          exit 1
-        end
-      else
-        puts "Please login to your automate instance using 'inspec compliance login_automate SERVER --user AUTOMATE_USER --ent AUTOMATE_ENT --dctoken DC_TOKEN or --usertoken USER_TOKEN' "
-        exit 1
+      if url && !options['user'].nil? && !options['ent'].nil? && (!options['dctoken'].nil? || !options['usertoken'].nil?)
+        msg = login_automate_config(url, options['user'], options['dctoken'], options['usertoken'], options['ent'], options['insecure'])
+        puts '', msg
+        exit 0
       end
-      puts '', msg
+
+      # parameters are missing if we reach here
+      puts 'Please specify an user using `--user \'USER\'`' if options['user'].nil?
+      puts 'Please specify an enterprise using `--ent \'cd\'`' if options['ent'].nil?
+      puts 'Please specify a token using `--usertoken=\'AUTOMATE_TOKEN\'`' if options['usertoken'].nil? && options['dctoken'].nil?
+      exit 1
     end
 
     desc 'profiles', 'list all available profiles in Chef Compliance'
+
     def profiles
       config = Compliance::Configuration.new
       return if !loggedin(config)
 
       msg, profiles = Compliance::API.profiles(config)
+      profiles.sort_by! { |hsh| hsh['title'] }
       if !profiles.empty?
         # iterate over profiles
         headline('Available profiles:')
         profiles.each { |profile|
-          li("#{profile[:org]}/#{profile[:name]}")
+          li("#{profile['title']} #{mark_text(profile['owner_id'] + '/' + profile['name'])}")
         }
       else
         puts msg, 'Could not find any profiles'
@@ -110,7 +118,7 @@ module Compliance
       config = Compliance::Configuration.new
       return if !loggedin(config)
       # iterate over tests and add compliance scheme
-      tests = tests.map { |t| 'compliance://' + t }
+      tests = tests.map { |t| 'compliance://' + sanitize_profile_name(t) }
       # execute profile from inspec exec implementation
       diagnose
       run_tests(tests, opts)
@@ -126,6 +134,7 @@ module Compliance
       config = Compliance::Configuration.new
       return if !loggedin(config)
 
+      profile_name = sanitize_profile_name(profile_name)
       if Compliance::API.exist?(config, profile_name)
         puts "Downloading `#{profile_name}`"
 
@@ -259,6 +268,16 @@ module Compliance
     end
 
     private
+
+    # returns a parsed url for `admin/profile` or `compliance://admin/profile`
+    def sanitize_profile_name(profile)
+      if profile.is_a?(String) && URI(profile).scheme == 'compliance'
+        uri = URI(profile)
+      else
+        uri = URI("compliance://#{profile}")
+      end
+      uri.host + uri.path
+    end
 
     def login_automate_config(url, user, dctoken, usertoken, ent, insecure) # rubocop:disable Metrics/ParameterLists
       config = Compliance::Configuration.new

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -271,7 +271,7 @@ module Compliance
 
     # returns a parsed url for `admin/profile` or `compliance://admin/profile`
     def sanitize_profile_name(profile)
-      if profile.is_a?(String) && URI(profile).scheme == 'compliance'
+      if URI(profile).scheme == 'compliance'
         uri = URI(profile)
       else
         uri = URI("compliance://#{profile}")

--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -79,6 +79,7 @@ EOF
 
     private
 
+    # determine the owner_id and the profile name from the url
     def compliance_profile_name
       m = if @config['server_type'] == 'automate'
             %r{^#{@config['server']}/(?<owner>[^/]+)/(?<id>[^/]+)/tar$}

--- a/test/functional/inspec_compliance_test.rb
+++ b/test/functional/inspec_compliance_test.rb
@@ -39,7 +39,7 @@ describe 'inspec compliance' do
     out = inspec('compliance login_automate http://example.com')
     out.exit_status.must_equal 1
     #TODO: inspec should really use stderr for errors
-    out.stdout.must_include 'Please login to your automate instance using'
+    out.stdout.must_include 'Please specify'
   end
 
   it 'inspec compliance profiles without authentication' do


### PR DESCRIPTION
This PR:
- updates the documentation
- updates the `inspec compliance profiles` list to our supermarket view
- allows `compliance://admin/profile` and `admin/profile` as input
<img width="988" alt="screen shot 2017-04-12 at 11 04 53 pm" src="https://cloud.githubusercontent.com/assets/1178413/24979846/145c6a32-1fd6-11e7-882d-1121ec9c2d32.png">
