### PR TITLE
Modify linux regular expression to handle process names with spaces

### DIFF
--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -81,7 +81,7 @@ module Inspec::Resources
 
       if os.linux?
         command = 'ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command'
-        regex = /^(.+)\s+(\d+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+(\w{3} \d{2}|\d{2}:\d{2}:\d{2})\s+([^ ]+)\s+([^ ]+)\s+(.*)$/
+        regex = /^(.+?)\s+(\d+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+(\w{3} \d{2}|\d{2}:\d{2}:\d{2})\s+([^ ]+)\s+([^ ]+)\s+(.*)$/
       elsif os.windows?
         command = '$Proc = Get-Process -IncludeUserName | Where-Object {$_.Path -ne $null } | Select-Object PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path | ConvertTo-Csv -NoTypeInformation;$Proc.Replace("""","").Replace("`r`n","`n")'
         # Wanted to use /(?:^|,)([^,]*)/; works on rubular.com not sure why here?

--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -81,7 +81,7 @@ module Inspec::Resources
 
       if os.linux?
         command = 'ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command'
-        regex = /^([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+(\w{3} \d{2}|\d{2}:\d{2}:\d{2})\s+([^ ]+)\s+([^ ]+)\s+(.*)$/
+        regex = /^(.+)\s+(\d+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+(\w{3} \d{2}|\d{2}:\d{2}:\d{2})\s+([^ ]+)\s+([^ ]+)\s+(.*)$/
       elsif os.windows?
         command = '$Proc = Get-Process -IncludeUserName | Where-Object {$_.Path -ne $null } | Select-Object PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path | ConvertTo-Csv -NoTypeInformation;$Proc.Replace("""","").Replace("`r`n","`n")'
         # Wanted to use /(?:^|,)([^,]*)/; works on rubular.com not sure why here?

--- a/test/unit/mock/cmd/ps-axoZ
+++ b/test/unit/mock/cmd/ps-axoZ
@@ -6,3 +6,4 @@ system_u:system_r:init_t:s0      5169  0.0  0.0   4084   536 ?        S    10:54
 -                               11662  0.0  0.0  70992  1460 ?        S      Nov 28 00:00:13 httpd                            /usr/local/apache2/bin/httpd -k start
 -                               11663  0.0  0.1 874196  4792 ?        Sl     Nov 28 00:00:12 httpd                            /usr/local/apache2/bin/httpd -k start
 -                               11664  0.0  0.1 874156  4468 ?        Sl     Nov 28 00:00:11 httpd                            /usr/local/apache2/bin/httpd -k start
+/usr/sbin/ntpd (enforce)        14415  0.0  0.5 110032  5164 ?        Ssl  22:39:25 00:00:00 ntp                              /usr/sbin/ntpd -p /var/run/ntpd.pid -g -u 112:117

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -52,7 +52,7 @@ describe 'Inspec::Resources::Processes' do
 
   it 'verify processes resource using where filters on linux os. String match regex' do
     resource = MockLoader.new(:centos6).load_resource('processes', '.+')
-    _(resource.entries.length).must_equal 7
+    _(resource.entries.length).must_equal 8
     _(resource.where { pid < 11663 && cpu == '0.0' }.users).must_equal(["opscode-pgsql", "opscode", "root", "httpd"])
     _(resource.where { user =~ /opscode-.*/ }.entries[0].to_h).must_equal({
       label: 'system_u:system_r:init_t:s0',
@@ -120,6 +120,25 @@ describe 'Inspec::Resources::Processes' do
   it 'command name matches with output (regex)' do
     resource = MockLoader.new(:centos6).load_resource('processes', /mysqld/)
     _(resource.to_s).must_equal 'Processes /mysqld/'
+  end
+
+  it 'handles labels with spaces' do
+    resource = MockLoader.new(:centos6).load_resource('processes', 'ntpd')
+    _(resource.entries.length).must_equal 1
+    _(resource.entries[0].to_h).must_equal({
+      label: '/usr/sbin/ntpd (enforce)',
+      pid: 14415,
+      cpu: '0.0',
+      mem: '0.5',
+      vsz: 110032,
+      rss: 5164,
+      tty: '?',
+      stat: 'Ssl',
+      start: '22:39:25',
+      time: '00:00:00',
+      user: 'ntp',
+      command: '/usr/sbin/ntpd -p /var/run/ntpd.pid -g -u 112:117',
+    })
   end
 
   it 'command name matches with output (string)' do


### PR DESCRIPTION
Fixes #1497

Tested on Ubuntu 14.04, Ubuntu 16.04, and CentOS 7.3