### PR TITLE
Add label to skip all Expeditor tasks

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -10,13 +10,19 @@ github:
 
 merge_actions:
   built_in:bump_version:
-    ignore_labels: "Version: Skip Bump"
+    ignore_labels:
+      - "Version: Skip Bump"
+      - "Expeditor: Skip All"
   bash:.expeditor/update_version.sh:
     only_if: built_in:bump_version
   built_in:update_changelog:
-    ignore_labels: "Changelog: Skip Update"
+    ignore_labels:
+      - "Changelog: Skip Update"
+      - "Expeditor: Skip All"
   built_in:trigger_omnibus_release_build:
-    ignore_labels: "Omnibus: Skip Build"
+    ignore_labels:
+      - "Omnibus: Skip Build"
+      - "Expeditor: Skip All"
     only_if: built_in:bump_version
 
 artifact_actions:


### PR DESCRIPTION
In the event we have a docs-only change or similar which does not necessitate a version bump, changelog update, or omnibus build, a single label named `Expeditor: Skip All` can be used rather than adding individual labels.