### PR TITLE
Remove bundler install during Appveyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,6 @@ platform:
   - x64
 
 environment:
-  bundler_url: https://rubygems.org/downloads/bundler-1.9.9.gem
-
   matrix:
     - ruby_version: "23"
     - ruby_version: "24"
@@ -26,8 +24,6 @@ install:
   - echo %PATH%
   - ruby --version
   - gem --version
-  - appveyor DownloadFile -Url %bundler_url% -FileName bundler.gem
-  - gem install --local bundler --quiet --no-document
   - bundler --version
   - ruby -r rubygems -e "p Gem.path"
 


### PR DESCRIPTION
It appears that the Appveyor images changed recently and the Ruby
installs for all version (2.2, 2.3, and 2.4) already include Bundler
installed. Attempting to install it will hang the tests at an
interactive prompt asking if you want to override the install, and
--force'ing the install causes path issues and Rubygems won't be able
to activate the gem.

Removing the bundler install appears to solve the problem nicely.