### PR TITLE
Add deprecation warning to auditd_rules resource

### DIFF
--- a/lib/resources/auditd_rules.rb
+++ b/lib/resources/auditd_rules.rb
@@ -87,6 +87,8 @@ module Inspec::Resources
         parse_content
         @legacy = nil
       end
+
+      warn '[DEPRECATION] The `auditd_rules` resource is deprecated and will be removed in InSpec 2.0. Use the `auditd` resource instead.'
     end
 
     # non-legacy instances are not asked for `its('LIST_RULES')`


### PR DESCRIPTION
The auditd_rules resource has been replaced by the auditd resource. We are planning on removing the auditd_rules resource in InSpec 2.0. This change will provide a warning to any user using the old resource.

Resolves #2145