### PR TITLE
provide the `inspec` keyword

### DIFF
--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -48,6 +48,10 @@ module Inspec
             r.new(backend, id.to_s, *args)
           end
         end
+
+        define_method :inspec do
+          backend
+        end
       end
     end
   end

--- a/test/unit/dsl/other_keywords_test.rb
+++ b/test/unit/dsl/other_keywords_test.rb
@@ -10,6 +10,14 @@ describe 'inspec keyword' do
     res = runner.eval_with_virtual_profile(content)
   end
 
+  it 'is a vailable as a global keyword' do
+    load('inspec') # wont raise anything
+  end
+
+  it 'is a vailable inside of control blocks' do
+    load('control 1 do inspec end') # wont raise anything
+  end
+
   it 'is associated with resources' do
     i = load('os.inspec')
     i.wont_be_nil
@@ -17,10 +25,10 @@ describe 'inspec keyword' do
   end
 
   it 'prints a nice to_s' do
-    load('os.inspec').to_s.must_equal 'Inspec::Backend::Class'
+    load('inspec').to_s.must_equal 'Inspec::Backend::Class'
   end
 
   it 'prints a nice inspect line' do
-    load('os.inspec').inspect.must_equal 'Inspec::Backend::Class @transport=Train::Transports::Mock::Connection'
+    load('inspec').inspect.must_equal 'Inspec::Backend::Class @transport=Train::Transports::Mock::Connection'
   end
 end


### PR DESCRIPTION
Instead of my favorite shortcut of `os.inspec` just finally add it as a global keyword.

Preparation for https://github.com/chef/inspec/issues/1396