### PR TITLE
Reduce warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,9 +4,6 @@
 require 'bundler'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
-
-PROJECT_DIR = File.expand_path(".")
-
 require_relative 'tasks/changelog'
 require_relative 'tasks/maintainers'
 require_relative 'tasks/spdx'

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,9 @@
 require 'bundler'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
+
+PROJECT_DIR = File.expand_path(".")
+
 require_relative 'tasks/changelog'
 require_relative 'tasks/maintainers'
 require_relative 'tasks/spdx'

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -96,6 +96,8 @@ module Fetchers
       @insecure = opts['insecure']
       @token = opts['token']
       @config = opts
+      @archive_path = nil
+      @temp_archive_path = nil
     end
 
     def fetch(path)

--- a/lib/inspec/plugins/resource.rb
+++ b/lib/inspec/plugins/resource.rb
@@ -58,7 +58,7 @@ module Inspec
         end
 
         def resource_skipped
-          @resource_skipped
+          @resource_skipped if defined?(@resource_skipped)
         end
 
         def skip_resource(message)

--- a/lib/resources/auditd_rules.rb
+++ b/lib/resources/auditd_rules.rb
@@ -86,6 +86,7 @@ module Inspec::Resources
         @legacy = AuditdRulesLegacy.new(@content)
       else
         parse_content
+        @legacy = nil
       end
     end
 

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -20,7 +20,6 @@ require 'ruby-progressbar'
 require 'fileutils'
 require_relative './shared'
 
-PROJECT_DIR = File.join(File.expand_path(File.dirname(__FILE__)), '..').freeze
 WWW_DIR     = File.join(PROJECT_DIR, 'www').freeze
 DOCS_DIR    = File.join(PROJECT_DIR, 'docs').freeze
 

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -20,8 +20,8 @@ require 'ruby-progressbar'
 require 'fileutils'
 require_relative './shared'
 
-WWW_DIR     = File.join(PROJECT_DIR, 'www').freeze
-DOCS_DIR    = File.join(PROJECT_DIR, 'docs').freeze
+WWW_DIR     = File.expand_path(File.join(__dir__, '..', 'www')).freeze
+DOCS_DIR    = File.expand_path(File.join(__dir__, '..', 'docs')).freeze
 
 class Markdown
   class << self

--- a/tasks/spdx.rb
+++ b/tasks/spdx.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-UTILS_DIR = File.join(PROJECT_DIR, 'lib/utils').freeze
+UTILS_DIR = File.expand_path(File.join(__dir__, '..', 'lib/utils')).freeze
 
 desc 'Updates the list of the spdx valid licenses'
 task :spdx do

--- a/tasks/spdx.rb
+++ b/tasks/spdx.rb
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-PROJECT_DIR = File.join(File.expand_path(File.dirname(__FILE__)), '..').freeze
-UTILS_DIR     = File.join(PROJECT_DIR, 'lib/utils').freeze
+UTILS_DIR = File.join(PROJECT_DIR, 'lib/utils').freeze
 
 desc 'Updates the list of the spdx valid licenses'
 task :spdx do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -38,6 +38,8 @@ require 'train'
 CMD = Train.create('local').connection
 TMP_CACHE = {}
 
