### PR TITLE
Add clarifying docs for mysql_conf resource

### DIFF
--- a/docs/resources/mysql_conf.md.erb
+++ b/docs/resources/mysql_conf.md.erb
@@ -14,9 +14,20 @@ A `mysql_conf` resource block declares one (or more) settings in the `my.cnf` fi
       its('setting') { should eq 'value' }
     end
 
+    # Test a parameter set within the [mysqld] section
+    describe mysql_conf do
+      its('mysqld.port') { should cmp 3306 }
+    end
+
+    # Test a parameter set within the [mariadb] section using array notation
+    describe mysql_conf do
+      its(['mariadb', 'max-connections']) { should_not be_nil }
+    end
+
 where
 
 * `'setting'` specifies a setting in the `my.cnf` file, such as `max_connections`
+  * when checking a setting within sections, such as `[mysqld]`, the section name must be included
 * `('path')` is the non-default path to the `my.cnf` file
 * `should eq 'value'` is the value that is expected
 

--- a/lib/resources/mysql_conf.rb
+++ b/lib/resources/mysql_conf.rb
@@ -33,6 +33,16 @@ module Inspec::Resources
       describe mysql_conf('path') do
         its('setting') { should eq 'value' }
       end
+
+      # Test a parameter set within the [mysqld] section
+      describe mysql_conf do
+        its('mysqld.port') { should cmp 3306 }
+      end
+
+      # Test a parameter set within the [mariadb] section using array notation
+      describe mysql_conf do
+        its(['mariadb', 'max-connections']) { should_not be_nil }
+      end
     "
 
     include FindFiles


### PR DESCRIPTION
The docs did not include examples for querying settings set within a named section.

Fixes #504