### PR TITLE
Update minitest nil assertions

### DIFF
--- a/test/unit/resources/bridge_test.rb
+++ b/test/unit/resources/bridge_test.rb
@@ -38,7 +38,7 @@ describe 'Inspec::Resources::Bridge' do
     _(resource.exists?).must_equal true
 
     # get associated interfaces is not supported on windows
-    _(resource.interfaces).must_equal nil
+    _(resource.interfaces).must_be_nil
   end
 
   it 'check bridge on unsupported os' do
@@ -51,6 +51,6 @@ describe 'Inspec::Resources::Bridge' do
     _(resource.has_interface?('eth2')).must_equal false
 
     # get associated interfaces
-    _(resource.interfaces).must_equal nil
+    _(resource.interfaces).must_be_nil
   end
 end

--- a/test/unit/resources/docker_container_test.rb
+++ b/test/unit/resources/docker_container_test.rb
@@ -11,7 +11,7 @@ describe 'Inspec::Resources::DockerContainer' do
       _(resource.id).must_equal 'd94f854370d2b02912e8fc636502bc72b74fbd567a7eba3fc6a52045bb28904e'
       _(resource.image).must_equal 'alpine'
       _(resource.repo).must_equal 'alpine'
-      _(resource.tag).must_equal nil
+      _(resource.tag).must_be_nil
       _(resource.command).must_equal '/bin/sh'
       _(resource.ports).must_equal ''
     end

--- a/test/unit/resources/group_test.rb
+++ b/test/unit/resources/group_test.rb
@@ -26,7 +26,7 @@ describe 'Inspec::Resources::Group' do
   it 'verify group on ubuntu' do
     resource = MockLoader.new(:ubuntu1404).load_resource('group', 'nogroup')
     _(resource.exists?).must_equal false
-    _(resource.gid).must_equal nil
+    _(resource.gid).must_be_nil
     _(resource.has_gid?(0)).must_equal false
   end
 
@@ -58,7 +58,7 @@ describe 'Inspec::Resources::Group' do
   it 'verify non-existing group on windows' do
     resource = MockLoader.new(:windows).load_resource('group', 'dhcp')
     _(resource.exists?).must_equal false
-    _(resource.gid).must_equal nil
+    _(resource.gid).must_be_nil
     _(resource.has_gid?(0)).must_equal false
   end
 
@@ -66,7 +66,7 @@ describe 'Inspec::Resources::Group' do
   it 'verify package handling on unsupported os' do
     resource = MockLoader.new(:undefined).load_resource('group', 'root')
     _(resource.exists?).must_equal false
-    _(resource.gid).must_equal nil
+    _(resource.gid).must_be_nil
     _(resource.has_gid?(0)).must_equal false
   end
 

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -39,7 +39,7 @@ describe 'Inspec::Resources::Host' do
     resource = MockLoader.new(:undefined).load_resource('host', 'example.com')
     _(resource.resolvable?).must_equal false
     _(resource.reachable?).must_equal false
-    _(resource.ipaddress).must_equal nil
+    _(resource.ipaddress).must_be_nil
   end
 
 end

--- a/test/unit/resources/inetd_conf_test.rb
+++ b/test/unit/resources/inetd_conf_test.rb
@@ -8,8 +8,8 @@ require 'inspec/resource'
 describe 'Inspec::Resources::InetdConf' do
   it 'verify limits.conf config parsing' do
     resource = load_resource('inetd_conf')
-    _(resource.send('shell')).must_equal nil
-    _(resource.send('login')).must_equal nil
+    _(resource.send('shell')).must_be_nil
+    _(resource.send('login')).must_be_nil
     _(resource.send('ftp')).must_equal %w{stream tcp nowait root /usr/sbin/in.ftpd in.ftpd}
   end
 end

--- a/test/unit/resources/interface_test.rb
+++ b/test/unit/resources/interface_test.rb
@@ -19,7 +19,7 @@ describe 'Inspec::Resources::Interface' do
     resource = MockLoader.new(:ubuntu1404).load_resource('interface', 'eth1')
     _(resource.exists?).must_equal false
     _(resource.up?).must_equal false
-    _(resource.speed).must_equal nil
+    _(resource.speed).must_be_nil
   end
 
   it 'verify interface on windows' do
@@ -40,7 +40,7 @@ describe 'Inspec::Resources::Interface' do
     resource = MockLoader.new(:windows).load_resource('interface', 'eth1')
     _(resource.exists?).must_equal false
     _(resource.up?).must_equal false
-    _(resource.speed).must_equal nil
+    _(resource.speed).must_be_nil
   end
 
   # undefined
@@ -48,7 +48,7 @@ describe 'Inspec::Resources::Interface' do
     resource = MockLoader.new(:undefined).load_resource('interface', 'eth0')
     _(resource.exists?).must_equal false
     _(resource.up?).must_equal false
