### PR TITLE
[docker_container] fix repo property

### DIFF
--- a/lib/resources/docker_container.rb
+++ b/lib/resources/docker_container.rb
@@ -74,8 +74,13 @@ module Inspec::Resources
     end
 
     def repo
-      return if image_name_from_image.nil?
-      image_name_from_image.split(':')[0]
+      return if image.nil? || image_name_from_image.nil?
+      if image.include?('/')                       # host:port/ubuntu:latest
+        repo_part, image_part = image.split('/')   # host:port, ubuntu:latest
+        repo_part + '/' + image_part.split(':')[0] # host:port + / + ubuntu
+      else
+        image_name_from_image.split(':')[0]
+      end
     end
 
     def tag

--- a/test/unit/resources/docker_container_test.rb
+++ b/test/unit/resources/docker_container_test.rb
@@ -26,14 +26,16 @@ describe 'Inspec::Resources::DockerContainer' do
       _(resource.ports).must_equal ''
     end
 
-    it 'check image containing repo with port and tag gives correct tag' do
+    it 'check image containing repo with port and tag gives correct repo, image, and tag' do
       resource = load_resource('docker_container', 'heuristic_almeida')
+      _(resource.repo).must_equal 'repo.example.com:5000/ubuntu'
       _(resource.image).must_equal 'repo.example.com:5000/ubuntu:14.04'
       _(resource.tag).must_equal '14.04'
     end
 
-    it 'check image containing repo with port and no tag gives correct tag' do
+    it 'check image containing repo with port and no tag gives correct repo, image, and tag' do
       resource = load_resource('docker_container', 'laughing_lamport')
+      _(resource.repo).must_equal 'repo.example.com:5000/ubuntu'
       _(resource.image).must_equal 'repo.example.com:5000/ubuntu'
       _(resource.tag).must_be_nil
     end


### PR DESCRIPTION
With last weeks tag fix, `ourorg/container` ended up having its `repo` reported as `container`.
With this it'll be `ourorg/container` again.
