### PR TITLE
Allow crontab resource to read crontab at user specified paths.

### DIFF
--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -104,7 +104,7 @@ module Inspec::Resources
     end
 
     def path?
-      @destination.include?('/')
+      @destination.to_s.include?('/')
     end
   end
 end

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-# author: Adam Leff
 
 require 'utils/parser'
 require 'utils/filter'

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -96,8 +96,12 @@ module Inspec::Resources
     filter.connect(self, :params)
 
     def to_s
-      @destination.nil? ? 'crontab for current user' : "crontab for user #{@destination}"
+      @destination.nil? ? 'crontab for current user' : path_or_user
     end
+
+    def path_or_user
+      pou = @destination.include?('/') ? 'path' : 'user'
+      "crontab for #{pou} #{@destination}"
     end
   end
 end

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -100,8 +100,12 @@ module Inspec::Resources
     end
 
     def path_or_user
-      pou = @destination.include?('/') ? 'path' : 'user'
+      pou = path? ? 'path' : 'user'
       "crontab for #{pou} #{@destination}"
+    end
+
+    def path?
+      @destination.include?('/')
     end
   end
 end

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -38,7 +38,8 @@ module Inspec::Resources
     end
 
     def read_crontab
-      inspec.command(crontab_cmd).stdout.lines.map { |l| parse_crontab_line(l) }.compact
+      ct = path? ? inspec.file(@destination).content : inspec.command(crontab_cmd).stdout
+      ct.lines.map { |l| parse_crontab_line(l) }.compact
     end
 
     def parse_crontab_line(l)

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -31,8 +31,8 @@ module Inspec::Resources
 
     include CommentParser
 
-    def initialize(user = nil)
-      @user   = user
+    def initialize(destination = nil)
+      @destination = destination
       @params = read_crontab
 
       return skip_resource 'The `crontab` resource is not supported on your OS.' unless inspec.os.unix?
@@ -73,7 +73,7 @@ module Inspec::Resources
     end
 
     def crontab_cmd
-      @user.nil? ? 'crontab -l' : "crontab -l -u #{@user}"
+      @destination.nil? ? 'crontab -l' : "crontab -l -u #{@destination}"
     end
 
     filter = FilterTable.create
@@ -96,7 +96,8 @@ module Inspec::Resources
     filter.connect(self, :params)
 
     def to_s
-      @user.nil? ? 'crontab for current user' : "crontab for user #{@user}"
+      @destination.nil? ? 'crontab for current user' : "crontab for user #{@destination}"
+    end
     end
   end
 end

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -24,6 +24,10 @@ module Inspec::Resources
       describe crontab.where { command =~ /a partial command string/ } do
         its('entries.length') { should cmp 1 }
       end
+
+      describe crontab('/etc/cron.d/some_crontab') do
+        its('commands') { should include '/path/to/some/script' }
+      end
     "
 
     attr_reader :params

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -44,7 +44,7 @@ module Inspec::Resources
     end
 
     def read_crontab
-      ct = path? ? inspec.file(@destination).content : inspec.command(crontab_cmd).stdout
+      ct = @path.nil? ? inspec.command(crontab_cmd).stdout : inspec.file(@path).content
       ct.lines.map { |l| parse_crontab_line(l) }.compact
     end
 

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     name 'crontab'
     desc 'Use the crontab InSpec audit resource to test the contents of the crontab for a given user which contains information about scheduled tasks owned by that user.'
     example "
-      describe crontab({user:'root'}) do
+      describe crontab({user: 'root'}) do
         its('commands') { should include '/path/to/some/script' }
       end
 
@@ -25,7 +25,7 @@ module Inspec::Resources
         its('entries.length') { should cmp 1 }
       end
 
-      describe crontab({path:'/etc/cron.d/some_crontab'}) do
+      describe crontab({path: '/etc/cron.d/some_crontab'}) do
         its('commands') { should include '/path/to/some/script' }
       end
     "

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     name 'crontab'
     desc 'Use the crontab InSpec audit resource to test the contents of the crontab for a given user which contains information about scheduled tasks owned by that user.'
     example "
-      describe crontab('root') do
+      describe crontab({user:'root'}) do
         its('commands') { should include '/path/to/some/script' }
       end
 
@@ -25,7 +25,7 @@ module Inspec::Resources
         its('entries.length') { should cmp 1 }
       end
 
