### PR TITLE
Updated unit tests for the groups resource

### DIFF
--- a/test/unit/resources/group_test.rb
+++ b/test/unit/resources/group_test.rb
@@ -26,7 +26,7 @@ describe 'Inspec::Resources::Group' do
   it 'verify group on ubuntu' do
     resource = MockLoader.new(:ubuntu1404).load_resource('group', 'nogroup')
     _(resource.exists?).must_equal false
-    _(resource.gid).must_equal nil
+    _(resource.gid).must_be_nil
     _(resource.has_gid?(0)).must_equal false
   end
 
@@ -52,13 +52,15 @@ describe 'Inspec::Resources::Group' do
     _(resource.exists?).must_equal true
     _(resource.gid).must_equal 'S-1-5-32-544'
     _(resource.has_gid?(0)).must_equal false
+    _(resource.local).must_equal true
+    _(resource.to_s).must_equal 'Group Administrators'
   end
 
   # windows non-existent group
   it 'verify non-existing group on windows' do
     resource = MockLoader.new(:windows).load_resource('group', 'dhcp')
     _(resource.exists?).must_equal false
-    _(resource.gid).must_equal nil
+    _(resource.gid).must_be_nil
     _(resource.has_gid?(0)).must_equal false
   end
 
@@ -66,8 +68,7 @@ describe 'Inspec::Resources::Group' do
   it 'verify package handling on unsupported os' do
     resource = MockLoader.new(:undefined).load_resource('group', 'root')
     _(resource.exists?).must_equal false
-    _(resource.gid).must_equal nil
+    _(resource.gid).must_be_nil
     _(resource.has_gid?(0)).must_equal false
   end
-
 end


### PR DESCRIPTION
Hi 

I noticed a number of DEPRECATED messages when rake testing last week, I thought I would attempt to resolve them, So this PR is to start to remove the Minitest DEPRECATED messages.  I've also tried to improve the coverage or this resource/
 example.....
`DEPRECATED: Use assert_nil if expecting nil from C:/git-repo/chef/inspec/test/unit/shell_detector_test.rb:75. This will fail in Minitest 6.`

Let me know if this if OK and I'll chip away at these whilst my other half watches soaps :)

Best Regards

Gary