### PR TITLE
Remove rubocop from example Gemfiles

### DIFF
--- a/examples/kitchen-ansible/Gemfile
+++ b/examples/kitchen-ansible/Gemfile
@@ -7,7 +7,6 @@ group :test do
   gem 'bundler', '~> 1.5'
   gem 'minitest', '~> 5.5'
   gem 'rake', '~> 10'
-  gem 'rubocop', '~> 0.33.0'
   gem 'simplecov', '~> 0.10'
 end
 

--- a/examples/kitchen-chef/Gemfile
+++ b/examples/kitchen-chef/Gemfile
@@ -7,7 +7,6 @@ group :test do
   gem 'bundler', '~> 1.5'
   gem 'minitest', '~> 5.5'
   gem 'rake', '~> 10'
-  gem 'rubocop', '~> 0.33.0'
   gem 'simplecov', '~> 0.10'
 end
 

--- a/examples/kitchen-puppet/Gemfile
+++ b/examples/kitchen-puppet/Gemfile
@@ -7,7 +7,6 @@ group :test do
   gem 'bundler', '~> 1.5'
   gem 'minitest', '~> 5.5'
   gem 'rake', '~> 10'
-  gem 'rubocop', '~> 0.33.0'
   gem 'simplecov', '~> 0.10'
 end
 


### PR DESCRIPTION
The pinned version of Rubocop in some of the TK examples' Gemfiles was a very old version with known vulnerabilities. Since these are just examples and have no Rake tasks that rely on them, I removed rubocop outright from the example Gemfiles.

Signed-off-by: Adam Leff <adam@leff.co>