### PR TITLE
Update expeditor version-update script

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -6,4 +6,4 @@
 
 set -evx
 
-sed -i -r "s/VERSION = '.+'\.freeze/VERSION = '$(cat VERSION)'\.freeze/" lib/inspec/version.rb
+sed -i -r "s/VERSION = '.*'/VERSION = '$(cat VERSION)'/" lib/inspec/version.rb

--- a/lib/inspec/version.rb
+++ b/lib/inspec/version.rb
@@ -4,5 +4,5 @@
 # author: Christoph Hartmann
 
 module Inspec
-  VERSION = '1.45.7'
+  VERSION = '1.45.8'
 end


### PR DESCRIPTION
PR #2311 updated the Rubocop engine to use Ruby 2.3 to evaluate, and the default behavior is to no longer require `.freeze` to be added to string literals that are treated like constants. This caused the pattern match used in the Expeditor version update script to no longer work.

Also manually fixing the `lib/inspec/version.rb` file to be correct.

Signed-off-by: Adam Leff <adam@leff.co>