-    _(resource.speed).must_equal nil
+    _(resource.speed).must_be_nil
   end
 
 end

--- a/test/unit/resources/login_def_test.rb
+++ b/test/unit/resources/login_def_test.rb
@@ -11,6 +11,6 @@ describe 'Inspec::Resources::LoginDef' do
     _(resource.UMASK).must_equal '022'
     _(resource.PASS_MIN_DAYS).must_equal '0'
     _(resource.PASS_WARN_AGE).must_equal '7'
-    _(resource.USERDEL_CMD).must_equal nil
+    _(resource.USERDEL_CMD).must_be_nil
   end
 end

--- a/test/unit/resources/oneget_test.rb
+++ b/test/unit/resources/oneget_test.rb
@@ -39,7 +39,7 @@ describe 'Inspec::Resources::OneGet' do
     resource = MockLoader.new(:centos7).load_resource('oneget', 'Not available')
     pkg = { type: 'oneget', installed: false }
     _(resource.installed?).must_equal false
-    _(resource.version).must_equal nil
+    _(resource.version).must_be_nil
     _(resource.info).must_equal pkg
   end
 end

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -100,6 +100,6 @@ describe 'Inspec::Resources::Package' do
   it 'verify package handling on unsupported os' do
     resource = MockLoader.new(:undefined).load_resource('package', 'curl')
     _(resource.installed?).must_equal false
-    _(resource.info).must_equal nil
+    _(resource.info).must_be_nil
   end
 end

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -29,7 +29,7 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'upstart'
     _(resource.name).must_equal 'ssh'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
@@ -41,12 +41,12 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'upstart'
     _(resource.name).must_equal 'ssh'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
-    _(resource.params.UnitFileState).must_equal nil
+    _(resource.params.UnitFileState).must_be_nil
   end
 
   # ubuntu 15.04 with systemd
@@ -81,7 +81,7 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'upstart'
     _(resource.name).must_equal 'ssh'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
@@ -93,12 +93,12 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'upstart'
     _(resource.name).must_equal 'ssh'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
-    _(resource.params.UnitFileState).must_equal nil
+    _(resource.params.UnitFileState).must_be_nil
   end
 
   # mint 18 with systemd
@@ -133,12 +133,12 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'sysv'
     _(resource.name).must_equal 'sshd'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
-    _(resource.params.SubState).must_equal nil
+    _(resource.params.SubState).must_be_nil
   end
 
   it 'verify centos 6 package parsing with default sysv_service' do
@@ -146,7 +146,7 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'sysv'
     _(resource.name).must_equal 'sshd'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
@@ -197,7 +197,7 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'bsd-init'
     _(resource.name).must_equal 'sendmail'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
@@ -209,7 +209,7 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'bsd-init'
     _(resource.name).must_equal 'sendmail'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
@@ -235,7 +235,7 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'sysv'
     _(resource.name).must_equal 'sshd'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
@@ -261,7 +261,7 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'darwin'
     _(resource.name).must_equal 'org.openbsd.ssh-agent'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
@@ -273,7 +273,7 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'darwin'
     _(resource.name).must_equal 'com.apple.FilesystemUI'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal false
@@ -285,7 +285,7 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'darwin'
     _(resource.name).must_equal 'org.openbsd.ssh-agent'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
@@ -298,7 +298,7 @@ describe 'Inspec::Resources::Service' do
     params = Hashie::Mash.new({})
     _(resource.type).must_equal 'sysv'
     _(resource.name).must_equal 'sshd'
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.installed?).must_equal true
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
@@ -311,7 +311,7 @@ describe 'Inspec::Resources::Service' do
     resource = MockLoader.new(:undefined).load_resource('service', 'dhcp')
     params = Hashie::Mash.new({})
     _(resource.installed?).must_equal false
-    _(resource.description).must_equal nil
+    _(resource.description).must_be_nil
     _(resource.params).must_equal params
   end
 

--- a/test/unit/resources/ssh_conf_test.rb
+++ b/test/unit/resources/ssh_conf_test.rb
@@ -11,7 +11,7 @@ describe 'Inspec::Resources::SshConf' do
     it 'check ssh config parsing' do
       resource = load_resource('ssh_config')
       _(resource.Host).must_equal '*'
-      _(resource.Tunnel).must_equal nil
+      _(resource.Tunnel).must_be_nil
       _(resource.SendEnv).must_equal 'LANG LC_*'
       _(resource.HashKnownHosts).must_equal 'yes'
     end
@@ -28,7 +28,7 @@ describe 'Inspec::Resources::SshConf' do
       resource = load_resource('sshd_config')
       _(resource.Port).must_equal '22'
       _(resource.UsePAM).must_equal 'yes'
