### PR TITLE
Added support for proxy_command for remote SSH connections

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -45,6 +45,8 @@ module Inspec
         desc: 'Allow remote scans with self-signed certificates (WinRM).'
       option :json_config, type: :string,
         desc: 'Read configuration from JSON file (`-` reads from stdin).'
+      option :proxy_command, type: :string,
+        desc: 'Specifies the command to use to connect to the server'
     end
 
     def self.profile_options


### PR DESCRIPTION
**NOTE** This is just a simple wrapper which relies on the underlying support being added to train: https://github.com/chef/train/pull/227
Solves #431.

Signed-off-by: Christian Becker <c.becker@mediaevent.services>