### PR TITLE
Add instructions for building `docs/` child pages

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -8,6 +8,12 @@ Get all dependencies:
 bundle install
 ```
 
+To build the `docs/` child pages run:
+
+```bash
+bundle exec rake docs
+```
+
 To run it live run:
 
 ```bash


### PR DESCRIPTION
Currently, `middleman server` does not render the `docs/` pages.

Running `rake docs` before `middleman server` solves this.