### PR TITLE
Typo fix in example profile documentation

### DIFF
--- a/examples/meta-profile/README.md
+++ b/examples/meta-profile/README.md
@@ -23,7 +23,7 @@ depends:
     compliance: base/linux
 ```
 
-You could use those dependencies in your `exmaple.rb`:
+You could use those dependencies in your `example.rb`:
 
 ```
 


### PR DESCRIPTION
Fixes typo in the README.md
Obvious fix.