### PR TITLE
Clean-up kitchen-inspec reference doc

### DIFF
--- a/docs/plugin_kitchen_inspec.md
+++ b/docs/plugin_kitchen_inspec.md
@@ -4,19 +4,19 @@ title: About kitchen-inspec
 
 # kitchen-inspec
 
-The `kitchen-inspec` driver enables InSpec to be used as a verifier within Kitchen.
+Use InSpec as a Kitchen verifier with `kitchen-inspec`.
 
-To use InSpec as a verifier, add it to the kitchen.yml file:
+Add the InSpec verifier to the `.kitchen.yml` file:
 
     verifier:
       name: inspec
 
-To define a suite that pulls its run-list from the Chef Compliance server:
+Use a compliance profile from the Chef Compliance server:
 
     suites:
       - name: compliance
         run_list:
-          - recipe[ssh-hardening]
+          - recipe[ssh-hardening::default]
         verifier:
           inspec_tests:
             - compliance://base/ssh
@@ -27,29 +27,23 @@ and then run the following command:
 
 where `--insecure` is required when using self-signed certificates.
 
-To define a suite that pulls its run-list from the Chef Supermarket:
+Use a compliance profile from the Chef Supermarket:
 
     suites:
       - name: supermarket
         run_list:
-          - recipe[ssh-hardening]
+          - recipe[ssh-hardening::default]
         verifier:
           inspec_tests:
-            - supermarket://hardening/ssh-hardening
+            - supermarket://dev-sec/ssh-baseline
 
-The `kitchen-inspec` driver expects tests to be located in the `test/integration` directory in a cookbook. For example::
+Use InSpec tests from the local file system:
 
-    .
-    ├── Berksfile
-    ├── Gemfile
-    ├── README.md
-    ├── metadata.rb
-    ├── recipes
-    │   ├── default.rb
-    │   └── nginx.rb
-    └── test
-        └── integration
-            └── default
-                ├── controls
-                ├── inspec.yml
-                └── libraries
+    suites:
+      - name: local
+        run_list:
+          - recipe[my_cookbook::default]
+        verifier:
+          inspec_tests:
+            - test/integration/default
+


### PR DESCRIPTION
* Clarify the copy
* Fix the name of the kitchen configuration file.  `.kitchen.yml`, not
* `kitchen.yml`
* Use proper syntax for specifying recipes in the sample code
* Use a valid Supermarket-based profile in the sample code
* Demonstrate using local InSpec tests

Resolves #1565

Signed-off-by: Nathen Harvey <nharvey@chef.io>