### PR TITLE
Fix code block CSS.

### DIFF
--- a/www/source/stylesheets/_code.scss
+++ b/www/source/stylesheets/_code.scss
@@ -7,6 +7,10 @@ code {
 	border-color: $color_lt_blue;
 }
 
+.highlight code {
+  padding-left: 0;
+}
+
 pre {
     padding: 10px;
     margin-bottom: 1em;


### PR DESCRIPTION
Hi,

While looking at the Inspec docs recently, I noticed what looked like some extra whitespace in the code samples. It turns out that it's actually some left padding that makes it look like the first line of a code block look like it has an extra space in front of it. The attached CSS fixes things for me.

| Before | After |
| --- | --- |
| ![Before Resource DSL](https://user-images.githubusercontent.com/22962/26955997-955db026-4c6f-11e7-8c18-b6cf8f867061.png) | ![After Resource DSL](https://user-images.githubusercontent.com/22962/26956099-3d7d892a-4c70-11e7-866e-654efd961077.png) | 
| ![Before service resource](https://user-images.githubusercontent.com/22962/26956006-a0a864a8-4c6f-11e7-8e4d-a75c9b7935d3.png) | ![After service resource](https://user-images.githubusercontent.com/22962/26956122-67518468-4c70-11e7-9d80-6a8f3caf0dbd.png)
 |





