### PR TITLE
Lazy filtertable schema opt

### DIFF
--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -125,10 +125,11 @@ module FilterTable
       end
     end
 
-    def resolve_column(func, args, field)
+    def resolve_column(func, field)
       @params.each_with_index do |line, i|
-        mapped_args = args.map { |x| line[x] }
-        @params[i][field] = func.call(*mapped_args)
+        mapped_args = func.parameters.map { |x| x[1] }
+        mapped_vals = line.values_at(*mapped_args)
+        @params[i][field] = func.call(*mapped_vals)
       end
     end
 
@@ -264,7 +265,7 @@ module FilterTable
 
       lambda { |condition = Show, &cond_block|
         r = where(nil)
-        r.resolve_column(c.opts[:lazy], c.opts[:args] || [], c.field_name) if c.opts.key?(:lazy)
+        r.resolve_column(c.opts[:lazy], c.field_name) if c.opts.key?(:lazy)
         if condition == Show && !block_given?
           r = r.get_field(c.field_name)
           r = r.flatten.uniq.compact if c.opts[:style] == :simple

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -125,11 +125,9 @@ module FilterTable
       end
     end
 
-    def resolve_column(func, field)
+    def resolve_column(func, field, cond)
       @params.each_with_index do |line, i|
-        mapped_args = func.parameters.map { |x| x[1] }
-        mapped_vals = line.values_at(*mapped_args)
-        @params[i][field] = func.call(*mapped_vals)
+        @params[i][field] = func.call(line, cond)
       end
     end
 
@@ -265,7 +263,7 @@ module FilterTable
 
       lambda { |condition = Show, &cond_block|
         r = where(nil)
-        r.resolve_column(c.opts[:lazy], c.field_name) if c.opts.key?(:lazy)
+        r.resolve_column(c.opts[:lazy], c.field_name, condition) if c.opts.key?(:lazy)
         if condition == Show && !block_given?
           r = r.get_field(c.field_name)
           r = r.flatten.uniq.compact if c.opts[:style] == :simple

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -98,7 +98,7 @@ module FilterTable
       table = @params
       conditions.each do |field, condition|
         filters += " #{field} == #{condition.inspect}"
-        @resource.send(field) if @resource.respond_to?(field)
+        @resource.send(field) if !table[0].key?(field) && @resource.respond_to?(field)
         table = filter_lines(table, field, condition)
       end
 

--- a/test/unit/utils/filter_table_test.rb
+++ b/test/unit/utils/filter_table_test.rb
@@ -190,7 +190,9 @@ describe FilterTable do
       factory
         .add_accessor(:where)
         .add(:deferred, {
-          :lazy => Proc.new { |foo, bar| foo.to_s + " + " + bar.to_s }
+          :lazy => Proc.new { |table_row, condition|
+            table_row[:foo].to_s + " + " + table_row[:bar].to_s
+          }
           }).connect(resource, :data)
     }
 

--- a/test/unit/utils/filter_table_test.rb
+++ b/test/unit/utils/filter_table_test.rb
@@ -184,4 +184,43 @@ describe FilterTable do
       instance.baz(/zzz/).params.must_equal []
     end
   end
+
+  describe 'with lazy loading field' do
+    before {
+      factory
+        .add_accessor(:where)
+        .add(:deferred, {
+          :lazy => Proc.new { |foo, bar| foo.to_s + " + " + bar.to_s },
+          :args => [:foo, :bar]
+          }).connect(resource, :data)
+    }
+
+    it 'can expose a data column' do
+      instance.deferred(123).must_be_kind_of(FilterTable::Table)
+    end
+
+    it 'retrieves all entries' do
+      instance.deferred.must_equal(["3 + true", "2 + false", "2 + false"])
+    end
+
+    it 'filter by existing strings' do
+      instance.deferred('3 + true').params.must_equal [data[0]]
+    end
+
+    it 'filter by existing strings using where' do
+      instance.where( { deferred: '3 + true'} ).params.must_equal [data[0]]
+    end
+
+    it 'filter by missing string' do
+      instance.deferred('num').params.must_equal []
+    end
+
+    it 'filter by existing regex' do
+      instance.deferred(/A/i).params.must_equal [data[1], data[2]]
+    end
+
+    it 'filter by missing regex' do
+      instance.deferred(/zzz/).params.must_equal []
+    end
+  end
 end

--- a/test/unit/utils/filter_table_test.rb
+++ b/test/unit/utils/filter_table_test.rb
@@ -190,8 +190,7 @@ describe FilterTable do
       factory
         .add_accessor(:where)
         .add(:deferred, {
-          :lazy => Proc.new { |foo, bar| foo.to_s + " + " + bar.to_s },
-          :args => [:foo, :bar]
+          :lazy => Proc.new { |foo, bar| foo.to_s + " + " + bar.to_s }
           }).connect(resource, :data)
     }
 


### PR DESCRIPTION
As per https://github.com/chef/inspec/issues/2370

This enables deferred function execution in the `FilterTable`, like so:

```
  # assuming we always pass some things to the procs
  def self.lookup_access_keys(table_row, condition)
      # condition is presumably the username
      # table_row is a hash with the other info about a user
  end

   # You could also define a proc out here in a variable
   login_count = Proc.new(table_row, condition) do
      # Same args as above
      # go fetch login count for this user from CloudTrail
   end

  filter = FilterTable.create
    filter.add_accessor(:where)
            .add(:username,     field: 'username')
            .add(:access_keys, lazy: self.method(:lookup_access_keys) ) # No need to specify or pass args here
            .add(:login_count, lazy: login_count)
```

There is also a test script created to play around with this implementation here https://gist.github.com/aduric/7f6ba3f3998b2c14d000cbc0e4e627ad