### PR TITLE
Remove rainbow dependency, fix duplicate rake gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'ffi', '>= 1.9.14'
 group :test do
   gem 'bundler', '~> 1.5'
   gem 'minitest', '~> 5.5'
-  gem 'rake', '~> 10'
+  gem 'rake', '>= 10'
   gem 'rubocop', '= 0.49.1'
   gem 'simplecov', '~> 0.10'
   gem 'concurrent-ruby', '~> 0.9'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'train', '~> 0.31', '>= 0.31.1'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
-  spec.add_dependency 'rainbow', '~> 2'
   spec.add_dependency 'method_source', '~> 0.8'
   spec.add_dependency 'rubyzip', '~> 1.1'
   spec.add_dependency 'rspec', '~> 3'


### PR DESCRIPTION
The version of Rainbow brought in as a direct dependency also depends directly on Rake, and our pin of Rake was inaccurate. This was causing Omnibus to build packages that contained two rake gems which would emit "Unresolved specs during Gem::Specification.reset" warnings when running InSpec.

Rainbow does not appear to be used anywhere in InSpec, so I'm removing it.

Fixes #2105