### PR TITLE
Add support for Darwin Directory Service groups

### DIFF
--- a/lib/resources/groups.rb
+++ b/lib/resources/groups.rb
@@ -14,7 +14,11 @@ module Inspec::Resources
     # returns nil, if no group manager was found for the operating system
     def select_group_manager(os)
       if os.unix?
-        @group_provider = UnixGroup.new(inspec)
+        @group_provider = if os.darwin?
+                            DarwinGroup.new(inspec)
+                          else
+                            UnixGroup.new(inspec)
+                          end
       elsif os.windows?
         @group_provider = WindowsGroup.new(inspec)
       end
@@ -151,6 +155,35 @@ module Inspec::Resources
   class UnixGroup < GroupInfo
     def groups
       inspec.etc_group.entries
+    end
+  end
+
+  # OSX uses opendirectory for groups, so `/etc/group` may not be accurate
+  class DarwinGroup < GroupInfo
+    def groups
+      raw_output = inspec.command('dscacheutil -q group').stdout
+      raw_group_info = raw_output.split("\n\n")
+
+      group_info = []
+      regex = /^([^:]*?)\s*:\s(.*?)\s*$/
+      raw_group_info.each do |data|
+        group_info << inspec.parse_config(data, assignment_regex: regex).params
+      end
+
+      match_etc_group_output(group_info)
+    end
+
+    # Converts the `dscacheutil` groups to match `inspec.etc_group.entries`
+    def match_etc_group_output(dscacheutil_groups)
+      dscacheutil_groups.each { |g| g['gid'] = g['gid'].to_i }
+
+      # Convert `users` to `members` and ` ` to `,`
+      dscacheutil_groups.each do |g|
+        next if g['users'].nil?
+        g['members'] = g['users']
+        dscacheutil_groups.delete(:users)
+        g['members'].tr!(' ', ',')
+      end
     end
   end
 

--- a/lib/resources/groups.rb
+++ b/lib/resources/groups.rb
@@ -13,15 +13,13 @@ module Inspec::Resources
     # select group provider based on the operating system
     # returns nil, if no group manager was found for the operating system
     def select_group_manager(os)
-      if os.unix?
-        @group_provider = if os.darwin?
-                            DarwinGroup.new(inspec)
-                          else
-                            UnixGroup.new(inspec)
-                          end
-      elsif os.windows?
-        @group_provider = WindowsGroup.new(inspec)
-      end
+      @group_provider = if os.darwin?
+                          DarwinGroup.new(inspec)
+                        elsif os.unix?
+                          UnixGroup.new(inspec)
+                        elsif os.windows?
+                          WindowsGroup.new(inspec)
+                        end
     end
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -307,6 +307,8 @@ class MockLoader
       '27c6cda89fa5d196506251c0ed0d20468b378c5689711981dc1e1e683c7b02c1' => cmd.call('adsiusers'),
       # group info for windows
       'd8d5b3e3355650399e23857a526ee100b4e49e5c2404a0a5dbb7d85d7f4de5cc' => cmd.call('adsigroups'),
+      # group info for Darwin
+      'dscacheutil -q group' => cmd.call('dscacheutil-query-group'),
       # network interface
       'fddd70e8b8510f5fcc0413cfdc41598c55d6922bb2a0a4075e2118633a0bf422' => cmd.call('find-net-interface'),
       'c33821dece09c8b334e03a5bb9daefdf622007f73af4932605e758506584ec3f' => empty.call,

--- a/test/unit/mock/cmd/dscacheutil-query-group
+++ b/test/unit/mock/cmd/dscacheutil-query-group
@@ -1,0 +1,8 @@
+name: humans
+password: *
+gid: 81
+users: bob sue joe
+
+name: root
+password: *
+gid: 0


### PR DESCRIPTION
This allows users to verify groups added by Chef on OS X.

The current method that `UnixGroup` uses is to check the contents of `/etc/group`, but OS X adds groups to Directory Service and not `/etc/group`. This modifies the `group` resource on Darwin to use `dscacheutil` to get group info.

This fixes #2330