### PR TITLE
Docs: describe custom matcher cmp on version strings

### DIFF
--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -68,6 +68,13 @@ end
       its('log_format') { should cmp 'RAW' }
     end
     ```
+* Recognize versions embedded in strings
+
+    ```ruby
+    describe package(curl) do
+      its('version') { should cmp > '7.35.0-1ubuntu2.10' }
+    end
+    ```
 
 * Compare arrays with only one entry to a value
 

--- a/docs/resources/package.md.erb
+++ b/docs/resources/package.md.erb
@@ -116,4 +116,4 @@ You can also use the `cmp OPERATOR` matcher to perform comparisions using the ve
 
     its('version') { should cmp >= '7.35.0-1ubuntu3.10' }
 
-`cmp` understands version numbers using Gem::Version, and can use the operators `==, <, <=, >=, >`.  It will compare versions by each segment, not as a string - so '7.4' is smaller than '7.30', for example.  
+`cmp` understands version numbers using Gem::Version, and can use the operators `==, <, <=, >=, and >`.  It will compare versions by each segment, not as a string - so '7.4' is smaller than '7.30', for example.  

--- a/docs/resources/package.md.erb
+++ b/docs/resources/package.md.erb
@@ -111,3 +111,9 @@ The `be_installed` matcher tests if the named package is installed on the system
 The `version` matcher tests if the named package version is on the system:
 
     its('version') { should eq '1.2.3' }
+
+You can also use the `cmp OPERATOR` matcher to perform comparisions using the version attribute:
+
+    its('version') { should cmp >= '7.35.0-1ubuntu3.10' }
+
+`cmp` understands version numbers using Gem::Version, and can use the operators `==, <, <=, >=, >`.  It will compare versions by each segment, not as a string - so '7.4' is smaller than '7.30', for example.  


### PR DESCRIPTION
Refs #2147, describes an existing but undocumented way to compare version strings (on packages or anything else).

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>