### PR TITLE
http resource: use proper syntax in `curl` header option

### DIFF
--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -210,7 +210,7 @@ module Inspec::Resources
           cmd << "--data #{Shellwords.shellescape(request_body)}" unless request_body.nil?
 
           request_headers.each do |k, v|
-            cmd << "-H '#{k}=#{v}'"
+            cmd << "-H '#{k}: #{v}'"
           end
 
           cmd << "'#{url}'"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -457,7 +457,7 @@ class MockLoader
       "curl -i -X GET --connect-timeout 60 'http://www.example.com'" => cmd.call('http-remote-no-options'),
       "curl -i -X GET --connect-timeout 60 --user 'user:pass' 'http://www.example.com'" => cmd.call('http-remote-basic-auth'),
       '2bdc8826b66efa554bdebd8cc5f3eaf7bfba5ada36adc7904a6b178d331395ea' => cmd.call('http-remote-post'),
-      "curl -i -X GET --connect-timeout 60 -H 'accept=application/json' -H 'foo=bar' 'http://www.example.com'" => cmd.call('http-remote-headers'),
+      "curl -i -X GET --connect-timeout 60 -H 'accept: application/json' -H 'foo: bar' 'http://www.example.com'" => cmd.call('http-remote-headers'),
 
       # elasticsearch resource
       "curl -H 'Content-Type: application/json' http://localhost:9200/_nodes" => cmd.call('elasticsearch-cluster-nodes-default'),


### PR DESCRIPTION
`curl` expects a valid header per RFC 2616 when using the `-H`/`--header` option. RFC 2616 declares header field/values should be separated using a colon (`:`):
https://tools.ietf.org/html/rfc2616#section-4.2

Signed-off-by: Seth Chisamore <schisamo@chef.io>