### PR TITLE
Update security_policy resource to return Names, not SIDs

### DIFF
--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -154,7 +154,7 @@ module Inspec::Resources
         if @translate_sid
           val.split(',').map { |v|
             object_name = inspec.command("(New-Object System.Security.Principal.SecurityIdentifier(\"#{v.sub('*S', 'S')}\")).Translate( [System.Security.Principal.NTAccount]).Value").stdout.to_s.strip
-            object_name.blank? ? v.sub('*S', 'S') : object_name
+            object_name.empty? || object_name.nil? ? v.sub('*S', 'S') : object_name
           }
         else
           val.split(',').map { |v|

--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -151,10 +151,10 @@ module Inspec::Resources
         val.to_i
       # special handling for SID array
       elsif val =~ /[,]{0,1}\*\S/
-        if (@translate_sid)
+        if @translate_sid
           val.split(',').map { |v|
-              temp = inspec.command("(New-Object System.Security.Principal.SecurityIdentifier(\"#{v.sub('*S', 'S')}\")).Translate( [System.Security.Principal.NTAccount]).Value").stdout.to_s.strip
-              v = temp.blank? ? v.sub('*S', 'S') : temp
+            temp = inspec.command("(New-Object System.Security.Principal.SecurityIdentifier(\"#{v.sub('*S', 'S')}\")).Translate( [System.Security.Principal.NTAccount]).Value").stdout.to_s.strip
+            temp.blank? ? v.sub('*S', 'S') : temp
           }
         else
           val.split(',').map { |v|

--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -74,7 +74,15 @@ module Inspec::Resources
       describe security_policy do
         its('SeNetworkLogonRight') { should include 'S-1-5-11' }
       end
+
+      describe security_policy(translate_sid: true) do
+        its('SeNetworkLogonRight') { should include 'NT AUTHORITY\\Authenticated Users' }
+      end
     "
+
+    def initialize(pars = {})
+      @translate_sid = pars[:translate_sid] || false
+    end
 
     def content
       read_content
@@ -142,10 +150,17 @@ module Inspec::Resources
       if val =~ /^\d+$/
         val.to_i
       # special handling for SID array
-      elsif val =~ /^\*\S/
-        val.split(',').map { |v|
-          v.sub('*S', 'S')
-        }
+      elsif val =~ /[,]{0,1}\*\S/
+        if (@translate_sid)
+          val.split(',').map { |v|
+              temp = inspec.command("(New-Object System.Security.Principal.SecurityIdentifier(\"#{v.sub('*S', 'S')}\")).Translate( [System.Security.Principal.NTAccount]).Value").stdout.to_s.strip
+              v = temp.blank? ? v.sub('*S', 'S') : temp
+          }
+        else
+          val.split(',').map { |v|
+            v.sub('*S', 'S')
+          }
+        end
       # special handling for string values with "
       elsif !(m = /^\"(.*)\"$/.match(val)).nil?
         m[1]

--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -153,8 +153,8 @@ module Inspec::Resources
       elsif val =~ /[,]{0,1}\*\S/
         if @translate_sid
           val.split(',').map { |v|
-            temp = inspec.command("(New-Object System.Security.Principal.SecurityIdentifier(\"#{v.sub('*S', 'S')}\")).Translate( [System.Security.Principal.NTAccount]).Value").stdout.to_s.strip
-            temp.blank? ? v.sub('*S', 'S') : temp
+            object_name = inspec.command("(New-Object System.Security.Principal.SecurityIdentifier(\"#{v.sub('*S', 'S')}\")).Translate( [System.Security.Principal.NTAccount]).Value").stdout.to_s.strip
+            object_name.blank? ? v.sub('*S', 'S') : object_name
           }
         else
           val.split(',').map { |v|

--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -80,8 +80,8 @@ module Inspec::Resources
       end
     "
 
-    def initialize(pars = {})
-      @translate_sid = pars[:translate_sid] || false
+    def initialize(opts = {})
+      @translate_sid = opts[:translate_sid] || false
     end
 
     def content

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -480,8 +480,8 @@ class MockLoader
       "curl -H 'Content-Type: application/json' http://elasticsearch.mycompany.biz:1234/_nodes" => cmd.call('elasticsearch-cluster-url'),
 
       #security_policy resource SID translation
-      "New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-544\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-translated'),
-      "New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-555\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-untranslated'),
+      "(New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-544\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-translated'),
+      "(New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-555\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-untranslated'),
     }
     @backend
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -481,7 +481,7 @@ class MockLoader
 
       #security_policy resource SID translation
       "New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-544\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-translated'),
-      "New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-555\")).Translate( [System.Security.Principal.NTAccount]).Value" => empty.call,
+      "New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-555\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-untranslated'),
     }
     @backend
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -483,7 +483,7 @@ class MockLoader
       "(New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-544\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-translated'),
       "(New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-555\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-untranslated'),
     }
-    @bacgitkend
+    @backend
   end
 
   # loads a resource class and instantiates the class with the given arguments

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -478,6 +478,10 @@ class MockLoader
       "curl -k -H 'Content-Type: application/json' http://localhost:9200/_nodes" => cmd.call('elasticsearch-cluster-no-ssl'),
       "curl -H 'Content-Type: application/json'  -u es_admin:password http://localhost:9200/_nodes" => cmd.call('elasticsearch-cluster-auth'),
       "curl -H 'Content-Type: application/json' http://elasticsearch.mycompany.biz:1234/_nodes" => cmd.call('elasticsearch-cluster-url'),
+
+      #security_policy resource SID translation
+      "New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-544\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('securitt-policy-sid-translated'),
+      "curl -H 'Content-Type: application/json' http://localhost:9200/_nodes" => empty.call,
     }
     @backend
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -222,9 +222,6 @@ class MockLoader
       'ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command' => cmd.call('ps-axoZ'),
       'ps -o pid,vsz,rss,tty,stat,time,ruser,args' => cmd.call('ps-busybox'),
       'ps --help' => empty.call,
