### PR TITLE
Update shell resource help to return what is defined

### DIFF
--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -139,21 +139,21 @@ EOF
       elsif topic == 'matchers'
         print_matchers_help
       elsif !Inspec::Resource.registry[topic].nil?
-        puts <<EOF
-#{mark 'Name:'} #{topic}
+        topic_info = Inspec::Resource.registry[topic]
+        info = "#{mark 'Name:'} #{topic}\n\n"
+        unless topic_info.desc.nil?
+          info += "#{mark 'Description:'}\n\n"
+          info += "#{topic_info.desc}\n\n"
+        end
 
-#{mark 'Description:'}
+        unless topic_info.example.nil?
+          info += "#{mark 'Example:'}\n"
+          info += "#{print_example(topic_info.example)}\n\n"
+        end
 
-#{Inspec::Resource.registry[topic].desc}
-
-#{mark 'Example:'}
-#{print_example(Inspec::Resource.registry[topic].example)}
-
-#{mark 'Web Reference:'}
-
-https://www.inspec.io/docs/reference/resources/#{topic}
-
-EOF
+        info += "#{mark 'Web Reference:'}\n\n"
+        info += "https://www.inspec.io/docs/reference/resources/#{topic}\n\n"
+        puts info
       else
         puts "The resource #{topic} does not exist. For a list of valid resources, type: help resources"
       end

--- a/test/functional/inspec_shell_test.rb
+++ b/test/functional/inspec_shell_test.rb
@@ -160,6 +160,14 @@ describe 'inspec shell tests' do
       out.stdout.must_include 'For more examples, see: https://www.inspec.io/docs/reference/matchers/'
     end
 
+    it 'provides empty example help' do
+      out = do_shell('help file')
+      out.stdout.must_include 'Name'
+      out.stdout.must_include 'Description'
+      out.stdout.must_include 'Example'
+      out.stdout.must_include 'Web Reference'
+    end
+
     it 'exposes all resources' do
       out = do_shell('os')
       out.stdout.must_match(/\=> .*Operating.* .*System.* .*Detection/)


### PR DESCRIPTION
This fixes #1664. I refactored the help of the resource to build the output depending on what is available. If only the name is available the output will now look like this:
![screen shot 2017-10-05 at 4 38 57 pm](https://user-images.githubusercontent.com/574637/31251835-526c2492-a9ed-11e7-8fcc-d75dcd443679.png)

Signed-off-by: Jared Quick <jquick@chef.io>