### PR TITLE
Fix issue when xinetd.conf does not end in newline

### DIFF
--- a/lib/utils/parser.rb
+++ b/lib/utils/parser.rb
@@ -211,7 +211,7 @@ module XinetdParser
     res = {}
     cur_group = nil
     simple_conf = []
-    rest = raw
+    rest = raw + "\n"
     until rest.empty?
       # extract content line
       nl = rest.index("\n") || (rest.length-1)


### PR DESCRIPTION
Add a newline symbol to the end of the parsed input.

Sample hexdump of xinetd.conf when deployed by the xinetd cookbook:

```
$ hexdump -C /var/chef/cache/cookbooks/xinetd/templates/default/xinetd.conf.erb | tail -2
000000b0  72 20 2f 65 74 63 2f 78  69 6e 65 74 64 2e 64     |r /etc/xinetd.d|
000000bf
```