### PR TITLE
Extend Windows ACL matchers

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -66,27 +66,6 @@ RSpec::Matchers.define :be_executable do
   end
 end
 
-RSpec::Matchers.define :allow do |perm|
-  match do |file|
-    file.allowed?(perm, @by, @by_user)
-  end
-
-  chain :by do |by|
-    @by = by
-  end
-
-  chain :by_user do |by_user|
-    @by_user = by_user
-  end
-
-  description do
-    res = "allows #{perm} permission"
-    res += " by #{@by}" unless @by.nil?
-    res += " by user #{@by_user}" unless @by_user.nil?
-    res
-  end
-end
-
 # matcher to check /etc/passwd, /etc/shadow and /etc/group
 RSpec::Matchers.define :contain_legacy_plus do
   match do |file|

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -66,6 +66,27 @@ RSpec::Matchers.define :be_executable do
   end
 end
 
+RSpec::Matchers.define :allow do |perm|
+  match do |file|
+    file.allowed?(perm, @by, @by_user)
+  end
+
+  chain :by do |by|
+    @by = by
+  end
+
+  chain :by_user do |by_user|
+    @by_user = by_user
+  end
+
+  description do
+    res = "allows #{perm} permission"
+    res += " by #{@by}" unless @by.nil?
+    res += " by user #{@by_user}" unless @by_user.nil?
+    res
+  end
+end
+
 # matcher to check /etc/passwd, /etc/shadow and /etc/group
 RSpec::Matchers.define :contain_legacy_plus do
   match do |file|

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -239,7 +239,7 @@ module Inspec::Resources
       when 'write'
         translate_perm_names('modify') + %w{Write}
       when 'execute'
-        translate_perm_names('modify') + %w{ReadAndExecute ExecuteFile}
+        translate_perm_names('modify') + %w{ReadAndExecute ExecuteFile Traverse}
       else
         raise 'Invalid access_type provided'
       end

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -84,11 +84,11 @@ module Inspec::Resources
       file_permission_granted?('execute', by_usergroup, by_specific_user)
     end
 
-    def allowed?(permission, by_usergroup, by_specific_user)
+    def allowed?(permission, opts = {})
       return false unless exist?
       return skip_resource '`allowed?` is not supported on your OS yet.' if @perms_provider.nil?
 
-      file_permission_granted?(permission, by_usergroup, by_specific_user)
+      file_permission_granted?(permission, opts[:by], opts[:by_user])
     end
 
     def mounted?(expected_options = nil, identical = false)

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -240,6 +240,8 @@ module Inspec::Resources
         translate_perm_names('modify') + %w{Write}
       when 'execute'
         translate_perm_names('modify') + %w{ReadAndExecute ExecuteFile Traverse}
+      when 'delete'
+        translate_perm_names('modify') + %w{Delete}
       else
         raise 'Invalid access_type provided'
       end

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -235,7 +235,7 @@ module Inspec::Resources
       when 'modify'
         translate_perm_names('full-control') + %w{Modify}
       when 'read'
-        translate_perm_names('modify') + %w{ReadAndExecute Read ReadData ListDirectory}
+        translate_perm_names('modify') + %w{ReadAndExecute Read}
       when 'write'
         translate_perm_names('modify') + %w{Write}
       when 'execute'

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -84,6 +84,13 @@ module Inspec::Resources
       file_permission_granted?('execute', by_usergroup, by_specific_user)
     end
 
+    def allowed?(permission, by_usergroup, by_specific_user)
+      return false unless exist?
+      return skip_resource '`allowed?` is not supported on your OS yet.' if @perms_provider.nil?
+
+      file_permission_granted?(permission, by_usergroup, by_specific_user)
+    end
+
     def mounted?(expected_options = nil, identical = false)
       mounted = file.mounted
 

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -236,6 +236,13 @@ module Inspec::Resources
     #
     # See also: https://www.codeproject.com/Reference/871338/AccessControl-FileSystemRights-Permissions-Table
     def translate_perm_names(access_type)
