### PR TITLE
Fix classname in JUnit formatter

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -893,7 +893,14 @@ class InspecRspecJUnit < InspecRspecJson
   def build_result_xml(control, result)
     result_xml = REXML::Element.new('testcase')
     result_xml.add_attribute('name', result[:code_desc])
-    result_xml.add_attribute('class', control[:title].nil? ? 'Anonymous' : control[:id])
+    # if there is no control title, we are likely receiving test results from a
+    # "naked" test (a test not located within a control block). Therefore, rather
+    # than outputting the auto-generated ID, i.e.
+    #
+    # "(generated from test_spec.rb:1 de0ce10e4bbbd4d0ff7a65f4234de8c1)")
+    #
+    # ... we'll output "Anonymous" instead.
+    result_xml.add_attribute('classname', control[:title].nil? ? 'Anonymous' : control[:id])
     result_xml.add_attribute('time', result[:run_time])
 
     if result[:status] == 'failed'

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -874,8 +874,9 @@ class InspecRspecJUnit < InspecRspecJson
   private
 
   def build_profile_xml(profile)
+    profile_name = profile[:name]
     profile_xml = REXML::Element.new('testsuite')
-    profile_xml.add_attribute('name', profile[:name])
+    profile_xml.add_attribute('name', profile_name)
     profile_xml.add_attribute('tests', count_profile_tests(profile))
     profile_xml.add_attribute('failed', count_profile_failed_tests(profile))
 
@@ -883,14 +884,14 @@ class InspecRspecJUnit < InspecRspecJson
       next if control[:results].nil?
 
       control[:results].each do |result|
-        profile_xml.add(build_result_xml(control, result))
+        profile_xml.add(build_result_xml(profile_name, control, result))
       end
     end
 
     profile_xml
   end
 
-  def build_result_xml(control, result)
+  def build_result_xml(profile_name, control, result)
     result_xml = REXML::Element.new('testcase')
     result_xml.add_attribute('name', result[:code_desc])
     # if there is no control title, we are likely receiving test results from a
@@ -900,7 +901,7 @@ class InspecRspecJUnit < InspecRspecJson
     # "(generated from test_spec.rb:1 de0ce10e4bbbd4d0ff7a65f4234de8c1)")
     #
     # ... we'll output "Anonymous" instead.
-    result_xml.add_attribute('classname', control[:title].nil? ? 'Anonymous' : control[:id])
+    result_xml.add_attribute('classname', control[:title].nil? ? "#{profile_name}.Anonymous" : "#{profile_name}.#{control[:id]}")
     result_xml.add_attribute('time', result[:run_time])
 
     if result[:status] == 'failed'

--- a/test/functional/inspec_exec_junit_test.rb
+++ b/test/functional/inspec_exec_junit_test.rb
@@ -51,7 +51,7 @@ describe 'inspec exec with junit formatter' do
       end
 
       describe 'the testcase named "gordon_config Can\'t find file ..."' do
-        let(:gordon_yml_tests) { REXML::XPath.match(suite, "//testcase[@class='gordon-1.0' and @name='gordon_config']") }
+        let(:gordon_yml_tests) { REXML::XPath.match(suite, "//testcase[@classname='profile.gordon-1.0' and @name='gordon_config']") }
         let(:first_gordon_test) {gordon_yml_tests.first}
 
         it 'should be unique' do


### PR DESCRIPTION
The JUnit formatter currently incorrectly uses `class` instead of `classname` as an attribute.

Fixes #2276