### PR TITLE
Exclude 2.0 Release PRs from current changelog

### DIFF
--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -38,7 +38,7 @@ begin
       # Group PRs by section accordingly
       config.enhancement_labels = ['enhancement', 'feature request', 'new feature']
       config.bug_labels = ['bug']
-      config.exclude_labels = ['docs', 'duplicate', 'invalid', 'question', 'wontfix', 'www', 'Exclude From Changelog']
+      config.exclude_labels = ['docs', 'duplicate', 'invalid', 'question', 'wontfix', 'www', 'Exclude From Changelog', '2.0 Release']
     end
   end
 


### PR DESCRIPTION
PRs that get merged to the 'release-2.0' branch will have this label applied which we want to ensure do not get included in the existing CHANGELOG.md