### PR TITLE
Fix OWCA detection for `compliance login`

### DIFF
--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -270,7 +270,7 @@ module Compliance
           "Received 401 from #{url}#{automate_endpoint} " \
           'assuming target is a Chef Automate instance',
         )
-        return true
+        true
       when '200'
         # Chef Automate currently returns 401 for `/compliance/version` but some
         # versions of OpsWorks Chef Automate return 200 and a Chef Manage page
@@ -280,15 +280,21 @@ module Compliance
             "Received 200 from #{url}#{automate_endpoint} " \
             'assuming target is an OpsWorks Chef Automate instance',
           )
-          return true
+          true
         else
           Inspec::Log.debug(
             "Received 200 from #{url}#{automate_endpoint} " \
             'but did not receive the Chef Manage page. ' \
             'Continuing with detection attempts',
           )
-          return false
+          false
         end
+      else
+        Inspec::Log.debug(
+          "Received neither 200 nor 401 from #{url}#{automate_endpoint}. " \
+          'Continuing with detection attempts',
+        )
+        false
       end
     end
 

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -251,10 +251,14 @@ module Compliance
     end
 
     def self.determine_server_type(url, insecure)
-      return :automate if target_is_automate_server?(url, insecure)
-      return :compliance if target_is_compliance_server?(url, insecure)
-      Inspec::Log.debug('Could not determine server type using known endpoints')
-      nil
+      if target_is_automate_server?(url, insecure)
+        :automate
+      elsif target_is_compliance_server?(url, insecure)
+        :compliance
+      else
+        Inspec::Log.debug('Could not determine server type using known endpoints')
+        nil
+      end
     end
 
     def self.target_is_automate_server?(url, insecure)

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -267,7 +267,7 @@ module Compliance
       case response.code
       when '401'
         Inspec::Log.debug(
-          "Received 401 from #{url}#{automate_endpoint} " \
+          "Received 401 from #{url}#{automate_endpoint} - " \
           'assuming target is a Chef Automate instance',
         )
         true
@@ -277,22 +277,23 @@ module Compliance
         # when unauthenticated requests are received.
         if response.body.include?('Are You Looking For the Chef Server?')
           Inspec::Log.debug(
-            "Received 200 from #{url}#{automate_endpoint} " \
+            "Received 200 from #{url}#{automate_endpoint} - " \
             'assuming target is an OpsWorks Chef Automate instance',
           )
           true
         else
           Inspec::Log.debug(
             "Received 200 from #{url}#{automate_endpoint} " \
-            'but did not receive the Chef Manage page. ' \
-            'Continuing with detection attempts',
+            'but did not receive the Chef Manage page - ' \
+            'assuming target is not a Chef Automate instance',
           )
           false
         end
       else
         Inspec::Log.debug(
-          "Received neither 200 nor 401 from #{url}#{automate_endpoint}. " \
-          'Continuing with detection attempts',
+          "Received unexpected status code #{response.code} " \
+          "from #{url}#{automate_endpoint} - " \
+          'assuming target is not a Chef Automate instance',
         )
         false
       end
@@ -306,7 +307,7 @@ module Compliance
       return false unless response.code == '200'
 
       Inspec::Log.debug(
-        "Received 200 from #{url}#{compliance_endpoint} " \
+        "Received 200 from #{url}#{compliance_endpoint} - " \
         'assuming target is a Compliance server',
       )
       true

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -280,7 +280,7 @@ module Compliance
         else
           Inspec::Log.debug(
             "Received 200 from #{url}#{automate_endpoint} " \
-            "but not the Chef Manage page. " \
+            'but did not receive the Chef Manage page. ' \
             'Continuing with detection attempts',
           )
           return false
@@ -291,14 +291,15 @@ module Compliance
     def self.target_is_compliance_server?(url, insecure)
       # All versions of Chef Compliance return 200 for `/api/version`
       compliance_endpoint = '/api/version'
+
       response = Compliance::HTTP.get(url + compliance_endpoint, nil, insecure)
-      if response.code == '200'
-        Inspec::Log.debug(
-          "Received 200 from #{url}#{compliance_endpoint} " \
-          'assuming target is a Compliance server',
-        )
-        return true
-      end
+      return false unless response.code == '200'
+
+      Inspec::Log.debug(
+        "Received 200 from #{url}#{compliance_endpoint} " \
+        'assuming target is a Compliance server',
+      )
+      true
     end
   end
 end

--- a/test/unit/bundles/inspec-compliance/api_test.rb
+++ b/test/unit/bundles/inspec-compliance/api_test.rb
@@ -281,6 +281,24 @@ describe Compliance::API do
       Compliance::API.determine_server_type(url, insecure).must_equal(:automate)
     end
 
