### PR TITLE
bugfix: dependency chaining in libraries

### DIFF
--- a/lib/inspec/dsl_shared.rb
+++ b/lib/inspec/dsl_shared.rb
@@ -18,6 +18,14 @@ module Inspec
         # We cannot rely on libraries residing on disk however.
         # TODO: Sandboxing.
         content, path, line = @require_loader.load(rbpath)
+
+        # If we are in the realm of libraries and the LibraryEvalContext
+        # we should have access to the __inspec_binding, which is a Binding
+        # context that provides the correct plane to evaluate all required files to.
+        # It will ensure that embedded calls to `require` still call this
+        # method and get loaded from their correct paths.
+        # return __inspec_binding.eval(content, path, line) if defined?(__inspec_binding)
+
         eval(content, TOPLEVEL_BINDING, path, line) # rubocop:disable Security/Eval
       end
     end

--- a/lib/inspec/dsl_shared.rb
+++ b/lib/inspec/dsl_shared.rb
@@ -26,6 +26,7 @@ module Inspec
         # method and get loaded from their correct paths.
         return __inspec_binding.eval(content, path, line) if defined?(__inspec_binding)
 
+        warn("[DEPRECATION] Do not use the `require` keyword in control files. See: https://github.com/chef/inspec/pull/2428")
         eval(content, TOPLEVEL_BINDING, path, line) # rubocop:disable Security/Eval
       end
     end

--- a/lib/inspec/dsl_shared.rb
+++ b/lib/inspec/dsl_shared.rb
@@ -24,7 +24,7 @@ module Inspec
         # context that provides the correct plane to evaluate all required files to.
         # It will ensure that embedded calls to `require` still call this
         # method and get loaded from their correct paths.
-        # return __inspec_binding.eval(content, path, line) if defined?(__inspec_binding)
+        return __inspec_binding.eval(content, path, line) if defined?(__inspec_binding)
 
         eval(content, TOPLEVEL_BINDING, path, line) # rubocop:disable Security/Eval
       end

--- a/lib/inspec/dsl_shared.rb
+++ b/lib/inspec/dsl_shared.rb
@@ -26,7 +26,6 @@ module Inspec
         # method and get loaded from their correct paths.
         return __inspec_binding.eval(content, path, line) if defined?(__inspec_binding)
 
-        warn('[DEPRECATION] Do not use the `require` keyword in control files. See: https://github.com/chef/inspec/pull/2428')
         eval(content, TOPLEVEL_BINDING, path, line) # rubocop:disable Security/Eval
       end
     end

--- a/lib/inspec/dsl_shared.rb
+++ b/lib/inspec/dsl_shared.rb
@@ -26,7 +26,7 @@ module Inspec
         # method and get loaded from their correct paths.
         return __inspec_binding.eval(content, path, line) if defined?(__inspec_binding)
 
-        warn("[DEPRECATION] Do not use the `require` keyword in control files. See: https://github.com/chef/inspec/pull/2428")
+        warn('[DEPRECATION] Do not use the `require` keyword in control files. See: https://github.com/chef/inspec/pull/2428')
         eval(content, TOPLEVEL_BINDING, path, line) # rubocop:disable Security/Eval
       end
     end

--- a/lib/inspec/library_eval_context.rb
+++ b/lib/inspec/library_eval_context.rb
@@ -37,11 +37,22 @@ module Inspec
         include Inspec::DSL::RequireOverride
         def initialize(require_loader)
           @require_loader = require_loader
+          @inspec_binding = nil
+        end
+
+        def __inspec_binding
+          @inspec_binding
         end
       end
 
       c3.const_set(:Inspec, c2)
-      c3.new(require_loader)
+      res = c3.new(require_loader)
+
+      # Provide the local binding for this context which is necessary for
+      # calls to `require` to create all dependent objects in the correct
+      # context.
+      res.instance_variable_set("@inspec_binding", res.instance_eval('binding'))
+      res
     end
   end
 end

--- a/lib/inspec/library_eval_context.rb
+++ b/lib/inspec/library_eval_context.rb
@@ -51,7 +51,7 @@ module Inspec
       # Provide the local binding for this context which is necessary for
       # calls to `require` to create all dependent objects in the correct
       # context.
-      res.instance_variable_set("@inspec_binding", res.instance_eval('binding'))
+      res.instance_variable_set('@inspec_binding', res.instance_eval('binding'))
       res
     end
   end

--- a/test/unit/profiles/library_eval_context_test.rb
+++ b/test/unit/profiles/library_eval_context_test.rb
@@ -37,4 +37,8 @@ EOF
     eval_context.instance_eval(resource_content)
     old_default_registry.must_equal Inspec::Resource.default_registry
   end
