### PR TITLE
Fix detection of Automate pre-0.8.x in Compliance::API

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -204,11 +204,22 @@ module Compliance
     end
 
     def self.is_automate_server_pre_080?(config)
-      config['server_type'] == 'automate' && config['version'].nil?
+      # Automate versions before 0.8.x may have a "version" key in the config.
+      # Unless it's a hash that also contains a "version" key, it came from
+      # an Automate server that is pre-0.8.x.
+      return false unless config['server_type'] == 'automate'
+      return true unless config.key?('version')
+      return true unless config['version'].is_a?(Hash)
+      config['version']['version'].nil?
     end
 
     def self.is_automate_server_080_and_later?(config)
-      config['server_type'] == 'automate' && !config['version'].nil?
+      # Automate versions 0.8.x and later will have a "version" key in the config
+      # that looks like: "version":{"api":"compliance","version":"0.8.24"}
+      return false unless config['server_type'] == 'automate'
+      return false unless config.key?('version')
+      return false unless config['version'].is_a?(Hash)
+      !config['version']['version'].nil?
     end
 
     def self.is_automate_server?(config)

--- a/lib/bundles/inspec-compliance/configuration.rb
+++ b/lib/bundles/inspec-compliance/configuration.rb
@@ -28,6 +28,10 @@ module Compliance
       @config[key] = value
     end
 
+    def key?(key)
+      @config.key?(key)
+    end
+
     def clean
       @config = {}
     end

--- a/test/unit/bundles/inspec-compliance/api_test.rb
+++ b/test/unit/bundles/inspec-compliance/api_test.rb
@@ -73,4 +73,69 @@ describe Compliance::API do
       end
     end
   end
+
+  describe 'automate/compliance is? checks' do
+    describe 'when the config has a compliance server_type' do
+      it 'automate/compliance server is? methods return correctly' do
+        config = Compliance::Configuration.new
+        config.clean
+        config['server_type'] = 'compliance'
+        Compliance::API.is_compliance_server?(config).must_equal true
+        Compliance::API.is_automate_server?(config).must_equal false
+        Compliance::API.is_automate_server_pre_080?(config).must_equal false
+        Compliance::API.is_automate_server_080_and_later?(config).must_equal false
+      end
+    end
+
+    describe 'when the config has an automate server_type and no version key' do
+      it 'automate/compliance server is? methods return correctly' do
+        config = Compliance::Configuration.new
+        config.clean
+        config['server_type'] = 'automate'
+        Compliance::API.is_compliance_server?(config).must_equal false
+        Compliance::API.is_automate_server?(config).must_equal true
+        Compliance::API.is_automate_server_pre_080?(config).must_equal true
+        Compliance::API.is_automate_server_080_and_later?(config).must_equal false
+      end
+    end
+
+    describe 'when the config has an automate server_type and a version key that is not a hash' do
+      it 'automate/compliance server is? methods return correctly' do
+        config = Compliance::Configuration.new
+        config.clean
+        config['server_type'] = 'automate'
+        config['version'] = '1.2.3'
+        Compliance::API.is_compliance_server?(config).must_equal false
+        Compliance::API.is_automate_server?(config).must_equal true
+        Compliance::API.is_automate_server_pre_080?(config).must_equal true
+        Compliance::API.is_automate_server_080_and_later?(config).must_equal false
+      end
+    end
+
+    describe 'when the config has an automate server_type and a version hash with no version' do
+      it 'automate/compliance server is? methods return correctly' do
+        config = Compliance::Configuration.new
+        config.clean
+        config['server_type'] = 'automate'
+        config['version'] = {}
+        Compliance::API.is_compliance_server?(config).must_equal false
+        Compliance::API.is_automate_server?(config).must_equal true
+        Compliance::API.is_automate_server_pre_080?(config).must_equal true
+        Compliance::API.is_automate_server_080_and_later?(config).must_equal false
+      end
+    end
+
+    describe 'when the config has an automate server_type and a version hash with a version' do
+      it 'automate/compliance server is? methods return correctly' do
+        config = Compliance::Configuration.new
+        config.clean
+        config['server_type'] = 'automate'
+        config['version'] = { 'version' => '0.8.1' }
+        Compliance::API.is_compliance_server?(config).must_equal false
+        Compliance::API.is_automate_server?(config).must_equal true
+        Compliance::API.is_automate_server_pre_080?(config).must_equal false
+        Compliance::API.is_automate_server_080_and_later?(config).must_equal true
+      end
+    end
+  end
 end


### PR DESCRIPTION
The is_automate_server_pre_080? and is_automate_server_080_and_later?
methods needed some fixing. The Compliance configuration could have
a "version" key that was not nil but was an empty hash, indicating
that it came from a pre-0.8.x Automate server. What we really need
to look for is config['version']['version'] being nil?.

Fixes #1921 