### PR TITLE
sudo-detection for target execution

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_dependency 'train', '>=0.22.0', '<1.0'
+  spec.add_dependency 'train', '>=0.24.0', '<1.0'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'rainbow', '~> 2'

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -155,13 +155,6 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
     configure_logger(opts)
     o = opts.dup
 
-    # print error if user passed --sudo but with no --target
-    if opts[:sudo] && opts[:target].nil?
-      Inspec::Log.error('--sudo is only valid when running against a remote host using --target')
-      Inspec::Log.error('To run InSpec locally with elevated privileges, run `sudo inspec exec ...`')
-      exit 1
-    end
-
     # run tests
     run_tests(targets, o)
   rescue StandardError => e


### PR DESCRIPTION
When running `inspec exec` without the `target` option but against remote endpoints OR when executing it with the `localhost://` target AND having `--sudo` active it would abort the execution. `--target` is a helper to set the Train parameters for `backend`, `host`, `user`, `port`, and potentially `password`. The detection would fail on providing any of these separately without specifying `--target`. The same holds true for the `localhost` train backend or just `localhost://` target.

This type of detection has since moved to Train. The driving reason was to have this very useful check for localhost vs sudo run for any type of inspec (or for that matter: train) execution.

This PR depends on https://github.com/chef/train/pull/179 and the next release of train.

Strongly influenced by the original bugfix: https://github.com/chef/inspec/pull/1741

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>