### PR TITLE
Add expeditor configuration for rubygems

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,5 +1,8 @@
 product_key: inspec
 
+rubygems:
+ - inspec
+
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:
   notify_channel: inspec-notify


### PR DESCRIPTION
This config section was missed and is required in order to properly push gems during an artifact action.