### PR TITLE
Refine the profile/test summary output of the CLI formatter

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -613,10 +613,18 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
     summary = profile_summary
     return unless summary['total'] > 0
 
+    success_str = summary['passed'] == 1 ? '1 successful control' : "#{summary['passed']} successful controls"
+    failed_str  = summary['failed']['total'] == 1 ? '1 control failure' : "#{summary['failed']['total']} control failures"
+    skipped_str = summary['skipped'] == 1 ? '1 control skipped' : "#{summary['skipped']} controls skipped"
+
+    success_color = summary['passed'] > 0 ? 'passed' : 'no_color'
+    failed_color = summary['failed']['total'] > 0 ? 'failed' : 'no_color'
+    skipped_color = summary['skipped'] > 0 ? 'skipped' : 'no_color'
+
     s = format('Profile Summary: %s, %s, %s',
-               format_with_color('passed', "#{summary['passed']} successful"),
-               format_with_color('failed', "#{summary['failed']['total']} failures"),
-               format_with_color('skipped', "#{summary['skipped']} skipped"),
+               format_with_color(success_color, success_str),
+               format_with_color(failed_color, failed_str),
+               format_with_color(skipped_color, skipped_str),
               )
     output.puts(s) if summary['total'] > 0
   end
@@ -624,10 +632,16 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
   def print_tests_summary
     summary = tests_summary
 
