### PR TITLE
Support profile versions for automate profiles storage

### DIFF
--- a/lib/bundles/inspec-compliance/README.md
+++ b/lib/bundles/inspec-compliance/README.md
@@ -148,6 +148,17 @@ Finished in 0.02862 seconds (files took 0.62628 seconds to load)
 5 examples, 0 failures, 1 pending
 ```
 
+Exec a specific version(2.0.1) of a profile when logged in with Automate:
+
+```
+$ inspec exec compliance://admin/apache-baseline#2.0.1
+```
+
+Download a specific version(2.0.2) of a profile when logged in with Automate:
+```
+$ inspec compliance download compliance://admin/apache-baseline#2.0.2
+```
+
 ### To Logout from Chef Compliance
 
 ```

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -85,12 +85,11 @@ module Compliance
       _msg, profiles = Compliance::API.profiles(config)
       owner, id, ver = profile_split(profile)
       if !profiles.empty?
-        index = profiles.index { |p|
+        profiles.any? do |p|
           p['owner_id'] == owner &&
             p['name'] == id &&
             (ver == nil || p['version'] == ver)
-        }
-        !index.nil? && index >= 0
+        end
       else
         false
       end

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -88,7 +88,7 @@ module Compliance
         profiles.any? do |p|
           p['owner_id'] == owner &&
             p['name'] == id &&
-            (ver == nil || p['version'] == ver)
+            (ver.nil? || p['version'] == ver)
         end
       else
         false
@@ -183,24 +183,21 @@ module Compliance
     end
 
     def self.target_url(config, profile)
-      if is_automate_server?(config)
-        owner, id, ver = profile_split(profile)
-        if ver.nil?
-          target = "#{config['server']}/profiles/#{owner}/#{id}/tar"
-        else
-          target = "#{config['server']}/profiles/#{owner}/#{id}/version/#{ver}/tar"
-        end
+      owner, id, ver = profile_split(profile)
+
+      return "#{config['server']}/owners/#{owner}/compliance/#{id}/tar" unless is_automate_server?(config)
+
+      if ver.nil?
+        "#{config['server']}/profiles/#{owner}/#{id}/tar"
       else
-        owner, id, ver = profile_split(profile)
-        target = "#{config['server']}/owners/#{owner}/compliance/#{id}/tar"
+        "#{config['server']}/profiles/#{owner}/#{id}/version/#{ver}/tar"
       end
-      target
     end
 
     def self.profile_split(profile)
       owner, id = profile.split('/')
       id, version = id.split('#')
-      return owner, id, version
+      [owner, id, version]
     end
 
     # returns a parsed url for `admin/profile` or `compliance://admin/profile`

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -83,8 +83,13 @@ module Compliance
     # verifies that a profile
     def self.exist?(config, profile)
       _msg, profiles = Compliance::API.profiles(config)
+      owner, id, ver = profile_split(profile)
       if !profiles.empty?
-        index = profiles.index { |p| "#{p['owner_id']}/#{p['name']}" == profile }
+        index = profiles.index { |p|
+          p['owner_id'] == owner &&
+            p['name'] == id &&
+            (ver == nil || p['version'] == ver)
+        }
         !index.nil? && index >= 0
       else
         false
@@ -180,13 +185,23 @@ module Compliance
 
     def self.target_url(config, profile)
       if is_automate_server?(config)
-        owner, id = profile.split('/')
-        target = "#{config['server']}/profiles/#{owner}/#{id}/tar"
+        owner, id, ver = profile_split(profile)
+        if ver.nil?
+          target = "#{config['server']}/profiles/#{owner}/#{id}/tar"
+        else
+          target = "#{config['server']}/profiles/#{owner}/#{id}/version/#{ver}/tar"
+        end
       else
-        owner, id = profile.split('/')
+        owner, id, ver = profile_split(profile)
         target = "#{config['server']}/owners/#{owner}/compliance/#{id}/tar"
       end
       target
+    end
+
+    def self.profile_split(profile)
+      owner, id = profile.split('/')
+      id, version = id.split('#')
+      return owner, id, version
     end
 
     # returns a parsed url for `admin/profile` or `compliance://admin/profile`

--- a/test/unit/bundles/inspec-compliance/api_test.rb
+++ b/test/unit/bundles/inspec-compliance/api_test.rb
@@ -238,13 +238,11 @@ describe Compliance::API do
       config['server_type'] = 'automate'
       config['server'] = 'https://myautomate'
       config['version'] = '1.6.99'
-      profile = mock
-      profile.stubs(:profiles).returns(profiles_response)
+      Compliance::API.stubs(:profiles).returns([nil, profiles_response])
       Compliance::API.exist?(config, 'admin/apache-baseline').must_equal true
       Compliance::API.exist?(config, 'admin/apache-baseline#2.0.1').must_equal true
       Compliance::API.exist?(config, 'admin/apache-baseline#2.0.999').must_equal false
       Compliance::API.exist?(config, 'admin/missing-in-action').must_equal false
     end
-
   end
 end


### PR DESCRIPTION
After `inspec compliance login_automate ...`

```
$ be inspec compliance exec compliance://admin/apache-baseline#2.0.1

Profile: DevSec Apache Baseline (apache-baseline)
Version: 2.0.1
...
```

```
$ be inspec compliance exec admin/apache-baseline

Profile: DevSec Apache Baseline (apache-baseline)
Version: 2.0.2
```


```
$ be inspec exec compliance://admin/apache-baseline#2.0.1

Profile: DevSec Apache Baseline (apache-baseline)
Version: 2.0.1
```

```
$ be inspec exec compliance://admin/apache-baseline

Profile: DevSec Apache Baseline (apache-baseline)
Version: 2.0.2
```

```
$ be inspec compliance download compliance://admin/apache-baseline#2.0.1
Downloading `admin/apache-baseline#2.0.1`
Profile stored to apache-baseline#2.0.1.tar.gz
$ inspec json apache-baseline#2.0.1.tar.gz | jq .version
"2.0.1"
```