### PR TITLE
forgiving default attributes

### DIFF
--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -5,7 +5,17 @@ module Inspec
     attr_accessor :name
     attr_writer :value
 
-    def initialize(name, options)
+    DEFAULT_ATTRIBUTE = Class.new do
+      def method_missing(*_) # rubocop:disable Style/MethodMissing
+        self
+      end
+
+      def respond_to_missing?(_, _)
+        true
+      end
+    end
+
+    def initialize(name, options = {})
       @name = name
       @opts = options
       @value = nil
@@ -17,7 +27,7 @@ module Inspec
     end
 
     def default
-      @opts[:default]
+      @opts[:default] || DEFAULT_ATTRIBUTE.new
     end
 
     def title

--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -6,7 +6,7 @@ module Inspec
     attr_writer :value
 
     DEFAULT_ATTRIBUTE = Class.new do
-      def method_missing(*_) # rubocop:disable Style/MethodMissing
+      def method_missing(*_)
         self
       end
 

--- a/test/unit/objects/attribute_test.rb
+++ b/test/unit/objects/attribute_test.rb
@@ -4,11 +4,7 @@ require 'helper'
 require 'inspec/objects/attribute'
 
 describe Inspec::Attribute do
-  let(:attribute) { Inspec::Attribute.new('test_attribute', default: 'default_value') }
-
-  it 'returns the default value if no value is assigned' do
-    attribute.value.must_equal 'default_value'
-  end
+  let(:attribute) { Inspec::Attribute.new('test_attribute') }
 
   it 'returns the actual value, not the default, if one is assigned' do
     attribute.value = 'new_value'
@@ -18,5 +14,25 @@ describe Inspec::Attribute do
   it 'support storing and returning false' do
     attribute.value = false
     attribute.value.must_equal false
+  end
+
+  it 'returns the default value if no value is assigned' do
+    attribute.value.must_be_kind_of Inspec::Attribute::DEFAULT_ATTRIBUTE
+  end
+
+  it 'has a default value that can be called like a nested map' do
+    attribute.value['hello']['world'][1][2]['three'].wont_be_nil
+  end
+
+  it 'has a default value that can take any nested method calls' do
+    attribute.value.call.some.fancy.functions.wont_be_nil
+  end
+
+  describe 'attribute with a default value set' do
+    let(:attribute) { Inspec::Attribute.new('test_attribute', default: 'default_value') }
+
+    it 'returns the user-configured default value if no value is assigned' do
+      attribute.value.must_equal 'default_value'
+    end
   end
 end


### PR DESCRIPTION
When default attributes arent specified provide one that is much more forgiving.
See this https://github.com/chef/inspec/issues/2176