### PR TITLE
add bitbucket repo url handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,9 @@ habitat/results
 /.direnv
 /.envrc
 results/
-
+.vagrant/
+Vagrantfile
+.gitignore
 www/source/index.html.slim
 
 www/source/index.html.slim

--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,7 @@ habitat/results
 /.direnv
 /.envrc
 results/
-.vagrant/
-Vagrantfile
-.gitignore
+
 www/source/index.html.slim
 
 www/source/index.html.slim

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -37,8 +37,8 @@ module Fetchers
       nil
     end
 
-    # Transforms a browser github url to github tar url
-    # We distinguish between three different Github URL types:
+    # Transforms a browser github/bitbucket url to github/bitbucket tar url
+    # We distinguish between three different Github/Bitbucket URL types:
     #  - Master URL
     #  - Branch URL
     #  - Commit URL
@@ -46,22 +46,39 @@ module Fetchers
     # master url:
     # https://github.com/nathenharvey/tmp_compliance_profile/ is transformed to
     # https://github.com/nathenharvey/tmp_compliance_profile/archive/master.tar.gz
+    # https://bitbucket.org/username/repo is transformed to
+    # https://bitbucket.org/username/repo/get/master.tar.gz
     #
-    # github branch:
+    # branch:
     # https://github.com/hardening-io/tests-os-hardening/tree/2.0 is transformed to
     # https://github.com/hardening-io/tests-os-hardening/archive/2.0.tar.gz
+    # https://bitbucket.org/username/repo/branch/branchname is transformed to
+    # https://bitbucket.org/username/repo/get/newbranch.tar.gz
     #
-    # github commit:
+    # commit:
     # https://github.com/hardening-io/tests-os-hardening/tree/48bd4388ddffde68badd83aefa654e7af3231876
     # is transformed to
     # https://github.com/hardening-io/tests-os-hardening/archive/48bd4388ddffde68badd83aefa654e7af3231876.tar.gz
