### PR TITLE
Updates the docs for mysql_session

### DIFF
--- a/docs/resources/mysql_session.md.erb
+++ b/docs/resources/mysql_session.md.erb
@@ -13,14 +13,14 @@ Use the `mysql_session` InSpec audit resource to test SQL commands run against a
 A `mysql_session` resource block declares the username and password to use for the session, and then the command to be run:
 
     describe mysql_session('username', 'password').query('QUERY') do
-      its('output') { should eq('') }
+      its('stdout') { should match(/expected-result/) }
     end
 
 where
 
-* `mysql_session` declares a username and password with permission to run the query
+* `mysql_session` declares a username and password, connecting locally, with permission to run the query
 * `query('QUERY')` contains the query to be run
-* `its('output') { should eq('') }` compares the results of the query against the expected result in the test
+* `its('stdout') { should eq(/expected-result/) }` compares the results of the query against the expected result in the test
 
 <br>
 
@@ -38,24 +38,36 @@ The following examples show how to use this InSpec audit resource.
 
 ### Alternate Connection: Different Host
 
-  sql = mysql_session('my_user','password','db.example.com')
+    sql = mysql_session('my_user','password','db.example.com')
 
 ### Alternate Connection: Different Port
 
-  sql = mysql_seesion('my_user','password','localhost',3307)
+    sql = mysql_session('my_user','password','localhost',3307)
 
 ### Alternate Connection: Using a socket
 
-  sql = mysql_session('my_user','password', nil, nil, '/var/lib/mysql-default/mysqld.sock')
+    sql = mysql_session('my_user','password', nil, nil, '/var/lib/mysql-default/mysqld.sock')
+
+### Test for a successful query
+
+    describe mysql_session('my_user','password').query('show tables in existing_database;') do
+      its('exit_status') { should eq(0) }
+    end
+
+### Test for a failing query
+
+    describe mysql_session('my_user','password').query('show tables in non_existent_database;') do
+      its('exit_status') { should_not eq(0) }
+    end
+
+### Test for specific error message
+
+    describe mysql_session('my_user','password').query('show tables in non_existent_database;') do
+      its('stderr') { should match(/Unknown database/) }
+    end
 
 <br>
 
 ## Matchers
 
-This InSpec audit resource has the following matchers. For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
-
-### output
-
-The `output` matcher tests the results of the query:
-
-    its('output') { should eq(/^0/) }
+This InSpec audit resource builds a [command](https://www.inspec.io/docs/reference/resources/command) object and returns the the result object. For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).


### PR DESCRIPTION
* Fixes usage of 'output' to 'stdout'
* Fixes the format of the examples to proper 4 space ident to become code blocks
* Adds examples for 'exit_status' and 'stderr'
* Modifies the matchers section to point to the command resource

Signed-off-by: Franklin Webber <franklin@chef.io>