### PR TITLE
Add inspec habitat profile setup command

### DIFF
--- a/lib/bundles/inspec-habitat/cli.rb
+++ b/lib/bundles/inspec-habitat/cli.rb
@@ -7,14 +7,19 @@ module Habitat
   class HabitatProfileCLI < Thor
     namespace 'habitat profile'
 
-    desc 'create PATH', 'Create a Habitat artifact for the profile found at PATH'
+    desc 'create PATH', 'Create a one-time Habitat artifact for the profile found at PATH'
     option :output_dir, type: :string, required: false,
       desc: 'Directory in which to save the generated Habitat artifact. Default: current directory'
     def create(path)
       Habitat::Profile.create(path, options)
     end
 
-    desc 'upload PATH', 'Create a Habitat artifact for the profile found at PATH, and upload it to a Habitat Depot'
+    desc 'setup PATH', 'Configure the profile at PATH for Habitat, including a plan and hooks'
+    def setup(path)
+      Habitat::Profile.setup(path)
+    end
+
+    desc 'upload PATH', 'Create a one-time Habitat artifact for the profile found at PATH, and upload it to a Habitat Depot'
     def upload(path)
       Habitat::Profile.upload(path, options)
     end


### PR DESCRIPTION
Introduces a new `inspec habitat profile setup` command which will set up an existing profile repository with all the files necessary to build a Habitat package. This will prime a repository to be used by the Habitat Builder service.