### PR TITLE
oracledb_session resource: fix credential passing to sql/sqlplus

### DIFF
--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -60,7 +60,9 @@ module Inspec::Resources
         p = :parse_html_result
       end
 
-      command = "echo \"#{opts}\n#{verify_query(escaped_query)}\nEXIT\" | #{bin} -s #{@user}/#{@password}@//#{@host}:#{@port}/#{@service}"
+      query = verify_query(escaped_query)
+      query += ';' unless query.end_with?(';')
+      command = %{echo "#{opts}\n#{query}\nEXIT" | #{bin} "#{@user}"/"#{@password}"@#{@host}:#{@port}/#{@service}}
       cmd = inspec.command(command)
 
       out = cmd.stdout + "\n" + cmd.stderr

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -416,7 +416,7 @@ class MockLoader
       "5c2bc0f0568d11451d6cf83aff02ee3d47211265b52b6c5d45f8e57290b35082" => cmd.call('mssql-getdate'),
       # oracle
       "bash -c 'type \"sqlplus\"'" => cmd.call('oracle-cmd'),
-      "ef04e5199abee80e662cc0dd1dd3bf3e0aaae9b4498217d241db00b413820911" => cmd.call('oracle-result'),
+      "527f243fe9b01fc7b7d78eb1ef5200e272b011aa07c9f59836d950107d6d2a5c" => cmd.call('oracle-result'),
       # nginx mock cmd
       %{nginx -V 2>&1} => cmd.call('nginx-v'),
       %{/usr/sbin/nginx -V 2>&1} => cmd.call('nginx-v'),


### PR DESCRIPTION
Also, because of some reason sqlplus doesn't accept queries with \n, adding of ";" has fixed the problem

Signed-off-by: Dmytro Malovany <dmytro.malovannyy@gmail.com>