### PR TITLE
security_policy resource: use PID for filename instead of random

### DIFF
--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -14,7 +14,6 @@
 # parameters. Therefore we need a combination of Registry and secedit output
 
 require 'hashie'
-require 'securerandom'
 
 module Inspec::Resources
   # known and supported MS privilege rights
@@ -109,8 +108,8 @@ module Inspec::Resources
     def read_content
       return @content if defined?(@content)
 
-      # using random hex to prevent any race conditions with multiple runners
-      export_file = "win_secpol-#{SecureRandom.hex}.cfg"
+      # using process pid to prevent any race conditions with multiple runners
+      export_file = "win_secpol-#{Process.pid}.cfg"
 
       # export the security policy
       cmd = inspec.command("secedit /export /cfg #{export_file}")

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -73,7 +73,7 @@ class MockLoader
   # pass the os identifier to emulate a specific operating system
   def initialize(os = nil)
     # selects operating system
-    @os = OPERATING_SYSTEMS[os || :ubuntu1404]
+    @platform = OPERATING_SYSTEMS[os || :ubuntu1404]
   end
 
   def backend
@@ -84,11 +84,12 @@ class MockLoader
     @backend = Inspec::Backend.create({ backend: :mock, verbose: true })
     mock = @backend.backend
 
-    # set os emulation
-    mock.mock_os(@os)
-
     # create all mock files
     local = Train.create('local').connection
+
+    # set os emulation
+    mock.mock_os(@platform)
+
     mockfile = lambda { |x|
       path = ::File.join(scriptpath, '/unit/mock/files', x)
       local.file(path)

--- a/test/unit/resources/security_policy_test.rb
+++ b/test/unit/resources/security_policy_test.rb
@@ -8,7 +8,7 @@ require 'inspec/resource'
 describe 'Inspec::Resources::SecurityPolicy' do
   it 'verify processes resource' do
     resource = load_resource('security_policy')
-    SecureRandom.expects(:hex).returns('abc123')
+    Process.expects(:pid).returns('abc123')
 
     _(resource.MaximumPasswordAge).must_equal 42
     _(resource.send('MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Setup\RecoveryConsole\SecurityLevel')).must_equal '4,0'
@@ -18,7 +18,7 @@ describe 'Inspec::Resources::SecurityPolicy' do
 
   it 'parse empty policy file' do
     resource = load_resource('security_policy')
-    SecureRandom.expects(:hex).returns('abc123')
+    Process.expects(:pid).returns('abc123')
     backend = resource.inspec.backend
     backend.commands['Get-Content win_secpol-abc123.cfg'] = backend.mock_command('', '', '', 0)
 


### PR DESCRIPTION
There is an issue with the security policy when used with the new Train caching. Since it creates a unique export name every call it will not be cached. This change was originally created to protect from parallel runners. Moving it to Process.pid will allow it to be cached as well as protect from parallel runners. 

Signed-off-by: Jared Quick <jquick@chef.io>