### PR TITLE
Add core/lsof package to facilitate port detection.

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -14,7 +14,6 @@ pkg_deps=(
   core/libxslt
   core/ruby
   core/net-tools
-  core/hab
   core/lsof
 )
 pkg_build_deps=(

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -15,6 +15,7 @@ pkg_deps=(
   core/ruby
   core/net-tools
   core/hab
+  core/lsof
 )
 pkg_build_deps=(
   core/bundler


### PR DESCRIPTION
This depends on https://github.com/habitat-sh/core-plans/pull/508 landing and the package being uploaded to `core`.