### PR TITLE
Rubocop: disable GuardClause and ClassLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,8 @@ Metrics/AbcSize:
   Max: 33
 Metrics/BlockLength:
   Max: 50
+Metrics/ClassLength:
+  Enabled: false
 Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/PerceivedComplexity:
@@ -59,6 +61,8 @@ Style/EmptyMethod:
 Style/Encoding:
   Enabled: false
 Style/FileName:
+  Enabled: false
+Style/GuardClause:
   Enabled: false
 Style/IfUnlessModifier:
   Enabled: false

--- a/lib/bundles/inspec-artifact/cli.rb
+++ b/lib/bundles/inspec-artifact/cli.rb
@@ -90,8 +90,6 @@ module Artifact
 
   SIGNED_PROFILE_SUFFIX='iaf'
   SIGNED_REPORT_SUFFIX='iar'
-
-  # rubocop:disable Metrics/ClassLength
   class CLI < Inspec::BaseCLI
     namespace 'artifact'
 

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -12,7 +12,7 @@ module Compliance
 
   # API Implementation does not hold any state by itself,
   # everything will be stored in local Configuration store
-  class API # rubocop:disable Metrics/ClassLength
+  class API
     extend Compliance::API::Login
 
     # return all compliance profiles available for the user

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -6,7 +6,7 @@ require 'thor'
 require 'erb'
 
 module Compliance
-  class ComplianceCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
+  class ComplianceCLI < Inspec::BaseCLI
     namespace 'compliance'
 
     # TODO: find another solution, once https://github.com/erikhuda/thor/issues/261 is fixed

--- a/lib/bundles/inspec-habitat/profile.rb
+++ b/lib/bundles/inspec-habitat/profile.rb
@@ -6,7 +6,7 @@ require 'mixlib/shellout'
 require 'tomlrb'
 
 module Habitat
-  class Profile # rubocop:disable Metrics/ClassLength
+  class Profile
     attr_reader :options, :path, :profile
 
     def self.create(path, options = {})

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -8,7 +8,7 @@ require 'tempfile'
 require 'open-uri'
 
 module Fetchers
