### PR TITLE
read source code if profile is in tgz/zip

### DIFF
--- a/lib/inspec/method_source.rb
+++ b/lib/inspec/method_source.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+
+module Inspec
+  module MethodSource
+    def self.code_at(location, source_reader)
+      # TODO: logger for these cases
+      return '' if location.nil? || location[:ref].nil? || location[:line].nil?
+      return '' unless source_reader && source_reader.target
+
+      # TODO: Non-controls still need more detection
+      ref = location[:ref]
+      ref = ref.sub(source_reader.target.prefix, '')
+      src = source_reader.tests[ref]
+      return '' if src.nil?
+
+      ::MethodSource.expression_at(src.lines, location[:line]).force_encoding('utf-8')
+    rescue SyntaxError => e
+      raise ::MethodSource::SourceNotFoundError,
+            "Could not parse source at #{location[:ref]}:#{location[:line]}: #{e.message}"
+    end
+  end
+end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -15,6 +15,7 @@ require 'inspec/rule'
 require 'inspec/log'
 require 'inspec/profile_context'
 require 'inspec/runtime_profile'
+require 'inspec/method_source'
 require 'inspec/dependencies/cache'
 require 'inspec/dependencies/lockfile'
 require 'inspec/dependencies/dependency_set'
@@ -471,6 +472,7 @@ module Inspec
 
     def load_rule(rule, file, controls, groups)
       id = Inspec::Rule.rule_id(rule)
+      location = rule.instance_variable_get(:@__source_location)
       controls[id] = {
         title: rule.title,
         desc: rule.desc,
@@ -478,8 +480,8 @@ module Inspec
         refs: rule.ref,
         tags: rule.tag,
         checks: Inspec::Rule.checks(rule),
-        code: rule.instance_variable_get(:@__code),
-        source_location: rule.instance_variable_get(:@__source_location),
+        code: Inspec::MethodSource.code_at(location, source_reader),
+        source_location: location,
       }
 
       groups[file] ||= {

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -39,7 +39,6 @@ module Inspec
 
       # not changeable by the user:
       @__block = block
-      @__code = __get_block_source(&block)
       @__source_location = __get_block_source_location(&block)
       @__rule_id = id
       @__profile_id = profile_id
@@ -247,14 +246,6 @@ module Inspec
       return '' if text.nil?
       len = text.split("\n").reject { |l| l.strip.empty? }.map { |x| x.index(/[^\s]/) }.compact.min
       text.gsub(/^[[:blank:]]{#{len}}/, '').strip
-    end
-
-    # get the rule's source code
-    def __get_block_source(&block)
-      return '' unless block_given?
-      block.source.to_s
-    rescue MethodSource::SourceNotFoundError
-      ''
     end
 
     # get the source location of the block

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -341,7 +341,7 @@ class MockLoader
 
   def self.profile_path(name)
     dst = name
-    dst = "#{home}/mock/profiles/#{name}" unless name.start_with?(home)
+    dst = "#{home}/mock/profiles/#{name}" unless (Pathname.new name).absolute?
     dst
   end
 

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -74,6 +74,33 @@ describe Inspec::Profile do
     end
   end
 
+  describe 'code info' do
+    let(:profile_id) { 'complete-profile' }
+    let(:code) { "control 'test01' do\n  impact 0.5\n  title 'Catchy title'\n  desc '\n    There should always be a /proc\n  '\n  describe file('/proc') do\n    it { should be_mounted }\n  end\nend\n" }
+    let(:loc) { {:ref=>"controls/filesystem_spec.rb", :line=>7} }
+
+    it 'gets code from an uncompressed profile' do
+      info = MockLoader.load_profile(profile_id).info
+      info[:controls][0][:code].must_equal code
+      loc[:ref] = File.join(MockLoader.profile_path(profile_id), loc[:ref])
+      info[:controls][0][:source_location].must_equal loc
+    end
+
+    it 'gets code on zip profiles' do
+      path = MockLoader.profile_zip(profile_id)
+      info = MockLoader.load_profile(path).info
+      info[:controls][0][:code].must_equal code
+      info[:controls][0][:source_location].must_equal loc
+    end
+
+    it 'gets code on tgz profiles' do
+      path = MockLoader.profile_tgz(profile_id)
+      info = MockLoader.load_profile(path).info
+      info[:controls][0][:code].must_equal code
+      info[:controls][0][:source_location].must_equal loc
+    end
+  end
+
   describe 'when checking' do
     describe 'an empty profile' do
       let(:profile_id) { 'empty-metadata' }


### PR DESCRIPTION
To note: the source location between archived files and an uncompressed profiel is still different. When the block gets processed the location for uncompressed files will have the full path on the system, while archives still only carry their mocked paths. This can be improved in a separate PR. This PR respects this distinction and only targets the empty code fields.

This issue has been bugging me since InSpec's original inception 😁 