### PR TITLE
Fix release_habitat rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -175,7 +175,7 @@ task :release_habitat do
         raise "Please set the HAB_AUTH_TOKEN environment variable"
     end
     cmd = "echo #{version} > ./habitat/VERSION && "\
-          "hab studio build ./habitat && " \
+          "hab pkg build . && " \
           "hab pkg upload ./results/*.hart"
     puts "--> #{cmd}"
     sh('sh', '-c', cmd)


### PR DESCRIPTION
A change made to how we generate the Gemfile during the Habitat build process means we cannot have the PLAN_CONTEXT be the "habitat" directory but instead need it to be the repo root itself.

Also changed to the preferred `hab pkg build` command instead of the original `hab studio build` command.