### PR TITLE
Improve "Which Serverspec resources are available in InSpec?"

### DIFF
--- a/docs/reference/migration/index.html
+++ b/docs/reference/migration/index.html
@@ -12,11 +12,125 @@
 
 <p>The following resources are available in InSpec:</p>
 
-<p><a href="http://inspec.io/docs/reference/resources/bond/"><code>bond</code></a>, <a href="http://inspec.io/docs/reference/resources/bridge/"><code>bridge</code></a>, <a href="http://inspec.io/docs/reference/resources/command/"><code>command</code></a>, <a href="http://inspec.io/docs/reference/resources/file/"><code>file</code></a>, <a href="http://inspec.io/docs/reference/resources/group/"><code>group</code></a>, <a href="http://inspec.io/docs/reference/resources/host/"><code>host</code></a>, <a href="http://inspec.io/docs/reference/resources/interface/"><code>interface</code></a>, <a href="http://inspec.io/docs/reference/resources/iis_site/"><code>iis_website</code></a>, <a href="http://inspec.io/docs/reference/resources/iptables/"><code>iptables</code></a>, <a href="http://inspec.io/docs/reference/resources/kernel_module/"><code>kernel_module</code></a>, <a href="http://inspec.io/docs/reference/resources/kernel_parameter/"><code>linux_kernel_parameter</code></a>, <a href="http://inspec.io/docs/reference/resources/mysql_config/"><code>mysql_config</code></a>, <a href="http://inspec.io/docs/reference/resources/package/"><code>package</code></a>, <a href="http://inspec.io/docs/reference/resources/port/"><code>port</code></a>, <a href="http://inspec.io/docs/reference/resources/ppa/"><code>ppa</code></a>, <a href="http://inspec.io/docs/reference/resources/process/"><code>process</code></a>, <a href="http://inspec.io/docs/reference/resources/service/"><code>service</code></a>, <a href="http://inspec.io/docs/reference/resources/user/"><code>user</code></a>, <a href="http://inspec.io/docs/reference/resources/windows_feature/"><code>windows_feature</code></a>, <a href="http://inspec.io/docs/reference/resources/windows_registry_key/"><code>windows_registry_key</code></a>, <a href="http://inspec.io/docs/reference/resources/yum/"><code>yumrepo</code></a></p>
+<table>
+<tr>
+<th>Serverspec</th>
+<th>InSpec</th>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#bond"><code>bond</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/bond/"><code>bond</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#bridge"><code>bridge</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/bridge/"><code>bridge</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#command"><code>command</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/command/"><code>command</code></a></td>
+</tr>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#cron"><code>cron</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/crontab/"><code>crontab</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#docker_container"><code>docker_container</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/docker_container/"><code>docker_container</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#docker_image"><code>docker_image</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/docker_image/"><code>docker_image</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#file"><code>file</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/file/"><code>file</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#group"><code>group</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/group/"><code>group</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#host"><code>host</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/host/"><code>host</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#interface"><code>interface</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/interface/"><code>interface</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#iis_website"><code>iis_website</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/iis_site/"><code>iis_website</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#iis_app_pool"><code>iis_app_pool</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/iis_site/"><code>iis_website</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#iptables"><code>iptables</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/iptables/"><code>iptables</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#kernel_module"><code>kernel_module</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/kernel_module/"><code>kernel_module</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#linux_kernel_parameter"><code>linux_kernel_parameter</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/kernel_parameter/"><code>kernel_parameter</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#mysql_config"><code>mysql_config</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/mysql_conf/"><code>mysql_conf</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#package"><code>package</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/package/"><code>package</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#port"><code>port</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/port/"><code>port</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#ppa"><code>ppa</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/apt/"><code>apt</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#process"><code>process</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/processes/"><code>processes</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#service"><code>service</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/service/"><code>service</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#user"><code>user</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/user/"><code>user</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#windows_feature"><code>windows_feature</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/windows_feature/"><code>windows_feature</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#windows_registry_key"><code>windows_registry_key</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/registry_key/"><code>registry_key</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#x509_certificate"><code>x509_certificate</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/x509_certificate/"><code>x509_certificate</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#yumrepo"><code>yumrepo</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/yum/"><code>yum</code></a></td>
+</tr>
+<tr>
+<td><a href="http://serverspec.org/resource_types.html#zfs"><code>zfs</code></a></td>
+<td><a href="http://inspec.io/docs/reference/resources/zfs_pool/"><code>zfs_pool</code></a></td>
+</tr>
+</table>
 
 <p>Some Serverspec resources are not available yet. We implement those resources based on user feedback. If you need a resource that is not available in InSpec, please open an <a href="https://github.com/chef/inspec/issues">Github issue</a>. The list of resources that are not available in InSpec:</p>
 
