### PR TITLE
Fix version method call for refresh token

### DIFF
--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -355,7 +355,7 @@ module Compliance
       config['user'] = user
       config['insecure'] = insecure
       config['server_type'] = 'compliance'
-      config['version'] = Compliance::API.version(url, insecure)
+      config['version'] = Compliance::API.version(config)
 
       if !verify
         config.store


### PR DESCRIPTION
@chris-rock I think you missed one when you refactored `Compliance::API.version` here:

https://github.com/chef/inspec/commit/5cc288d5df673caa04db6260307563b65941d492

Fixes below error:
```
inspec compliance login https://compliance.something --user='someuser' --refresh-token='atoken'
/opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.26.0/lib/bundles/inspec-compliance/api.rb:64:in `version': wrong number of arguments (given 2, expected 1) (ArgumentError)
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.26.0/lib/bundles/inspec-compliance/cli.rb:358:in `store_refresh_token'
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.26.0/lib/bundles/inspec-compliance/cli.rb:48:in `login'
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/invocation.rb:115:in `invoke'
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor.rb:235:in `block in subcommand'
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.26.0/bin/inspec:12:in `<top (required)>'
	from /opt/inspec/bin/inspec:59:in `load'
	from /opt/inspec/bin/inspec:59:in `<main>'

```