-      _(resource.ListenAddress).must_equal nil
+      _(resource.ListenAddress).must_be_nil
       _(resource.HostKey).must_equal [
         '/etc/ssh/ssh_host_rsa_key',
         '/etc/ssh/ssh_host_dsa_key',

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -81,9 +81,9 @@ describe 'Inspec::Resources::User' do
     _(resource.groups).must_equal ['root']
     _(resource.home).must_equal '/root'
     _(resource.shell).must_equal '/bin/csh'
-    _(resource.mindays).must_equal nil
-    _(resource.maxdays).must_equal nil
-    _(resource.warndays).must_equal nil
+    _(resource.mindays).must_be_nil
+    _(resource.maxdays).must_be_nil
+    _(resource.warndays).must_be_nil
   end
 
   it 'read user on OSX' do
@@ -93,22 +93,22 @@ describe 'Inspec::Resources::User' do
     _(resource.groups).must_equal ['staff', 'com.apple.sharepoint.group.1', 'everyone']
     _(resource.home).must_equal '/Users/chartmann'
     _(resource.shell).must_equal '/bin/zsh'
-    _(resource.mindays).must_equal nil
-    _(resource.maxdays).must_equal nil
-    _(resource.warndays).must_equal nil
+    _(resource.mindays).must_be_nil
+    _(resource.maxdays).must_be_nil
+    _(resource.warndays).must_be_nil
   end
 
   it 'read administrator user on Windows' do
     resource = MockLoader.new(:windows).load_resource('user', 'Administrator')
     _(resource.uid).wont_be_nil
     _(resource.exists?).must_equal true
-    _(resource.group).must_equal nil
+    _(resource.group).must_be_nil
     _(resource.groups).must_equal ['Administrators', 'Users']
-    _(resource.home).must_equal nil
-    _(resource.shell).must_equal nil
-    _(resource.mindays).must_equal nil
-    _(resource.maxdays).must_equal nil
-    _(resource.warndays).must_equal nil
+    _(resource.home).must_be_nil
+    _(resource.shell).must_be_nil
+    _(resource.mindays).must_be_nil
+    _(resource.maxdays).must_be_nil
+    _(resource.warndays).must_be_nil
     _(resource.disabled?).must_equal false
   end
 
@@ -116,13 +116,13 @@ describe 'Inspec::Resources::User' do
     resource = MockLoader.new(:windows).load_resource('user', 'Guest')
     _(resource.uid).wont_be_nil
     _(resource.exists?).must_equal true
-    _(resource.group).must_equal nil
+    _(resource.group).must_be_nil
     _(resource.groups).must_equal ['Users']
-    _(resource.home).must_equal nil
-    _(resource.shell).must_equal nil
-    _(resource.mindays).must_equal nil
-    _(resource.maxdays).must_equal nil
-    _(resource.warndays).must_equal nil
+    _(resource.home).must_be_nil
+    _(resource.shell).must_be_nil
+    _(resource.mindays).must_be_nil
+    _(resource.maxdays).must_be_nil
+    _(resource.warndays).must_be_nil
     _(resource.disabled?).must_equal true
   end
 
@@ -136,12 +136,12 @@ describe 'Inspec::Resources::User' do
   it 'read user on undefined os' do
     resource = MockLoader.new(:undefined).load_resource('user', 'root')
     _(resource.exists?).must_equal false
-    _(resource.group).must_equal nil
-    _(resource.groups).must_equal nil
-    _(resource.home).must_equal nil
-    _(resource.shell).must_equal nil
-    _(resource.mindays).must_equal nil
-    _(resource.maxdays).must_equal nil
-    _(resource.warndays).must_equal nil
+    _(resource.group).must_be_nil
+    _(resource.groups).must_be_nil
+    _(resource.home).must_be_nil
+    _(resource.shell).must_be_nil
+    _(resource.mindays).must_be_nil
+    _(resource.maxdays).must_be_nil
+    _(resource.warndays).must_be_nil
   end
 end

--- a/test/unit/resources/wmi_test.rb
+++ b/test/unit/resources/wmi_test.rb
@@ -25,18 +25,18 @@ describe 'Inspec::Resources::WMI' do
   # ubuntu 14.04 with upstart
   it 'fail wmi on ubuntu' do
     resource = MockLoader.new(:ubuntu1404).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
-    _(resource.send('DisplayName')).must_equal nil
+    _(resource.send('DisplayName')).must_be_nil
   end
 
   # centos 7 with systemd
   it 'fail wmi on centos' do
     resource = MockLoader.new(:centos7).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
-    _(resource.send('DisplayName')).must_equal nil
+    _(resource.send('DisplayName')).must_be_nil
   end
 
   # unknown OS
   it 'fail wmi on unknown os' do
     resource = MockLoader.new(:undefined).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
-    _(resource.send('DisplayName')).must_equal nil
+    _(resource.send('DisplayName')).must_be_nil
   end
 end


### PR DESCRIPTION
`must_equal nil` will fail in MiniTest 6. Changing those to `must_be_nil`
quiets down all the warnings we currently see and preps us for Minitest 6.