### PR TITLE
provide `inspec.version` information

### DIFF
--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -36,6 +36,13 @@ module Inspec
           "Inspec::Backend::Class @transport=#{backend.class}"
         end
 
+        # Provide a shorthand to retrieve the inspec version from within a profile
+        #
+        # @return [String] inspec version
+        def version
+          Inspec::VERSION
+        end
+
         define_method :backend do
           connection
         end

--- a/test/unit/dsl/other_keywords_test.rb
+++ b/test/unit/dsl/other_keywords_test.rb
@@ -18,6 +18,10 @@ describe 'inspec keyword' do
     load('control 1 do inspec end') # wont raise anything
   end
 
+  it 'provides version information' do
+    load('inspec.version').must_equal Inspec::VERSION
+  end
+
   it 'is associated with resources' do
     i = load('os.inspec')
     i.wont_be_nil


### PR DESCRIPTION
as a friendly shortcut and a native call within profiles (i.e. instead of `Inspec::VERSION`)