### PR TITLE
updated postgres_session resource properly escape queries

### DIFF
--- a/lib/resources/postgres_session.rb
+++ b/lib/resources/postgres_session.rb
@@ -66,7 +66,6 @@ module Inspec::Resources
 
     def create_psql_cmd(query, db = [])
       dbs = db.map { |x| "-d #{x}" }.join(' ')
-      @escaped_query = escaped_query(query)
       "PGPASSWORD='#{@pass}' psql -U #{@user} #{dbs} -h #{@host} -A -t -c #{escaped_query(query)}"
     end
   end

--- a/test/unit/resources/postgres_session_test.rb
+++ b/test/unit/resources/postgres_session_test.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+# author: Aaron Lippold
+
+require 'helper'
+
+describe 'Inspec::Resources::PostgresSession' do
+  it 'verify postgres_session basic init configuration' do
+    resource = load_resource('postgres_session','myuser','mypass','127.0.0.1')
+      _(resource.user).must_equal "myuser"
+      _(resource.pass).must_equal "mypass"
+      _(resource.host).must_equal "127.0.0.1"
+  end
+
+  it 'verify postgres_session create_psql_cmd function' do
+    resource = load_resource('postgres_session','myuser','mypass','127.0.0.1')
+      _(resource.create_psql_cmd("SELECT * FROM STUDENTS;",['testdb'])).must_equal "PGPASSWORD='mypass' psql -U myuser -d testdb -h 127.0.0.1 -A -t -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;"
+      _(resource.db).must_equal ['testdb']
+  end
+
+  it 'verify postgres_session escaped_query function' do
+    resource = load_resource('postgres_session','myuser','mypass','127.0.0.1')
+      _(resource.escaped_query("SELECT * FROM STUDENTS;")).must_equal "SELECT\\ \\*\\ FROM\\ STUDENTS\\;"
+    resource = load_resource('postgres_session','myuser','mypass','127.0.0.1')
+      _(resource.escaped_query("SELECT current_setting('client_min_messages')")).must_equal "SELECT\\ current_setting\\(\\'client_min_messages\\'\\)"
+  end
+end

--- a/test/unit/resources/postgres_session_test.rb
+++ b/test/unit/resources/postgres_session_test.rb
@@ -4,23 +4,12 @@
 require 'helper'
 
 describe 'Inspec::Resources::PostgresSession' do
-  it 'verify postgres_session basic init configuration' do
+  it 'verify postgres_session create_psql_cmd with a basic query' do
     resource = load_resource('postgres_session','myuser','mypass','127.0.0.1')
-      _(resource.user).must_equal "myuser"
-      _(resource.pass).must_equal "mypass"
-      _(resource.host).must_equal "127.0.0.1"
+    _(resource.send(:create_psql_cmd,"SELECT * FROM STUDENTS;",['testdb']).must_equal "PGPASSWORD='mypass' psql -U myuser -d testdb -h 127.0.0.1 -A -t -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;")
   end
-
-  it 'verify postgres_session create_psql_cmd function' do
+  it 'verify postgres_session escaped_query with a complex query' do
     resource = load_resource('postgres_session','myuser','mypass','127.0.0.1')
-      _(resource.create_psql_cmd("SELECT * FROM STUDENTS;",['testdb'])).must_equal "PGPASSWORD='mypass' psql -U myuser -d testdb -h 127.0.0.1 -A -t -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;"
-      _(resource.db).must_equal ['testdb']
-  end
-
-  it 'verify postgres_session escaped_query function' do
-    resource = load_resource('postgres_session','myuser','mypass','127.0.0.1')
-      _(resource.escaped_query("SELECT * FROM STUDENTS;")).must_equal "SELECT\\ \\*\\ FROM\\ STUDENTS\\;"
-    resource = load_resource('postgres_session','myuser','mypass','127.0.0.1')
-      _(resource.escaped_query("SELECT current_setting('client_min_messages')")).must_equal "SELECT\\ current_setting\\(\\'client_min_messages\\'\\)"
+    _(resource.send(:create_psql_cmd,"SELECT current_setting('client_min_messages')",['testdb']).must_equal "PGPASSWORD='mypass' psql -U myuser -d testdb -h 127.0.0.1 -A -t -c SELECT\\ current_setting\\(\\'client_min_messages\\'\\)")
   end
 end


### PR DESCRIPTION
updated resource to use 'shellwords' module to escape the query
fixed a small courner case in the error detection - error: vs error

Fixes: #1814

Signed-off-by: Aaron Lippold <lippold@gmail.com>