### PR TITLE
Derive information from the XCCDF file based on reference

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -263,8 +263,6 @@ module Inspec
     end
 
     def register_rule(rule)
-      id = false
-      source = false
       Inspec::Log.debug "Registering rule #{rule}"
      
       #get the tags from the rule 

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 # copyright: 2015, Dominik Richter
-# license: All rights reserved
 # author: Dominik Richter
 # author: Christoph Hartmann
 
@@ -264,8 +263,6 @@ module Inspec
 
     def register_rule(rule)
       Inspec::Log.debug "Registering rule #{rule}"
-     
-      #get the tags from the rule 
       tags = rule.tag
       #check if the tags have an xccdf id and source
       if tags.key?(:xccdf_id) && tags.key?(:xccdf_source)

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -186,7 +186,7 @@ module Inspec
       end
 
       if !profile.supports_os?
-        raise "This OS/platform (#{@backend.os[:new_name]}) is not supported by this profile."
+        raise "This OS/platform (#{@backend.os[:name]}) is not supported by this profile."
       end
 
       true
@@ -211,7 +211,7 @@ module Inspec
 
     def eval_with_virtual_profile(command)
       require 'fetchers/mock'
-      add_target({ 'inspec.yml' => 'new_name: inspec-shell' })
+      add_target({ 'inspec.yml' => 'name: inspec-shell' })
       our_profile = @target_profiles.first
       ctx = our_profile.runner_context
       ctx.load(command)
@@ -228,7 +228,7 @@ module Inspec
       opts
     end
 
-    def get_check_example(method_new_name, arg, block)
+    def get_check_example(method_name, arg, block)
       opts = block_source_info(block)
 
       if !arg.empty? &&
@@ -239,7 +239,7 @@ module Inspec
         end
       else
         # add the resource
-        case method_new_name
+        case method_name
         when 'describe'
           return @test_collector.example_group(*arg, opts, &block)
         when 'expect'
@@ -255,7 +255,7 @@ module Inspec
           # otherwise return all working tests
           return ok_tests
         else
-          raise "A rule was registered with #{method_new_name.inspect}, "\
+          raise "A rule was registered with #{method_name.inspect}, "\
                "which isn't understood and cannot be processed."
         end
       end


### PR DESCRIPTION
This change allows someone to specify the path to an XCCDF file and an id, then the tags and other information associated with it will be automatically transferred from the XCCDF file into the inspec rule.  This will allow for easier writing of inspec rules, because most of information will be auto-generated instead of having to be typed in by hand.