### PR TITLE
Unify method in which file content is read across all resources

### DIFF
--- a/lib/resources/aide_conf.rb
+++ b/lib/resources/aide_conf.rb
@@ -2,6 +2,7 @@
 
 require 'utils/filter'
 require 'utils/parser'
+require 'utils/file_reader'
 module Inspec::Resources
   class AideConf < Inspec.resource(1)
     name 'aide_conf'
@@ -25,6 +26,7 @@ module Inspec::Resources
     attr_reader :params
 
     include CommentParser
+    include FileReader
 
     def initialize(aide_conf_path = nil)
       @conf_path = aide_conf_path || '/etc/aide.conf'
@@ -55,20 +57,10 @@ module Inspec::Resources
       return @content unless @content.nil?
       @rules = {}
 
-      file = inspec.file(@conf_path)
-      if !file.file?
-        return skip_resource "Can't find file \"#{@conf_path}\""
-      end
-      raw_conf = file.content
-      if raw_conf.nil?
-        return skip_resource "File can't be opened or is empty \"#{@conf_path}\""
-      end
-      if raw_conf.empty? && !file.empty?
-        return skip_resource "Can't read file \"#{@conf_path}\""
-      end
+      raw_conf = read_file_content(@conf_path)
 
       # If there is a file and it contains content, continue
-      @content = filter_comments(inspec.file(@conf_path).content.lines)
+      @content = filter_comments(raw_conf.lines)
       @params = parse_conf(@content)
     end
 

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -3,6 +3,7 @@
 
 require 'utils/simpleconfig'
 require 'utils/find_files'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class ApacheConf < Inspec.resource(1)
@@ -17,6 +18,7 @@ module Inspec::Resources
     "
 
     include FindFiles
+    include FileReader
 
     attr_reader :conf_path
 
@@ -63,16 +65,7 @@ module Inspec::Resources
       @content = ''
       @params = {}
 
-      # skip if the main configuration file doesn't exist
-      file = inspec.file(conf_path)
-      if !file.file?
-        return skip_resource "Can't find file \"#{conf_path}\""
-      end
-
-      raw_conf = file.content
-      if raw_conf.empty? && !file.empty?
-        return skip_resource("Can't read file \"#{conf_path}\"")
-      end
+      read_file_content(conf_path)
 
       to_read = [conf_path]
       until to_read.empty?
@@ -124,7 +117,7 @@ module Inspec::Resources
     end
 
     def read_file(path)
-      @files_contents[path] ||= inspec.file(path).content
+      @files_contents[path] ||= read_file_content(path)
     end
 
     def conf_dir

--- a/lib/resources/auditd_conf.rb
+++ b/lib/resources/auditd_conf.rb
@@ -2,6 +2,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require 'utils/simpleconfig'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class AuditDaemonConf < Inspec.resource(1)
@@ -14,8 +15,11 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     def initialize(path = nil)
       @conf_path = path || '/etc/audit/auditd.conf'
+      @content = read_file_content(@conf_path)
     end
 
     def method_missing(name)
@@ -32,17 +36,7 @@ module Inspec::Resources
       return @params if defined?(@params)
 
       # read the file
