### PR TITLE
inspec archive for tgz files on windows

### DIFF
--- a/lib/inspec/archive/tar.rb
+++ b/lib/inspec/archive/tar.rb
@@ -17,7 +17,7 @@ module Inspec::Archive
                 tar.mkdir(input_filename, stat.mode)
               else
                 tar.add_file_simple(input_filename, stat.mode, stat.size) do |io|
-                  io.write(File.read(path))
+                  io.write(File.binread(path))
                 end
               end
             end


### PR DESCRIPTION
On Windows, `inspec archive` would sometimes produce incorrect archive files. These would look fine, as tgz files, but would not execute correctly. This would lead to bewildering error messages like this one:

```
Unable to parse inspec.yml: line 1, control characters are not allowed
```

Fix it by treating the files as binary before writing them to get around any encoding issues, since the stream handler is a raw io object anyway.

Closely related to https://github.com/chef/inspec/pull/1906