### PR TITLE
Habitat packages should run as root

### DIFF
--- a/lib/bundles/inspec-habitat/profile.rb
+++ b/lib/bundles/inspec-habitat/profile.rb
@@ -294,6 +294,7 @@ pkg_origin=#{habitat_origin}
 pkg_source="nosuchfile.tar.gz"
 pkg_deps=(chef/inspec)
 pkg_build_deps=()
+pkg_svc_user=root
 EOL
 
       plan += "pkg_license='#{profile.metadata.params[:license]}'\n\n" if profile.metadata.params[:license]


### PR DESCRIPTION
Many InSpec resources require root access to properly scan. Let's
default the run user to root until we need to accommodate different
options.