### PR TITLE
Allow docs Rake task to be run from outside www dir

### DIFF
--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -18,6 +18,7 @@
 require 'erb'
 require 'ruby-progressbar'
 require 'fileutils'
+require_relative './shared'
 
 PROJECT_DIR = File.join(File.expand_path(File.dirname(__FILE__)), '..').freeze
 WWW_DIR     = File.join(PROJECT_DIR, 'www').freeze


### PR DESCRIPTION
The docs Rake task requires classes defined in the "shared"
Rake tasks file. However, only the www Rakefile includes the
"shared" tasks file.

Since the "docs" Rake task is what needs it, I'm adding a require
there to ensure it works from outside the www directory.