### PR TITLE
package resource: fix NilClass errors on arch linux

### DIFF
--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -64,6 +64,10 @@ module Inspec::Resources
     # returns the package description
     def info
       return @cache if !@cache.nil?
+      # All `@pkgman.info` methods return `{}`. This matches that
+      # behavior if `@pkgman` can't be determined, thus avoiding the
+      # `undefined method 'info' for nil:NilClass` error
+      return {} if @pkgman.nil?
       @pkgman.info(@package_name)
     end
 

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -139,6 +139,7 @@ describe 'Inspec::Resources::Package' do
   # undefined
   it 'verify package handling on unsupported os' do
     resource = MockLoader.new(:undefined).load_resource('package', 'curl')
+    _(resource.info).must_be_empty
     _(resource.resource_skipped?).must_equal true
     _(resource.resource_exception_message).must_equal 'The `package` resource is not supported on your OS yet.'
   end

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -139,7 +139,7 @@ describe 'Inspec::Resources::Package' do
   # undefined
   it 'verify package handling on unsupported os' do
     resource = MockLoader.new(:undefined).load_resource('package', 'curl')
-    _(resource.info).must_be_empty
+    _(resource.info).must_equal({})
     _(resource.resource_skipped?).must_equal true
     _(resource.resource_exception_message).must_equal 'The `package` resource is not supported on your OS yet.'
   end


### PR DESCRIPTION
This modifies `.info` to return `{}` in cases where the package manager cannot be determined. This matches the behavior of `@pkgman.info`.