### PR TITLE
Add missed 'html' to 'format' option explanation and arrange formatters in alphabetical order

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -186,7 +186,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   option :command, aliases: :c,
     desc: 'A single command string to run instead of launching the shell'
   option :format, type: :string, default: nil, hide: true,
-    desc: 'Which formatter to use: cli, progress, documentation, json, json-min, junit'
+    desc: 'Which formatter to use: cli, documentation, html, json, json-min, junit, progress'
   def shell_func
     diagnose
     o = opts.dup


### PR DESCRIPTION
### Before:
```
inspec help exec
...
      [--format=FORMAT]                            # Which formatter to use: cli, progress, documentation, json, json-min, junit
```

### After:
```
inspec help exec
...
      [--format=FORMAT]                            # Which formatter to use: cli, documentation, html, json, json-min, junit, progress
```

I found that `inspec` can produce reports in HTML format from StackOverflow thread, there is no info about it in official documentation. I think we should fix it.