### PR TITLE
Add changelog categories to expeditor configuration

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -8,6 +8,13 @@ github:
   maintainer_group: chef/inspec-maintainers
   version_tag_format: v{{version}}
 
+changelog:
+  categories:
+    - "Type: New Resource": "New Resources"
+    - "Type: New Feature": "New Features"
+    - "Type: Enhancement": "Enhancements"
+    - "Type: Bug": "Bug Fixes"
+
 merge_actions:
   built_in:bump_version:
     ignore_labels:


### PR DESCRIPTION
This will allow for four different changelog categories (in addition to the default)
that will be used based on PR label.