### PR TITLE
Bump default timeouts for `http` resource

### DIFF
--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -24,15 +24,16 @@ module Inspec::Resources
       end
     "
 
-    # rubocop:disable ParameterLists
-    def initialize(url, method: 'GET', params: nil, auth: {}, headers: {}, data: nil, ssl_verify: true)
+    def initialize(url, opts = {})
       @url = url
-      @method = method
-      @params = params
-      @auth = auth
-      @headers = headers
-      @data = data
-      @ssl_verify = ssl_verify
+      @method = opts.fetch(:method, 'GET')
+      @params = opts.fetch(:params, nil)
+      @auth = opts.fetch(:auth, {})
+      @headers = opts.fetch(:headers, {})
+      @data = opts.fetch(:data, nil)
+      @open_timeout = opts.fetch(:open_timeout, 60)
+      @read_timeout = opts.fetch(:read_timeout, 60)
+      @ssl_verify = opts.fetch(:ssl_verify, true)
     end
 
     def status
@@ -60,8 +61,8 @@ module Inspec::Resources
       conn.basic_auth @auth[:user], @auth[:pass] unless @auth.empty?
 
       # set default timeout
-      conn.options.timeout      = 5  # open/read timeout in seconds
-      conn.options.open_timeout = 3  # connection open timeout in seconds
+      conn.options.timeout      = @read_timeout  # open/read timeout in seconds
+      conn.options.open_timeout = @open_timeout  # connection open timeout in seconds
 
       @response = conn.send(@method.downcase) do |req|
         req.body = @data

--- a/test/unit/resources/http_test.rb
+++ b/test/unit/resources/http_test.rb
@@ -51,4 +51,12 @@ describe 'Inspec::Resources::Http' do
     _(resource.status).must_equal 200
     _(resource.body).must_equal 'params ok'
   end
+
+  it 'verify http with timeouts' do
+    stub_request(:get, "www.example.com").to_return(status: 200, body: 'params ok')
+
+    resource = load_resource('http', 'http://www.example.com', open_timeout: 10, read_timeout: 10)
+    _(resource.instance_variable_get(:@open_timeout)).must_equal 10
+    _(resource.instance_variable_get(:@read_timeout)).must_equal 10
+  end
 end


### PR DESCRIPTION
This changes the default read and open timeouts to be 60 seconds which matches the defaults for `Net::HTTP` backend which Faraday uses by default:
https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout-attribute-method
https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout-attribute-method

The current timeout values are too small which causes tests to be flakey.

Signed-off-by: Seth Chisamore <schisamo@chef.io>