### PR TITLE
http resource: make header keys case insensitive

### DIFF
--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -241,20 +241,11 @@ module Inspec::Resources
       end
 
       def [](requested_key)
-        unless requested_key.match(/[[:upper:]]/).nil?
-          warn '[DEPRECATION] HTTP resource: only use lower-case letters when specifying a header name.'
-        end
-
         fetch(requested_key.downcase, nil)
       end
 
       def method_missing(requested_key)
-        requested_key = requested_key.to_s
-        unless requested_key.match(/[[:upper:]]/).nil?
-          warn '[DEPRECATION] HTTP resource: only use lower-case letters when specifying a header name.'
-        end
-
-        fetch(requested_key.downcase, nil)
+        fetch(requested_key.to_s.downcase, nil)
       end
     end
   end

--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -47,7 +47,7 @@ module Inspec::Resources
     end
 
     def headers
-      Hashie::Mash.new(@worker.response_headers)
+      @headers ||= Inspec::Resources::Http::Headers.create(@worker.response_headers)
     end
 
     def body
@@ -232,6 +232,29 @@ module Inspec::Resources
 
           cmd.join(' ')
         end
+      end
+    end
+
+    class Headers < Hash
+      def self.create(header_data)
+        header_data.each_with_object(new) { |(k, v), memo| memo[k.to_s.downcase] = v }
+      end
+
+      def [](requested_key)
+        unless requested_key.match(/[[:upper:]]/).nil?
+          warn '[DEPRECATION] HTTP resource: only use lower-case letters when specifying a header name.'
+        end
+
+        fetch(requested_key.downcase, nil)
+      end
+
+      def method_missing(requested_key)
+        requested_key = requested_key.to_s
+        unless requested_key.match(/[[:upper:]]/).nil?
+          warn '[DEPRECATION] HTTP resource: only use lower-case letters when specifying a header name.'
+        end
+
+        fetch(requested_key.downcase, nil)
       end
     end
   end

--- a/test/unit/resources/http_test.rb
+++ b/test/unit/resources/http_test.rb
@@ -128,4 +128,40 @@ describe 'Inspec::Resources::Http' do
       end
     end
   end
+
+  describe 'Inspec::Resource::Http::Headers' do
+    let(:headers) { Inspec::Resources::Http::Headers.create(a: 1, B: 2, 'c' => 3, 'D' => 4) }
+
+    it 'returns the correct data via hash syntax ensuring case-insensitive keys' do
+      headers['a'].must_equal(1)
+      headers['A'].must_equal(1)
+      headers['b'].must_equal(2)
+      headers['B'].must_equal(2)
+      headers['c'].must_equal(3)
+      headers['C'].must_equal(3)
+      headers['d'].must_equal(4)
+      headers['D'].must_equal(4)
+    end
+
+    it 'returns the correct data via method syntax ensuring case-insensitive keys' do
+      headers.a.must_equal(1)
+      headers.A.must_equal(1)
+      headers.b.must_equal(2)
+      headers.B.must_equal(2)
+      headers.c.must_equal(3)
+      headers.C.must_equal(3)
+      headers.d.must_equal(4)
+      headers.D.must_equal(4)
+    end
+
+    it 'emits a warning when an upper-case parameter is provided' do
+      headers.expects(:warn).with('[DEPRECATION] HTTP resource: only use lower-case letters when specifying a header name.')
+      headers.A
+    end
+
+    it 'does not emit a warning when an upper-case parameter is provided' do
+      headers.expects(:warn).never
+      headers.a
+    end
+  end
 end

--- a/test/unit/resources/http_test.rb
+++ b/test/unit/resources/http_test.rb
@@ -153,15 +153,5 @@ describe 'Inspec::Resources::Http' do
       headers.d.must_equal(4)
       headers.D.must_equal(4)
     end
-
-    it 'emits a warning when an upper-case parameter is provided' do
-      headers.expects(:warn).with('[DEPRECATION] HTTP resource: only use lower-case letters when specifying a header name.')
-      headers.A
-    end
-
-    it 'does not emit a warning when an upper-case parameter is provided' do
-      headers.expects(:warn).never
-      headers.a
-    end
   end
 end


### PR DESCRIPTION
HTTP header keys are currently case-sensitive, and the local and remote workers currently store the keys in different formats due to the different tools generating them.

This change ensures the ability to fetch headers by key is case-insensitive.

Fixes #2453