### PR TITLE
Fix Docker build in the Expeditor pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Chef Software, Inc. <docker@chef.io>
 ARG VERSION=1.48.0
 ARG GEM_SOURCE=https://rubygems.org
 
-RUN mkdir /share
+RUN mkdir -p /share
 RUN apk add --update build-base libxml2-dev libffi-dev && \
     gem install --no-document --source ${GEM_SOURCE} --version ${VERSION} inspec && \
     apk del build-base


### PR DESCRIPTION
The new ruby:alpine image already has a /share directory, so our attempt to create one is breaking the Docker builds. This change updates the Dockerfile to try to make the /share directory but silently fail if it's already there.