### PR TITLE
Update postgresql conf resource to accept include_dir as a string as well as an array

### DIFF
--- a/lib/resources/postgres_conf.rb
+++ b/lib/resources/postgres_conf.rb
@@ -93,7 +93,7 @@ module Inspec::Resources
     def include_files(params)
       include_files = params['include'] || []
       include_files += params['include_if_exists'] || []
-      dirs = params['include_dir'] || []
+      dirs = Array(params['include_dir']) || []
       dirs.each do |dir|
         dir = File.join(@conf_dir, dir) if dir[0] != '/'
         include_files += find_files(dir, depth: 1, type: 'file')


### PR DESCRIPTION
Even though I couldn't find any docs around include_dir accepting anything other than a string I left the existing functionality alone.
This forces include_dir to check multiple directories as well as single string directories for additional conf files.

Signed-off-by: Elliott Davis <edavis@chef.io>