### PR TITLE
Fix host resolution on Darwin, use dig wherever possible

### DIFF
--- a/docs/resources/host.md.erb
+++ b/docs/resources/host.md.erb
@@ -15,7 +15,7 @@ A `host` resource block declares a host name, and then (depending on what is to 
    describe host('example.com', port: 80, protocol: 'tcp') do
      it { should be_reachable }
      it { should be_resolvable }
-     its('ipaddress') { should eq '12.34.56.78' }
+     its('ipaddress') { should include '12.34.56.78' }
    end
 
 where

--- a/docs/resources/host.md.erb
+++ b/docs/resources/host.md.erb
@@ -14,6 +14,8 @@ A `host` resource block declares a host name, and then (depending on what is to 
 
    describe host('example.com', port: 80, protocol: 'tcp') do
      it { should be_reachable }
+     it { should be_resolvable }
+     its('ipaddress') { should eq '12.34.56.78' }
    end
 
 where
@@ -22,7 +24,6 @@ where
 * `'example.com'` is the host name
 * `port:` is the port number
 * `protocol: 'name'` is the Internet protocol: TCP (`protocol: 'tcp'`), UDP (`protocol: 'udp'` or  ICMP (`protocol: 'icmp'`))
-* `be_reachable` is a valid matcher for this resource
 
 
 ## Matchers
@@ -82,4 +83,12 @@ The following examples show how to use this InSpec audit resource.
     describe host('example.com') do
       it { should be_resolvable }
       its('ipaddress') { should include '192.168.1.1' }
+    end
+
+### Review the connection setup and socket contents when checking reachability
+
+    describe host('example.com', port: 12345, protocol: 'tcp') do
+      it { should be_reachable }
+      its('connection') { should_not match /connection refused/ }
+      its('socket') { should match /STATUS_OK/ }
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -356,6 +356,9 @@ class MockLoader
       # oracle
       "bash -c 'type \"sqlplus\"'" => cmd.call('oracle-cmd'),
       "ef04e5199abee80e662cc0dd1dd3bf3e0aaae9b4498217d241db00b413820911" => cmd.call('oracle-result'),
+      # host resource: dig commands,
+      "dig +short A example.com" => cmd.call('dig-A-example.com'),
+      "dig +short AAAA example.com" => cmd.call('dig-AAAA-example.com'),
     }
     @backend
   end

--- a/test/unit/mock/cmd/dig-A-example.com
+++ b/test/unit/mock/cmd/dig-A-example.com
@@ -1,0 +1,3 @@
+some.cname.target
+another.cname.target
+12.34.56.78

--- a/test/unit/mock/cmd/dig-AAAA-example.com
+++ b/test/unit/mock/cmd/dig-AAAA-example.com
@@ -1,0 +1,3 @@
+some.cname.target
+another.cname.target
+2606:2800:220:1:248:1893:25c8:1946

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -78,9 +78,9 @@ describe 'Inspec::Resources::Host' do
   end
 end
 
-describe Inspec::Resources::HostProvider do
+describe Inspec::Resources::UnixHostProvider do
   describe '#resolve_with_dig' do
-    let(:provider) { Inspec::Resources::HostProvider.new(inspec) }
+    let(:provider) { Inspec::Resources::UnixHostProvider.new(inspec) }
     let(:inspec)   { mock('inspec-backend') }
     let(:v4_command) { mock('v4_command') }
     let(:v6_command) { mock('v6_command') }
@@ -157,9 +157,7 @@ EOL
       provider.resolve_with_dig('testdomain.com').must_be_nil
     end
   end
-end
 
-describe Inspec::Resources::LinuxHostProvider do
   describe '#resolve_with_getent' do
     it 'returns an array of IP addresses when successful' do
       command_output = "2607:f8b0:4004:805::200e testdomain.com\n"

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -7,25 +7,25 @@ require 'inspec/resource'
 
 describe 'Inspec::Resources::Host' do
 
-  it 'check host ping on ubuntu' do
+  it 'check host ping on ubuntu with dig' do
     resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com')
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
-    _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
+    _(resource.ipaddress).must_equal ["2606:2800:220:1:248:1893:25c8:1946", "12.34.56.78"]
   end
 
   it 'check host ping on centos 7' do
     resource = MockLoader.new(:centos7).load_resource('host', 'example.com')
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
-    _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
+    _(resource.ipaddress).must_equal ["2606:2800:220:1:248:1893:25c8:1946", "12.34.56.78"]
   end
 
   it 'check host ping on darwin' do
     resource = MockLoader.new(:osx104).load_resource('host', 'example.com')
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
-    _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
+    _(resource.ipaddress).must_equal ["2606:2800:220:1:248:1893:25c8:1946", "12.34.56.78"]
   end
 
   it 'check host ping on windows' do
@@ -46,21 +46,21 @@ describe 'Inspec::Resources::Host' do
     resource = MockLoader.new(:ubuntu1404).load_resource('host', 'example.com', port: 1234, protocol: 'tcp')
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
-    _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
+    _(resource.ipaddress).must_equal ["2606:2800:220:1:248:1893:25c8:1946", "12.34.56.78"]
   end
 
   it 'check host tcp on centos 7' do
     resource = MockLoader.new(:centos7).load_resource('host', 'example.com', port: 1234, protocol: 'tcp')
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
-    _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
+    _(resource.ipaddress).must_equal ["2606:2800:220:1:248:1893:25c8:1946", "12.34.56.78"]
   end
 
   it 'check host tcp on darwin' do
     resource = MockLoader.new(:osx104).load_resource('host', 'example.com', port: 1234, protocol: 'tcp')
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
-    _(resource.ipaddress).must_equal ['2606:2800:220:1:248:1893:25c8:1946']
+    _(resource.ipaddress).must_equal ["2606:2800:220:1:248:1893:25c8:1946", "12.34.56.78"]
   end
 
   it 'check host tcp on windows' do
@@ -75,5 +75,114 @@ describe 'Inspec::Resources::Host' do
     _(resource.resolvable?).must_equal false
     _(resource.reachable?).must_equal false
     _(resource.ipaddress).must_be_nil
+  end
+end
+
+describe Inspec::Resources::HostProvider do
+  describe '#resolve_with_dig' do
+    let(:provider) { Inspec::Resources::HostProvider.new(inspec) }
+    let(:inspec)   { mock('inspec-backend') }
+    let(:v4_command) { mock('v4_command') }
+    let(:v6_command) { mock('v6_command') }
+
+    it 'returns an array of IP addresses' do
+      ipv4_command_output = <<-EOL
+a.cname.goes.here
+another.cname.cool
+12.34.56.78
+EOL
+      ipv6_command_output = <<-EOL
+a.cname.goes.here
+another.cname.cool
+2A03:2880:F112:83:FACE:B00C::25DE
+EOL
+
+      v4_command.stubs(:stdout).returns(ipv4_command_output)
+      v6_command.stubs(:stdout).returns(ipv6_command_output)
+      inspec.stubs(:command).with('dig +short AAAA testdomain.com').returns(v6_command)
+      inspec.stubs(:command).with('dig +short A testdomain.com').returns(v4_command)
+      provider.resolve_with_dig('testdomain.com').must_equal(['2A03:2880:F112:83:FACE:B00C::25DE', '12.34.56.78'])
+    end
+
+    it 'returns only v4 addresses if no v6 addresses are available' do
+      ipv4_command_output = <<-EOL
+a.cname.goes.here
+another.cname.cool
+12.34.56.78
+EOL
+      ipv6_command_output = <<-EOL
+a.cname.goes.here
+another.cname.cool
+EOL
+
+      v4_command.stubs(:stdout).returns(ipv4_command_output)
+      v6_command.stubs(:stdout).returns(ipv6_command_output)
+      inspec.stubs(:command).with('dig +short AAAA testdomain.com').returns(v6_command)
+      inspec.stubs(:command).with('dig +short A testdomain.com').returns(v4_command)
+      provider.resolve_with_dig('testdomain.com').must_equal(['12.34.56.78'])
+    end
+
+    it 'returns only v6 addresses if no v4 addresses are available' do
+      ipv4_command_output = <<-EOL
+a.cname.goes.here
+another.cname.cool
+EOL
+      ipv6_command_output = <<-EOL
+a.cname.goes.here
+another.cname.cool
+2A03:2880:F112:83:FACE:B00C::25DE
+EOL
+
+      v4_command.stubs(:stdout).returns(ipv4_command_output)
+      v6_command.stubs(:stdout).returns(ipv6_command_output)
+      inspec.stubs(:command).with('dig +short AAAA testdomain.com').returns(v6_command)
+      inspec.stubs(:command).with('dig +short A testdomain.com').returns(v4_command)
+      provider.resolve_with_dig('testdomain.com').must_equal(['2A03:2880:F112:83:FACE:B00C::25DE'])
+    end
+
+    it 'returns nil if no addresses are available' do
+      ipv4_command_output = <<-EOL
+a.cname.goes.here
+another.cname.cool
+EOL
+      ipv6_command_output = <<-EOL
+a.cname.goes.here
+another.cname.cool
+EOL
+
+      v4_command.stubs(:stdout).returns(ipv4_command_output)
+      v6_command.stubs(:stdout).returns(ipv6_command_output)
+      inspec.stubs(:command).with('dig +short AAAA testdomain.com').returns(v6_command)
+      inspec.stubs(:command).with('dig +short A testdomain.com').returns(v4_command)
+      provider.resolve_with_dig('testdomain.com').must_be_nil
+    end
+  end
+end
+
+describe Inspec::Resources::LinuxHostProvider do
+  describe '#resolve_with_getent' do
+    it 'returns an array of IP addresses when successful' do
+      command_output = "2607:f8b0:4004:805::200e testdomain.com\n"
+      command = mock('getent_command')
+      command.stubs(:stdout).returns(command_output)
+      command.stubs(:exit_status).returns(0)
+
+      inspec = mock('inspec')
+      inspec.stubs(:command).with('getent hosts testdomain.com').returns(command)
+
+      provider = Inspec::Resources::LinuxHostProvider.new(inspec)
+      provider.resolve_with_getent('testdomain.com').must_equal(['2607:f8b0:4004:805::200e'])
+    end
+
+    it 'returns nil if command is not successful' do
+      command = mock('getent_command')
+      command.stubs(:exit_status).returns(1)
+
+      inspec = mock('inspec')
+      inspec.stubs(:command).with('getent hosts testdomain.com').returns(command)
+
+      provider = Inspec::Resources::LinuxHostProvider.new(inspec)
+      provider.resolve_with_getent('testdomain.com').must_be_nil
+    end
   end
 end


### PR DESCRIPTION
The `host` and `dig` commands do not return non-zero if a query returns NXDOMAIN or NOERROR, but the DarwinHostProvider was expecting it when deciding whether to fall back to IPv4 if a IPv6 query failed. Therefore, the `host` resource would not function properly when resolving hostnames on Darwin. The logic has been changed to use `dig` short output and query for both v6 and v4 addresses.

Additionally, the LinuxHostProvider has been modified to prefer `dig` if it's available to keep behavior similar between Darwin and Linux whenever possible. This has the added benefit of providing v6 and v4 resolution if possible where `getent hosts` only returns v6 if v6 records exist.