### PR TITLE
Support PAX-formatted tar files, standardize file lists

### DIFF
--- a/test/functional/inspec_json_profile_test.rb
+++ b/test/functional/inspec_json_profile_test.rb
@@ -3,6 +3,7 @@
 # author: Christoph Hartmann
 
 require 'functional/helper'
+require 'mixlib/shellout'
 
 describe 'inspec json' do
   include FunctionalHelper
@@ -101,5 +102,23 @@ describe 'inspec json' do
     hm = JSON.load(File.read(dst.path))
     hm['name'].must_equal 'profile'
     hm['controls'].length.must_equal 4
+  end
+
+  describe 'json test for pax header archives' do
+    let(:profile_tgz) { File.join(Dir.mktmpdir, "pax-profile-test.tar.gz") }
+
+    before do
+      files = Dir.glob("#{example_profile}/**/*").delete_if { |x| !File.file?(x) }
+      relatives = files.map { |e| Pathname.new(e).relative_path_from(Pathname.new(example_profile)).to_s }
+
+      cmd = Mixlib::ShellOut.new("tar --format=pax -czf #{profile_tgz} #{relatives.join(' ')}", cwd: example_profile)
+      cmd.run_command
+      cmd.error!
+    end
+
+    it 'successfully reads a pax-formatted tar file' do
+      out = inspec("json #{profile_tgz}")
+      out.exit_status.must_equal 0
+    end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,7 +11,6 @@ end
 
 require 'minitest/autorun'
 require 'minitest/spec'
-require 'mixlib/shellout'
 require 'webmock/minitest'
 require 'mocha/setup'
 require 'fileutils'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -486,21 +486,6 @@ class MockLoader
     dst
   end
 
-  def self.profile_pax_tgz(name)
-    path = File.join(home, 'mock', 'profiles', name)
-    dst = File.join(Dir.mktmpdir, "#{name}.tar.gz")
-
-    # generate relative paths
-    files = Dir.glob("#{path}/**/*").delete_if { |x| !File.file?(x) }
-    relatives = files.map { |e| Pathname.new(e).relative_path_from(Pathname.new(path)).to_s }
-
-    cmd = Mixlib::ShellOut.new("tar --format=pax -czf #{dst} #{relatives.join(' ')}", cwd: path)
-    cmd.run_command
-    cmd.error!
-
-    dst
-  end
-
   def self.profile_zip(name, opts = {})
     path = File.join(home, 'mock', 'profiles', name)
     dst = File.join(Dir.mktmpdir, "#{name}.zip")

--- a/test/unit/file_provider_test.rb
+++ b/test/unit/file_provider_test.rb
@@ -166,24 +166,6 @@ describe Inspec::TarProvider do
     end
   end
 
-  describe 'applied to a pax-formatted tar archive' do
-    let(:target) { MockLoader.profile_pax_tgz('complete-profile') }
-
-    it 'must contain all files' do
-      subject.files.sort.must_equal %w{inspec.yml libraries/testlib.rb
-        controls/filesystem_spec.rb files/a_sub_dir/sub_items.conf
-        files/items.conf}.sort
-    end
-
-    it 'must not read if the file isnt included' do
-      subject.read('file-not-in-archive').must_be_nil
-    end
-
-    it 'must read the contents of the file' do
-      subject.read('inspec.yml').must_match(/^name: complete$/)
-    end
-  end
-
   describe 'applied to a tar with an empty filename' do
     # Just a placeholder, it will be ignored anyway:
     let(:cls) {

--- a/test/unit/file_provider_test.rb
+++ b/test/unit/file_provider_test.rb
@@ -152,9 +152,27 @@ describe Inspec::TarProvider do
     let(:target) { MockLoader.profile_tgz('complete-profile') }
 
     it 'must contain all files' do
-      subject.files.sort.must_equal %w{inspec.yml libraries libraries/testlib.rb
-        controls controls/filesystem_spec.rb files files/a_sub_dir
-        files/a_sub_dir/sub_items.conf files/items.conf}.sort
+      subject.files.sort.must_equal %w{inspec.yml libraries/testlib.rb
+        controls/filesystem_spec.rb files/a_sub_dir/sub_items.conf
+        files/items.conf}.sort
+    end
+
+    it 'must not read if the file isnt included' do
+      subject.read('file-not-in-archive').must_be_nil
+    end
+
+    it 'must read the contents of the file' do
+      subject.read('inspec.yml').must_match(/^name: complete$/)
+    end
+  end
+
+  describe 'applied to a pax-formatted tar archive' do
+    let(:target) { MockLoader.profile_pax_tgz('complete-profile') }
+
+    it 'must contain all files' do
+      subject.files.sort.must_equal %w{inspec.yml libraries/testlib.rb
+        controls/filesystem_spec.rb files/a_sub_dir/sub_items.conf
+        files/items.conf}.sort
     end
 
     it 'must not read if the file isnt included' do
@@ -170,10 +188,10 @@ describe Inspec::TarProvider do
     # Just a placeholder, it will be ignored anyway:
     let(:cls) {
       class MockTarProvider < Inspec::TarProvider
-        Entry = Struct.new(:full_name)
+        Entry = Struct.new(:full_name, :file?)
         private
         def walk_tar(path, &callback)
-          callback.call([Entry.new(''), Entry.new('tartar'), Entry.new('')])
+          callback.call([Entry.new('', true), Entry.new('tartar', true), Entry.new('', true)])
         end
       end
       MockTarProvider


### PR DESCRIPTION
When a tar file is generated in PAX format, the files have an additional relative path prefix added to them. For example, instead of:

`inspec.yml`

... the file is listed as:

`./inspec.yml`

And the source reader plugin looks only for a "inspec.yml" file to determine the profile format.

This change addresses this issue by normalizing the file paths in the TarReader and accounting for the additional "./" prefix that may exist whenever the tar file is walked looking for a file to read its content.

Fixes #2028