### PR TITLE
Modify Upstart enabled check to use config file

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -169,6 +169,7 @@ class MockLoader
       '/etc/aide.conf' => mockfile.call('aide.conf'),
       '/var/lib/fake_rpmdb' => mockdir.call(true),
       '/var/lib/rpmdb_does_not_exist' => mockdir.call(false),
+      '/etc/init/ssh.conf' => mockfile.call('upstart_ssh_enabled.conf'),
     }
 
     # create all mock commands
@@ -236,8 +237,6 @@ class MockLoader
       '6785190b3df7291a7622b0b75b0217a9a78bd04690bc978df51ae17ec852a282' => cmd.call('get-item-property-package'),
       # service status upstart on ubuntu
       'initctl status ssh' => cmd.call('initctl-status-ssh'),
-      # service config for upstart on ubuntu
-      'initctl show-config ssh' => cmd.call('initctl-show-config-ssh'),
       # upstart version on ubuntu
       'initctl --version' => cmd.call('initctl--version'),
       # show ssh service Centos 7

--- a/test/unit/mock/cmd/initctl-show-config-ssh
+++ b/test/unit/mock/cmd/initctl-show-config-ssh
@@ -1,3 +1,0 @@
-ssh
-  start on (filesystem or runlevel [2345])
-  stop on runlevel [!2345]

--- a/test/unit/mock/files/upstart_ssh_enabled.conf
+++ b/test/unit/mock/files/upstart_ssh_enabled.conf
@@ -1,0 +1,26 @@
+# ssh - OpenBSD Secure Shell server
+#
+# The OpenSSH server provides secure shell access to the system.
+
+description     "OpenSSH server"
+
+start on filesystem
+stop on runlevel [!2345]
+
+respawn
+respawn limit 10 5
+umask 022
+# replaces SSHD_OOM_ADJUST in /etc/default/ssh
+oom never
+
+pre-start script
+    test -x /usr/sbin/sshd || { stop; exit 0; }
+    test -e /etc/ssh/sshd_not_to_be_run && { stop; exit 0; }
+    test -c /dev/null || { stop; exit 0; }
+
+    mkdir -p -m0755 /var/run/sshd
+end script
+
+# if you used to set SSHD_OPTS in /etc/default/ssh, you can change the
+# 'exec' line here instead
+exec /usr/sbin/sshd -D


### PR DESCRIPTION
This modifies the enabled check for the `service` resource to use the service's config file instead of `initctl show-config`.

`initctl show-config` does not accurately show the state of a service if that service's config file is modified while the service is running.

This fixes #1834.

Signed-off-by: Jerry Aldrich <jerryaldrichiii@gmail.com>