### PR TITLE
allow users to specify user/namespace when fetching profiles from Chef Automate

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -18,14 +18,15 @@ module Compliance
     # return all compliance profiles available for the user
     # the user is either specified in the options hash or by default
     # the username of the account is used that is logged in
-    def self.profiles(config, options = {})
+    def self.profiles(config)
+      owner = config['owner'] || config['user']
+
       # Chef Compliance
       if is_compliance_server?(config)
         url = "#{config['server']}/user/compliance"
       # Chef Automate
       elsif is_automate_server?(config)
-        user = options['user'] || config['user']
-        url = "#{config['server']}/profiles/#{user}"
+        url = "#{config['server']}/profiles/#{owner}"
       else
         raise ServerConfigurationMissing
       end
@@ -48,9 +49,8 @@ module Compliance
         elsif is_automate_server_pre_080?(config)
           mapped_profiles = profiles.values.flatten
         else
-          owner_id = config['user']
           mapped_profiles = profiles.map { |e|
-            e['owner_id'] = owner_id
+            e['owner_id'] = owner
             e
           }
         end
@@ -88,8 +88,12 @@ module Compliance
 
     # verifies that a profile
     def self.exist?(config, profile)
-      _msg, profiles = Compliance::API.profiles(config)
       owner, id, ver = profile_split(profile)
+
+      c = config.dup
+      c['owner'] = owner
+      _msg, profiles = Compliance::API.profiles(config)
+
       if !profiles.empty?
         profiles.any? do |p|
           p['owner_id'] == owner &&
@@ -107,10 +111,10 @@ module Compliance
         url = "#{config['server']}/owners/#{owner}/compliance/#{profile_name}/tar"
       # Chef Automate pre 0.8.0
       elsif is_automate_server_pre_080?(config)
-        url = "#{config['server']}/#{config['user']}"
+        url = "#{config['server']}/#{owner}"
       # Chef Automate
       else
-        url = "#{config['server']}/profiles/#{config['user']}"
+        url = "#{config['server']}/profiles/#{owner}"
       end
 
       headers = get_headers(config)

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -16,13 +16,16 @@ module Compliance
     extend Compliance::API::Login
 
     # return all compliance profiles available for the user
-    def self.profiles(config)
+    # the user is either specified in the options hash or by default
+    # the username of the account is used that is logged in
+    def self.profiles(config, options = {})
       # Chef Compliance
       if is_compliance_server?(config)
         url = "#{config['server']}/user/compliance"
       # Chef Automate
       elsif is_automate_server?(config)
-        url = "#{config['server']}/profiles/#{config['user']}"
+        user = options['user'] || config['user']
+        url = "#{config['server']}/profiles/#{user}"
       else
         raise ServerConfigurationMissing
       end

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -90,9 +90,10 @@ module Compliance
     def self.exist?(config, profile)
       owner, id, ver = profile_split(profile)
 
-      c = config.dup
-      c['owner'] = owner
-      _msg, profiles = Compliance::API.profiles(config)
+      # ensure that we do not manipulate the configuration object
+      user_config = config.dup
+      user_config['owner'] = owner
+      _msg, profiles = Compliance::API.profiles(user_config)
 
       if !profiles.empty?
         profiles.any? do |p|

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -79,12 +79,13 @@ module Compliance
     end
 
     desc 'profiles', 'list all available profiles in Chef Compliance'
-
+    option :user, type: :string, required: false,
+      desc: 'Username whose profiles to list'
     def profiles
       config = Compliance::Configuration.new
       return if !loggedin(config)
 
-      msg, profiles = Compliance::API.profiles(config)
+      msg, profiles = Compliance::API.profiles(config, options)
       profiles.sort_by! { |hsh| hsh['title'] }
       if !profiles.empty?
         # iterate over profiles


### PR DESCRIPTION
By default it uses the username of the user that is logged into the system. However, the user can now specify the `--user` on the cli to list profiles from a user other than his own domain.

Fixes #1500 