### PR TITLE
Fix gid filtering for etc_group resource

### DIFF
--- a/lib/resources/etc_group.rb
+++ b/lib/resources/etc_group.rb
@@ -85,7 +85,7 @@ module Inspec::Resources
       conditions.each do |k, v|
         idx = fields[k.to_sym]
         next if idx.nil?
-        res = res.select { |x| x[idx] == v.to_s }
+        res = res.select { |x| x[idx].to_s == v.to_s }
       end
 
       EtcGroupView.new(self, res)

--- a/test/unit/resources/etc_group_test.rb
+++ b/test/unit/resources/etc_group_test.rb
@@ -34,4 +34,39 @@ describe 'Inspec::Resources::EtcGroup' do
     _(wrong_filter.groups).must_equal []
     _(wrong_filter.users).must_equal []
   end
+
+  it 'verify group filter with gid' do
+    www_filter = resource.where(gid: 33)
+    _(www_filter.gids).must_equal [33]
+    _(www_filter.groups).must_equal ['www-data']
+    _(www_filter.users).must_equal ['www-data', 'root']
+  end
+
+  it 'verify group filter with wrong gid' do
+    www_filter = resource.where(group_id: 60)
+    _(www_filter.gids).must_equal []
+    _(www_filter.groups).must_equal []
+    _(www_filter.users).must_equal []
+  end
+
+  it 'verify group filter with group members' do
+    www_filter = resource.where(users: 'www-data,root')
+    _(www_filter.gids).must_equal [33]
+    _(www_filter.groups).must_equal ['www-data']
+    _(www_filter.users).must_equal ['www-data', 'root']
+  end
+
+  it 'verify group filter with no group members' do
+    www_filter = resource.where(members: '')
+    _(www_filter.gids).must_equal [0, 999]
+    _(www_filter.groups).must_equal ['root', 'GroupWithCaps']
+    _(www_filter.users).must_equal []
+  end
+
+  it 'verify group filter with wrong member' do
+    wrong_filter = resource.where(users: 'wrong_member')
+    _(wrong_filter.gids).must_equal []
+    _(wrong_filter.groups).must_equal []
+    _(wrong_filter.users).must_equal []
+  end
 end


### PR DESCRIPTION
'etc_group' resource stores 'gid' as integer but the 'where' method
compares 'gid' as string. By this fix, the 'where' method get to compares
'gid' as integer.

Signed-off-by: ERAMOTO Masaya <eramoto.masaya@jp.fujitsu.com>