### PR TITLE
inspec control.to_ruby to use newlines instead of `\n`

### DIFF
--- a/lib/inspec/objects/control.rb
+++ b/lib/inspec/objects/control.rb
@@ -23,7 +23,7 @@ module Inspec
     def to_ruby
       res = ["control #{id.inspect} do"]
       res.push "  title #{title.inspect}" unless title.to_s.empty?
-      res.push "  desc  #{desc.inspect}" unless desc.to_s.empty?
+      res.push "  desc  #{desc.inspect.gsub('\n', "\n")}" unless desc.to_s.empty?
       res.push "  impact #{impact}" unless impact.nil?
       tags.each { |t| res.push(indent(t.to_ruby, 2)) }
       tests.each { |t| res.push(indent(t.to_ruby, 2)) }

--- a/test/unit/dsl/objects_test.rb
+++ b/test/unit/dsl/objects_test.rb
@@ -253,6 +253,17 @@ control "sample.control.id" do
 end
 '.strip
     end
+
+    it 'constructs a multiline desc in a control' do
+      control = Inspec::Control.new
+      control.desc = "Multiline\ncontrol"
+      control.to_ruby.must_equal '
+control nil do
+  desc  "Multiline
+control"
+end
+'.strip
+    end
   end
 
   describe 'Inspec::Variable, take #1' do


### PR DESCRIPTION
I.e. instead of printing them as:

```
desc "hello\nworld"
```

it would instead do:

```
desc "hello
world"
```

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>