### PR TITLE
Support array syntax for registry_key resource

### DIFF
--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -106,10 +106,19 @@ module Inspec::Resources
     end
 
     # returns nil, if not existant or value
-    def method_missing(meth)
+    def method_missing(*keys)
+      # allow the use of array syntax in an `its` block so that users
+      # can use it to query for keys with . characters in them
+      if keys.is_a?(Array)
+        keys.shift if keys[0] == :[]
+        key = keys.first
+      else
+        key = keys
+      end
+
       # get data
       val = registry_key(@options[:path])
-      registry_property_value(val, meth)
+      registry_property_value(val, key)
     end
 
     def to_s

--- a/test/unit/mock/cmd/reg_schedule
+++ b/test/unit/mock/cmd/reg_schedule
@@ -2,5 +2,9 @@
     "Start":  {
                   "value":  2,
                   "type":  4
+              },
+    "key.with.period":  {
+                  "value":  12345,
+                  "type":  4
               }
 }

--- a/test/unit/resources/registry_key_test.rb
+++ b/test/unit/resources/registry_key_test.rb
@@ -16,6 +16,11 @@ describe 'Inspec::Resources::RegistryKey' do
     _(resource_without_name.Start).must_equal 2
   end
 
+  it 'supports array syntax for keys with periods in them' do
+    resource = MockLoader.new(:windows).load_resource('registry_key', 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule')
+    _(resource.send(:[], "key.with.period")).must_equal 12345
+  end
+
   it 'generates a proper path from options' do
     resource = MockLoader.new(:windows).load_resource(
       'registry_key',


### PR DESCRIPTION
Users cannot query for registry keys that have periods in them because of how rspec-its works. This change enables Array-style syntax for the registry_key resource so users can use that as a workaround.

Fixes #1281