### PR TITLE
print and prettyprint the inspec backend class

### DIFF
--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -26,9 +26,20 @@ module Inspec
       end
 
       cls = Class.new do
+        # Ruby internal for printing a nice name for this class
+        def to_s
+          'Inspec::Backend::Class'
+        end
+
+        # Ruby internal for pretty-printing a summary for this class
+        def inspect
+          "Inspec::Backend::Class @transport=#{backend.class}"
+        end
+
         define_method :backend do
           connection
         end
+
         Inspec::Resource.registry.each do |id, r|
           define_method id.to_sym do |*args|
             r.new(self, id.to_s, *args)

--- a/test/unit/dsl/other_keywords_test.rb
+++ b/test/unit/dsl/other_keywords_test.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+
+require 'helper'
+
+describe 'inspec keyword' do
+  def load(content)
+    runner = Inspec::Runner.new({backend: 'mock'})
+    res = runner.eval_with_virtual_profile(content)
+  end
+
+  it 'is associated with resources' do
+    i = load('os.inspec')
+    i.wont_be_nil
+    i.backend.must_be_kind_of Train::Transports::Mock::Connection
+  end
+
+  it 'prints a nice to_s' do
+    load('os.inspec').to_s.must_equal 'Inspec::Backend::Class'
+  end
+
+  it 'prints a nice inspect line' do
+    load('os.inspec').inspect.must_equal 'Inspec::Backend::Class @transport=Train::Transports::Mock::Connection'
+  end
+end


### PR DESCRIPTION
This is always bothersome when debugging code and drilling down objects, since it will just a return a two-layer anonymous class with no help at all:

```ruby
inspec> os.inspec
=> #<#<Class:0x000000036fc9f0>:0x0000000371e2d0>
```

"What is this? ^^" is the repeated question and "Where does it come from?".

Instead print a nice name and even give a bit of information on pretty-printing (which pry does naturally):

```ruby
inspec> os.inspec
=> Inspec::Backend::Class @transport=Train::Transports::Local::Connection
inspec> puts os.inspec
Inspec::Backend::Class
```