### PR TITLE
Revert "Update SHA1 fingerprint for MSI signing cert (#2013)"

### DIFF
--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -66,7 +66,7 @@ package :msi do
   fast_msi true
   upgrade_code 'DFCD452F-31E5-4236-ACD1-253F4720250B'
   wix_light_extension 'WixUtilExtension'
-  signing_identity 'E05FF095D07F233B78EB322132BFF0F035E11B5B', machine_store: true
+  signing_identity 'F74E1A68005E8A9C465C3D2FF7B41F3988F0EA09', machine_store: true
 end
 
 exclude '**/.git'


### PR DESCRIPTION
This reverts commit b803194abdad831e3e7aa94a0e4c71e6deed861a.

Reverting this as we are investigating using an EV cert which has instant reputation with Microsoft Smartscreen filter.