### PR TITLE
Fix compliance uploads when version is not present

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -70,13 +70,14 @@ module Compliance
       headers = get_headers(config)
       response = Compliance::HTTP.get(url+'/version', headers, insecure)
       return {} if response.code == '404'
-      data = response.body
 
-      if !data.nil?
-        JSON.parse(data)
-      else
-        {}
-      end
+      data = response.body
+      return {} if data.nil? || data.empty?
+
+      parsed = JSON.parse(data)
+      return {} unless parsed.key?('version') && !parsed['version'].empty?
+
+      parsed
     end
 
     # verifies that a profile
@@ -203,11 +204,11 @@ module Compliance
     end
 
     def self.is_automate_server_pre_080?(config)
-      config['server_type'] == 'automate' && config['version'].empty?
+      config['server_type'] == 'automate' && config['version'].nil?
     end
 
     def self.is_automate_server_080_and_later?(config)
-      config['server_type'] == 'automate' && !config['version'].empty?
+      config['server_type'] == 'automate' && !config['version'].nil?
     end
 
     def self.is_automate_server?(config)

--- a/test/unit/bundles/inspec-compliance/api_test.rb
+++ b/test/unit/bundles/inspec-compliance/api_test.rb
@@ -1,0 +1,76 @@
+require 'helper'
+
+describe Compliance::API do
+  describe '.version' do
+    let(:headers) { 'test-headers' }
+    let(:config) do
+      {
+        'server' => 'myserver',
+        'insecure' => true
+      }
+    end
+
+    before do
+      Compliance::API.expects(:get_headers).returns(headers)
+    end
+
+    describe 'when a 404 is received' do
+      it 'should return an empty hash' do
+        response = mock
+        response.stubs(:code).returns('404')
+        Compliance::HTTP.expects(:get).with('myserver/version', 'test-headers', true).returns(response)
+        Compliance::API.version(config).must_equal({})
+      end
+    end
+
+    describe 'when the returned body is nil' do
+      it 'should return an empty hash' do
+        response = mock
+        response.stubs(:code).returns('200')
+        response.stubs(:body).returns(nil)
+        Compliance::HTTP.expects(:get).with('myserver/version', 'test-headers', true).returns(response)
+        Compliance::API.version(config).must_equal({})
+      end
+    end
+
+    describe 'when the returned body is an empty string' do
+      it 'should return an empty hash' do
+        response = mock
+        response.stubs(:code).returns('200')
+        response.stubs(:body).returns('')
+        Compliance::HTTP.expects(:get).with('myserver/version', 'test-headers', true).returns(response)
+        Compliance::API.version(config).must_equal({})
+      end
+    end
+
+    describe 'when the returned body has no version key' do
+      it 'should return an empty hash' do
+        response = mock
+        response.stubs(:code).returns('200')
+        response.stubs(:body).returns('{"api":"compliance"}')
+        Compliance::HTTP.expects(:get).with('myserver/version', 'test-headers', true).returns(response)
+        Compliance::API.version(config).must_equal({})
+      end
+    end
+
+    describe 'when the returned body has an empty version key' do
+      it 'should return an empty hash' do
+        response = mock
+        response.stubs(:code).returns('200')
+        response.stubs(:body).returns('{"api":"compliance","version":""}')
+        Compliance::HTTP.expects(:get).with('myserver/version', 'test-headers', true).returns(response)
+        Compliance::API.version(config).must_equal({})
+      end
+    end
+
+    describe 'when the returned body has a proper version' do
+      it 'should return an empty hash' do
+        response = mock
+        response.stubs(:code).returns('200')
+        response.stubs(:body).returns('{"api":"compliance","version":"1.2.3"}')
+        Compliance::HTTP.expects(:get).with('myserver/version', 'test-headers', true).returns(response)
+        Compliance::API.version(config).must_equal({'version' => '1.2.3', 'api' => 'compliance'})
+      end
+    end
+  end
+end


### PR DESCRIPTION
The Compliance::API.version method could potentially return
a hash containing no "version" key but would return an empty
hash upon any expected failure. Downstream callers of the
Compliance::API.version method were looking for a "version"
key to always be present when, in some cases, it would not be.

This change ensures that if a version is not available, there
is no "version" key in the hash, and downstream callers of this
method have been changed to check for nil instead of empty.

Fixes #1847