### PR TITLE
Fix `x509_certificate` integration tests

### DIFF
--- a/test/integration/default/controls/x509_spec.rb
+++ b/test/integration/default/controls/x509_spec.rb
@@ -11,9 +11,9 @@ describe x509_certificate('/tmp/mycert.pem') do
   its('signature_algorithm') { should eq 'sha256WithRSAEncryption' }
   its('validity_in_days') { should_not be < 100 }
   its('validity_in_days') { should be >= 100 }
-  its('subject_dn') { should eq '/C=US/O=Foo Bar/OU=Lab/CN=www.f00bar.com' }
+  its('subject_dn') { should eq '/C=US/ST= /L= /O=Foo Bar/OU=Lab/CN=www.f00bar.com' }
   its('subject.C') { should eq 'US' }
-  its('issuer_dn') { should eq '/C=US/O=Foo Bar/OU=Lab/CN=www.f00bar.com' }
+  its('issuer_dn') { should eq '/C=US/ST= /L= /O=Foo Bar/OU=Lab/CN=www.f00bar.com' }
   its('key_length') { should be >= 2048 }
 end
 


### PR DESCRIPTION
An update to the openssl cookbook modified the defaults for `state` and
`city` in the `openssl_x509` resource. That change modified the output
of `issuer_dn` and `subject_dn` in InSpec's `x509_certificate` resource.

This modifies the expected output of the integration tests to match
these new defaults.

See: https://github.com/chef-cookbooks/openssl/commit/06f790bb34453ccad38ed2bf6c233cd9f2775861