### PR TITLE
Fix merge_actions in expeditor config, add create_github_release

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -11,6 +11,8 @@ slack:
 
 github:
   maintainer_group: chef/inspec-maintainers
+  minor_bump_labels:
+    - "Version: Bump Minor"
   version_tag_format: v{{version}}
 
 changelog:
@@ -21,24 +23,25 @@ changelog:
     - "Type: Bug": "Bug Fixes"
 
 merge_actions:
-  built_in:bump_version:
-    ignore_labels:
-      - "Version: Skip Bump"
-      - "Expeditor: Skip All"
-  bash:.expeditor/update_version.sh:
-    only_if: built_in:bump_version
-  built_in:update_changelog:
-    ignore_labels:
-      - "Changelog: Skip Update"
-      - "Expeditor: Skip All"
-  built_in:trigger_omnibus_release_build:
-    ignore_labels:
-      - "Omnibus: Skip Build"
-      - "Expeditor: Skip All"
-    only_if: built_in:bump_version
+  - built_in:bump_version:
+      ignore_labels:
+        - "Version: Skip Bump"
+        - "Expeditor: Skip All"
+  - bash:.expeditor/update_version.sh:
+      only_if: built_in:bump_version
+  - built_in:update_changelog:
+      ignore_labels:
+        - "Changelog: Skip Update"
+        - "Expeditor: Skip All"
+  - built_in:trigger_omnibus_release_build:
+      ignore_labels:
+        - "Omnibus: Skip Build"
+        - "Expeditor: Skip All"
+      only_if: built_in:bump_version
 
 artifact_actions:
   promoted_to_stable:
     - built_in:publish_rubygems
     - built_in:rollover_changelog
+    - built_in:create_github_release
     - built_in:notify_chefio_slack_channels


### PR DESCRIPTION
merge_actions must now be an array rather than a hash. Also adding the ability for Expeditor to create a GitHub Release entry when an artifact is promoted to stable.