### PR TITLE
bugfix: reading tgz files with binread

### DIFF
--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -24,6 +24,13 @@ module Inspec
     def initialize(_path)
     end
 
+    # List all files that are offered.
+    #
+    # @return [Array[String]] list of file paths that are included
+    def files
+      raise "Fetcher #{self} does not implement `files()`. This is required."
+    end
+
     # Read the contents of a file. This will typically refer to a text
     # file reading a string.
     #
@@ -37,10 +44,9 @@ module Inspec
     # It will default to #read if not defined. For most streams that implement
     # it, it will be the same. For some special cases, it will add change the
     # way in which encoding of the returned data structure is handled.
-    alias binread read
-
-    def files
-      raise "Fetcher #{self} does not implement `files()`. This is required."
+    # Does not work with alias nor alias_method.
+    def binread(file)
+      read(file)
     end
 
     def relative_provider


### PR DESCRIPTION
This is currently failing because both `alias` and `alias_method` create method imprints in the FileProvider. This leads to a failure where the TarProvider assumes it doesn't implement `binread`, which in fact it does, since it just calls `read`.

Easily visible with:
```
> inspec json meta-profile-0.2.0.tar.gz
RuntimeError: #<Inspec::TarProvider:0x00000003b83280> does not implement `read(...)`. This is required.
```

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>