### PR TITLE
Add changelog rollover on stable promotion

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -18,3 +18,7 @@ merge_actions:
   built_in:trigger_omnibus_release_build:
     ignore_labels: "Omnibus: Skip Build"
     only_if: built_in:bump_version
+
+artifact_actions:
+  promoted_to_stable:
+    built_in:rollover_changelog:


### PR DESCRIPTION
With this configuration change, expeditor will add a "latest stable"
section to the changelog automatically whenever we promote InSpec
to the stable channel. All existing changelog entries will remain,
and any additional changelog entries that have been made in newer
versions that are newer than the artifact being promoted will
remain intact.