### PR TITLE
bugfix: do not send nil to command on unsupported OS

### DIFF
--- a/lib/resources/powershell.rb
+++ b/lib/resources/powershell.rb
@@ -20,6 +20,7 @@ module Inspec::Resources
 
     def initialize(script)
       unless inspec.os.windows?
+        super('')
         return skip_resource 'The `script` resource is not supported on your OS yet.'
       end
       # since WinRM 2.0 and the default use of powershell for local execution in

--- a/test/unit/resources/powershell_test.rb
+++ b/test/unit/resources/powershell_test.rb
@@ -23,4 +23,10 @@ describe 'Inspec::Resources::Powershell' do
     # string should be the same
     _(resource.command.to_s).must_equal ps1_script
   end
+
+  it 'will return an empty array when called on a non-supported OS with children' do
+    resource = MockLoader.new.load_resource('powershell', '...')
+    # string should be the same
+    _(resource.stdout).must_equal ''
+  end
 end


### PR DESCRIPTION
Unsupported operating systems AND the mockloader when using inspec analysis tools may lead to powershell being called with the command being `nil`, because the resource skips during the initialize phase. Instead, propagate an empty string so that `command` has a valid input and then skip the resource.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>