### PR TITLE
Use RubyGems version for habitat plan

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -45,7 +45,7 @@ do_prepare() {
   # Instead, we build a minimal Gemfile in the $CACHE_PATH and bundle using that.
   cat > "$CACHE_PATH/Gemfile" <<GEMFILE
 source 'https://rubygems.org'
-gem '$pkg_name', path: '$SRC_PATH'
+gem '$pkg_name', '= $pkg_version'
 GEMFILE
 
   export BUNDLE_SILENCE_ROOT_WARNING GEM_HOME GEM_PATH


### PR DESCRIPTION
In #1820 we made it so inspec would install the checked out source
version rather than the version from RubyGems.

This actually didn't work (though it wasn't apparent in a development
environment) because it used a relative path to bin/inspec that pointed
at /src/bin/inspec, which only exists if you're in a Habitat studio
started from the InSpec repo.

Revert back to getting the gem from RubyGems to avoid this problem and
have a working package.

![tenor-36056381](https://cloud.githubusercontent.com/assets/9912/26701637/877f9524-46e7-11e7-950a-8830fb7af919.gif)
