### PR TITLE
Remove any "All Rights Reserved" references

### DIFF
--- a/bin/inspec
+++ b/bin/inspec
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
-# Copyright 2015 Dominik Richter. All rights reserved.
+# Copyright 2015 Dominik Richter
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/examples/inheritance/controls/example.rb
+++ b/examples/inheritance/controls/example.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2016, Chef Software, Inc.
-# license: All rights reserved
 
 # manipulate controls of `profile`
 include_controls 'profile' do

--- a/examples/meta-profile/controls/example.rb
+++ b/examples/meta-profile/controls/example.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, The Authors
-# license: All rights reserved
 
 # import full profile
 include_controls 'dev-sec/ssh-baseline'

--- a/examples/profile/controls/example.rb
+++ b/examples/profile/controls/example.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Chef Software, Inc.
-# license: All rights reserved
 
 title '/tmp profile'
 

--- a/examples/profile/controls/gordon.rb
+++ b/examples/profile/controls/gordon.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2016, Chef Software, Inc.
-# license: All rights reserved
 
 title 'Gordon Config Checks'
 

--- a/lib/bundles/inspec-init/templates/profile/controls/example.rb
+++ b/lib/bundles/inspec-init/templates/profile/controls/example.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, The Authors
-# license: All rights reserved
 
 title 'sample section'
 

--- a/lib/inspec.rb
+++ b/lib/inspec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Dominik Richter
-# license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Dominik Richter
-# license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
-# Copyright 2015 Dominik Richter. All rights reserved.
+# Copyright 2015 Dominik Richter
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-# Copyright 2015 Dominik Richter. All rights reserved.
+# Copyright 2015 Dominik Richter
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/inspec/polyfill.rb
+++ b/lib/inspec/polyfill.rb
@@ -2,7 +2,6 @@
 # copyright: 2016, Chef Software Inc.
 # author: Dominik Richter
 # author: Christoph Hartmann
-# license: All rights reserved
 
 class Struct
   unless instance_methods.include? :to_h

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-# Copyright 2015 Dominik Richter. All rights reserved.
+# Copyright 2015 Dominik Richter
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
-# license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 require 'inspec/plugins'

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Dominik Richter
-# license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Dominik Richter
-# license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
-# license: All rights reserved
 
 RSpec::Matchers.define :be_readable do
   match do |file|

--- a/lib/resources/apache.rb
+++ b/lib/resources/apache.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 module Inspec::Resources
   class Apache < Inspec.resource(1)

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
-# license: All rights reserved
 
 require 'utils/simpleconfig'
 require 'utils/find_files'

--- a/lib/resources/audit_policy.rb
+++ b/lib/resources/audit_policy.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 # Advanced Auditing:
 # As soon as you start applying Advanced Audit Configuration Policy, legacy policies will be completely ignored.

--- a/lib/resources/auditd_conf.rb
+++ b/lib/resources/auditd_conf.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 require 'utils/simpleconfig'
 

--- a/lib/resources/auditd_rules.rb
+++ b/lib/resources/auditd_rules.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 require 'forwardable'
 require 'utils/filter_array'

--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
-# license: All rights reserved
 
 module Inspec::Resources
   class Cmd < Inspec.resource(1)

--- a/lib/resources/etc_group.rb
+++ b/lib/resources/etc_group.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 # The file format consists of
 # - group name

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
-# license: All rights reserved
 
 require 'shellwords'
 

--- a/lib/resources/grub_conf.rb
+++ b/lib/resources/grub_conf.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # author: Thomas Cate
-# license: All rights reserved
 
 require 'utils/simpleconfig'
 

--- a/lib/resources/inetd_conf.rb
+++ b/lib/resources/inetd_conf.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 require 'utils/simpleconfig'
 

--- a/lib/resources/kernel_module.rb
+++ b/lib/resources/kernel_module.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 module Inspec::Resources
   class KernelModule < Inspec.resource(1)

--- a/lib/resources/kernel_parameter.rb
+++ b/lib/resources/kernel_parameter.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # author: Christoph Hartmann
-# license: All rights reserved
 
 module Inspec::Resources
   class KernelParameter < Inspec.resource(1)

--- a/lib/resources/limits_conf.rb
+++ b/lib/resources/limits_conf.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 require 'utils/simpleconfig'
 

--- a/lib/resources/login_def.rb
+++ b/lib/resources/login_def.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 require 'utils/simpleconfig'
 

--- a/lib/resources/mysql.rb
+++ b/lib/resources/mysql.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
-# license: All rights reserved
 
 module Inspec::Resources
   class Mysql < Inspec.resource(1)