+      names = translate_common_perms(access_type)
+      names ||= translate_granular_perms(access_type)
+      names ||= translate_uncommon_perms(access_type)
+      raise 'Invalid access_type provided' unless names
+    end
+
+    def translate_common_perms(access_type)
       case access_type
       when 'full-control'
         %w{FullControl}
@@ -249,7 +256,22 @@ module Inspec::Resources
         translate_perm_names('modify') + %w{ReadAndExecute ExecuteFile Traverse}
       when 'delete'
         translate_perm_names('modify') + %w{Delete}
+      end
+    end
 
+    def translate_uncommon_perms(access_type)
+      case access_type
+      when 'delete-subdirectories-and-files'
+        translate_perm_names('full-control') + %w{DeleteSubdirectoriesAndFiles}
+      when 'change-permissions'
+        translate_perm_names('full-control') + %w{ChangePermissions}
+      when 'take-ownership'
+        translate_perm_names('full-control') + %w{TakeOwnership}
+      end
+    end
+
+    def translate_granular_perms(access_type)
+      case access_type
       when 'write-data', 'create-files'
         translate_perm_names('write') + %w{WriteData CreateFiles}
       when 'append-data', 'create-directories'
@@ -266,15 +288,6 @@ module Inspec::Resources
         translate_perm_names('read') + %w{ReadExtendedAttributes}
       when 'read-permissions'
         translate_perm_names('read') + %w{ReadPermissions}
-
-      when 'delete-subdirectories-and-files'
-        translate_perm_names('full-control') + %w{DeleteSubdirectoriesAndFiles}
-      when 'change-permissions'
-        translate_perm_names('full-control') + %w{ChangePermissions}
-      when 'take-ownership'
-        translate_perm_names('full-control') + %w{TakeOwnership}
-      else
-        raise 'Invalid access_type provided'
       end
     end
   end

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -249,6 +249,30 @@ module Inspec::Resources
         translate_perm_names('modify') + %w{ReadAndExecute ExecuteFile Traverse}
       when 'delete'
         translate_perm_names('modify') + %w{Delete}
+
+      when 'write-data', 'create-files'
+        translate_perm_names('write') + %w{WriteData CreateFiles}
+      when 'append-data', 'create-directories'
+        translate_perm_names('write') + %w{CreateDirectories AppendData}
+      when 'write-extended-attributes'
+        translate_perm_names('write') + %w{WriteExtendedAttributes}
+      when 'write-attributes'
+        translate_perm_names('write') + %w{WriteAttributes}
+      when 'read-data', 'list-directory'
+        translate_perm_names('read') + %w{ReadData ListDirectory}
+      when 'read-attributes'
+        translate_perm_names('read') + %w{ReadAttributes}
+      when 'read-extended-attributes'
+        translate_perm_names('read') + %w{ReadExtendedAttributes}
+      when 'read-permissions'
+        translate_perm_names('read') + %w{ReadPermissions}
+
+      when 'delete-subdirectories-and-files'
+        translate_perm_names('full-control') + %w{DeleteSubdirectoriesAndFiles}
+      when 'change-permissions'
+        translate_perm_names('full-control') + %w{ChangePermissions}
+      when 'take-ownership'
+        translate_perm_names('full-control') + %w{TakeOwnership}
       else
         raise 'Invalid access_type provided'
       end

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -232,12 +232,14 @@ module Inspec::Resources
       case access_type
       when 'full-control'
         %w{FullControl}
+      when 'modify'
+        translate_perm_names('full-control') + %w{Modify}
       when 'read'
-        translate_perm_names('full-control') + %w{Modify ReadAndExecute Read ReadData ListDirectory}
+        translate_perm_names('modify') + %w{ReadAndExecute Read ReadData ListDirectory}
       when 'write'
-        translate_perm_names('full-control') + %w{Modify Write}
+        translate_perm_names('modify') + %w{Write}
       when 'execute'
