### PR TITLE
Fix v1.23.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,15 @@
 # Change Log
 
-## [1.23.0](https://github.com/chef/inspec/tree/1.23.0) (2017-05-04)
-[Full Changelog](https://github.com/chef/inspec/compare/v1.22.0...1.23.0)
+## [v1.23.0](https://github.com/chef/inspec/tree/v1.23.0) (2017-05-04)
+[Full Changelog](https://github.com/chef/inspec/compare/v1.22.0...v1.23.0)
 
 **Implemented enhancements:**
 
-- Warn when using --sudo locally [\#1690](https://github.com/chef/inspec/issues/1690)
+- Add command-line completions for fish shell [\#1760](https://github.com/chef/inspec/pull/1760) ([smith](https://github.com/smith))
 - Error and exit when using --sudo locally [\#1741](https://github.com/chef/inspec/pull/1741) ([adamleff](https://github.com/adamleff))
 
 **Fixed bugs:**
 
-- xinetd.rb `read\_content': undefined method `empty?' for nil:NilClass [\#1729](https://github.com/chef/inspec/issues/1729)
 - Make the --no-color flag work for inspec exec [\#1749](https://github.com/chef/inspec/pull/1749) ([adamleff](https://github.com/adamleff))
 - Fix xinetd resource failing when file cannot be read [\#1746](https://github.com/chef/inspec/pull/1746) ([adamleff](https://github.com/adamleff))
 - Habitat profile bug fixes and improvements [\#1735](https://github.com/chef/inspec/pull/1735) ([rhass](https://github.com/rhass))


### PR DESCRIPTION
The changelog for v1.23.0 had some incorrect links and included
some redundant issues. All fixed up.