### PR TITLE
xinetd_conf resource: fix false positives when config file or directory doesn't exist

### DIFF
--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -53,12 +53,12 @@ module Inspec::Resources
       return @contents[path] if @contents.key?(path)
       file = inspec.file(path)
       if !file.file?
-        return skip_resource "Can't find file \"#{path}\""
+        raise Inspec::Exceptions::ResourceSkipped, "Can't find file: #{path}"
       end
 
       @contents[path] = file.content
       if @contents[path].nil? || @contents[path].empty?
-        return skip_resource "Can't read file \"#{path}\""
+        raise Inspec::Exceptions::ResourceSkipped, "Can't read file: #{path}"
       end
 
       @contents[path]
@@ -69,7 +69,6 @@ module Inspec::Resources
       flat_params = parse_xinetd(read_content)
       # we need to map service data in order to use it with filtertable
       params = { 'services' => {} }
-
       # map services that were defined and map it to the service hash
       flat_params.each do |k, v|
         name = k[/^service (.+)$/, 1]

--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -56,12 +56,11 @@ module Inspec::Resources
         raise Inspec::Exceptions::ResourceSkipped, "Can't find file: #{path}"
       end
 
-      @contents[path] = file.content
-      if @contents[path].nil? || @contents[path].empty?
+      if file.content.nil? || file.content.empty?
         raise Inspec::Exceptions::ResourceSkipped, "Can't read file: #{path}"
       end
 
-      @contents[path]
+      @contents[path] = file.content
     end
 
     def read_params

--- a/lib/utils/parser.rb
+++ b/lib/utils/parser.rb
@@ -217,7 +217,7 @@ module XinetdParser
     return [] if dir.nil?
 
     unless inspec.file(dir).directory?
-      return skip_resource "Cannot read folder in #{dir}"
+      raise Inspec::Exceptions::ResourceSkipped, "Can't find folder: #{dir}"
     end
 
     files = inspec.command("find #{dir} -type f").stdout.split("\n")


### PR DESCRIPTION
Not return 'nil' when xinetd_conf resource checks an empty file or a
non-existent file. So the following test succeeds, where /empty_file is
empty file.

  describe xinetd_conf("/empty_file") do
    it { should be_disabled }
  end

Signed-off-by: ERAMOTO Masaya <eramoto.masaya@jp.fujitsu.com>