-<p><code>cgroup</code>, <code>cron</code>, <code>default_gateway</code>, <code>docker_container</code>, <code>docker_image</code>, <code>iis_app_pool</code>, <code>ip6tables</code>, <code>ipfilter</code>, <code>ipnat</code>, <code>linux_audit_system</code>, <code>lxc</code>, <code>mail_alias</code>, <code>php_config</code>, <code>routing_table</code>, <code>selinux</code>, <code>selinux_module</code>, <code>x509_certificate</code>, <code>x509_private_key</code>, <code>zfs</code></p>
+<p><a href="http://serverspec.org/resource_types.html#cgroup"><code>cgroup</code></a>, <a href="http://serverspec.org/resource_types.html#default_gateway"><code>default_gateway</code></a>, <a href="http://serverspec.org/resource_types.html#ip6tables"><code>ip6tables</code></a>, <a href="http://serverspec.org/resource_types.html#ipfilter"><code>ipfilter</code></a>, <a href="http://serverspec.org/resource_types.html#ipnat"><code>ipnat</code></a>, <a href="http://serverspec.org/resource_types.html#linux_audit_system"><code>linux_audit_system</code></a>, <a href="http://serverspec.org/resource_types.html#lxc"><code>lxc</code></a>, <a href="http://serverspec.org/resource_types.html#mail_alias"><code>mail_alias</code></a>, <a href="http://serverspec.org/resource_types.html#php_config"><code>php_config</code></a>, <a href="http://serverspec.org/resource_types.html#routing_table"><code>routing_table</code></a>, <a href="http://serverspec.org/resource_types.html#selinux"><code>selinux</code></a>, <a href="http://serverspec.org/resource_types.html#selinux_module"><code>selinux_module</code></a>, <a href="http://serverspec.org/resource_types.html#x509_private_key"><code>x509_private_key</code></a>, <a href="http://serverspec.org/resource_types.html#zfs"><code>zfs</code></a></p>
 
 <p>In addition InSpec provides additional <a href="http://inspec.io/docs/reference/resources/">resources</a> that are not available in Serverspec:
 <a href="http://inspec.io/docs/reference/resources/apache_conf/"><code>apache_conf</code></a>, <a href="http://inspec.io/docs/reference/resources/apt/"><code>apt</code></a>, <a href="http://inspec.io/docs/reference/resources/audit_policy/"><code>audit_policy</code></a>, <a href="http://inspec.io/docs/reference/resources/auditd_conf/"><code>auditd_conf</code></a>, <a href="http://inspec.io/docs/reference/resources/bash/"><code>bash</code></a>, <a href="http://inspec.io/docs/reference/resources/csv/"><code>csv</code></a>, <a href="http://inspec.io/docs/reference/resources/etc_shadow/"><code>etc_shadow</code></a>, <a href="http://inspec.io/docs/reference/resources/gem/"><code>gem</code></a>, <a href="http://inspec.io/docs/reference/resources/grub_conf/"><code>grub_conf</code></a>, <a href="http://inspec.io/docs/reference/resources/inetd_conf/"><code>inetd_conf</code></a>, <a href="http://inspec.io/docs/reference/resources/ini/"><code>ini</code></a>, <a href="http://inspec.io/docs/reference/resources/json/"><code>json</code></a>, <a href="http://inspec.io/docs/reference/resources/npm/"><code>npm</code></a>, <a href="http://inspec.io/docs/reference/resources/ntp_conf/"><code>ntp_conf</code></a>, <a href="http://inspec.io/docs/reference/resources/oneget/"><code>oneget</code></a>, <a href="http://inspec.io/docs/reference/resources/pip/"><code>pip</code></a>, <a href="http://inspec.io/docs/reference/resources/powershell/"><code>powershell</code></a>, <a href="http://inspec.io/docs/reference/resources/security_policy/"><code>security_policy</code></a>, <a href="http://inspec.io/docs/reference/resources/ssh_config/"><code>ssh_config</code></a>, <a href="http://inspec.io/docs/reference/resources/sshd_config/"><code>sshd_config</code></a>, <a href="http://inspec.io/docs/reference/resources/sys_info/"><code>sys_info</code></a></p>
