### PR TITLE
Replace Google Custom Search with Swiftype

### DIFF
--- a/www/source/docs/search.html.slim
+++ b/www/source/docs/search.html.slim
@@ -5,16 +5,6 @@ title: Search InSpec Docs
 .row
   h2.margin-under-xs- Search the InSpec Documentation
 
-  javascript:
-    // TODO: add the inspec search here
-    (function() {
-      var cx = '014746884379529974319:rvxyzhpu2us';
-      var gcse = document.createElement('script');
-      gcse.type = 'text/javascript';
-      gcse.async = true;
-      gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
-      var s = document.getElementsByTagName('script')[0];
-      s.parentNode.insertBefore(gcse, s);
-    })();
+  input.st-default-search-input type="text" placeholder="Search" id="docs-search" name="q"
 
-  <gcse:search webSearchResultSetSize="20"></gcse:search>
+  .st-search-container

--- a/www/source/layouts/docs.slim
+++ b/www/source/layouts/docs.slim
@@ -10,8 +10,7 @@
         .column.columns
 
             form.main-sidebar--search action="/docs/search/" method="get"
-              input type="text" placeholder="Search Documentation" name="q"
-
+              input.st-default-search-input type="text" placeholder="Search Documentation" name="q"
 
               button.search.shadow action="/docs/search/" method="get"
                 img src="/images/community/search.svg"
@@ -39,3 +38,15 @@
     column.columns.large-9.medium-9
 
       == yield
+
+  javascript:
+    // Swiftype JS code snippet
+    (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+    (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+    e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+    })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
+
+    _st('install','xzyJV6P7pgscygGyyTm8','2.0.0');
+    // end Swiftype code snippet
+
+    document.getElementsByClassName("st-default-search-input")[0].focus();

--- a/www/source/stylesheets/_layout.scss
+++ b/www/source/stylesheets/_layout.scss
@@ -406,6 +406,12 @@ form.main-sidebar--search input[type="text"] {
 	width: 90%;
 	display: inline;
 	margin-top: 1.2em;
+  // overriding some of Swiftype's styles
+  height: 2.4375rem;
+  padding: 0.5rem;
+  box-sizing: border-box;
+  background: $color_white;
+  font-size: 1rem;
 
 	@include nav-small {
 		width:100%;

--- a/www/source/stylesheets/_search.scss
+++ b/www/source/stylesheets/_search.scss
@@ -1,0 +1,9 @@
+// styles for search on docs
+#docs-search {
+  width: 100%;
+  height: 2.4375rem;
+  padding: .5rem;
+  margin-bottom: 1rem;
+  box-sizing: border-box;
+  background: transparent;
+}

--- a/www/source/stylesheets/_sidebar.scss
+++ b/www/source/stylesheets/_sidebar.scss
@@ -49,39 +49,3 @@ li.t-purple > i.focus{
     color: white;
   }
 }
-
-// THIS IS STILL OLD STUFF  - don't know what it is - hannah//
-
-.gcsc-branding,
-.gsc-adBlock {
-  display: none !important;
-}
-
-.gsc-control-cse {
-  padding: 0 !important;
-
-  tbody {
-    border: none;
-    background: none;
-  }
-
-  .gsc-input-box {
-    height: 3rem;
-
-    table {
-      margin-bottom: 0;
-    }
-  }
-
-  .gsc-input input {
-    box-shadow: none !important;
-  }
-
-  .gsc-search-button {
-    min-width: 54px;
-    height: 27px;
-    padding: 5px 18px;
-    font-family: inherit;
-    font-size: 11px;
-  }
-}

--- a/www/source/stylesheets/site.css.scss
+++ b/www/source/stylesheets/site.css.scss
@@ -14,3 +14,4 @@
 @import "homepage";
 @import "tutorials-page";
 @import "code";
+@import "search";


### PR DESCRIPTION
Since Google is EOL-ing it's Google Custom Search, we are replacing all of our site searches on our marketing sites with Swiftype. This adds the required js snippets and markup, as well as some CSS overrides. 
![screen shot 2017-07-05 at 1 09 54 pm](https://user-images.githubusercontent.com/7217000/27885811-37deec74-618e-11e7-8bfc-c9f24d06c92e.png)

