### PR TITLE
bugfix: dev-sec/ssl-benchmark -> ssl-baseline

### DIFF
--- a/examples/meta-profile/README.md
+++ b/examples/meta-profile/README.md
@@ -15,7 +15,7 @@ depends:
   - name: os-hardening
     url: https://github.com/dev-sec/tests-os-hardening/archive/master.zip
   # git
-  - git: https://github.com/dev-sec/ssl-benchmark.git
+  - git: https://github.com/dev-sec/ssl-baseline.git
   - name: windows-patch-benchmark
     git: https://github.com/chris-rock/windows-patch-benchmark.git
   # Chef Compliance
@@ -29,7 +29,7 @@ You could use those dependencies in your `exmaple.rb`:
 
 include_controls 'hardening/ssh-hardening'
 include_controls 'os-hardening'
-include_controls 'ssl-benchmark'
+include_controls 'ssl-baseline'
 include_controls 'linux'
 include_controls 'windows-patch-benchmark'
 ```

--- a/examples/meta-profile/controls/example.rb
+++ b/examples/meta-profile/controls/example.rb
@@ -6,7 +6,7 @@
 include_controls 'dev-sec/ssh-baseline'
 
 # select only individual controls
-include_controls 'ssl-benchmark' do
+include_controls 'ssl-baseline' do
   control "tls1.2"
 end
 

--- a/examples/meta-profile/inspec.yml
+++ b/examples/meta-profile/inspec.yml
@@ -8,6 +8,6 @@ summary: InSpec Profile that is only consuming dependencies
 version: 0.2.0
 depends:
   - name: dev-sec/ssh-baseline  # defaults to supermarket
-  - url: https://github.com/dev-sec/ssl-benchmark
+  - url: https://github.com/dev-sec/ssl-baseline
   - name: windows-patch-benchmark
     url: https://github.com/chris-rock/windows-patch-benchmark

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -59,7 +59,7 @@ describe 'example inheritance profile' do
 
     out = inspec('exec ' + meta_path + ' -l debug --no-create-lockfile')
     out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:url=>"https://github.com/dev-sec/ssh-baseline/archive/master.tar.gz"'
-    out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:url=>"https://github.com/dev-sec/ssl-benchmark/archive/master.tar.gz"'
+    out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:url=>"https://github.com/dev-sec/ssl-baseline/archive/master.tar.gz"'
     out.stdout.force_encoding(Encoding::UTF_8).must_include 'Using cached dependency for {:url=>"https://github.com/chris-rock/windows-patch-benchmark/archive/master.tar.gz"'
     out.stdout.force_encoding(Encoding::UTF_8).index('Fetching URL:').must_be_nil
     out.stdout.force_encoding(Encoding::UTF_8).index('Fetched archive moved to:').must_be_nil


### PR DESCRIPTION
It was renamed upstream, we missed to update it.