### PR TITLE
Add bsd platform family to etc_hosts resource

### DIFF
--- a/lib/resources/etc_hosts.rb
+++ b/lib/resources/etc_hosts.rb
@@ -20,7 +20,7 @@ class EtcHosts < Inspec.resource(1)
   include CommentParser
 
   def initialize(hosts_path = nil)
-    return skip_resource 'The `etc_hosts` resource is not supported on your OS.' unless inspec.os.linux? || inspec.os.windows?
+    return skip_resource 'The `etc_hosts` resource is not supported on your OS.' unless inspec.os.bsd? || inspec.os.linux? || inspec.os.windows?
     @conf_path      = hosts_path || default_hosts_file_path
     @content        = nil
     @params         = nil


### PR DESCRIPTION
This feels like an Obvious Fix, but I've signed off below, just in case.

I just ran the current unit tests for the resource, since this isn't changing any other logic/functionality:
```
$ bundle exec m test/unit/resources/etc_hosts_test.rb
Run options: -n "/^(test_0001_Verify\\ etc_hosts\\ filtering\\ by\\ `ip_address`|test_0002_Verify\\ etc_hosts\\ filtering\\ by\\ `canonical_hostname`|test_0003_Verify\\ etc_hosts\\ filtering\\ by\\ `all_host_names`|test_0004_Verify\\ etc_hosts\\ with\\ no\\ `all_host_names`)$/" --seed 20392

# Running:

....

Finished in 0.218581s, 18.2998 runs/s, 36.5997 assertions/s.

4 runs, 8 assertions, 0 failures, 0 errors, 0 skips
```

Signed-off-by: Craig Barrett <craig.barrett@outreach.io>
