### PR TITLE
auditd_rules resource: fix get_keys error on lines that have no keys

### DIFF
--- a/lib/resources/auditd_rules.rb
+++ b/lib/resources/auditd_rules.rb
@@ -177,7 +177,7 @@ module Inspec::Resources
 
     # NB only in file lines
     def get_key(line)
-      line.match(/-k ([^ ]+)/)[1] if line =~ /-k/
+      line.match(/-k ([^ ]+)/)[1] if line.include?('-k ')
     end
 
     # NOTE there are NO precautions wrt. filenames containing spaces in auditctl

--- a/lib/resources/auditd_rules.rb
+++ b/lib/resources/auditd_rules.rb
@@ -177,7 +177,7 @@ module Inspec::Resources
 
     # NB only in file lines
     def get_key(line)
-      line.match(/-k ([^ ]+)/)[1]
+      line.match(/-k ([^ ]+)/)[1] if line =~ /-k/
     end
 
     # NOTE there are NO precautions wrt. filenames containing spaces in auditctl

--- a/test/unit/mock/cmd/auditctl
+++ b/test/unit/mock/cmd/auditctl
@@ -2,3 +2,4 @@
 -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=500 f24!=0 -F key=perm_mod
 -w /etc/ssh/sshd_config -p rwxa -k CFG_sshd_config
 -w /etc/sudoers -p wa
+-w /etc/private-keys -p x

--- a/test/unit/mock/cmd/auditctl
+++ b/test/unit/mock/cmd/auditctl
@@ -1,3 +1,4 @@
 -a always,exit -F arch=b64 -S open,openat -F exit=-EACCES -F key=access
 -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=500 f24!=0 -F key=perm_mod
 -w /etc/ssh/sshd_config -p rwxa -k CFG_sshd_config
+-w /etc/sudoers -p wa

--- a/test/unit/resources/auditd_rules_test.rb
+++ b/test/unit/resources/auditd_rules_test.rb
@@ -13,6 +13,7 @@ describe 'Inspec::Resources::AuditDaemonRules' do
        '-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=500 f24!=0 -F key=perm_mod',
        '-w /etc/ssh/sshd_config -p rwxa -k CFG_sshd_config',
        '-w /etc/sudoers -p wa',
+       '-w /etc/private-keys -p x',
     ]
   end
 
@@ -54,6 +55,13 @@ describe 'Inspec::Resources::AuditDaemonRules' do
     resource = MockLoader.new(:centos7).load_resource('auditd_rules')
     _(resource.send('key', 'CFG_sshd_config').send('rules')).must_equal [
       { file: '/etc/ssh/sshd_config', key: 'CFG_sshd_config', permissions: 'rwxa'},
+    ]
+  end
+
+  it 'check auditd_rules file interface with no keys' do
+    resource = MockLoader.new(:centos7).load_resource('auditd_rules')
+    _(resource.send('file', '/etc/private-keys').send('rules')).must_equal [
+      { file: '/etc/private-keys', key: nil, permissions: 'x'},
     ]
   end
 

--- a/test/unit/resources/auditd_rules_test.rb
+++ b/test/unit/resources/auditd_rules_test.rb
@@ -12,6 +12,7 @@ describe 'Inspec::Resources::AuditDaemonRules' do
        '-a always,exit -F arch=b64 -S open,openat -F exit=-EACCES -F key=access',
        '-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=500 f24!=0 -F key=perm_mod',
        '-w /etc/ssh/sshd_config -p rwxa -k CFG_sshd_config',
+       '-w /etc/sudoers -p wa',
     ]
   end
 


### PR DESCRIPTION
Currently, if a file rule found by audtictl -l does not contain a key, the get_key function in auditd_rules.rb generates a NilClass error. This PR alters the single line in get_key to be sure that a key exists before line.match can throw the error. The unit tests and mock auditctl command file have also been updated to verify this fix prevents the NilClass error.

Signed-off-by: Jennifer Burns <jburns@mitre.org>