+    failed_str = summary['failed'] == 1 ? '1 failure' : "#{summary['failed']} failures"
+
+    success_color = summary['passed'] > 0 ? 'passed' : 'no_color'
+    failed_color = summary['failed'] > 0 ? 'failed' : 'no_color'
+    skipped_color = summary['skipped'] > 0 ? 'skipped' : 'no_color'
+
     s = format('Test Summary: %s, %s, %s',
-               format_with_color('passed', "#{summary['passed']} successful"),
-               format_with_color('failed', "#{summary['failed']} failures"),
-               format_with_color('skipped', "#{summary['skipped']} skipped"),
+               format_with_color(success_color, "#{summary['passed']} successful"),
+               format_with_color(failed_color, failed_str),
+               format_with_color(skipped_color, "#{summary['skipped']} skipped"),
               )
 
     output.puts(s)

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -18,8 +18,8 @@ describe 'inspec exec' do
 \e[38;5;247m  ↺  gordon-1.0: Verify the version number of Gordon (1 skipped)\e[0m
 \e[38;5;247m     ↺  Can't find file \"/tmp/gordon/config.yaml\"\e[0m
 "
-    stdout.must_include "\nProfile Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m1 skipped\e[0m"
-    stdout.must_include "\nTest Summary: \e[38;5;41m4 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m1 skipped\e[0m\n"
+    stdout.must_include "\nProfile Summary: \e[38;5;41m2 successful controls\e[0m, 0 control failures, \e[38;5;247m1 control skipped\e[0m\n"
+    stdout.must_include "\nTest Summary: \e[38;5;41m4 successful\e[0m, 0 failures, \e[38;5;247m1 skipped\e[0m\n"
   end
 
   it 'executes a minimum metadata-only profile' do
@@ -34,7 +34,7 @@ Target:  local://
 
      No tests executed.
 
-Test Summary: \e[38;5;41m0 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m
+Test Summary: 0 successful, 0 failures, 0 skipped
 "
   end
 
@@ -50,7 +50,7 @@ Target:  local://
 
      No tests executed.
 
-Test Summary: \e[38;5;41m0 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m
+Test Summary: 0 successful, 0 failures, 0 skipped
 "
   end
 
@@ -58,7 +58,7 @@ Test Summary: \e[38;5;41m0 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;2
     out = inspec("exec #{File.join(examples_path, 'profile-attribute')} --no-create-lockfile --attrs #{File.join(examples_path, "profile-attribute.yml")}")
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
-    out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m"
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped"
   end
 
   it 'executes a specs-only profile' do
@@ -72,22 +72,22 @@ Test Summary: \e[38;5;41m0 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;2
     out.stdout.force_encoding(Encoding::UTF_8).must_include "↺  This will be skipped intentionally"
     out.stdout.force_encoding(Encoding::UTF_8).must_include "failing should"
     out.stdout.force_encoding(Encoding::UTF_8).must_include "∅  eq \"as intended\""
-    out.stdout.force_encoding(Encoding::UTF_8).must_include "Test Summary: \e[38;5;41m1 successful\e[0m, \e[38;5;9m1 failures\e[0m, \e[38;5;247m1 skipped\e[0m"
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Test Summary: \e[38;5;41m1 successful\e[0m, \e[38;5;9m1 failure\e[0m, \e[38;5;247m1 skipped\e[0m\n"
   end
 
   it 'executes only specified controls' do
     out = inspec('exec ' + example_profile + ' --no-create-lockfile --controls tmp-1.0')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
-    out.stdout.must_include "\nProfile Summary: \e[38;5;41m1 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m\n"
+    out.stdout.must_include "\nProfile Summary: \e[38;5;41m1 successful control\e[0m, 0 control failures, 0 controls skipped\n"
   end
 
   it 'can execute a simple file with the default formatter' do
     out = inspec('exec ' + example_control  + ' --no-create-lockfile')
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
-    out.stdout.must_include "\nProfile Summary: \e[38;5;41m1 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m\n"
-    out.stdout.must_include "\nTest Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m"
+    out.stdout.must_include "\nProfile Summary: \e[38;5;41m1 successful control\e[0m, 0 control failures, 0 controls skipped\n"
+    out.stdout.must_include "\nTest Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
   end
 
   describe 'with a profile that is not supported on this OS/platform' do
@@ -107,7 +107,7 @@ Test Summary: \e[38;5;41m0 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;2
     it 'exits with an error' do
       out.stdout.force_encoding(Encoding::UTF_8).must_include "skippy\e[0m\n\e[38;5;247m     ↺  This will be skipped super intentionally.\e[0m\n"
       out.stdout.force_encoding(Encoding::UTF_8).must_include "  ↺  CONTROL database: MySQL Session\e[0m\n\e[38;5;247m     ↺  Can't run MySQL SQL checks without authentication\e[0m\n"
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: \e[38;5;41m0 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m2 skipped\e[0m"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: 0 successful controls, 0 control failures, \e[38;5;247m2 controls skipped\e[0m\nTest Summary: 0 successful, 0 failures, \e[38;5;247m2 skipped\e[0m\n"
       out.exit_status.must_equal 0
     end
   end
@@ -153,9 +153,8 @@ Target:  local://
   File /tmp
 \e[38;5;41m     \xE2\x9C\x94  should be directory\e[0m
 
-Profile Summary: \e[38;5;41m1 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m
-Test Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m
-"
+Profile Summary: \e[38;5;41m1 successful control\e[0m, 0 control failures, 0 controls skipped
+Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
     end
   end
 
@@ -208,7 +207,7 @@ Test Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;2
       out = inspec('exec ' + File.join(profile_path, 'dependencies', 'resource-namespace') + ' --no-create-lockfile')
       out.stderr.must_equal ''
       out.exit_status.must_equal 0
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[38;5;41m5 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m\n"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: \e[38;5;41m1 successful control\e[0m, 0 control failures, 0 controls skipped\n"
     end
   end
 
@@ -217,7 +216,7 @@ Test Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;2
       out = inspec('exec ' + File.join(profile_path, 'dependencies', 'require_controls_test') + ' --no-create-lockfile')
       out.stderr.must_equal ''
       out.exit_status.must_equal 0
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[38;5;41m1 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m\n"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: \e[38;5;41m1 successful control\e[0m, 0 control failures, 0 controls skipped\n"
     end
   end
 
@@ -226,26 +225,26 @@ Test Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;2
       out = inspec('exec ' + File.join(profile_path, 'dependencies', 'inheritance') + ' --no-create-lockfile')
       out.stderr.must_equal ''
       out.exit_status.must_equal 0
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[38;5;41m6 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m\n"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: \e[38;5;41m6 successful controls\e[0m, 0 control failures, 0 controls skipped\n"
     end
   end
 
   describe 'when using profiles on the supermarket' do
     it 'can run supermarket profiles directly from the command line' do
       out = inspec("exec supermarket://nathenharvey/tmp-compliance-profile --no-create-lockfile")
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m\n"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: \e[38;5;41m2 successful controls\e[0m, 0 control failures, 0 controls skipped\n"
     end
 
     it 'can run supermarket profiles from inspec.yml' do
       out = inspec("exec #{File.join(profile_path, 'supermarket-dep')} --no-create-lockfile")
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m0 skipped\e[0m\n"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: \e[38;5;41m2 successful controls\e[0m, 0 control failures, 0 controls skipped\n"
     end
   end
 
   describe 'when a dependency does not support our backend platform' do
     it 'skips the controls from that profile' do
       out = inspec("exec #{File.join(profile_path, 'profile-support-skip')} --no-create-lockfile")
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "Summary: \e[38;5;41m0 successful\e[0m, \e[38;5;9m0 failures\e[0m, \e[38;5;247m2 skipped\e[0m\n"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: 0 successful controls, 0 control failures, \e[38;5;247m2 controls skipped\e[0m\n"
     end
   end
 

--- a/test/functional/inspec_shell_test.rb
+++ b/test/functional/inspec_shell_test.rb
@@ -84,7 +84,7 @@ describe 'inspec shell tests' do
     it 'runs anonymous tests that fail' do
       out = do_shell_c("describe file(\"foo/bar/baz\") do it { should exist } end", 1)
       out.stdout.must_include '0 successful'
-      out.stdout.must_include '1 failures'
+      out.stdout.must_include '1 failure'
     end
 
     it 'runs controls with tests (json output)' do
@@ -114,7 +114,7 @@ describe 'inspec shell tests' do
     it 'runs controls with multiple tests' do
       out = do_shell_c("control \"test\" do describe file(\"#{__FILE__}\") do it { should exist } end; describe file(\"foo/bar/baz\") do it { should exist } end end", 1)
       out.stdout.must_include '0 successful'
-      out.stdout.must_include '1 failures'
+      out.stdout.must_include '1 failure'
     end
   end
 
@@ -186,7 +186,7 @@ describe 'inspec shell tests' do
     it 'runs anonymous tests that fail' do
       out = do_shell("describe file(\"foo/bar/baz\") do it { should exist } end")
       out.stdout.must_include '0 successful'
-      out.stdout.must_include '1 failures'
+      out.stdout.must_include '1 failure'
     end
 
     it 'runs controls with tests' do
@@ -198,13 +198,13 @@ describe 'inspec shell tests' do
     it 'runs controls with multiple tests' do
       out = do_shell("control \"test\" do describe file(\"#{__FILE__}\") do it { should exist } end; describe file(\"foo/bar/baz\") do it { should exist } end end")
       out.stdout.must_include '0 successful'
-      out.stdout.must_include '1 failures'
+      out.stdout.must_include '1 failure'
     end
 
     it 'reruns controls when redefined' do
       out = do_shell("control \"test\" do describe file(\"#{__FILE__}\") do it { should exist } end end\ncontrol \"test\" do describe file(\"foo/bar/baz\") do it { should exist } end end")
       out.stdout.must_include '1 successful'
-      out.stdout.must_include '1 failures'
+      out.stdout.must_include '1 failure'
     end
   end
 end


### PR DESCRIPTION
* The "Profile Summary" is misleading as it's not a summary of profile success/failure but rather the controls within the profile(s). Altered the output to be clear. I still like calling it the "profile summary" but wanted to add clarity that the numbers are about the controls.

* Made the colorized output dynamic. The success/failure will only be green/red if there are controls/tests that fall into that category. That way we are not printing red failure text when there are no actual failures. Fixes #1752.

* Cleaned up some grammar issues. ("1 failure" vs "1 failures")