### PR TITLE
Hide event blurb on main page

### DIFF
--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -18,11 +18,11 @@ header.blue-gradient.margin-top-offset
       img src="/images/circ-arrow.svg" /
       
 /! Event Details go here
-.code-pop
-  .strict-center
-    p.t-white
-      | Hey Seattle, learn how to make the most of InSpec! Join us on Tuesday, May 9.
-    a href="https://events.chef.io/events/chef-hq-meetup-inspec/" target="_blank"  Join us!
+/!.code-pop
+/!  .strict-center
+/!    p.t-white
+/!      | Hey Seattle, learn how to make the most of InSpec! Join us on Tuesday, May 9.
+/!    a href="https://events.chef.io/events/chef-hq-meetup-inspec/" target="_blank"  Join us!
     
 /! Second Content
 .row.margin-both


### PR DESCRIPTION
There are no pending events other than ChefConf, so I'm hiding
the upcoming event blurb section for now.