### PR TITLE
Build and tag docker image via Expeditor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -5,6 +5,10 @@ product_key: inspec
 rubygems:
  - inspec
 
+docker:
+  build_args:
+    - GEM_SOURCE: http://artifactory.chef.co/omnibus-gems-local
+
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:
   notify_channel: inspec-notify
@@ -40,8 +44,14 @@ merge_actions:
       only_if: built_in:bump_version
 
 artifact_actions:
+  promoted_to_unstable:
+    - built_in:build_docker_image
+  promoted_to_current:
+    - built_in:tag_docker_image
   promoted_to_stable:
     - built_in:publish_rubygems
     - built_in:rollover_changelog
     - built_in:create_github_release
+    - built_in:tag_docker_image
+    - bash:.expeditor/update_dockerfile.sh
     - built_in:notify_chefio_slack_channels

--- a/.expeditor/update_dockerfile.sh
+++ b/.expeditor/update_dockerfile.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# This file updates the default VERSION build argument in the Dockerfile to the
+# VERSION passed in to the file via environment variables.
+#
+# This ensures the Dockerfile in inspec master will list the version of the latest
+# stable release for any community member who wishes to build their own container
+# from scratch.
+#
+
+set -evx
+
+sed -i -r "s/^ARG VERSION=.*/ARG VERSION=${VERSION}/" Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:alpine
 MAINTAINER Chef Software, Inc. <docker@chef.io>
 
-ARG CHANNEL=stable
 ARG VERSION=1.36.1
 ARG GEM_SOURCE=https://rubygems.org
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM ruby:alpine
+MAINTAINER Chef Software, Inc. <docker@chef.io>
+
+ARG CHANNEL=stable
+ARG VERSION=1.36.1
+ARG GEM_SOURCE=https://rubygems.org
+
 RUN mkdir /share
-COPY inspec.gem /
 RUN apk add --update build-base libxml2-dev libffi-dev && \
-    gem install /inspec.gem --no-document && \
+    gem install --no-document --source ${GEM_SOURCE} --version ${VERSION} inspec && \
     apk del build-base
 ENTRYPOINT ["inspec"]
 CMD ["help"]


### PR DESCRIPTION
In order to provide Docker images of all unstable, current, and stable builds of InSpec, and to avoid having to manually publish Docker images each time we release InSpec, Expeditor will now take care of this for us.