### PR TITLE
Fix assert that a gem is not installed

### DIFF
--- a/lib/resources/gem.rb
+++ b/lib/resources/gem.rb
@@ -39,16 +39,16 @@ module Inspec::Resources
       return @info if defined?(@info)
 
       cmd = inspec.command("#{@gem_binary} list --local -a -q \^#{@package_name}\$")
-      @info = {
-        installed: cmd.exit_status.zero?,
-        type: 'gem',
-      }
-      return @info unless @info[:installed]
+      return {} unless cmd.exit_status.zero?
 
       # extract package name and version
       # parses data like winrm (1.3.4, 1.3.3)
       params = /^\s*([^\(]*?)\s*\((.*?)\)\s*$/.match(cmd.stdout.chomp)
-      return {} if params.nil?
+      @info = {
+        installed: !params.nil?,
+        type: 'gem',
+      }
+      return @info unless @info[:installed]
 
       versions = params[2].split(',')
       @info[:name] = params[1]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -174,6 +174,7 @@ class MockLoader
       'rpm -qia curl' => cmd.call('rpm-qia-curl'),
       'pacman -Qi curl' => cmd.call('pacman-qi-curl'),
       'brew info --json=v1 curl' => cmd.call('brew-info--json-v1-curl'),
+      'gem list --local -a -q ^not-installed$' => cmd.call('gem-list-local-a-q-not-installed'),
       'gem list --local -a -q ^rubocop$' => cmd.call('gem-list-local-a-q-rubocop'),
       '/opt/ruby-2.3.1/embedded/bin/gem list --local -a -q ^pry$' => cmd.call('gem-list-local-a-q-pry'),
       '/opt/chef/embedded/bin/gem list --local -a -q ^chef-sugar$' => cmd.call('gem-list-local-a-q-chef-sugar'),

--- a/test/unit/resources/gem_test.rb
+++ b/test/unit/resources/gem_test.rb
@@ -7,6 +7,11 @@ require 'helper'
 require 'inspec/resource'
 
 describe 'Inspec::Resources::Gem' do
+  it 'verify gem is not installed' do
+    resource = load_resource('gem', 'not-installed')
+    _(resource.installed?).must_equal false
+  end
+
   it 'verify gem package detail parsing' do
     resource = load_resource('gem', 'rubocop')
     pkg = {


### PR DESCRIPTION
### Description

There are some compliance situations where we want to enforce that a gem is not installed on a system. The following spec code (which is shown in the documentation) does not pass:

```
describe gem("gem_name") do
  it { should_not be_installed }
end
```

I originally spotted this bug in v1.18.0 which threw the following error:

```
  gem package
     ∅  undefined method `[]' for nil:NilClass
```

Since v1.20.0, now the test is skipped completely because the `stdout` result of the gem command is blank, which is to be expected for any gem that is not installed. 

The gem resource is determining if a gem is installed based on the exit status of the `gem` command, however that command will return zero if the package was found or not. 

### InSpec and Platform Version

Inspec: v1.25.1
Platform: RedHat 7 & OS/X Sierra

Looking at the code, this appears it might apply to all platforms, assuming the return code behavior of the `gem` command doesn't differ across different platforms. 

### Replication Case

This issue can be replicated with a simple `describe` spec:

```
# test.rb
describe gem("gem_i_do_not_want") do
  it { should_not be_installed }
end
```

Then run:

```
$ gem install inspec --version v1.25.1
$ inspec exec test.rb
  gem package
     ↺  Unable to retrieve gem information

Test Summary: 0 successful, 0 failures, 1 skipped
```

### Possible Solutions

1. Remove support for writing tests for gems that are not installed. The documentation for the `gem` resource currently includes a sample test which suggests that this feature should be supported. This solution would just remove that test case and add a note that this feature is no longer supported. 

2. Check the return of the `gem list --local -a -q <gemname>` stdout to see if the output contains the name of the gem. If it does then the gem is installed, otherwise the gem is not installed. This check would be added in addition to the existing check for the zero return status to ensure that the command also completed successfully. This is necessary because the `gem list` command will return zero if the gem exists or not. 

This pull request implements the second option. One thing I wasn't sure about was what should happen if the command exit status is not zero. For the time being, I left the logic in place to trigger the `skip_resource` call in the constructor, but I think the better solution should be to raise an error. I just wasn't sure what error class to use for that. 
