### PR TITLE
file resource: adds `Synchronize` permission to windows ACL checks

### DIFF
--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -269,6 +269,8 @@ module Inspec::Resources
         translate_perm_names('full-control') + %w{ChangePermissions}
       when 'take-ownership'
         translate_perm_names('full-control') + %w{TakeOwnership}
+      when 'synchronize'
+        translate_perm_names('full-control') + %w{Synchronize}
       end
     end
 


### PR DESCRIPTION
Obvious fix (to me)

`Synchronize` is only included if specifically set on the ACL or if the user is provided `FullControl`. Rarely used, so it was an oversight on originally submitting the feature for granular windows ACL checks.

I've since gone through all permissions noted in the official docs to make sure this was the only one missed: https://docs.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.filesystemrights?view=netframework-4.7.1