### PR TITLE
ER-508 Extended http resource to support no ssl verification

### DIFF
--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -25,13 +25,14 @@ module Inspec::Resources
     "
 
     # rubocop:disable ParameterLists
-    def initialize(url, method: 'GET', params: nil, auth: {}, headers: {}, data: nil)
+    def initialize(url, method: 'GET', params: nil, auth: {}, headers: {}, data: nil, ssl_verify: true)
       @url = url
       @method = method
       @params = params
       @auth = auth
       @headers = headers
       @data = data
+      @ssl_verify = ssl_verify
     end
 
     def status
@@ -53,7 +54,7 @@ module Inspec::Resources
     private
 
     def response
-      conn = Faraday.new url: @url, headers: @headers, params: @params
+      conn = Faraday.new url: @url, headers: @headers, params: @params, ssl: { verify: @ssl_verify }
 
       # set basic authentication
       conn.basic_auth @auth[:user], @auth[:pass] unless @auth.empty?


### PR DESCRIPTION
We needed to be able to run inspec against endpoints with self signed certificates and this was the quickest way for us to get there.

We originally started working on a [Faraday resource](https://github.com/chef/inspec/issues/1649), but had a lot of implementation questions, and felt this was the simplest way to have something up for review. We'd love advice on how to test this if you think this is a fine change, or advice on how to change it, if not.