### PR TITLE
Enhance cmp matcher to work with symbols, fix file documentation

### DIFF
--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -479,7 +479,7 @@ The `type` matcher tests for the file type. The available types are:
 * `link`: the object is a symbolic link
 * `pipe`: the object is a named pipe
 * `socket`: the object is a socket
-* `character`: the object is a character device
+* `character_device`: the object is a character device
 * `block`: the object is a block device
 * `door`: the object is a door device
 

--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -480,7 +480,7 @@ The `type` matcher tests for the file type. The available types are:
 * `pipe`: the object is a named pipe
 * `socket`: the object is a socket
 * `character_device`: the object is a character device
-* `block`: the object is a block device
+* `block_device`: the object is a block device
 * `door`: the object is a door device
 
 The `type` method usually returns the type as a Ruby "symbol". We recommend using the `cmp` matcher to match

--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -110,9 +110,9 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test the mtime for a file
 
-    describe file('/').mtime.to_i do
-      it { should <= Time.now.to_i }
-      it { should >= Time.now.to_i - 1000}
+    describe file('/') do
+      its('mtime') { should <= Time.now.to_i }
+      its('mtime') { should >= Time.now.to_i - 1000 }
     end
 
 ### Test that a file's size is between 64 and 10240
@@ -421,15 +421,11 @@ The `mode` matcher tests if the mode assigned to the file matches the specified 
 
 ### mtime
 
-The `mtime` matcher tests if the file modification time for the file matches the specified value:
+The `mtime` matcher tests if the file modification time for the file matches the specified value. The mtime, where supported, is returned as the number of seconds since the epoch.
 
-    its('mtime') { should eq 'October 31 2015 12:10:45' }
-
-or:
-
-    describe file('/').mtime.to_i do
-      it { should <= Time.now.to_i }
-      it { should >= Time.now.to_i - 1000}
+    describe file('/') do
+      its('mtime') { should <= Time.now.to_i }
+      its('mtime') { should >= Time.now.to_i - 1000 }
     end
 
 ### owner

--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -58,7 +58,7 @@ The following examples show how to use this InSpec audit resource.
 ### Test if a path is a file and not a directory
 
     describe file('/proc/version') do
-      its('type') { should eq 'file' }
+      its('type') { should cmp 'file' }
       it { should be_file }
       it { should_not be_directory }
     end
@@ -66,7 +66,7 @@ The following examples show how to use this InSpec audit resource.
 ### Test if a file is a symbolic link
 
     describe file('/dev/stdout') do
-      its('type') { should eq 'symlink' }
+      its('type') { should cmp 'symlink' }
       it { should be_symlink }
       it { should_not be_file }
       it { should_not be_directory }
@@ -75,7 +75,7 @@ The following examples show how to use this InSpec audit resource.
 ### Test if a file is a character device
 
     describe file('/dev/zero') do
-      its('type') { should eq 'character' }
+      its('type') { should cmp 'character' }
       it { should be_character_device }
       it { should_not be_file }
       it { should_not be_directory }
@@ -84,7 +84,7 @@ The following examples show how to use this InSpec audit resource.
 ### Test if a file is a block device
 
     describe file('/dev/zero') do
-      its('type') { should eq 'block' }
+      its('type') { should cmp 'block' }
       it { should be_character_device }
       it { should_not be_file }
       it { should_not be_directory }
@@ -193,7 +193,7 @@ For example, for the following symlink:
       it { should be_owned_by 'ovirtagent' }
       it { should be_grouped_into 'ovirtagent' }
     end
-    
+
 <br>
 
 ## Matchers
@@ -472,21 +472,26 @@ Less than:
 
 ### type
 
-The `type` matcher tests if the first letter of the file's mode string contains one of the following characters:
+The `type` matcher tests for the file type. The available types are:
 
-* `-` or `f` (the file is a file); use `'file` to test for this file type
-* `d` (the file is a directory); use `'directory` to test for this file type
-* `l` (the file is a symbolic link); use `'link` to test for this file type
-* `p` (the file is a named pipe); use `'pipe` to test for this file type
-* `s` (the file is a socket); use `'socket` to test for this file type
-* `c` (the file is a character device); use `'character` to test for this file type
-* `b` (the file is a block device); use `'block` to test for this file type
-* `D` (the file is a door); use `'door` to test for this file type
+* `file`: the object is a file
+* `directory`: the object is a directory
+* `link`: the object is a symbolic link
+* `pipe`: the object is a named pipe
+* `socket`: the object is a socket
+* `character`: the object is a character device
+* `block`: the object is a block device
+* `door`: the object is a door device
+
+The `type` method usually returns the type as a Ruby "symbol". We recommend using the `cmp` matcher to match
+either by symbol or string.
 
 For example:
 
-    its('type') { should eq 'file' }
+    its('type') { should eq :file }
+    its('type') { should cmp 'file' }
 
 or:
 
-    its('type') { should eq 'socket' }
+    its('type') { should eq :socket }
+    its('type') { should cmp 'socket' }

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -316,6 +316,8 @@ RSpec::Matchers.define :cmp do |first_expected|
       return actual.to_i.method(op).call(expected)
     elsif expected.is_a?(Float) && float?(actual)
       return actual.to_f.method(op).call(expected)
+    elsif actual.is_a?(Symbol) && expected.is_a?(String)
+      return actual.to_s.method(op).call(expected)
     elsif octal?(expected) && actual.is_a?(Integer)
       return actual.method(op).call(expected.to_i(8))
     end


### PR DESCRIPTION
The `cmp` matcher will now stringify symbol actual values if the expected value was passed in as a string. This will help with the file resource `type` method where Train returns the file type as a symbol.

Fixes #2204