### PR TITLE
Switch to tomlrb for TOML parsing

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sslshake', '~> 1.2'
   spec.add_dependency 'parallel', '~> 1.9'
   spec.add_dependency 'faraday', '>=0.9.0'
-  spec.add_dependency 'toml', '~> 0.1'
+  spec.add_dependency 'tomlrb', '~> 1.2'
   spec.add_dependency 'addressable', '~> 2.4'
   spec.add_dependency 'parslet', '~> 1.5'
   spec.add_dependency 'semverse'

--- a/lib/bundles/inspec-habitat/profile.rb
+++ b/lib/bundles/inspec-habitat/profile.rb
@@ -3,7 +3,7 @@
 
 require 'inspec/profile_vendor'
 require 'mixlib/shellout'
-require 'toml'
+require 'tomlrb'
 
 module Habitat
   class Profile # rubocop:disable Metrics/ClassLength
@@ -298,7 +298,7 @@ module Habitat
       config_file = File.join(ENV['HOME'], '.hab', 'etc', 'cli.toml')
       return {} unless File.exist?(config_file)
 
-      @cli_config = TOML.load_file(config_file)
+      @cli_config = Tomlrb.load_file(config_file)
     end
 
     def output_dir

--- a/lib/resources/toml.rb
+++ b/lib/resources/toml.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # author: Nolan Davidson
 
-require 'toml'
+require 'tomlrb'
 
 module Inspec::Resources
   class TomlConfig < JsonConfig
@@ -16,7 +16,7 @@ module Inspec::Resources
     "
 
     def parse(content)
-      TOML::Parser.new(content).parsed
+      Tomlrb.parse(content)
     end
 
     def to_s

--- a/test/unit/bundles/inspec-habitat/profile_test.rb
+++ b/test/unit/bundles/inspec-habitat/profile_test.rb
@@ -175,7 +175,7 @@ describe Habitat::Profile do
     it 'returns parsed TOML from the hab config file' do
       config_file = File.join(ENV['HOME'], '.hab', 'etc', 'cli.toml')
       File.expects(:exist?).with(config_file).returns(true)
-      TOML.expects(:load_file).with(config_file).returns(foo: 1)
+      Tomlrb.expects(:load_file).with(config_file).returns(foo: 1)
       subject.send(:habitat_cli_config).must_equal(foo: 1)
     end
   end


### PR DESCRIPTION
The `toml` gem has a very strict version dependency on an old version of parslet. This change switches us to use `tomlrb` instead which has no direct dependencies. This will allow us to bump up to a later version of parslet that has better error handling and insight into parser errors.