### PR TITLE
Add nil check for sshd config file

### DIFF
--- a/lib/resources/ssh_conf.rb
+++ b/lib/resources/ssh_conf.rb
@@ -63,7 +63,7 @@ module Inspec::Resources
       end
 
       @content = file.content
-      if @content.nil? || (@content.empty? && File.size?(@conf_path))
+      if @content.nil? || (@content.empty? && !file.size.zero?)
         return skip_resource "Can't read file \"#{@conf_path}\""
       end
 

--- a/lib/resources/ssh_conf.rb
+++ b/lib/resources/ssh_conf.rb
@@ -63,7 +63,7 @@ module Inspec::Resources
       end
 
       @content = file.content
-      if @content.empty? && !file.empty?
+      if @content.nil? || (@content.empty? && File.size?(@conf_path))
         return skip_resource "Can't read file \"#{@conf_path}\""
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -104,13 +104,16 @@ class MockLoader
       end
       md
     }
+    emptyfile = lambda {
+      mockfile.call('emptyfile')
+    }
 
     mock.files = {
       '/proc/net/bonding/bond0' => mockfile.call('bond0'),
       '/etc/ssh/ssh_config' => mockfile.call('ssh_config'),
       '/etc/ssh/sshd_config' => mockfile.call('sshd_config'),
       '/etc/ssh/sshd_config_does_not_exist' => mockfile.call('sshd_config_does_not_exist'),
-      '/etc/ssh/sshd_config_empty' => mockfile.call('sshd_config_empty'),
+      '/etc/ssh/sshd_config_empty' => emptyfile.call,
       '/etc/passwd' => mockfile.call('passwd'),
       '/etc/shadow' => mockfile.call('shadow'),
       '/etc/ntp.conf' => mockfile.call('ntp.conf'),

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -109,6 +109,8 @@ class MockLoader
       '/proc/net/bonding/bond0' => mockfile.call('bond0'),
       '/etc/ssh/ssh_config' => mockfile.call('ssh_config'),
       '/etc/ssh/sshd_config' => mockfile.call('sshd_config'),
+      '/etc/ssh/sshd_config_does_not_exist' => mockfile.call('sshd_config_does_not_exist'),
+      '/etc/ssh/sshd_config_empty' => mockfile.call('sshd_config_empty'),
       '/etc/passwd' => mockfile.call('passwd'),
       '/etc/shadow' => mockfile.call('shadow'),
       '/etc/ntp.conf' => mockfile.call('ntp.conf'),

--- a/test/unit/resources/ssh_conf_test.rb
+++ b/test/unit/resources/ssh_conf_test.rb
@@ -39,14 +39,14 @@ describe 'Inspec::Resources::SshConf' do
     it 'check bad path' do
       resource = load_resource('sshd_config', '/etc/ssh/sshd_config_does_not_exist')
       _(resource.send(:read_content)).must_equal "Can't find file \"/etc/ssh/sshd_config_does_not_exist\""
-      assert_nil(resource.Protocol)
+      _(resource.Protocol).must_be_nil
     end
 
     it 'check cannot read' do
-      File.expects(:size?).at_least_once.returns(5)
+      Inspec::Resources::FileResource.any_instance.stubs(:size).at_least_once.returns(5)
       resource = load_resource('sshd_config', '/etc/ssh/sshd_config_empty')
       _(resource.send(:read_content)).must_equal "Can't read file \"/etc/ssh/sshd_config_empty\""
-      assert_nil(resource.Protocol)
+      _(resource.Protocol).must_be_nil
     end
   end
 end

--- a/test/unit/resources/ssh_conf_test.rb
+++ b/test/unit/resources/ssh_conf_test.rb
@@ -35,5 +35,18 @@ describe 'Inspec::Resources::SshConf' do
         '/etc/ssh/ssh_host_ecdsa_key',
       ]
     end
+
+    it 'check bad path' do
+      resource = load_resource('sshd_config', '/etc/ssh/sshd_config_does_not_exist')
+      _(resource.send(:read_content)).must_equal "Can't find file \"/etc/ssh/sshd_config_does_not_exist\""
+      assert_nil(resource.Protocol)
+    end
+
+    it 'check cannot read' do
+      File.expects(:size?).at_least_once.returns(5)
+      resource = load_resource('sshd_config', '/etc/ssh/sshd_config_empty')
+      _(resource.send(:read_content)).must_equal "Can't read file \"/etc/ssh/sshd_config_empty\""
+      assert_nil(resource.Protocol)
+    end
   end
 end


### PR DESCRIPTION
This fixes #1778. There was a issue where if the user did not have read permissions on /etc/ssh/sshd_config it would error out on the empty? check. The fix here is to also look for nil on the file content. Along with this I refactored the inspec file empty? check as it does not exist and was also erroring during my testing. Output with the changes:
![screen shot 2017-10-05 at 10 43 37 am](https://user-images.githubusercontent.com/574637/31233222-1846fa90-a9ba-11e7-8c96-42e3c49a5acd.png)

Signed-off-by: Jared Quick <jquick@chef.io>