### PR TITLE
pip resource docs: mention custom path to pip

### DIFF
--- a/docs/resources/pip.md.erb
+++ b/docs/resources/pip.md.erb
@@ -40,6 +40,13 @@ The following examples show how to use this InSpec audit resource.
       its('version') { should eq '2.8' }
     end
 
+### Test packages installed into a non-default location (e.g. virtualenv) by passing a custom path to pip executable
+
+    describe pip('Jinja2', '/path/to/bin/pip') do
+      it { should be_installed }
+      its('version') { should eq '2.8' }
+    end
+
 <br>
 
 ## Matchers


### PR DESCRIPTION
... as introduced by GH-2097

The docs lacks a note on how to pass a custom path to the `pip` resource, which is especially useful when checking packages within virtualenv's or if python2/python3 (pip2/pip3) is installed on the same system.

Signed-off-by: Markus Grobelin <grobi@koppzu.de>