### PR TITLE
Support mixed-case group entries

### DIFF
--- a/lib/resources/groups.rb
+++ b/lib/resources/groups.rb
@@ -90,7 +90,6 @@ module Inspec::Resources
 
     def initialize(groupname)
       @group = groupname
-      @group = @group.downcase unless inspec.os.windows?
 
       # select group manager
       @group_provider = select_group_manager(inspec.os)

--- a/test/unit/mock/files/etcgroup
+++ b/test/unit/mock/files/etcgroup
@@ -1,3 +1,4 @@
 # comment
 root:x:0:
 www-data:x:33:www-data,root
+GroupWithCaps:x:999:

--- a/test/unit/resources/etc_group_test.rb
+++ b/test/unit/resources/etc_group_test.rb
@@ -9,8 +9,8 @@ describe 'Inspec::Resources::EtcGroup' do
   let(:resource) { load_resource('etc_group') }
 
   it 'verify /etc/group config parsing' do
-    _(resource.gids).must_equal [0, 33]
-    _(resource.groups).must_equal %w{ root www-data }
+    _(resource.gids).must_equal [0, 33, 999]
+    _(resource.groups).must_equal %w{ root www-data GroupWithCaps }
     _(resource.users).must_equal %w{ www-data root }
   end
 

--- a/test/unit/resources/group_test.rb
+++ b/test/unit/resources/group_test.rb
@@ -15,11 +15,11 @@ describe 'Inspec::Resources::Group' do
     _(resource.has_gid?(0)).must_equal true
   end
 
-  it 'verify group on ubuntu with UPPER CASE' do
-    resource = MockLoader.new(:ubuntu1404).load_resource('group', 'ROOT')
+  it 'verify group on ubuntu with mixed case' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('group', 'GroupWithCaps')
     _(resource.exists?).must_equal true
-    _(resource.gid).must_equal 0
-    _(resource.has_gid?(0)).must_equal true
+    _(resource.gid).must_equal 999
+    _(resource.has_gid?(999)).must_equal true
   end
 
   # ubuntu with non-existent group


### PR DESCRIPTION
The `group` resource downcased the input parameter unless the target
was a Windows node. However, it's completely legitimate for a Unix-y
node to have mixed case group and passwd entries.

This change does have the potential to break people that did not carefully
match their case when searching for a group, but we're currently blocking
people from using the group resource properly if they have mixed-case
entries.

Signed-off-by: Adam Leff <adam@leff.co>