### PR TITLE
Extract Compliance::API version parsing to separate method

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -204,26 +204,28 @@ module Compliance
     end
 
     def self.is_automate_server_pre_080?(config)
-      # Automate versions before 0.8.x may have a "version" key in the config.
-      # Unless it's a hash that also contains a "version" key, it came from
-      # an Automate server that is pre-0.8.x.
+      # Automate versions before 0.8.x do not have a valid version in the config
       return false unless config['server_type'] == 'automate'
-      return true unless config.key?('version')
-      return true unless config['version'].is_a?(Hash)
-      config['version']['version'].nil?
+      server_version_from_config(config).nil?
     end
 
     def self.is_automate_server_080_and_later?(config)
       # Automate versions 0.8.x and later will have a "version" key in the config
-      # that looks like: "version":{"api":"compliance","version":"0.8.24"}
+      # that is properly parsed out via server_version_from_config below
       return false unless config['server_type'] == 'automate'
-      return false unless config.key?('version')
-      return false unless config['version'].is_a?(Hash)
-      !config['version']['version'].nil?
+      !server_version_from_config(config).nil?
     end
 
     def self.is_automate_server?(config)
       config['server_type'] == 'automate'
+    end
+
+    def self.server_version_from_config(config)
+      # Automate versions 0.8.x and later will have a "version" key in the config
+      # that looks like: "version":{"api":"compliance","version":"0.8.24"}
+      return nil unless config.key?('version')
+      return nil unless config['version'].is_a?(Hash)
+      config['version']['version']
     end
   end
 end

--- a/test/unit/bundles/inspec-compliance/api_test.rb
+++ b/test/unit/bundles/inspec-compliance/api_test.rb
@@ -138,4 +138,26 @@ describe Compliance::API do
       end
     end
   end
+
+  describe '.server_version_from_config' do
+    it 'returns nil when the config has no version key' do
+      config = {}
+      Compliance::API.server_version_from_config(config).must_be_nil
+    end
+
+    it 'returns nil when the version value is not a hash' do
+      config = { 'version' => '123' }
+      Compliance::API.server_version_from_config(config).must_be_nil
+    end
+
+    it 'returns nil when the version value is a hash but has no version key inside' do
+      config = { 'version' => {} }
+      Compliance::API.server_version_from_config(config).must_be_nil
+    end
+
+    it 'returns the version if the version value is a hash containing a version' do
+      config = { 'version' => { 'version' => '1.2.3' } }
+      Compliance::API.server_version_from_config(config).must_equal '1.2.3'
+    end
+  end
 end


### PR DESCRIPTION
For cleanliness and ease of testing, I've moved the logic that parses the server version from the compliance config to a separate method.