### PR TITLE
Enhance `package` resource error handling

### DIFF
--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -21,6 +21,8 @@ module Inspec::Resources
     "
 
     def initialize(package_name = nil, opts = {}) # rubocop:disable Metrics/AbcSize
+      raise Inspec::Exceptions::ResourceFailed, 'Package name required but not specified' if package_name.nil?
+
       @package_name = package_name
       @name = @package_name
       @cache = nil
@@ -45,7 +47,7 @@ module Inspec::Resources
       elsif ['hpux'].include?(os[:family])
         @pkgman = HpuxPkg.new(inspec)
       else
-        return skip_resource 'The `package` resource is not supported on your OS yet.'
+        raise Inspec::Exceptions::ResourceSkipped, 'The `package` resource is not supported on your OS yet.'
       end
 
       evaluate_missing_requirements
@@ -53,13 +55,11 @@ module Inspec::Resources
 
     # returns true if the package is installed
     def installed?(_provider = nil, _version = nil)
-      return false if info.nil?
       info[:installed] == true
     end
 
     # returns true it the package is held (if the OS supports it)
     def held?(_provider = nil, _version = nil)
-      return false if info.nil?
       return false unless info.key?(:held)
       info[:held] == true
     end
@@ -67,14 +67,12 @@ module Inspec::Resources
     # returns the package description
     def info
       return @cache if !@cache.nil?
-      return nil if @pkgman.nil?
       @pkgman.info(@package_name)
     end
 
     # return the package version
     def version
       info = @pkgman.info(@package_name)
-      return nil if info.nil?
       info[:version]
     end
 
@@ -87,7 +85,7 @@ module Inspec::Resources
     def evaluate_missing_requirements
       missing_requirements_string = @pkgman.missing_requirements.uniq.join(', ')
       return if missing_requirements_string.empty?
-      skip_resource "The following requirements are not met for this resource: #{missing_requirements_string}"
+      raise Inspec::Exceptions::ResourceSkipped, "The following requirements are not met for this resource: #{missing_requirements_string}"
     end
   end
 
@@ -99,7 +97,7 @@ module Inspec::Resources
 
     def missing_requirements
       # Each provider can provide an Array of missing requirements that will be
-      # combined into a `skip_resource` message
+      # combined into a `ResourceSkipped` exception message.
       []
     end
   end
@@ -108,7 +106,7 @@ module Inspec::Resources
   class Deb < PkgManagement
     def info(package_name)
       cmd = inspec.command("dpkg -s #{package_name}")
