### PR TITLE
Correct `.where` usage in `passwd` documentation

### DIFF
--- a/docs/resources/passwd.md.erb
+++ b/docs/resources/passwd.md.erb
@@ -59,7 +59,7 @@ The following examples show how to use this InSpec audit resource.
       its('count') { should eq 1 }
     end
 
-    describe passwd.filter(user: 'www-data') do
+    describe passwd.where { user == 'www-data' } do
       its('uids') { should cmp 33 }
       its('count') { should eq 1 }
     end


### PR DESCRIPTION
Current documentation references `.filter` which doesn't exist.

This closes #2417