### PR TITLE
Fix postgres_conf ability to test parameters that have a dot in them

### DIFF
--- a/docs/resources/postgres_conf.md.erb
+++ b/docs/resources/postgres_conf.md.erb
@@ -14,6 +14,7 @@ A `postgres_conf` resource block declares one (or more) settings in the `postgre
       its('setting') { should eq 'value' }
     end
 
+
 where
 
 * `'setting'` specifies a setting in the `postgresql.conf` file
@@ -71,6 +72,7 @@ The following examples show how to use this InSpec audit resource.
       its('log_duration') { should eq 'on' }
       its('log_hostname') { should eq 'on' }
       its('log_line_prefix') { should eq '%t %u %d %h' }
+      its(['pgaudit.log_parameter']) { should cmp 'on' }
     end
 
 ### Test the port on which PostgreSQL listens

--- a/lib/resources/postgres_conf.rb
+++ b/lib/resources/postgres_conf.rb
@@ -2,6 +2,7 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
+# author: Aaron Lippold
 # license: All rights reserved
 
 require 'utils/simpleconfig'
@@ -19,6 +20,7 @@ module Inspec::Resources
     "
 
     include FindFiles
+    include ObjectTraverser
 
     def initialize(conf_path = nil)
       @conf_path = conf_path || inspec.postgres.conf_path
@@ -42,8 +44,13 @@ module Inspec::Resources
       res
     end
 
-    def method_missing(name)
-      param = params[name.to_s]
+    def value(key)
+      extract_value(key, @params)
+    end
+
+    def method_missing(*keys)
+      keys.shift if keys.is_a?(Array) && keys[0] == :[]
+      param = value(keys)
       return nil if param.nil?
       # extract first value if we have only one value in array
       return param[0] if param.length == 1

--- a/test/unit/mock/files/postgresql.conf
+++ b/test/unit/mock/files/postgresql.conf
@@ -5,3 +5,4 @@ log_connections = on
 doublequote = ''value''
 empty =
 key
+pgaudit.log_parameter='on'

--- a/test/unit/resources/postgres_conf_test.rb
+++ b/test/unit/resources/postgres_conf_test.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+# author: Aaron Lippold
+
+require 'helper'
+
+describe 'Inspec::Resources::Postgres' do
+  it 'verify postgresql.conf config parsing of a simple key value' do
+    resource = load_resource('postgres_conf', '/etc/postgresql/9.4/main/postgresql.conf')
+    _(resource.params('log_connections')).must_equal 'on'
+  end
+  it 'verify postgresql.conf config parsing of a complex key value' do
+    resource = load_resource('postgres_conf', '/etc/postgresql/9.4/main/postgresql.conf')
+    _(resource.value(['pgaudit.log_parameter'])).must_equal 'on'
+  end
+end


### PR DESCRIPTION
Fixes #1671

Signed-off-by: Aaron Lippold <lippold@gmail.com>