### PR TITLE
Require Ruby 2.3 and later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,40 +14,39 @@ before_install:
 - gem --version
 matrix:
   include:
-  - rvm: 2.2.6
-  - rvm: 2.3.4
-  - rvm: 2.4.1
+  - rvm: 2.3.5
+  - rvm: 2.4.2
     script: bundle exec rake $SUITE
     env: SUITE="lint test test:functional"
-  - rvm: 2.4.1
+  - rvm: 2.4.2
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS=default-ubuntu-1204 DOCKER=true
-  - rvm: 2.4.1
+  - rvm: 2.4.2
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-ubuntu-1604' DOCKER=true
-  - rvm: 2.4.1
+  - rvm: 2.4.2
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-centos-68' DOCKER=true
-  - rvm: 2.4.1
+  - rvm: 2.4.2
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-centos-7' DOCKER=true
-  - rvm: 2.4.1
+  - rvm: 2.4.2
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-debian-8' DOCKER=true
-  - rvm: 2.4.1
+  - rvm: 2.4.2
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-oracle-72' DOCKER=true
-  - rvm: 2.4.1
+  - rvm: 2.4.2
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-fedora-24' DOCKER=true
-  - rvm: 2.4.1
+  - rvm: 2.4.2
     sudo: false
     cache:
       apt: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ environment:
   bundler_url: https://rubygems.org/downloads/bundler-1.9.9.gem
 
   matrix:
-    - ruby_version: "22"
     - ruby_version: "23"
     - ruby_version: "24"
 

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'train', '~> 0.28'
   spec.add_dependency 'thor', '~> 0.19'


### PR DESCRIPTION
Ruby 2.1 is EOL, and Ruby 2.2 is on security fixes only. This moves
InSpec to support the current "normal maintenance" versions of Ruby
like Chef does and also bumps the versions used in Travis tests.

Signed-off-by: Adam Leff <adam@leff.co>