### PR TITLE
throw an error during inspec check if the version is not correct

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -43,4 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'toml', '~> 0.1'
   spec.add_dependency 'addressable', '~> 2.4'
   spec.add_dependency 'parslet', '~> 1.5'
+  spec.add_dependency 'semverse'
 end

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -6,6 +6,7 @@
 require 'logger'
 require 'rubygems/version'
 require 'rubygems/requirement'
+require 'semverse'
 
 module Inspec
   # Extract metadata.rb information
@@ -109,6 +110,12 @@ module Inspec
         next unless params[field.to_sym].nil?
         errors.push("Missing profile #{field} in #{ref}")
       end
+
+      # if version is set, ensure it is correct
+      if !params[:version].nil? && !valid_version?(params[:version])
+        errors.push('Version needs to be in SemVer format')
+      end
+
       %w{ title summary maintainer copyright }.each do |field|
         next unless params[field.to_sym].nil?
         warnings.push("Missing profile #{field} in #{ref}")
@@ -121,6 +128,13 @@ module Inspec
     def valid?
       errors, _warnings = valid
       errors.empty? && unsupported.empty?
+    end
+
+    def valid_version?(value)
+      Semverse::Version.new(value)
+      true
+    rescue Semverse::InvalidVersionFormat
+      false
     end
 
     def method_missing(sth, *args)

--- a/test/unit/mock/profiles/invalid-version/inspec.yml
+++ b/test/unit/mock/profiles/invalid-version/inspec.yml
@@ -1,0 +1,8 @@
+name: invalid-version
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile
+version: 0.1.0.999

--- a/test/unit/profiles/metadata_test.rb
+++ b/test/unit/profiles/metadata_test.rb
@@ -39,6 +39,20 @@ describe 'metadata with supported operating systems' do
       res.params[:name].must_equal('mock')
     end
 
+    it 'reads the version from metadata' do
+      res = Inspec::Metadata.from_yaml('mock', "---\nversion: '1.1.0'", nil)
+      Inspec::Metadata.finalize(res, 'mock', empty_options)
+      res.params[:version].must_equal('1.1.0')
+      res.valid_version?(res.params[:version]).must_equal(true)
+    end
+
+    it 'does not accept invalid version from metadata' do
+      res = Inspec::Metadata.from_yaml('mock', "---\nversion: '1.1.0.1'", nil)
+      Inspec::Metadata.finalize(res, 'mock', empty_options)
+      res.params[:version].must_equal('1.1.0.1')
+      res.valid_version?(res.params[:version]).must_equal(false)
+    end
+
     it 'finalizes a loaded metadata by turning strings into symbols' do
       res = Inspec::Metadata.from_yaml('mock', "---\nauthor: world", nil)
       Inspec::Metadata.finalize(res, 'mock', empty_options)


### PR DESCRIPTION
This ensures that inspec check fails if a non-semver version is used in inspec.yml
