### PR TITLE
add Inspec::Describe for abstract describe state

### DIFF
--- a/lib/inspec/objects.rb
+++ b/lib/inspec/objects.rb
@@ -4,6 +4,7 @@ module Inspec
   autoload :Attribute, 'inspec/objects/attribute'
   autoload :Tag, 'inspec/objects/tag'
   autoload :Control, 'inspec/objects/control'
+  autoload :Describe, 'inspec/objects/describe'
   autoload :EachLoop, 'inspec/objects/each_loop'
   autoload :List, 'inspec/objects/list'
   autoload :OrTest, 'inspec/objects/or_test'

--- a/lib/inspec/objects/describe.rb
+++ b/lib/inspec/objects/describe.rb
@@ -1,0 +1,92 @@
+# encoding:utf-8
+
+module Inspec
+  class Describe
+    # Internal helper to structure test objects.
+    # Should not be exposed to the user as it is hidden behind
+    # `add_test`, `to_hash`, and `to_ruby` in Inspec::Describe
+    Test = Struct.new(:its, :matcher, :expectation, :negated) do
+      def negate!
+        self.negated = !negated
+      end
+
+      def to_ruby
+        itsy = its.nil? ? 'it' : 'its(' + its.to_s.inspect + ')'
+        naughty = negated ? '_not' : ''
+        xpect = if expectation.nil?
+                  ''
+                elsif expectation.class == Regexp
+                  # without this, xpect values like / \/zones\// will not be parsed properly
+                  "(#{expectation.inspect})"
+                else
+                  ' ' + expectation.inspect
+                end
+        format('%s { should%s %s%s }', itsy, naughty, matcher, xpect)
+      end
+    end
+
+    # A qualifier describing the resource that will be tested. It may consist
+    # of the resource identification and multiple accessors to pinpoint the data
+    # the user wants to test.
+    attr_accessor :qualifier
+
+    # An array of individual tests for the qualifier. Every entry will be
+    # translated into an `it` or `its` clause.
+    attr_accessor :tests
+
+    # Optional variables which are used by tests.
+    attr_accessor :variables
+
+    # Optional method to skip this describe block altogether. If `skip` is
+    # defined it takes precendence and will print the skip statement instead
+    # of adding other tests.
+    attr_accessor :skip
+
+    include RubyHelper
+
+    def initialize
+      @qualifier = []
+      @tests = []
+      @variables = []
+    end
+
+    def add_test(its, matcher, expectation)
+      test = Inspec::Describe::Test.new(its, matcher, expectation, false)
+      tests.push(test)
+      test
+    end
+
+    def to_ruby
+      return rb_skip if !skip.nil?
+      rb_describe
+    end
+
+    def to_hash
+      { qualifier: qualifier, tests: tests.map(&:to_h), variables: variables, skip: skip }
+    end
+
+    def resource
+      return nil if qualifier.empty? || qualifier[0].empty? || qualifier[0][0].empty?
+      qualifier[0][0]
+    end
+
+    private
+
+    def rb_describe
+      vars = variables.map(&:to_ruby).join("\n")
+      vars += "\n" unless vars.empty?
+
+      objarr = @qualifier
+      objarr = [['unknown object'.inspect]] if objarr.nil? || objarr.empty?
+      obj = objarr.map { |q| ruby_qualifier(q) }.join('.')
+
+      rbtests = tests.map(&:to_ruby).join("\n  ")
+      format("%sdescribe %s do\n  %s\nend", vars, obj, rbtests)
+    end
+
+    def rb_skip
+      obj = @qualifier || skip.inspect
+      format("describe %s do\n  skip %s\nend", obj, skip.inspect)
+    end
+  end
+end

