### PR TITLE
support FIPS 140-2 compliant digest calls

### DIFF
--- a/lib/fetchers/local.rb
+++ b/lib/fetchers/local.rb
@@ -2,6 +2,8 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 
+require 'openssl'
+
 module Fetchers
   class Local < Inspec.fetcher(1)
     name 'local'
@@ -65,7 +67,8 @@ module Fetchers
 
     def sha256
       return nil if File.directory?(@target)
-      @archive_shasum ||= Digest::SHA256.hexdigest File.read(@target)
+      @archive_shasum ||=
+        OpenSSL::Digest::SHA256.digest(File.read(@target)).unpack('H*')[0]
     end
 
     def resolved_source

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -3,7 +3,7 @@
 # author: Christoph Hartmann
 
 require 'uri'
-require 'digest'
+require 'openssl'
 require 'tempfile'
 require 'open-uri'
 
@@ -101,7 +101,7 @@ module Fetchers
 
     def sha256
       file = @archive_path || temp_archive_path
-      Digest::SHA256.hexdigest File.read(file)
+      OpenSSL::Digest::SHA256.digest(File.read(file)).unpack('H*')[0]
     end
 
     def file_type_from_remote(remote)

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require 'digest'
 require 'fileutils'
 
 module Inspec

--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require 'inspec/cached_fetcher'
 require 'inspec/dependencies/dependency_set'
-require 'digest'
 
 module Inspec
   #

--- a/lib/inspec/plugins/fetcher.rb
+++ b/lib/inspec/plugins/fetcher.rb
@@ -3,7 +3,6 @@
 # author: Christoph Hartmann
 require 'utils/plugin_registry'
 require 'inspec/file_provider'
-require 'digest'
 
 module Inspec
   module Plugins

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -4,7 +4,7 @@
 # author: Christoph Hartmann
 
 require 'forwardable'
-require 'digest'
+require 'openssl'
 require 'inspec/polyfill'
 require 'inspec/cached_fetcher'
 require 'inspec/file_provider'
@@ -406,7 +406,7 @@ module Inspec
       # get all dependency checksums
       deps = Hash[locked_dependencies.list.map { |k, v| [k, v.profile.sha256] }]
 
-      res = Digest::SHA256.new
+      res = OpenSSL::Digest::SHA256.new
       files = source_reader.tests.to_a + source_reader.libraries.to_a +
               source_reader.data_files.to_a +
               [['inspec.yml', source_reader.metadata.content]] +
@@ -415,7 +415,7 @@ module Inspec
       files.sort { |a, b| a[0] <=> b[0] }
            .map { |f| res << f[0] << "\0" << f[1] << "\0" }
 
-      res.hexdigest
+      res.digest.unpack('H*')[0]
     end
 
     private


### PR DESCRIPTION
Calling the `digest` library directly unfortunately causes issues in FIPS 140-2 mode:

    sha512.c(81): OpenSSL internal error, assertion failed:
    Low level API call to digest SHA512 forbidden in FIPS mode!

Switching to `OpenSSL` as the caller resolve these issues