### PR TITLE
reject `nil` as a command input

### DIFF
--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -24,6 +24,9 @@ module Inspec::Resources
     attr_reader :command
 
     def initialize(cmd)
+      if cmd.nil?
+        raise 'InSpec `command` was called with `nil` as the argument. This is not supported. Please provide a valid command instead.'
+      end
       @command = cmd
     end
 

--- a/test/unit/resources/command_test.rb
+++ b/test/unit/resources/command_test.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+require 'helper'
+require 'inspec/resource'
+
+describe Inspec::Resources::Cmd do
+  let(:x) { rand.to_s }
+  def resource(y)
+    load_resource('command', y)
+  end
+
+  it 'prints as a bash command' do
+    resource(x).to_s.must_equal 'Command '+x
+  end
+
+  it 'runs a valid mocked command' do
+    resource('env').result.wont_be_nil
+    resource('env').stdout.must_equal "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n"
+    resource('env').stderr.must_equal ''
+    resource('env').exit_status.must_equal 0
+  end
+
+  it 'raises when called with nil as a command' do
+    proc { resource(nil).result }.must_raise StandardError
+  end
+end


### PR DESCRIPTION
It is not valid and the errors get very cryptic once it passes train and goes to the various backends. Let's just catch it early on. It is a user error that should be avoided.