### PR TITLE
windows_hotfix resource: Replace WMI query with PowerShell cmdlet "get-hotfix"

### DIFF
--- a/lib/resources/windows_hotfix.rb
+++ b/lib/resources/windows_hotfix.rb
@@ -18,7 +18,7 @@ module Inspec::Resources
       @content = nil
       os = inspec.os
       return skip_resource 'The `windows_hotfix` resource is not a feature of your OS.' unless os.windows?
-      query = "Get-WmiObject -class \"win32_quickfixengineering\" -filter \"HotFixID = '" + @id + "'\""
+      query = "get-hotfix -id #{@id}"
       cmd = inspec.powershell(query)
       @content = cmd.stdout
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -361,9 +361,9 @@ class MockLoader
       # hostname windows
       '$env:computername' => cmd.call('$env-computername'),
       # windows_hotfix windows
-      "Get-WmiObject -class \"win32_quickfixengineering\" -filter \"HotFixID = 'KB4019215'\"" => cmd.call('kb4019215'),
+      'get-hotfix -id KB4019215' => cmd.call('kb4019215'),
       # windows_hotfix windows doesn't exist
-      "Get-WmiObject -class \"win32_quickfixengineering\" -filter \"HotFixID = 'KB9999999'\"" => empty.call(),
+      'get-hotfix -id KB9999999' => empty.call(),
       # windows_task doesnt exist
       "schtasks /query /v /fo csv /tn 'does-not-exist' | ConvertFrom-Csv | Select @{N='URI';E={$_.TaskName}},@{N='State';E={$_.Status.ToString()}},'Logon Mode','Last Result','Task To Run','Run As User','Scheduled Task State' | ConvertTo-Json -Compress"  => cmd.call('schtasks-error'),
       # windows_task exist


### PR DESCRIPTION
Built-in PowerShell cmdlet "get-hotfix" is easier to read.

Signed-off-by: Matt Ray <matthewhray@gmail.com>