### PR TITLE
Fix documentation of `split` matcher

### DIFF
--- a/docs/resources/os_env.md.erb
+++ b/docs/resources/os_env.md.erb
@@ -70,14 +70,8 @@ The `content` matcher return the value of the environment variable:
 
 ### split
 
-The `split` splits the content with the `:` deliminator:
+The `split` matcher splits the value of the environment variable with the `:` deliminator (use the `;` deliminator if Windows):
 
-    its('split') { should include (':') }
+    its('split') { should include ('/usr/bin') }
 
-or:
-
-    its('split') { should_not include ('.') }
-
-Use `-1` to test for cases where there is a trailing colon (`:`), such as `dir1::dir2:`:
-
-    its('split') { should include ('-1') }
+Note: the `split` matcher returns an array including `""` for cases where there is a trailing colon (`:`), such as `dir1::dir2:`


### PR DESCRIPTION
Describes actual behavior for the `split` of os_env matcher.

Signed-off-by: ERAMOTO Masaya <eramoto.masaya@jp.fujitsu.com>