### PR TITLE
Add with_toc_data option to markdown renderer

### DIFF
--- a/www/config.rb
+++ b/www/config.rb
@@ -54,4 +54,4 @@ activate :directory_indexes
 activate :syntax
 set :trailing_slash, false
 set :markdown_engine, :redcarpet
-set :markdown, fenced_code_blocks: true, smartypants: true, coderay_line_numbers: :table, tables: true
+set :markdown, fenced_code_blocks: true, smartypants: true, coderay_line_numbers: :table, tables: true, with_toc_data: true


### PR DESCRIPTION
This adds 'id="foo"' attributes to headers, which lets you link directly
to a specific section of the documentation.

Note: this doesn't actually generate a table of contents on any page, but it provides the anchors for you to link directly with something like <https://www.inspec.io/docs/reference/profiles/#profile_files>.