### PR TITLE
Add a downloads page

### DIFF
--- a/www/source/downloads.html.slim
+++ b/www/source/downloads.html.slim
@@ -1,7 +1,70 @@
 ---
 title: InSpec - Downloads
+description: Download InSpec and start using Compliance-as-Code.
 ---
 
-javascript:
+.row.margin-both-offset
+  .columns.large-6.medium-6.mobile-grow
 
-  location.replace("http://downloads.chef.io/inspec");
+    h2#icon-trigger data-enllax-ratio=".1" data-enllax-type="foreground"
+
+      | Compliance as Code starts here.
+      br/
+      | Download InSpec and let's get started.
+    hr.strict-left.margin-under-xs
+    h3.clear
+      | Ready-made packages
+    p
+      | Installable packages that include everything you need to write and execute profiles.
+    p
+      a.btn.slack href="https://downloads.chef.io/inspec" Download InSpec
+    p.margin-under-xs
+      | InSpec is also included in the ChefDK.
+    h3
+      | Habitat Packages
+    p
+      | Use Habitat to install InSpec, or include InSpec in your own Habitat packages.
+    p.margin-under-xs
+      a.btn.forums href="https://bldr.habitat.sh/#/pkgs/chef/inspec" InSpec on the Depot
+    h3
+      | Use Your System Package Manager
+    p
+      | The same ready-made packages are available via yum and apt, too.
+    p.margin-under-xs
+      a.btn.events href="https://docs.chef.io/packages.html" Learn More
+
+  .columns.large-6.medium-6.relative.mobile-hide
+    img.grid.strict-right src="/images/community/blue-web.svg" /
+    img.ball src="/images/community/glow-ball.png" /
+    img.ball.bright-animate src="/images/community/glow-ball.png" /
+    img.ball src="/images/community/glow-ball.png" /
+
+.row
+  .icon.shadow
+    img src="/images/circ-arrow.svg" /
+.block-angl.blue-gradient.relative
+  .section.purp-shade
+    #particles-second
+     canvas.particles-js-canvas-el
+    .row.relative-top.padding-top-xl.padding-under
+        .large-6.medium-6.strict-center.column.margin-under-xs
+          .box-white.shadow
+            img.icon-art src="/images/community/contribute.svg" /
+            h3 Contribute to InSpec
+            p
+              | InSpec is an open source project created and supported by active and
+                passionate users. If you would like to contribute, we would love to have you.
+            br/
+            a.btn.margin-top-xs href="https://github.com/chef/inspec" Start Contributing
+            p
+
+        .large-6.medium-6.strict-center.column
+          .box-white.shadow
+            img.icon-art src="/images/community/bugs.svg" /
+            h3 Report Bugs and Request Features
+            p
+              | We rely on your feedback to improve InSpec. <br>Whether you found a bug
+                or have a great idea for an improvement, join us on GitHub.
+            br/
+            a.btn.margin-top-xs href="https://github.com/chef/inspec/issues" Give Feedback
+            p

--- a/www/source/downloads.html.slim
+++ b/www/source/downloads.html.slim
@@ -19,7 +19,7 @@ description: Download InSpec and start using Compliance-as-Code.
     p
       a.btn.slack href="https://downloads.chef.io/inspec" Download InSpec
     p.margin-under-xs
-      | InSpec is also included in the ChefDK.
+      | InSpec is also included in the <a href="https://downloads.chef.io/chefdk">ChefDK</a> and is available as a standalone <a href="https://rubygems.org/gems/inspec">Ruby gem</a>.
     h3
       | Habitat Packages
     p

--- a/www/source/layouts/_nav.slim
+++ b/www/source/layouts/_nav.slim
@@ -27,7 +27,7 @@ nav#main-nav
       li.main-nav--link.nav-cta.hide-for-small-only
         a.btn.try-demo href="/tutorial" Try the Demo
       li.main-nav--link.nav-cta
-        a.btn href="https://downloads.chef.io/inspec" 
+        a.btn href="/downloads"
           i.fa.fa-cloud-download
           span.main-nav--link-text Download
           


### PR DESCRIPTION
Having a dedicated downloads page will allow us to better communicate different ways of downloading InSpec and also provide links to helpful documentation.

Fixes #1344