### PR TITLE
Make the --no-color flag work for inspec exec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :test do
   gem 'ruby-progressbar', '~> 1.8'
   gem 'webmock', '~> 2.3.2'
   gem 'jsonschema', '~> 2.0.2'
+  gem 'm'
 end
 
 group :integration do

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -32,7 +32,7 @@ Profile: yumyum profile
 Version: (not specified)
 Target:  local://
 
-     No tests executed.\e[0m
+     No tests executed.
 
 Test Summary: \e[38;5;41m0 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m
 "
@@ -48,7 +48,7 @@ Profile: title (name)
 Version: 1.2.3
 Target:  local://
 
-     No tests executed.\e[0m
+     No tests executed.
 
 Test Summary: \e[38;5;41m0 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m
 "
@@ -254,6 +254,14 @@ Test Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;2
       out = inspec("exec #{File.join(profile_path, 'profile-support-skip')} --sudo")
       out.stdout.force_encoding(Encoding::UTF_8).must_include "--sudo is only valid when running against a remote host using --target"
       out.exit_status.must_equal 1
+    end
+  end
+
+  describe 'when --no-color is used' do
+    it 'does not output color control characters' do
+      out = inspec('exec ' + File.join(profile_path, 'simple-metadata') + ' --no-color')
+      out.exit_status.must_equal 0
+      out.stdout.wont_include "\e[38"
     end
   end
 end


### PR DESCRIPTION
The CLI formatter is not currently honoring the --no-color flag
when outputting CLI output. This change cleans up how we format
with color and properly support the flag for use cases where
color-encoding characters make the output difficult to use
(i.e. when someone redirects CLI output to a text file for
sharing with others).

I also added the 'm' gem to the `test` group in the Gemfile, a
super-handy gem for running the minitest tests in a single file,
or a single test in a file.

Fixes #1024