### PR TITLE
Fix typo in the version_from_dir method in postgres_session resource

### DIFF
--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -31,7 +31,7 @@ module Inspec::Resources
              a version number and unversioned data directories were found.'
             nil
           else
-            @version = version_from_dir('/var/lib/pgsql/')
+            @version = version_from_dir('/var/lib/pgsql')
           end
         end
         @data_dir = locate_data_dir_location_by_version(@version)


### PR DESCRIPTION
small typo. Removed extra `/`

Signed-off-by: Aaron Lippold <lippold@gmail.com>