+    it 'returns `nil` if a 200 is received from `https://URL/compliance/version` but not redirected to Chef Manage' do
+      bad_response.stubs(:code).returns('200')
+      bad_response.stubs(:body).returns('No Chef Manage here')
+
+      Compliance::HTTP.expects(:get)
+        .with(url + automate_endpoint, headers, insecure)
+        .returns(bad_response)
+
+      mock_compliance_response = mock
+      mock_compliance_response.stubs(:code).returns('404')
+      Compliance::HTTP.expects(:get)
+        .with(url + compliance_endpoint, headers, insecure)
+        .returns(mock_compliance_response)
+
+      Compliance::API.determine_server_type(url, insecure).must_be_nil
+    end
+
+
     it 'returns `:compliance` when a 200 is received from `https://URL/api/version`' do
       good_response.stubs(:code).returns('200')
       bad_response.stubs(:code).returns('404')

--- a/test/unit/bundles/inspec-compliance/api_test.rb
+++ b/test/unit/bundles/inspec-compliance/api_test.rb
@@ -247,32 +247,65 @@ describe Compliance::API do
   end
 
   describe '.determine_server_type' do
-    it 'returns `automate` when a 401 is received from `https://automate.example.com/compliance/version`' do
-      good_response = mock
+    let(:url) { 'https://someserver.onthe.net/' }
+
+    let(:compliance_endpoint) { '/api/version' }
+    let(:automate_endpoint) { '/compliance/version' }
+    let(:headers) { nil }
+    let(:insecure) { true }
+
+    let(:good_response) { mock }
+    let(:bad_response) { mock }
+
+    it 'returns `:automate` when a 401 is received from `https://URL/compliance/version`' do
       good_response.stubs(:code).returns('401')
-      url = 'https://automate.example.com'
-      Compliance::HTTP.expects(:get).with(url + '/compliance/version', nil, true).returns(good_response)
-      Compliance::API.determine_server_type(url, true).must_equal(:automate)
+
+      Compliance::HTTP.expects(:get)
+        .with(url + automate_endpoint, headers, insecure)
+        .returns(good_response)
+
+      Compliance::API.determine_server_type(url, insecure).must_equal(:automate)
     end
 
-    it 'returns `compliance` when a 200 is received from `https://compliance.example.com/api/version`' do
-      good_response = mock
+    # Chef Automate currently returns 401 for `/compliance/version` but some
+    # versions of OpsWorks Chef Automate return 200 and a Chef Manage page when
+    # unauthenticated requests are received.
+    it 'returns `:automate` when a 200 is received from `https://URL/compliance/version`' do
       good_response.stubs(:code).returns('200')
-      bad_response = mock
-      bad_response.stubs(:code).returns('404')
-      url = 'https://compliance.example.com'
-      Compliance::HTTP.expects(:get).with(url + '/compliance/version', nil, true).returns(bad_response)
-      Compliance::HTTP.expects(:get).with(url + '/api/version', nil, true).returns(good_response)
-      Compliance::API.determine_server_type(url, true).must_equal(:compliance)
+      good_response.stubs(:body).returns('Are You Looking For the Chef Server?')
+
+      Compliance::HTTP.expects(:get)
+        .with(url + automate_endpoint, headers, insecure)
+        .returns(good_response)
+
+      Compliance::API.determine_server_type(url, insecure).must_equal(:automate)
     end
 
-    it 'returns `nil` if no response returns favorably' do
-      bad_response = mock
+    it 'returns `:compliance` when a 200 is received from `https://URL/api/version`' do
+      good_response.stubs(:code).returns('200')
       bad_response.stubs(:code).returns('404')
-      url = 'https://bad.example.com'
-      Compliance::HTTP.expects(:get).with(url + '/compliance/version', nil, true).returns(bad_response)
-      Compliance::HTTP.expects(:get).with(url + '/api/version', nil, true).returns(bad_response)
-      Compliance::API.determine_server_type(url, true).must_be_nil
+
+      Compliance::HTTP.expects(:get)
+        .with(url + automate_endpoint, headers, insecure)
+        .returns(bad_response)
+      Compliance::HTTP.expects(:get)
+        .with(url + compliance_endpoint, headers, insecure)
+        .returns(good_response)
+
+      Compliance::API.determine_server_type(url, insecure).must_equal(:compliance)
+    end
+
+    it 'returns `nil` if it cannot determine the server type' do
+      bad_response.stubs(:code).returns('404')
+
+      Compliance::HTTP.expects(:get)
+        .with(url + automate_endpoint, headers, insecure)
+        .returns(bad_response)
+      Compliance::HTTP.expects(:get)
+        .with(url + compliance_endpoint, headers, insecure)
+        .returns(bad_response)
+
+      Compliance::API.determine_server_type(url, insecure).must_be_nil
     end
   end
 end


### PR DESCRIPTION
This adds detection logic for logging into OpsWorks Chef Automate via `inspec compliance login`.

Currently, the OWCA `/compliance/version` endpoint returns a 200 code instead of a 401.  This is due to a redirect when doing a GET request without authentication headers. This may change in the future, but I recommend leaving this in to support older versions.

Would welcome thoughts on the matter though.

Fixes #2375 