### PR TITLE
Fix sorting of resources on website

### DIFF
--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -206,7 +206,8 @@ namespace :docs do
     docs = ResourceDocs.new(src)
     resources = Dir[File.join(src, 'resources/*.md.erb')]
                 .map { |x| x.sub(/^#{src}/, '') }
-    puts "Found #{src.length} resource docs"
+                .sort
+    puts "Found #{resources.length} resource docs"
     puts "Rendering docs to #{dst}/"
 
     progressbar = ProgressBar.create(total: resources.length, title: 'Rendering')


### PR DESCRIPTION
Not sure how this ever worked without us force-sorting, but the
list of resources is now guaranteed to be alpha-sorted.

Signed-off-by: Adam Leff <adam@leff.co>