### PR TITLE
Support `false` for attribute value

### DIFF
--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -3,6 +3,8 @@
 module Inspec
   class Attribute
     attr_accessor :name
+    attr_writer :value
+
     def initialize(name, options)
       @name = name
       @opts = options
@@ -10,11 +12,8 @@ module Inspec
     end
 
     # implicit call is done by inspec to determine the value of an attribute
-    def value(newvalue = nil)
-      unless newvalue.nil?
-        @value = newvalue
-      end
-      @value || default
+    def value
+      @value.nil? ? default : @value
     end
 
     def default

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -177,7 +177,7 @@ module Inspec
       # we need to return an attribute object, to allow dermination of default values
       attr = Attribute.new(name, options)
       # read value from given gived values
-      attr.value(@conf['attributes'][attr.name]) unless @conf['attributes'].nil?
+      attr.value = @conf['attributes'][attr.name] unless @conf['attributes'].nil?
       @attributes.push(attr)
       attr.value
     end

--- a/test/unit/objects/attribute_test.rb
+++ b/test/unit/objects/attribute_test.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+
+require 'helper'
+require 'inspec/objects/attribute'
+
+describe Inspec::Attribute do
+  let(:attribute) { Inspec::Attribute.new('test_attribute', default: 'default_value') }
+
+  it 'returns the default value if no value is assigned' do
+    attribute.value.must_equal 'default_value'
+  end
+
+  it 'returns the actual value, not the default, if one is assigned' do
+    attribute.value = 'new_value'
+    attribute.value.must_equal 'new_value'
+  end
+
+  it 'support storing and returning false' do
+    attribute.value = false
+    attribute.value.must_equal false
+  end
+end


### PR DESCRIPTION
The logic in `Inspec::Attribute` prohibited the use of `false` (FalseClass) as a valid attribute. If the attribute value supplied was `false`, then it would fall back to the default value.

This change properly allows the use of `false` as a value, adds the initial tests for Inspec::Attribute, and also uses better attr_writer semantics for writing/storing the value.

Fixes #2164