### PR TITLE
fix command.exists for mock environments

### DIFF
--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -47,7 +47,7 @@ module Inspec::Resources
 
     def exist?
       # silent for mock resources
-      return false if inspec.os[:name].to_s == 'unknown'
+      return false if inspec.os.name.nil?
 
       if inspec.os.linux?
         res = inspec.backend.run_command("bash -c 'type \"#{@command}\"'")


### PR DESCRIPTION
…since inspec.os.name was “” instead of unknown. I changed to nil to catch that case.

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>