### PR TITLE
Habitat build works for all versions, eliminates rake

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -10,6 +10,9 @@ docker_images:
       build_args:
         - GEM_SOURCE: http://artifactory.chef.co/omnibus-gems-local
 
+habitat_packages:
+  - inspec
+
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:
   notify_channel: inspec-notify
@@ -43,6 +46,10 @@ merge_actions:
         - "Omnibus: Skip Build"
         - "Expeditor: Skip All"
       only_if: built_in:bump_version
+  - built_in:trigger_habitat_package_build:
+      ignore_labels:
+        - "Habitat: Skip Build"
+        - "Expeditor: Skip All"
 
 artifact_actions:
   promoted_to_unstable:

--- a/Rakefile
+++ b/Rakefile
@@ -150,23 +150,6 @@ task :release_docker do
   sh('sh', '-c', cmd)
 end
 
-desc 'Release a new Habitat package'
-task :release_habitat do
-    version = Inspec::VERSION
-    ENV['HAB_ORIGIN'] = "chef"
-    if Dir.exist?("./results") then
-        raise "Please remove the ./results directory"
-    end
-    if ! ENV.has_key?("HAB_AUTH_TOKEN") then
-        raise "Please set the HAB_AUTH_TOKEN environment variable"
-    end
-    cmd = "echo #{version} > ./habitat/VERSION && "\
-          "hab pkg build . && " \
-          "hab pkg upload ./results/*.hart --channel stable"
-    puts "--> #{cmd}"
-    sh('sh', '-c', cmd)
-end
-
 desc 'Release the website [deprecated]'
 task :www do
   puts 'The Rake tasks for releasing the website are now in the www/ directory.'


### PR DESCRIPTION
The Habitat plan has been modified to support building from the repo rather than relying on a gem being pushed to RubyGems. This allows us to build current packages at every merge rather than only pushing to Habitat Builder when we promote to stable.

This change also enables Expeditor to perform builds for us and removes the dependency on the rake task as it is no longer needed.