### PR TITLE
Use names when quering for containers

### DIFF
--- a/docs/resources/docker.md.erb
+++ b/docs/resources/docker.md.erb
@@ -18,7 +18,7 @@ A `docker` resource block declares allows you to write test for many containers:
 
 or:
 
-    describe docker.containers.where { name == 'flamboyant_colden' } do
+    describe docker.containers.where { names == 'flamboyant_colden' } do
       it { should be_running }
     end
 


### PR DESCRIPTION
Name does not work.

I am not sure if it changes across various docker versions or it was a typo from beginning. Anyway 'names' works now.

Obvious fix.