--- a/lib/resources/mysql_conf.rb
+++ b/lib/resources/mysql_conf.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
-# license: All rights reserved
 
 require 'utils/simpleconfig'
 require 'utils/find_files'

--- a/lib/resources/mysql_session.rb
+++ b/lib/resources/mysql_session.rb
@@ -3,7 +3,6 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 # author: Aaron Lippold
-# license: All rights reserved
 
 module Inspec::Resources
   class MysqlSession < Inspec.resource(1)

--- a/lib/resources/ntp_conf.rb
+++ b/lib/resources/ntp_conf.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 require 'utils/simpleconfig'
 

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # author: Nolan Davidson
-# license: All rights reserved
 
 module Inspec::Resources
   class OracledbSession < Inspec.resource(1)

--- a/lib/resources/os_env.rb
+++ b/lib/resources/os_env.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 # Usage:
 #

--- a/lib/resources/packages.rb
+++ b/lib/resources/packages.rb
@@ -2,7 +2,6 @@
 # copyright: 2017, Chef Software, Inc. <legal@chef.io>
 # author: Joshua Timberman
 # author: Alex Pop
-# license: All rights reserved
 
 require 'utils/filter'
 

--- a/lib/resources/parse_config.rb
+++ b/lib/resources/parse_config.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
-# license: All rights reserved
 
 # Usage example:
 #

--- a/lib/resources/passwd.rb
+++ b/lib/resources/passwd.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 # The file format consists of
 # - username

--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -3,7 +3,6 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 # author: Aaron Lippold
-# license: All rights reserved
 
 module Inspec::Resources
   class Postgres < Inspec.resource(1)

--- a/lib/resources/postgres_conf.rb
+++ b/lib/resources/postgres_conf.rb
@@ -3,7 +3,6 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 # author: Aaron Lippold
-# license: All rights reserved
 
 require 'utils/simpleconfig'
 require 'utils/find_files'

--- a/lib/resources/postgres_session.rb
+++ b/lib/resources/postgres_session.rb
@@ -3,7 +3,6 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 # author: Aaron Lippold
-# license: All rights reserved
 
 module Inspec::Resources
   class Lines

--- a/lib/resources/powershell.rb
+++ b/lib/resources/powershell.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
 # author: Dominik Richter
-# license: All rights reserved
 
 module Inspec::Resources
   class PowershellScript < Cmd

--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
-# license: All rights reserved
 
 require 'utils/filter'
 

--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
 # author: Christoph Hartmann
-# license: All rights reserved
 
 require 'json'
 

--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -2,7 +2,7 @@
 # author: Christoph Hartmann
 # author: Dominik Richter
 # author: Stephan Renatus
-# license: All rights reserved
+
 require 'hashie'
 
 module Inspec::Resources

--- a/lib/resources/ssh_conf.rb
+++ b/lib/resources/ssh_conf.rb
@@ -2,7 +2,6 @@
 # copyright: 2015, Vulcano Security GmbH
 # author: Dominik Richter
 # author: Christoph Hartmann
-# license: All rights reserved
 
 require 'utils/simpleconfig'
 

--- a/lib/resources/ssl.rb
+++ b/lib/resources/ssl.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Chef Software Inc.
-# license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/utils/filter_array.rb
+++ b/lib/utils/filter_array.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Chef Software, Inc.
-# license: All rights reserved
 # author: Stephan Renatus
 
 class FilterArray

--- a/lib/utils/find_files.rb
+++ b/lib/utils/find_files.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Vulcano Security GmbH
-# license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/lib/utils/simpleconfig.rb
+++ b/lib/utils/simpleconfig.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Dominik Richter
-# license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 

--- a/tasks/spdx.rb
+++ b/tasks/spdx.rb
@@ -26,7 +26,7 @@ task :spdx do
   require 'net/http'
   json_data = JSON.parse(Net::HTTP.get(URI('https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json')))
   licenses = json_data['licenses'].map { |l| l['licenseId'] }
-  # "All Rights Reserved" is non-standard extra value to cover proriatary license
+  # "All Rights Reserved" is non-standard extra value to cover proprietary license
   licenses.push('All Rights Reserved')
   File.write(File.join(UTILS_DIR, 'spdx.txt'), licenses.join("\n"))
 end

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -58,7 +58,7 @@ describe 'inspec exec with json formatter' do
         "license" => "Apache-2.0",
         "summary" => "Demonstrates the use of InSpec Compliance Profile",
         "version" => "1.0.0",
-        "sha256" => "821f866e407a91cfadb44af5d4570b92ac7f7a272025da7aa9a92aa635cc4440",
+        "sha256" => "8eed5154c9fa0174067ab475c0ad4a053f772590d129eb324101fe43ef30794d",
         "supports" => [{"os-family" => "unix"}],
         "attributes" => []
       })
