### PR TITLE
PR to resolve the weird encoding issue within inspec shell

### DIFF
--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -42,7 +42,7 @@ module Inspec
 
       # configure pry shell prompt
       Pry.config.prompt_name = 'inspec'
-      Pry.prompt = [proc { "#{readline_ignore("\e[0;32m")}#{Pry.config.prompt_name}> #{readline_ignore("\e[0m")}" }]
+      Pry.prompt = [proc { "#{readline_ignore("\e[1m\e[32m")}#{Pry.config.prompt_name}> #{readline_ignore("\e[0m")}" }]
 
       # Add a help menu as the default intro
       Pry.hooks.add_hook(:before_session, 'inspec_intro') do
@@ -79,7 +79,7 @@ module Inspec
     end
 
     def mark(x)
-      "#{readline_ignore("\033[1m")}#{x}#{readline_ignore("\033[0m")}"
+      "\e[1m\e[39m#{x}\e[0m"
     end
 
     def print_example(example)
@@ -106,8 +106,8 @@ module Inspec
       puts <<EOF
 You are currently running on:
 
-    OS platform:  #{mark ctx.os[:name] || 'unknown'}
-    OS family:  #{mark ctx.os[:family] || 'unknown'}
+    OS platform: #{mark ctx.os[:name] || 'unknown'}
+    OS family: #{mark ctx.os[:family] || 'unknown'}
     OS release: #{mark ctx.os[:release] || 'unknown'}
 EOF
     end


### PR DESCRIPTION
This PR is an attempt to resolve #1967 

I have observed this on few different operating systems.    I use to suffer from the issue when you use the backspace key it would jump your cursor postion 10 places, which is why I think the function `readline_ignore` was added.  

From my testing today this was due to the use of colour when defining the prompt.  for whatever reason the extra chars I see are a result of `mark` calling out to the `readline_ignore` method and having `\001` & `\002` (the readline ignore flags) added.

The `readline_ignore` seems to work fine for the prompt but not for the `mark` method, so I revised the method not to use it.

Before ....
![image](https://user-images.githubusercontent.com/13700297/31360301-9c0d99d6-ad45-11e7-9edd-8cdb865eb1be.png)
![image](https://user-images.githubusercontent.com/13700297/31360307-a14ff3ee-ad45-11e7-919c-1f7e81dc0b95.png)
![image](https://user-images.githubusercontent.com/13700297/31360312-a58a9a9a-ad45-11e7-89dd-7054509de4e8.png)

After ...
![image](https://user-images.githubusercontent.com/13700297/31360326-ba1d1a8c-ad45-11e7-8a28-0b335b0b5c2a.png)
![image](https://user-images.githubusercontent.com/13700297/31360330-be180ade-ad45-11e7-9179-4f605f1ba8cf.png)

rightly or wrongly I've also amend the `mark` colour escape code, I don't envy you having to design a cross os ascii colour scheme, from my testing the same esc code resulted in different colours depending on the os lol :) (unless you wanted red but I thought red was bad :)  so for the mark method I opted for the system default and bumped the green for the prompt.

![image](https://user-images.githubusercontent.com/13700297/31360666-5af7bc86-ad47-11e7-89f4-790aeeccf3fa.png)
![image](https://user-images.githubusercontent.com/13700297/31360739-aa5cbbf0-ad47-11e7-92df-00d981af5d3a.png)

I've tested it on windows rhel and centos, I think it looks pretty good, but happy to go with what you think.

Lastly removing the couple of extra spaces within `print_target_info` is just for my ocd 

You can flame me in the morning if you don't agree, see you at the summit.



