### PR TITLE
Unique export file for security policy resource

### DIFF
--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -119,12 +119,8 @@ module Inspec::Resources
       # store file content
       cmd = inspec.command("Get-Content #{export_file}")
       return skip_resource "Can't read security policy" if cmd.exit_status.to_i != 0
-      @content = cmd.stdout
 
-      if @content.empty?
-        return skip_resource "Can't read security policy"
-      end
-      @content
+      @content = cmd.stdout
     ensure
       # delete temp file
       inspec.command("Remove-Item #{export_file}").exit_status.to_i

--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -14,6 +14,7 @@
 # parameters. Therefore we need a combination of Registry and secedit output
 
 require 'hashie'
+require 'securerandom'
 
 module Inspec::Resources
   # known and supported MS privilege rights
@@ -108,22 +109,25 @@ module Inspec::Resources
     def read_content
       return @content if defined?(@content)
 
+      # using random hex to prevent any race conditions with multiple runners
+      export_file = "win_secpol-#{SecureRandom.hex}.cfg"
+
       # export the security policy
-      cmd = inspec.command('secedit /export /cfg win_secpol.cfg')
+      cmd = inspec.command("secedit /export /cfg #{export_file}")
       return nil if cmd.exit_status.to_i != 0
 
       # store file content
-      cmd = inspec.command('Get-Content win_secpol.cfg')
+      cmd = inspec.command("Get-Content #{export_file}")
       return skip_resource "Can't read security policy" if cmd.exit_status.to_i != 0
       @content = cmd.stdout
 
-      if @content.empty? && !file.empty?
+      if @content.empty?
         return skip_resource "Can't read security policy"
       end
       @content
     ensure
       # delete temp file
-      inspec.command('Remove-Item win_secpol.cfg').exit_status.to_i
+      inspec.command("Remove-Item #{export_file}").exit_status.to_i
     end
 
     def read_params

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -214,9 +214,9 @@ class MockLoader
       'ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command' => cmd.call('ps-axoZ'),
       'ps -o pid,vsz,rss,tty,stat,time,ruser,args' => cmd.call('ps-busybox'),
       'ps --help' => empty.call,
-      'Get-Content win_secpol.cfg' => cmd.call('secedit-export'),
-      'secedit /export /cfg win_secpol.cfg' => cmd.call('success'),
-      'Remove-Item win_secpol.cfg' => cmd.call('success'),
+      'Get-Content win_secpol-abc123.cfg' => cmd.call('secedit-export'),
+      'secedit /export /cfg win_secpol-abc123.cfg' => cmd.call('success'),
+      'Remove-Item win_secpol-abc123.cfg' => cmd.call('success'),
       'env' => cmd.call('env'),
       '${Env:PATH}'  => cmd.call('$env-PATH'),
       # registry key test using winrm 2.0

--- a/test/unit/resources/security_policy_test.rb
+++ b/test/unit/resources/security_policy_test.rb
@@ -15,4 +15,16 @@ describe 'Inspec::Resources::SecurityPolicy' do
     _(resource.SeUndockPrivilege).must_equal ["S-1-5-32-544"]
     _(resource.SeRemoteInteractiveLogonRight).must_equal ["S-1-5-32-544","S-1-5-32-555"]
   end
+
+  it 'parse empty policy file' do
+    resource = load_resource('security_policy')
+    SecureRandom.expects(:hex).returns('abc123')
+    backend = resource.inspec.backend
+    backend.commands['Get-Content win_secpol-abc123.cfg'] = backend.mock_command('', '', '', 0)
+
+    _(resource.MaximumPasswordAge).must_be_nil
+    _(resource.send('MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Setup\RecoveryConsole\SecurityLevel')).must_be_nil
+    _(resource.SeUndockPrivilege).must_equal []
+    _(resource.SeRemoteInteractiveLogonRight).must_equal []
+  end
 end

--- a/test/unit/resources/security_policy_test.rb
+++ b/test/unit/resources/security_policy_test.rb
@@ -8,6 +8,8 @@ require 'inspec/resource'
 describe 'Inspec::Resources::SecurityPolicy' do
   it 'verify processes resource' do
     resource = load_resource('security_policy')
+    SecureRandom.expects(:hex).returns('abc123')
+
     _(resource.MaximumPasswordAge).must_equal 42
     _(resource.send('MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Setup\RecoveryConsole\SecurityLevel')).must_equal '4,0'
     _(resource.SeUndockPrivilege).must_equal ["S-1-5-32-544"]


### PR DESCRIPTION
The SecurityPolicy resource has a potential race condition when exporting the policy. If two runners were both working on the SecurityPolicy resource one could delete the policy export file before the other finished the export. This would cause the policy test to fail on the second runner. 

This change is to create a SecureRandom hex and append it to the policy export file. This resolves the issue as each instance will have its own unique file.

Signed-off-by: Jared Quick <jquick@chef.io>