@@ -93,7 +93,7 @@ describe 'inspec exec with json formatter' do
 
       src = actual.delete('source_location')
       src['ref'].must_match %r{examples/profile/controls/example.rb$}
-      src['line'].must_equal 8
+      src['line'].must_equal 7
 
       result = actual.delete('results')[0]
       result.wont_be :nil?

--- a/test/functional/inspec_json_profile_test.rb
+++ b/test/functional/inspec_json_profile_test.rb
@@ -68,7 +68,7 @@ describe 'inspec json' do
       it 'has a source location' do
         loc = File.join(example_profile, '/controls/example.rb')
         control['source_location']['ref'].must_equal loc
-        control['source_location']['line'].must_equal 8
+        control['source_location']['line'].must_equal 7
       end
 
       it 'has a the source code' do

--- a/test/unit/mock/profiles/complete-profile/controls/filesystem_spec.rb
+++ b/test/unit/mock/profiles/complete-profile/controls/filesystem_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Chef Software, Inc
-# license: All rights reserved
 
 title 'Proc Filesystem Configuration'
 

--- a/test/unit/mock/profiles/complete-profile/inspec.yml
+++ b/test/unit/mock/profiles/complete-profile/inspec.yml
@@ -3,7 +3,7 @@ title: complete example profile
 maintainer: Chef Software, Inc.
 copyright: Chef Software, Inc.
 copyright_email: support@chef.io
-license: Proprietary, All rights reserved
+license: Apache-2.0
 summary: Testing stub
 version: 1.0.0
 license: Apache-2.0

--- a/test/unit/mock/profiles/dependencies/profile_a/controls/example.rb
+++ b/test/unit/mock/profiles/dependencies/profile_a/controls/example.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, The Authors
-# license: All rights reserved
 
 title 'sample section'
 include_controls 'profile_c'

--- a/test/unit/mock/profiles/dependencies/profile_a/inspec.yml
+++ b/test/unit/mock/profiles/dependencies/profile_a/inspec.yml
@@ -3,7 +3,7 @@ title: InSpec Profile
 maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
-license: All Rights Reserved
+license: Apache-2.0
 summary: An InSpec Compliance Profile
 version: 0.1.0
 depends:

--- a/test/unit/mock/profiles/dependencies/profile_b/controls/example.rb
+++ b/test/unit/mock/profiles/dependencies/profile_b/controls/example.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, The Authors
-# license: All rights reserved
 
 title 'sample section'
 include_controls 'profile_d'

--- a/test/unit/mock/profiles/dependencies/profile_b/inspec.yml
+++ b/test/unit/mock/profiles/dependencies/profile_b/inspec.yml
@@ -3,7 +3,7 @@ title: InSpec Profile
 maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
-license: All Rights Reserved
+license: Apache-2.0
 summary: An InSpec Compliance Profile
 version: 0.1.0
 depends:

--- a/test/unit/mock/profiles/dependencies/profile_c/inspec.yml
+++ b/test/unit/mock/profiles/dependencies/profile_c/inspec.yml
@@ -3,6 +3,6 @@ title: InSpec Profile
 maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
-license: All Rights Reserved
+license: Apache-2.0
 summary: An InSpec Compliance Profile
 version: 0.1.0

--- a/test/unit/mock/profiles/dependencies/profile_d/inspec.yml
+++ b/test/unit/mock/profiles/dependencies/profile_d/inspec.yml
@@ -3,6 +3,6 @@ title: InSpec Profile
 maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
-license: All Rights Reserved
+license: Apache-2.0
 summary: An InSpec Compliance Profile
 version: 0.1.0

--- a/test/unit/mock/profiles/dependencies/resource-namespace/controls/example.rb
+++ b/test/unit/mock/profiles/dependencies/resource-namespace/controls/example.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # copyright: 2015, The Authors
-# license: All rights reserved
+
 require_resource(profile: 'profile_c', resource: 'gordon_config', as: 'gordy_config')
 
 describe gordy_config do

--- a/test/unit/mock/profiles/dependencies/resource-namespace/inspec.yml
+++ b/test/unit/mock/profiles/dependencies/resource-namespace/inspec.yml
@@ -3,7 +3,7 @@ title: InSpec Profile
 maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
-license: All Rights Reserved
+license: Apache-2.0
 summary: An InSpec Compliance Profile
 version: 0.1.0
 depends:

--- a/test/unit/mock/profiles/failures/controls/failures.rb
+++ b/test/unit/mock/profiles/failures/controls/failures.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Chef Software, Inc.
-# license: All rights reserved
 
 title 'failures /tmp profile'
 