--- a/test/unit/dsl/describe_test.rb
+++ b/test/unit/dsl/describe_test.rb
@@ -1,0 +1,123 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+
+require 'helper'
+require 'inspec/objects'
+
+describe 'Objects' do
+  describe 'Inspec::Describe' do
+    let(:obj) { Inspec::Describe.new }
+    it 'constructs a simple resource + its("argument")' do
+      obj.qualifier.push(['resource'])
+      obj.add_test('version', 'cmp >=', '2.4.2')
+      obj.to_ruby.must_equal '
+describe resource do
+  its("version") { should cmp >= "2.4.2" }
+end
+'.strip
+    end
+
+    it 'constructs a simple resource.argument' do
+      obj.qualifier = [['resource'], ['version']]
+      obj.add_test(nil, 'cmp >=', '2.4.2')
+      obj.to_ruby.must_equal '
+describe resource.version do
+  it { should cmp >= "2.4.2" }
+end
+'.strip
+    end
+
+    it 'constructs a simple resource+argument with to_s' do
+      obj.qualifier = [['resource'], ['to_s']]
+      obj.add_test(nil, 'cmp', Regexp.new('^Desc.+$'))
+      obj.to_ruby.must_equal '
+describe resource.to_s do
+  it { should cmp(/^Desc.+$/) }
+end
+'.strip
+    end
+
+    it 'constructs a simple resource+argument with to_i' do
+      obj.qualifier = [['resource'], ['to_i']]
+      obj.add_test(nil, 'cmp >', 3)
+      obj.to_ruby.must_equal '
+describe resource.to_i do
+  it { should cmp > 3 }
+end
+'.strip
+    end
+
+    it 'constructs a simple resource+argument with array accessors' do
+      obj.qualifier = [['resource'], ['name[2]']]
+      obj.add_test(nil, 'eq', 'mytest')
+      obj.to_ruby.must_equal '
+describe resource.name[2] do
+  it { should eq "mytest" }
+end
+'.strip
+    end
+
+    it 'constructs a simple resource+argument with method calls' do
+      obj.qualifier = [['resource'], ['hello', 'world']]
+      obj.add_test(nil, 'eq', 'mytest')
+      obj.to_ruby.must_equal '
+describe resource.hello("world") do
+  it { should eq "mytest" }
+end
+'.strip
+    end
+
+    it 'constructs a simple resource+argument with method calls' do
+      obj.qualifier = [['resource']]
+      obj.add_test(:mode, 'cmp', '0755')
+      obj.to_ruby.must_equal '
+describe resource do
+  its("mode") { should cmp "0755" }
+end
+'.strip
+    end
+
+    it 'constructs a resource+argument block with method call, matcher and expectation' do
+      obj.qualifier = [['command','ls /etc']]
+      obj.add_test('exit_status', 'eq', 0)
+      obj.to_ruby.must_equal '
+describe command("ls /etc") do
+  its("exit_status") { should eq 0 }
+end
+'.strip
+    end
+
+    it 'constructs a simple describe with static data, negated regex matcher and expectation' do
+      obj.qualifier = [['"aaa"']]
+      obj.add_test(nil, 'match', Regexp.new('^aa.*')).negate!
+      obj.to_ruby.must_equal '
+describe "aaa" do
+  it { should_not match(/^aa.*/) }
+end
+'.strip
+    end
+
+    it 'constructs a resource+argument block without a property call' do
+      obj.qualifier = [['service', 'avahi-daemon']]
+      obj.qualifier.push(["info['properties']['UnitFileState']"])
+      obj.add_test(nil, 'eq', 'enabled')
+      obj.to_ruby.must_equal '
+describe service("avahi-daemon").info[\'properties\'][\'UnitFileState\'] do
+  it { should eq "enabled" }
+end
+'.strip
+    end
+
+    it 'contains multiple tests' do
+      obj.add_test(nil, 'eq', 123)
+      obj.add_test(:aba, 'cmp', 'cba').negate!
+      obj.to_ruby.must_equal '
+describe "unknown object" do
+  it { should eq 123 }
+  its("aba") { should_not cmp "cba" }
+end
+'.strip
+    end
+  end
+end


### PR DESCRIPTION
Unlike `Inspec::Test` this supports having multiple tests within one block that describes a resource. This has now been seen as an optimization problem where a resource may be computed once and tested multiple times with `it` and `its` within the body.

If successful, it requires a follow-up to deprecated Inspec::Test and remove it for 2.0 completely with a recommendation to use Inspec::Describe.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>