### PR TITLE
Add command-line completions for fish shell

### DIFF
--- a/lib/inspec/completions/fish.sh.erb
+++ b/lib/inspec/completions/fish.sh.erb
@@ -1,0 +1,34 @@
+function __fish_inspec_no_command --description 'Test if inspec has yet to be given the main command'
+  set -l cmd (commandline -opc)
+  test (count $cmd) -eq 1
+end
+
+function __fish_inspec_using_command
+  set -l cmd (commandline -opc)
+  set -q cmd[2]; and test "$argv[1]" = $cmd[2]
+end
+
+function __fish_inspec_using_command_and_no_subcommand
+  set -l cmd (commandline -opc)
+  test (count $cmd) -eq 2; and test "$argv[1]" = "$cmd[2]"
+end
+
+function __fish_inspec_using_subcommand --argument-names cmd_main cmd_sub
+    set -l cmd (commandline -opc)
+    set -q cmd[3]; and test "$cmd_main" = $cmd[2] -a "$cmd_sub" = $cmd[3]
+end
+
+<% top_level_commands_with_descriptions.each do |command_and_description| %>
+  <% command, description = command_and_description.split(':') %>
+  <% description.gsub!(/\\/, '') %>
+  # <%= command %> commands
+  complete -c inspec -f -n '__fish_inspec_no_command' -a <%= command %> -d "<%= description %>"
+  # <%= command %> help
+  complete -c inspec -f -n '__fish_inspec_using_command help' -a <%= command %> -d "<%= description %>"
+
+  <% (subcommands_with_commands_and_descriptions[command] || []).each do |command_and_description| %>
+    <% subcommand, description = command_and_description.split(':') %>
+    <% description.gsub!(/\\/, '') %>
+    complete -c inspec -f -n '__fish_inspec_using_command_and_no_subcommand <%= command %>' -a <%= subcommand %> -d "<%= description %>"
+  <% end %>
+<% end %>

--- a/lib/inspec/env_printer.rb
+++ b/lib/inspec/env_printer.rb
@@ -5,6 +5,14 @@ require 'shellwords'
 
 module Inspec
   class EnvPrinter
+    attr_reader :shell
+
+    EVAL_COMMANDS = {
+      'bash' => 'eval \"$(inspec env bash)\"',
+      'fish' => 'inspec env fish > ~/.config/fish/completions/inspec.fish',
+      'zsh' => 'eval \"$(inspec env zsh)\"',
+    }.freeze
+
     def initialize(command_class, shell = nil)
       if !shell
         @detected = true
@@ -56,7 +64,7 @@ module Inspec
       puts <<EOF
 # To use this, eval it in your shell
 #
-#    eval "$(inspec env #{@shell})"
+#    #{EVAL_COMMANDS[shell]}
 #
 #
 EOF


### PR DESCRIPTION
Since the command to enable them is different, also make that change in
the output based on the shell used.

![tenor-195720707](https://cloud.githubusercontent.com/assets/9912/25690876/3691ae9c-305b-11e7-9c51-0dded46921c4.gif)
