### PR TITLE
Promote artifact to stable during Habitat upload

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -176,7 +176,7 @@ task :release_habitat do
     end
     cmd = "echo #{version} > ./habitat/VERSION && "\
           "hab pkg build . && " \
-          "hab pkg upload ./results/*.hart"
+          "hab pkg upload ./results/*.hart --channel stable"
     puts "--> #{cmd}"
     sh('sh', '-c', cmd)
 end


### PR DESCRIPTION
`pkg` commands in Habitat 0.25 now use channels and prefer the `stable` channel by default. However, artifacts uploaded with hab pkg upload go to `unstable` by default (as it should).

This change ensures that `chef/inspec` artifacts land in `stable` during our release process.