### PR TITLE
mount resource: fix for Device-/Sharenames and Mountpoints including …

### DIFF
--- a/lib/utils/parser.rb
+++ b/lib/utils/parser.rb
@@ -73,7 +73,7 @@ module LinuxMountParser
       type_split = mount_line.split(' type ')
       fs_path = type_split[0]
       other_opts = type_split[1]
-      fs, path = fs_path.match(/^(.+?)\son\s(\/.+?)$/).captures
+      fs, path = fs_path.match(%r{^(.+?)\son\s(/.+?)$}).captures
       mount = [fs, 'on', path, 'type']
       mount.concat other_opts.scan(/\S+/)
     else
@@ -106,9 +106,9 @@ module LinuxMountParser
   end
 
   # Device-/Sharename or Mountpoint includes whitespaces?
-  def includes_whitespaces? mount_line
+  def includes_whitespaces?(mount_line)
     ws = mount_line.match(/^(.+)\son\s(.+)\stype\s.*$/)
-    ws.captures[0].include? " " or ws.captures[1].include? " "
+    ws.captures[0].include? ' ' or ws.captures[1].include? ' '
   end
 end
 

--- a/lib/utils/parser.rb
+++ b/lib/utils/parser.rb
@@ -67,7 +67,7 @@ module LinuxMountParser
   # this parses the output of mount command (only tested on linux)
   # this method expects only one line of the mount output
   def parse_mount_options(mount_line, compatibility = false)
-    if includes_whitespaces? mount_line
+    if includes_whitespaces?(mount_line)
       # Device-/Sharenames and Mountpoints including whitespaces require special treatment:
       # We use the keyword ' type ' to split up and rebuild the desired array of fields
       type_split = mount_line.split(' type ')

--- a/lib/utils/parser.rb
+++ b/lib/utils/parser.rb
@@ -75,7 +75,7 @@ module LinuxMountParser
       other_opts = type_split[1]
       fs, path = fs_path.match(%r{^(.+?)\son\s(/.+?)$}).captures
       mount = [fs, 'on', path, 'type']
-      mount.concat other_opts.scan(/\S+/)
+      mount.concat(other_opts.scan(/\S+/))
     else
       # ... otherwise we just split the fields by whitespaces
       mount = mount_line.scan(/\S+/)
@@ -108,7 +108,7 @@ module LinuxMountParser
   # Device-/Sharename or Mountpoint includes whitespaces?
   def includes_whitespaces?(mount_line)
     ws = mount_line.match(/^(.+)\son\s(.+)\stype\s.*$/)
-    ws.captures[0].include? ' ' or ws.captures[1].include? ' '
+    ws.captures[0].include?(' ') or ws.captures[1].include?(' ')
   end
 end
 

--- a/lib/utils/parser.rb
+++ b/lib/utils/parser.rb
@@ -67,7 +67,19 @@ module LinuxMountParser
   # this parses the output of mount command (only tested on linux)
   # this method expects only one line of the mount output
   def parse_mount_options(mount_line, compatibility = false)
-    mount = mount_line.scan(/\S+/)
+    if includes_whitespaces? mount_line
+      # Device-/Sharenames and Mountpoints including whitespaces require special treatment:
+      # We use the keyword ' type ' to split up and rebuild the desired array of fields
+      type_split = mount_line.split(' type ')
+      fs_path = type_split[0]
+      other_opts = type_split[1]
+      fs, path = fs_path.match(/^(.+?)\son\s(\/.+?)$/).captures
+      mount = [fs, 'on', path, 'type']
+      mount.concat other_opts.scan(/\S+/)
+    else
+      # ... otherwise we just split the fields by whitespaces
+      mount = mount_line.scan(/\S+/)
+    end
 
     # parse device and type
     mount_options    = { device: mount[0], type: mount[4] }
@@ -91,6 +103,12 @@ module LinuxMountParser
     end
 
     mount_options
+  end
+
+  # Device-/Sharename or Mountpoint includes whitespaces?
+  def includes_whitespaces? mount_line
+    ws = mount_line.match(/^(.+)\son\s(.+)\stype\s.*$/)
+    ws.captures[0].include? " " or ws.captures[1].include? " "
   end
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -334,6 +334,7 @@ class MockLoader
       # mount
       "mount | grep -- ' on /'" => cmd.call("mount"),
       "mount | grep -- ' on /mnt/iso-disk'" => cmd.call("mount-multiple"),
+      "mount | grep -- ' on /mnt/Research & Development'" => cmd.call("mount-whitespaces"),
       # solaris 10 package manager
       'pkginfo -l SUNWzfsr' => cmd.call('pkginfo-l-SUNWzfsr'),
       # solaris 11 package manager

--- a/test/unit/mock/cmd/mount-whitespaces
+++ b/test/unit/mock/cmd/mount-whitespaces
@@ -1,0 +1,1 @@
+//fileserver.corp.internal/Research & Development on /mnt/Research & Development type cifs (rw,vers=1.0)

--- a/test/unit/resources/mount_test.rb
+++ b/test/unit/resources/mount_test.rb
@@ -23,4 +23,13 @@ describe Inspec::Resources::FileResource do
     iso_resource.send(:options).must_equal(['ro'])
     iso_resource.send(:count).must_equal(2)
   end
+
+  let(:ws_resource) { load_resource('mount', '/mnt/Research & Development') }
+
+  it 'parses the mount data properly even if whitespaces are included' do
+    ws_resource.send(:device).must_equal('//fileserver.corp.internal/Research & Development')
+    ws_resource.send(:type).must_equal('cifs')
+    ws_resource.send(:options).must_equal(['rw','vers=1.0'])
+    ws_resource.send(:count).must_equal(1)
+  end
 end


### PR DESCRIPTION
…whitespaces

Device-/Sharenames and Mountpoints on Linux may include whitespaces (\040), e.g. /etc/fstab entry like:

```
//fileserver.corp.internal/Research\040&\040Development /mnt/Research\040&\040Development cifs OTHER_OPTS
```

... results in a mount line like:

```
//fileserver.corp.internal/Research & Development on /mnt/Research & Development type cifs (OTHER_OPTS)
```

The Linux mount command replaces \040 with whitspace automatically, so this should be tributed.

I used a control like this:

```
    describe mount('/mnt/Research & Development') do
      it { should be_mounted }
      its('device') { should eq  '//fileserver.corp.internal/Research & Development' }
    end
```

Before:

```
  ×  whitespaces-1: Mount with whitespace within sharename and mountpoint. (1 failed)
     ✔  Mount /mnt/Research & Development should be mounted
     ×  Mount /mnt/Research & Development device should eq "//fileserver.corp.internal/Research & Development"

     expected: "//fileserver.corp.internal/Research & Development"
          got: "//fileserver.corp.internal/operational/Research"

     (compared using ==)
```

After:

```
  ✔  whitespaces-01: Mount with whitespace within sharename and mountpoint.
     ✔  Mount /mnt/Research & Development should be mounted
     ✔  Mount /mnt/Research & Development device should eq "//fileserver.corp.internal/Research & Development"
```

Signed-off-by: Markus Grobelin <grobi@koppzu.de>