-        translate_perm_names('full-control') + %w{Modify ReadAndExecute ExecuteFile}
+        translate_perm_names('modify') + %w{ReadAndExecute ExecuteFile}
       else
         raise 'Invalid access_type provided'
       end

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -230,12 +230,14 @@ module Inspec::Resources
     # See also: https://www.codeproject.com/Reference/871338/AccessControl-FileSystemRights-Permissions-Table
     def translate_perm_names(access_type)
       case access_type
+      when 'full-control'
+        %w{FullControl}
       when 'read'
-        %w{FullControl Modify ReadAndExecute Read ReadData ListDirectory}
+        translate_perm_names('full-control') + %w{Modify ReadAndExecute Read ReadData ListDirectory}
       when 'write'
-        %w{FullControl Modify Write}
+        translate_perm_names('full-control') + %w{Modify Write}
       when 'execute'
-        %w{FullControl Modify ReadAndExecute ExecuteFile}
+        translate_perm_names('full-control') + %w{Modify ReadAndExecute ExecuteFile}
       else
         raise 'Invalid access_type provided'
       end

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -208,7 +208,7 @@ module Inspec::Resources
     def check_file_permission_by_user(access_type, user, path)
       access_rule = case access_type
                     when 'read'
-                      '@(\'FullControl\', \'Modify\', \'ReadAndExecute\', \'Read\', \'ListDirectory\')'
+                      '@(\'FullControl\', \'Modify\', \'ReadAndExecute\', \'Read\', \'ReadData\', \'ListDirectory\')'
                     when 'write'
                       '@(\'FullControl\', \'Modify\', \'Write\')'
                     when 'execute'

--- a/test/integration/default/controls/file_spec.rb
+++ b/test/integration/default/controls/file_spec.rb
@@ -67,50 +67,50 @@ if os.unix?
     its('sticky') { should eq false }
 
     it { should be_readable }
-    it { should allow('read') }
+    it { should be_allowed('read') }
     it { should be_readable.by('owner') }
-    it { should allow('read').by('owner') }
+    it { should be_allowed('read', by: 'owner') }
     it { should be_readable.by('group') }
-    it { should allow('read').by('group') }
+    it { should be_allowed('read', by: 'group') }
     it { should be_readable.by('other') }
-    it { should allow('read').by('other') }
+    it { should be_allowed('read', by: 'other') }
     it { should be_readable.by_user(filedata[:user]) }
-    it { should allow('read').by_user(filedata[:user]) }
+    it { should be_allowed('read', by_user: filedata[:user]) }
     it { should_not be_readable.by_user('noroot') }
-    it { should_not allow('read').by_user('noroot') }
+    it { should_not be_allowed('read', by_user: 'noroot') }
     # for server spec compatibility
     it { should be_readable.by('others') }
-    it { should allow('read').by('others') }
+    it { should be_allowed('read', by: 'others') }
 
     it { should be_writable }
-    it { should allow('write') }
+    it { should be_allowed('write') }
     it { should be_writable.by('owner') }
-    it { should allow('write').by('owner') }
+    it { should be_allowed('write', by: 'owner') }
     it { should be_writable.by('group') }
-    it { should allow('write').by('group') }
+    it { should be_allowed('write', by: 'group') }
     it { should_not be_writable.by('other') }
-    it { should_not allow('write').by('other') }
+    it { should_not be_allowed('write', by: 'other') }
     it { should be_writable.by_user(filedata[:user]) }
-    it { should allow('write').by_user(filedata[:user]) }
+    it { should be_allowed('write', by_user: filedata[:user]) }
     # it { should_not be_writable.by_user('noroot') }
     # for server spec compatibility
     it { should_not be_writable.by('others') }
-    it { should_not allow('write').by('others') }
+    it { should_not be_allowed('write', by: 'others') }
 
     it { should be_executable }
-    it { should allow('execute') }
+    it { should be_allowed('execute') }
     it { should be_executable.by('owner') }
