### PR TITLE
Wrapper profile and dependency with same filename in controls directory breaks inspec check

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -492,6 +492,12 @@ module Inspec
         code: Inspec::MethodSource.code_at(location, source_reader),
         source_location: location,
       }
+      # Don't try to read code if the control is inherited from another profile
+      if rule.instance_variable_get(:@__profile_id) == name
+        controls[id][:code] = Inspec::MethodSource.code_at(location, source_reader)
+      else
+        controls[id][:code] = ''
+      end
 
       groups[file] ||= {
         title: rule.instance_variable_get(:@__group_title),

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -489,7 +489,6 @@ module Inspec
         refs: rule.ref,
         tags: rule.tag,
         checks: Inspec::Rule.checks(rule),
-        code: Inspec::MethodSource.code_at(location, source_reader),
         source_location: location,
       }
       # Don't try to read code if the control is inherited from another profile


### PR DESCRIPTION
### Description

When a wrapper profile has a filename in `controls/` that matches that of the dependency profile, running `inspec check` on the wrapper profile tries to read source code for the rule from its own `controls/` directory and fails.

### InSpec and Platform Version

Inspec 1.43.5
macOS 10.13

### Replication Case

Install the cis-ubuntu14.04lts-level1 profile to your Automate server. Create a wrapper profile with the following contents (probably have to adjust the compliance path).

inspec.yml:

```name: wrapper-cis
title: Wrapper
summary: Wrapper
version: 0.1.0

maintainer: The Authors
copyright: The Authors
copyright_email: example@example.com
license: Apache-2.0

supports:
  - os-family: linux
depends:
  - name: cis-ubuntu14.04lts-level1
    compliance: bcurran/cis-ubuntu14.04lts-level1
    version: 1.0.0-2
```

controls/translated-controls.rb:

```# encoding: utf-8
# copyright: 2017, The Authors

require_controls 'cis-ubuntu14.04lts-level1' do
  control 'xccdf_org.cisecurity.benchmarks_rule_7.4.4_Create_etchosts.deny'
end
```

Run `inspec check` on your wrapper profile.

### Possible Solutions

The easiest workaround is just renaming the file in `controls/` so it doesn't match anything in the dependency profile. This seems to be happening because nothing in `profile.rb` recognizes that the `location` variable in the `load_rule` method is referring to a file in the dependency profile (not a file in the wrapper profile) and when `Inspec::MethodSource.code_at(location, source_reader)` is called, it bails because `src = source_reader.tests[ref]` in `method_source.rb` returns some code, but not the code from the dependency profile, so it tries to read a line number that doesn't exist.

This doesn't happen with local dependencies because `location` in the `load_rule` method has an absolute path and doesn't match `source_reader.tests[ref]`:

```
[1] pry(Inspec::MethodSource)> location
=> {:ref=>"/Users/bcurran/git/inspec/profiles/cis-ubuntu14.04lts-level1/controls/translated-controls.rb", :line=>1011}
[2] pry(Inspec::MethodSource)> source_reader.tests
=> {"controls/translated-controls.rb"=>
  "# encoding: utf-8\n# copyright: 2017, The Authors\n\nrequire_controls 'cis-ubuntu14.04lts-level1' do\n  control 'xccdf_org.cisecurity.benchmarks_rule_7.4.4_Create_etchosts.deny'\n  control 'asdf'\nend\n"}
```

I'm not very well-versed in Ruby, but I attempted a fix here that removes `code` from the `controls[id]` hash and sets it conditionally immediately afterward, only using `code_at` if the current profile `name` matches the `profile_id` of the current rule, and sets it to `''` otherwise.

If this needs unit tests or anything let me know and I can take a shot at those. (Or if this is totally off-track and I'm missing something, let me know and I'll just file an issue 🙂.)

### Stacktrace

```
/opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/lib/inspec/method_source.rb:23:in `rescue in code_at': Could not parse source at controls/translated-controls.rb:1011: unexpected $end (MethodSource::SourceNotFoundError)
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/lib/inspec/method_source.rb:11:in `code_at'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/lib/inspec/profile.rb:495:in `load_rule'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/lib/inspec/profile.rb:472:in `block in load_checks_params'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/lib/inspec/profile.rb:469:in `each'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/lib/inspec/profile.rb:469:in `load_checks_params'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/lib/inspec/profile.rb:458:in `load_params'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/lib/inspec/profile.rb:152:in `params'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/lib/inspec/profile.rb:318:in `controls_count'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/lib/inspec/profile.rb:289:in `check'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/lib/inspec/cli.rb:69:in `check'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /opt/inspec/embedded/lib/ruby/gems/2.3.0/gems/inspec-1.43.5/bin/inspec:12:in `<top (required)>'
        from /usr/local/bin/inspec:23:in `load'
        from /usr/local/bin/inspec:23:in `<main>'
```