-      describe crontab('/etc/cron.d/some_crontab') do
+      describe crontab({path:'/etc/cron.d/some_crontab'}) do
         its('commands') { should include '/path/to/some/script' }
       end
     "

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -102,7 +102,13 @@ module Inspec::Resources
     filter.connect(self, :params)
 
     def to_s
-      @destination.nil? ? 'crontab for current user' : path_or_user
+      if !@path.nil?
+        "crontab for path #{@path}"
+      elsif !@user.nil?
+        "crontab for user #{@user}"
+      else
+        'crontab for current user'
+      end
     end
 
     private

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -103,6 +103,8 @@ module Inspec::Resources
       @destination.nil? ? 'crontab for current user' : path_or_user
     end
 
+    private
+
     def path_or_user
       pou = path? ? 'path' : 'user'
       "crontab for #{pou} #{@destination}"

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -90,12 +90,13 @@ module Inspec::Resources
           .add(:days,     field: 'day')
           .add(:months,   field: 'month')
           .add(:weekdays, field: 'weekday')
+          .add(:user,     field: 'user')
           .add(:commands, field: 'command')
 
     # rebuild the crontab line from raw content
     filter.add(:content) { |t, _|
       t.entries.map do |e|
-        [e.minute, e.hour, e.day, e.month, e.weekday, e.command].join(' ')
+        [e.minute, e.hour, e.day, e.month, e.weekday, e.user, e.command].compact.join(' ')
       end.join("\n")
     }
 

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -114,13 +114,8 @@ module Inspec::Resources
 
     private
 
-    def path_or_user
-      pou = path? ? 'path' : 'user'
-      "crontab for #{pou} #{@destination}"
     end
 
-    def path?
-      @destination.to_s.include?('/')
     end
   end
 end

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -34,8 +34,10 @@ module Inspec::Resources
 
     include CommentParser
 
-    def initialize(destination = nil)
-      @destination = destination
+    def initialize(opts = {})
+      Hash[opts.map { |k, v| [k.to_sym, v] }] if opts.respond_to?(:fetch)
+      @user = opts.respond_to?(:fetch) ? opts.fetch(:user, nil) : opts
+      @path = opts.fetch(:path, nil) if opts.respond_to?(:fetch)
       @params = read_crontab
 
       return skip_resource 'The `crontab` resource is not supported on your OS.' unless inspec.os.unix?

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -52,30 +52,7 @@ module Inspec::Resources
       data, = parse_comment_line(l, comment_char: '#', standalone_comments: false)
       return nil if data.nil? || data.empty?
 
-      case data
-      when /@hourly .*/
-        { 'minute' => '0', 'hour' => '*', 'day' => '*', 'month' => '*', 'weekday' => '*', 'command' => data.split(/\s+/, 2).at(1) }
-      when /@(midnight|daily) .*/
-        { 'minute' => '0', 'hour' => '0', 'day' => '*', 'month' => '*', 'weekday' => '*', 'command' => data.split(/\s+/, 2).at(1) }
-      when /@weekly .*/
-        { 'minute' => '0', 'hour' => '0', 'day' => '*', 'month' => '*', 'weekday' => '0', 'command' => data.split(/\s+/, 2).at(1) }
-      when /@monthly ./
-        { 'minute' => '0', 'hour' => '0', 'day' => '1', 'month' => '*', 'weekday' => '*', 'command' => data.split(/\s+/, 2).at(1) }
-      when /@(annually|yearly) .*/
-        { 'minute' => '0', 'hour' => '0', 'day' => '1', 'month' => '1', 'weekday' => '*', 'command' => data.split(/\s+/, 2).at(1) }
-      when /@reboot .*/
-        { 'minute' => '-1', 'hour' => '-1', 'day' => '-1', 'month' => '-1', 'weekday' => '-1', 'command' => data.split(/\s+/, 2).at(1) }
-      else
-        elements = data.split(/\s+/, 6)
-        {
-          'minute'  => elements.at(0),
-          'hour'    => elements.at(1),
-          'day'     => elements.at(2),
-          'month'   => elements.at(3),
-          'weekday' => elements.at(4),
-          'command' => elements.at(5),
-        }
-      end
+      !@path.nil? ? parse_system_crontab(data) : parse_user_crontab(data)
     end
 
     def crontab_cmd
@@ -114,8 +91,66 @@ module Inspec::Resources
 
     private
 