+
+  it 'provides an inspec context for requiring local files' do
+    eval_context.__inspec_binding.must_be_kind_of Binding
+  end
 end

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -369,12 +369,25 @@ describe Inspec::ProfileContext do
       profile.load('Net::POP3').to_s.must_equal 'Net::POP3'
     end
 
+    it 'supports creating a simple library file (no require)' do
+      profile.load_libraries([
+        ['module A; end', 'libraries/a.rb']
+      ])
+    end
+
     it 'supports loading across the library' do
       profile.load_libraries([
         ["require 'a'\nA", 'libraries/b.rb'],
         ['module A; end', 'libraries/a.rb']
       ])
-      profile.load('A').to_s.must_equal 'A'
+    end
+
+    it 'supports chain loading across the library' do
+      profile.load_libraries([
+        ["require 'b'\nA", 'libraries/c.rb'],
+        ["require 'a'\nA", 'libraries/b.rb'],
+        ['module A; end', 'libraries/a.rb']
+      ])
     end
 
     it 'fails loading if reference error occur' do

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -370,12 +370,14 @@ describe Inspec::ProfileContext do
     end
 
     it 'supports creating a simple library file (no require)' do
+      # this test will throw an exception if chaining doesn't work
       profile.load_libraries([
         ['module A; end', 'libraries/a.rb']
       ])
     end
 
     it 'supports loading across the library' do
+      # this test will throw an exception if chaining doesn't work
       profile.load_libraries([
         ["require 'a'\nA", 'libraries/b.rb'],
         ['module A; end', 'libraries/a.rb']
@@ -383,6 +385,7 @@ describe Inspec::ProfileContext do
     end
 
     it 'supports chain loading across the library' do
+      # this test will throw an exception if chaining doesn't work
       profile.load_libraries([
         ["require 'b'\nA", 'libraries/c.rb'],
         ["require 'a'\nA", 'libraries/b.rb'],

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -393,6 +393,20 @@ describe Inspec::ProfileContext do
       ])
     end
 
+    it 'supports loading a regular ruby gem' do
+      profile.load_libraries([
+        ["require 'erb'\nERB", 'libraries/a.rb']
+      ])
+    end
+
+    it 'fails if a required gem or lib doesnt exist' do
+      proc {
+        profile.load_libraries([
+          ["require 'erbluuuuub'", 'libraries/a.rb']
+        ])
+      }.must_raise LoadError
+    end
+
     it 'fails loading if reference error occur' do
       proc {
         profile.load_libraries([


### PR DESCRIPTION
InSpec's library loading mechanism has 2 issues we saw recently:
1. It creates objects inside of libraries and exposes them in controls in a highly inconsistent way.
2. It doesn't support dependency chains in libraries.

**1. object exposure**

Inside of libraries it is possible ot create a quasi-global object that becomes accessible in InSpec. This is reflected in the current unit test: https://github.com/chef/inspec/pull/2428/files#diff-68dd3c3283c75f19fd29ca98b5e3f510L377 . This unit test essentially:

```ruby
library/b ---requires---> library/a ---creates---> module A
control/x ---calls---> module A
```

It's pretty to look at, until you realize that it doesn't behave consistently at all:

```ruby
library/a ---creates---> module A
control/x ---calls---> module A ! fails ! because it doesn't exist
```

The reason is that through the call of `require` we attach to the global context and define the module there, which becomes accessible to the control across the eval context boundaries between libraries and controls.

This behavior is not intended! It leads to a number of issues if you think about vendored dependencies. Imagine a library creating such a global object in a vendored dependency. Is it accessible to the dependent profile in a control file? If so, what happens if two child resources depend on different versions of a shared resource? It would lead to a clash which cannot be safely resolved.

To get around the problem, we don't want to expose the objects outside of their library interpretation context. Libraries have a stable interface to expose objects to controls and that is the resources interface. You define resources which then become available.


**2. dependency chaining**

Calling `require` once in a library was tested and resolved correctly. But the file that was required was always interpreted against the global context, which doesn't have the logic around `require`ing files from profiles and their dependencies. Profiles have the wonderful ability to be run from urls, zips, tars, or local folders equally without extracting them, i.e. in memory. This means that we need handling around ruby's `require` method to allow us to define where these files are loaded from. As soon as the first file was called, all embedded `require` calls would not call inspec's `require` method anymore.

To allow for chaining of dependencies we need `require` to behave the same way no matter which file in the library it is called from.


**Solution**

As seen in the PR:
1. Library objects don't leak into controls anymore (inconsisten behavior test removed)
2. Calls to `require` now behave the same way in all library files and allow for chaining of dependencies

Fixes: https://github.com/chef/inspec-aws/issues/138