### PR TITLE
Markdown titles sometimes need underscores escaped

### DIFF
--- a/docs/resources/etc_hosts_allow.md.erb
+++ b/docs/resources/etc_hosts_allow.md.erb
@@ -2,7 +2,7 @@
 title: About the etc_hosts_allow Resource
 ---
 
-# etc_hosts_allow
+# etc\_hosts\_allow
 
 Use the `etc_hosts_allow` InSpec audit resource to test rules set to accept daemon and client traffic set in /etc/hosts.allow file.
 

--- a/docs/resources/etc_hosts_deny.md.erb
+++ b/docs/resources/etc_hosts_deny.md.erb
@@ -2,7 +2,7 @@
 title: About the etc_hosts_deny Resource
 ---
 
-# etc_hosts_deny
+# etc\_hosts\_deny
 
 Use the `etc_hosts_deny` InSpec audit resource to test rules set to reject daemon and client traffic set in /etc/hosts.deny.
 

--- a/docs/resources/postgres_hba_conf.md.erb
+++ b/docs/resources/postgres_hba_conf.md.erb
@@ -2,7 +2,7 @@
 title: About the postgres_hba_conf Resource
 ---
 
-# postgres_hba_conf
+# postgres\_hba\_conf
 
 Use the `postgres_hba_conf` InSpec audit resource to test the client authentication data defined in the pg_hba.conf file.
 

--- a/docs/resources/postgres_ident_conf.md.erb
+++ b/docs/resources/postgres_ident_conf.md.erb
@@ -2,7 +2,7 @@
 title: About the postgres_ident_conf Resource
 ---
 
-# postgres_ident_conf
+# postgres\_ident\_conf
 
 Use the `postgres_ident_conf` InSpec audit resource to test the client authentication data defined in the pg_hba.conf file.
 

--- a/docs/resources/windows_hotfix.md.erb
+++ b/docs/resources/windows_hotfix.md.erb
@@ -2,6 +2,8 @@
 title: About the windows_hotfix Resource
 ---
 
+# windows_hotfix
+
 Use the `windows_hotfix` InSpec audit resource to test if the hotfix has been installed on a Windows system.
 
 <br>


### PR DESCRIPTION
When a header includes two `_`s, they must be escaped, otherwise, the
text between the two `_`s is rendered with emphasis.  E.g.,

`<h1 id="etchostsallow">etc<em>hosts</em>allow</h1>`

Escaping the `_`s fixes this and the header is rendered properly.

This is a fix for:

* etc_hosts_allow
* etc_hosts_deny
* postgres_hba_conf
* postgres_ident_conf

This change also adds the `h1` title to the windows_hotfix resource
page.

Signed-off-by: Nathen Harvey <nharvey@chef.io>