### PR TITLE
Remove debug message from unit test

### DIFF
--- a/test/unit/file_provider_test.rb
+++ b/test/unit/file_provider_test.rb
@@ -45,7 +45,6 @@ describe Inspec::DirProvider do
 
     it 'must not read files not covered' do
       not_covered = File.expand_path('../../helper.rb', __FILE__)
-      puts "#{not_covered}"
       File.file?(not_covered).must_equal true
       subject.read(not_covered).must_be_nil
     end


### PR DESCRIPTION
Stops to output the meaningless message to standard output when testing.

Obvious fix.

Signed-off-by: ERAMOTO Masaya <eramoto.masaya@jp.fujitsu.com>