### PR TITLE
Show versions for inspec compliance profiles

### DIFF
--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -104,7 +104,7 @@ module Compliance
         # iterate over profiles
         headline('Available profiles:')
         profiles.each { |profile|
-          li("#{profile['title']} #{mark_text(profile['owner_id'] + '/' + profile['name'])}")
+          li("#{profile['title']} v#{profile['version']} (#{mark_text(profile['owner_id'] + '/' + profile['name'])})")
         }
       else
         puts msg, 'Could not find any profiles'


### PR DESCRIPTION
Automate supports same profile with multiple versions.

Before:
```
$ be inspec compliance profiles

== Available profiles:

 * CIS AIX 5.3 and AIX 6.1 Benchmark Level 1 admin/cis-aix-5.3-6.1-level1
 * CIS AIX 5.3 and AIX 6.1 Benchmark Level 2 admin/cis-aix-5.3-6.1-level2
 * DevSec Apache Baseline admin/apache-baseline
 * DevSec Apache Baseline admin/apache-baseline
```

After:
```
$ be inspec compliance profiles

== Available profiles:

 * CIS AIX 5.3 and AIX 6.1 Benchmark Level 1 v1.1.0 (admin/cis-aix-5.3-6.1-level1)
 * CIS AIX 5.3 and AIX 6.1 Benchmark Level 2 v1.1.0 (admin/cis-aix-5.3-6.1-level2)
 * DevSec Apache Baseline v2.0.1 (admin/apache-baseline)
 * DevSec Apache Baseline v2.0.2 (admin/apache-baseline)
```