-      return nil if cmd.exit_status.to_i != 0
+      return {} if cmd.exit_status.to_i != 0
 
       params = SimpleConfig.new(
         cmd.stdout.chomp,
@@ -152,7 +150,7 @@ module Inspec::Resources
       cmd = inspec.command(rpm_cmd)
       # CentOS does not return an error code if the package is not installed,
       # therefore we need to check for emptyness
-      return nil if cmd.exit_status.to_i != 0 || cmd.stdout.chomp.empty?
+      return {} if cmd.exit_status.to_i != 0 || cmd.stdout.chomp.empty?
       params = SimpleConfig.new(
         cmd.stdout.chomp,
         assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
@@ -195,7 +193,7 @@ module Inspec::Resources
     def info(package_name)
       brew_path = inspec.command('brew').exist? ? 'brew' : '/usr/local/bin/brew'
       cmd = inspec.command("#{brew_path} info --json=v1 #{package_name}")
-      return nil if cmd.exit_status.to_i != 0
+      return {} if cmd.exit_status.to_i != 0
       # parse data
       pkg = JSON.parse(cmd.stdout)[0]
       {
@@ -204,8 +202,10 @@ module Inspec::Resources
         version: pkg['installed'][0]['version'],
         type: 'brew',
       }
-    rescue JSON::ParserError => _e
-      return nil
+    rescue JSON::ParserError => e
+      raise Inspec::Exceptions::ResourceFailed,
+        'Failed to parse JSON from `brew` command. ' \
+        "Error: #{e}"
     end
   end
 
@@ -213,7 +213,7 @@ module Inspec::Resources
   class Pacman < PkgManagement
     def info(package_name)
       cmd = inspec.command("pacman -Qi #{package_name}")
-      return nil if cmd.exit_status.to_i != 0
+      return {} if cmd.exit_status.to_i != 0
 
       params = SimpleConfig.new(
         cmd.stdout.chomp,
@@ -233,7 +233,7 @@ module Inspec::Resources
   class HpuxPkg < PkgManagement
     def info(package_name)
       cmd = inspec.command("swlist -l product | grep #{package_name}")
-      return nil if cmd.exit_status.to_i != 0
+      return {} if cmd.exit_status.to_i != 0
       pkg = cmd.stdout.strip.split(' ')
       {
         name: pkg[0],
@@ -268,8 +268,10 @@ module Inspec::Resources
 
       begin
         package = JSON.parse(cmd.stdout)
-      rescue JSON::ParserError => _e
-        return nil
+      rescue JSON::ParserError => e
+        raise Inspec::Exceptions::ResourceFailed,
+          'Failed to parse JSON from PowerShell. ' \
+          "Error: #{e}"
       end
 
       # What if we match multiple packages?  just pick the first one for now.
@@ -288,7 +290,7 @@ module Inspec::Resources
   class BffPkg < PkgManagement
     def info(package_name)
       cmd = inspec.command("lslpp -cL #{package_name}")
-      return nil if cmd.exit_status.to_i != 0
+      return {} if cmd.exit_status.to_i != 0
 
       bff_pkg = cmd.stdout.split("\n").last.split(':')
       {
@@ -313,7 +315,7 @@ module Inspec::Resources
     # solaris 10
     def solaris10_info(package_name)
       cmd = inspec.command("pkginfo -l #{package_name}")
-      return nil if cmd.exit_status.to_i != 0
+      return {} if cmd.exit_status.to_i != 0
 
       params = SimpleConfig.new(
         cmd.stdout.chomp,
@@ -334,7 +336,7 @@ module Inspec::Resources
     # solaris 11
     def solaris11_info(package_name)
       cmd = inspec.command("pkg info #{package_name}")
-      return nil if cmd.exit_status.to_i != 0
+      return {} if cmd.exit_status.to_i != 0
 
       params = SimpleConfig.new(
         cmd.stdout.chomp,

--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -58,7 +58,6 @@ module Inspec::Resources
 
     # returns true it the package is held (if the OS supports it)
     def held?(_provider = nil, _version = nil)
-      return false unless info.key?(:held)
       info[:held] == true
     end
 

--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -20,7 +20,7 @@ module Inspec::Resources
       end
     "
 
-    def initialize(package_name = nil, opts = {}) # rubocop:disable Metrics/AbcSize
+    def initialize(package_name = nil, opts = {}) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
       raise Inspec::Exceptions::ResourceFailed, 'Package name required but not specified' if package_name.nil?
 
       @package_name = package_name
@@ -204,8 +204,8 @@ module Inspec::Resources
       }
     rescue JSON::ParserError => e
       raise Inspec::Exceptions::ResourceFailed,
-        'Failed to parse JSON from `brew` command. ' \
-        "Error: #{e}"
+            'Failed to parse JSON from `brew` command. ' \
+            "Error: #{e}"
     end
   end
 
@@ -270,8 +270,8 @@ module Inspec::Resources
         package = JSON.parse(cmd.stdout)
       rescue JSON::ParserError => e
         raise Inspec::Exceptions::ResourceFailed,
-          'Failed to parse JSON from PowerShell. ' \
-          "Error: #{e}"
+              'Failed to parse JSON from PowerShell. ' \
+              "Error: #{e}"
       end
 
       # What if we match multiple packages?  just pick the first one for now.

--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -20,9 +20,7 @@ module Inspec::Resources
       end
     "
 
-    def initialize(package_name = nil, opts = {}) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
-      raise Inspec::Exceptions::ResourceFailed, 'Package name required but not specified' if package_name.nil?
-
+    def initialize(package_name, opts = {}) # rubocop:disable Metrics/AbcSize
       @package_name = package_name
       @name = @package_name
       @cache = nil

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -6,13 +6,6 @@ require 'helper'
 require 'inspec/resource'
 
 describe 'Inspec::Resources::Package' do
-  # any os
-  it 'fails the resource if a package name is not specified' do
-    resource = MockLoader.new(:undefined).load_resource('package', nil)
-    _(resource.resource_failed?).must_equal true
-    _(resource.resource_exception_message).must_equal 'Package name required but not specified'
-  end
-
   # arch linux
   it 'verify arch linux package parsing' do
     resource = MockLoader.new(:arch).load_resource('package', 'curl')

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -6,6 +6,13 @@ require 'helper'
 require 'inspec/resource'
 
 describe 'Inspec::Resources::Package' do
+  # any os
+  it 'fails the resource if a package name is not specified' do
+    resource = MockLoader.new(:undefined).load_resource('package', nil)
+    _(resource.resource_failed?).must_equal true
+    _(resource.resource_exception_message).must_equal 'Package name required but not specified'
+  end
+
   # arch linux
   it 'verify arch linux package parsing' do
     resource = MockLoader.new(:arch).load_resource('package', 'curl')
@@ -139,7 +146,7 @@ describe 'Inspec::Resources::Package' do
   # undefined
   it 'verify package handling on unsupported os' do
     resource = MockLoader.new(:undefined).load_resource('package', 'curl')
-    _(resource.installed?).must_equal false
-    _(resource.info).must_be_nil
+    _(resource.resource_skipped?).must_equal true
+    _(resource.resource_exception_message).must_equal 'The `package` resource is not supported on your OS yet.'
   end
 end


### PR DESCRIPTION
This does the following:
  - Modifies `info` to return an empty hash instead of `nil`
  - Adds a failure case if package name is not specified
  - Adds a skip case if no package manager can be found
  - Changes `skip_resource` to use the `ResourceSkipped` exception
  - Raises an error if JSON parsing fails for Windows/MacOS/Darwin

This closes #1692
This closes #2373