### PR TITLE
Add warning for potential empty password option

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -155,6 +155,20 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
     configure_logger(opts)
     o = opts.dup
 
+    # Thor is silly. If you supply a flag like --password but don't provide a value,
+    # it uses a value matching the name of the options key. In this case: {'password' => 'password'}
+    # But some users may pass in --password expecting it to prompt for a password or
+    # otherwise. This means there's really no way for us to detect if a user is
+    # trying to login with a password of "password" or if they supplied --password
+    # without a value.
+    #
+    # This is a helpful warning that perhaps InSpec is going to try and log in with a
+    # password they didn't mean to.
+    if opts[:password] == 'password'
+      Inspec::Log.warn('Attempting to log in using a password of "password"')
+      Inspec::Log.warn('If this is intended, you can ignore this warning. If this is not intended, it is likely because you supplied --password without providing a password.')
+    end
+
     # run tests
     run_tests(targets, o)
   rescue StandardError => e


### PR DESCRIPTION
If a user supplies --password on the command line but fails to provide a value, Thor will set the value of the `password` option to the word "password". Users may expect to be prompted for a password if leaving this blank, but InSpec will happily try to log in to the target system with the password of "password".

Unfortunately, there is no way to alter Thor's behavior for this, and users may actually have a password of "password".

Proposing we add a warning if the password is "password" in an attempt to catch those users that accidentally provide an empty password. It may also serve as a warning to users that legitimately have a password of "password" they should perhaps use a different phrase. :)

Fixes #1901