### PR TITLE
Update left-hand nav link to point to Downloads

### DIFF
--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -5,7 +5,7 @@ sidebar_links:
   - title: Overview
     link: "/docs"
   - title: Get InSpec
-    link: "https://downloads.chef.io/inspec"
+    link: "/downloads"
   - title: Tutorials
     link: "/tutorials"
   - title: InSpec and friends


### PR DESCRIPTION
The Get InSpec link points to the donwloads.chef.io page rather than
our local downloads page.

Fixes #2442 
  