### PR TITLE
Fix `only_if` behavior when used outside controls

### DIFF
--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -45,12 +45,14 @@ module Inspec
         include Inspec::DSL::RequireOverride
         include resources_dsl
 
+        attr_writer :skip_file
+
         def initialize(backend, conf, dependencies, require_loader)
           @backend = backend
           @conf = conf
           @dependencies = dependencies
           @require_loader = require_loader
-          @skip_profile = false
+          @skip_file = false
         end
 
         define_method :title do |arg|
@@ -113,7 +115,7 @@ module Inspec
         end
 
         define_method :register_control do |control, &block|
-          if @skip_profile || !profile_context_owner.profile_supports_os?
+          if @skip_file || !profile_context_owner.profile_supports_os?
             ::Inspec::Rule.set_skip_rule(control, true)
           end
 
@@ -131,7 +133,7 @@ module Inspec
 
         def only_if
           return unless block_given?
-          @skip_profile ||= !yield
+          @skip_file ||= !yield
         end
 
         alias_method :rule, :control

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -35,7 +35,7 @@ module Inspec
     # @param profile_context [Inspec::ProfileContext]
     # @param outer_dsl [OuterDSLClass]
     # @return [ProfileContextClass]
-    def self.create(profile_context, resources_dsl) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def self.create(profile_context, resources_dsl) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       rule_class = rule_context(resources_dsl)
       profile_context_owner = profile_context
       profile_id = profile_context.profile_id

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -127,6 +127,7 @@ module Inspec
     end
 
     def load_control_file(*args)
+      control_eval_context.skip_file = false
       load_with_context(control_eval_context, *args)
     end
     alias load load_control_file

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -127,6 +127,7 @@ module Inspec
     end
 
     def load_control_file(*args)
+      # Set `skip_file` to `false` between file loads to prevent skips from spanning multiple control files
       control_eval_context.skip_file = false
       load_with_context(control_eval_context, *args)
     end

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -94,6 +94,10 @@ module Inspec
       @tags
     end
 
+    def source_file
+      @__file
+    end
+
     # Skip all checks if only_if is false
     #
     # @param [Type] &block returns true if tests are added, false otherwise

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -55,12 +55,9 @@ describe Inspec::ProfileContext do
   let(:backend) { MockLoader.new.backend }
   let(:profile) { Inspec::ProfileContext.new(nil, backend, {}) }
 
-  def get_rule
-    profile.rules.values[0]
-  end
-
-  def get_checks
-    Inspec::Rule.prepare_checks(get_rule)
+  def get_checks(rule_index = 0)
+    rule = profile.rules.values[rule_index]
+    Inspec::Rule.prepare_checks(rule)
   end
 
   it 'must be able to load empty content' do
@@ -178,8 +175,8 @@ describe Inspec::ProfileContext do
       it 'doesnt extend into other control files' do
         profile.load_control_file(if_false + control)
         profile.load_control_file(control_2)
-        check_1 = get_checks
-        check_2 = Inspec::Rule.prepare_checks(profile.rules.values[1])
+        check_1 = get_checks(0)
+        check_2 = get_checks(1)
         check_1[0][1][0].resource_skipped.must_equal 'Skipped control due to only_if condition.'
         check_2[0][1][0].must_be_nil
       end

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -121,7 +121,8 @@ describe Inspec::ProfileContext do
       let(:if_true) { "only_if { true }\n" }
       let(:if_false) { "only_if { false }\n" }
       let(:describe) { "describe nil do its(:to_i) { should eq rand } end\n" }
-      let(:control) { "control 1 do\n#{describe}end" }
+      let(:control) { "control 1 do\n#{describe}\nend\n" }
+      let(:control_2) { "control 2 do\n#{describe}\nend\n" }
 
       it 'provides the keyword' do
         profile.load(if_true)
@@ -172,6 +173,15 @@ describe Inspec::ProfileContext do
         profile.load(if_true + if_false + control)
         get_checks.length.must_equal 1
         get_checks[0][1][0].resource_skipped.must_equal 'Skipped control due to only_if condition.'
+      end
+
+      it 'doesnt extend into other control files' do
+        profile.load_control_file(if_false + control)
+        profile.load_control_file(control_2)
+        check_1 = get_checks
+        check_2 = Inspec::Rule.prepare_checks(profile.rules.values[1])
+        check_1[0][1][0].resource_skipped.must_equal 'Skipped control due to only_if condition.'
+        check_2[0][1][0].must_be_nil
       end
     end
 

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -173,12 +173,43 @@ describe Inspec::ProfileContext do
       end
 
       it 'doesnt extend into other control files' do
-        profile.load_control_file(if_false + control)
-        profile.load_control_file(control_2)
-        check_1 = get_checks(0)
-        check_2 = get_checks(1)
-        check_1[0][1][0].resource_skipped.must_equal 'Skipped control due to only_if condition.'
-        check_2[0][1][0].must_be_nil
+        fake_control_file = if_false + control
+        profile.load_control_file(fake_control_file, '(eval)', nil)
+        profile.load_control_file(control_2, '(eval)', nil)
+        first_file_check = get_checks(0)
+        second_file_check = get_checks(1)
+        first_file_check[0][1][0].resource_skipped.must_equal 'Skipped control due to only_if condition.'
+        second_file_check[0][1][0].must_be_nil
+      end
+
+      it 'applies to the controls above it when at the bottom of the file' do
+        fake_control_file = control + if_false
+        profile.load_control_file(fake_control_file, '(eval)', 1)
+        get_checks[0][1][0].resource_skipped.must_equal 'Skipped control due to only_if condition.'
+      end
+
+      it 'applies to the controls below it when at the top of the file' do
+        fake_control_file = if_false + control
+        profile.load_control_file(fake_control_file, '(eval)', 1)
+        get_checks[0][1][0].resource_skipped.must_equal 'Skipped control due to only_if condition.'
+      end
+
+      it 'applies to the controls above and below it when at the middle of the file' do
+        fake_control_file = control + if_false + control_2
+        profile.load_control_file(fake_control_file, '(eval)', 1)
+        check_top = get_checks(0)
+        check_bottom = get_checks(1)
+        check_top[0][1][0].resource_skipped.must_equal 'Skipped control due to only_if condition.'
+        check_bottom[0][1][0].resource_skipped.must_equal 'Skipped control due to only_if condition.'
+      end
+
+      it 'applies to the describe blocks above and below it when at the middle of the file' do
+        fake_control_file = describe + if_false + describe
+        profile.load_control_file(fake_control_file, '(eval)', 1)
+        check_top = get_checks(0)
+        check_bottom = get_checks(1)
+        check_top[0][1][0].resource_skipped.must_equal 'Skipped control due to only_if condition.'
+        check_bottom[0][1][0].resource_skipped.must_equal 'Skipped control due to only_if condition.'
       end
     end
 


### PR DESCRIPTION
This renames `@skip_profile` to `@skip_file` and modifies the scope of `only_if` (used outside of a control) to only apply to the control file that contains it instead of the entire profile.

This does this by exposing `@skip_file` from the control context so that it can be set back to `false` between loading control files in the profile context.

This fixes #1914