### PR TITLE
Fix directory resource output and exists check

### DIFF
--- a/lib/resources/directory.rb
+++ b/lib/resources/directory.rb
@@ -13,9 +13,9 @@ module Inspec::Resources
         it { should be_directory }
       end
     "
-  end
 
-  def to_s
-    "Directory #{@path}"
+    def to_s
+      "Directory #{source_path}"
+    end
   end
 end

--- a/lib/resources/directory.rb
+++ b/lib/resources/directory.rb
@@ -14,6 +14,10 @@ module Inspec::Resources
       end
     "
 
+    def exist?
+      file.exist? && file.directory?
+    end
+
     def to_s
       "Directory #{source_path}"
     end


### PR DESCRIPTION
The `to_s` method on the `directory` resource is not defined in the correct class, leading `directory` resources to be printed as the parent resource (`file`) instead.

Also, the `exist?` method just reuses the `file` resource's `exist?` method which can lead to perceived false results when a user calls `it {should exist}` on a file with the `directory` method thinking it's actually checking to see if the target is a directory as well. This change ensures that the `exist?` method also checks to make sure the target is a directory.

Fixes #1944