### PR TITLE
Update apache_conf regular expression to exclude whitespace.

### DIFF
--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -78,10 +78,17 @@ module Inspec::Resources
         raw_conf = read_file(to_read[0])
         @content += raw_conf
 
-        # parse include file parameters
+        # An explaination of the below regular expression.
+        # Creates two capture groups.
+        # The first group captures the first group of non-whitespace character
+        # surrounded whitespace characters.
+        # The second group contains a conditional with a positive lookahead
+        # (does the line end with one or more spaces?). If the lookahead succeeds
+        # a non-greedy capture takes place, if it fails then a greedy capture takes place.
+        # The regex is terminated by an expression that matches zero or more spaces.
         params = SimpleConfig.new(
           raw_conf,
-          assignment_regex: /^\s*(\S+)\s+(.*)\s*$/,
+          assignment_regex: /^\s*(\S+)\s+((?=.*\s+$).*?|.*)\s*$/,
           multiple_values: true,
         ).params
         @params.merge!(params)

--- a/test/unit/mock/files/apache2.conf
+++ b/test/unit/mock/files/apache2.conf
@@ -1,5 +1,6 @@
 # This is the main Apache server configuration file.  It contains comments.
 ServerRoot "/etc/apache2"
+ServerAlias inspec.test www.inspec.test io.inspec.test 
 
 User ${APACHE_RUN_USER}
 Include ports.conf

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -12,7 +12,7 @@ describe 'Inspec::Resources::ApacheConf' do
     _(resource.params).must_be_kind_of Hash
     _(resource.content).must_be_kind_of String
     _(resource.params('ServerRoot')).must_equal ['"/etc/apache2"']
-    _(resource.params('ServerAlias')).must_equal ['inspec.test', 'www.inspec.test', 'io.inspec.test']
+    _(resource.params('ServerAlias')).must_equal ['inspec.test www.inspec.test io.inspec.test']
     _(resource.params('Listen').sort).must_equal ['443', '80']
     # sourced using a linked file in conf-enabled/
     _(resource.params('ServerSignature')).must_equal ['Off']

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -12,6 +12,7 @@ describe 'Inspec::Resources::ApacheConf' do
     _(resource.params).must_be_kind_of Hash
     _(resource.content).must_be_kind_of String
     _(resource.params('ServerRoot')).must_equal ['"/etc/apache2"']
+    _(resource.params('ServerAlias')).must_equal ['inspec.test', 'www.inspec.test', 'io.inspec.test']
     _(resource.params('Listen').sort).must_equal ['443', '80']
     # sourced using a linked file in conf-enabled/
     _(resource.params('ServerSignature')).must_equal ['Off']


### PR DESCRIPTION
This PR updates the regular expression used in apache_conf to use a conditional lookahead to greedily or non-greedily capture configuration values to ensure our values don't end with whitespace.

Thanks to feedback from @adamleff and help from @jerryaldrichiii this fix now works without [modifying SimpleConfig](https://github.com/chef/inspec/pull/2402). =)

Fixes #1241