### PR TITLE
Fix command exists check on Windows with full paths

### DIFF
--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -50,7 +50,7 @@ module Inspec::Resources
       if inspec.os.linux?
         res = inspec.backend.run_command("bash -c 'type \"#{@command}\"'")
       elsif inspec.os.windows?
-        res = inspec.backend.run_command("where.exe \"#{@command}\"")
+        res = inspec.backend.run_command("If(Test-Path \"#{@command}\"){exit 0}Else{exit 1}")
       elsif inspec.os.unix?
         res = inspec.backend.run_command("type \"#{@command}\"")
       else


### PR DESCRIPTION
Amended the `command.rb` file as it wasn't passing the path correctly.

Needed to force the return of exit code numbers (rather than $ture $false) to maintain compatiblity with the existing script 

chefconf 2017

Fixes #1839