### PR TITLE
http resource: prevent repeat calls during a control with multiple tests

### DIFF
--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -55,6 +55,7 @@ module Inspec::Resources
     private
 
     def response
+      return @response if @response
       conn = Faraday.new url: @url, headers: @headers, params: @params, ssl: { verify: @ssl_verify }
 
       # set basic authentication


### PR DESCRIPTION
Currently, if you check two properties of a http resource, such as
status and body, two different http requests are made to the server.
However, the response is already stored in an instance variable, so this
change just checks to see if a response is already available and uses it
rather than making another http request.

The following is an example control that will demonstrate the issue (run `python -mSimpleHTTPServer` to start a web server listening on port 8000 and see the requests made):

```
control 'foo-1' do
  describe http('http://127.0.0.1:8000') do
    its('status') { should cmp 200 }
    its('body') { should_not cmp 'foo' }
  end
end
```