### PR TITLE
Update command resource to check for mock backend

### DIFF
--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -45,9 +45,9 @@ module Inspec::Resources
       result.exit_status.to_i
     end
 
-    def exist?
+    def exist? # rubocop:disable Metrics/AbcSize
       # silent for mock resources
-      return false if inspec.os.name.nil?
+      return false if inspec.os.name.nil? || inspec.os.name == 'mock'
 
       if inspec.os.linux?
         res = inspec.backend.run_command("bash -c 'type \"#{@command}\"'")
@@ -56,7 +56,7 @@ module Inspec::Resources
       elsif inspec.os.unix?
         res = inspec.backend.run_command("type \"#{@command}\"")
       else
-        warn "`command(#{@command}).exist?` is not suported on your OS: #{inspec.os[:name]}"
+        warn "`command(#{@command}).exist?` is not supported on your OS: #{inspec.os[:name]}"
         return false
       end
       res.exit_status.to_i == 0

--- a/test/unit/resources/command_test.rb
+++ b/test/unit/resources/command_test.rb
@@ -22,6 +22,16 @@ describe Inspec::Resources::Cmd do
     resource('env').exit_status.must_equal 0
   end
 
+  it 'exist? returns false on nil os name' do
+    Inspec::Resources::OSResource.any_instance.stubs(:name).returns(nil)
+    resource('test').exist?.must_equal false
+  end
+
+  it 'exist? returns false on mock os name' do
+    Inspec::Resources::OSResource.any_instance.stubs(:name).returns('mock')
+    resource('test').exist?.must_equal false
+  end
+
   it 'raises when called with nil as a command' do
     proc { resource(nil).result }.must_raise StandardError
   end


### PR DESCRIPTION
This change removes the command errors when using a mock backend that does not set a os.name. Ex: `command(docker).exist? is not supported on your OS: unknown` 

This change goes in tandem with https://github.com/chef/train/pull/221. It can be merged early if needed but we will not see the errors go away till both are merged and inspec is updated to use the new version of train.

Signed-off-by: Jared Quick <jquick@chef.io>