### PR TITLE
load local dependencies in inspec shell

### DIFF
--- a/docs/shell.md
+++ b/docs/shell.md
@@ -40,6 +40,28 @@ $ inspec shell -t winrm://UserName:Password@windowsmachine:1234  # Login to wind
 $ inspec shell -t docker://container_id # Login to a docker container.
 ```
 
+## Resource packs
+
+The InSpec shell may use additional keywords provided in resource packs.
+A resource pack is a profile that defines new language terms that can
+be used in InSpec. For example, the profile in `examples/profile` in
+the InSpec git repo defines a `gordon_config` resource. To use these
+resources with the InSpec shell, you will need to download and specify
+them as a dependency.
+
+To use the `gordon_config` resource that is provided in the `examples/profile`
+in the InSpec repo you can run the following:
+
+```bash
+inspec shell --depends examples/profile
+```
+
+Once inside the shell your resource will be available:
+
+```ruby
+inspec> gordon_config
+```
+
 ## Using Ruby in InSpec shell
 
 Since InSpec shell is pry based, you may treat the shell as an

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -194,6 +194,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: 'A single command string to run instead of launching the shell'
   option :format, type: :string, default: nil, hide: true,
     desc: 'Which formatter to use: cli, documentation, html, json, json-min, junit, progress'
+  option :depends, type: :array, default: [],
+    desc: 'A list of local folders that are loaded as dependencies (e.g. for resources)'
   def shell_func
     diagnose
     o = opts.dup

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -195,7 +195,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :format, type: :string, default: nil, hide: true,
     desc: 'Which formatter to use: cli, documentation, html, json, json-min, junit, progress'
   option :depends, type: :array, default: [],
-    desc: 'A list of local folders that are loaded as dependencies (e.g. for resources)'
+    desc: 'A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell'
   def shell_func
     diagnose
     o = opts.dup

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -40,6 +40,7 @@ module Inspec
       @conf[:logger] ||= Logger.new(nil)
       @target_profiles = []
       @controls = @conf[:controls] || []
+      @depends = @conf[:depends] || []
       @ignore_supports = @conf[:ignore_supports]
       @create_lockfile = @conf[:create_lockfile]
       @cache = Inspec::Cache.new(@conf[:vendor_cache])
@@ -217,7 +218,7 @@ module Inspec
 
       # Load local profile dependencies. This is used in inspec shell
       # to provide access to local profiles that add resources.
-      @conf['depends']
+      @depends
         .map { |x| Inspec::Profile.for_path(x, { profile_context: ctx }) }
         .each(&:load_libraries)
 

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -214,6 +214,13 @@ module Inspec
       add_target({ 'inspec.yml' => 'name: inspec-shell' })
       our_profile = @target_profiles.first
       ctx = our_profile.runner_context
+
+      # Load local profile dependencies. This is used in inspec shell
+      # to provide access to local profiles that add resources.
+      pros = @conf['depends']
+        .map { |x| Inspec::Profile.for_path(x, { profile_context: ctx }) }
+        .each(&:load_libraries)
+
       ctx.load(command)
     end
 

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -217,7 +217,7 @@ module Inspec
 
       # Load local profile dependencies. This is used in inspec shell
       # to provide access to local profiles that add resources.
-      pros = @conf['depends']
+      @conf['depends']
         .map { |x| Inspec::Profile.for_path(x, { profile_context: ctx }) }
         .each(&:load_libraries)
 

--- a/test/functional/inspec_shell_test.rb
+++ b/test/functional/inspec_shell_test.rb
@@ -14,6 +14,13 @@ describe 'inspec shell tests' do
       out
     end
 
+    it 'loads a dependency' do
+      res = inspec("shell -c 'gordon_config' --depends #{example_profile}")
+      res.stderr.must_equal ''
+      res.exit_status.must_equal 0
+      res.stdout.chop.must_equal 'gordon_config'
+    end
+
     it 'confirm file caching is disabled' do
       out = do_shell_c('inspec.backend.cache_enabled?(:file)', 0)
       out.stdout.chop.must_equal 'false'
@@ -135,6 +142,13 @@ describe 'inspec shell tests' do
       #out.stderr.must_equal stderr
       out.exit_status.must_equal exit_status
       out
+    end
+
+    it 'loads a dependency' do
+      cmd = "echo 'gordon_config' | #{exec_inspec} shell --depends #{example_profile}"
+      res = CMD.run_command(cmd)
+      res.exit_status.must_equal 0
+      res.stdout.must_include "=> gordon_config"
     end
 
     it 'displays the target device information for the user without requiring the help command' do


### PR DESCRIPTION
for loading dependencies from local folders. mainly used for development.

![depends](https://user-images.githubusercontent.com/1307529/34507973-056dd91c-eff0-11e7-8a87-fcca663cb40b.gif)

Fixes #1486 