-    it { should allow('execute').by('owner') }
+    it { should be_allowed('execute', by: 'owner') }
     it { should_not be_executable.by('group') }
-    it { should_not allow('execute').by('group') }
+    it { should_not be_allowed('execute', by: 'group') }
     it { should be_executable.by('other') }
-    it { should allow('execute').by('other') }
+    it { should be_allowed('execute', by: 'other') }
     it { should be_executable.by_user(filedata[:user]) }
-    it { should allow('execute').by_user(filedata[:user]) }
+    it { should be_allowed('execute', by_user: filedata[:user]) }
     # it { should_not be_executable.by_user('noroot') }
     # for server spec compatibility
     it { should be_executable.by('others') }
-    it { should allow('execute').by('others') }
+    it { should be_allowed('execute', by: 'others') }
 
     # test extended linux attributes
     # it { should be_immutable }
@@ -186,34 +186,34 @@ if os.windows?
     it { should exist }
     it { should be_file }
     it { should be_readable.by_user('NT AUTHORITY\SYSTEM') }
-    it { should allow('read').by_user('NT AUTHORITY\SYSTEM') }
+    it { should be_allowed('read', by_user: 'NT AUTHORITY\SYSTEM') }
     it { should be_writable.by_user('NT AUTHORITY\SYSTEM') }
-    it { should allow('write').by_user('NT AUTHORITY\SYSTEM') }
+    it { should be_allowed('write', by_user: 'NT AUTHORITY\SYSTEM') }
     it { should be_executable.by_user('NT AUTHORITY\SYSTEM') }
-    it { should allow('execute').by_user('NT AUTHORITY\SYSTEM') }
+    it { should be_allowed('execute', by_user: 'NT AUTHORITY\SYSTEM') }
     it { should_not be_readable.by_user(filedata[:user]) }
-    it { should_not allow('read').by_user(filedata[:user]) }
+    it { should_not be_allowed('read', by_user: filedata[:user]) }
     it { should_not be_writable.by_user(filedata[:user]) }
-    it { should_not allow('write').by_user(filedata[:user]) }
+    it { should_not be_allowed('write', by_user: filedata[:user]) }
     it { should_not be_executable.by_user(filedata[:user]) }
-    it { should_not allow('execute').by_user(filedata[:user]) }
+    it { should_not be_allowed('execute', by_user: filedata[:user]) }
   end
 
   describe file('C:/Test Directory') do
     it { should exist }
     it { should be_directory }
     it { should be_readable.by_user('NT AUTHORITY\SYSTEM') }
-    it { should allow('read').by_user('NT AUTHORITY\SYSTEM') }
+    it { should be_allowed('read', by_user: 'NT AUTHORITY\SYSTEM') }
     it { should be_writable.by_user('NT AUTHORITY\SYSTEM') }
-    it { should allow('write').by_user('NT AUTHORITY\SYSTEM') }
+    it { should be_allowed('write', by_user: 'NT AUTHORITY\SYSTEM') }
     it { should be_executable.by_user('NT AUTHORITY\SYSTEM') }
-    it { should allow('execute').by_user('NT AUTHORITY\SYSTEM') }
+    it { should be_allowed('execute', by_user: 'NT AUTHORITY\SYSTEM') }
     it { should_not be_readable.by_user(filedata[:user]) }
-    it { should_not allow('read').by_user(filedata[:user]) }
+    it { should_not be_allowed('read', by_user: filedata[:user]) }
     it { should_not be_writable.by_user(filedata[:user]) }
-    it { should_not allow('write').by_user(filedata[:user]) }
+    it { should_not be_allowed('write', by_user: filedata[:user]) }
     it { should_not be_executable.by_user(filedata[:user]) }
-    it { should_not allow('execute').by_user(filedata[:user]) }
+    it { should_not be_allowed('execute', by_user: filedata[:user]) }
   end
 
   describe file("C:/Program Files (x86)/Windows NT/Accessories/wordpad.exe") do
