### PR TITLE
Properly compare profile version strings as SemVer

### DIFF
--- a/lib/inspec/dependencies/resolver.rb
+++ b/lib/inspec/dependencies/resolver.rb
@@ -71,7 +71,7 @@ module Inspec
         end
 
         if !dep.source_satisfies_spec?
-          raise Inspec::UnsatisfiedVersionSpecification, "The profile #{dep.name} from #{dep.resolved_source} has a version #{dep.source_version} which doesn't match #{dep.required_version}"
+          raise Inspec::UnsatisfiedVersionSpecification, "The profile #{dep.name} from #{dep.resolved_source} has a version #{dep.source_version} which doesn't match #{dep.version_constraints}"
         end
 
         Inspec::Log.debug("Adding dependency #{dep.name} (#{dep.resolved_source})")

--- a/test/unit/dependencies/requirement_test.rb
+++ b/test/unit/dependencies/requirement_test.rb
@@ -1,0 +1,75 @@
+require 'helper'
+require 'inspec/dependencies/requirement'
+
+describe Inspec::Requirement do
+  describe '#source_satisfies_spec?' do
+    let(:req) { Inspec::Requirement.new('foo', constraints, nil, nil, {}) }
+
+    describe 'when there are no version constraints' do
+      let(:constraints) { nil }
+      it 'returns true' do
+        req.source_satisfies_spec?.must_equal true
+      end
+    end
+
+    describe 'when there is a single, matching version constraint' do
+      let(:constraints) { '>= 1' }
+      it 'returns true' do
+        profile = mock
+        profile.stubs(:version).returns('2.0.0')
+        req.stubs(:profile).returns(profile)
+        req.source_satisfies_spec?.must_equal true
+      end
+    end
+
+    describe 'when there is a single, non-matching version constraint' do
+      let(:constraints) { '>= 2' }
+      it 'returns true' do
+        profile = mock
+        profile.stubs(:version).returns('1.0.0')
+        req.stubs(:profile).returns(profile)
+        req.source_satisfies_spec?.must_equal false
+      end
+    end
+
+    describe 'when there are multiple matching version constraints' do
+      let(:constraints) { ['>= 1', '< 3'] }
+      it 'returns true' do
+        profile = mock
+        profile.stubs(:version).returns('2.0.0')
+        req.stubs(:profile).returns(profile)
+        req.source_satisfies_spec?.must_equal true
+      end
+    end
+
+    describe 'when there are multiple version constraints and one does not match' do
+      let(:constraints) { ['>= 1', '< 3'] }
+      it 'returns true' do
+        profile = mock
+        profile.stubs(:version).returns('4.0.0')
+        req.stubs(:profile).returns(profile)
+        req.source_satisfies_spec?.must_equal false
+      end
+    end
+
+    describe 'when a profile has a version with a build number and the constraint matches' do
+      let(:constraints) { '>= 1' }
+      it 'returns true' do
+        profile = mock
+        profile.stubs(:version).returns('2.0.0+1')
+        req.stubs(:profile).returns(profile)
+        req.source_satisfies_spec?.must_equal true
+      end
+    end
+
+    describe 'when the constraint is the default >=0 and the profile has a pre-release number' do
+      let(:constraints) { '>= 0' }
+      it 'returns true' do
+        profile = mock
+        profile.stubs(:version).returns('2.0.0-1')
+        req.stubs(:profile).returns(profile)
+        req.source_satisfies_spec?.must_equal true
+      end
+    end
+  end
+end

--- a/test/unit/dependencies/resolver_test.rb
+++ b/test/unit/dependencies/resolver_test.rb
@@ -47,7 +47,7 @@ describe Inspec::Resolver do
       dep = FakeDep.new("fake_dep_0")
       dep.expects(:source_satisfies_spec?).returns(false)
       dep.expects(:source_version).returns("1.0.0")
-      dep.expects(:required_version).returns(">= 1.0.1")
+      dep.expects(:version_constraints).returns([">= 1.0.1"])
       lambda { subject.resolve([dep]) }.must_raise Inspec::UnsatisfiedVersionSpecification
     end
   end


### PR DESCRIPTION
When configuring a profile dependency, if the dependent profile had a hyphen in it, it would not properly match the default version constraint of `>= 0`. This is because a hyphen indicates the version is a pre-release version and proper version matching would require the constraint to also be listed with a pre-release version string.

The proper solution is to use the `+` character instead which indicates a build number, which is what the hyphen was meant to convey. In the meantime, this change properly compares version strings as SemVer and also adds tests.

Fixes #1940