### PR TITLE
fix spelling mistake in powershell resource documentation

### DIFF
--- a/lib/resources/powershell.rb
+++ b/lib/resources/powershell.rb
@@ -10,7 +10,7 @@ module Inspec::Resources
     desc 'Use the powershell InSpec audit resource to test a Windows PowerShell script on the Microsoft Windows platform.'
     example "
       script = <<-EOH
-        # you powershell script
+        # your powershell script
       EOH
 
       describe powershell(script) do


### PR DESCRIPTION
Change 'you' to 'your'.

Obvious fix.