### PR TITLE
feat: Adds port/ protocol support for host

### DIFF
--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -121,11 +121,7 @@ module Inspec::Resources
   end
 
   class LinuxHostProvider < HostProvider
-    def ping(hostname, port = nil, proto = nil)
-      # assume tcp if port is given without corresponding protocol
-      if port && !proto
-        proto = 'tcp'
-      end
+    def ping(hostname, port = nil, proto = 'tcp')
       # use bash builtin capability for checking connectivity
       # for those os's with timeout from coreutils packages
       # TODO: Verify whether this works on other linux versions

--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -121,12 +121,20 @@ module Inspec::Resources
   end
 
   class LinuxHostProvider < HostProvider
-    # ping is difficult to achieve, since we are not sure
-    def ping(hostname, _port = nil, _proto = nil)
-      # fall back to ping, but we can only test ICMP packages with ping
-      # therefore we have to skip the test, if we do not have everything on the node to run the test
-      ping = inspec.command("ping -w 1 -c 1 #{hostname}")
-      ping.exit_status.to_i != 0 ? false : true
+    def ping(hostname, port = nil, proto = nil)
+      #assume tcp if port is given without corresponding protocol
+      if port && !proto
+        proto = 'tcp'
+      end
+      #use bash builtin capability for checking connectivity
+      #for those os's with timeout from coreutils packages
+      # TODO: Verify whether this works on other linux versions
+      if port && ( inspec.os.redhat? || inspec.os.debian? )
+        resp = inspec.command("timeout 1 bash -c 'cat </dev/null >/dev/#{proto}/#{hostname}/#{port}'")
+      else
+        resp = inspec.command("ping -W 1 -c 1 #{hostname}")
+      end
+      resp.exit_status.to_i != 0 ? false : true
     end
 
     def resolve(hostname)

--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -122,14 +122,14 @@ module Inspec::Resources
 
   class LinuxHostProvider < HostProvider
     def ping(hostname, port = nil, proto = nil)
-      #assume tcp if port is given without corresponding protocol
+      # assume tcp if port is given without corresponding protocol
       if port && !proto
         proto = 'tcp'
       end
-      #use bash builtin capability for checking connectivity
-      #for those os's with timeout from coreutils packages
+      # use bash builtin capability for checking connectivity
+      # for those os's with timeout from coreutils packages
       # TODO: Verify whether this works on other linux versions
-      if port && ( inspec.os.redhat? || inspec.os.debian? )
+      if port && (inspec.os.redhat? || inspec.os.debian?)
         resp = inspec.command("timeout 1 bash -c 'cat </dev/null >/dev/#{proto}/#{hostname}/#{port}'")
       else
         resp = inspec.command("ping -W 1 -c 1 #{hostname}")

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -8,10 +8,23 @@ require 'inspec/resource'
 describe 'Inspec::Resources::Host' do
 
   it 'check host on ubuntu' do
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com')
+    loader = MockLoader.new(:ubuntu1404)
+    resource = loader.load_resource('host', 'example.com')
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
+
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80)
+    _(resource.reachable?).must_equal true
+
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080)
+    _(resource.reachable?).must_equal false
+
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80, 'tcp')
+    _(resource.reachable?).must_equal true
+
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080, 'tcp')
+    _(resource.reachable?).must_equal false
   end
 
   it 'check host on centos 7' do
@@ -19,6 +32,18 @@ describe 'Inspec::Resources::Host' do
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
+
+    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', 80)
+    _(resource.reachable?).must_equal true
+
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080)
+    _(resource.reachable?).must_equal false
+
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80, 'tcp')
+    _(resource.reachable?).must_equal true
+
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080, 'tcp')
+    _(resource.reachable?).must_equal false
   end
 
   it 'check host on darwin' do

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -14,11 +14,51 @@ describe 'Inspec::Resources::Host' do
     _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
   end
 
