### PR TITLE
Modify `DirProvider` to allow special characters

### DIFF
--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -72,7 +72,7 @@ module Inspec
       @files = if File.file?(path)
                  [path]
                else
-                 Dir[File.join(path, '**', '*')]
+                 Dir[File.join(Shellwords.shellescape(path), '**', '*')]
                end
       @path = path
     end

--- a/test/functional/inspec_check_test.rb
+++ b/test/functional/inspec_check_test.rb
@@ -5,12 +5,21 @@
 require 'functional/helper'
 require 'jsonschema'
 
-describe 'inspec check with json formatter' do
+describe 'inspec check' do
   include FunctionalHelper
 
-  it 'can execute a simple file and validate the json schema' do
-    out = inspec('check ' + integration_test_path + ' --format json')
-    out.exit_status.must_equal 0
-    data = JSON.parse(out.stdout)
+  describe 'inspec check with json formatter' do
+    it 'can check a profile and produce valid JSON' do
+      out = inspec('check ' + integration_test_path + ' --format json')
+      out.exit_status.must_equal 0
+      JSON.parse(out.stdout)
+    end
+  end
+
+  describe 'inspec check with special characters in path' do
+    it 'can check a profile with special characters in its path' do
+      out = inspec('check ' + File.join(profile_path, '{{special-path}}'))
+      out.exit_status.must_equal 0
+    end
   end
 end

--- a/test/unit/mock/profiles/{{special-path}}/README.md
+++ b/test/unit/mock/profiles/{{special-path}}/README.md
@@ -1,0 +1,4 @@
+# Profile with Special Characters in Path
+
+This is used to test `inspec check` on a path containing special characters. See: https://github.com/chef/inspec/issues/2111
+

--- a/test/unit/mock/profiles/{{special-path}}/controls/special-path.rb
+++ b/test/unit/mock/profiles/{{special-path}}/controls/special-path.rb
@@ -1,0 +1,10 @@
+title 'special-path'
+
+control 'normal-profile-1.0' do
+  impact 0.7
+  title 'Test Paths with Special Chars'
+  desc 'Not a real test, check with `inspec check`'
+  describe 'foo' do
+    it { should eq 'foo' }
+  end
+end

--- a/test/unit/mock/profiles/{{special-path}}/inspec.yml
+++ b/test/unit/mock/profiles/{{special-path}}/inspec.yml
@@ -1,0 +1,8 @@
+name: normal-profile
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0


### PR DESCRIPTION
This modifies `Inspec::DirProvider` to allow special characters in the file glob by escaping those characters via `Shellwords.shellescape`.

This fixes #2111 (`inspec check` on path with special characters)