### PR TITLE
Bump Omnibus Ruby (and Travis Rubies) to 2.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,40 +16,40 @@ before_install:
 - bundle --version
 matrix:
   include:
-  - rvm: 2.3.5
-  - rvm: 2.4.2
-  - rvm: 2.4.2
+  - rvm: 2.3.6
+  - rvm: 2.4.3
+  - rvm: 2.4.3
     script: bundle exec rake $SUITE
     env: SUITE="test:functional"
-  - rvm: 2.4.2
+  - rvm: 2.4.3
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration OS=default-ubuntu-1204 DOCKER=true
-  - rvm: 2.4.2
+  - rvm: 2.4.3
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration OS='default-ubuntu-1604' DOCKER=true
-  - rvm: 2.4.2
+  - rvm: 2.4.3
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration OS='default-centos-68' DOCKER=true
-  - rvm: 2.4.2
+  - rvm: 2.4.3
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration OS='default-centos-7' DOCKER=true
-  - rvm: 2.4.2
+  - rvm: 2.4.3
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration OS='default-debian-8' DOCKER=true
-  - rvm: 2.4.2
+  - rvm: 2.4.3
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration OS='default-oracle-72' DOCKER=true
-  - rvm: 2.4.2
+  - rvm: 2.4.3
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration OS='default-fedora-24' DOCKER=true
-  - rvm: 2.4.2
+  - rvm: 2.4.3
     sudo: false
     cache:
       apt: true

--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -37,7 +37,7 @@ end
 build_version Inspec::VERSION
 build_iteration 1
 
-override 'ruby', version: '2.4.2'
+override 'ruby', version: '2.4.3'
 # RubyGems 2.7.0 caused issues in the Jenkins pipelines, trouble installing bundler.
 # This issue is not evident in 2.6.x, hence the pin.
 override 'rubygems', version: '2.6.14'


### PR DESCRIPTION
Addresses CVE-2017-17405.

Signed-off-by: Adam Leff <adam@leff.co>