### PR TITLE
Properly return postgres query errors on failure

### DIFF
--- a/lib/resources/postgres_session.rb
+++ b/lib/resources/postgres_session.rb
@@ -52,7 +52,7 @@ module Inspec::Resources
       cmd = inspec.command(psql_cmd)
       out = cmd.stdout + "\n" + cmd.stderr
       if cmd.exit_status != 0 || out =~ /could not connect to .*/ || out.downcase =~ /^error:.*/
-        skip_resource "Can't read run query #{query.inspect} on postgres_session: #{out}"
+        Lines.new(out, "PostgreSQL query with errors: #{query}")
       else
         Lines.new(cmd.stdout.strip, "PostgreSQL query: #{query}")
       end


### PR DESCRIPTION
When using the `query` method in the `postgres_session` resource, if the query fails, the `query` method attempts to call `skip_resource` with an error message. Not only does the `skip_resource` not properly work, but it also returns a `String` object back to the test which is probably going to try and call the `output` method on it to run the test.

This results in an error like this:

```
  Can't read
     ∅  undefined method `output' for "output":String
```

This change returns the full psql output as a Lines object to the user, including stderr, so they can at least get the error in their test output and avoids undefined method errors.