### PR TITLE
bugfix: default attributes for nil and false

### DIFF
--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -27,7 +27,7 @@ module Inspec
     end
 
     def default
-      @opts[:default] || DEFAULT_ATTRIBUTE.new
+      @opts.key?(:default) ? @opts[:default] : DEFAULT_ATTRIBUTE.new
     end
 
     def title

--- a/test/unit/objects/attribute_test.rb
+++ b/test/unit/objects/attribute_test.rb
@@ -29,10 +29,19 @@ describe Inspec::Attribute do
   end
 
   describe 'attribute with a default value set' do
-    let(:attribute) { Inspec::Attribute.new('test_attribute', default: 'default_value') }
-
     it 'returns the user-configured default value if no value is assigned' do
+      attribute = Inspec::Attribute.new('test_attribute', default: 'default_value')
       attribute.value.must_equal 'default_value'
+    end
+
+    it 'returns the user-configured default value if no value is assigned (nil)' do
+      attribute = Inspec::Attribute.new('test_attribute', default: nil)
+      attribute.value.must_equal nil
+    end
+
+    it 'returns the user-configured default value if no value is assigned (false)' do
+      attribute = Inspec::Attribute.new('test_attribute', default: false)
+      attribute.value.must_equal false
     end
   end
 end


### PR DESCRIPTION
Traditionally those would translated DEFAULT_ATTRIBUTE. but that was wrong, it should have been nil or false or whatever the user supplied.