### PR TITLE
Improvements to Habitat plan

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,68 +1,85 @@
 pkg_name=inspec
 pkg_origin=chef
-pkg_version=$(cat "VERSION")
 pkg_description="InSpec is an open-source testing framework for infrastructure
   with a human- and machine-readable language for specifying compliance,
   security and policy requirements."
-pkg_upstream_url=https://github.com/chef/inspec
+pkg_upstream_url=https://www.inspec.io/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source=false
 pkg_deps=(
+  core/busybox-static
+  core/cacerts
   core/coreutils
   core/libxml2
   core/libxslt
-  core/ruby
   core/net-tools
-  core/busybox-static
+  core/ruby
 )
 pkg_build_deps=(
   core/bundler
-  core/coreutils
   core/gcc
   core/make
   core/readline
+  core/sed
 )
 pkg_bin_dirs=(bin)
 
-do_download() {
-  return 0
+pkg_version() {
+  cat VERSION
 }
 
-do_verify() {
-  return 0
-}
-
-do_unpack() {
-  return 0
+do_before() {
+  if [[ ! -f VERSION ]]; then
+    exit_with "habitat/VERSION not found. Run 'rake release_habitat' to ensure it exists" 1
+  fi
+  update_pkg_version
 }
 
 do_prepare() {
-  # Create a Gemfile with what we need
-  cat > Gemfile <<GEMFILE
+  # If we use the Gemfile in the project ($SRC_PATH/Gemfile), and run `bundle
+  # install` (which we do in `do_build` below), Bundler will write out a
+  # .bundle/config into the $SRC_PATH. If this happens, if you try to use
+  # InSpec outside of the build process it will fail, since the settings used
+  # in this plan will be saved in the .bundle/config.
+  #
+  # Instead, we build a minimal Gemfile in the $CACHE_PATH and bundle using that.
+  cat > "$CACHE_PATH/Gemfile" <<GEMFILE
 source 'https://rubygems.org'
-gem '$pkg_name', '= $pkg_version'
-gem 'rake'
+gem '$pkg_name', path: '$SRC_PATH'
 GEMFILE
+
+  export BUNDLE_SILENCE_ROOT_WARNING GEM_HOME GEM_PATH
+  BUNDLE_SILENCE_ROOT_WARNING=1
+  build_line "Setting BUNDLE_SILENCE_ROOT_WARNING=$BUNDLE_SILENCE_ROOT_WARNING"
+  GEM_HOME="$pkg_prefix/vendor/bundle"
+  build_line "Setting GEM_HOME=$GEM_HOME"
+  GEM_PATH="$(pkg_path_for bundler):$GEM_HOME"
+  build_line "Setting GEM_PATH=$GEM_PATH"
 }
 
 do_build() {
-  local _bundler_dir
-  local _libxml2_dir
-  local _libxslt_dir
-
-  _bundler_dir="$(pkg_path_for bundler)"
-
-  export GEM_HOME=${pkg_path}/vendor/bundle
-  export GEM_PATH=${_bundler_dir}:${GEM_HOME}
-  export BUNDLE_SILENCE_ROOT_WARNING=1
-
-  bundle install --jobs "$(nproc)" --retry 5 --standalone \
+  bundle install \
+    --binstubs "$pkg_prefix/bin" \
+    --gemfile "$CACHE_PATH/Gemfile" \
+    --jobs "$(nproc)" \
     --path "$pkg_prefix/bundle" \
-    --binstubs "$pkg_prefix/bin"
+    --retry 5 \
+    --standalone
+
+  # Delete everything that's not inspec in bin
+  find "$pkg_prefix/bin" -type f -not -name 'inspec' -delete
+
+  fix_interpreter "$pkg_prefix/bin/inspec" core/coreutils bin/env
+
+  # Insert the SSL cert path into the inspec executable
+  sed -i "2iENV['SSL_CERT_FILE'] = '$(pkg_path_for cacerts)/ssl/cert.pem'" \
+    "$pkg_prefix/bin/inspec"
 }
 
-do_install () {
-  fix_interpreter "$pkg_prefix/bin/*" core/coreutils bin/env
-  cp Gemfile.lock "$pkg_prefix"
+do_install() {
+  install -m 0644 Gemfile.lock "$pkg_prefix/Gemfile.lock"
+}
+
+do_strip() {
+  return 0
 }


### PR DESCRIPTION
These are kind of all over the place, but should improve things:

* Use the new `pkg_version` mechanism to set the version, and fail if
  the VERSION file is not present
* Use inspec.io for the upstream url
* Remove pkg_source and it's associated callbacks; they aren't required
  any more
* Alphabetize the deps list
* Remove duplicate coreutils from build deps
* Move environment variable setting to `do_prepare`
* Delete all binstubs in bin that aren't inspec
* Put the generated Gemfile in $CACHE_PATH so it doesn't stomp on the
  developer's Gemfile
* Insert the SSL_CERT_FILE env var in the binstub (Fixes #1582)
* Use install instead of cp to drop off Gemfile.lock

Works for me on Habitat 0.23.

Since all the "building" is done now in `do_install`, it would be
possible to define a `do_check` that runs `inspec exec` on profiles to
verify inspec is working by running inspec.

Signed-off-by: Nathan L Smith <smith@chef.io>