### PR TITLE
Bump train to 0.28 to allow for more net-ssh versions

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_dependency 'train', '~> 0.27'
+  spec.add_dependency 'train', '~> 0.28'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'rainbow', '~> 2'


### PR DESCRIPTION
Train 0.27.0 has a dependency on net-ssh `~> 4.2` which causes issues with certain Chef installs that only support 4.1.0 or 3.x versions of net-ssh, causing gem conflicts. This bumps InSpec to use Train 0.28.0 which has a looser dependency on net-ssh and also properly addresses a net-ssh deprecation introduced in net-ssh 4.2.0.

Fixes #2183 