--- a/test/unit/mock/profiles/failures/inspec.yml
+++ b/test/unit/mock/profiles/failures/inspec.yml
@@ -3,6 +3,6 @@ title: InSpec Profile
 maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
-license: All Rights Reserved
+license: Apache-2.0
 summary: An InSpec Compliance Profile
 version: 0.1.0

--- a/test/unit/mock/profiles/library/controls/filesystem_spec.rb
+++ b/test/unit/mock/profiles/library/controls/filesystem_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Chef Software, Inc
-# license: All rights reserved
  
 describe gordon do
   it { should be_enabled }

--- a/test/unit/mock/profiles/library/inspec.yml
+++ b/test/unit/mock/profiles/library/inspec.yml
@@ -3,7 +3,7 @@ title: complete example profile
 maintainer: Chef Software, Inc.
 copyright: Chef Software, Inc.
 copyright_email: support@chef.io
-license: Proprietary, All rights reserved
+license: Apache-2.0
 summary: Testing stub
 version: 1.0.0
 supports:

--- a/test/unit/mock/profiles/license-proprietary/inspec.yml
+++ b/test/unit/mock/profiles/license-proprietary/inspec.yml
@@ -3,6 +3,6 @@ title: InSpec Profile
 maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
-license: All Rights Reserved
+license: Apache-2.0
 summary: An InSpec Compliance Profile
 version: 0.1.0

--- a/test/unit/mock/profiles/profile-support-skip/controls/example.rb
+++ b/test/unit/mock/profiles/profile-support-skip/controls/example.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
 # copyright: 2015, The Authors
-# license: All rights reserved
 
 include_controls 'windows-only'

--- a/test/unit/mock/profiles/profile-support-skip/inspec.yml
+++ b/test/unit/mock/profiles/profile-support-skip/inspec.yml
@@ -3,7 +3,7 @@ title: InSpec Profile
 maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
-license: All Rights Reserved
+license: Apache-2.0
 summary: An InSpec Compliance Profile
 version: 0.1.0
 depends:

--- a/test/unit/mock/profiles/profile-with-bad-metadata/controls/example.rb
+++ b/test/unit/mock/profiles/profile-with-bad-metadata/controls/example.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, The Authors
-# license: All rights reserved
 
 title 'sample section'
 

--- a/test/unit/mock/profiles/profile-with-bad-metadata/inspec.yml
+++ b/test/unit/mock/profiles/profile-with-bad-metadata/inspec.yml
@@ -3,7 +3,7 @@ title: InSpec Profile
 maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
-license: All Rights Reserved
+license: Apache-2.0
 summary: An InSpec Compliance Profile
 and this is
 bad metadata because

--- a/test/unit/mock/profiles/windows-only/controls/example.rb
+++ b/test/unit/mock/profiles/windows-only/controls/example.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, The Authors
-# license: All rights reserved
 
 control 'dhcp-disabled' do
   title 'DHCP is disabled'

--- a/test/unit/mock/profiles/windows-only/inspec.yml
+++ b/test/unit/mock/profiles/windows-only/inspec.yml
@@ -3,7 +3,7 @@ title: InSpec Profile
 maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
-license: All Rights Reserved
+license: Apache-2.0
 summary: An InSpec Compliance Profile
 version: 0.1.0
 supports:

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -70,14 +70,14 @@ describe Inspec::Profile do
     end
 
     it 'works on a complete profile' do
-      MockLoader.load_profile('complete-profile').sha256.must_equal 'f9dbfad594ff9eff2209c8a791a1a88a0330f3d3800395e56acf981e4cc5e236'
+      MockLoader.load_profile('complete-profile').sha256.must_equal 'b3dc0ec4603499ca9613e34da4a9476266875b8361b16be9284b39d1beacddd3'
     end
   end
 
   describe 'code info' do
     let(:profile_id) { 'complete-profile' }
     let(:code) { "control 'test01' do\n  impact 0.5\n  title 'Catchy title'\n  desc '\n    There should always be a /proc\n  '\n  describe file('/proc') do\n    it { should be_mounted }\n  end\nend\n" }
-    let(:loc) { {:ref=>"controls/filesystem_spec.rb", :line=>7} }
+    let(:loc) { {:ref=>"controls/filesystem_spec.rb", :line=>6} }
 
     it 'gets code from an uncompressed profile' do
       info = MockLoader.load_profile(profile_id).info


### PR DESCRIPTION
InSpec is licensed and released under the Apache 2.0 license. This change removes all reference to legacy code files that still had any Copyright or License lines referring to "All Rights Reserved".