### PR TITLE
ssl resource: properly raise error when unable to determine if port is enabled

### DIFF
--- a/test/unit/resources/ssl_test.rb
+++ b/test/unit/resources/ssl_test.rb
@@ -1,6 +1,4 @@
 # encoding: utf-8
-# author: Christoph Hartmann
-# author: Dominik Richter
 
 require 'helper'
 require 'inspec/resource'

--- a/test/unit/resources/ssl_test.rb
+++ b/test/unit/resources/ssl_test.rb
@@ -1,0 +1,57 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+require 'helper'
+require 'inspec/resource'
+
+describe 'Inspec::Resources::SSL' do
+  it 'verify cipher enabled' do
+    SSLShake.expects(:hello).at_least_once.returns({ 'cipher_suite'=>'TLS_RSA_WITH_AES_128_CBC_SHA', 'success' => true })
+    resource = load_resource('ssl', host: 'localhost').ciphers(/rsa/i)
+    _(resource.enabled?).must_equal true
+  end
+
+  it 'verify cipher disabled' do
+    SSLShake.expects(:hello).at_least_once.returns({ 'error'=>'SSL Alert.' })
+    resource = load_resource('ssl', host: 'localhost').ciphers(/rc4/i)
+    _(resource.enabled?).must_equal false
+  end
+
+  it 'verify protocol enabled' do
+    SSLShake.expects(:hello).at_least_once.returns({ 'version' => 'tls1.2', 'success' => true })
+    resource = load_resource('ssl', host: 'localhost').protocols('tls1.2')
+    _(resource.enabled?).must_equal true
+  end
+
+  it 'verify protocol disabled' do
+    SSLShake.expects(:hello).at_least_once.returns({ 'error'=>'Failed to parse response. Cannot handle SSLv2 responses' })
+    resource = load_resource('ssl', host: 'localhost').protocols('ssl2')
+    _(resource.enabled?).must_equal false
+  end
+
+  it 'verify host reachable' do
+    SSLShake.expects(:hello).at_least_once.returns({ 'success' => true })
+    resource = load_resource('ssl', host: 'localhost')
+    _(resource.enabled?).must_equal true
+  end
+
+  it 'verify host unreachable' do
+    SSLShake.expects(:hello).at_least_once.returns({ 'error'=>'Connection error Errno::ECONNREFUSED, can\'t connect to localhost:443.' })
+    resource = load_resource('ssl', host: 'localhost')
+    _(resource.enabled?).must_equal false
+  end
+
+  it 'error with nil host' do
+    resource = load_resource('ssl', host: nil)
+    err = proc { resource.enabled? }.must_raise(RuntimeError)
+    err.message.must_equal 'Cannot determine host for SSL test. Please specify it or use a different target.'
+  end
+
+  it 'verify sslshake resources' do
+    resource = load_resource('ssl', host: 'localhost')
+    _(resource.protocols.uniq).must_equal ['ssl2', 'ssl3', 'tls1.0', 'tls1.1', 'tls1.2']
+    _(resource.ciphers.include?('TLS_RSA_WITH_AES_128_CBC_SHA256')).must_equal true
+    _(resource.ciphers.count).must_equal 681
+  end
+end


### PR DESCRIPTION
This is related to #1205. This will fix the ssl resource for now until we redo the exceptions. Still looking around the code and need to build some unit tests for the ssl resource.
![screen shot 2017-10-03 at 10 38 59 am](https://user-images.githubusercontent.com/574637/31131098-2baab62e-a827-11e7-9dc1-875c9ce4a029.png)

My fix here is to move the raise condition till later in the flow, specifically the enabled? method. This lets the raise get caught accordingly without killing the other tests.