### PR TITLE
inspec compliance login: Ensure supplied server has a proper URI scheme

### DIFF
--- a/lib/bundles/inspec-compliance/api/login.rb
+++ b/lib/bundles/inspec-compliance/api/login.rb
@@ -11,6 +11,8 @@ module Compliance
       def login(options)
         raise ArgumentError, 'Please specify a server using `inspec compliance login https://SERVER`' unless options['server']
 
+        options['server'] = URI("https://#{options['server']}").to_s if URI(options['server']).scheme.nil?
+
         options['server_type'] = Compliance::API.determine_server_type(options['server'], options['insecure'])
 
         case options['server_type']


### PR DESCRIPTION
An issue was discovered whereby a user logging in with `inspec compliance login` did not specify `https://` in their `SERVER` argument. This causes https://github.com/chef/inspec/blob/master/lib/fetchers/url.rb#L146 to fail because https://github.com/ruby/ruby/blob/trunk/lib/open-uri.rb#L33 doesn't interpret the option as a URL.

This adds `https://` to the front of `options['server']` if the URI doesn't contain a scheme, thus fixing the issue.