@@ -41,7 +155,7 @@ set :backend, :exec
 -----&gt; Starting Kitchen (v1.14.2)
 -----&gt; Verifying &lt;package-install-centos-72&gt;...
        Detected alternative framework tests for `inspec`
-       Loaded  
+       Loaded
 
 Target:  ssh://vagrant@127.0.0.1:2200
 
@@ -215,7 +329,7 @@ $('.code-trigger').click(function() {
   $('.code-pop').slideToggle(500);
 });</script><script>//Animate HR on scroll
 
-$(window).scroll(function() {    
+$(window).scroll(function() {
 
 var scroll = $(window).scrollTop();
 var objectSelect = $('#icon-trigger'); //parent that triggers scroll
@@ -223,7 +337,7 @@ var objectPosition = objectSelect.offset().top;
 if (scroll > objectPosition) {
 $('hr.first').addClass('stretch')  //add class animate class to HR
 
-} 
+}
 });</script><script>//Animating progress bar for header
 
 $(document).ready(function(){
@@ -251,16 +365,16 @@ if('max' in document.createElement('progress')){
     $(window).resize(function(){
         // On resize, both Max/Value attr needs to be calculated
         progressBar.attr({ max: getMax(), value: getValue() });
-    });   
+    });
 }
 else {
-    var progressBar = $('.progress-bar'), 
-        max = getMax(), 
+    var progressBar = $('.progress-bar'),
+        max = getMax(),
         value, width;
 
     var getWidth = function(){
         // Calculate width in percentage
-        value = getValue();            
+        value = getValue();
         width = (value/max) * 100;
         width = width + '%';
         return width;

--- a/docs/reference/migration/index.html
+++ b/docs/reference/migration/index.html
@@ -19,112 +19,112 @@
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#bond"><code>bond</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/bond/"><code>bond</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/bond/"><code>bond</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#bridge"><code>bridge</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/bridge/"><code>bridge</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/bridge/"><code>bridge</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#command"><code>command</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/command/"><code>command</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/command/"><code>command</code></a></td>
 </tr>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#cron"><code>cron</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/crontab/"><code>crontab</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/crontab/"><code>crontab</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#docker_container"><code>docker_container</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/docker_container/"><code>docker_container</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/docker_container/"><code>docker_container</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#docker_image"><code>docker_image</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/docker_image/"><code>docker_image</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/docker_image/"><code>docker_image</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#file"><code>file</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/file/"><code>file</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/file/"><code>file</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#group"><code>group</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/group/"><code>group</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/group/"><code>group</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#host"><code>host</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/host/"><code>host</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/host/"><code>host</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#interface"><code>interface</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/interface/"><code>interface</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/interface/"><code>interface</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#iis_website"><code>iis_website</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/iis_site/"><code>iis_website</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/iis_site/"><code>iis_website</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#iis_app_pool"><code>iis_app_pool</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/iis_site/"><code>iis_website</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/iis_site/"><code>iis_website</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#iptables"><code>iptables</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/iptables/"><code>iptables</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/iptables/"><code>iptables</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#kernel_module"><code>kernel_module</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/kernel_module/"><code>kernel_module</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/kernel_module/"><code>kernel_module</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#linux_kernel_parameter"><code>linux_kernel_parameter</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/kernel_parameter/"><code>kernel_parameter</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/kernel_parameter/"><code>kernel_parameter</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#mysql_config"><code>mysql_config</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/mysql_conf/"><code>mysql_conf</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/mysql_conf/"><code>mysql_conf</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#package"><code>package</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/package/"><code>package</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/package/"><code>package</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#port"><code>port</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/port/"><code>port</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/port/"><code>port</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#ppa"><code>ppa</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/apt/"><code>apt</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/apt/"><code>apt</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#process"><code>process</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/processes/"><code>processes</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/processes/"><code>processes</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#service"><code>service</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/service/"><code>service</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/service/"><code>service</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#user"><code>user</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/user/"><code>user</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/user/"><code>user</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#windows_feature"><code>windows_feature</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/windows_feature/"><code>windows_feature</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/windows_feature/"><code>windows_feature</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#windows_registry_key"><code>windows_registry_key</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/registry_key/"><code>registry_key</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/registry_key/"><code>registry_key</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#x509_certificate"><code>x509_certificate</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/x509_certificate/"><code>x509_certificate</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/x509_certificate/"><code>x509_certificate</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#yumrepo"><code>yumrepo</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/yum/"><code>yum</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/yum/"><code>yum</code></a></td>
 </tr>
 <tr>
 <td><a href="http://serverspec.org/resource_types.html#zfs"><code>zfs</code></a></td>
-<td><a href="http://inspec.io/docs/reference/resources/zfs_pool/"><code>zfs_pool</code></a></td>
+<td><a href="https://www.inspec.io/docs/reference/resources/zfs_pool/"><code>zfs_pool</code></a></td>
 </tr>
 </table>
 
@@ -132,8 +132,8 @@
 
 <p><a href="http://serverspec.org/resource_types.html#cgroup"><code>cgroup</code></a>, <a href="http://serverspec.org/resource_types.html#default_gateway"><code>default_gateway</code></a>, <a href="http://serverspec.org/resource_types.html#ip6tables"><code>ip6tables</code></a>, <a href="http://serverspec.org/resource_types.html#ipfilter"><code>ipfilter</code></a>, <a href="http://serverspec.org/resource_types.html#ipnat"><code>ipnat</code></a>, <a href="http://serverspec.org/resource_types.html#linux_audit_system"><code>linux_audit_system</code></a>, <a href="http://serverspec.org/resource_types.html#lxc"><code>lxc</code></a>, <a href="http://serverspec.org/resource_types.html#mail_alias"><code>mail_alias</code></a>, <a href="http://serverspec.org/resource_types.html#php_config"><code>php_config</code></a>, <a href="http://serverspec.org/resource_types.html#routing_table"><code>routing_table</code></a>, <a href="http://serverspec.org/resource_types.html#selinux"><code>selinux</code></a>, <a href="http://serverspec.org/resource_types.html#selinux_module"><code>selinux_module</code></a>, <a href="http://serverspec.org/resource_types.html#x509_private_key"><code>x509_private_key</code></a>, <a href="http://serverspec.org/resource_types.html#zfs"><code>zfs</code></a></p>
 
-<p>In addition InSpec provides additional <a href="http://inspec.io/docs/reference/resources/">resources</a> that are not available in Serverspec:
-<a href="http://inspec.io/docs/reference/resources/apache_conf/"><code>apache_conf</code></a>, <a href="http://inspec.io/docs/reference/resources/apt/"><code>apt</code></a>, <a href="http://inspec.io/docs/reference/resources/audit_policy/"><code>audit_policy</code></a>, <a href="http://inspec.io/docs/reference/resources/auditd_conf/"><code>auditd_conf</code></a>, <a href="http://inspec.io/docs/reference/resources/bash/"><code>bash</code></a>, <a href="http://inspec.io/docs/reference/resources/csv/"><code>csv</code></a>, <a href="http://inspec.io/docs/reference/resources/etc_shadow/"><code>etc_shadow</code></a>, <a href="http://inspec.io/docs/reference/resources/gem/"><code>gem</code></a>, <a href="http://inspec.io/docs/reference/resources/grub_conf/"><code>grub_conf</code></a>, <a href="http://inspec.io/docs/reference/resources/inetd_conf/"><code>inetd_conf</code></a>, <a href="http://inspec.io/docs/reference/resources/ini/"><code>ini</code></a>, <a href="http://inspec.io/docs/reference/resources/json/"><code>json</code></a>, <a href="http://inspec.io/docs/reference/resources/npm/"><code>npm</code></a>, <a href="http://inspec.io/docs/reference/resources/ntp_conf/"><code>ntp_conf</code></a>, <a href="http://inspec.io/docs/reference/resources/oneget/"><code>oneget</code></a>, <a href="http://inspec.io/docs/reference/resources/pip/"><code>pip</code></a>, <a href="http://inspec.io/docs/reference/resources/powershell/"><code>powershell</code></a>, <a href="http://inspec.io/docs/reference/resources/security_policy/"><code>security_policy</code></a>, <a href="http://inspec.io/docs/reference/resources/ssh_config/"><code>ssh_config</code></a>, <a href="http://inspec.io/docs/reference/resources/sshd_config/"><code>sshd_config</code></a>, <a href="http://inspec.io/docs/reference/resources/sys_info/"><code>sys_info</code></a></p>
+<p>In addition InSpec provides additional <a href="https://www.inspec.io/docs/reference/resources/">resources</a> that are not available in Serverspec:
+<a href="https://www.inspec.io/docs/reference/resources/apache_conf/"><code>apache_conf</code></a>, <a href="https://www.inspec.io/docs/reference/resources/apt/"><code>apt</code></a>, <a href="https://www.inspec.io/docs/reference/resources/audit_policy/"><code>audit_policy</code></a>, <a href="https://www.inspec.io/docs/reference/resources/auditd_conf/"><code>auditd_conf</code></a>, <a href="https://www.inspec.io/docs/reference/resources/bash/"><code>bash</code></a>, <a href="https://www.inspec.io/docs/reference/resources/csv/"><code>csv</code></a>, <a href="https://www.inspec.io/docs/reference/resources/etc_shadow/"><code>etc_shadow</code></a>, <a href="https://www.inspec.io/docs/reference/resources/gem/"><code>gem</code></a>, <a href="https://www.inspec.io/docs/reference/resources/grub_conf/"><code>grub_conf</code></a>, <a href="https://www.inspec.io/docs/reference/resources/inetd_conf/"><code>inetd_conf</code></a>, <a href="https://www.inspec.io/docs/reference/resources/ini/"><code>ini</code></a>, <a href="https://www.inspec.io/docs/reference/resources/json/"><code>json</code></a>, <a href="https://www.inspec.io/docs/reference/resources/npm/"><code>npm</code></a>, <a href="https://www.inspec.io/docs/reference/resources/ntp_conf/"><code>ntp_conf</code></a>, <a href="https://www.inspec.io/docs/reference/resources/oneget/"><code>oneget</code></a>, <a href="https://www.inspec.io/docs/reference/resources/pip/"><code>pip</code></a>, <a href="https://www.inspec.io/docs/reference/resources/powershell/"><code>powershell</code></a>, <a href="https://www.inspec.io/docs/reference/resources/security_policy/"><code>security_policy</code></a>, <a href="https://www.inspec.io/docs/reference/resources/ssh_config/"><code>ssh_config</code></a>, <a href="https://www.inspec.io/docs/reference/resources/sshd_config/"><code>sshd_config</code></a>, <a href="https://www.inspec.io/docs/reference/resources/sys_info/"><code>sys_info</code></a></p>
 
 <h2>How do I migrate my Serverspec tests to InSpec</h2>
 


### PR DESCRIPTION
- Switch serverspec and inspec resource compare to a table and fix the links
- Add links for serverspec resources not in inspec
- update inspec.io links to HTTPS in migration doc

@adamleff this is the update to the migration doc page that i talked to you about a couple weeks ago on slack