@@ -226,7 +226,7 @@ if os.windows?
   describe directory('C:/opscode/chef') do
     its('owner') { should cmp 'NT AUTHORITY\SYSTEM' }
     it { should be_owned_by 'NT AUTHORITY\SYSTEM' }
-    it { should allow('full-control').by_user('NT AUTHORITY\SYSTEM') }
-    it { should allow('modify').by_user('NT AUTHORITY\SYSTEM') }
+    it { should be_allowed('full-control', by_user: 'NT AUTHORITY\SYSTEM') }
+    it { should be_allowed('modify', by_user: 'NT AUTHORITY\SYSTEM') }
   end
 end

--- a/test/integration/default/controls/file_spec.rb
+++ b/test/integration/default/controls/file_spec.rb
@@ -67,31 +67,50 @@ if os.unix?
     its('sticky') { should eq false }
 
     it { should be_readable }
+    it { should allow('read') }
     it { should be_readable.by('owner') }
+    it { should allow('read').by('owner') }
     it { should be_readable.by('group') }
+    it { should allow('read').by('group') }
     it { should be_readable.by('other') }
+    it { should allow('read').by('other') }
     it { should be_readable.by_user(filedata[:user]) }
+    it { should allow('read').by_user(filedata[:user]) }
     it { should_not be_readable.by_user('noroot') }
+    it { should_not allow('read').by_user('noroot') }
     # for server spec compatibility
     it { should be_readable.by('others') }
+    it { should allow('read').by('others') }
 
     it { should be_writable }
+    it { should allow('write') }
     it { should be_writable.by('owner') }
+    it { should allow('write').by('owner') }
     it { should be_writable.by('group') }
+    it { should allow('write').by('group') }
     it { should_not be_writable.by('other') }
+    it { should_not allow('write').by('other') }
     it { should be_writable.by_user(filedata[:user]) }
+    it { should allow('write').by_user(filedata[:user]) }
     # it { should_not be_writable.by_user('noroot') }
     # for server spec compatibility
     it { should_not be_writable.by('others') }
+    it { should_not allow('write').by('others') }
 
     it { should be_executable }
+    it { should allow('execute') }
     it { should be_executable.by('owner') }
+    it { should allow('execute').by('owner') }
     it { should_not be_executable.by('group') }
+    it { should_not allow('execute').by('group') }
     it { should be_executable.by('other') }
+    it { should allow('execute').by('other') }
     it { should be_executable.by_user(filedata[:user]) }
+    it { should allow('execute').by_user(filedata[:user]) }
     # it { should_not be_executable.by_user('noroot') }
     # for server spec compatibility
     it { should be_executable.by('others') }
+    it { should allow('execute').by('others') }
 
     # test extended linux attributes
     # it { should be_immutable }
@@ -167,22 +186,34 @@ if os.windows?
     it { should exist }
     it { should be_file }
     it { should be_readable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should allow('read').by_user('NT AUTHORITY\SYSTEM') }
     it { should be_writable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should allow('write').by_user('NT AUTHORITY\SYSTEM') }
     it { should be_executable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should allow('execute').by_user('NT AUTHORITY\SYSTEM') }
     it { should_not be_readable.by_user(filedata[:user]) }
+    it { should_not allow('read').by_user(filedata[:user]) }
     it { should_not be_writable.by_user(filedata[:user]) }
+    it { should_not allow('write').by_user(filedata[:user]) }
     it { should_not be_executable.by_user(filedata[:user]) }
+    it { should_not allow('execute').by_user(filedata[:user]) }
   end
 
   describe file('C:/Test Directory') do
     it { should exist }
     it { should be_directory }
     it { should be_readable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should allow('read').by_user('NT AUTHORITY\SYSTEM') }
     it { should be_writable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should allow('write').by_user('NT AUTHORITY\SYSTEM') }
     it { should be_executable.by_user('NT AUTHORITY\SYSTEM') }
