### PR TITLE
Remove relative path from Gemfile.

### DIFF
--- a/www/Gemfile
+++ b/www/Gemfile
@@ -25,7 +25,7 @@ gem 'github-markup'
 gem 'docker-api'
 
 # Build process requirements
-gem 'inspec', path: File.join(File.expand_path(File.dirname(__FILE__)), '..')
+gem 'inspec', path: '..'
 gem 'rake'
 gem 'ruby-progressbar'
 gem 'inquirer'

--- a/www/Gemfile.lock
+++ b/www/Gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /Users/aleff/projects/inspec
+  remote: ..
   specs:
     inspec (1.27.0)
       addressable (~> 2.4)


### PR DESCRIPTION
Removes a relative path from the `Gemfile.lock`. Without this change, running `bundle install` modifies the `Gemfile.lock` with a path specific to my machine, making it a hassle to change between branches.