### PR TITLE
Add windows support to the `processes` resource

### DIFF
--- a/docs/resources/processes.md.erb
+++ b/docs/resources/processes.md.erb
@@ -60,16 +60,31 @@ The following examples show how to use this InSpec audit resource.
       its('list.length') { should eq 1 }
     end
 
-### Test if the init process is owned by the root user
+### Test if the process is owned by a specifc user
 
     describe processes('init') do
       its('users') { should eq ['root'] }
     end
 
+    describe processes('winlogon') do
+      its('users') { should cmp "NT AUTHORITY\\SYSTEM" }
+    end
+
+
 ### Test if a high-priority process is running
 
-    describe processes('some_process') do
+    describe processes('linux_process') do
       its('states') { should eq ['R<'] }
+    end
+
+    describe processes('windows_process') do
+      its('labels') { should cmp "High" }
+    end
+
+### Test if a process exists on the system
+
+    describe processes('some_process') do
+      it { should exist }
     end
 
 ### Test for a process using a specific Regexp
@@ -81,3 +96,28 @@ needed.
     describe processes(Regexp.new("/usr/local/bin/swap -d")) do
       its('list.length') { should eq 1 }
     end
+
+### Notes for auditing Windows systems
+
+Sometimes with system properties there isn't a direct comparison between different operating systems.
+Most of the `property_name`'s do align between the different OS's.  
+
+There are however some exception's, for example, within linux `states` offers multiple properties. 
+Windows doesn't have direct comparison that is a single property so instead `states` is mapped to the property of `Responding`, This is a boolean true/false flag to help determine if the process is hung.
+
+Below is a mapping table to help you understand what property the unix field maps to the windows `Get-Process` Property
+
+| *unix ps field* | *windows PowerShell Property* |
+|:---------------:|:-----------------------------:|
+|labels           |PriorityClass|
+|pids             |Id|
+|cpus             |CPU|
+|mem              |PM|
+|vsz              |VirtualMemorySize|
+|rss              |NPM|
+|tty              |SessionId|
+|states           |Responding|
+|start            |StartTime|
+|time             |TotalProcessorTime|
+|users            |UserName|
+|commands         |Path|

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -303,10 +303,10 @@ class MockLoader
       'crontab -l' => cmd.call('crontab-root'),
       # crontab display for non-current user
       'crontab -l -u foouser' => cmd.call('crontab-foouser'),
-  	  # zfs output for dataset tank/tmp
-  	  '/sbin/zfs get -Hp all tank/tmp' => cmd.call('zfs-get-all-tank-tmp'),
-  	  # zfs output for pool tank
-  	  '/sbin/zpool get -Hp all tank' => cmd.call('zpool-get-all-tank'),
+      # zfs output for dataset tank/tmp
+      '/sbin/zfs get -Hp all tank/tmp' => cmd.call('zfs-get-all-tank-tmp'),
+      # zfs output for pool tank
+      '/sbin/zpool get -Hp all tank' => cmd.call('zpool-get-all-tank'),
       # docker
       "docker ps -a --no-trunc --format '{{ json . }}'" => cmd.call('docker-ps-a'),
       "docker version --format '{{ json . }}'"  => cmd.call('docker-version'),
@@ -314,8 +314,9 @@ class MockLoader
       "docker inspect 71b5df59442b" => cmd.call('docker-inspec'),
       # docker images
       "83c36bfade9375ae1feb91023cd1f7409b786fd992ad4013bf0f2259d33d6406" => cmd.call('docker-images'),
-     }
-
+      # get-process cmdlet for processes resource
+      '$Proc = Get-Process -IncludeUserName | Where-Object {$_.Path -ne $null } | Select-Object PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path | ConvertTo-Csv -NoTypeInformation;$Proc.Replace("""","").Replace("`r`n","`n")' => cmd.call('get-process_processes')
+    }
     @backend
   end
 

--- a/test/unit/mock/cmd/get-process_processes
+++ b/test/unit/mock/cmd/get-process_processes
@@ -1,0 +1,3 @@
+PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path
+Normal,2456,0.296875,4808704,118202368,14576,1,True,5/31/2017 9:13:17 AM,00:00:00.2968750,WINVAGR-QQQNHPN\Administrator,C:\Windows\system32\mmc.exe
+High,396,0.15625,1323008,53710848,7776,1,True,5/31/2017 9:12:56 AM,00:00:00.1562500,NT AUTHORITY\SYSTEM,C:\Windows\system32\winlogon.exe

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -109,6 +109,7 @@ describe 'Inspec::Resources::Processes' do
     resource = MockLoader.new(:centos6).load_resource('processes', 'postgres: bifrost bifrost')
     _(resource.users.sort).must_equal ['opscode-pgsql']
     _(resource.states.sort).must_equal ['Ss']
+    _(resource.exists?).must_equal true
   end
 
   it 'command name matches with output (string)' do
@@ -119,5 +120,25 @@ describe 'Inspec::Resources::Processes' do
   it 'command name matches with output (regex)' do
     resource = MockLoader.new(:centos6).load_resource('processes', /mysqld/)
     _(resource.to_s).must_equal 'Processes /mysqld/'
+  end
+
+  it 'command name matches with output (string)' do
+    resource = MockLoader.new(:windows).load_resource('processes', 'winlogon.exe')
+    _(resource.to_s).must_equal 'Processes winlogon.exe'
+  end
+
+  it 'retrieves the users and states as arrays on windows os' do
+    resource = MockLoader.new(:windows).load_resource('processes', 'winlogon.exe')
+    _(resource.users.sort).must_equal ['NT AUTHORITY\\SYSTEM']
+  end
+
+  it 'process should exist' do
+    resource = MockLoader.new(:windows).load_resource('processes', 'winlogon.exe')
+    _(resource.exists?).must_equal true
+  end
+
+  it 'process should_not exist' do
+    resource = MockLoader.new(:windows).load_resource('processes', 'unicorn.exe')
+    _(resource.exists?).must_equal false
   end
 end


### PR DESCRIPTION
Hi 

This PR is my attempt to really fix #1851 rather than patch it, by adding windows support.

I've also added an `exists` method as I found it useful. 

- [x] Add support for Windows
- [x] Add Exists Method
- [x] Create unit tests to include windows runner
- [x] Update the docs to include the an example for Exists
- [x] Update the docs to provide a windows example

  **Exists Method example...**
```
You are currently running on:

    OS platform:  ☺☻Windows Server 2012 R2 Standard☺☻
    OS family:  ☺☻windows☺☻
    OS release: ☺☻6.3.9600☺☻
inspec> describe processes('svchost') do
inspec>   it { should exist }
inspec> end

Profile: inspec-shell
Version: (not specified)

  Processes svchost
     [PASS]  should exist

Test Summary: 1 successful, 0 failures, 0 skipped
```


Any comments or feedback is appreciated.

**Question regarding converting strings**
Don't know if anyone has an opinion but I thought it was better to convert the cpu and memory stats to numbers to make it easier to use is something like is it greater than a number rather then use a regex to parse a string?  (Hope that makes sense :) I saw that the pid,vsz,rss where already converted.

but thought it could be a breaking change which is why they are only converted on windows.  Happy to strip out.

Well let me know what you think, happy to start work on the tests (something else to learn :)

Gary


 