### PR TITLE
Add option to allow SimpleConfig to strip trailing whitespace

### DIFF
--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -83,6 +83,7 @@ module Inspec::Resources
           raw_conf,
           assignment_regex: /^\s*(\S+)\s+(.*)\s*$/,
           multiple_values: true,
+          strip_values: true,
         ).params
         @params.merge!(params)
 

--- a/lib/utils/simpleconfig.rb
+++ b/lib/utils/simpleconfig.rb
@@ -74,6 +74,7 @@ class SimpleConfig
     if opts[:multiple_values]
       @vals[m[1]] ||= []
       @vals[m[1]].push(parse_values(m, opts[:key_values]))
+      @vals.each_value { |i| i.collect!(&:strip) } if opts[:strip_values]
     else
       @vals[m[1]] = parse_values(m, opts[:key_values])
     end
@@ -127,6 +128,7 @@ class SimpleConfig
       key_values: 1, # default for key=value, may require for 'key val1 val2 val3'
       standalone_comments: false,
       multiple_values: false,
+      strip_values: false,
     }
   end
 end

--- a/test/unit/mock/files/apache2.conf
+++ b/test/unit/mock/files/apache2.conf
@@ -1,5 +1,7 @@
 # This is the main Apache server configuration file.  It contains comments.
 ServerRoot "/etc/apache2"
+ServerAlias inspec.test 
+ServerAlias io.inspec.test 
 
 User ${APACHE_RUN_USER}
 Include ports.conf

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -12,6 +12,7 @@ describe 'Inspec::Resources::ApacheConf' do
     _(resource.params).must_be_kind_of Hash
     _(resource.content).must_be_kind_of String
     _(resource.params('ServerRoot')).must_equal ['"/etc/apache2"']
+    _(resource.params('ServerAlias')).must_equal ['inspec.test', 'io.inspec.test']
     _(resource.params('Listen').sort).must_equal ['443', '80']
     # sourced using a linked file in conf-enabled/
     _(resource.params('ServerSignature')).must_equal ['Off']

--- a/test/unit/utils/simpleconfig_test.rb
+++ b/test/unit/utils/simpleconfig_test.rb
@@ -118,4 +118,11 @@ describe 'SimpleConfig Default Parser' do
       cur.params.must_equal({'1' => ['2', '3']})
     end
   end
+
+  it 'supports :strip_values for removing trailing whitespace from values' do
+    cur = SimpleConfig.new('ServerAlias www.inspec.test ',
+                           assignment_regex: /^\s*(\S+)\s+(.*)\s*$/,
+                           multiple_values: true, strip_values: true)
+    cur.params.must_equal({ 'ServerAlias' => ['www.inspec.test'] })
+  end
 end


### PR DESCRIPTION
This PR Updates `SimpleConfig` to allow users to strip trailing whitespace from parsed values. The `:strip_values` option is defaulted to false, users must explicitly enable it.

Note the whitespace after www.inspec.test:
```
SimpleConfig.new('ServerAlias www.inspec.test ', assignment_regex: /^\s*(\S+)\s+(.*)\s*$/, multiple_values: true, strip_values: true)
```

Will result in params including `{ 'ServerAlias' => ['www.inspec.test'] }`

This PR also updates the `apache_conf` resource to enable `:strip_values` by default.

Because Apache allows you to pass multiple values, and define the setting more than once you can still end up with parameters like this:

```
# apache2.conf
ServerAlias io.inspec.test inspec.test
ServerAlias www.inspec.test
```

`{ 'ServerAlias' => ['io.inspec.test inspec.test', 'www.inspec.test'] }`

But they will no longer include trailing whitespace =)

Fixes https://github.com/chef/inspec/issues/1241