### PR TITLE
Update the inspec support check to warn to stderr.

### DIFF
--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -56,7 +56,7 @@ module Inspec
     def inspec_requirement
       inspec_in_supports = params[:supports].find { |x| !x[:inspec].nil? }
       if inspec_in_supports
-        Inspec::Log.warn '[DEPRECATED] The use of inspec.yml `supports:inspec` is deprecated and will be removed in InSpec 2.0. Please use `inspec_version` instead.'
+        warn '[DEPRECATED] The use of inspec.yml `supports:inspec` is deprecated and will be removed in InSpec 2.0. Please use `inspec_version` instead.'
         Gem::Requirement.create(inspec_in_supports[:inspec])
       else
         # using Gem::Requirement here to allow nil values which

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -42,7 +42,7 @@ describe 'example inheritance profile' do
       File.exist?(File.join(dir, 'inspec.lock')).must_equal true
 
       out = inspec('exec ' + dir + ' -l debug --no-create-lockfile')
-      out.stderr.must_equal ''
+      out.stderr.must_equal "[DEPRECATED] The use of inspec.yml `supports:inspec` is deprecated and will be removed in InSpec 2.0. Please use `inspec_version` instead.\n"
       out.stdout.must_include 'Using cached dependency for {:url=>"https://github.com/dev-sec/ssh-baseline/archive/master.tar.gz"'
       out.stdout.must_include 'Using cached dependency for {:url=>"https://github.com/dev-sec/ssl-baseline/archive/master.tar.gz"'
       out.stdout.must_include 'Using cached dependency for {:url=>"https://github.com/chris-rock/windows-patch-benchmark/archive/master.tar.gz"'


### PR DESCRIPTION
This change makes the deprecation warning for inspec version check output to stderr instead of stdout.
![screen shot 2018-01-05 at 2 23 24 pm](https://user-images.githubusercontent.com/574637/34624634-067c9bd2-f224-11e7-9b56-dec48efeb9bc.png)


Signed-off-by: Jared Quick <jquick@chef.io>