### PR TITLE
Update default cli options to be uniq per command type

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -73,9 +73,11 @@ module Inspec
 
     def self.default_options
       {
-        color: true,
-        create_lockfile: true,
-        backend_cache: false,
+        exec: {
+          'color' => true,
+          'create_lockfile' => true,
+          'backend_cache' => false,
+        },
       }
     end
 
@@ -109,8 +111,8 @@ module Inspec
       puts
     end
 
-    def opts
-      o = merged_opts
+    def opts(type = nil)
+      o = merged_opts(type)
 
       # Due to limitations in Thor it is not possible to set an argument to be
       # both optional and its value to be mandatory. E.g. the user supplying
@@ -126,9 +128,11 @@ module Inspec
       o
     end
 
-    def merged_opts
-      # start with default options
-      opts = BaseCLI.default_options
+    def merged_opts(type = nil)
+      opts = {}
+
+      # start with default options if we have any
+      opts = BaseCLI.default_options[type] unless type.nil?
 
       # merge in any options from json-config
       opts.merge!(options_json)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -152,8 +152,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
   exec_options
   def exec(*targets)
     diagnose
-    configure_logger(opts)
-    o = opts.dup
+    o = opts(:exec).dup
+    configure_logger(o)
 
     # run tests
     run_tests(targets, o)

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -9,28 +9,28 @@ describe 'BaseCLI' do
 
   describe 'merge_options' do
     it 'cli defaults populate correctly' do
-      default_options = { format: 'json', backend_cache: false }
+      default_options = { exec: { format: 'json', backend_cache: false }}
       Inspec::BaseCLI.stubs(:default_options).returns(default_options)
 
-      opts = cli.send(:merged_opts)
+      opts = cli.send(:merged_opts, :exec)
       expected = { 'format' => 'json', 'backend_cache' => false }
       opts.must_equal expected
     end
 
     it 'json-config options override cli defaults' do
-      default_options = { format: 'json', backend_cache: false }
+      default_options = { exec: { format: 'json', backend_cache: false }}
       Inspec::BaseCLI.stubs(:default_options).returns(default_options)
 
       parsed_json = { 'backend_cache' => true }
       cli.expects(:options_json).returns(parsed_json)
 
-      opts = cli.send(:merged_opts)
+      opts = cli.send(:merged_opts, :exec)
       expected = { 'format' => 'json', 'backend_cache' => true }
       opts.must_equal expected
     end
 
     it 'cli options override json-config and default' do
-      default_options = { format: 'json', backend_cache: false }
+      default_options = { exec: { format: 'json', backend_cache: false }}
       Inspec::BaseCLI.stubs(:default_options).returns(default_options)
 
       parsed_json = { 'backend_cache' => false }
@@ -39,8 +39,17 @@ describe 'BaseCLI' do
       cli_options = { 'backend_cache' => true }
       cli.instance_variable_set(:@options, cli_options)
 
-      opts = cli.send(:merged_opts)
+      opts = cli.send(:merged_opts, :exec)
       expected = { 'format' => 'json', 'backend_cache' => true }
+      opts.must_equal expected
+    end
+
+    it 'make sure shell does not get exec defaults' do
+      default_options = { exec: { format: 'json', backend_cache: false }}
+      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
+
+      opts = cli.send(:merged_opts)
+      expected = {}
       opts.must_equal expected
     end
   end


### PR DESCRIPTION
https://github.com/chef/inspec/pull/2377 was released to solve the default command issue with json-config. While this fix works it makes the default cli commands global. This means any command you run will have these defaults. This could cause unintended issues as shell and other inspec commands will be getting exec defaults.

This change breaks out the defaults by command type so we only load the correct defaults.
Signed-off-by: Jared Quick <jquick@chef.io>