### PR TITLE
Split unit tests from functional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ matrix:
   include:
   - rvm: 2.3.5
   - rvm: 2.4.2
+  - rvm: 2.4.2
     script: bundle exec rake $SUITE
-    env: SUITE="lint test test:functional"
+    env: SUITE="test:functional"
   - rvm: 2.4.2
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE


### PR DESCRIPTION
Functional tests can sometimes be picky. Moving them to their own matrix item so they're smaller and faster to re-run if needed.
