### PR TITLE
Add `rpm_dbpath` support to the package resource

### DIFF
--- a/docs/resources/package.md.erb
+++ b/docs/resources/package.md.erb
@@ -96,6 +96,12 @@ The following examples show how to use this InSpec audit resource.
       it { should_not be_running }
     end
 
+### Verify if some_package is installed according to my_rpmdb
+
+   describe package('some_package', rpm_dbpath: '/var/lib/my_rpmdb') do
+     it { should be_installed }
+   end
+
 ### Verify if Memcached is installed, enabled, and running
 
 Memcached is an in-memory key-value store that helps improve the performance of database-driven websites and can be installed, maintained, and tested using the `memcached` cookbook (maintained by Chef). The following example is from the `memcached` cookbook and shows how to use a combination of the `package`, `service`, and `port` InSpec audit resources to test if Memcached is installed, enabled, and running:

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -149,6 +149,8 @@ class MockLoader
       # Test DH parameters, 2048 bit long safe prime, generator 2 for dh_params in PEM format
       'dh_params.dh_pem' => mockfile.call('dh_params.dh_pem'),
       'default.toml' => mockfile.call('default.toml'),
+      '/var/lib/fake_rpmdb' => mockdir.call(true),
+      '/var/lib/rpmdb_does_not_exist' => mockdir.call(false),
     }
 
     # create all mock commands
@@ -160,6 +162,8 @@ class MockLoader
     empty = lambda {
       mock.mock_command('', '', '', 0)
     }
+
+    cmd_exit_1 = mock.mock_command('', '', '', 1)
 
     mock.commands = {
       'ps axo pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user,command' => cmd.call('ps-axo'),
@@ -177,6 +181,8 @@ class MockLoader
       'yum -v repolist all'  => cmd.call('yum-repolist-all'),
       'dpkg -s curl' => cmd.call('dpkg-s-curl'),
       'rpm -qia curl' => cmd.call('rpm-qia-curl'),
+      'rpm -qia --dbpath /var/lib/fake_rpmdb curl' => cmd.call('rpm-qia-curl'),
+      'rpm -qia --dbpath /var/lib/rpmdb_does_not_exist curl' => cmd_exit_1,
       'pacman -Qi curl' => cmd.call('pacman-qi-curl'),
       'brew info --json=v1 curl' => cmd.call('brew-info--json-v1-curl'),
       'gem list --local -a -q ^not-installed$' => cmd.call('gem-list-local-a-q-not-installed'),

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -34,12 +34,42 @@ describe 'Inspec::Resources::Package' do
   end
 
   # centos
-  it 'verify centos package parsing' do
-    resource = MockLoader.new(:centos7).load_resource('package', 'curl')
-    pkg = { name: 'curl', installed: true, version: '7.29.0-19.el7', type: 'rpm' }
-    _(resource.installed?).must_equal true
-    _(resource.version).must_equal '7.29.0-19.el7'
-    _(resource.info).must_equal pkg
+  describe 'Rpm' do # rubocop:disable BlockLength
+    let(:pkg) do
+      {
+        name: 'curl',
+        installed: true,
+        version: '7.29.0-19.el7',
+        type: 'rpm',
+      }
+    end
+
+    it 'can parse RPM package info' do
+      resource = MockLoader.new(:centos7).load_resource('package', 'curl')
+      _(resource.installed?).must_equal true
+      _(resource.version).must_equal '7.29.0-19.el7'
+      _(resource.info).must_equal pkg
+    end
+
+    it 'can build an `rpm` command containing `--dbpath`' do
+      resource = MockLoader.new(:centos7).load_resource(
+        'package',
+        'curl',
+        rpm_dbpath: '/var/lib/fake_rpmdb',
+      )
+      _(resource.installed?).must_equal true
+      _(resource.version).must_equal '7.29.0-19.el7'
+      _(resource.info).must_equal pkg
+    end
+
+    it 'can add to `resource_skipped` when `--rpmdb` path does not exist' do
+      resource = MockLoader.new(:centos7).load_resource(
+        'package',
+        'curl',
+        rpm_dbpath: '/var/lib/rpmdb_does_not_exist',
+      )
+      _(resource.resource_skipped).wont_equal nil
+    end
   end
 
   # hpux


### PR DESCRIPTION
This adds support for querying a specific RPMDB

Example:

```
describe package('my_package', rpm_dbpath: '/var/lib/my_rpmdb') do
  it { should be_installed }
end
```

Fixes #1959