### PR TITLE
Add support for Windows auth in mssql_resourcet

### DIFF
--- a/docs/resources/mssql_session.md.erb
+++ b/docs/resources/mssql_session.md.erb
@@ -1,0 +1,79 @@
+---
+title: About the mssql_session Resource
+---
+
+# mssql_session
+
+Use the `mssql_session` InSpec audit resource to test SQL commands run against a Microsoft SQL database.
+
+## Syntax
+
+A `mssql_session` resource block declares the username and password to use for the session, and then the command to be run:
+
+    describe mssql_session(user: 'username', pass: 'password').query('QUERY') do
+      its('output') { should eq('') }
+    end
+
+where
+
+* `mssql_session` declares a username and password with permission to run the query.  Omitting the username or password parameters results in the use of Windows authentication as the user InSpec is executing as.  You may also optionally pass a host and instance name.  If omitted, they will default to host: localhost and the default instance.
+* `query('QUERY')` contains the query to be run
+* `its('output') { should eq('') }` compares the results of the query against the expected result in the test
+
+## Matchers
+
+This InSpec audit resource has the following matchers:
+
+### be
+
+<%= partial "/shared/matcher_be" %>
+
+### cmp
+
+<%= partial "/shared/matcher_cmp" %>
+
+### eq
+
+<%= partial "/shared/matcher_eq" %>
+
+### include
+
+<%= partial "/shared/matcher_include" %>
+
+### match
+
+<%= partial "/shared/matcher_match" %>
+
+### output
+
+The `output` matcher tests the results of the query:
+
+    its('output') { should eq(/^0/) }
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test for matching databases
+
+    sql = mssql_session(user: 'my_user', pass: 'password')
+
+    describe sql.query('show databases like \'test\';') do
+      its('stdout') { should_not match(/test/) }
+    end
+
+### Test using Windows authentication
+
+    sql = mssql_session
+
+    describe sql.query('show databases like \'test\';') do
+      its('stdout') { should_not match(/test/) }
+    end
+
+### Test a specific host and instance
+
+    sql = mssql_session(user: 'my_user', pass: 'password', host: 'mssqlserver', instance: 'foo')
+
+    describe sql.query('show databases like \'test\';') do
+      its('stdout') { should_not match(/test/) }
+    end

--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -7,27 +7,48 @@ module Inspec::Resources
     name 'mssql_session'
     desc 'Use the mssql_session InSpec audit resource to test SQL commands run against a MS Sql Server database.'
     example "
-      sql = mssql_session('myuser','mypassword')
+      # Using SQL authentication
+      sql = mssql_session(user: 'myuser', pass: 'mypassword')
       describe sql.query('select * from sys.databases where name like \'*test*\') do
-        its('stdout') {should_not match(/test/) }
+        its('stdout') { should_not match(/test/) }
+      end
+
+      # Passing no credentials to mssql_session forces it to use Windows authentication
+      sql_windows_auth = mssql_session
+      describe sql_window_auth.query('select * from sys.databases where name like \'*test*\') do
+        its('stdout') { should_not match(/test/) }
       end
     "
 
-    def initialize(user = nil, pass = nil)
-      @user = user
-      @pass = pass
-      skip_resource('user and pass are required for MSSQL tests') if @user.nil? or @pass.nil?
+    attr_reader :user, :pass, :host
+
+    def initialize(opts = {})
+      @user = opts[:user]
+      @pass = opts[:pass]
+      @host = opts[:host] || 'localhost'
+      @instance = opts[:instance]
     end
 
     def query(q)
       escaped_query = q.gsub(/\\/, '\\\\').gsub(/"/, '\\"').gsub(/\$/, '\\$').gsub(/\@/, '`@')
-      cmd = inspec.command("sqlcmd -U #{@user} -P #{@pass} -Q \"#{escaped_query}\"")
-
+      cmd_string = "sqlcmd -Q \"#{escaped_query}\""
+      cmd_string += " -U #{@user} -P #{@pass}" unless @user.nil? or @pass.nil?
+      if @instance.nil?
+        cmd_string += " -S #{@host}"
+      else
+        cmd_string += " -S #{@host}\\#{@instance}"
+      end
+      puts cmd_string
+      cmd = inspec.command(cmd_string)
+      out = cmd.stdout + "\n" + cmd.stderr
+      if out =~ /Sqlcmd: Error/
+        skip_resource("Can't connect to the MS SQL Server.")
+      end
       cmd
     end
 
     def to_s
-      'MSSQL'
+      'MSSQL session'
     end
   end
 end

--- a/test/unit/resources/mssql_session_test.rb
+++ b/test/unit/resources/mssql_session_test.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# author: Nolan Davidson
+
+require 'helper'
+
+describe 'Inspec::Resources::MssqlSession' do
+  it 'verify mssql_session configuration' do
+    resource = load_resource('mssql_session', user: 'myuser', pass: 'mypass', host: 'windowshost')
+    _(resource.user).must_equal 'myuser'
+    _(resource.pass).must_equal 'mypass'
+    _(resource.host).must_equal 'windowshost'
+  end
+end


### PR DESCRIPTION
This adds supports for connecting to MS SQL instances using Window
authentication rather than SQL authentication.  By leaving either the
user or password parameters blank causes the sqlcmd to leave off the -U
and -P params.  This will cause sqlcmd to authenticate as the current
Windows user.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>

rebased from https://github.com/chef/inspec/pull/1750