+Inspec::Log.logger = Logger.new(nil)
+
 class MockLoader
   # collects emulation operating systems
   OPERATING_SYSTEMS = {

--- a/test/unit/dsl/other_keywords_test.rb
+++ b/test/unit/dsl/other_keywords_test.rb
@@ -7,7 +7,7 @@ require 'helper'
 describe 'inspec keyword' do
   def load(content)
     runner = Inspec::Runner.new({backend: 'mock'})
-    res = runner.eval_with_virtual_profile(content)
+    runner.eval_with_virtual_profile(content)
   end
 
   def load_in_profile(cmd)

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -4,11 +4,9 @@
 require 'helper'
 
 describe Fetchers::Url do
-  let(:fetcher) { Fetchers::Url }
-
   it 'registers with the fetchers registry' do
     reg = Inspec::Fetcher.registry
-    _(reg['url']).must_equal fetcher
+    _(reg['url']).must_equal Fetchers::Url
   end
 
   describe 'testing different urls' do
@@ -24,7 +22,7 @@ describe Fetchers::Url do
 
     it 'handles a http url' do
       url = 'http://chef.io/some.tar.gz'
-      res = fetcher.resolve(url)
+      res = Fetchers::Url.resolve(url)
       res.expects(:open).returns(mock_open)
       _(res).must_be_kind_of Fetchers::Url
       _(res.resolved_source).must_equal({url: 'http://chef.io/some.tar.gz', sha256: expected_shasum})
@@ -32,7 +30,7 @@ describe Fetchers::Url do
 
     it 'handles a https url' do
       url = 'https://chef.io/some.tar.gz'
-      res = fetcher.resolve(url)
+      res = Fetchers::Url.resolve(url)
       res.expects(:open).returns(mock_open)
       _(res).must_be_kind_of Fetchers::Url
       _(res.resolved_source).must_equal({url: 'https://chef.io/some.tar.gz', sha256: expected_shasum})
@@ -40,11 +38,11 @@ describe Fetchers::Url do
     end
 
     it 'doesnt handle other schemas' do
-      fetcher.resolve('gopher://chef.io/some.tar.gz').must_be_nil
+      Fetchers::Url.resolve('gopher://chef.io/some.tar.gz').must_be_nil
     end
 
     it 'only handles URLs' do
-      fetcher.resolve(__FILE__).must_be_nil
+      Fetchers::Url.resolve(__FILE__).must_be_nil
     end
 
     %w{https://github.com/chef/inspec
@@ -54,7 +52,7 @@ describe Fetchers::Url do
        http://github.com/chef/inspec.git
        http://www.github.com/chef/inspec.git}.each do |github|
       it "resolves a github url #{github}" do
-        res = fetcher.resolve(github)
+        res = Fetchers::Url.resolve(github)
         res.expects(:open).returns(mock_open)
         _(res).wont_be_nil
         _(res.resolved_source).must_equal({url: 'https://github.com/chef/inspec/archive/master.tar.gz', sha256: expected_shasum})
@@ -63,7 +61,7 @@ describe Fetchers::Url do
 
     it "resolves a github branch url" do
       github = 'https://github.com/hardening-io/tests-os-hardening/tree/2.0'
-      res = fetcher.resolve(github)
+      res = Fetchers::Url.resolve(github)
       res.expects(:open).returns(mock_open)
       _(res).wont_be_nil
       _(res.resolved_source).must_equal({url: 'https://github.com/hardening-io/tests-os-hardening/archive/2.0.tar.gz', sha256: expected_shasum})
@@ -71,7 +69,7 @@ describe Fetchers::Url do
 
     it "resolves a github commit url" do
       github = 'https://github.com/hardening-io/tests-os-hardening/tree/48bd4388ddffde68badd83aefa654e7af3231876'
-      res = fetcher.resolve(github)
+      res = Fetchers::Url.resolve(github)
       res.expects(:open).returns(mock_open)
       _(res).wont_be_nil
       _(res.resolved_source).must_equal({url: 'https://github.com/hardening-io/tests-os-hardening/archive/48bd4388ddffde68badd83aefa654e7af3231876.tar.gz',
@@ -85,7 +83,7 @@ describe Fetchers::Url do
        http://bitbucket.org/chef/inspec.git
        http://www.bitbucket.org/chef/inspec.git}.each do |bitbucket|
       it "resolves a bitbucket url #{bitbucket}" do
-        res = fetcher.resolve(bitbucket)
+        res = Fetchers::Url.resolve(bitbucket)
         res.expects(:open).returns(mock_open)
         _(res).wont_be_nil
         _(res.resolved_source).must_equal({url: 'https://bitbucket.org/chef/inspec/get/master.tar.gz', sha256: expected_shasum})
@@ -94,7 +92,7 @@ describe Fetchers::Url do
 
     it "resolves a bitbucket branch url" do
       bitbucket = 'https://bitbucket.org/chef/inspec/branch/newbranch'
-      res = fetcher.resolve(bitbucket)
+      res = Fetchers::Url.resolve(bitbucket)
       res.expects(:open).returns(mock_open)
       _(res).wont_be_nil
       _(res.resolved_source).must_equal({url: 'https://bitbucket.org/chef/inspec/get/newbranch.tar.gz', sha256: expected_shasum})
@@ -102,7 +100,7 @@ describe Fetchers::Url do
 
     it "resolves a bitbucket commit url" do
       bitbucket = 'https://bitbucket.org/chef/inspec/commits/48bd4388ddffde68badd83aefa654e7af3231876'
-      res = fetcher.resolve(bitbucket)
+      res = Fetchers::Url.resolve(bitbucket)
       res.expects(:open).returns(mock_open)
       _(res).wont_be_nil
       _(res.resolved_source).must_equal({url: 'https://bitbucket.org/chef/inspec/get/48bd4388ddffde68badd83aefa654e7af3231876.tar.gz', sha256: expected_shasum})
@@ -113,7 +111,7 @@ describe Fetchers::Url do
   describe 'applied to a valid url (mocked tar.gz)' do
     let(:mock_file) { MockLoader.profile_tgz('complete-profile') }
     let(:target) { 'http://myurl/file.tar.gz' }
-    let(:subject) { fetcher.resolve(target) }
+    let(:subject) { Fetchers::Url.resolve(target) }
     let(:mock_open) {
       m = Minitest::Mock.new
       m.expect :meta, {'content-type' => 'application/gzip'}

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -12,17 +12,6 @@ describe Fetchers::Url do
   end
 
   describe 'testing different urls' do
-
-    let(:fetcher) {
-      Class.new(Fetchers::Url) do
-        attr_reader :target, :archive
-        def initialize(target, opts)
-          @target = target
-          @archive = File.new(__FILE__)
-        end
-      end
-    }
-
     # We don't use the MockLoader here becuase it produces tarballs
     # with different sha's on each run
     let(:expected_shasum) { "98b1ae45059b004178a8eee0c1f6179dcea139c0fd8a69ee47a6f02d97af1f17" }


### PR DESCRIPTION
I noticed yesterday the test output was pretty noisy. I fixed some of the low hanging fruit and knocked just over 100 lines off the output:

```
Petes-MBP:inspec pete$ wc -l test_output_before
     510 test_output_before
Petes-MBP:inspec pete$ wc -l test_output_after
     401 test_output_after
```