### PR TITLE
Fix xinetd resource failing when file cannot be read

### DIFF
--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -57,7 +57,7 @@ module Inspec::Resources
       end
 
       @contents[path] = file.content
-      if @contents[path].empty? && !file.empty?
+      if @contents[path].nil? || @contents[path].empty?
         return skip_resource "Can't read file \"#{path}\""
       end
 


### PR DESCRIPTION
The file resource's `#content` method will return nil if the file
cannot be read for permissions issues. If you try to run a profile
that uses the `xinetd` resource without sudo privileges, InSpec
would try to call `#empty` on nil.

This change fixes this issue by checking for nil before checking
for emptiness.

Fixes #1729