### PR TITLE
[win-perf] reduce number of powershell commands

### DIFF
--- a/lib/resources/groups.rb
+++ b/lib/resources/groups.rb
@@ -157,6 +157,8 @@ module Inspec::Resources
   class WindowsGroup < GroupInfo
     # returns all local groups
     def groups
+      return @@groups_cache if defined?(@@groups_cache)
+
       script = <<-EOH
 Function  ConvertTo-SID { Param([byte[]]$BinarySID)
   (New-Object  System.Security.Principal.SecurityIdentifier($BinarySID,0)).Value
@@ -183,7 +185,7 @@ $groups | ConvertTo-Json -Depth 3
 
       # ensure we have an array of groups
       groups = [groups] if !groups.is_a?(Array)
-      groups
+      @@groups_cache = groups
     end
   end
 end

--- a/lib/resources/users.rb
+++ b/lib/resources/users.rb
@@ -574,7 +574,7 @@ module Inspec::Resources
 
     # https://msdn.microsoft.com/en-us/library/aa746340(v=vs.85).aspx
     def collect_user_details # rubocop:disable Metrics/MethodLength
-      return @users_cache if defined?(@users_cache)
+      return @@users_cache if defined?(@@users_cache)
       script = <<-EOH
 Function ConvertTo-SID { Param([byte[]]$BinarySID)
   (New-Object System.Security.Principal.SecurityIdentifier($BinarySID,0)).Value
@@ -646,7 +646,7 @@ $adsi.Children | where {$_.SchemaClassName -eq 'user'} | ForEach {
       # ensure we have an array of groups
       users = [users] if !users.is_a?(Array)
       # convert keys to symbols
-      @users_cache = users.map { |user| user.each_with_object({}) { |(k, v), h| h[k.to_sym] = v } }
+      @@users_cache = users.map { |user| user.each_with_object({}) { |(k, v), h| h[k.to_sym] = v } }
     end
   end
 end


### PR DESCRIPTION
## overview

we incur an overhead of roughly 250ms per powershell call when running compliance profiles against Windows in local mode. this change memoizes the results of powershell calls where possible in the `security_policy` and `registry_key` modules and batches the calls to reduce the overhead for the `wmi_command` module.

## impact

**security_policy**: huge
this module previously made 3 powershell calls for every instance and has been reduced to 3 for the entire run. this has a huge impact on performance. we save ~750ms per `security_policy` block.

**registry_key**: small
this change dedups multiple calls to the same registry key. in the case where a user has multiple blocks for the same registry key, this will save the overhead of an additional powershell call. the speedup here is completely conditional on the number of duplicate registry key blocks.

**wmi_command**: small
this change batches all `Get-WmiObject` commands into a single powershell command. since the powershell `Get-WmiObject` cmdlet is so expensive, the savings we get from this aren't as drastic. e.g. if you're making heavy use of `wmi_command` then your profiles are going to be slow. this results in about a 10-15% speedup for `wmi_command` calls.

**users**: huge
this module previously executed the same powershell script for every instance of a control. this change results in making that call once for the entire duration of the tests.

**groups**: huge
this module previously executed the same powershell script every time it was called with no caching. this change results in making that call once for the entire duration of the tests.

## results
The following is the execution time of the `cis-windows2012r2-level2-memberserver-v2.2.0` profile:

* `master`: 1806.237s
* `65f7d0b`: 783.394s
* `d635691`: 83.779s

`cis-windows2012r2-level2-domaincontroller-v2.2.0`:
* `master`: 2168.065s
* `d635691`: 77.123s

## bonus results
When these changes are combined with the approach taken in chef/train#196, the execution time is further reduced to:

* `cis-windows2012r2-level2-memberserver-v2.2.0`: 47.826s
* `cis-windows2012r2-level2-domaincontroller-v2.2.0`: 33.967s

## notes
I think 65f7d0b probably needs a bit more cleanup before it gets merged.