### PR TITLE
Issue warning during check if profile name contains slash

### DIFF
--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -11,7 +11,7 @@ require 'utils/spdx'
 
 module Inspec
   # Extract metadata.rb information
-  # A Metadata object may be created and finalized with invalid data.  
+  # A Metadata object may be created and finalized with invalid data.
   # This allows the check CLI command to analyse the issues.
   # Use valid? to determine if the metadata is coherent.
   class Metadata # rubocop:disable Metrics/ClassLength
@@ -115,10 +115,10 @@ module Inspec
         errors.push("Missing profile #{field} in #{ref}")
       end
 
-      if params[:name] =~ /[\/\\]/
+      if params[:name] =~ %r{[\/\\]}
         warnings.push("Profile names containing slashes (#{params[:name]}) are deprecated.")
       end
-      
+
       # if version is set, ensure it is correct
       if !params[:version].nil? && !valid_version?(params[:version])
         errors.push('Version needs to be in SemVer format')
@@ -221,7 +221,7 @@ module Inspec
       # create a new name based on the original target if it exists
       # Crudely slug the target to not contain slashes, to avoid breaking
       # unit tests that look for warning sequences
-      metadata.params[:name] = "tests from #{original_target}".gsub(/[\\\/]/, '.') unless original_target.to_s.empty?
+      metadata.params[:name] = "tests from #{original_target}".gsub(%r{[\\\/]}, '.') unless original_target.to_s.empty?
     end
 
     def self.finalize(metadata, profile_id, options, logger = nil)

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -11,6 +11,9 @@ require 'utils/spdx'
 
 module Inspec
   # Extract metadata.rb information
+  # A Metadata object may be created and finalized with invalid data.  
+  # This allows the check CLI command to analyse the issues.
+  # Use valid? to determine if the metadata is coherent.
   class Metadata # rubocop:disable Metrics/ClassLength
     attr_reader :ref
     attr_accessor :params, :content
@@ -112,6 +115,10 @@ module Inspec
         errors.push("Missing profile #{field} in #{ref}")
       end
 
+      if params[:name] =~ /[\/\\]/
+        warnings.push("Profile names containing slashes (#{params[:name]}) are deprecated.")
+      end
+      
       # if version is set, ensure it is correct
       if !params[:version].nil? && !valid_version?(params[:version])
         errors.push('Version needs to be in SemVer format')

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -219,7 +219,9 @@ module Inspec
       return unless metadata.params[:title].nil?
 
       # create a new name based on the original target if it exists
-      metadata.params[:name] = "tests from #{original_target}" unless original_target.to_s.empty?
+      # Crudely slug the target to not contain slashes, to avoid breaking
+      # unit tests that look for warning sequences
+      metadata.params[:name] = "tests from #{original_target}".gsub(/[\\\/]/, '.') unless original_target.to_s.empty?
     end
 
     def self.finalize(metadata, profile_id, options, logger = nil)

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -117,8 +117,8 @@ module Inspec
 
       if params[:name] =~ %r{[\/\\]}
         warnings.push("Your profile name (#{params[:name]}) contains a slash " \
-          "which will not be permitted in InSpec 2.0. Please change your profile " \
-          "name in the `inspec.yml` file.")
+          'which will not be permitted in InSpec 2.0. Please change your profile ' \
+          'name in the `inspec.yml` file.')
       end
 
       # if version is set, ensure it is correct

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -116,7 +116,9 @@ module Inspec
       end
 
       if params[:name] =~ %r{[\/\\]}
-        warnings.push("Profile names containing slashes (#{params[:name]}) are deprecated.")
+        warnings.push("Your profile name (#{params[:name]}) contains a slash " \
+          "which will not be permitted in InSpec 2.0. Please change your profile " \
+          "name in the `inspec.yml` file.")
       end
 
       # if version is set, ensure it is correct

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -225,7 +225,7 @@ module Inspec
       # unit tests that look for warning sequences
       unless original_target.to_s.empty?
         metadata.params[:title] = "tests from #{original_target}"
-        metadata.params[:name] = metadata.params[:title].gsub(%r{[\\\/]}, '.') 
+        metadata.params[:name] = metadata.params[:title].gsub(%r{[\\\/]}, '.')
       end
     end
 

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -223,7 +223,10 @@ module Inspec
       # create a new name based on the original target if it exists
       # Crudely slug the target to not contain slashes, to avoid breaking
       # unit tests that look for warning sequences
-      metadata.params[:name] = "tests from #{original_target}".gsub(%r{[\\\/]}, '.') unless original_target.to_s.empty?
+      unless original_target.to_s.empty?
+        metadata.params[:title] = "tests from #{original_target}"
+        metadata.params[:name] = metadata.params[:title].gsub(%r{[\\\/]}, '.') 
+      end
     end
 
     def self.finalize(metadata, profile_id, options, logger = nil)

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -142,7 +142,7 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     let(:out) { inspec('exec ' + example_control + ' --no-create-lockfile') }
 
     it 'prints the control results, then the anonymous describe block results' do
-      out.stdout.force_encoding(Encoding::UTF_8).must_match(%r{Profile: tests from .*examples/profile/controls/example.rb})
+      out.stdout.force_encoding(Encoding::UTF_8).must_match(%r{Profile: tests from .*examples.profile.controls.example.rb})
       out.stdout.force_encoding(Encoding::UTF_8).must_include "
 Version: (not specified)
 Target:  local://

