### PR TITLE
Regex Integer Octal Matching

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -306,8 +306,10 @@ RSpec::Matchers.define :cmp do |first_expected|
       return actual.casecmp(expected) == 0 if op == :==
       return Gem::Version.new(actual).method(op).call(Gem::Version.new(expected)) if
         version?(expected) && version?(actual)
-    elsif expected.is_a?(Regexp) && (actual.is_a?(String) || actual.is_a?(Integer))
+    elsif expected.is_a?(Regexp) && actual.is_a?(String)
       return !actual.to_s.match(expected).nil?
+    elsif expected.is_a?(Regexp) && actual.is_a?(Integer)
+      return !actual.to_s(8).match(expected).nil?
     elsif expected.is_a?(String) && integer?(expected) && actual.is_a?(Integer)
       return actual.method(op).call(expected.to_i)
     elsif expected.is_a?(String) && boolean?(expected) && [true, false].include?(actual)


### PR DESCRIPTION
When trying to use regex to match against file modes, it must be converted from a decimal to an octal. This change separates the or statement allowing for integer/decimal permission values to be converted to octals before matching against regex.

Signed-off-by: Kyle Boyer <kyle.boyer@optum.com>