-  class Url < Inspec.fetcher(1) # rubocop:disable Metrics/ClassLength
+  class Url < Inspec.fetcher(1)
     MIME_TYPES = {
       'application/x-zip-compressed' => '.zip',
       'application/zip' => '.zip',

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -7,7 +7,7 @@ require 'inspec/log'
 require 'inspec/profile_vendor'
 
 module Inspec
-  class BaseCLI < Thor # rubocop:disable Metrics/ClassLength
+  class BaseCLI < Thor
     def self.target_options
       option :target, aliases: :t, type: :string,
         desc: 'Simple targeting option using URIs, e.g. ssh://user:pass@host:port'

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -15,7 +15,7 @@ require 'inspec/runner_mock'
 require 'inspec/env_printer'
 require 'inspec/schema'
 
-class Inspec::InspecCLI < Inspec::BaseCLI # rubocop:disable Metrics/ClassLength
+class Inspec::InspecCLI < Inspec::BaseCLI
   class_option :log_level, aliases: :l, type: :string,
                desc: 'Set the log level: info (default), debug, warn, error'
 

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -13,7 +13,7 @@ module Inspec
   # as the basic DSL of the control files (describe, control, title,
   # etc).
   #
-  class ControlEvalContext # rubocop:disable Metrics/ClassLength
+  class ControlEvalContext
     # Create the context for controls. This includes all components of the DSL,
     # including matchers and resources.
     #

--- a/lib/inspec/dependencies/lockfile.rb
+++ b/lib/inspec/dependencies/lockfile.rb
@@ -28,7 +28,6 @@ module Inspec
       from_content(content)
     end
 
-    # rubocop:disable Style/GuardClause
     def self.validate_lockfile_version!(version)
       if version < MINIMUM_SUPPORTED_VERSION
         raise <<~EOF
@@ -49,7 +48,6 @@ module Inspec
         EOF
       end
     end
-    # rubocop:enable Style/GuardClause
 
     attr_reader :version, :deps
     def initialize(lockfile_content_hash)

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -14,7 +14,7 @@ module Inspec
   # A Metadata object may be created and finalized with invalid data.
   # This allows the check CLI command to analyse the issues.
   # Use valid? to determine if the metadata is coherent.
-  class Metadata # rubocop:disable Metrics/ClassLength
+  class Metadata
     attr_reader :ref
     attr_accessor :params, :content
     def initialize(ref, logger = nil)

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -21,7 +21,7 @@ require 'inspec/dependencies/lockfile'
 require 'inspec/dependencies/dependency_set'
 
 module Inspec
-  class Profile # rubocop:disable Metrics/ClassLength
+  class Profile
     extend Forwardable
 
     def self.resolve_target(target, cache)

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -11,7 +11,7 @@ require 'securerandom'
 require 'inspec/objects/attribute'
 
 module Inspec
-  class ProfileContext # rubocop:disable Metrics/ClassLength
+  class ProfileContext
     def self.for_profile(profile, backend, attributes)
       new(profile.name, backend, { 'profile' => profile,
                                    'attributes' => attributes,

--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -110,7 +110,7 @@ class InspecRspecMiniJson < RSpec::Core::Formatters::JsonFormatter
   end
 end
 
-class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLength
+class InspecRspecJson < InspecRspecMiniJson
   RSpec::Core::Formatters.register self, :stop, :dump_summary
   attr_writer :backend
 
@@ -279,7 +279,7 @@ class InspecRspecJson < InspecRspecMiniJson # rubocop:disable Metrics/ClassLengt
   end
 end
 
-class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
+class InspecRspecCli < InspecRspecJson
   RSpec::Core::Formatters.register self, :close
 
   case RUBY_PLATFORM
@@ -685,7 +685,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
   # This class wraps a control hash object to provide a useful inteface for
   # maintaining the associated profile, ids, results, title, etc.
   #
-  class Control # rubocop:disable Metrics/ClassLength
+  class Control
     include Comparable
 
     STATUS_TYPES = {

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -8,7 +8,7 @@ require 'inspec/describe'
 require 'inspec/expect'
 
 module Inspec
-  class Rule # rubocop:disable Metrics/ClassLength
+  class Rule
     include ::RSpec::Matchers
 
     #

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -28,7 +28,7 @@ module Inspec
   # r.run
   # ```
   #
-  class Runner # rubocop:disable Metrics/ClassLength
+  class Runner
     extend Forwardable
 
     def_delegator :@test_collector, :report

--- a/lib/inspec/schema.rb
+++ b/lib/inspec/schema.rb
@@ -2,7 +2,7 @@
 require 'json'
 
 module Inspec
-  class Schema # rubocop:disable Metrics/ClassLength
+  class Schema
     STATISTICS = {
       'type' => 'object',
       'additionalProperties' => false,

--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -9,7 +9,7 @@ module Inspec
   # A pry based shell for inspec. Given a runner (with a configured backend and
   # all that jazz), this shell will produce a pry shell from which you can run
   # inspec/ruby commands that will be run within the context of the runner.
-  class Shell # rubocop:disable Metrics/ClassLength
+  class Shell
     def initialize(runner)
       @runner = runner
     end

--- a/lib/resources/aide_conf.rb
+++ b/lib/resources/aide_conf.rb
@@ -3,8 +3,6 @@
 
 require 'utils/filter'
 require 'utils/parser'
-
-# rubocop:disable Metrics/ClassLength
 module Inspec::Resources
   class AideConf < Inspec.resource(1)
     name 'aide_conf'

--- a/lib/resources/auditd.rb
+++ b/lib/resources/auditd.rb
@@ -9,7 +9,6 @@ require 'utils/filter'
 require 'utils/parser'
 
 module Inspec::Resources
-  # rubocop:disable Metrics/ClassLength
   class AuditDaemon < Inspec.resource(1)
     extend Forwardable
     attr_accessor :lines

--- a/lib/resources/auditd_rules.rb
+++ b/lib/resources/auditd_rules.rb
@@ -43,8 +43,6 @@ module Inspec::Resources
       'Audit Daemon Rules (for auditd version < 2.3)'
     end
   end
-
-  # rubocop:disable Metrics/ClassLength
   class AuditDaemonRules < Inspec.resource(1)
     extend Forwardable
     attr_accessor :rules, :lines

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -4,7 +4,7 @@ require 'utils/parser'
 require 'utils/filter'
 
 module Inspec::Resources
-  class Crontab < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
+  class Crontab < Inspec.resource(1)
     name 'crontab'
     desc 'Use the crontab InSpec audit resource to test the contents of the crontab for a given user which contains information about scheduled tasks owned by that user.'
     example "

--- a/lib/resources/docker.rb
+++ b/lib/resources/docker.rb
@@ -63,7 +63,7 @@ module Inspec::Resources
   # For compatability with Serverspec we also offer the following resouses:
   # - docker_container
   # - docker_image
-  class Docker < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
+  class Docker < Inspec.resource(1)
     name 'docker'
 
     desc "

--- a/lib/resources/elasticsearch.rb
+++ b/lib/resources/elasticsearch.rb
@@ -5,7 +5,7 @@ require 'hashie/mash'
 require 'resources/package'
 
 module Inspec::Resources
-  class Elasticsearch < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
+  class Elasticsearch < Inspec.resource(1)
     name 'elasticsearch'
     desc "Use the Elasticsearch InSpec audit resource to test the status of nodes in
       an Elasticsearch cluster."

--- a/lib/resources/grub_conf.rb
+++ b/lib/resources/grub_conf.rb
@@ -3,7 +3,7 @@
 
 require 'utils/simpleconfig'
 
-class GrubConfig < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
+class GrubConfig < Inspec.resource(1)
   name 'grub_conf'
   desc 'Use the grub_conf InSpec audit resource to test the boot config of Linux systems that use Grub.'
   example "

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -381,7 +381,7 @@ module Inspec::Resources
   end
 
   # extract port information from netstat
-  class LinuxPorts < PortsInfo # rubocop:disable Metrics/ClassLength
+  class LinuxPorts < PortsInfo
     ALLOWED_PROTOCOLS = %w{tcp tcp6 udp udp6}.freeze
 
     def info

--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -7,7 +7,7 @@ require 'utils/filter'
 require 'ostruct'
 
 module Inspec::Resources
-  class Processes < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
+  class Processes < Inspec.resource(1)
     name 'processes'
     desc 'Use the processes InSpec audit resource to test properties for programs that are running on the system.'
     example "

--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -47,7 +47,7 @@ require 'json'
 # end
 
 module Inspec::Resources
-  class RegistryKey < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
+  class RegistryKey < Inspec.resource(1)
     name 'registry_key'
     desc 'Use the registry_key InSpec audit resource to test key values in the Microsoft Windows registry.'
     example "

--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -68,7 +68,7 @@ module Inspec::Resources
   # Ubuntu < 15.04 : upstart
   #
   # TODO: extend the logic to detect the running init system, independently of OS
-  class Service < Inspec.resource(1) # rubocop:disable ClassLength
+  class Service < Inspec.resource(1)
     name 'service'
     desc 'Use the service InSpec audit resource to test if the named service is installed, running and/or enabled.'
     example "

--- a/lib/resources/virtualization.rb
+++ b/lib/resources/virtualization.rb
@@ -4,7 +4,7 @@
 require 'hashie/mash'
 
 module Inspec::Resources
-  class Virtualization < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
+  class Virtualization < Inspec.resource(1)
     name 'virtualization'
     desc 'Use the virtualization InSpec audit resource to test the virtualization platform on which the system is running'
     example "

--- a/lib/resources/x509_certificate.rb
+++ b/lib/resources/x509_certificate.rb
@@ -6,7 +6,7 @@ require 'openssl'
 require 'hashie/mash'
 
 module Inspec::Resources
-  class X509CertificateResource < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
+  class X509CertificateResource < Inspec.resource(1)
     name 'x509_certificate'
     desc 'Used to test x.509 certificates'
     example "


### PR DESCRIPTION
Neither of these cops is helping us write good code, and GuardClause specifically is actually contributing to us writing sometimes-unclear code. Disabling both of these cops and removing all unnecessary disable decorators in the codebase.

Signed-off-by: Adam Leff <adam@leff.co>