### PR TITLE
Update rspec cli control summary to not uniq fails/skips

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -776,8 +776,8 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
           examples[0][:message].to_s
         else
           [
-            !fails.empty? ? "#{fails.uniq.length} failed" : nil,
-            !skips.empty? ? "#{skips.uniq.length} skipped" : nil,
+            !fails.empty? ? "#{fails.length} failed" : nil,
+            !skips.empty? ? "#{skips.length} skipped" : nil,
           ].compact.join(' ')
         end
 

--- a/test/unit/rspec_json_formatter_test.rb
+++ b/test/unit/rspec_json_formatter_test.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+# copyright: 2017, Chef Software Inc.
+
+require 'helper'
+require 'inspec/objects'
+
+describe 'rspec_json_formatter' do
+  describe 'InspecRspecCli::Control' do
+    # have to require here else it messes with minitest
+    require 'inspec/rspec_json_formatter'
+
+    let(:control) do
+      control = { results: [], title: 'test' }
+      InspecRspecCli::Control.new(control, nil) 
+    end
+
+    it 'summary must count unique fails/skips' do
+      control.expects(:summary_calculation_needed?).returns(false)
+      control.stubs(:fails).returns([1, 1])
+      control.stubs(:skips).returns([1, 1])
+      control.summary.must_equal 'test (2 failed 2 skipped)'
+    end
+
+    it 'summary must count different fails/skips' do
+      control.expects(:summary_calculation_needed?).returns(false)
+      control.stubs(:fails).returns([1, 2])
+      control.stubs(:skips).returns([1, 2])
+      control.summary.must_equal 'test (2 failed 2 skipped)'
+    end
+  end
+end


### PR DESCRIPTION
This fixes #2361

This change removes the uniq limiter on fails and skips. This ensures the control summary output is accurate even if tests are the same.

Signed-off-by: Jared Quick <jquick@chef.io>