### PR TITLE
nginx resource: support quoted identifiers

### DIFF
--- a/lib/utils/nginx_parser.rb
+++ b/lib/utils/nginx_parser.rb
@@ -21,8 +21,16 @@ class NginxParser < Parslet::Parser
     (identifier >> values.maybe.as(:args)).as(:assignment) >> str(';') >> filler?
   }
 
-  rule(:identifier) {
+  rule(:standard_identifier) {
     (match('[a-zA-Z]') >> match('\S').repeat).as(:identifier) >> space >> space.repeat
+  }
+
+  rule(:quoted_identifier) {
+    str('"') >> (str('"').absent? >> any).repeat.as(:identifier) >> str('"') >> space.repeat
+  }
+
+  rule(:identifier) {
+    standard_identifier | quoted_identifier
   }
 
   rule(:value) {
@@ -30,6 +38,7 @@ class NginxParser < Parslet::Parser
       str('\\') >> any | match('[#;{]|\s').absent? >> any
     ).repeat).as(:value) >> space.repeat
   }
+
   rule(:values) {
     value.repeat >> space.maybe
   }

--- a/test/unit/utils/nginx_parser_test.rb
+++ b/test/unit/utils/nginx_parser_test.rb
@@ -49,6 +49,10 @@ describe NginxParser do
   it 'parses nested groups' do
     _(parsestr("f {g {h {\n# comment\n}}}")).must_equal "[{:section=>{:identifier=>\"f\"@0}, :args=>\"\", :expressions=>[{:section=>{:identifier=>\"g\"@3}, :args=>\"\", :expressions=>[{:section=>{:identifier=>\"h\"@6}, :args=>\"\", :expressions=>[]}]}]}]"
   end
+
+  it 'parses quoted identifiers for assignments' do
+    _(parsestr(%{"~^\/opcache-api" 1;})).must_equal "[{:assignment=>{:identifier=>\"~^/opcache-api\"@1, :args=>[{:value=>\"1\"@17}]}}]"
+  end
 end
 
 describe NginxTransform do


### PR DESCRIPTION
An nginx config may contain configuration settings that are quoted, such as a map entry:

```
"~^\/opcache-api" 1;
```

The `nginx_conf` resource was failing to properly parse these.

Fixes #2278