### PR TITLE
Include ref when writing out inspec control objects

### DIFF
--- a/lib/inspec/objects/control.rb
+++ b/lib/inspec/objects/control.rb
@@ -21,7 +21,7 @@ module Inspec
       { id: id, title: title, desc: desc, impact: impact, tests: tests.map(&:to_hash), tags: tags.map(&:to_hash) }
     end
 
-    def to_ruby
+    def to_ruby # rubocop:disable Metrics/AbcSize
       res = ["control #{id.inspect} do"]
       res.push "  title #{title.inspect}" unless title.to_s.empty?
       res.push "  desc  #{prettyprint_text(desc, 2)}" unless desc.to_s.empty?

--- a/lib/inspec/objects/control.rb
+++ b/lib/inspec/objects/control.rb
@@ -2,10 +2,11 @@
 
 module Inspec
   class Control
-    attr_accessor :id, :title, :desc, :impact, :tests, :tags
+    attr_accessor :id, :title, :desc, :impact, :tests, :tags, :refs
     def initialize
       @tests = []
       @tags = []
+      @refs = []
     end
 
     def add_test(t)
@@ -26,12 +27,19 @@ module Inspec
       res.push "  desc  #{prettyprint_text(desc, 2)}" unless desc.to_s.empty?
       res.push "  impact #{impact}" unless impact.nil?
       tags.each { |t| res.push(indent(t.to_ruby, 2)) }
+      refs.each { |t| res.push("  ref   #{print_ref(t)}") }
       tests.each { |t| res.push(indent(t.to_ruby, 2)) }
       res.push 'end'
       res.join("\n")
     end
 
     private
+
+    def print_ref(x)
+      return x.inspect if x.is_a?(String)
+      raise "Cannot process the ref: #{x}" unless x.is_a?(Hash)
+      '('+x.inspect+')'
+    end
 
     # Pretty-print a text block of InSpec code
     #

--- a/test/unit/dsl/objects_test.rb
+++ b/test/unit/dsl/objects_test.rb
@@ -275,12 +275,15 @@ end
       control.id = 'sample.control.id'
       control.title = 'Sample Control Important Title'
       control.desc = 'The most critical control the world has ever seen'
+      control.refs = ['simple ref', {ref: 'title', url: 'my url'}]
       control.impact = 1.0
       control.to_ruby.must_equal '
 control "sample.control.id" do
   title "Sample Control Important Title"
   desc  "The most critical control the world has ever seen"
   impact 1.0
+  ref   "simple ref"
+  ref   ({:ref=>"title", :url=>"my url"})
   describe command("ls /etc") do
     its("exit_status") { should eq 0 }
   end


### PR DESCRIPTION
just like tags for all auto-generation and api-driven development :)