### PR TITLE
Update GH Pages CNAME

### DIFF
--- a/www/Rakefile
+++ b/www/Rakefile
@@ -89,7 +89,7 @@ namespace :www do
       raise 'Please make sure you have no uncommitted changes in this repository.'
     end
 
-    File.write(File.join(dst, 'CNAME'), 'inspec.io')
+    File.write(File.join(dst, 'CNAME'), 'origin.inspec.io')
     file_count = Dir[File.join(dst, '*')].length
     file_size = `du -hs #{dst}`.sub(/\s+.*$/m, '')
 


### PR DESCRIPTION
GH pages is now an origin server with a new FQDN, "origin.inspec.io"

Signed-off-by: Adam Leff <adam@leff.co>