### PR TITLE
enforce option values where needed

### DIFF
--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -265,4 +265,20 @@ Test Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;2
       out.stdout.wont_include "\e[38"
     end
   end
+
+  describe 'when --password is used' do
+    it 'raises an exception if no password is provided' do
+      out = inspec('exec ' + example_profile + ' --password')
+      out.exit_status.must_equal 1
+      out.stderr.must_include 'Please provide a value for --password. For example: --password=hello.'
+    end
+  end
+
+  describe 'when --sudo-password is used' do
+    it 'raises an exception if no sudo password is provided' do
+      out = inspec('exec ' + example_profile + ' --sudo-password')
+      out.exit_status.must_equal 1
+      out.stderr.must_include 'Please provide a value for --sudo-password. For example: --sudo-password=hello.'
+    end
+  end
 end


### PR DESCRIPTION
Due to limitations in Thor it is not possible to set an argument to be both optional and its value to be mandatory. E.g. the user supplying the --password argument is optional and not always required, but whenever it is used, it requires a value. Handle options that were defined with mandatory values in a way that fails with an `ArgumentError` if the value is missing, i.e.:

```
> inspec exec examples/profile --password
ArgumentError: Please provide a value for --password. For example: --password=hello.
```

It works without `--password` or with `--password=arg`. Also handled for `--sudo-password`.

Fixes: https://github.com/chef/inspec/issues/1901
An alternative approach: https://github.com/chef/inspec/pull/1904