### PR TITLE
Update method in which Pry hooks are removed

### DIFF
--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -26,8 +26,13 @@ module Inspec
     end
 
     def configure_pry # rubocop:disable Metrics/AbcSize
-      # Remove all hooks and checks
-      Pry.hooks.clear_all
+      # Delete any before_session, before_eval, and after_eval hooks so we can
+      # replace them with our own. Pry 0.10 used to have a single method to clear
+      # all hooks, but this was removed in Pry 0.11.
+      [ :before_session, :before_eval, :after_eval ].each do |event|
+        Pry.hooks.get_hooks(event).keys.map { |hook| Pry.hooks.delete_hook(event, hook) }
+      end
+
       that = self
 
       # Add the help command

--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -29,7 +29,7 @@ module Inspec
       # Delete any before_session, before_eval, and after_eval hooks so we can
       # replace them with our own. Pry 0.10 used to have a single method to clear
       # all hooks, but this was removed in Pry 0.11.
-      [ :before_session, :before_eval, :after_eval ].each do |event|
+      [:before_session, :before_eval, :after_eval].each do |event|
         Pry.hooks.get_hooks(event).keys.map { |hook| Pry.hooks.delete_hook(event, hook) }
       end
 


### PR DESCRIPTION
Pry 0.11 removed the clear_all method for removing all hooks. This change updates the way we clear hooks for the events we care about.