### PR TITLE
Add support for Windows auth in mssql_resource

### DIFF
--- a/docs/resources/mssql_session.md.erb
+++ b/docs/resources/mssql_session.md.erb
@@ -10,13 +10,13 @@ Use the `mssql_session` InSpec audit resource to test SQL commands run against a
 
 A `mssql_session` resource block declares the username and password to use for the session, and then the command to be run:
 
-    describe mysql_session('username', 'password').query('QUERY') do
+    describe mssql_session(user: 'username', pass: 'password').query('QUERY') do
       its('output') { should eq('') }
     end
 
 where
 
-* `mssql_session` declares a username and password with permission to run the query.  Omitting the username or password parameters results in the use of Windows authentication as the user InSpec is executing as.
+* `mssql_session` declares a username and password with permission to run the query.  Omitting the username or password parameters results in the use of Windows authentication as the user InSpec is executing as.  You may also optionally pass a host and instance name.  If omitted, they will default to host: localhost and the default instance.
 * `query('QUERY')` contains the query to be run
 * `its('output') { should eq('') }` compares the results of the query against the expected result in the test
 
@@ -56,7 +56,7 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test for matching databases
 
-    sql = mssql_session('my_user','password')
+    sql = mssql_session(user: 'my_user', pass: 'password')
 
     describe sql.query('show databases like \'test\';') do
       its('stdout') { should_not match(/test/) }
@@ -65,6 +65,13 @@ The following examples show how to use this InSpec audit resource.
 ### Test using Windows authentication
     
     sql = mssql_session
+
+    describe sql.query('show databases like \'test\';') do
+      its('stdout') { should_not match(/test/) }
+    end
+
+### Test a specific host and instance
+    sql = mssql_session(user: 'my_user', pass: 'password', host: 'mysqlserver', instance: 'foo')
 
     describe sql.query('show databases like \'test\';') do
       its('stdout') { should_not match(/test/) }

--- a/docs/resources/mssql_session.md.erb
+++ b/docs/resources/mssql_session.md.erb
@@ -1,0 +1,71 @@
+---
+title: About the mssql_session Resource
+---
+
+# mssql_session
+
+Use the `mssql_session` InSpec audit resource to test SQL commands run against a Microsoft SQL database.
+
+## Syntax
+
+A `mssql_session` resource block declares the username and password to use for the session, and then the command to be run:
+
+    describe mysql_session('username', 'password').query('QUERY') do
+      its('output') { should eq('') }
+    end
+
+where
+
+* `mssql_session` declares a username and password with permission to run the query.  Omitting the username or password parameters results in the use of Windows authentication as the user InSpec is executing as.
+* `query('QUERY')` contains the query to be run
+* `its('output') { should eq('') }` compares the results of the query against the expected result in the test
+
+## Matchers
+
+This InSpec audit resource has the following matchers:
+
+### be
+
+<%= partial "/shared/matcher_be" %>
+
+### cmp
+
+<%= partial "/shared/matcher_cmp" %>
+
+### eq
+
+<%= partial "/shared/matcher_eq" %>
+
+### include
+
+<%= partial "/shared/matcher_include" %>
+
+### match
+
+<%= partial "/shared/matcher_match" %>
+
+### output
+
+The `output` matcher tests the results of the query:
+
+    its('output') { should eq(/^0/) }
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test for matching databases
+
+    sql = mssql_session('my_user','password')
+
+    describe sql.query('show databases like \'test\';') do
+      its('stdout') { should_not match(/test/) }
+    end
+
+### Test using Windows authentication
+    
+    sql = mssql_session
+
+    describe sql.query('show databases like \'test\';') do
+      its('stdout') { should_not match(/test/) }
+    end

--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -11,18 +11,31 @@ module Inspec::Resources
       describe sql.query('select * from sys.databases where name like \'*test*\') do
         its('stdout') {should_not match(/test/) }
       end
+
+      # Passing no credentials to mssql_session forces it to use Windows authentication
+      sql_windows_auth = mssql_session
+      describe sql_window_auth.query('select * from sys.databases where name like \'*test*\') do
+        its('stdout') {should_not match(/test/) }
+      end
     "
 
     def initialize(user = nil, pass = nil)
       @user = user
       @pass = pass
-      skip_resource('user and pass are required for MSSQL tests') if @user.nil? or @pass.nil?
     end
 
     def query(q)
       escaped_query = q.gsub(/\\/, '\\\\').gsub(/"/, '\\"').gsub(/\$/, '\\$').gsub(/\@/, '`@')
-      cmd = inspec.command("sqlcmd -U #{@user} -P #{@pass} -Q \"#{escaped_query}\"")
-
+      cmd_string =  if @user.nil? or @pass.nil?
+                      "sqlcmd -Q \"#{escaped_query}\""
+                    else
+                      "sqlcmd -U #{@user} -P #{@pass} -Q \"#{escaped_query}\""
+                    end
+      cmd = inspec.command(cmd_string)
+      out = cmd.stdout + "\n" + cmd.stderr
+      if out =~ /Sqlcmd: Error/
+        skip_resource("Can't connect to the MS SQL Server.")
+      end
       cmd
     end
 

--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -23,14 +23,14 @@ module Inspec::Resources
     def initialize(opts = {})
       @user = opts[:user]
       @pass = opts[:pass]
-      @host = opts[:host] || "localhost"
+      @host = opts[:host] || 'localhost'
       @instance = opts[:instance]
     end
 
     def query(q)
       escaped_query = q.gsub(/\\/, '\\\\').gsub(/"/, '\\"').gsub(/\$/, '\\$').gsub(/\@/, '`@')
       cmd_string = "sqlcmd -Q \"#{escaped_query}\""
-      cmd_string +=  " -U #{@user} -P #{@pass}" unless @user.nil? or @pass.nil?
+      cmd_string += " -U #{@user} -P #{@pass}" unless @user.nil? or @pass.nil?
       if @instance.nil?
         cmd_string += " -S #{@host}"
       else


### PR DESCRIPTION
This adds supports for connecting to MS SQL instances using Window
authentication rather than SQL authentication.  By leaving either the
user or password parameters blank causes the sqlcmd to leave off the -U
and -P params.  This will cause sqlcmd to authenticate as the current
Windows user.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>