### PR TITLE
Bump train to 0.27

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_dependency 'train', '~> 0.26'
+  spec.add_dependency 'train', '~> 0.27'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'rainbow', '~> 2'


### PR DESCRIPTION
Train 0.27.0 includes a fix to properly support net-ssh 4.2 which had a deprecation issue for the `paranoid` ssh connection option.