+    def parse_system_crontab(data)
+      case data
+      when /@hourly .*/
+        elements = data.split(/\s+/, 3)
+        { 'minute' => '0', 'hour' => '*', 'day' => '*', 'month' => '*', 'weekday' => '*', 'user' => elements.at(1), 'command' => elements.at(2) }
+      when /@(midnight|daily) .*/
+        elements = data.split(/\s+/, 3)
+        { 'minute' => '0', 'hour' => '0', 'day' => '*', 'month' => '*', 'weekday' => '*', 'user' => elements.at(1), 'command' => elements.at(2) }
+      when /@weekly .*/
+        elements = data.split(/\s+/, 3)
+        { 'minute' => '0', 'hour' => '0', 'day' => '*', 'month' => '*', 'weekday' => '0', 'user' => elements.at(1), 'command' => elements.at(2) }
+      when /@monthly ./
+        elements = data.split(/\s+/, 3)
+        { 'minute' => '0', 'hour' => '0', 'day' => '1', 'month' => '*', 'weekday' => '*', 'user' => elements.at(1), 'command' => elements.at(2) }
+      when /@(annually|yearly) .*/
+        elements = data.split(/\s+/, 3)
+        { 'minute' => '0', 'hour' => '0', 'day' => '1', 'month' => '1', 'weekday' => '*', 'user' => elements.at(1), 'command' => elements.at(2) }
+      when /@reboot .*/
+        elements = data.split(/\s+/, 3)
+        { 'minute' => '-1', 'hour' => '-1', 'day' => '-1', 'month' => '-1', 'weekday' => '-1', 'user' => elements.at(1), 'command' => elements.at(2) }
+      else
+        elements = data.split(/\s+/, 7)
+        {
+          'minute'  => elements.at(0),
+          'hour'    => elements.at(1),
+          'day'     => elements.at(2),
+          'month'   => elements.at(3),
+          'weekday' => elements.at(4),
+          'user'    => elements.at(5),
+          'command' => elements.at(6),
+        }
+      end
     end
 
+    def parse_user_crontab(data)
+      case data
+      when /@hourly .*/
+        { 'minute' => '0', 'hour' => '*', 'day' => '*', 'month' => '*', 'weekday' => '*', 'user' => @user, 'command' => data.split(/\s+/, 2).at(1) }
+      when /@(midnight|daily) .*/
+        { 'minute' => '0', 'hour' => '0', 'day' => '*', 'month' => '*', 'weekday' => '*', 'user' => @user, 'command' => data.split(/\s+/, 2).at(1) }
+      when /@weekly .*/
+        { 'minute' => '0', 'hour' => '0', 'day' => '*', 'month' => '*', 'weekday' => '0', 'user' => @user, 'command' => data.split(/\s+/, 2).at(1) }
+      when /@monthly ./
+        { 'minute' => '0', 'hour' => '0', 'day' => '1', 'month' => '*', 'weekday' => '*', 'user' => @user, 'command' => data.split(/\s+/, 2).at(1) }
+      when /@(annually|yearly) .*/
+        { 'minute' => '0', 'hour' => '0', 'day' => '1', 'month' => '1', 'weekday' => '*', 'user' => @user, 'command' => data.split(/\s+/, 2).at(1) }
+      when /@reboot .*/
+        { 'minute' => '-1', 'hour' => '-1', 'day' => '-1', 'month' => '-1', 'weekday' => '-1', 'user' => @user, 'command' => data.split(/\s+/, 2).at(1) }
+      else
+        elements = data.split(/\s+/, 6)
+        {
+          'minute'  => elements.at(0),
+          'hour'    => elements.at(1),
+          'day'     => elements.at(2),
+          'month'   => elements.at(3),
+          'weekday' => elements.at(4),
+          'user'    => @user,
+          'command' => elements.at(5),
+        }
+      end
     end
   end
 end

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -79,7 +79,7 @@ module Inspec::Resources
     end
 
     def crontab_cmd
-      @destination.nil? ? 'crontab -l' : "crontab -l -u #{@destination}"
+      @user.nil? ? 'crontab -l' : "crontab -l -u #{@user}"
     end
 
     filter = FilterTable.create

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -3,6 +3,7 @@
 require 'utils/parser'
 require 'utils/filter'
 
