### PR TITLE
remove duplicate message in describe.one blocks

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -52,7 +52,7 @@ class InspecRspecMiniJson < RSpec::Core::Formatters::JsonFormatter
       format_example(example).tap do |hash|
         e = example.exception
         next unless e
-        hash[:message] = e.message
+        hash[:message] = exception_message(e)
 
         next if e.is_a? RSpec::Expectations::ExpectationNotMetError
         hash[:exception] = e.class.name
@@ -62,6 +62,14 @@ class InspecRspecMiniJson < RSpec::Core::Formatters::JsonFormatter
   end
 
   private
+
+  def exception_message(exception)
+    if exception.is_a?(RSpec::Core::MultipleExceptionError)
+      exception.all_exceptions.map(&:message).uniq.join("\n\n")
+    else
+      exception.message
+    end
+  end
 
   def format_example(example)
     if !example.metadata[:description_args].empty? && example.metadata[:skip]

--- a/test/functional/inspec_exec_jsonmin_test.rb
+++ b/test/functional/inspec_exec_jsonmin_test.rb
@@ -28,6 +28,14 @@ describe 'inspec exec' do
     JSON::Schema.validate(data, schema)
   end
 
+  it 'does not contain any dupilcate results with describe.one' do
+    out = inspec("shell -c 'describe.one do describe 1 do it { should cmp 2 } end end' --format=json-min")
+    out.stderr.must_equal ''
+    data = JSON.parse(out.stdout)
+    data['controls'].length.must_equal 1
+    data['controls'][0]['message'].must_equal "\nexpected: 2\n     got: 1\n\n(compared using `cmp` matcher)\n"
+  end
+
   describe 'execute a profile with mini json formatting' do
     let(:json) { JSON.load(inspec('exec ' + example_profile + ' --format json-min --no-create-lockfile').stdout) }
     let(:controls) { json['controls'] }


### PR DESCRIPTION
Generated duplicate messages due to the way that examples are aggregated in RSpec. Make sure we never show any duplicate test result messages, as they offer not value to any user.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>