-      file = inspec.file(@conf_path)
-      if !file.file?
-        skip_resource "Can't find file '#{@conf_path}'"
-        return @params = {}
-      end
-
-      content = file.content
-      if content.empty? && !file.empty?
-        skip_resource "Can't read file '#{@conf_path}'"
-        return @params = {}
-      end
+      content = read_file_content(@conf_path)
 
       # parse the file
       conf = SimpleConfig.new(

--- a/lib/resources/auditd_conf.rb
+++ b/lib/resources/auditd_conf.rb
@@ -35,12 +35,9 @@ module Inspec::Resources
     def read_params
       return @params if defined?(@params)
 
-      # read the file
-      content = read_file_content(@conf_path)
-
       # parse the file
       conf = SimpleConfig.new(
-        content,
+        @content,
         multiple_values: false,
       )
       @params = conf.params

--- a/lib/resources/bond.rb
+++ b/lib/resources/bond.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'resources/file'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class Bond < FileResource
@@ -13,20 +14,22 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     def initialize(bond)
       @bond = bond
       @path = "/proc/net/bonding/#{bond}"
       @file = inspec.file(@path)
-      @content = nil
+      @content = read_file_content(@path, allow_empty: true)
       @params = {}
       @loaded = false
     end
 
     def read_content
       # parse the file
-      @content = @file.content
+      @content = read_file_content(@path, allow_empty: true)
       @params = SimpleConfig.new(
-        @file.content,
+        @content,
         assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
         multiple_values: true,
       ).params if @file.exist?

--- a/lib/resources/bond.rb
+++ b/lib/resources/bond.rb
@@ -26,8 +26,6 @@ module Inspec::Resources
     end
 
     def read_content
-      # parse the file
-      @content = read_file_content(@path, allow_empty: true)
       @params = SimpleConfig.new(
         @content,
         assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,

--- a/lib/resources/dh_params.rb
+++ b/lib/resources/dh_params.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'openssl'
+require 'utils/file_reader'
 
 class DhParams < Inspec.resource(1)
   name 'dh_params'
@@ -22,17 +23,11 @@ class DhParams < Inspec.resource(1)
     end
   "
 
+  include FileReader
+
   def initialize(filename)
     @dh_params_path = filename
-    file = inspec.file(@dh_params_path)
-    return skip_resource "Unable to find DH parameters file #{@dh_params_path}" unless file.exist?
-
-    begin
-      @dh_params = OpenSSL::PKey::DH.new file.content
-    rescue
-      @dh_params = nil
-      return skip_resource "Unable to load DH parameters #{@dh_params_path}"
-    end
+    @dh_params = OpenSSL::PKey::DH.new read_file_content(@dh_params_path, allow_empty: true)
   end
 
   # it { should be_dh_params }

--- a/lib/resources/dh_params.rb
+++ b/lib/resources/dh_params.rb
@@ -27,7 +27,7 @@ class DhParams < Inspec.resource(1)
 
   def initialize(filename)
     @dh_params_path = filename
-    @dh_params = OpenSSL::PKey::DH.new read_file_content(@dh_params_path, allow_empty: true)
+    @dh_params = OpenSSL::PKey::DH.new read_file_content(@dh_params_path)
   end
 
   # it { should be_dh_params }

--- a/lib/resources/etc_fstab.rb
+++ b/lib/resources/etc_fstab.rb
@@ -2,6 +2,7 @@
 # copyright:
 
 require 'utils/parser'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class EtcFstab < Inspec.resource(1)
@@ -26,6 +27,7 @@ module Inspec::Resources
     attr_reader :params
 
     include CommentParser
+    include FileReader
 
     def initialize(fstab_path = nil)
       @conf_path      = fstab_path || '/etc/fstab'
@@ -86,16 +88,7 @@ module Inspec::Resources
     end
 
     def read_file(conf_path = @conf_path)
-      file = inspec.file(conf_path)
-      if !file.file?
-        return skip_resource "Can't find \"#{@conf_path}\""
-      end
-
-      raw_conf = file.content
-      if raw_conf.empty? && !file.empty?
-        return skip_resource("File is empty or unable to read file at path:\"#{@conf_path}\"")
-      end
-      raw_conf.lines
+      read_file_content(conf_path).lines
     end
   end
 end

--- a/lib/resources/etc_group.rb
+++ b/lib/resources/etc_group.rb
@@ -20,6 +20,7 @@
 
 require 'utils/convert'
 require 'utils/parser'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class EtcGroup < Inspec.resource(1)
@@ -36,6 +37,8 @@ module Inspec::Resources
         its('users') { should include 'my_user' }
       end
     "
+
+    include FileReader
 
     attr_accessor :gid, :entries
     def initialize(path = nil)
@@ -91,11 +94,8 @@ module Inspec::Resources
     private
 
     def parse_group(path)
-      @content = inspec.file(path).content
-      if @content.nil?
-        skip_resource "Can't access group file in #{path}"
-        return []
-      end
+      @content = read_file_content(path, allow_empty: true)
+
       # iterate over each line and filter comments
       @content.split("\n").each_with_object([]) do |line, lines|
         grp_info = parse_group_line(line)

--- a/lib/resources/etc_hosts.rb
+++ b/lib/resources/etc_hosts.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'utils/parser'
+require 'utils/file_reader'
 
 class EtcHosts < Inspec.resource(1)
   name 'etc_hosts'
@@ -20,6 +21,7 @@ class EtcHosts < Inspec.resource(1)
   attr_reader :params
 
   include CommentParser
+  include FileReader
 
   def initialize(hosts_path = nil)
     @conf_path      = hosts_path || default_hosts_file_path
@@ -68,15 +70,6 @@ class EtcHosts < Inspec.resource(1)
   end
 
   def read_file(conf_path = @conf_path)
-    file = inspec.file(conf_path)
-    if !file.file?
-      return skip_resource "Can't find file. \"#{@conf_path}\""
-    end
-
-    raw_conf = file.content
-    if raw_conf.empty? && !file.empty?
-      return skip_resource("Could not read file contents\" #{@conf_path}\"")
-    end
-    raw_conf.lines
+    read_file_content(conf_path).lines
   end
 end

--- a/lib/resources/etc_hosts_allow_deny.rb
+++ b/lib/resources/etc_hosts_allow_deny.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'utils/parser'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class EtcHostsAllow < Inspec.resource(1)
@@ -18,6 +19,7 @@ module Inspec::Resources
     attr_reader :params
 
     include CommentParser
+    include FileReader
 
     def initialize(hosts_allow_path = nil)
       @conf_path      = hosts_allow_path || '/etc/hosts.allow'
@@ -82,19 +84,7 @@ module Inspec::Resources
     end
 
     def read_file(conf_path = @conf_path)
-      # Determine if the file exists and contains anything, if not
-      # then access control is turned off.
-      file = inspec.file(conf_path)
-      if !file.file?
-        return skip_resource "Can't find file at \"#{@conf_path}\""
-      end
-      raw_conf = file.content
-      if raw_conf.empty? && !file.empty?
-        return skip_resource("Unable to read file \"#{@conf_path}\"")
-      end
-
-      # If there is a file and it contains content, continue
-      raw_conf.lines
+      read_file_content(conf_path).lines
     end
   end
 

--- a/lib/resources/grub_conf.rb
+++ b/lib/resources/grub_conf.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'utils/simpleconfig'
+require 'utils/file_reader'
 
 class GrubConfig < Inspec.resource(1)
   name 'grub_conf'
@@ -20,10 +21,13 @@ class GrubConfig < Inspec.resource(1)
     end
   "
 
+  include FileReader
+
   class UnknownGrubConfig < StandardError; end
 
   def initialize(path = nil, kernel = nil)
     config_for_platform(path)
+    @content = read_file(@conf_path)
     @kernel = kernel || 'default'
   rescue UnknownGrubConfig
     return skip_resource 'The `grub_config` resource is not supported on your OS yet.'
@@ -175,21 +179,7 @@ class GrubConfig < Inspec.resource(1)
   end
 
   def read_file(config_file)
-    file = inspec.file(config_file)
-
-    if !file.file? && !file.symlink?
-      skip_resource "Can't find file '#{@conf_path}'"
-      return @params = {}
-    end
-
-    content = file.content
-
-    if content.empty? && !file.empty?
-      skip_resource "Can't read file '#{@conf_path}'"
-      return @params = {}
-    end
-
-    content
+    read_file_content(config_file)
   end
 
   def read_params

--- a/lib/resources/inetd_conf.rb
+++ b/lib/resources/inetd_conf.rb
@@ -36,11 +36,10 @@ module Inspec::Resources
 
     def read_params
       return @params if defined?(@params)
-      content = read_file_content(@conf_path)
 
       # parse the file
       conf = SimpleConfig.new(
-        content,
+        @content,
         assignment_regex: /^\s*(\S+?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s*$/,
         key_values: 6,
         multiple_values: false,

--- a/lib/resources/inetd_conf.rb
+++ b/lib/resources/inetd_conf.rb
@@ -2,6 +2,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require 'utils/simpleconfig'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class InetdConf < Inspec.resource(1)
@@ -16,8 +17,11 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     def initialize(path = nil)
       @conf_path = path || '/etc/inetd.conf'
+      @content = read_file_content(@conf_path)
     end
 
     # overwrite exec to ensure it works with its
@@ -32,19 +36,8 @@ module Inspec::Resources
 
     def read_params
       return @params if defined?(@params)
+      content = read_file_content(@conf_path)
 
-      # read the file
-      file = inspec.file(@conf_path)
-      if !file.file?
-        skip_resource "Can't find file \"#{@conf_path}\""
-        return @params = {}
-      end
-
-      content = file.content
-      if content.empty? && !file.empty?
-        skip_resource "Can't read file \"#{@conf_path}\""
-        return @params = {}
-      end
       # parse the file
       conf = SimpleConfig.new(
         content,

--- a/lib/resources/json.rb
+++ b/lib/resources/json.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'utils/object_traversal'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class JsonConfig < Inspec.resource(1)
@@ -26,6 +27,7 @@ module Inspec::Resources
     "
 
     include ObjectTraverser
+    include FileReader
 
     # make params readable
     attr_reader :params, :raw_content
@@ -90,15 +92,7 @@ module Inspec::Resources
     end
 
     def load_raw_from_file(path)
-      file = inspec.file(path)
-
-      # these are currently ResourceSkipped to maintain consistency with the resource
-      # pre-refactor (which used skip_resource). These should likely be changed to
-      # ResourceFailed during a major version bump.
-      raise Inspec::Exceptions::ResourceSkipped, "No such file: #{path}" unless file.file?
-      raise Inspec::Exceptions::ResourceSkipped, "File #{path} is empty or is not readable by current user" if file.content.nil? || file.content.empty?
-
-      file.content
+      read_file_content(path)
     end
 
     def load_raw_from_command(command)

--- a/lib/resources/key_rsa.rb
+++ b/lib/resources/key_rsa.rb
@@ -2,6 +2,7 @@
 
 require 'openssl'
 require 'hashie/mash'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class RsaKey < Inspec.resource(1)
@@ -20,19 +21,12 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     def initialize(keypath, passphrase = nil)
       @key_path = keypath
-      @key_file = inspec.file(@key_path)
-      @key = nil
       @passphrase = passphrase
-
-      return skip_resource "Unable to find key file #{@key_path}" unless @key_file.exist?
-
-      begin
-        @key = OpenSSL::PKey.read(@key_file.content, @passphrase)
-      rescue OpenSSL::PKey::RSAError => _
-        return skip_resource "Unable to load key file #{@key_path}"
-      end
+      @key = OpenSSL::PKey.read(read_file_content(@key_path, allow_empty: true), @passphrase)
     end
 
     def public?

--- a/lib/resources/limits_conf.rb
+++ b/lib/resources/limits_conf.rb
@@ -28,11 +28,10 @@ module Inspec::Resources
 
     def read_params
       return @params if defined?(@params)
-      content = read_file_content(@conf_path)
 
       # parse the file
       conf = SimpleConfig.new(
-        content,
+        @content,
         assignment_regex: /^\s*(\S+?)\s+(.*?)\s+(.*?)\s+(.*?)\s*$/,
         key_values: 3,
         multiple_values: true,

--- a/lib/resources/limits_conf.rb
+++ b/lib/resources/limits_conf.rb
@@ -2,6 +2,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require 'utils/simpleconfig'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class LimitsConf < Inspec.resource(1)
@@ -14,8 +15,11 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     def initialize(path = nil)
       @conf_path = path || '/etc/security/limits.conf'
+      @content = read_file_content(@conf_path)
     end
 
     def method_missing(name)
@@ -24,19 +28,7 @@ module Inspec::Resources
 
     def read_params
       return @params if defined?(@params)
-
-      # read the file
-      file = inspec.file(@conf_path)
-      if !file.file?
-        skip_resource "Can't find file \"#{@conf_path}\""
-        return @params = {}
-      end
-
-      content = file.content
-      if content.empty? && !file.empty?
-        skip_resource "Can't read file \"#{@conf_path}\""
-        return @params = {}
-      end
+      content = read_file_content(@conf_path)
 
       # parse the file
       conf = SimpleConfig.new(

--- a/lib/resources/login_def.rb
+++ b/lib/resources/login_def.rb
@@ -40,11 +40,10 @@ module Inspec::Resources
 
     def read_params
       return @params if defined?(@params)
-      content = read_file_content(@conf_path)
 
       # parse the file
       conf = SimpleConfig.new(
-        content,
+        @content,
         assignment_regex: /^\s*(\S+)\s+(\S*)\s*$/,
         multiple_values: false,
       )

--- a/lib/resources/login_def.rb
+++ b/lib/resources/login_def.rb
@@ -2,6 +2,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require 'utils/simpleconfig'
+require 'utils/file_reader'
 
 # Usage:
 #
@@ -26,8 +27,11 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     def initialize(path = nil)
       @conf_path = path || '/etc/login.defs'
+      @content = read_file_content(@conf_path)
     end
 
     def method_missing(name)
@@ -36,19 +40,7 @@ module Inspec::Resources
 
     def read_params
       return @params if defined?(@params)
-
-      # read the file
-      file = inspec.file(@conf_path)
-      if !file.file?
-        skip_resource "Can't find file \"#{@conf_path}\""
-        return @params = {}
-      end
-
-      content = file.content
-      if content.empty? && !file.empty?
-        skip_resource "Can't read file \"#{@conf_path}\""
-        return @params = {}
-      end
+      content = read_file_content(@conf_path)
 
       # parse the file
       conf = SimpleConfig.new(

--- a/lib/resources/mysql_conf.rb
+++ b/lib/resources/mysql_conf.rb
@@ -3,6 +3,7 @@
 
 require 'utils/simpleconfig'
 require 'utils/find_files'
+require 'utils/file_reader'
 require 'utils/hash'
 require 'resources/mysql'
 
@@ -47,6 +48,7 @@ module Inspec::Resources
     "
 
     include FindFiles
+    include FileReader
 
     def initialize(conf_path = nil)
       @conf_path = conf_path || inspec.mysql.conf_path
@@ -77,15 +79,6 @@ module Inspec::Resources
     def read_content
       @content = ''
       @params = {}
-
-      # skip if the main configuration file doesn't exist
-      if !inspec.file(@conf_path).file?
-        return skip_resource "Can't find file \"#{@conf_path}\""
-      end
-      raw_conf = read_file(@conf_path)
-      if raw_conf.empty? && !inspec.file(@conf_path).empty?
-        return skip_resource("Can't read file \"#{@conf_path}\"")
-      end
 
       to_read = [@conf_path]
       until to_read.empty?
@@ -124,7 +117,7 @@ module Inspec::Resources
     end
 
     def read_file(path)
-      @files_contents[path] ||= inspec.file(path).content
+      @files_contents[path] ||= read_file_content(path)
     end
 
     def to_s

--- a/lib/resources/nginx_conf.rb
+++ b/lib/resources/nginx_conf.rb
@@ -2,6 +2,7 @@
 
 require 'utils/nginx_parser'
 require 'utils/find_files'
+require 'utils/file_reader'
 require 'forwardable'
 
 # STABILITY: Experimental
@@ -26,6 +27,7 @@ module Inspec::Resources
     extend Forwardable
 
     include FindFiles
+    include FileReader
 
     attr_reader :contents
 
@@ -33,6 +35,7 @@ module Inspec::Resources
       @conf_path = conf_path || '/etc/nginx/nginx.conf'
       @contents = {}
       return skip_resource 'The `nginx_conf` resource is currently not supported on Windows.' if inspec.os.windows?
+      read_content(@conf_path)
     end
 
     def params
@@ -56,11 +59,7 @@ module Inspec::Resources
 
     def read_content(path)
       return @contents[path] if @contents.key?(path)
-      file = inspec.file(path)
-      if !file.file?
-        return skip_resource "Can't find file \"#{path}\""
-      end
-      @contents[path] = file.content
+      @contents[path] = read_file_content(path, allow_empty: true)
     end
 
     def parse_nginx(path)

--- a/lib/resources/ntp_conf.rb
+++ b/lib/resources/ntp_conf.rb
@@ -2,6 +2,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require 'utils/simpleconfig'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class NtpConf < Inspec.resource(1)
@@ -15,8 +16,11 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     def initialize(path = nil)
       @conf_path = path || '/etc/ntp.conf'
+      @content = read_file_content(@conf_path)
     end
 
     def method_missing(name)
@@ -34,17 +38,7 @@ module Inspec::Resources
 
     def read_params
       return @params if defined?(@params)
-
-      if !inspec.file(@conf_path).file?
-        skip_resource "Can't find file \"#{@conf_path}\""
-        return @params = {}
-      end
-
-      content = inspec.file(@conf_path).content
-      if content.empty? && !inspec.file(@conf_path).empty?
-        skip_resource "Can't read file \"#{@conf_path}\""
-        return @params = {}
-      end
+      content = read_file_content(@conf_path)
 
       # parse the file
       conf = SimpleConfig.new(

--- a/lib/resources/ntp_conf.rb
+++ b/lib/resources/ntp_conf.rb
@@ -38,11 +38,10 @@ module Inspec::Resources
 
     def read_params
       return @params if defined?(@params)
-      content = read_file_content(@conf_path)
 
       # parse the file
       conf = SimpleConfig.new(
-        content,
+        @content,
         assignment_regex: /^\s*(\S+)\s+(.*)\s*$/,
         multiple_values: true,
       )

--- a/lib/resources/parse_config.rb
+++ b/lib/resources/parse_config.rb
@@ -10,6 +10,8 @@
 #  }
 #  describe parse_config(audit, options ) do
 
+require 'utils/file_reader'
+
 module Inspec::Resources
   class PConfig < Inspec.resource(1)
     name 'parse_config'
@@ -41,6 +43,8 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     attr_reader :content
     def initialize(content = nil, useropts = nil)
       @opts = {}
@@ -69,21 +73,13 @@ module Inspec::Resources
 
     def parse_file(conf_path)
       @conf_path = conf_path
-
-      # read the file
-      if !inspec.file(conf_path).file?
-        return skip_resource "Can't find file \"#{conf_path}\""
-      end
       @content = read_file(conf_path).to_s
-      if @content.empty? && !inspec.file(conf_path).empty?
-        return skip_resource "Can't read file \"#{conf_path}\""
-      end
 
       read_params
     end
 
     def read_file(path)
-      @files_contents[path] ||= inspec.file(path).content
+      @files_contents[path] ||= read_file_content(path)
     end
 
     def read_params

--- a/lib/resources/passwd.rb
+++ b/lib/resources/passwd.rb
@@ -12,6 +12,7 @@
 
 require 'utils/parser'
 require 'utils/filter'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class Passwd < Inspec.resource(1)
@@ -34,6 +35,7 @@ module Inspec::Resources
     "
 
     include PasswdParser
+    include FileReader
 
     attr_reader :params
     attr_reader :content
@@ -42,7 +44,7 @@ module Inspec::Resources
     def initialize(path = nil, opts = nil)
       opts ||= {}
       @path = path || '/etc/passwd'
-      @content = opts[:content] || inspec.file(@path).content
+      @content = opts[:content] || read_file_content(@path, allow_empty: true)
       @lines = @content.to_s.split("\n")
       @params = parse_passwd(@content)
     end

--- a/lib/resources/postgres_conf.rb
+++ b/lib/resources/postgres_conf.rb
@@ -3,6 +3,7 @@
 
 require 'utils/simpleconfig'
 require 'utils/find_files'
+require 'utils/file_reader'
 require 'resources/postgres'
 
 module Inspec::Resources
@@ -18,6 +19,7 @@ module Inspec::Resources
     "
 
     include FindFiles
+    include FileReader
     include ObjectTraverser
 
     def initialize(conf_path = nil)
@@ -68,15 +70,6 @@ module Inspec::Resources
       @content = ''
       @params = {}
 
-      # skip if the main configuration file doesn't exist
-      if !inspec.file(@conf_path).file?
-        return skip_resource "Can't find file \"#{@conf_path}\""
-      end
-      raw_conf = read_file(@conf_path)
-      if raw_conf.empty? && !inspec.file(@conf_path).empty?
-        return skip_resource("Can't read file \"#{@conf_path}\"")
-      end
-
       to_read = [@conf_path]
       until to_read.empty?
         base_dir = File.dirname(to_read[0])
@@ -115,7 +108,7 @@ module Inspec::Resources
     end
 
     def read_file(path)
-      @files_contents[path] ||= inspec.file(path).content
+      @files_contents[path] ||= read_file_content(path)
     end
   end
 end

--- a/lib/resources/postgres_hba_conf.rb
+++ b/lib/resources/postgres_hba_conf.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'resources/postgres'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class PostgresHbaConf < Inspec.resource(1)
@@ -13,6 +14,8 @@ module Inspec::Resources
         its('auth_method') { should eq ['peer'] }
       end
     "
+
+    include FileReader
 
     attr_reader :conf_file, :params
 
@@ -43,7 +46,7 @@ module Inspec::Resources
     private
 
     def clean_conf_file(conf_file = @conf_file)
-      data = inspec.file(conf_file).content.to_s.lines
+      data = read_file_content(conf_file).to_s.lines
       content = []
       data.each do |line|
         line.chomp!
@@ -53,22 +56,10 @@ module Inspec::Resources
     end
 
     def read_content(config_file = @conf_file)
-      file = inspec.file(config_file)
-
-      if !file.file?
-        return skip_resource "Can't find file \"#{@conf_file}\""
-      end
-
-      raw_conf = file.content
-
-      if raw_conf.empty? && !file.empty?
-        return skip_resource("Can't read the contents of \"#{@conf_file}\"")
-      end
-
       # @todo use SimpleConfig here if we can
       # ^\s*(\S+)\s+(\S+)\s+(\S+)\s(?:(\d*.\d*.\d*.\d*\/\d*)|(::\/\d+))\s+(\S+)\s*(.*)?\s*$
 
-      @content = clean_conf_file(@conf_file)
+      @content = clean_conf_file(config_file)
       @params = parse_conf(@content)
       @params.each do |line|
         if line['type'] == 'local'

--- a/lib/resources/postgres_ident_conf.rb
+++ b/lib/resources/postgres_ident_conf.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require 'utils/file_reader'
 require 'resources/postgres'
 
 module Inspec::Resources
@@ -13,6 +14,8 @@ module Inspec::Resources
         its('map_name') { should eq ['ssl-test'] }
       end
     "
+
+    include FileReader
 
     attr_reader :params, :conf_file
 
@@ -70,7 +73,7 @@ module Inspec::Resources
     end
 
     def read_file(conf_file = @conf_file)
-      inspec.file(conf_file).content.lines
+      read_file_content(conf_file, allow_empty: true).lines
     end
   end
 end

--- a/lib/resources/rabbitmq_conf.rb
+++ b/lib/resources/rabbitmq_conf.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'utils/erlang_parser'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class RabbitmqConf < Inspec.resource(1)
@@ -15,8 +16,11 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     def initialize(conf_path = nil)
       @conf_path = conf_path || '/etc/rabbitmq/rabbitmq.config'
+      @content = read_file_content(@conf_path, allow_empty: true)
     end
 
     def params(*opts)
@@ -33,12 +37,7 @@ module Inspec::Resources
 
     def read_content
       return @content if defined?(@content)
-      file = inspec.file(@conf_path)
-      if !file.file?
-        return skip_resource "Can't find file \"#{@conf_path}\""
-      end
-
-      @content = file.content
+      @content = read_file_content(@conf_path, allow_empty: true)
     end
 
     def read_params

--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -40,9 +40,9 @@ module Inspec::Resources
     def initialize(path = '/etc/shadow', opts = nil)
       opts ||= {}
       @path = path || '/etc/shadow'
+      @filters = opts[:filters] || ''
       @raw_content = opts[:content] || read_file_content(@path, allow_empty: true)
       @lines = @raw_content.to_s.split("\n")
-      @filters = opts[:filters] || ''
       @params = @lines.map { |l| parse_shadow_line(l) }
     end
 

--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -2,6 +2,7 @@
 # copyright: 2016, Chef Software Inc.
 
 require 'utils/filter'
+require 'utils/file_reader'
 
 # The file format consists of
 # - user
@@ -31,13 +32,15 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     attr_reader :params
     attr_reader :lines
 
     def initialize(path = '/etc/shadow', opts = nil)
       opts ||= {}
       @path = path || '/etc/shadow'
-      @raw_content = opts[:content] || inspec.file(@path).content
+      @raw_content = opts[:content] || read_file_content(@path, allow_empty: true)
       @lines = @raw_content.to_s.split("\n")
       @filters = opts[:filters] || ''
       @params = @lines.map { |l| parse_shadow_line(l) }

--- a/lib/resources/ssh_conf.rb
+++ b/lib/resources/ssh_conf.rb
@@ -61,14 +61,6 @@ module Inspec::Resources
     def read_content
       return @content if defined?(@content)
 
-      # XXX: Leave the following verification into code since in
-      # inspec_vendor_test.rb the vendored profile can not find the file
-      # sshd_config at Travis CI despite the existence of it.
-      file = inspec.file(@conf_path)
-      if !file.file?
-        return skip_resource "Can't find file: #{@conf_path}"
-      end
-
       @content = read_file_content(@conf_path)
     end
 

--- a/lib/resources/ssh_conf.rb
+++ b/lib/resources/ssh_conf.rb
@@ -2,6 +2,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require 'utils/simpleconfig'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class SshConf < Inspec.resource(1)
@@ -16,10 +17,13 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     def initialize(conf_path = nil, type = nil)
       @conf_path = conf_path || '/etc/ssh/ssh_config'
       typename = (@conf_path.include?('sshd') ? 'Server' : 'Client')
       @type = type || "SSH #{typename} configuration #{conf_path}"
+      read_content
     end
 
     def content
@@ -56,17 +60,16 @@ module Inspec::Resources
 
     def read_content
       return @content if defined?(@content)
+
+      # XXX: Leave the following verification into code since in
+      # inspec_vendor_test.rb the vendored profile can not find the file
+      # sshd_config at Travis CI despite the existence of it.
       file = inspec.file(@conf_path)
       if !file.file?
-        return skip_resource "Can't find file \"#{@conf_path}\""
+        return skip_resource "Can't find file: #{@conf_path}"
       end
 
-      @content = file.content
-      if @content.nil? || (@content.empty? && !file.size.zero?)
-        return skip_resource "Can't read file \"#{@conf_path}\""
-      end
-
-      @content
+      @content = read_file_content(@conf_path)
     end
 
     def read_params

--- a/lib/resources/x509_certificate.rb
+++ b/lib/resources/x509_certificate.rb
@@ -2,6 +2,7 @@
 
 require 'openssl'
 require 'hashie/mash'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class X509CertificateResource < Inspec.resource(1)
@@ -32,6 +33,8 @@ module Inspec::Resources
       end
     "
 
+    include FileReader
+
     # @see https://tools.ietf.org/html/rfc5280#page-23
     def initialize(filename)
       @certpath = filename
@@ -39,16 +42,7 @@ module Inspec::Resources
       @parsed_subject = nil
       @parsed_issuer = nil
       @extensions = nil
-
-      file = inspec.file(@certpath)
-      return skip_resource "Unable to find certificate file #{@certpath}" unless file.exist?
-
-      begin
-        @cert = OpenSSL::X509::Certificate.new file.content
-      rescue OpenSSL::X509::CertificateError
-        @cert = nil
-        return skip_resource "Unable to load certificate #{@certpath}"
-      end
+      @cert = OpenSSL::X509::Certificate.new read_file_content(@certpath, allow_empty: true)
     end
 
     # Forward these methods directly to OpenSSL::X509::Certificate instance

--- a/lib/resources/x509_certificate.rb
+++ b/lib/resources/x509_certificate.rb
@@ -42,7 +42,7 @@ module Inspec::Resources
       @parsed_subject = nil
       @parsed_issuer = nil
       @extensions = nil
-      @cert = OpenSSL::X509::Certificate.new read_file_content(@certpath, allow_empty: true)
+      @cert = OpenSSL::X509::Certificate.new read_file_content(@certpath)
     end
 
     # Forward these methods directly to OpenSSL::X509::Certificate instance

--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -2,6 +2,7 @@
 
 require 'utils/parser'
 require 'utils/filter'
+require 'utils/file_reader'
 
 module Inspec::Resources
   class XinetdConf < Inspec.resource(1)
@@ -19,10 +20,12 @@ module Inspec::Resources
     "
 
     include XinetdParser
+    include FileReader
 
     def initialize(conf_path = '/etc/xinetd.conf')
       @conf_path = conf_path
       @contents = {}
+      read_content(@conf_path)
     end
 
     def to_s
@@ -50,16 +53,8 @@ module Inspec::Resources
 
     def read_content(path = @conf_path)
       return @contents[path] if @contents.key?(path)
-      file = inspec.file(path)
-      if !file.file?
-        raise Inspec::Exceptions::ResourceSkipped, "Can't find file: #{path}"
-      end
 
-      if file.content.nil? || file.content.empty?
-        raise Inspec::Exceptions::ResourceSkipped, "Can't read file: #{path}"
-      end
-
-      @contents[path] = file.content
+      @contents[path] = read_file_content(path)
     end
 
     def read_params

--- a/lib/utils/file_reader.rb
+++ b/lib/utils/file_reader.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+# author: ERAMOTO Masaya
+
+module FileReader
+  def read_file_content(path, allow_empty = false)
+    # these are currently ResourceSkipped to maintain consistency with the resource
+    # pre-refactor (which used skip_resource). These should likely be changed to
+    # ResourceFailed during a major version bump.
+    file = inspec.file(path)
+    if !file.file?
+      raise Inspec::Exceptions::ResourceSkipped, "Can't find file: #{path}"
+    end
+
+    raw_content = file.content
+    if raw_content.nil?
+      raise Inspec::Exceptions::ResourceSkipped, "Can't read file: #{path}"
+    end
+
+    if !allow_empty && raw_content.empty?
+      raise Inspec::Exceptions::ResourceSkipped, "File is empty: #{path}"
+    end
+
+    raw_content
+  end
+end

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -60,6 +60,7 @@ describe 'example inheritance profile' do
       out.exit_status.must_equal 0
 
       out = inspec('json ' + dir + ' --output ' + dst.path)
+      out.stderr.must_equal ''
       out.exit_status.must_equal 0
 
       hm = JSON.load(File.read(dst.path))
@@ -84,7 +85,11 @@ describe 'example inheritance profile' do
     prepare_examples('meta-profile') do |dir|
       # ensure the profile is vendored and packaged as tar
       out = inspec('vendor ' + dir + ' --overwrite')
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+
       out = inspec('archive ' + dir + ' --overwrite')
+      out.stderr.must_equal ''
       out.exit_status.must_equal 0
 
       # execute json command

--- a/test/unit/resources/json_test.rb
+++ b/test/unit/resources/json_test.rb
@@ -38,7 +38,7 @@ describe 'Inspec::Resources::JSON' do
     let(:resource) { load_resource('json', 'nonexistent.json') }
 
     it 'produces an error' do
-      _(resource.resource_exception_message).must_equal 'No such file: nonexistent.json'
+      _(resource.resource_exception_message).must_equal "Can't find file: nonexistent.json"
     end
 
     it 'still provides an empty hash for params' do

--- a/test/unit/resources/ssh_conf_test.rb
+++ b/test/unit/resources/ssh_conf_test.rb
@@ -38,15 +38,12 @@ describe 'Inspec::Resources::SshConf' do
 
     it 'check bad path' do
       resource = load_resource('sshd_config', '/etc/ssh/sshd_config_does_not_exist')
-      _(resource.send(:read_content)).must_equal "Can't find file \"/etc/ssh/sshd_config_does_not_exist\""
-      _(resource.Protocol).must_be_nil
+      _(resource.resource_exception_message).must_equal "Can't find file: /etc/ssh/sshd_config_does_not_exist"
     end
 
     it 'check cannot read' do
-      Inspec::Resources::FileResource.any_instance.stubs(:size).at_least_once.returns(5)
       resource = load_resource('sshd_config', '/etc/ssh/sshd_config_empty')
-      _(resource.send(:read_content)).must_equal "Can't read file \"/etc/ssh/sshd_config_empty\""
-      _(resource.Protocol).must_be_nil
+      _(resource.resource_exception_message).must_equal "File is empty: /etc/ssh/sshd_config_empty"
     end
   end
 end


### PR DESCRIPTION
There are the similar issues as PR #2302. Almost resources return false positives when a file does not exist or is not read.
