### PR TITLE
wmi resource: properly escape quotes in WMI query

### DIFF
--- a/lib/resources/wmi.rb
+++ b/lib/resources/wmi.rb
@@ -27,7 +27,7 @@ module Inspec::Resources
 
     def initialize(wmiclass = nil, opts = nil)
       # verify that this resource is only supported on Windows
-      return skip_resource 'The `windows_feature` resource is not supported on your OS.' unless inspec.os.windows?
+      return skip_resource 'The `wmi` resource is not supported on your OS.' unless inspec.os.windows?
 
       @options = opts || {}
       # if wmiclass is not a hash, we have to handle deprecation behavior
@@ -67,7 +67,7 @@ module Inspec::Resources
 
       # convert to Get-WmiObject arguments
       params = ''
-      args.each { |key, value| params += " -#{key} \"#{value}\"" }
+      args.each { |key, value| params += " -#{key} \"#{value.gsub('"', '`"')}\"" }
 
       # run wmi command and filter empty wmi
       script = <<-EOH

--- a/test/integration/default/controls/wmi_spec.rb
+++ b/test/integration/default/controls/wmi_spec.rb
@@ -14,7 +14,7 @@ end
 # Use win32_service with filter, it returns a single service object
 describe wmi({
   class: 'win32_service',
-  filter: "name like '%winrm%'"
+  filter: 'name like "%winrm%"'
 }) do
   its('Status') { should cmp 'ok' }
   its('State') { should cmp 'Running' }


### PR DESCRIPTION
Fixes #2260.

This modifies an existing test to include that scenario and fixes it as 2 separate commits.