### PR TITLE
[www] Add rake task for flushing Fastly cache

### DIFF
--- a/support/ci/deploy_website_to_acceptance.sh
+++ b/support/ci/deploy_website_to_acceptance.sh
@@ -7,5 +7,5 @@ fi
 
 cd www
 npm install -g gulp
-bundle install
-bundle exec rake www:acceptance
+BUNDLE_GEMFILE="./Gemfile" bundle install
+BUNDLE_GEMFILE="./Gemfile" bundle exec rake www:acceptance

--- a/www/Gemfile
+++ b/www/Gemfile
@@ -29,3 +29,6 @@ gem 'inspec', path: File.join(File.expand_path(File.dirname(__FILE__)), '..')
 gem 'rake'
 gem 'ruby-progressbar'
 gem 'inquirer'
+
+# Ability to flush the cache during a deploy
+gem 'fastly'

--- a/www/Gemfile.lock
+++ b/www/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /Users/aleff/projects/inspec
   specs:
-    inspec (1.20.0)
+    inspec (1.22.0)
       addressable (~> 2.4)
       faraday (>= 0.9.0)
       hashie (~> 3.4)
@@ -67,10 +67,11 @@ GEM
     eventmachine (1.2.3)
     excon (0.55.0)
     execjs (2.7.0)
-    faraday (0.12.0.1)
+    faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     fast_blank (1.0.0)
     fastimage (2.1.0)
+    fastly (1.10.0)
     ffi (1.9.18)
     github-markup (1.6.0)
     gssapi (1.2.0)
@@ -173,7 +174,8 @@ GEM
     rack (2.0.1)
     rack-livereload (0.3.16)
       rack
-    rainbow (2.2.1)
+    rainbow (2.2.2)
+      rake
     rake (12.0.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
@@ -197,7 +199,7 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     ruby-progressbar (1.8.1)
-    rubyntlm (0.6.1)
+    rubyntlm (0.6.2)
     rubyzip (1.2.1)
     sass (3.4.23)
     servolux (0.13.0)
@@ -250,6 +252,7 @@ PLATFORMS
 
 DEPENDENCIES
   docker-api
+  fastly
   github-markup
   inquirer
   inspec!

--- a/www/README.md
+++ b/www/README.md
@@ -51,3 +51,12 @@ ruby -run -e httpd . -p 8000
 Open your browser to [localhost:8000](http://localhost:8000).
 
 If you are happy, you can confirm the site and let the release task push it live.
+
+### Flushing the Fastly Cache
+
+The `www` Rake task will flush the cache at Fastly if you have the following environment variables set:
+
+ * `FASTLY_API_KEY`
+ * `FASTLY_SERVICE_ID`
+
+These can be found in Chef's shared password manager. If these aren't set, the cache will not be flushed and will expire on its own. The cache can be flushed without doing a full website release by running `rake www:flush`

--- a/www/Rakefile
+++ b/www/Rakefile
@@ -20,6 +20,7 @@ $LOAD_PATH.unshift(File.join(File.expand_path(File.dirname(__FILE__)), '..', 'li
 
 require 'uri'
 require 'net/http'
+require 'fastly'
 
 require_relative '../tasks/docs.rb'
 require_relative '../tasks/shared.rb'
@@ -173,6 +174,38 @@ namespace :www do
     Log.info 'Removing zip file'
     File.unlink(File.join(Dir.pwd, 'build', 'inspec-acceptance.zip'))
   end
+
+  desc 'Flush the inspec.io cache at Fastly'
+  task :flush do
+    api_key    = ENV['FASTLY_API_KEY']
+    service_id = ENV['FASTLY_SERVICE_ID']
+
+    if api_key.nil? || service_id.nil?
+      puts ''
+      puts 'WARNING: could not flush the Fastly cache for inspec.io.'
+      puts 'Please set FASTLY_API_KEY and FASTLY_SERVICE_ID environment variables'
+      puts 'and run `rake www:flush`.'
+      puts ''
+      next
+    end
+
+    Log.info 'Flushing the Fastly cache'
+
+    begin
+      fastly_client  = Fastly.new(api_key: api_key)
+      fastly_service = Fastly::Service.new({ id: service_id }, fastly_client)
+      purge_result = fastly_service.purge_all
+    rescue => e
+      puts "ERROR: Fastly cache could not be purged: #{e.class} - #{e.message}"
+      next
+    end
+
+    if purge_result['status'] == 'ok'
+      puts 'Success! The Fastly cache is purged.'
+    else
+      puts "ERROR: Fastly cache could not be purged: #{purge_result}"
+    end
+  end
 end
 
 desc 'Full website release: includes local clean, docs build, site build, and then release'
@@ -181,4 +214,5 @@ task :www do
   Rake::Task['docs'].invoke
   Rake::Task['www:build'].invoke
   Rake::Task['www:release'].invoke
+  Rake::Task['www:flush'].invoke
 end


### PR DESCRIPTION
inspec.io is now hosted by Fastly which operates as a caching reverse
proxy. This change adds a Rake task that will flush the cache at Fastly
if the API key and Service ID are set in the appropriate environment
variables.

Flushing the cache is not required, so this will not error out if the
environment variables aren't provided; the cache will eventually clear
on its own. This will simply speed along the process as needed.