### PR TITLE
Resolve merge issue with json-config vs thor defaults

### DIFF
--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -40,7 +40,7 @@ module Inspec
     #
     # @param [Hash] config for the transport backend
     # @return [TransportBackend] enriched transport instance
-    def self.create(config)
+    def self.create(config) # rubocop:disable Metrics/AbcSize
       conf = Train.target_config(config)
       name = Train.validate_backend(conf)
       transport = Train.create(name, conf)
@@ -56,12 +56,15 @@ module Inspec
       # Set caching settings. We always want to enable caching for
       # the Mock transport for testing.
       if config[:backend_cache] || config[:backend] == :mock
+        Inspec::Log.debug 'Option backend_cache is enabled'
         connection.enable_cache(:file)
         connection.enable_cache(:command)
       elsif config[:debug_shell]
+        Inspec::Log.debug 'Option backend_cache is disabled'
         connection.disable_cache(:file)
         connection.disable_cache(:command)
       else
+        Inspec::Log.debug 'Option backend_cache is disabled'
         connection.disable_cache(:command)
       end
 

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -120,7 +120,7 @@ module Inspec
 
     def merged_opts
       # argv overrides json
-      Thor::CoreExt::HashWithIndifferentAccess.new(options_json.merge(options))
+      Thor::CoreExt::HashWithIndifferentAccess.new(options.merge(options_json))
     end
 
     def options_json

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -59,16 +59,24 @@ module Inspec
         desc: 'A list of controls to run. Ignore all other tests.'
       option :format, type: :string,
         desc: 'Which formatter to use: cli, progress, documentation, json, json-min, junit'
-      option :color, type: :boolean, default: true,
+      option :color, type: :boolean,
         desc: 'Use colors in output.'
       option :attrs, type: :array,
         desc: 'Load attributes file (experimental)'
       option :cache, type: :string,
         desc: 'Use the given path for caching dependencies. (default: ~/.inspec/cache)'
-      option :create_lockfile, type: :boolean, default: true,
+      option :create_lockfile, type: :boolean,
         desc: 'Write out a lockfile based on this execution (unless one already exists)'
-      option :backend_cache, type: :boolean, default: false,
+      option :backend_cache, type: :boolean,
         desc: 'Allow caching for backend command output.'
+    end
+
+    def self.default_options
+      {
+        color: true,
+        create_lockfile: true,
+        backend_cache: false,
+      }
     end
 
     private
@@ -119,8 +127,15 @@ module Inspec
     end
 
     def merged_opts
-      # argv overrides json
-      Thor::CoreExt::HashWithIndifferentAccess.new(options.merge(options_json))
+      # start with default options
+      opts = BaseCLI.default_options
+
+      # merge in any options from json-config
+      opts.merge!(options_json)
+
+      # merge in any options defined via thor
+      opts.merge!(options)
+      Thor::CoreExt::HashWithIndifferentAccess.new(opts)
     end
 
     def options_json

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -8,19 +8,35 @@ describe 'BaseCLI' do
   let(:cli) { Inspec::BaseCLI.new }
 
   describe 'merge_options' do
-    it 'json options override cli' do
-      json = { "backend_cache":true }
-      cli_options = { 'json_config' => 'dummy', 'backend_cache' => false }
-      cli.instance_variable_set(:@options, cli_options)
-      cli.expects(:read_config).returns(json)
+    it 'cli defaults populate correctly' do
+      default_options = { format: 'json', backend_cache: false }
+      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
 
       opts = cli.send(:merged_opts)
-      expected = { 'json_config' => 'dummy', 'backend_cache' => true}
+      expected = { 'format' => 'json', 'backend_cache' => false }
       opts.must_equal expected
     end
 
-    it 'cli options merge without json options' do
-      cli_options = { 'format' => 'json', 'backend_cache' => true }
+    it 'json-config options override cli defaults' do
+      default_options = { format: 'json', backend_cache: false }
+      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
+
+      parsed_json = { 'backend_cache' => true }
+      cli.expects(:options_json).returns(parsed_json)
+
+      opts = cli.send(:merged_opts)
+      expected = { 'format' => 'json', 'backend_cache' => true }
+      opts.must_equal expected
+    end
+
+    it 'cli options override json-config and default' do
+      default_options = { format: 'json', backend_cache: false }
+      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
+
+      parsed_json = { 'backend_cache' => false }
+      cli.expects(:options_json).returns(parsed_json)
+
+      cli_options = { 'backend_cache' => true }
       cli.instance_variable_set(:@options, cli_options)
 
       opts = cli.send(:merged_opts)

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+# copyright: 2017, Chef Software Inc.
+
+require 'helper'
+require 'thor'
+
+describe 'BaseCLI' do
+  let(:cli) { Inspec::BaseCLI.new }
+
+  describe 'merge_options' do
+    it 'json options override cli' do
+      json = { "backend_cache":true }
+      cli_options = { 'json_config' => 'dummy', 'backend_cache' => false }
+      cli.instance_variable_set(:@options, cli_options)
+      cli.expects(:read_config).returns(json)
+
+      opts = cli.send(:merged_opts)
+      expected = { 'json_config' => 'dummy', 'backend_cache' => true}
+      opts.must_equal expected
+    end
+
+    it 'cli options merge without json options' do
+      cli_options = { 'format' => 'json', 'backend_cache' => true }
+      cli.instance_variable_set(:@options, cli_options)
+
+      opts = cli.send(:merged_opts)
+      expected = { 'format' => 'json', 'backend_cache' => true }
+      opts.must_equal expected
+    end
+  end
+end


### PR DESCRIPTION
When testing the backend_cache via json-config we noticed that the Thor defaults were overriding the json-config settings. This was due to a hash merge using the wrong hash as the source. Rearranging the hash merge and using the json-config options as the override hash fixes this issue.

Along with this change it was requested for debug lines to ensure backend_cache was enabled or not. 

Signed-off-by: Jared Quick <jquick@chef.io>