+    # https://bitbucket.org/username/repo/commits/95ce1f83d5bbe9eec34c5973f6894617e8d6d8cc is transformed to
+    # https://bitbucket.org/username/repo/get/95ce1f83d5bbe9eec34c5973f6894617e8d6d8cc.tar.gz
+
     GITHUB_URL_REGEX = %r{^https?://(www\.)?github\.com/(?<user>[\w-]+)/(?<repo>[\w-]+)(\.git)?(/)?$}
     GITHUB_URL_WITH_TREE_REGEX = %r{^https?://(www\.)?github\.com/(?<user>[\w-]+)/(?<repo>[\w-]+)/tree/(?<commit>[\w\.]+)(/)?$}
+    BITBUCKET_URL_REGEX = %r{^https?://(www\.)?bitbucket\.org/(?<user>[\w-]+)/(?<repo>[\w-]+)(\.git)?(/)?$}
+    BITBUCKET_URL_BRANCH_REGEX = %r{^https?://(www\.)?bitbucket\.org/(?<user>[\w-]+)/(?<repo>[\w-]+)/branch/(?<branch>[\w\.]+)(/)?$}
+    BITBUCKET_URL_COMMIT_REGEX = %r{^https?://(www\.)?bitbucket\.org/(?<user>[\w-]+)/(?<repo>[\w-]+)/commits/(?<commit>[\w\.]+)(/)?$}
+
     def self.transform(target)
       transformed_target = if m = GITHUB_URL_REGEX.match(target) # rubocop:disable Lint/AssignmentInCondition
                              "https://github.com/#{m[:user]}/#{m[:repo]}/archive/master.tar.gz"
                            elsif m = GITHUB_URL_WITH_TREE_REGEX.match(target) # rubocop:disable Lint/AssignmentInCondition
                              "https://github.com/#{m[:user]}/#{m[:repo]}/archive/#{m[:commit]}.tar.gz"
+                           elsif m = BITBUCKET_URL_REGEX.match(target) # rubocop:disable Lint/AssignmentInCondition
+                             "https://bitbucket.org/#{m[:user]}/#{m[:repo]}/get/master.tar.gz"
+                           elsif m = BITBUCKET_URL_BRANCH_REGEX.match(target) # rubocop:disable Lint/AssignmentInCondition
+                             "https://bitbucket.org/#{m[:user]}/#{m[:repo]}/get/#{m[:branch]}.tar.gz"
+                           elsif m = BITBUCKET_URL_COMMIT_REGEX.match(target) # rubocop:disable Lint/AssignmentInCondition
+                             "https://bitbucket.org/#{m[:user]}/#{m[:repo]}/get/#{m[:commit]}.tar.gz"
                            end
 
       if transformed_target

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -88,6 +88,37 @@ describe Fetchers::Url do
       _(res.resolved_source).must_equal({url: 'https://github.com/hardening-io/tests-os-hardening/archive/48bd4388ddffde68badd83aefa654e7af3231876.tar.gz',
                                          sha256: expected_shasum})
     end
+
+    %w{https://bitbucket.org/chef/inspec
+       https://bitbucket.org/chef/inspec.git
+       https://www.bitbucket.org/chef/inspec.git
+       http://bitbucket.org/chef/inspec
+       http://bitbucket.org/chef/inspec.git
+       http://www.bitbucket.org/chef/inspec.git}.each do |bitbucket|
+      it "resolves a bitbucket url #{bitbucket}" do
+           res = fetcher.resolve(bitbucket)
+           res.expects(:open).returns(mock_open)
+           _(res).wont_be_nil
+           _(res.resolved_source).must_equal({url: 'https://bitbucket.org/chef/inspec/get/master.tar.gz', sha256: expected_shasum})
+         end
+       end
+
+    it "resolves a bitbucket branch url" do
+      bitbucket = 'https://bitbucket.org/chef/inspec/branch/newbranch'
+      res = fetcher.resolve(bitbucket)
+      res.expects(:open).returns(mock_open)
+      _(res).wont_be_nil
+      _(res.resolved_source).must_equal({url: 'https://bitbucket.org/chef/inspec/get/newbranch.tar.gz', sha256: expected_shasum})
+    end
+
+    it "resolves a bitbucket commit url" do
+      bitbucket = 'https://bitbucket.org/chef/inspec/commits/48bd4388ddffde68badd83aefa654e7af3231876'
+      res = fetcher.resolve(bitbucket)
+      res.expects(:open).returns(mock_open)
+      _(res).wont_be_nil
+      _(res.resolved_source).must_equal({url: 'https://bitbucket.org/chef/inspec/get/48bd4388ddffde68badd83aefa654e7af3231876.tar.gz', sha256: expected_shasum})
+    end
+
   end
 
   describe 'applied to a valid url (mocked tar.gz)' do

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -96,12 +96,12 @@ describe Fetchers::Url do
        http://bitbucket.org/chef/inspec.git
        http://www.bitbucket.org/chef/inspec.git}.each do |bitbucket|
       it "resolves a bitbucket url #{bitbucket}" do
-           res = fetcher.resolve(bitbucket)
-           res.expects(:open).returns(mock_open)
-           _(res).wont_be_nil
-           _(res.resolved_source).must_equal({url: 'https://bitbucket.org/chef/inspec/get/master.tar.gz', sha256: expected_shasum})
-         end
-       end
+        res = fetcher.resolve(bitbucket)
+        res.expects(:open).returns(mock_open)
+        _(res).wont_be_nil
+        _(res.resolved_source).must_equal({url: 'https://bitbucket.org/chef/inspec/get/master.tar.gz', sha256: expected_shasum})
+      end
+    end
 
     it "resolves a bitbucket branch url" do
       bitbucket = 'https://bitbucket.org/chef/inspec/branch/newbranch'
@@ -112,7 +112,7 @@ describe Fetchers::Url do
     end
 
     it "resolves a bitbucket commit url" do
-      bitbucket = 'https://bitbucket.org/chef/inspec/commits/48bd4388ddffde68badd83aefa654e7af3231876'
+      bitbucket = 'https://bitbucket.org/chefsta/inspec/commits/48bd4388ddffde68badd83aefa654e7af3231876'
       res = fetcher.resolve(bitbucket)
       res.expects(:open).returns(mock_open)
       _(res).wont_be_nil

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -112,7 +112,7 @@ describe Fetchers::Url do
     end
 
     it "resolves a bitbucket commit url" do
-      bitbucket = 'https://bitbucket.org/chefsta/inspec/commits/48bd4388ddffde68badd83aefa654e7af3231876'
+      bitbucket = 'https://bitbucket.org/chef/inspec/commits/48bd4388ddffde68badd83aefa654e7af3231876'
       res = fetcher.resolve(bitbucket)
       res.expects(:open).returns(mock_open)
       _(res).wont_be_nil


### PR DESCRIPTION
The current master is smart enough to recognize urls for githib repositories/branches/commits and transform them into the url for the corresponding gzip, but it doesn't know how to handle bitbucket urls.  I've added a couple of regexes to recognize these patterns, and a few additional elsifs to make the necessary modifications when they're used.