-      'Get-Content win_secpol-abc123.cfg' => cmd.call('secedit-export'),
-      'secedit /export /cfg win_secpol-abc123.cfg' => cmd.call('success'),
-      'Remove-Item win_secpol-abc123.cfg' => cmd.call('success'),
       'env' => cmd.call('env'),
       '${Env:PATH}'  => cmd.call('$env-PATH'),
       # registry key test using winrm 2.0
@@ -479,11 +476,14 @@ class MockLoader
       "curl -H 'Content-Type: application/json'  -u es_admin:password http://localhost:9200/_nodes" => cmd.call('elasticsearch-cluster-auth'),
       "curl -H 'Content-Type: application/json' http://elasticsearch.mycompany.biz:1234/_nodes" => cmd.call('elasticsearch-cluster-url'),
 
-      #security_policy resource SID translation
+      #security_policy resource calls
+      'Get-Content win_secpol-abc123.cfg' => cmd.call('secedit-export'),
+      'secedit /export /cfg win_secpol-abc123.cfg' => cmd.call('success'),
+      'Remove-Item win_secpol-abc123.cfg' => cmd.call('success'),
       "(New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-544\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-translated'),
       "(New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-555\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-untranslated'),
     }
-    @backend
+    @bacgitkend
   end
 
   # loads a resource class and instantiates the class with the given arguments

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -480,7 +480,7 @@ class MockLoader
       "curl -H 'Content-Type: application/json' http://elasticsearch.mycompany.biz:1234/_nodes" => cmd.call('elasticsearch-cluster-url'),
 
       #security_policy resource SID translation
-      "New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-544\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('securitt-policy-sid-translated'),
+      "New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-544\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-translated'),
       "curl -H 'Content-Type: application/json' http://localhost:9200/_nodes" => empty.call,
     }
     @backend

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -481,7 +481,7 @@ class MockLoader
 
       #security_policy resource SID translation
       "New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-544\")).Translate( [System.Security.Principal.NTAccount]).Value" => cmd.call('security-policy-sid-translated'),
-      "curl -H 'Content-Type: application/json' http://localhost:9200/_nodes" => empty.call,
+      "New-Object System.Security.Principal.SecurityIdentifier(\"S-1-5-32-555\")).Translate( [System.Security.Principal.NTAccount]).Value" => empty.call,
     }
     @backend
   end

--- a/test/unit/mock/cmd/security-policy-sid-translated
+++ b/test/unit/mock/cmd/security-policy-sid-translated
@@ -1,0 +1,1 @@
+BUILTIN\Administrators

--- a/test/unit/resources/security_policy_test.rb
+++ b/test/unit/resources/security_policy_test.rb
@@ -29,7 +29,7 @@ describe 'Inspec::Resources::SecurityPolicy' do
   end
 
   it 'verify sids are successfully translated or returned SID' do
-    resource = load_resource('security_policy(translate_sid: true)')
+    resource = load_resource('security_policy', translate_sid: true)
     Process.expects(:pid).returns('abc123')
 
     _(resource.MaximumPasswordAge).must_equal 42

--- a/test/unit/resources/security_policy_test.rb
+++ b/test/unit/resources/security_policy_test.rb
@@ -27,4 +27,14 @@ describe 'Inspec::Resources::SecurityPolicy' do
     _(resource.SeUndockPrivilege).must_equal []
     _(resource.SeRemoteInteractiveLogonRight).must_equal []
   end
+
+  it 'verify sids are successfully translated or returned SID' do
+    resource = load_resource('security_policy(translate_sid: true)')
+    Process.expects(:pid).returns('abc123')
+
+    _(resource.MaximumPasswordAge).must_equal 42
+    _(resource.send('MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Setup\RecoveryConsole\SecurityLevel')).must_equal '4,0'
+    _(resource.SeUndockPrivilege).must_equal ["BUILTIN\\Administrators"]
+    _(resource.SeRemoteInteractiveLogonRight).must_equal ["BUILTIN\\Administrators","S-1-5-32-555"]
+  end
 end


### PR DESCRIPTION
Added possibility to translate SID to human-readable name. As it would be a breaking change, i added optional 'translate_sid' param to the resource.

Calling the resource 
```ruby
security_policy
```
would return previous output.

Calling it 
```ruby
security_policy(translate_sid: true)
```
will attempt to translate sid to human-readable name.

For example
```ruby
describe security_policy(translate_sid: true) do       
  its('SeNetworkLogonRight') { should include "NT AUTHORITY\\Authenticated Users" }
end
```
will return

>  Security Policy
>      [PASS]  SeNetworkLogonRight should include "NT AUTHORITY\\Authenticated Users"