+# rubocop:disable Metrics/ClassLength
 module Inspec::Resources
   class Crontab < Inspec.resource(1)
     name 'crontab'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -182,6 +182,7 @@ class MockLoader
       '/etc/hosts.deny' => mockfile.call('hosts.deny'),
       '/fakepath/fakefile' => emptyfile.call,
       'C:/fakepath/fakefile' => emptyfile.call,
+      '/etc/cron.d/crondotd' => mockfile.call('crondotd'),
     }
 
     # create all mock commands

--- a/test/unit/mock/files/crondotd
+++ b/test/unit/mock/files/crondotd
@@ -1,0 +1,10 @@
+#
+# This is a sample cron.d file for unit testing crontab with paths.
+#
+
+
+# entry number 1
+0 2 11 9 4 /path/to/crondotd1
+
+# entry number 2
+1 3 12 10 5 /path/to/crondotd2 arg1 arg2

--- a/test/unit/mock/files/crondotd
+++ b/test/unit/mock/files/crondotd
@@ -4,7 +4,7 @@
 
 
 # entry number 1
-0 2 11 9 4 /path/to/crondotd1
+0 2 11 9 4 root /path/to/crondotd1
 
 # entry number 2
-1 3 12 10 5 /path/to/crondotd2 arg1 arg2
+1 3 12 10 5 daemon /path/to/crondotd2 arg1 arg2

--- a/test/unit/mock/files/crondotd
+++ b/test/unit/mock/files/crondotd
@@ -8,3 +8,6 @@
 
 # entry number 2
 1 3 12 10 5 daemon /path/to/crondotd2 arg1 arg2
+
+# entry number 3
+@yearly root /usr/local/bin/foo.sh bar

--- a/test/unit/resources/crontab_test.rb
+++ b/test/unit/resources/crontab_test.rb
@@ -76,6 +76,14 @@ describe 'Inspec::Resources::Crontab' do
     end
   end
 
+  describe 'query by path' do
+    let(:crontab) { load_resource('crontab', '/etc/cron.d/crondotd') }
+
+    it 'prints a nice to_s string' do
+      _(crontab.to_s).must_equal 'crontab for path /etc/cron.d/crondotd'
+    end
+  end
+
   describe 'special strings' do
     let(:crontab) { load_resource('crontab', 'special') }
 

--- a/test/unit/resources/crontab_test.rb
+++ b/test/unit/resources/crontab_test.rb
@@ -82,6 +82,27 @@ describe 'Inspec::Resources::Crontab' do
     it 'prints a nice to_s string' do
       _(crontab.to_s).must_equal 'crontab for path /etc/cron.d/crondotd'
     end
+
+    it 'returns all params of the file' do
+      _(crontab.params).must_equal(
+        [{
+          'minute'  => '0',
+          'hour'    => '2',
+          'day'     => '11',
+          'month'   => '9',
+          'weekday' => '4',
+          'command' => '/path/to/crondotd1',
+        },
+        {
+          'minute'  => '1',
+          'hour'    => '3',
+          'day'     => '12',
+          'month'   => '10',
+          'weekday' => '5',
+          'command' => '/path/to/crondotd2 arg1 arg2',
+        }],
+      )
+    end
   end
 
   describe 'special strings' do

--- a/test/unit/resources/crontab_test.rb
+++ b/test/unit/resources/crontab_test.rb
@@ -79,7 +79,7 @@ describe 'Inspec::Resources::Crontab' do
   end
 
   describe 'query by path' do
-    let(:crontab) { load_resource('crontab', {path: '/etc/cron.d/crondotd'}) }
+    let(:crontab) { load_resource('crontab', { path: '/etc/cron.d/crondotd' }) }
 
     it 'prints a nice to_s string' do
       _(crontab.to_s).must_equal 'crontab for path /etc/cron.d/crondotd'

--- a/test/unit/resources/crontab_test.rb
+++ b/test/unit/resources/crontab_test.rb
@@ -39,6 +39,7 @@ describe 'Inspec::Resources::Crontab' do
         'day'     => '11',
         'month'   => '9',
         'weekday' => '4',
+        'user'    => nil,
         'command' => '/path/to/script1',
       },
       {
@@ -47,6 +48,7 @@ describe 'Inspec::Resources::Crontab' do
         'day'     => '12',
         'month'   => '10',
         'weekday' => '5',
+        'user'    => nil,
         'command' => '/path/to/script2 arg1 arg2'
       },
     ])
