### PR TITLE
Add docs for http resource options

### DIFF
--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -14,7 +14,7 @@ This will be corrected in a future version of InSpec. New InSpec releases are po
 
 An `http` resource block declares the configuration settings to be tested:
 
-    describe http('url', auth: {user: 'user', pass: 'test'}, params: {params}, method: 'method', headers: {headers}, body: body) do
+    describe http('url', auth: {user: 'user', pass: 'test'}, params: {params}, method: 'method', headers: {headers}, data: data, open_timeout: 60, read_timeout: 60, ssl_verify: true) do
       its('status') { should eq number }
       its('body') { should eq 'body' }
       its('headers.name') { should eq 'header' }
@@ -23,11 +23,14 @@ An `http` resource block declares the configuration settings to be tested:
 where
 
 * `('url')` is the url to test
-* `{user: 'user', pass: 'test'}` may be specified for basic auth request
+* `auth: { user: 'user', pass: 'test' }` may be specified for basic auth request
 * `{params}` may be specified for http request parameters
 * `'method'` may be specified for http request method (default to 'GET')
 * `{headers}` may be specified for http request headers
-* `body` may be specified for http request body
+* `data` may be specified for http request body
+* `open_timeout` may be specified for a timeout for opening connections (default to 60)
+* `read_timeout` may be specified for a timeout for reading connections (default to 60)
+* `ssl_verify` may be specified to enable or disable verification of SSL certificates (default to `true`)
 
 ## Matchers
 


### PR DESCRIPTION
`auth` and `data` were incorrect; the timeouts and `ssl_verify` were missing.