### PR TITLE
Fix incorrect case in paragraph.

### DIFF
--- a/docs/ruby_usage.md
+++ b/docs/ruby_usage.md
@@ -73,7 +73,7 @@ independent of programming languages and their resolver mechanisms.
 ## Interactive Debugging with Pry
 
 Here's a sample InSpec control that users Ruby variables to instantiate
-an InSpec resource once and use the content in multipLe tests.
+an InSpec resource once and use the content in multiple tests.
 
 ```ruby
 control 'check-perl' do


### PR DESCRIPTION
Incorrect case used in paragraph to describe interactive debugging with Pry.

Obvious fix.