### PR TITLE
json resource (et. al.): allow inspec check to succeed when using command

### DIFF
--- a/lib/resources/csv.rb
+++ b/lib/resources/csv.rb
@@ -34,6 +34,8 @@ module Inspec::Resources
 
       # convert to hash
       csv.to_a.map(&:to_hash)
+    rescue => e
+      raise Inspec::Exceptions::ResourceFailed, "Unable to parse CSV: #{e.message}"
     end
 
     # override the value method from JsonConfig
@@ -45,8 +47,10 @@ module Inspec::Resources
       @params.map { |x| x[key.first.to_s] }.compact
     end
 
-    def to_s
-      "Csv #{@path}"
+    # used by JsonConfig to build up a full to_s method
+    # based on whether a file path, content, or command was supplied.
+    def resource_base_name
+      'CSV'
     end
   end
 end

--- a/lib/resources/csv.rb
+++ b/lib/resources/csv.rb
@@ -47,6 +47,8 @@ module Inspec::Resources
       @params.map { |x| x[key.first.to_s] }.compact
     end
 
+    private
+
     # used by JsonConfig to build up a full to_s method
     # based on whether a file path, content, or command was supplied.
     def resource_base_name

--- a/lib/resources/ini.rb
+++ b/lib/resources/ini.rb
@@ -18,8 +18,10 @@ module Inspec::Resources
       SimpleConfig.new(content).params
     end
 
-    def to_s
-      "INI #{@path}"
+    # used by JsonConfig to build up a full to_s method
+    # based on whether a file path, content, or command was supplied.
+    def resource_base_name
+      'INI'
     end
   end
 end

--- a/lib/resources/ini.rb
+++ b/lib/resources/ini.rb
@@ -18,6 +18,8 @@ module Inspec::Resources
       SimpleConfig.new(content).params
     end
 
+    private
+
     # used by JsonConfig to build up a full to_s method
     # based on whether a file path, content, or command was supplied.
     def resource_base_name

--- a/lib/resources/json.rb
+++ b/lib/resources/json.rb
@@ -55,12 +55,6 @@ module Inspec::Resources
       "#{resource_base_name} #{@resource_name_supplement || 'content'}"
     end
 
-    # for resources the subclass JsonConfig, this allows specification of the resource
-    # base name in each subclass so we can build a good to_s method
-    def resource_base_name
-      'JSON'
-    end
-
     private
 
     def parse(content)
@@ -104,6 +98,12 @@ module Inspec::Resources
       raise Inspec::Exceptions::ResourceSkipped, "No output from command: #{command}" if command_output.nil? || command_output.empty?
 
       command_output
+    end
+
+    # for resources the subclass JsonConfig, this allows specification of the resource
+    # base name in each subclass so we can build a good to_s method
+    def resource_base_name
+      'JSON'
     end
   end
 end

--- a/lib/resources/toml.rb
+++ b/lib/resources/toml.rb
@@ -17,10 +17,14 @@ module Inspec::Resources
 
     def parse(content)
       Tomlrb.parse(content)
+    rescue => e
+      raise Inspec::Exceptions::ResourceFailed, "Unable to parse TOML: #{e.message}"
     end
 
-    def to_s
-      "TOML #{@path}"
+    # used by JsonConfig to build up a full to_s method
+    # based on whether a file path, content, or command was supplied.
+    def resource_base_name
+      'TOML'
     end
   end
 end

--- a/lib/resources/toml.rb
+++ b/lib/resources/toml.rb
@@ -21,6 +21,8 @@ module Inspec::Resources
       raise Inspec::Exceptions::ResourceFailed, "Unable to parse TOML: #{e.message}"
     end
 
+    private
+
     # used by JsonConfig to build up a full to_s method
     # based on whether a file path, content, or command was supplied.
     def resource_base_name

--- a/lib/resources/xml.rb
+++ b/lib/resources/xml.rb
@@ -14,14 +14,18 @@ module Inspec::Resources
     def parse(content)
       require 'rexml/document'
       REXML::Document.new(content)
+    rescue => e
+      raise Inspec::Exceptions::ResourceFailed, "Unable to parse XML: #{e.message}"
     end
 
     def value(key)
       REXML::XPath.each(@params, key.first.to_s).map(&:text)
     end
 
-    def to_s
-      "XML #{@path}"
+    # used by JsonConfig to build up a full to_s method
+    # based on whether a file path, content, or command was supplied.
+    def resource_base_name
+      'XML'
     end
   end
 end

--- a/lib/resources/xml.rb
+++ b/lib/resources/xml.rb
@@ -22,6 +22,8 @@ module Inspec::Resources
       REXML::XPath.each(@params, key.first.to_s).map(&:text)
     end
 
+    private
+
     # used by JsonConfig to build up a full to_s method
     # based on whether a file path, content, or command was supplied.
     def resource_base_name

--- a/lib/resources/yaml.rb
+++ b/lib/resources/yaml.rb
@@ -30,10 +30,14 @@ module Inspec::Resources
     # override file load and parse hash from yaml
     def parse(content)
       YAML.load(content)
+    rescue => e
+      raise Inspec::Exceptions::ResourceFailed, "Unable to parse YAML: #{e.message}"
     end
 
-    def to_s
-      "YAML #{@path}"
+    # used by JsonConfig to build up a full to_s method
+    # based on whether a file path, content, or command was supplied.
+    def resource_base_name
+      'YAML'
     end
   end
 end

--- a/lib/resources/yaml.rb
+++ b/lib/resources/yaml.rb
@@ -34,6 +34,8 @@ module Inspec::Resources
       raise Inspec::Exceptions::ResourceFailed, "Unable to parse YAML: #{e.message}"
     end
 
+    private
+
     # used by JsonConfig to build up a full to_s method
     # based on whether a file path, content, or command was supplied.
     def resource_base_name


### PR DESCRIPTION
When using the `json` resource (or any of the resources that subclass JsonConfig), `inspec check` would fail if the content was supplied with the `command` option. This is because the `command` resource is mocked and an empty string would be returned for `stdout`. That content would be blindly passed to the `parse` method would which raise an exception and cause `inspec check` to fail.

This change refactors JsonConfig to be a bit cleaner and use some helper methods. Additionally, we use the new Exceptions to properly raise errors which are naturally caught by Inspec::Profile, etc.