### PR TITLE
Add warningaction to test-netconnection

### DIFF
--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -148,7 +148,7 @@ module Inspec::Resources
     def ping(hostname, port = nil, _proto = nil)
       # ICMP: Test-NetConnection www.microsoft.com
       # TCP and port: Test-NetConnection -ComputerName www.microsoft.com -RemotePort 80
-      request = "Test-NetConnection -ComputerName #{hostname}"
+      request = "Test-NetConnection -ComputerName #{hostname} -WarningAction SilentlyContinue"
       request += " -RemotePort #{port}" unless port.nil?
       request += '| Select-Object -Property ComputerName, TcpTestSucceeded, PingSucceeded | ConvertTo-Json'
       cmd = inspec.command(request)


### PR DESCRIPTION
Signed-off-by: Seth Thoenen <seththoenen@gmail.com>

If you audit a Windows machine with the `host` resource and the ping test fails, there will be a warning message printed to the console similar to this:
```
WARNING: Ping to 1.2.3.4 failed -- Status: TimedOut
{
    "ComputerName":  "1.2.3.4",
    "TcpTestSucceeded":  true,
    "PingSucceeded":  false
}
```

When this standard output is parsed into JSON on line 157, it fails since the WARNING message isn't valid JSON. Appending a `-WarningAction SilentlyContinue` to the `Test-NetConnection` command eliminates the  warning message and then the output is valid JSON and can be parsed successfully.