### PR TITLE
attributes-related note added to docs

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -286,12 +286,20 @@ For example, a control:
     val_user = attribute('user', default: 'alice', description: 'An identification for the user')
     val_password = attribute('password', description: 'A value for the password')
 
-    describe val_user do
-      it { should eq 'bob' }
-    end
+    control 'system-users' do
+      impact 0.8
+      desc '
+        This test assures that the user "Bob" has a user installed on the system, along with a
+        specified password.
+      '
 
-    describe val_password do
-      it { should eq 'secret' }
+      describe val_user do
+        it { should eq 'bob' }
+      end
+
+      describe val_password do
+        it { should eq 'secret' }
+      end
     end
 
 And a Yaml file named `profile-attribute.yml`:

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -282,6 +282,7 @@ Attributes may be used in profiles to define secrets, such as user names and pas
 
 For example, a control:
 
+    # define these attributes on the top-level of your file and re-use them across all tests!
     val_user = attribute('user', default: 'alice', description: 'An identification for the user')
     val_password = attribute('password', description: 'A value for the password')
 


### PR DESCRIPTION
Hello friends.

I just received two separate stacktraces and spent half an hour trying to figure out why my attribute()-calls didn't work. The Slack channel then notified me that these attribute()-calls must live on the top-level of the file. Thought I'd prepare a PR to save others this fight :)

Greetings from southern germany.