### PR TITLE
Fix YAML resource documentation

### DIFF
--- a/docs/resources/yaml.md.erb
+++ b/docs/resources/yaml.md.erb
@@ -17,7 +17,7 @@ A `yaml` resource block declares the configuration data to be tested. Assume the
 
 This file can be queried using:
 
-    describe yaml do
+    describe yaml('filename.yml') do
       its('name') { should eq 'foo' }
       its(['array', 1]) { should eq 'one' }
     end
@@ -26,6 +26,20 @@ where
 
 * `name` is a configuration setting in a Yaml file
 * `should eq 'foo'` tests a value of `name` as read from a Yaml file versus the value declared in the test
+
+Like the `json` resource, the `yaml` resource can read a file, run a command, or accept content inline:
+
+    describe yaml('config.yaml') do
+      its(['driver', 'name']) { should eq 'vagrant' }
+    end
+
+    describe yaml({ command: 'retrieve_data.py --yaml' }) do
+      its('state') { should eq 'open' }
+    end
+
+    describe yaml({ content: \"key1: value1\nkey2: value2\" }) do
+      its('key2') { should cmp 'value2' }
+    end
 
 
 ## Matchers

--- a/lib/resources/yaml.rb
+++ b/lib/resources/yaml.rb
@@ -14,8 +14,16 @@ module Inspec::Resources
     name 'yaml'
     desc 'Use the yaml InSpec audit resource to test configuration data in a YAML file.'
     example "
-      describe yaml do
-        its('name') { should eq 'foo' }
+      describe yaml('config.yaml') do
+        its(['driver', 'name']) { should eq 'vagrant' }
+      end
+
+      describe yaml({ command: 'retrieve_data.py --yaml' }) do
+        its('state') { should eq 'open' }
+      end
+
+      describe yaml({ content: \"key1: value1\nkey2: value2\" }) do
+        its('key2') { should cmp 'value2' }
       end
     "
 


### PR DESCRIPTION
The `yaml` resource documentation was missing many clues that users
need to successfully use the resource.