### PR TITLE
Add bonding mode matcher to bond resource

### DIFF
--- a/docs/resources/bond.md.erb
+++ b/docs/resources/bond.md.erb
@@ -37,7 +37,7 @@ The following examples show how to use this InSpec audit resource.
 ### Test parameters for bond0
 
     describe bond('bond0') do
-      its('Bonding Mode') { should eq 'IEEE 802.3ad Dynamic link aggregation' }
+      its('mode') { should eq 'IEEE 802.3ad Dynamic link aggregation' }
       its('Transmit Hash Policy') { should eq 'layer3+4 (1)' }
       its('MII Status') { should eq 'up' }
       its('MII Polling Interval (ms)') { should eq '100' }

--- a/docs/resources/bond.md.erb
+++ b/docs/resources/bond.md.erb
@@ -75,6 +75,11 @@ The `interfaces` matcher tests if the named secondary interfaces are available:
 
     its('interfaces') { should eq ['eth0', 'eth1', ...] }
 
+### mode
+The `mode` matcher tests the Bonding Mode:
+
+    its('mode') { should eq 'IEEE 802.3ad Dynamic link aggregation' }
+
 ### params
 
 The `params` matcher tests arbitrary parameters for the bonded network interface:

--- a/lib/resources/bond.rb
+++ b/lib/resources/bond.rb
@@ -58,6 +58,10 @@ module Inspec::Resources
       params['Slave Interface']
     end
 
+    def mode
+      params['Bonding Mode'].first
+    end
+
     def to_s
       "Bond #{@bond}"
     end

--- a/test/unit/resources/bond_test.rb
+++ b/test/unit/resources/bond_test.rb
@@ -11,6 +11,8 @@ describe 'Inspec::Resources::Bond' do
     resource = MockLoader.new(:ubuntu1404).load_resource('bond', 'bond0')
     # bond must be available
     resource.exist?.must_equal true
+    # get bonding mode
+    _(resource.mode).must_equal 'IEEE 802.3ad Dynamic link aggregation'
     # eth0 is part of bond
     _(resource.has_interface?('eth0')).must_equal true
     _(resource.has_interface?('eth1')).must_equal false


### PR DESCRIPTION
- Adds a mode matcher for testing the Bonding Mode of a bonded network interface.
- Updates unit test to use mode matcher.
- Updates documentation to provide an example of mode matcher.

