### PR TITLE
Modify `inspec json` to use `check_mode`

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -36,6 +36,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     o = opts.dup
     o[:ignore_supports] = true
     o[:backend] = Inspec::Backend.create(target: 'mock://')
+    o[:check_mode] = true
 
     profile = Inspec::Profile.for_target(target, o)
     dst = o[:output].to_s

--- a/test/functional/inspec_json_profile_test.rb
+++ b/test/functional/inspec_json_profile_test.rb
@@ -121,4 +121,11 @@ describe 'inspec json' do
       out.exit_status.must_equal 0
     end
   end
+
+  describe 'inspec json with a profile containing only_if' do
+    it 'ignores the `only_if`' do
+      out = inspec('json ' + File.join(profile_path, 'only-if-os-nope'))
+      out.exit_status.must_equal 0
+    end
+  end
 end


### PR DESCRIPTION
This modifies `inspec json` to make it not evaluate code inside of `only_if` blocks.

This closes #2434 