### PR TITLE
Publish rubygem via expeditor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -34,5 +34,5 @@ merge_actions:
 
 artifact_actions:
   promoted_to_stable:
-    built_in:publish_rubygems:
-    built_in:rollover_changelog:
+    - built_in:publish_rubygems
+    - built_in:rollover_changelog

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -34,4 +34,5 @@ merge_actions:
 
 artifact_actions:
   promoted_to_stable:
+    built_in:publish_rubygems:
     built_in:rollover_changelog:


### PR DESCRIPTION
When InSpec is promoted to the `stable` channel, Expeditor will take care of the gem publishing!