@@ -118,6 +120,7 @@ describe 'Inspec::Resources::Crontab' do
           'day'     => '*',
           'month'   => '*',
           'weekday' => '*',
+          'user'    => 'special',
           'command' => '/bin/custom_script.sh',
         },
         {
@@ -126,6 +129,7 @@ describe 'Inspec::Resources::Crontab' do
           'day'     => '1',
           'month'   => '1',
           'weekday' => '*',
+          'user'    => 'special',
           'command' => '/usr/local/bin/foo.sh bar'
         },
         {
@@ -134,6 +138,7 @@ describe 'Inspec::Resources::Crontab' do
           'day'     => '-1',
           'month'   => '-1',
           'weekday' => '-1',
+          'user'    => 'special',
           'command' => '/bin/echo "Rebooting" > /var/log/rebooting.log'
         }
       ])

--- a/test/unit/resources/crontab_test.rb
+++ b/test/unit/resources/crontab_test.rb
@@ -91,6 +91,7 @@ describe 'Inspec::Resources::Crontab' do
           'day'     => '11',
           'month'   => '9',
           'weekday' => '4',
+          'username' => 'root',
           'command' => '/path/to/crondotd1',
         },
         {
@@ -99,6 +100,7 @@ describe 'Inspec::Resources::Crontab' do
           'day'     => '12',
           'month'   => '10',
           'weekday' => '5',
+          'username' => 'daemon',
           'command' => '/path/to/crondotd2 arg1 arg2',
         }],
       )

--- a/test/unit/resources/crontab_test.rb
+++ b/test/unit/resources/crontab_test.rb
@@ -77,7 +77,7 @@ describe 'Inspec::Resources::Crontab' do
   end
 
   describe 'query by path' do
-    let(:crontab) { load_resource('crontab', '/etc/cron.d/crondotd') }
+    let(:crontab) { load_resource('crontab', {path: '/etc/cron.d/crondotd'}) }
 
     it 'prints a nice to_s string' do
       _(crontab.to_s).must_equal 'crontab for path /etc/cron.d/crondotd'

--- a/test/unit/resources/crontab_test.rb
+++ b/test/unit/resources/crontab_test.rb
@@ -93,18 +93,27 @@ describe 'Inspec::Resources::Crontab' do
           'day'     => '11',
           'month'   => '9',
           'weekday' => '4',
-          'username' => 'root',
+          'user'    => 'root',
           'command' => '/path/to/crondotd1',
         },
-        {
-          'minute'  => '1',
-          'hour'    => '3',
-          'day'     => '12',
-          'month'   => '10',
-          'weekday' => '5',
-          'username' => 'daemon',
-          'command' => '/path/to/crondotd2 arg1 arg2',
-        }],
+         {
+           'minute'  => '1',
+           'hour'    => '3',
+           'day'     => '12',
+           'month'   => '10',
+           'weekday' => '5',
+           'user'    => 'daemon',
+           'command' => '/path/to/crondotd2 arg1 arg2',
+         },
+         {
+           'minute'  => '0',
+           'hour'    => '0',
+           'day'     => '1',
+           'month'   => '1',
+           'weekday' => '*',
+           'user'    => 'root',
+           'command' => '/usr/local/bin/foo.sh bar',
+         }],
       )
     end
   end

--- a/test/unit/resources/crontab_test.rb
+++ b/test/unit/resources/crontab_test.rb
@@ -153,4 +153,18 @@ describe 'Inspec::Resources::Crontab' do
       ])
     end
   end
+
+  describe 'it raises errors' do
+    it 'raises error on unsupported os' do
+      resource = MockLoader.new(:windows).load_resource('crontab', { user: 'special' })
+      _(resource.resource_skipped?).must_equal true
+      _(resource.resource_exception_message).must_equal 'The `crontab` resource is not supported on your OS.'
+    end
+
+    it 'raises error when no user or path supplied' do
+      resource = load_resource('crontab', {})
+      _(resource.resource_failed?).must_equal true
+      _(resource.resource_exception_message).must_equal 'A user or path must be supplied.'
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for reading crontab files at user specified paths as requested in https://github.com/chef/inspec/issues/1461.

Example usage:
```
describe crontab('/etc/cron.d/some_crontab') do
  its('commands') { should include '/path/to/some/script' }
end
```