### PR TITLE
Add Chef Automate support to `inspec compliance login`

### DIFF
--- a/lib/bundles/inspec-compliance/README.md
+++ b/lib/bundles/inspec-compliance/README.md
@@ -2,18 +2,17 @@
 
 This extensions offers the following features:
 
- - list available profiles in Chef Compliance
- - execute profiles directly from Chef Compliance locally
- - upload a local profile to Chef Compliance
+ - list available profiles in Chef Automate/Chef Compliance
+ - execute profiles directly from Chef Automate/Chef Compliance locally
+ - upload a local profile to Chef Automate/Chef Compliance
 
 To use the CLI, this InSpec add-on adds the following commands:
 
- * `$ inspec compliance login` - authentication of the API token against Chef Compliance
- * `$ inspec compliance login_automate` - authentication of the API token against Chef Automate
- * `$ inspec compliance profiles` - list all available Chef Compliance profiles
- * `$ inspec exec compliance://profile` - runs a Chef Compliance profile
- * `$ inspec compliance upload path/to/local/profile` - uploads a local profile to Chef Compliance
- * `$ inspec compliance logout` - logout of Chef Compliance
+ * `$ inspec compliance login` - authentication of the API token against Chef Automate/Chef Compliance
+ * `$ inspec compliance profiles` - list all available Compliance profiles
+ * `$ inspec exec compliance://profile` - runs a Compliance profile
+ * `$ inspec compliance upload path/to/local/profile` - uploads a local profile to Chef Automate/Chef Compliance
+ * `$ inspec compliance logout` - logout of Chef Automate/Chef Compliance
 
 Compliance profiles can be executed in two mays:
 
@@ -31,8 +30,7 @@ Commands:
   inspec compliance download PROFILE  # downloads a profile from Chef Compliance
   inspec compliance exec PROFILE      # executes a Chef Compliance profile
   inspec compliance help [COMMAND]    # Describe subcommands or one specific subcommand
-  inspec compliance login SERVER      # Log in to a Chef Compliance SERVER
-  inspec compliance login_automate SERVER   # Log in to an Automate SERVER
+  inspec compliance login SERVER      # Log in to a Chef Automate/Chef Compliance SERVER
   inspec compliance logout            # user logout from Chef Compliance
   inspec compliance profiles          # list all available profiles in Chef Compliance
   inspec compliance upload PATH       # uploads a local profile to Chef Compliance
@@ -41,29 +39,22 @@ Commands:
 
 ### Login with Chef Automate
 