+  it 'check host with port reachable on ubuntu' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80)
+    _(resource.reachable?).must_equal true
+  end
+
+  it 'check host with port unreachable on ubuntu' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080)
+    _(resource.reachable?).must_equal false
+  end
+
+  it 'check host with port tcp protocol reachable on ubuntu' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80, 'tcp')
+    _(resource.reachable?).must_equal true
+  end
+
+  it 'check host with port tcp protocol unreachable on ubuntu' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080, 'tcp')
+    _(resource.reachable?).must_equal false
+  end
+
   it 'check host on centos 7' do
     resource = MockLoader.new(:centos7).load_resource('host', 'example.com')
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
+  end
+
+  it 'check host with port reachable on centos 7' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80)
+    _(resource.reachable?).must_equal true
+  end
+
+  it 'check host with port unreachable on centos 7' do
+    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', 8080)
+    _(resource.reachable?).must_equal false
+  end
+
+  it 'check host with port tcp protocol reachable on centos 7' do
+    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', 80, 'tcp')
+    _(resource.reachable?).must_equal true
+  end
+
+  it 'check host with port tcp protocol unreachable on centos 7' do
+    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', 8080, 'tcp')
+    _(resource.reachable?).must_equal false
   end
 
   it 'check host on darwin' do

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -13,18 +13,6 @@ describe 'Inspec::Resources::Host' do
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
-
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80)
-    _(resource.reachable?).must_equal true
-
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080)
-    _(resource.reachable?).must_equal false
-
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80, 'tcp')
-    _(resource.reachable?).must_equal true
-
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080, 'tcp')
-    _(resource.reachable?).must_equal false
   end
 
   it 'check host with port reachable on ubuntu' do
@@ -52,18 +40,6 @@ describe 'Inspec::Resources::Host' do
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
-
-    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', 80)
-    _(resource.reachable?).must_equal true
-
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080)
-    _(resource.reachable?).must_equal false
-
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80, 'tcp')
-    _(resource.reachable?).must_equal true
-
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080, 'tcp')
-    _(resource.reachable?).must_equal false
   end
 
   it 'check host with port reachable on centos 7' do

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -21,7 +21,7 @@ describe 'Inspec::Resources::Host' do
   end
 
   it 'check host with port unreachable on ubuntu' do
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', port: 8080)
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', port: 9080)
     _(resource.reachable?).must_equal false
   end
 
@@ -31,7 +31,7 @@ describe 'Inspec::Resources::Host' do
   end
 
   it 'check host with port tcp protocol unreachable on ubuntu' do
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', port: 8080, proto: 'tcp')
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', port: 9080, proto: 'tcp')
     _(resource.reachable?).must_equal false
   end
 
@@ -48,7 +48,7 @@ describe 'Inspec::Resources::Host' do
   end
 
   it 'check host with port unreachable on centos 7' do
-    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', port: 8080 )
+    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', port: 9080 )
     _(resource.reachable?).must_equal false
   end
 
@@ -58,7 +58,7 @@ describe 'Inspec::Resources::Host' do
   end
 
   it 'check host with port tcp protocol unreachable on centos 7' do
-    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', port: 8080, proto: 'tcp')
+    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', port: 9080, proto: 'tcp')
     _(resource.reachable?).must_equal false
   end
 

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -16,22 +16,22 @@ describe 'Inspec::Resources::Host' do
   end
 
   it 'check host with port reachable on ubuntu' do
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80)
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', port: 80)
     _(resource.reachable?).must_equal true
   end
 
   it 'check host with port unreachable on ubuntu' do
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080)
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', port: 80)
     _(resource.reachable?).must_equal false
   end
 
   it 'check host with port tcp protocol reachable on ubuntu' do
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80, 'tcp')
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', port: 80, proto: 'tcp')
     _(resource.reachable?).must_equal true
   end
 
   it 'check host with port tcp protocol unreachable on ubuntu' do
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 8080, 'tcp')
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', port: 8080, proto: 'tcp')
     _(resource.reachable?).must_equal false
   end
 
@@ -43,22 +43,22 @@ describe 'Inspec::Resources::Host' do
   end
 
   it 'check host with port reachable on centos 7' do
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', 80)
+    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', port: 80 )
     _(resource.reachable?).must_equal true
   end
 
   it 'check host with port unreachable on centos 7' do
-    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', 8080)
+    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', port: 8080 )
     _(resource.reachable?).must_equal false
   end
 
   it 'check host with port tcp protocol reachable on centos 7' do
-    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', 80, 'tcp')
+    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', port: 80, proto: 'tcp')
     _(resource.reachable?).must_equal true
   end
 
   it 'check host with port tcp protocol unreachable on centos 7' do
-    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', 8080, 'tcp')
+    resource = MockLoader.new(:centos7).load_resource('host', 'example.com', port: 8080, proto: 'tcp')
     _(resource.reachable?).must_equal false
   end
 

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -21,7 +21,7 @@ describe 'Inspec::Resources::Host' do
   end
 
   it 'check host with port unreachable on ubuntu' do
-    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', port: 80)
+    resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', port: 8080)
     _(resource.reachable?).must_equal false
   end
 


### PR DESCRIPTION
This update extends the host resource to use correct
port and protocol for the redhat and debian families.
It uses a feature from bash and the timeout command
from the coreutils packages.

When port is specified but protocol is omitted, it
assumes tcp is what was intended. When neither port
nor protcol is specified it falls back to ping the
host.

Tries to address issue #1439 to some degree.