### PR TITLE
Pin RubyGems to 2.6.14

### DIFF
--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -38,6 +38,8 @@ build_version Inspec::VERSION
 build_iteration 1
 
 override 'ruby', version: '2.3.5'
+# RubyGems 2.7.0 caused issues in the Jenkins pipelines, trouble installing bundler.
+# This issue is not evident in 2.6.x, hence the pin.
 override 'rubygems', version: '2.6.14'
 
 dependency 'preparation'

--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -38,6 +38,7 @@ build_version Inspec::VERSION
 build_iteration 1
 
 override 'ruby', version: '2.3.5'
+override 'rubygems', version: '2.6.14'
 
 dependency 'preparation'
 


### PR DESCRIPTION
2.7.0 seems to have introduced an issue causing bundler to fail to
install in our Jenkins pipeline.

Signed-off-by: Adam Leff <adam@leff.co>