### PR TITLE
add mock support for os_env resource

### DIFF
--- a/lib/resources/os_env.rb
+++ b/lib/resources/os_env.rb
@@ -49,6 +49,9 @@ module Inspec::Resources
     private
 
     def value_for(env)
+      # do mock handling
+      return nil if inspec.os.name.nil?
+
       command = if inspec.os.windows?
                   "${Env:#{env}}"
                 else


### PR DESCRIPTION
This PR prevents issues when the `os_env` resource is called via `inspec check`. This issues appears now, since we doing the return handling right in train for mock requests https://github.com/chef/train/pull/187

```
/Users/chartmann/Development/compliance/inspec/lib/resources/os_env.rb:61:in `value_for': undefined local variable or method `os' for Environment variable DOCKER_CONTENT_TRUST:#<Class:0x007fd1a4cdd700> (NameError)
	from /Users/chartmann/Development/compliance/inspec/lib/resources/os_env.rb:29:in `initialize'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/plugins/resource.rb:47:in `initialize'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/resource.rb:47:in `new'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/resource.rb:47:in `block (3 levels) in create_dsl'
	from /Users/chartmann/Development/hardening/cis-docker-benchmark/controls/container_images.rb:111:in `block in load_with_context'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/rule.rb:49:in `instance_eval'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/rule.rb:49:in `initialize'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/control_eval_context.rb:71:in `new'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/control_eval_context.rb:71:in `block (2 levels) in create'
	from /Users/chartmann/Development/hardening/cis-docker-benchmark/controls/container_images.rb:99:in `load_with_context'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/profile_context.rb:146:in `instance_eval'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/profile_context.rb:146:in `load_with_context'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/profile_context.rb:130:in `load_control_file'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/profile.rb:151:in `block in collect_tests'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/profile.rb:148:in `each'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/profile.rb:148:in `collect_tests'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/profile.rb:454:in `load_checks_params'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/profile.rb:447:in `load_params'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/profile.rb:141:in `params'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/profile.rb:307:in `controls_count'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/profile.rb:278:in `check'
	from /Users/chartmann/Development/compliance/inspec/lib/inspec/cli.rb:69:in `check'
	from /Users/chartmann/.rvm/gems/ruby-2.3.3/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /Users/chartmann/.rvm/gems/ruby-2.3.3/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/chartmann/.rvm/gems/ruby-2.3.3/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /Users/chartmann/.rvm/gems/ruby-2.3.3/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /Users/chartmann/Development/compliance/inspec/bin/inspec:12:in `<top (required)>'
	from /Users/chartmann/.rvm/gems/ruby-2.3.3/bin/inspec:22:in `load'
	from /Users/chartmann/.rvm/gems/ruby-2.3.3/bin/inspec:22:in `<main>'
	from /Users/chartmann/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:15:in `eval'
	from /Users/chartmann/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:15:in `<main>'
```