--- a/test/unit/mock/profiles/slash-in-name/not-allowed/controls/filesystem_spec.rb
+++ b/test/unit/mock/profiles/slash-in-name/not-allowed/controls/filesystem_spec.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+# copyright: 2015, Chef Software, Inc
+
+title 'Proc Filesystem Configuration'
+
+control 'test01' do
+  impact 0.5
+  title 'Catchy title'
+  desc '
+    There should always be a /proc
+  '
+  describe file('/proc') do
+    it { should be_mounted }
+  end
+end

--- a/test/unit/mock/profiles/slash-in-name/not-allowed/inspec.yml
+++ b/test/unit/mock/profiles/slash-in-name/not-allowed/inspec.yml
@@ -1,0 +1,10 @@
+name: slash-in-name/not-allowed
+version: 1.2.3
+maintainer: bob
+title: title
+copyright: left
+summary: nothing
+license: Apache-2.0
+supports:
+  - linux
+  - darwin

--- a/test/unit/profiles/metadata_test.rb
+++ b/test/unit/profiles/metadata_test.rb
@@ -63,7 +63,7 @@ describe 'metadata with supported operating systems' do
       res = Inspec::Metadata.from_yaml('mock', '---', nil, logger)
       options = { target: '/path/to/tests' }
       Inspec::Metadata.finalize(res, nil, options, logger)
-      res.params[:name].must_equal('tests from /path/to/tests')
+      res.params[:name].must_equal('tests from .path.to.tests')
     end
 
     it 'does not overwrite an existing name when name exists and profile_id is nil' do

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -128,7 +128,7 @@ describe Inspec::Profile do
         result[:warnings].length.must_equal 6
       end
     end
-
+    
     describe 'an empty profile (legacy mode)' do
       let(:profile_id) { 'legacy-empty-metadata' }
 
@@ -336,6 +336,21 @@ describe Inspec::Profile do
       end
     end
 
+    describe 'a profile with a slash in the name' do
+      let(:profile_path) { 'slash-in-name/not-allowed' } # Slashes allowed here
+      let(:profile_name) { 'slash-in-name/not-allowed' }   # But not here
+      it 'issues a deprecation warning' do
+        logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_path}"]
+        logger.expect :warn, nil, ["Profile names containing slashes (#{profile_name}) are deprecated."]
+        logger.expect :info, nil, ['Metadata OK.']
+        logger.expect :info, nil, ['Found 1 controls.']
+
+        result = MockLoader.load_profile(profile_path, {logger: logger}).check
+        logger.verify
+        result[:warnings].length.must_equal 1
+      end
+    end
+    
     describe 'shows warning if license is invalid' do
       let(:profile_id) { 'license-invalid' }
       let(:profile_path) { MockLoader.profile_zip(profile_id) }

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -341,7 +341,8 @@ describe Inspec::Profile do
       let(:profile_name) { 'slash-in-name/not-allowed' }   # But not here
       it 'issues a deprecation warning' do
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_path}"]
-        logger.expect :warn, nil, ["Profile names containing slashes (#{profile_name}) are deprecated."]
+        logger.expect :warn, nil, ["Your profile name (#{profile_name}) contains a slash which " \
+          "will not be permitted in InSpec 2.0. Please change your profile name in the `inspec.yml` file."]
         logger.expect :info, nil, ['Metadata OK.']
         logger.expect :info, nil, ['Found 1 controls.']
 

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -108,7 +108,6 @@ describe Inspec::Profile do
       it 'prints loads of warnings' do
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]
         logger.expect :error, nil, ["Missing profile version in inspec.yml"]
-        logger.expect :warn, nil, ["Missing profile title in inspec.yml"]
         logger.expect :warn, nil, ["Missing profile summary in inspec.yml"]
         logger.expect :warn, nil, ["Missing profile maintainer in inspec.yml"]
         logger.expect :warn, nil, ["Missing profile copyright in inspec.yml"]
@@ -125,7 +124,7 @@ describe Inspec::Profile do
         result[:summary][:profile].must_match(/tests from .*empty-metadata/)
         result[:summary][:controls].must_equal 0
         result[:errors].length.must_equal 1
-        result[:warnings].length.must_equal 6
+        result[:warnings].length.must_equal 5
       end
     end
     
@@ -136,7 +135,6 @@ describe Inspec::Profile do
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]
         logger.expect :warn, nil, ['The use of `metadata.rb` is deprecated. Use `inspec.yml`.']
         logger.expect :error, nil, ["Missing profile version in metadata.rb"]
-        logger.expect :warn, nil, ["Missing profile title in metadata.rb"]
         logger.expect :warn, nil, ["Missing profile summary in metadata.rb"]
         logger.expect :warn, nil, ["Missing profile maintainer in metadata.rb"]
         logger.expect :warn, nil, ["Missing profile copyright in metadata.rb"]
@@ -153,7 +151,7 @@ describe Inspec::Profile do
         result[:summary][:profile].must_match(/tests from .*legacy-empty-metadata/)
         result[:summary][:controls].must_equal 0
         result[:errors].length.must_equal 1
-        result[:warnings].length.must_equal 7
+        result[:warnings].length.must_equal 6
       end
     end
 


### PR DESCRIPTION
Fixes #1954 .   Also, in the case that no name can be determined and a name must be generated from the target (which is common in unit testing), replace slashes with dots.  This is sensible if the default name is arbitrary; if real-world use relies on having profiles with names like "tests from /path/to/tests", we can update the unit tests instead; however any real-world processes would have issues in InSpec 2.0 anyway due to #1783 .