### PR TITLE
Host resource ping method should return stdout

### DIFF
--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -161,7 +161,7 @@ module Inspec::Resources
       {
         success: resp.exit_status.to_i.zero?,
         connection_output: resp.stderr,
-        socket_output: resp.stdout
+        socket_output: resp.stdout,
       }
     end
 
@@ -200,7 +200,7 @@ module Inspec::Resources
       {
         success: resp.exit_status.to_i.zero?,
         connection_output: resp.stderr,
-        socket_output: resp.stdout
+        socket_output: resp.stdout,
       }
     end
 

--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -156,7 +156,7 @@ module Inspec::Resources
 
       {
         success: resp.exit_status.to_i.zero?,
-        output: resp.stderr,
+        output: resp.stdout,
       }
     end
 
@@ -194,7 +194,7 @@ module Inspec::Resources
 
       {
         success: resp.exit_status.to_i.zero?,
-        output: resp.stderr,
+        output: resp.stdout,
       }
     end
 

--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -95,12 +95,12 @@ module Inspec::Resources
       ping.fetch(:success, false)
     end
 
-    def connection_output
-      ping[:connection_output]
+    def connection
+      ping[:connection]
     end
 
-    def socket_output
-      ping[:socket_output]
+    def socket
+      ping[:socket]
     end
 
     # returns all A records of the IP address, will return an array
@@ -160,8 +160,8 @@ module Inspec::Resources
 
       {
         success: resp.exit_status.to_i.zero?,
-        connection_output: resp.stderr,
-        socket_output: resp.stdout,
+        connection: resp.stderr,
+        socket: resp.stdout,
       }
     end
 
@@ -199,8 +199,8 @@ module Inspec::Resources
 
       {
         success: resp.exit_status.to_i.zero?,
-        connection_output: resp.stderr,
-        socket_output: resp.stdout,
+        connection: resp.stderr,
+        socket: resp.stdout,
       }
     end
 

--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -95,8 +95,12 @@ module Inspec::Resources
       ping.fetch(:success, false)
     end
 
-    def output
-      ping[:output]
+    def connection_output
+      ping[:connection_output]
+    end
+
+    def socket_output
+      ping[:socket_output]
     end
 
     # returns all A records of the IP address, will return an array
@@ -156,7 +160,8 @@ module Inspec::Resources
 
       {
         success: resp.exit_status.to_i.zero?,
-        output: resp.stdout,
+        connection_output: resp.stderr,
+        socket_output: resp.stdout
       }
     end
 
@@ -194,7 +199,8 @@ module Inspec::Resources
 
       {
         success: resp.exit_status.to_i.zero?,
-        output: resp.stdout,
+        connection_output: resp.stderr,
+        socket_output: resp.stdout
       }
     end
 


### PR DESCRIPTION
Prior to this PR, the ping method would return the following for nc (stderr output):
```
> echo | nc -v -w 1 127.0.0.1 1900 1>/dev/null
Ncat: Version 6.40 ( http://nmap.org/ncat )
Ncat: Connected to 127.0.0.1:1900.
Ncat: Connection reset by peer.
```

After this PR, the ping method would return the following for nc (stdout output):
```
> echo | nc -v -w 1 127.0.0.1 1900 2>/dev/null
DOWN
```