### PR TITLE
Replace exec --cache with --vendor-cache

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -64,7 +64,7 @@ module Inspec
       option :attrs, type: :array,
         desc: 'Load attributes file (experimental)'
       option :cache, type: :string,
-        desc: '[DEPRECATION] Please use --vendor-cache - this will be removed in InSpec 2.0'
+        desc: '[DEPRECATED] Please use --vendor-cache - this will be removed in InSpec 2.0'
       option :vendor_cache, type: :string,
         desc: 'Use the given path for caching dependencies. (default: ~/.inspec/cache)'
       option :create_lockfile, type: :boolean,

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -64,6 +64,8 @@ module Inspec
       option :attrs, type: :array,
         desc: 'Load attributes file (experimental)'
       option :cache, type: :string,
+        desc: '[DEPRECATION] Please use --vendor-cache - this will be removed in InSpec 2.0'
+      option :vendor_cache, type: :string,
         desc: 'Use the given path for caching dependencies. (default: ~/.inspec/cache)'
       option :create_lockfile, type: :boolean,
         desc: 'Write out a lockfile based on this execution (unless one already exists)'

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -155,6 +155,13 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     o = opts(:exec).dup
     configure_logger(o)
 
+    # check for deprecated --cache
+    # TODO: REMOVE for inspec 2.0
+    if o.key?('cache')
+      o[:vendor_cache] = o[:cache]
+      o[:logger].warn '[DEPRECATION] The use of `--cache` is being deprecated in InSpec 2.0. Please use `--vendor-cache` instead.'
+    end
+
     # run tests
     run_tests(targets, o)
   rescue StandardError => e

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -159,7 +159,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     # TODO: REMOVE for inspec 2.0
     if o.key?('cache')
       o[:vendor_cache] = o[:cache]
-      o[:logger].warn '[DEPRECATION] The use of `--cache` is being deprecated in InSpec 2.0. Please use `--vendor-cache` instead.'
+      o[:logger].warn '[DEPRECATED] The use of `--cache` is being deprecated in InSpec 2.0. Please use `--vendor-cache` instead.'
     end
 
     # run tests

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -43,7 +43,7 @@ module Inspec
         next if content[key].nil?
         # remove prefix
         rel = Pathname.new(key).relative_path_from(Pathname.new('vendor')).to_s
-        tar = Pathname.new(opts[:cache].path).join(rel)
+        tar = Pathname.new(opts[:vendor_cache].path).join(rel)
 
         FileUtils.mkdir_p tar.dirname.to_s
         Inspec::Log.debug "Copy #{tar} to cache directory"
@@ -56,7 +56,7 @@ module Inspec
       rp = file_provider.relative_provider
 
       # copy embedded dependecies into global cache
-      copy_deps_into_cache(rp, opts) unless opts[:cache].nil?
+      copy_deps_into_cache(rp, opts) unless opts[:vendor_cache].nil?
 
       reader = Inspec::SourceReader.resolve(rp)
       if reader.nil?
@@ -67,14 +67,14 @@ module Inspec
     end
 
     def self.for_fetcher(fetcher, opts)
-      opts[:cache] = opts[:cache] || Cache.new
+      opts[:vendor_cache] = opts[:vendor_cache] || Cache.new
       path, writable = fetcher.fetch
       for_path(path, opts.merge(target: fetcher.target, writable: writable))
     end
 
     def self.for_target(target, opts = {})
-      opts[:cache] = opts[:cache] || Cache.new
-      fetcher = resolve_target(target, opts[:cache])
+      opts[:vendor_cache] = opts[:vendor_cache] || Cache.new
+      fetcher = resolve_target(target, opts[:vendor_cache])
       for_fetcher(fetcher, opts)
     end
 
@@ -92,7 +92,7 @@ module Inspec
       @controls = options[:controls] || []
       @writable = options[:writable] || false
       @profile_id = options[:id]
-      @cache = options[:cache] || Cache.new
+      @cache = options[:vendor_cache] || Cache.new
       @attr_values = options[:attributes]
       @tests_collected = false
       @libraries_loaded = false

--- a/lib/inspec/profile_vendor.rb
+++ b/lib/inspec/profile_vendor.rb
@@ -48,7 +48,7 @@ module Inspec
 
     def profile_opts
       {
-        cache: Inspec::Cache.new(cache_path.to_s),
+        vendor_cache: Inspec::Cache.new(cache_path.to_s),
         backend: Inspec::Backend.create(target: 'mock://'),
       }
     end

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -42,7 +42,7 @@ module Inspec
       @controls = @conf[:controls] || []
       @ignore_supports = @conf[:ignore_supports]
       @create_lockfile = @conf[:create_lockfile]
-      @cache = Inspec::Cache.new(@conf[:cache])
+      @cache = Inspec::Cache.new(@conf[:vendor_cache])
       @test_collector = @conf.delete(:test_collector) || begin
         require 'inspec/runner_rspec'
         RunnerRspec.new(@conf)
@@ -168,7 +168,7 @@ module Inspec
     #
     def add_target(target, _opts = [])
       profile = Inspec::Profile.for_target(target,
-                                           cache: @cache,
+                                           vendor_cache: @cache,
                                            backend: @backend,
                                            controls: @controls,
                                            attributes: @conf[:attributes])

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -94,4 +94,23 @@ describe 'example inheritance profile' do
       out.stdout.scan(/Fetching URL:/).length.must_equal 0
     end
   end
+
+  it 'can move vendor files into custom vendor cache' do
+    prepare_examples('meta-profile') do |dir|
+      out = inspec('vendor ' + dir + ' --overwrite')
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+
+      File.exist?(File.join(dir, 'vendor')).must_equal true
+      File.exist?(File.join(dir, 'inspec.lock')).must_equal true
+      File.exist?(File.join(dir, 'vendor_cache')).must_equal false
+
+      exec_out = inspec('exec ' + dir + ' --vendor-cache ' + dir + '/vendor_cache')
+
+      File.exist?(File.join(dir, 'vendor_cache')).must_equal true
+      vendor_files = Dir.entries("#{dir}/vendor/")
+      vendor_cache_files = Dir.entries("#{dir}/vendor_cache/")
+      vendor_files.must_equal vendor_cache_files
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/chef/inspec/issues/2339

This change deprecates the current `--cache` exec flag in favor of the `--vendor-cache` flag. Deprecation warnings have been added and code updated.

Signed-off-by: Jared Quick <jquick@chef.io>