-You need a Chef Automate server up and running. Compliance features need to [be activated](https://docs.chef.io/install_chef_automate.html#compliance), too.
-
-Now, you need a user token. You can retrieve that via [UI](https://docs.chef.io/api_delivery.html) or [CLI](https://docs.chef.io/ctl_delivery.html#delivery-token).
+You will need an access token for authentication. You can retrieve one via [UI](https://docs.chef.io/api_delivery.html) or [CLI](https://docs.chef.io/ctl_delivery.html#delivery-token).
 
 ```
-inspec compliance login_automate https://automate.compliance.test --insecure --user 'admin' --ent 'brewinc' --usertoken 'zuop..._KzE'
+$ inspec compliance login https://automate.compliance.test --insecure --user 'admin' --ent 'brewinc' --token 'zuop..._KzE'
 ```
 
 ### Login with Chef Compliance
 
-Before you start using the compliance plugin, you need a running [Chef Compliance](https://www.chef.io/compliance/) server. Please login and gather the access token:
+You will need an access token for authentication. You can retrieve one via:
 
 ![Chef Compliance Token](images/cc-token.png)
 
 You can choose the access token (`--token`) or the refresh token (`--refresh_token`)
 
 ```
-# login to chef compliance server
 $ inspec compliance login https://compliance.test --user admin --insecure --token '...'
-
-# display the chef compliance server version
-$ inspec compliance version
-Chef Compliance version: 1.0.11
 ```
 
 ### List available profiles via Chef Compliance / Automate
@@ -131,7 +122,7 @@ Available profiles:
  * cis/cis-ubuntu14.04lts-level2
 ```
 
-### Run a profile from Chef Compliance / Automate on Workstation
+### Run a profile from Chef Compliance / Chef Automate on Workstation
 
 ```
 $ inspec exec compliance://admin/profile

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -9,7 +9,6 @@ require_relative 'api/login'
 
 module Compliance
   class ServerConfigurationMissing < StandardError; end
-  class CannotDetermineServerType < StandardError; end
 
   # API Implementation does not hold any state by itself,
   # everything will be stored in local Configuration store
@@ -244,9 +243,11 @@ module Compliance
     end
 
     def self.determine_server_type(url, insecure)
-      return :automate if Compliance::HTTP.get(url + '/compliance/version', nil, insecure).code == '401'
-      return :compliance if Compliance::HTTP.get(url + '/api/version', nil, insecure).code == '200'
-      raise CannotDetermineServerType, "Unable to determine if #{url} is a Chef Automate or Chef Compliance server"
+      if Compliance::HTTP.get(url + '/compliance/version', nil, insecure).code == '401'
+        :automate
+      elsif Compliance::HTTP.get(url + '/api/version', nil, insecure).code == '200'
+        :compliance
+      end
     end
   end
 end

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -14,7 +14,6 @@ module Compliance
   # API Implementation does not hold any state by itself,
   # everything will be stored in local Configuration store
   class API # rubocop:disable Metrics/ClassLength
-
     extend Login
 
     # return all compliance profiles available for the user

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -244,8 +244,8 @@ module Compliance
     end
 
     def self.determine_server_type(url, insecure)
-      return 'automate' if Compliance::HTTP.get(url + '/compliance/version', nil, insecure).code == '401'
-      return 'compliance' if Compliance::HTTP.get(url + '/api/version', nil, insecure).code == '200'
+      return :automate if Compliance::HTTP.get(url + '/compliance/version', nil, insecure).code == '401'
+      return :compliance if Compliance::HTTP.get(url + '/api/version', nil, insecure).code == '200'
       raise CannotDetermineServerType, "Unable to determine if #{url} is a Chef Automate or Chef Compliance server"
     end
   end

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -14,7 +14,7 @@ module Compliance
   # API Implementation does not hold any state by itself,
   # everything will be stored in local Configuration store
   class API # rubocop:disable Metrics/ClassLength
-    extend Login
+    extend Compliance::API::Login
 
     # return all compliance profiles available for the user
     def self.profiles(config)

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -246,7 +246,7 @@ module Compliance
     def self.determine_server_type(url, insecure)
       return 'automate' if Compliance::HTTP.get(url + '/compliance/version', nil, insecure).code == '401'
       return 'compliance' if Compliance::HTTP.get(url + '/api/version', nil, insecure).code == '200'
-      raise CannotDetermineServerType
+      raise CannotDetermineServerType, "Unable to determine if #{url} is a Chef Automate or Chef Compliance server"
     end
   end
 end

--- a/lib/bundles/inspec-compliance/api/login.rb
+++ b/lib/bundles/inspec-compliance/api/login.rb
@@ -3,135 +3,143 @@
 # author: Dominik Ricter
 # author: Jerry Aldrich
 
-module Login
-  def login(options)
-    options['server_type'] = Compliance::API.determine_server_type(options['server'], options['insecure'])
+module Compliance
+  class API
+    module Login
+      def login(options)
+        options['server_type'] = Compliance::API.determine_server_type(options['server'], options['insecure'])
 
-    return Login::ComplianceServer.login(options) if options['server_type'] == 'compliance'
-    verify_thor_options(options)
+        return Login::ComplianceServer.login(options) if options['server_type'] == 'compliance'
+        Login::AutomateServer.login(options)
+      end
 
-    options['url'] = options['server'] + '/compliance'
-    token = options['dctoken'] || options['token']
-    puts store_access_token(options, token)
-  end
+      module AutomateServer
+        def self.login(options)
+          verify_thor_options(options)
 
-  private
+          options['url'] = options['server'] + '/compliance'
+          token = options['dctoken'] || options['token']
+          puts store_access_token(options, token)
+        end
 
-  def store_access_token(options, token)
-    token_info = if options['token']
-                   { type: 'usertoken', msg: 'automate user token' }
-                 else
-                   { type: 'dctoken', msg: 'data colletor token' }
-                 end
+        def self.store_access_token(options, token)
+          token_info = if options['token']
+                         { type: 'usertoken', msg: 'automate user token' }
+                       else
+                         { type: 'dctoken', msg: 'data colletor token' }
+                       end
 
-    config = Compliance::Configuration.new
+          config = Compliance::Configuration.new
 
-    config.clean
+          config.clean
 
-    config['automate'] = {}
-    config['automate']['ent'] = options['ent']
-    config['automate']['token_type'] = token_info[:type]
-    config['server'] = options['url']
-    config['user'] = options['user']
-    config['insecure'] = options['insecure'] || false
-    config['server_type'] = options['server_type']
+          config['automate'] = {}
+          config['automate']['ent'] = options['ent']
+          config['automate']['token_type'] = token_info[:type]
+          config['server'] = options['url']
+          config['user'] = options['user']
+          config['insecure'] = options['insecure'] || false
+          config['server_type'] = options['server_type']
 
-    config['token'] = token
-    config['version'] = Compliance::API.version(config)
-    config.store
-    "Stored configuration for Chef Automate: '#{config['server']}' with user: '#{config['user']}', ent: '#{config['automate']['ent']}' and your #{token_info[:msg]}"
-  end
+          config['token'] = token
+          config['version'] = Compliance::API.version(config)
+          config.store
+          "Stored configuration for Chef Automate: '#{config['server']}' with user: '#{config['user']}', ent: '#{config['automate']['ent']}' and your #{token_info[:msg]}"
+        end
 
-  # Automate login requires `--ent`, `--user`, and either `--token` or `--dctoken`
-  def verify_thor_options(o)
-    error_msg = []
+        # Automate login requires `--ent`, `--user`, and either `--token` or `--dctoken`
+        def self.verify_thor_options(o)
+          error_msg = []
 
-    error_msg.push('Please specify a server using `inspec compliance login https://SERVER`') if o['server'].nil?
-    error_msg.push('Please specify a user using `--user=\'USER\'`') if o['user'].nil?
-    error_msg.push('Please specify an enterprise using `--ent=\'automate\'`') if o['ent'].nil?
+          error_msg.push('Please specify a server using `inspec compliance login https://SERVER`') if o['server'].nil?
+          error_msg.push('Please specify a user using `--user=\'USER\'`') if o['user'].nil?
+          error_msg.push('Please specify an enterprise using `--ent=\'automate\'`') if o['ent'].nil?
 
-    if o['token'].nil? && o['dctoken'].nil?
-      error_msg.push('Please specify a token using `--token=\'AUTOMATE_TOKEN\'` or `--dctoken=\'DATA_COLLECTOR_TOKEN\'`')
+          if o['token'].nil? && o['dctoken'].nil?
+            error_msg.push('Please specify a token using `--token=\'AUTOMATE_TOKEN\'` or `--dctoken=\'DATA_COLLECTOR_TOKEN\'`')
+          end
+
+          raise ArgumentError, error_msg.join("\n") unless error_msg.empty?
+        end
+      end
+
+      module ComplianceServer
+        def self.login(options)
+          compliance_verify_thor_options(options)
+
+          options['url'] = options['server'] + '/api'
+
+          if options['user'] && options['token']
+            success = true
+            msg = compliance_store_access_token(options, options['token'])
+          elsif options['user'] && options['password']
+            success, msg = compliance_login_user_pass(options)
+          elsif options['refresh_token']
+            success, msg = compliance_login_refresh_token(options)
+          end
+
+          raise msg unless success
+
+          puts msg
+        end
+
+        def self.compliance_login_user_pass(options)
+          success, msg, token = Compliance::API.get_token_via_password(
+            options['url'],
+            options['user'],
+            options['password'],
+            options['insecure'],
+          )
+          msg += "\n" + compliance_store_access_token(options, token) if success
+
+          [success, msg]
+        end
+
+        def self.compliance_login_refresh_token(options)
+          success, msg, token = Compliance::API.get_token_via_refresh_token(
+            options['url'],
+            options['refresh_token'],
+            options['insecure'],
+          )
+          msg += "\n" + compliance_store_access_token(options, token) if success
+
+          [success, msg]
+        end
+
+        def self.compliance_store_access_token(options, token)
+          config = Compliance::Configuration.new
+          config.clean
+
+          config['user'] = options['user'] if options['user']
+          config['server'] = options['url']
+          config['insecure'] = options['insecure'] || false
+          config['server_type'] = options['server_type']
+          config['token'] = token
+          config['version'] = Compliance::API.version(config)
+
+          config.store
+
+          'API access token stored'
+        end
+
+        # Compliance login requires `--user` or `--refresh_token`
+        # If `--user` then either `--password`, `--token`, or `--refresh-token`, is required
+        def self.compliance_verify_thor_options(o)
+          error_msg = []
+
+          error_msg.push('Please specify a server using `inspec compliance login https://SERVER`') if o['server'].nil?
+
+          if o['user'].nil? && o['refresh_token'].nil?
+            error_msg.push('Please specify a `--user=\'USER\'` or a `--refresh-token=\'TOKEN\'`')
+          end
+
+          if o['user'] && o['password'].nil? && o['token'].nil? && o['refresh_token'].nil?
+            error_msg.push('Please specify either a `--password`, `--token`, or `--refresh-token`')
+          end
+
+          raise ArgumentError, error_msg.join("\n") unless error_msg.empty?
+        end
+      end
     end
-
-    raise ArgumentError, error_msg.join("\n") unless error_msg.empty?
-  end
-end
-
-module Login::ComplianceServer
-  def self.login(options)
-    compliance_verify_thor_options(options)
-
-    options['url'] = options['server'] + '/api'
-
-    if options['user'] && options['token']
-      success = true
-      msg = compliance_store_access_token(options, options['token'])
-    elsif options['user'] && options['password']
-      success, msg = compliance_login_user_pass(options)
-    elsif options['refresh_token']
-      success, msg = compliance_login_refresh_token(options)
-    end
-
-    raise msg unless success
-
-    puts msg
-  end
-
-  def self.compliance_login_user_pass(options)
-    success, msg, token = Compliance::API.get_token_via_password(
-      options['url'],
-      options['user'],
-      options['password'],
-      options['insecure'],
-    )
-    msg += "\n" + compliance_store_access_token(options, token) if success
-
-    [success, msg]
-  end
-
-  def self.compliance_login_refresh_token(options)
-    success, msg, token = Compliance::API.get_token_via_refresh_token(
-      options['url'],
-      options['refresh_token'],
-      options['insecure'],
-    )
-    msg += "\n" + compliance_store_access_token(options, token) if success
-
-    [success, msg]
-  end
-
-  def self.compliance_store_access_token(options, token)
-    config = Compliance::Configuration.new
-    config.clean
-
-    config['user'] = options['user'] if options['user']
-    config['server'] = options['url']
-    config['insecure'] = options['insecure'] || false
-    config['server_type'] = options['server_type']
-    config['token'] = token
-    config['version'] = Compliance::API.version(config)
-
-    config.store
-
-    'API access token stored'
-  end
-
-  # Compliance login requires `--user` or `--refresh_token`
-  # If `--user` then either `--password`, `--token`, or `--refresh-token`, is required
-  def self.compliance_verify_thor_options(o)
-    error_msg = []
-
-    error_msg.push('Please specify a server using `inspec compliance login https://SERVER`') if o['server'].nil?
-
-    if o['user'].nil? && o['refresh_token'].nil?
-      error_msg.push('Please specify a `--user=\'USER\'` or a `--refresh-token=\'TOKEN\'`')
-    end
-
-    if o['user'] && o['password'].nil? && o['token'].nil? && o['refresh_token'].nil?
-      error_msg.push('Please specify either a `--password`, `--token`, or `--refresh-token`')
-    end
-
-    raise ArgumentError, error_msg.join("\n") unless error_msg.empty?
   end
 end

--- a/lib/bundles/inspec-compliance/api/login.rb
+++ b/lib/bundles/inspec-compliance/api/login.rb
@@ -1,4 +1,4 @@
-# encodeing: utf-8
+# encoding: utf-8
 # author: Christoph Hartmann
 # author: Dominik Ricter
 # author: Jerry Aldrich

--- a/lib/bundles/inspec-compliance/api/login.rb
+++ b/lib/bundles/inspec-compliance/api/login.rb
@@ -7,7 +7,7 @@ module Compliance
   class API
     module Login
       def login(options)
-        options['server_type'] = Compliance::API.determine_server_type(options['server'], options['insecure'])
+        options['server_type'] = Compliance::API.determine_server_type(options['server'], options['insecure']).to_s
 
         return Login::ComplianceServer.login(options) if options['server_type'] == 'compliance'
         Login::AutomateServer.login(options)

--- a/lib/bundles/inspec-compliance/api/login.rb
+++ b/lib/bundles/inspec-compliance/api/login.rb
@@ -1,0 +1,134 @@
+# encodeing: utf-8
+# author: Christoph Hartmann
+# author: Dominik Ricter
+# author: Jerry Aldrich
+
+module Login
+  def login(options)
+    options['server_type'] = Compliance::API.determine_server_type(options['server'], options['insecure'])
+
+    return Login::ComplianceServer.login(options) if options['server_type'] == 'compliance'
+    verify_thor_options(options)
+
+    options['url'] = options['server'] + '/compliance'
+    token = options['dctoken'] || options['token']
+    puts store_access_token(options, token)
+  end
+
+  private
+
+  def store_access_token(options, token)
+    token_info = { type: 'dctoken', msg: 'data colletor token' } if options['dctoken']
+    token_info = { type: 'usertoken', msg: 'automate user token' } if options['token']
+
+    config = Compliance::Configuration.new
+
+    config.clean
+
+    config['automate'] = {}
+    config['automate']['ent'] = options['ent']
+    config['automate']['token_type'] = token_info[:type]
+    config['server'] = options['url']
+    config['user'] = options['user']
+    config['insecure'] = options['insecure'] || false
+    config['server_type'] = options['server_type']
+
+    config['token'] = token
+    config['version'] = Compliance::API.version(config)
+    config.store
+    "Stored configuration for Chef Automate: '#{config['server']}' with user: '#{config['user']}', ent: '#{config['automate']['ent']}' and your #{token_info[:msg]}"
+  end
+
+  # Automate login requires `--ent`, `--user`, and either `--token` or `--dctoken`
+  def verify_thor_options(o)
+    error_msg = []
+
+    error_msg.push('Please specify a server using `inspec compliance login https://SERVER`') if o['server'].nil?
+    error_msg.push('Please specify a user using `--user=\'USER\'`') if o['user'].nil?
+    error_msg.push('Please specify an enterprise using `--ent=\'automate\'`') if o['ent'].nil?
+
+    if o['token'].nil? && o['dctoken'].nil?
+      error_msg.push('Please specify a token using `--token=\'AUTOMATE_TOKEN\'` or `--dctoken=\'DATA_COLLECTOR_TOKEN\'`')
+    end
+
+    raise ArgumentError, error_msg.join("\n") unless error_msg.empty?
+  end
+end
+
+module Login::ComplianceServer
+  def self.login(options)
+    compliance_verify_thor_options(options)
+
+    options['url'] = options['server'] + '/api'
+
+    if options['user'] && options['token']
+      success = true
+      msg = compliance_store_access_token(options, options['token'])
+    elsif options['user'] && options['password']
+      success, msg = compliance_login_user_pass(options)
+    elsif options['refresh_token']
+      success, msg = compliance_login_refresh_token(options)
+    end
+
+    raise msg unless success
+
+    puts msg
+  end
+
+  def self.compliance_login_user_pass(options)
+    success, msg, token = Compliance::API.get_token_via_password(
+      options['url'],
+      options['user'],
+      options['password'],
+      options['insecure'],
+    )
+    msg += "\n" + compliance_store_access_token(options, token) if success
+
+    [success, msg]
+  end
+
+  def self.compliance_login_refresh_token(options)
+    success, msg, token = Compliance::API.get_token_via_refresh_token(
+      options['url'],
+      options['refresh_token'],
+      options['insecure'],
+    )
+    msg += "\n" + compliance_store_access_token(options, token) if success
+
+    [success, msg]
+  end
+
+  def self.compliance_store_access_token(options, token)
+    config = Compliance::Configuration.new
+    config.clean
+
+    config['user'] = options['user'] if options['user']
+    config['server'] = options['url']
+    config['insecure'] = options['insecure'] || false
+    config['server_type'] = options['server_type']
+    config['token'] = token
+    config['version'] = Compliance::API.version(config)
+
+    config.store
+
+    'API access token stored'
+  end
+
+  # Compliance login requires `--user` or `--refresh_token`
+  # If `--user` then either `--password`, `--token`, or `--refresh-token`, is required
+  def self.compliance_verify_thor_options(o)
+    error_msg = []
+
+    error_msg.push('Please specify a server using `inspec compliance login https://SERVER`') if o['server'].nil?
+
+    if o['user'].nil? && o['refresh_token'].nil?
+      error_msg.push('Please specify a `--user=\'USER\'` or a `--refresh-token=\'TOKEN\'`')
+    end
+
+    if o['user'] && o['password'].nil? && o['token'].nil? && o['refresh_token'].nil?
+      error_msg.push('Please specify either a `--password`, `--token`, or `--refresh-token`')
+    end
+
+    raise ArgumentError, error_msg.join("\n") unless error_msg.empty?
+  end
+end

--- a/lib/bundles/inspec-compliance/api/login.rb
+++ b/lib/bundles/inspec-compliance/api/login.rb
@@ -18,8 +18,11 @@ module Login
   private
 
   def store_access_token(options, token)
-    token_info = { type: 'dctoken', msg: 'data colletor token' } if options['dctoken']
-    token_info = { type: 'usertoken', msg: 'automate user token' } if options['token']
+    token_info = if options['token']
+                   { type: 'usertoken', msg: 'automate user token' }
+                 else
+                   { type: 'dctoken', msg: 'data colletor token' }
+                 end
 
     config = Compliance::Configuration.new
 

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -32,17 +32,52 @@ module Compliance
     option :user, type: :string, required: false,
       desc: 'Username'
     option :password, type: :string, required: false,
-      desc: 'Password'
+      desc: 'Password (Chef Compliance Only)'
     option :token, type: :string, required: false,
       desc: 'Access token'
     option :refresh_token, type: :string, required: false,
-      desc: 'Chef Compliance refresh token'
+      desc: 'Chef Compliance refresh token (Chef Compliance Only)'
     option :dctoken, type: :string, required: false,
-      desc: 'Data Collector token'
+      desc: 'Data Collector token (Chef Automate Only)'
     option :ent, type: :string, required: false,
-      desc: 'Enterprise for Chef Automate reporting'
+      desc: 'Enterprise for Chef Automate reporting (Chef Automate Only)'
     def login(server)
       options['server'] = server
+      Compliance::API.login(options)
+    end
+
+    desc "login_automate https://SERVER --insecure --user='USER' --ent='ENTERPRISE' --usertoken='TOKEN'", 'Log in to a Chef Automate SERVER (DEPRECATED: Please use `login`)'
+    long_desc <<-LONGDESC
+      This commmand is deprecated and will be removed, please use `--login`.
+
+      `login_automate` allows you to use InSpec with Chef Automate.
+
+      You need to a token for communication. More information about token retrieval
+      is available at:
+        https://docs.chef.io/api_automate.html#authentication-methods
+        https://docs.chef.io/api_compliance.html#obtaining-an-api-token
+    LONGDESC
+    option :insecure, aliases: :k, type: :boolean,
+      desc: 'Explicitly allows InSpec to perform "insecure" SSL connections and transfers'
+    option :user, type: :string, required: true,
+      desc: 'Username'
+    option :usertoken, type: :string, required: false,
+      desc: 'Access token (DEPRECATED: Please use `--token`)'
+    option :token, type: :string, required: false,
+      desc: 'Access token'
+    option :dctoken, type: :string, required: false,
+      desc: 'Data Collector token'
+    option :ent, type: :string, required: true,
+      desc: 'Enterprise for Chef Automate reporting'
+    def login_automate(server)
+      warn '[DEPRECATION] `inspec compliance login_automate` is deprecated. Please use `inspec compliance login`'
+      options['server'] = server
+
+      if options['usertoken']
+        warn '[DEPRECATION] `--usertoken` is deprecated. Please use `--token`.'
+        options['token'] = options['usertoken']
+      end
+
       Compliance::API.login(options)
     end
 

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -41,7 +41,7 @@ module Compliance
       desc: 'Data Collector token'
     option :ent, type: :string, required: false,
       desc: 'Enterprise for Chef Automate reporting'
-    def login(server) # rubocop:disable Metrics/AbcSize
+    def login(server)
       options['server'] = server
       Compliance::API.login(options)
     end

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -18,78 +18,32 @@ module Compliance
       namespace
     end
 
-    desc "login SERVER --insecure --user='USER' --token='TOKEN'", 'Log in to a Chef Compliance SERVER'
+    desc "login https://SERVER --insecure --user='USER' --ent='ENTERPRISE' --token='TOKEN'", 'Log in to a Chef Compliance/Chef Automate SERVER'
+    long_desc <<-LONGDESC
+      `login` allows you to use InSpec with Chef Automate or a Chef Compliance Server
+
+      You need to a token for communication. More information about token retrieval
+      is available at:
+        https://docs.chef.io/api_automate.html#authentication-methods
+        https://docs.chef.io/api_compliance.html#obtaining-an-api-token
+    LONGDESC
     option :insecure, aliases: :k, type: :boolean,
       desc: 'Explicitly allows InSpec to perform "insecure" SSL connections and transfers'
     option :user, type: :string, required: false,
-      desc: 'Chef Compliance Username'
+      desc: 'Username'
     option :password, type: :string, required: false,
-      desc: 'Chef Compliance Password'
-    option :apipath, type: :string, default: '/api',
-      desc: 'Set the path to the API, defaults to /api'
+      desc: 'Password'
     option :token, type: :string, required: false,
-      desc: 'Chef Compliance access token'
+      desc: 'Access token'
     option :refresh_token, type: :string, required: false,
       desc: 'Chef Compliance refresh token'
-    def login(server) # rubocop:disable Metrics/AbcSize
-      # show warning if the Compliance Server does not support
-
-      options['server'] = server
-      url = options['server'] + options['apipath']
-
-      if !options['user'].nil? && !options['password'].nil?
-        # username / password
-        _success, msg = login_username_password(url, options['user'], options['password'], options['insecure'])
-      elsif !options['user'].nil? && !options['token'].nil?
-        # access token
-        _success, msg = store_access_token(url, options['user'], options['token'], options['insecure'])
-      elsif !options['refresh_token'].nil? && !options['user'].nil?
-        # refresh token
-        _success, msg = store_refresh_token(url, options['refresh_token'], true, options['user'], options['insecure'])
-        # TODO: we should login with the refreshtoken here
-      elsif !options['refresh_token'].nil?
-        _success, msg = login_refreshtoken(url, options)
-      else
-        puts 'Please run `inspec compliance login SERVER` with options --token or --refresh_token, --user, and --insecure or --not-insecure'
-        exit 1
-      end
-
-      puts '', msg
-    end
-
-    desc "login_automate SERVER --insecure --user='USER' --ent='ENT' --usertoken='TOKEN'", 'Log in to an Automate SERVER'
-    long_desc <<-LONGDESC
-      `login_automate` allows you to use InSpec with Chef Automate
-
-      You need to a user-token for communication with Chef Automate. More
-      information about token retrieval for Automate is available at:
-      https://docs.chef.io/api_delivery.html
-    LONGDESC
-    option :dctoken, type: :string,
+    option :dctoken, type: :string, required: false,
       desc: 'Data Collector token'
-    option :usertoken, type: :string,
-      desc: 'Automate user token'
-    option :user, type: :string,
-      desc: 'Automate username'
-    option :ent, type: :string,
+    option :ent, type: :string, required: false,
       desc: 'Enterprise for Chef Automate reporting'
-    option :insecure, aliases: :k, type: :boolean,
-      desc: 'Explicitly allows InSpec to perform "insecure" SSL connections and transfers'
-    def login_automate(server) # rubocop:disable Metrics/AbcSize
+    def login(server) # rubocop:disable Metrics/AbcSize
       options['server'] = server
-      url = options['server'] + '/compliance'
-
-      if url && !options['user'].nil? && !options['ent'].nil? && (!options['dctoken'].nil? || !options['usertoken'].nil?)
-        msg = login_automate_config(url, options['user'], options['dctoken'], options['usertoken'], options['ent'], options['insecure'])
-        puts '', msg
-        exit 0
-      end
-
-      # parameters are missing if we reach here
-      puts 'Please specify an user using `--user \'USER\'`' if options['user'].nil?
-      puts 'Please specify an enterprise using `--ent \'cd\'`' if options['ent'].nil?
-      puts 'Please specify a token using `--usertoken=\'AUTOMATE_TOKEN\'`' if options['usertoken'].nil? && options['dctoken'].nil?
-      exit 1
+      Compliance::API.login(options)
     end
 
     desc 'profiles', 'list all available profiles in Chef Compliance'
@@ -111,7 +65,7 @@ module Compliance
         exit 1
       end
     rescue Compliance::ServerConfigurationMissing
-      puts "\nServer configuration information is missing. Please login using `inspec compliance login`"
+      STDERR.puts "\nServer configuration information is missing. Please login using `inspec compliance login`"
       exit 1
     end
 
@@ -272,109 +226,9 @@ module Compliance
 
     private
 
-    def login_automate_config(url, user, dctoken, usertoken, ent, insecure) # rubocop:disable Metrics/ParameterLists
-      config = Compliance::Configuration.new
-      config.clean
-      config['user'] = user
-      config['server'] = url
-      config['automate'] = {}
-      config['automate']['ent'] = ent
-      config['server_type'] = 'automate'
-      config['insecure'] = insecure
-
-      # determine token method being used
-      if !dctoken.nil?
-        config['token'] = dctoken
-        token_type = 'dctoken'
-        token_msg = 'data collector token'
-      else
-        config['token'] = usertoken
-        token_type = 'usertoken'
-        token_msg = 'automate user token'
-      end
-      config['automate']['token_type'] = token_type
-      config['version'] = Compliance::API.version(config)
-      config.store
-      msg = "Stored configuration for Chef Automate: '#{url}' with user: '#{user}', ent: '#{ent}' and your #{token_msg}"
-      msg
-    end
-
-    def login_refreshtoken(url, options)
-      success, msg, _access_token = Compliance::API.get_token_via_refresh_token(url, options['refresh_token'], options['insecure'])
-      if success
-        config = Compliance::Configuration.new
-        config.clean
-        config['server'] = url
-        config['insecure'] = options['insecure']
-        config['server_type'] = 'compliance'
-        config['version'] = Compliance::API.version(config)
-        config.store
-      end
-
-      [success, msg]
-    end
-
-    def login_username_password(url, username, password, insecure)
-      config = Compliance::Configuration.new
-      config.clean
-      success, msg, api_token = Compliance::API.get_token_via_password(url, username, password, insecure)
-      if success
-        config['server'] = url
-        config['user'] = username
-        config['token'] = api_token
-        config['insecure'] = insecure
-        config['server_type'] = 'compliance'
-        config['version'] = Compliance::API.version(config)
-        config.store
-        success = true
-      end
-      [success, msg]
-    end
-
-    # saves a user access token (limited time)
-    def store_access_token(url, user, token, insecure)
-      config = Compliance::Configuration.new
-      config.clean
-      config['server'] = url
-      config['insecure'] = insecure
-      config['user'] = user
-      config['token'] = token
-      config['server_type'] = 'compliance'
-      config['version'] = Compliance::API.version(config)
-      config.store
-
-      [true, 'API access token stored']
-    end
-
-    # saves a refresh token supplied by the user
-    def store_refresh_token(url, refresh_token, verify, user, insecure)
-      config = Compliance::Configuration.new
-      config.clean
-      config['server'] = url
-      config['refresh_token'] = refresh_token
-      config['user'] = user
-      config['insecure'] = insecure
-      config['server_type'] = 'compliance'
-      config['version'] = Compliance::API.version(config)
-
-      if !verify
-        config.store
-        success = true
-        msg = 'API refresh token stored'
-      else
-        success, msg, _access_token= Compliance::API.get_token_via_refresh_token(url, refresh_token, insecure)
-        if success
-          config.store
-          msg = 'API access token verified'
-        end
-      end
-
-      [success, msg]
-    end
-
     def loggedin(config)
       serverknown = !config['server'].nil?
-      puts 'You need to login first with `inspec compliance login` or `inspec compliance login_automate`' if !serverknown
+      puts 'You need to login first with `inspec compliance login`' if !serverknown
       serverknown
     end
   end

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -73,10 +73,7 @@ module Compliance
       warn '[DEPRECATION] `inspec compliance login_automate` is deprecated. Please use `inspec compliance login`'
       options['server'] = server
 
-      if options['usertoken']
-        warn '[DEPRECATION] `--usertoken` is deprecated. Please use `--token`.'
-        options['token'] = options['usertoken']
-      end
+      options['token'] = options['usertoken'] if options['usertoken']
 
       Compliance::API.login(options)
     end

--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -32,7 +32,7 @@ module Compliance
         if config['token'].nil? && config['refresh_token'].nil?
           if config['server_type'] == 'automate'
             server = 'automate'
-            msg = 'inspec compliance login_automate https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --usertoken USERTOKEN'
+            msg = 'inspec compliance login https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --token USERTOKEN'
           else
             server = 'compliance'
             msg = "inspec compliance login https://your_compliance_server --user admin --insecure --token 'PASTE TOKEN HERE' "
@@ -90,8 +90,7 @@ EOF
 
       raise 'Unable to determine compliance profile name. This can be caused by ' \
         'an incorrect server in your configuration. Try to login to compliance ' \
-        'via the `inspec compliance login` or `inspec compliance login_automate` ' \
-        'commands.' if m.nil?
+        'via the `inspec compliance login` command.' if m.nil?
 
       "#{m[:owner]}/#{m[:id]}"
     end

--- a/test/functional/inspec_compliance_test.rb
+++ b/test/functional/inspec_compliance_test.rb
@@ -23,23 +23,11 @@ describe 'inspec compliance' do
 
   it 'login server url missing' do
     out = inspec('compliance login')
-    #TODO: we need to convince thor that this is an error
+    # TODO: We need to convince Thor that this is an error
+    # This will be fixed in the 1.0 release of Thor
+    # See: https://github.com/erikhuda/thor/issues/244
     out.exit_status.must_equal 0
     out.stderr.must_include 'ERROR: "inspec login" was called with no arguments'
-  end
-
-  it 'login server with missing parameters' do
-    out = inspec('compliance login http://example.com')
-    out.exit_status.must_equal 1
-    #TODO: inspec should really use stderr for errors
-    out.stdout.must_include 'Please run `inspec compliance login SERVER` with options'
-  end
-
-  it 'automate with missing parameters' do
-    out = inspec('compliance login_automate http://example.com')
-    out.exit_status.must_equal 1
-    #TODO: inspec should really use stderr for errors
-    out.stdout.must_include 'Please specify'
   end
 
   it 'inspec compliance profiles without authentication' do

--- a/test/unit/bundles/inspec-compliance/api/login_test.rb
+++ b/test/unit/bundles/inspec-compliance/api/login_test.rb
@@ -49,7 +49,7 @@ describe Compliance::API do
   describe '.login' do
     describe 'when target is a Chef Automate server' do
       before do
-        Compliance::API.expects(:determine_server_type).returns('automate')
+        Compliance::API.expects(:determine_server_type).returns(:automate)
       end
 
       it 'raises an error if `https://SERVER` is missing' do
@@ -103,7 +103,7 @@ describe Compliance::API do
 
     describe 'when target is a Chef Compliance server' do
       before do
-        Compliance::API.expects(:determine_server_type).returns('compliance')
+        Compliance::API.expects(:determine_server_type).returns(:compliance)
       end
 
       it 'raises an error if `https://SERVER` is missing' do

--- a/test/unit/bundles/inspec-compliance/api/login_test.rb
+++ b/test/unit/bundles/inspec-compliance/api/login_test.rb
@@ -1,0 +1,150 @@
+require 'helper'
+
+describe Compliance::API do
+  let(:automate_options) do
+    {
+      'server' => 'https://automate.example.com',
+      'ent' => 'automate',
+      'user' => 'someone',
+      'token' => 'token',
+    }
+  end
+
+  let(:compliance_options) do
+    {
+      'server' => 'https://compliance.example.com',
+      'user' => 'someone',
+      'password' => 'password',
+      'token' => 'token',
+      'refresh_token' => 'refresh_token',
+    }
+  end
+
+  let(:fake_config) do
+    class FakeConfig
+      def initialize
+        @config = {}
+      end
+
+      def [](key)
+        @config[key]
+      end
+
+      def []=(key, value)
+        @config[key] = value
+      end
+
+      def clean
+        @config = {}
+      end
+
+      def store
+        nil
+      end
+    end
+
+    FakeConfig.new
+  end
+
+  describe '.login' do
+    describe 'when target is a Chef Automate server' do
+      before do
+        Compliance::API.expects(:determine_server_type).returns('automate')
+      end
+
+      it 'raises an error if `https://SERVER` is missing' do
+        options = automate_options
+        options.delete('server')
+        err = proc { Compliance::API.login(options) }.must_raise(ArgumentError)
+        err.message.must_match(/Please specify a server.*/)
+        err.message.lines.length.must_equal(1)
+      end
+
+      it 'raises an error if `--user` is missing' do
+        options = automate_options
+        options.delete('user')
+        err = proc { Compliance::API.login(options) }.must_raise(ArgumentError)
+        err.message.must_match(/Please specify a user.*/)
+        err.message.lines.length.must_equal(1)
+      end
+
+      it 'raises an error if `--ent` is missing' do
+        options = automate_options
+        options.delete('ent')
+        err = proc { Compliance::API.login(options) }.must_raise(ArgumentError)
+        err.message.must_match(/Please specify an enterprise.*/)
+        err.message.lines.length.must_equal(1)
+      end
+
+      it 'raises an error if `--token` and `--dctoken` are missing' do
+        options = automate_options
+        options.delete('token')
+        options.delete('dctoken')
+        err = proc { Compliance::API.login(options) }.must_raise(ArgumentError)
+        err.message.must_match(/Please specify a token.*/)
+        err.message.lines.length.must_equal(1)
+      end
+
+      it 'stores an access token' do
+        stub_request(:get, automate_options['server'] + '/compliance/version')
+          .to_return(status: 200, body: '', headers: {})
+        options = automate_options
+        Compliance::Configuration.expects(:new).returns(fake_config)
+
+        proc { Compliance::API.login(options) }.must_output(/Stored configuration/)
+        fake_config['automate']['ent'].must_equal('automate')
+        fake_config['automate']['token_type'].must_equal('usertoken')
+        fake_config['user'].must_equal('someone')
+        fake_config['server'].must_equal('https://automate.example.com/compliance')
+        fake_config['server_type'].must_equal('automate')
+        fake_config['token'].must_equal('token')
+      end
+    end
+
+    describe 'when target is a Chef Compliance server' do
+      before do
+        Compliance::API.expects(:determine_server_type).returns('compliance')
+      end
+
+      it 'raises an error if `https://SERVER` is missing' do
+        options = compliance_options
+        options.delete('server')
+        err = proc { Compliance::API.login(options) }.must_raise(ArgumentError)
+        err.message.must_match(/Please specify a server.*/)
+        err.message.lines.length.must_equal(1)
+      end
+
+      it 'raises an error if `--user` and `--refresh-token` are missing' do
+        options = automate_options
+        options.delete('user')
+        options.delete('refresh_token')
+        err = proc { Compliance::API.login(options) }.must_raise(ArgumentError)
+        err.message.must_match(/Please specify a.*--user.*--refresh-token.*/)
+        err.message.lines.length.must_equal(1)
+      end
+
+      it 'raises an error if `--user` is present but authentication method missing' do
+        options = automate_options
+        options.delete('password')
+        options.delete('token')
+        options.delete('refresh_token')
+        err = proc { Compliance::API.login(options) }.must_raise(ArgumentError)
+        err.message.must_match(/Please specify.*--password.*--token.*--refresh-token.*/)
+        err.message.lines.length.must_equal(1)
+      end
+
+      it 'stores an access token' do
+        stub_request(:get, compliance_options['server'] + '/api/version')
+          .to_return(status: 200, body: '', headers: {})
+        options = compliance_options
+        Compliance::Configuration.expects(:new).returns(fake_config)
+
+        proc { Compliance::API.login(options) }.must_output(/API access token stored/)
+        fake_config['user'].must_equal('someone')
+        fake_config['server'].must_equal('https://compliance.example.com/api')
+        fake_config['server_type'].must_equal('compliance')
+        fake_config['token'].must_equal('token')
+      end
+    end
+  end
+end

--- a/test/unit/bundles/inspec-compliance/api_test.rb
+++ b/test/unit/bundles/inspec-compliance/api_test.rb
@@ -252,7 +252,7 @@ describe Compliance::API do
       good_response.stubs(:code).returns('401')
       url = 'https://automate.example.com'
       Compliance::HTTP.expects(:get).with(url + '/compliance/version', nil, true).returns(good_response)
-      Compliance::API.determine_server_type(url, true).must_equal('automate')
+      Compliance::API.determine_server_type(url, true).must_equal(:automate)
     end
 
     it 'returns `compliance` when a 200 is received from `https://compliance.example.com/api/version`' do
@@ -263,7 +263,7 @@ describe Compliance::API do
       url = 'https://compliance.example.com'
       Compliance::HTTP.expects(:get).with(url + '/compliance/version', nil, true).returns(bad_response)
       Compliance::HTTP.expects(:get).with(url + '/api/version', nil, true).returns(good_response)
-      Compliance::API.determine_server_type(url, true).must_equal('compliance')
+      Compliance::API.determine_server_type(url, true).must_equal(:compliance)
     end
 
     it 'raises a `Compliance::CannotDetermineServerType` error if no response returns favorably' do

--- a/test/unit/bundles/inspec-compliance/api_test.rb
+++ b/test/unit/bundles/inspec-compliance/api_test.rb
@@ -266,13 +266,13 @@ describe Compliance::API do
       Compliance::API.determine_server_type(url, true).must_equal(:compliance)
     end
 
-    it 'raises a `Compliance::CannotDetermineServerType` error if no response returns favorably' do
+    it 'returns `nil` if no response returns favorably' do
       bad_response = mock
       bad_response.stubs(:code).returns('404')
       url = 'https://bad.example.com'
       Compliance::HTTP.expects(:get).with(url + '/compliance/version', nil, true).returns(bad_response)
       Compliance::HTTP.expects(:get).with(url + '/api/version', nil, true).returns(bad_response)
-      proc { Compliance::API.determine_server_type(url, true) }.must_raise(Compliance::CannotDetermineServerType)
+      Compliance::API.determine_server_type(url, true).must_be_nil
     end
   end
 end

--- a/test/unit/bundles/inspec-compliance/api_test.rb
+++ b/test/unit/bundles/inspec-compliance/api_test.rb
@@ -245,4 +245,34 @@ describe Compliance::API do
       Compliance::API.exist?(config, 'admin/missing-in-action').must_equal false
     end
   end
+
+  describe '.determine_server_type' do
+    it 'returns `automate` when a 401 is received from `https://automate.example.com/compliance/version`' do
+      good_response = mock
+      good_response.stubs(:code).returns('401')
+      url = 'https://automate.example.com'
+      Compliance::HTTP.expects(:get).with(url + '/compliance/version', nil, true).returns(good_response)
+      Compliance::API.determine_server_type(url, true).must_equal('automate')
+    end
+
+    it 'returns `compliance` when a 200 is received from `https://compliance.example.com/api/version`' do
+      good_response = mock
+      good_response.stubs(:code).returns('200')
+      bad_response = mock
+      bad_response.stubs(:code).returns('404')
+      url = 'https://compliance.example.com'
+      Compliance::HTTP.expects(:get).with(url + '/compliance/version', nil, true).returns(bad_response)
+      Compliance::HTTP.expects(:get).with(url + '/api/version', nil, true).returns(good_response)
+      Compliance::API.determine_server_type(url, true).must_equal('compliance')
+    end
+
+    it 'raises a `Compliance::CannotDetermineServerType` error if no response returns favorably' do
+      bad_response = mock
+      bad_response.stubs(:code).returns('404')
+      url = 'https://bad.example.com'
+      Compliance::HTTP.expects(:get).with(url + '/compliance/version', nil, true).returns(bad_response)
+      Compliance::HTTP.expects(:get).with(url + '/api/version', nil, true).returns(bad_response)
+      proc { Compliance::API.determine_server_type(url, true) }.must_raise(Compliance::CannotDetermineServerType)
+    end
+  end
 end


### PR DESCRIPTION
This provides a single interface for logging into either Chef Automate or Chef Compliance servers. Server type is evaluated at run time via HTTP responses from designated endpoints.

This also moves the login logic from `Compliance::ComplianceCLI` to a separate set of modules in `Compliance::API`. Thus removing logic from Thor and allowing for more in depth Unit testing.

This also adds deprecation warnings for `login_automate` and `--usertoken`.

This fixes #1795.

Signed-off-by: Jerry Aldrich <jerryaldrichiii@gmail.com>