### PR TITLE
quote username and hostname in mssql_session.rb

### DIFF
--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -51,11 +51,11 @@ module Inspec::Resources
       escaped_query = q.gsub(/\\/, '\\\\').gsub(/"/, '\\"').gsub(/\$/, '\\$')
       # surpress 'x rows affected' in SQLCMD with 'set nocount on;'
       cmd_string = "sqlcmd -Q \"set nocount on; #{escaped_query}\" -W -w 1024 -s ','"
-      cmd_string += " -U #{@user} -P '#{@password}'" unless @user.nil? || @password.nil?
+      cmd_string += " -U '#{@user}' -P '#{@password}'" unless @user.nil? || @password.nil?
       if @instance.nil?
-        cmd_string += " -S #{@host}"
+        cmd_string += " -S '#{@host}'"
       else
-        cmd_string += " -S #{@host}\\#{@instance}"
+        cmd_string += " -S '#{@host}\\#{@instance}'"
       end
       cmd = inspec.command(cmd_string)
       out = cmd.stdout + "\n" + cmd.stderr

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -366,8 +366,9 @@ class MockLoader
       %q(psql --version | awk '{ print $NF }' | awk -F. '{ print $1"."$2 }') => cmd.call('psql-version'),
       # mssql tests
       "bash -c 'type \"sqlcmd\"'" => cmd.call('mssql-sqlcmd'),
-      "cf33896c4bb500abc23dda5b5eddb03cd35a9c46a7358a2c0a0abe41e08a73ae" => cmd.call('mssql-getdate'),
-      "cd283a171cbd65698a2ea6a15524cb4b8566ff1caff430a51091bd5065dcbdf7" => cmd.call('mssql-result'),
+      "4b550bb227058ac5851aa0bc946be794ee46489610f17842700136cf8bb5a0e9" => cmd.call('mssql-getdate'),
+      "aeb859a4ae4288df230916075c0de28781a2b215f41d64ed1ea9c3fd633140fa" => cmd.call('mssql-result'),
+      "5c2bc0f0568d11451d6cf83aff02ee3d47211265b52b6c5d45f8e57290b35082" => cmd.call('mssql-getdate'),
       # oracle
       "bash -c 'type \"sqlplus\"'" => cmd.call('oracle-cmd'),
       "ef04e5199abee80e662cc0dd1dd3bf3e0aaae9b4498217d241db00b413820911" => cmd.call('oracle-result'),

--- a/test/unit/resources/mssql_session_test.rb
+++ b/test/unit/resources/mssql_session_test.rb
@@ -12,6 +12,13 @@ describe 'Inspec::Resources::MssqlSession' do
     _(resource.host).must_equal 'localhost'
   end
 
+  it 'verify mssql_session configuration with custom sqlserver port and user in domain' do
+    resource = load_resource('mssql_session', user: 'DOMAIN\sa', password: 'yourStrong(!)Password', host: 'localhost,1533')
+    _(resource.user).must_equal 'DOMAIN\sa'
+    _(resource.password).must_equal 'yourStrong(!)Password'
+    _(resource.host).must_equal 'localhost,1533'
+  end
+
   it 'run a SQL query' do
     resource = load_resource('mssql_session', user: 'sa', password: 'yourStrong(!)Password', host: 'localhost')
     query = resource.query("SELECT SERVERPROPERTY('ProductVersion') as result")


### PR DESCRIPTION
If username contains backslash or hosthame variable contains port number like:
```
host: "localhost,1433"
user: "DOMAIN\sa"
```

inspec scan fails with error:
```
Sqlcmd: '1433': Unexpected argument. Enter '-?' for help.
Could not execute the sql query
```

This PR fixes this issue.