+    it { should allow('execute').by_user('NT AUTHORITY\SYSTEM') }
     it { should_not be_readable.by_user(filedata[:user]) }
+    it { should_not allow('read').by_user(filedata[:user]) }
     it { should_not be_writable.by_user(filedata[:user]) }
+    it { should_not allow('write').by_user(filedata[:user]) }
     it { should_not be_executable.by_user(filedata[:user]) }
+    it { should_not allow('execute').by_user(filedata[:user]) }
   end
 
   describe file("C:/Program Files (x86)/Windows NT/Accessories/wordpad.exe") do
@@ -195,5 +226,7 @@ if os.windows?
   describe directory('C:/opscode/chef') do
     its('owner') { should cmp 'NT AUTHORITY\SYSTEM' }
     it { should be_owned_by 'NT AUTHORITY\SYSTEM' }
+    it { should allow('full-control').by_user('NT AUTHORITY\SYSTEM') }
+    it { should allow('modify').by_user('NT AUTHORITY\SYSTEM') }
   end
 end

--- a/test/unit/resources/file_test.rb
+++ b/test/unit/resources/file_test.rb
@@ -26,8 +26,11 @@ describe Inspec::Resources::FileResource do
     _(resource.mounted?).must_equal true
     _(resource.to_s).must_equal 'File /fakepath/fakefile'
     _(resource.readable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('read', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
     _(resource.writable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('write', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
     _(resource.executable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('execute', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
     _(resource.suid).must_equal true
     _(resource.sgid).must_equal true
     _(resource.sticky).must_equal true
@@ -40,12 +43,23 @@ describe Inspec::Resources::FileResource do
     resource.stubs(:file_permission_granted?).with('read', 'by_usergroup', 'by_specific_user').returns('test_result')
     resource.stubs(:file_permission_granted?).with('write', 'by_usergroup', 'by_specific_user').returns('test_result')
     resource.stubs(:file_permission_granted?).with('execute', 'by_usergroup', 'by_specific_user').returns('test_result')
+    resource.stubs(:file_permission_granted?).with('full-control', 'by_usergroup', 'by_specific_user').returns('test_result')
     _(resource.content).must_equal 'content'
     _(resource.exist?).must_equal true
     _(resource.mounted?).must_equal true
     _(resource.readable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('read', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
     _(resource.writable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('write', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
     _(resource.executable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('execute', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('full-control', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
+  end
+  it 'does not support Windows-style ACL on Ubuntu' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('file', '/fakepath/fakefile')
+    resource.stubs(:exist?).returns(true)
+    proc { resource.send('allowed?', 'full-control', 'by_usergroup', 'by_specific_user') }.must_raise(RuntimeError)
+    proc { resource.send('allowed?', 'modify', 'by_usergroup', 'by_specific_user') }.must_raise(RuntimeError)
   end
   it 'does not support check by mask on Windows' do
     resource = MockLoader.new(:windows).load_resource('file', 'C:/fakepath/fakefile')
@@ -61,6 +75,7 @@ describe Inspec::Resources::FileResource do
     _(resource.readable?('by_usergroup', 'by_specific_user')).must_equal '`readable?` is not supported on your OS yet.'
     _(resource.writable?('by_usergroup', 'by_specific_user')).must_equal '`writable?` is not supported on your OS yet.'
     _(resource.executable?('by_usergroup', 'by_specific_user')).must_equal '`executable?` is not supported on your OS yet.'
+    _(resource.allowed?('permission', 'by_usergroup', 'by_specific_user')).must_equal '`allowed?` is not supported on your OS yet.'
     proc { resource.send(:contain, nil) }.must_raise(RuntimeError)
   end
 end

--- a/test/unit/resources/file_test.rb
+++ b/test/unit/resources/file_test.rb
@@ -26,11 +26,11 @@ describe Inspec::Resources::FileResource do
     _(resource.mounted?).must_equal true
     _(resource.to_s).must_equal 'File /fakepath/fakefile'
     _(resource.readable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
-    _(resource.allowed?('read', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('read', by: 'by_usergroup', by_user: 'by_specific_user')).must_equal 'test_result'
     _(resource.writable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
-    _(resource.allowed?('write', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('write', by: 'by_usergroup', by_user: 'by_specific_user')).must_equal 'test_result'
     _(resource.executable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
-    _(resource.allowed?('execute', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('execute', by: 'by_usergroup', by_user: 'by_specific_user')).must_equal 'test_result'
     _(resource.suid).must_equal true
     _(resource.sgid).must_equal true
     _(resource.sticky).must_equal true
@@ -48,18 +48,18 @@ describe Inspec::Resources::FileResource do
     _(resource.exist?).must_equal true
     _(resource.mounted?).must_equal true
     _(resource.readable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
-    _(resource.allowed?('read', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('read', by: 'by_usergroup', by_user: 'by_specific_user')).must_equal 'test_result'
     _(resource.writable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
-    _(resource.allowed?('write', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('write', by: 'by_usergroup', by_user: 'by_specific_user')).must_equal 'test_result'
     _(resource.executable?('by_usergroup', 'by_specific_user')).must_equal 'test_result'
-    _(resource.allowed?('execute', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
-    _(resource.allowed?('full-control', 'by_usergroup', 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('execute', by: 'by_usergroup', by_user: 'by_specific_user')).must_equal 'test_result'
+    _(resource.allowed?('full-control', by: 'by_usergroup', by_user: 'by_specific_user')).must_equal 'test_result'
   end
   it 'does not support Windows-style ACL on Ubuntu' do
     resource = MockLoader.new(:ubuntu1404).load_resource('file', '/fakepath/fakefile')
     resource.stubs(:exist?).returns(true)
-    proc { resource.send('allowed?', 'full-control', 'by_usergroup', 'by_specific_user') }.must_raise(RuntimeError)
-    proc { resource.send('allowed?', 'modify', 'by_usergroup', 'by_specific_user') }.must_raise(RuntimeError)
+    proc { resource.send('allowed?', 'full-control', { by: 'by_usergroup', by_user: 'by_specific_user' }) }.must_raise(RuntimeError)
+    proc { resource.send('allowed?', 'modify', { by: 'by_usergroup', by_user: 'by_specific_user' }) }.must_raise(RuntimeError)
   end
   it 'does not support check by mask on Windows' do
     resource = MockLoader.new(:windows).load_resource('file', 'C:/fakepath/fakefile')
@@ -75,7 +75,7 @@ describe Inspec::Resources::FileResource do
     _(resource.readable?('by_usergroup', 'by_specific_user')).must_equal '`readable?` is not supported on your OS yet.'
     _(resource.writable?('by_usergroup', 'by_specific_user')).must_equal '`writable?` is not supported on your OS yet.'
     _(resource.executable?('by_usergroup', 'by_specific_user')).must_equal '`executable?` is not supported on your OS yet.'
-    _(resource.allowed?('permission', 'by_usergroup', 'by_specific_user')).must_equal '`allowed?` is not supported on your OS yet.'
+    _(resource.allowed?('permission', by: 'by_usergroup', by_user: 'by_specific_user')).must_equal '`allowed?` is not supported on your OS yet.'
     proc { resource.send(:contain, nil) }.must_raise(RuntimeError)
   end
 end


### PR DESCRIPTION
---

**Suggested Tags:** `enhancement`

---

Given the limitations outlined in #1743, it would be convenient to have a better interface with the Windows permissions.

I've chosen the following approach:

```ruby
describe file('C:/Temp/file.txt') do
  it { should allow('read').by_user('SomeOtherUser') }
  it { should allow('delete').by_user('MyUser') }
  it { should_not allow('change-permissions').by_user('SomeOtherUser') }
end
```

Note that `allow('read')` is synonymous with `be_readable`, but is included for consistency's sake.