### PR TITLE
Fix inspec appveyor test with the new local train transport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'train', git: 'https://github.com/chef/train'
+
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
   gem 'json', '~> 1.8'
   gem 'rack', '< 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'train', git: 'https://github.com/chef/train'
-
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
   gem 'json', '~> 1.8'
   gem 'rack', '< 2.0'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'train', '~> 0.30'
+  # spec.add_dependency 'train', '~> 0.30'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'rainbow', '~> 2'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  # spec.add_dependency 'train', '~> 0.30'
+  spec.add_dependency 'train', '~> 0.31', '>= 0.31.1'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'rainbow', '~> 2'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -35,7 +35,7 @@ require_relative '../lib/bundles/inspec-compliance'
 require_relative '../lib/bundles/inspec-habitat'
 
 require 'train'
-CMD = Train.create('local').connection
+CMD = Train.create('local', command_runner: :generic).connection
 TMP_CACHE = {}
 
 Inspec::Log.logger = Logger.new(nil)
@@ -85,7 +85,7 @@ class MockLoader
     mock = @backend.backend
 
     # create all mock files
-    local = Train.create('local').connection
+    local = Train.create('local', command_runner: :generic).connection
 
     # set os emulation
     mock.mock_os(@platform)

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -5,7 +5,7 @@ require 'helper'
 
 describe Inspec::Runner do
   describe '#load_attributes' do
-    let(:runner) { Inspec::Runner.new }
+    let(:runner) { Inspec::Runner.new({ command_runner: :generic }) }
 
     before do
       Inspec::Runner.any_instance.stubs(:validate_attributes_file_readability!)
@@ -13,7 +13,7 @@ describe Inspec::Runner do
 
     describe 'when backend caching is enabled' do
       it 'returns a backend with caching' do
-        opts = { backend_cache: true }
+        opts = { command_runner: :generic, backend_cache: true }
         runner = Inspec::Runner.new(opts)
         backend = runner.instance_variable_get(:@backend)
         backend.backend.cache_enabled?(:command).must_equal true
@@ -22,7 +22,7 @@ describe Inspec::Runner do
 
     describe 'when backend caching is disabled' do
       it 'returns a backend without caching' do
-        opts = { backend_cache: false }
+        opts = { command_runner: :generic, backend_cache: false }
         runner = Inspec::Runner.new(opts)
         backend = runner.instance_variable_get(:@backend)
         backend.backend.cache_enabled?(:command).must_equal false


### PR DESCRIPTION
The new Train local transport tries to use the new pipe runner here:
https://github.com/chef/inspec/blob/master/test/helper.rb#L84

This change forces it to use the generic runner which ensures we don't create pipes for every test. This PR requires https://github.com/chef/train/pull/225
Signed-off-by: Jared Quick <jquick@chef.io>