### PR TITLE
Updated "code" style on website

### DIFF
--- a/www/source/stylesheets/_code.scss
+++ b/www/source/stylesheets/_code.scss
@@ -1,18 +1,19 @@
 //default
 
 code {
-	color: white;
-	border-radius: 4px;
-	background: $color_paragraph;
-	border-color: $color_paragraph;
+	color: $color_paragraph;
+	border: 0px;
+	background: white;
 }
 
 .highlight code {
-  padding-left: 0;
+	color: white;
+	background: $color_paragraph;
+	padding-left: 0;
 }
 
 pre {
-		border-radius: 7px;
+	border-radius: 7px;
     padding: 10px;
     margin-bottom: 1em;
     background: $color_paragraph;


### PR DESCRIPTION
The existing style was a bit harsh, especially with a lot of code
blocks in a row. This lightens it a bit to be more focused on the
monospace aspect rather than offsetting code with different backgrounds.

Before:
![screen shot 2017-11-08 at 16 12 05](https://user-images.githubusercontent.com/3221128/32574647-d1111470-c49f-11e7-934c-f4640a649974.png)

After:
![screen shot 2017-11-08 at 16 11 49](https://user-images.githubusercontent.com/3221128/32574658-d772be54-c49f-11e7-8550-c5f5b0138192.png)


Signed-off-by: Adam Leff <adam@leff.co>