### PR TITLE
[OI] correctly check if auditd version is >= 2.3

### DIFF
--- a/lib/resources/auditd.rb
+++ b/lib/resources/auditd.rb
@@ -34,9 +34,10 @@ module Inspec::Resources
 
     def initialize
       @content = inspec.command('/sbin/auditctl -l').stdout.chomp
+      @version = inspec.command('/sbin/auditctl -v').stdout.chomp
       @params = []
 
-      if @content =~ /^LIST_RULES:/
+      if @version.to_f < 2.3
         return skip_resource 'The version of audit is outdated. The `auditd` resource supports versions of audit >= 2.3.'
       end
       parse_content


### PR DESCRIPTION
This change fixes the bug reported here, https://github.com/chef/inspec/issues/2334.

Further info:
"auditd" resource does not work for any auditd installation that its
listed rules (output of "auditctl -l") start with "LIST_RULES:".
Unfortunately, there is a wrong assumption made in the resource code
that kind of assumes output of "auditctl -l" for audit >= 2.3 does
not start with "LIST_RULES:". On a ubuntu 14.04 host with auditd 2.3.2
listed rules do indeed start with "LIST_RULES:"

Issue raised on Inspec github repo: https://github.com/chef/inspec/issues/2334

As workaround, "file" resource can be used though not ideal.