### PR TITLE
package resource: assume a default Homebrew path

### DIFF
--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -193,7 +193,8 @@ module Inspec::Resources
   # MacOS / Darwin implementation
   class Brew < PkgManagement
     def info(package_name)
-      cmd = inspec.command("brew info --json=v1 #{package_name}")
+      brew_path = inspec.command('brew').exist? ? 'brew' : '/usr/local/bin/brew'
+      cmd = inspec.command("#{brew_path} info --json=v1 #{package_name}")
       return nil if cmd.exit_status.to_i != 0
       # parse data
       pkg = JSON.parse(cmd.stdout)[0]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -202,6 +202,7 @@ class MockLoader
       'rpm -qia --dbpath /var/lib/rpmdb_does_not_exist curl' => cmd_exit_1,
       'pacman -Qi curl' => cmd.call('pacman-qi-curl'),
       'brew info --json=v1 curl' => cmd.call('brew-info--json-v1-curl'),
+      '/usr/local/bin/brew info --json=v1 curl' => cmd.call('brew-info--json-v1-curl'),
       'gem list --local -a -q ^not-installed$' => cmd.call('gem-list-local-a-q-not-installed'),
       'gem list --local -a -q ^rubocop$' => cmd.call('gem-list-local-a-q-rubocop'),
       '/opt/ruby-2.3.1/embedded/bin/gem list --local -a -q ^pry$' => cmd.call('gem-list-local-a-q-pry'),


### PR DESCRIPTION
Homebrew's `brew` script is installed to /usr/local/bin by default which is usually not in a non-interactive PATH. We will now first check to see if `brew` is in PATH, and if not, assume a default of `/usr/local/bin/brew`

Fixes #1574