### PR TITLE
Raise exception if profile target URL cannot be parsed

### DIFF
--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -87,6 +87,12 @@ EOF
           else
             %r{^#{@config['server']}/owners/(?<owner>[^/]+)/compliance/(?<id>[^/]+)/tar$}
           end.match(@target)
+
+      raise 'Unable to determine compliance profile name. This can be caused by ' \
+        'an incorrect server in your configuration. Try to login to compliance ' \
+        'via the `inspec compliance login` or `inspec compliance login_automate` ' \
+        'commands.' if m.nil?
+
       "#{m[:owner]}/#{m[:id]}"
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -31,6 +31,7 @@ require 'inspec/runner'
 require 'inspec/runner_mock'
 require 'fetchers/mock'
 
+require_relative '../lib/bundles/inspec-compliance'
 require_relative '../lib/bundles/inspec-habitat'
 
 require 'train'

--- a/test/unit/bundles/inspec-compliance/target_test.rb
+++ b/test/unit/bundles/inspec-compliance/target_test.rb
@@ -1,0 +1,53 @@
+require 'helper'
+
+describe Compliance::Fetcher do
+  let(:config) { { 'server' => 'myserver' } }
+
+  describe 'when the server is an automate server pre-0.8.0' do
+    before { Compliance::API.expects(:is_automate_server_pre_080?).with(config).returns(true) }
+
+    it 'returns the correct profile name when the url is correct' do
+      fetcher = Compliance::Fetcher.new('myserver/myowner/myprofile/tar', config)
+      fetcher.send(:compliance_profile_name).must_equal 'myowner/myprofile'
+    end
+
+    it 'raises an exception if the url is malformed' do
+      fetcher = Compliance::Fetcher.new('a/bad/url', config)
+      proc { fetcher.send(:compliance_profile_name) }.must_raise RuntimeError
+    end
+  end
+
+  describe 'when the server is an automate server 0.8.0-or-later' do
+    before do
+      Compliance::API.expects(:is_automate_server_pre_080?).with(config).returns(false)
+      Compliance::API.expects(:is_automate_server_080_and_later?).with(config).returns(true)
+    end
+
+    it 'returns the correct profile name when the url is correct' do
+      fetcher = Compliance::Fetcher.new('myserver/profiles/myowner/myprofile/tar', config)
+      fetcher.send(:compliance_profile_name).must_equal 'myowner/myprofile'
+    end
+
+    it 'raises an exception if the url is malformed' do
+      fetcher = Compliance::Fetcher.new('a/bad/url', config)
+      proc { fetcher.send(:compliance_profile_name) }.must_raise RuntimeError
+    end
+  end
+
+  describe 'when the server is not an automate server (likely a compliance server)' do
+    before do
+      Compliance::API.expects(:is_automate_server_pre_080?).with(config).returns(false)
+      Compliance::API.expects(:is_automate_server_080_and_later?).with(config).returns(false)
+    end
+
+    it 'returns the correct profile name when the url is correct' do
+      fetcher = Compliance::Fetcher.new('myserver/owners/myowner/compliance/myprofile/tar', config)
+      fetcher.send(:compliance_profile_name).must_equal 'myowner/myprofile'
+    end
+
+    it 'raises an exception if the url is malformed' do
+      fetcher = Compliance::Fetcher.new('a/bad/url', config)
+      proc { fetcher.send(:compliance_profile_name) }.must_raise RuntimeError
+    end
+  end
+end


### PR DESCRIPTION
When attempting to parse the profile out of the target URL, we
were not raising an exception if we failed to do so. Such a situation
could arise if a user's inspec config.json is incorrect either due to
manual editing or failure to re-login after an upgrade past Automate
0.8.0.

This change provides a clear exception if this occurs and also adds
tests for the compliance_profile_name method.

Fixes #1848