### PR TITLE
package resource: Add architecture support

### DIFF
--- a/docs/resources/package.md.erb
+++ b/docs/resources/package.md.erb
@@ -118,8 +118,8 @@ You can also use the `cmp OPERATOR` matcher to perform comparisions using the ve
 
 `cmp` understands version numbers using Gem::Version, and can use the operators `==, <, <=, >=, and >`.  It will compare versions by each segment, not as a string - so '7.4' is smaller than '7.30', for example.
 
-### architecture
+### arch
 
-The `architecture` matcher tests the named package's architecture on the system:
+The `arch` matcher tests the named package's architecture on the system:
 
-its('architecture') { should incluce 'x86_64' }
+its('arch') { should incluce 'x86_64' }

--- a/docs/resources/package.md.erb
+++ b/docs/resources/package.md.erb
@@ -116,4 +116,10 @@ You can also use the `cmp OPERATOR` matcher to perform comparisions using the ve
 
     its('version') { should cmp >= '7.35.0-1ubuntu3.10' }
 
-`cmp` understands version numbers using Gem::Version, and can use the operators `==, <, <=, >=, and >`.  It will compare versions by each segment, not as a string - so '7.4' is smaller than '7.30', for example.  
+`cmp` understands version numbers using Gem::Version, and can use the operators `==, <, <=, >=, and >`.  It will compare versions by each segment, not as a string - so '7.4' is smaller than '7.30', for example.
+
+### architecture
+
+The `architecture` matcher tests the named package's architecture on the system:
+
+its('architecture') { should incluce 'x86_64' }

--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -78,9 +78,9 @@ module Inspec::Resources
     end
 
     # return the package architecture
-    def architecture
+    def arch
       info = @pkgman.info(@package_name)
-      info[:architecture]
+      info[:arch]
     end
 
     def to_s
@@ -109,15 +109,15 @@ module Inspec::Resources
     end
 
     def extract_architecture(text, key)
-      architecture = SimpleConfig.new(
+      arch = SimpleConfig.new(
         text,
         assignment_regex: /^\s*(#{key})\s*:\s*(.*?)\s*$/,
         multiple_values: true,
       ).params[key]
 
       # For user experience, convert output to a string instead of `['x86_64']`
-      return architecture[0] if architecture.length == 1
-      architecture
+      return arch[0] if arch.length == 1
+      arch
     end
   end
 
@@ -143,7 +143,7 @@ module Inspec::Resources
         installed: params['Status'].split(' ')[2] == 'installed',
         held: params['Status'].split(' ')[0] == 'hold',
         version: params['Version'],
-        architecture: extract_architecture(cmd_output, 'Architecture'),
+        arch: extract_architecture(cmd_output, 'Architecture'),
         type: 'deb',
       }
     end
@@ -197,7 +197,7 @@ module Inspec::Resources
         name: params['Name'],
         installed: true,
         version: "#{v}-#{r}",
-        architecture: extract_architecture(cmd_output, 'Architecture'),
+        arch: extract_architecture(cmd_output, 'Architecture'),
         type: 'rpm',
       }
     end
@@ -253,7 +253,7 @@ module Inspec::Resources
         name: params['Name'],
         installed: true,
         version: params['Version'],
-        architecture: extract_architecture(cmd_output, 'Architecture'),
+        arch: extract_architecture(cmd_output, 'Architecture'),
         type: 'pacman',
       }
     end
@@ -360,7 +360,7 @@ module Inspec::Resources
         name: params['PKGINST'],
         installed: true,
         version: v[0] + '-' + v[1].split('=')[1],
-        architecture: extract_architecture(cmd_output, 'ARCH'),
+        arch: extract_architecture(cmd_output, 'ARCH'),
         type: 'pkg',
       }
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -231,6 +231,7 @@ class MockLoader
       'dpkg -s curl' => cmd.call('dpkg-s-curl'),
       'dpkg -s held-package' => cmd.call('dpkg-s-held-package'),
       'rpm -qia curl' => cmd.call('rpm-qia-curl'),
+      'rpm -qia compat-libstdc++-33' => cmd.call('rpm-qia-compat-libstdc++-33'),
       'rpm -qia --dbpath /var/lib/fake_rpmdb curl' => cmd.call('rpm-qia-curl'),
       'rpm -qia --dbpath /var/lib/rpmdb_does_not_exist curl' => cmd_exit_1,
       'pacman -Qi curl' => cmd.call('pacman-qi-curl'),

--- a/test/unit/mock/cmd/rpm-qia-compat-libstdc++-33
+++ b/test/unit/mock/cmd/rpm-qia-compat-libstdc++-33
@@ -1,0 +1,40 @@
+Name        : compat-libstdc++-33
+Version     : 3.2.3
+Release     : 72.el7
+Architecture: i686
+Install Date: Wed 17 Jan 2018 07:41:11 AM UTC
+Group       : System Environment/Libraries
+Size        : 739520
+License     : GPLv2+ with exceptions
+Signature   : RSA/SHA256, Sat 14 Mar 2015 07:42:42 AM UTC, Key ID 24c6a8a7f4a80eb5
+Source RPM  : compat-gcc-32-3.2.3-72.el7.src.rpm
+Build Date  : Thu 05 Mar 2015 10:51:50 PM UTC
+Build Host  : worker1.bsys.centos.org
+Relocations : (not relocatable)
+Packager    : CentOS BuildSystem <http://bugs.centos.org>
+Vendor      : CentOS
+URL         : http://gcc.gnu.org
+Summary     : Compatibility standard C++ libraries
+Description :
+The compat-libstdc++ package contains compatibility standard C++ library
+from GCC 3.3.4.
+Name        : compat-libstdc++-33
+Version     : 3.2.3
+Release     : 72.el7
+Architecture: x86_64
+Install Date: Wed 17 Jan 2018 07:41:18 AM UTC
+Group       : System Environment/Libraries
+Size        : 830776
+License     : GPLv2+ with exceptions
+Signature   : RSA/SHA256, Sat 14 Mar 2015 07:42:43 AM UTC, Key ID 24c6a8a7f4a80eb5
+Source RPM  : compat-gcc-32-3.2.3-72.el7.src.rpm
+Build Date  : Thu 05 Mar 2015 11:04:10 PM UTC
+Build Host  : worker1.bsys.centos.org
+Relocations : (not relocatable)
+Packager    : CentOS BuildSystem <http://bugs.centos.org>
+Vendor      : CentOS
+URL         : http://gcc.gnu.org
+Summary     : Compatibility standard C++ libraries
+Description :
+The compat-libstdc++ package contains compatibility standard C++ library
+from GCC 3.3.4.

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -9,37 +9,68 @@ describe 'Inspec::Resources::Package' do
   # arch linux
   it 'verify arch linux package parsing' do
     resource = MockLoader.new(:arch).load_resource('package', 'curl')
-    pkg = { name: 'curl', installed: true, version: '7.37.0-1', type: 'pacman' }
+    pkg = {
+      name: 'curl',
+      installed: true,
+      version: '7.37.0-1',
+      architecture: 'x86_64',
+      type: 'pacman',
+    }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal '7.37.0-1'
+    _(resource.architecture).must_equal 'x86_64'
     _(resource.info).must_equal pkg
   end
 
   # ubuntu
   it 'verify ubuntu package parsing' do
     resource = MockLoader.new(:ubuntu1404).load_resource('package', 'curl')
-    pkg = { name: 'curl', installed: true, held: false, version: '7.35.0-1ubuntu2', type: 'deb' }
+    pkg = {
+      name: 'curl',
+      installed: true,
+      held: false,
+      version: '7.35.0-1ubuntu2',
+      architecture: 'amd64',
+      type: 'deb',
+    }
     _(resource.installed?).must_equal true
     _(resource.held?).must_equal false
     _(resource.version).must_equal '7.35.0-1ubuntu2'
+    _(resource.architecture).must_equal 'amd64'
     _(resource.info).must_equal pkg
   end
 
   it 'verify ubuntu package which is held' do
     resource = MockLoader.new(:ubuntu1404).load_resource('package', 'held-package')
-    pkg = { name: 'held-package', installed: true, held: true, version: '1.2.3-1', type: 'deb' }
+    pkg = {
+      name: 'held-package',
+      installed: true,
+      held: true,
+      version: '1.2.3-1',
+      architecture: 'amd64',
+      type: 'deb',
+    }
     _(resource.installed?).must_equal true
     _(resource.held?).must_equal true
     _(resource.version).must_equal '1.2.3-1'
+    _(resource.architecture).must_equal 'amd64'
     _(resource.info).must_equal pkg
   end
 
   # mint
   it 'verify mint package parsing' do
     resource = MockLoader.new(:mint17).load_resource('package', 'curl')
-    pkg = { name: 'curl', installed: true, held: false, version: '7.35.0-1ubuntu2', type: 'deb' }
+    pkg = {
+      name: 'curl',
+      installed: true,
+      held: false,
+      version: '7.35.0-1ubuntu2',
+      architecture: 'amd64',
+      type: 'deb',
+    }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal '7.35.0-1ubuntu2'
+    _(resource.architecture).must_equal 'amd64'
     _(resource.info).must_equal pkg
   end
 
@@ -50,6 +81,7 @@ describe 'Inspec::Resources::Package' do
         name: 'curl',
         installed: true,
         version: '7.29.0-19.el7',
+        architecture: 'x86_64',
         type: 'rpm',
       }
     end
@@ -58,6 +90,23 @@ describe 'Inspec::Resources::Package' do
       resource = MockLoader.new(:centos7).load_resource('package', 'curl')
       _(resource.installed?).must_equal true
       _(resource.version).must_equal '7.29.0-19.el7'
+      _(resource.architecture).must_equal 'x86_64'
+      _(resource.info).must_equal pkg
+    end
+
+    it 'can parse the correct architecture info whem multiple are present' do
+      pkg = {
+        name: 'compat-libstdc++-33',
+        installed: true,
+        version: '3.2.3-72.el7',
+        architecture: ['i686', 'x86_64'],
+        type: 'rpm',
+      }
+      resource = MockLoader.new(:centos7).load_resource('package', pkg[:name])
+      _(resource.installed?).must_equal true
+      _(resource.version).must_equal '3.2.3-72.el7'
+      _(resource.architecture).must_include 'i686'
+      _(resource.architecture).must_include 'x86_64'
       _(resource.info).must_equal pkg
     end
 
@@ -94,9 +143,17 @@ describe 'Inspec::Resources::Package' do
   # wrlinux
   it 'verify wrlinux package parsing' do
     resource = MockLoader.new(:wrlinux).load_resource('package', 'curl')
-    pkg = { name: 'curl', installed: true, version: '7.29.0-19.el7', type: 'rpm' }
+    pkg = {
+      name: 'curl',
+      architecture: 'x86_64',
+      installed: true,
+      version: '7.29.0-19.el7',
+      type: 'rpm',
+    }
+
     _(resource.installed?).must_equal true
     _(resource.version).must_equal '7.29.0-19.el7'
+    _(resource.architecture).must_equal 'x86_64'
     _(resource.info).must_equal pkg
   end
 
@@ -112,9 +169,16 @@ describe 'Inspec::Resources::Package' do
   # solaris 10
   it 'verify solaris 10 package parsing' do
     resource = MockLoader.new(:solaris10).load_resource('package', 'SUNWzfsr')
-    pkg = { name: 'SUNWzfsr', installed: true, version: '11.10.0-2006.05.18.01.46', type: 'pkg' }
+    pkg = {
+      name: 'SUNWzfsr',
+      installed: true,
+      version: '11.10.0-2006.05.18.01.46',
+      architecture: 'i386',
+      type: 'pkg',
+    }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal '11.10.0-2006.05.18.01.46'
+    _(resource.architecture).must_equal 'i386'
     _(resource.info).must_equal pkg
   end
 

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -13,12 +13,12 @@ describe 'Inspec::Resources::Package' do
       name: 'curl',
       installed: true,
       version: '7.37.0-1',
-      architecture: 'x86_64',
+      arch: 'x86_64',
       type: 'pacman',
     }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal '7.37.0-1'
-    _(resource.architecture).must_equal 'x86_64'
+    _(resource.arch).must_equal 'x86_64'
     _(resource.info).must_equal pkg
   end
 
@@ -30,13 +30,13 @@ describe 'Inspec::Resources::Package' do
       installed: true,
       held: false,
       version: '7.35.0-1ubuntu2',
-      architecture: 'amd64',
+      arch: 'amd64',
       type: 'deb',
     }
     _(resource.installed?).must_equal true
     _(resource.held?).must_equal false
     _(resource.version).must_equal '7.35.0-1ubuntu2'
-    _(resource.architecture).must_equal 'amd64'
+    _(resource.arch).must_equal 'amd64'
     _(resource.info).must_equal pkg
   end
 
@@ -47,13 +47,13 @@ describe 'Inspec::Resources::Package' do
       installed: true,
       held: true,
       version: '1.2.3-1',
-      architecture: 'amd64',
+      arch: 'amd64',
       type: 'deb',
     }
     _(resource.installed?).must_equal true
     _(resource.held?).must_equal true
     _(resource.version).must_equal '1.2.3-1'
-    _(resource.architecture).must_equal 'amd64'
+    _(resource.arch).must_equal 'amd64'
     _(resource.info).must_equal pkg
   end
 
@@ -65,12 +65,12 @@ describe 'Inspec::Resources::Package' do
       installed: true,
       held: false,
       version: '7.35.0-1ubuntu2',
-      architecture: 'amd64',
+      arch: 'amd64',
       type: 'deb',
     }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal '7.35.0-1ubuntu2'
-    _(resource.architecture).must_equal 'amd64'
+    _(resource.arch).must_equal 'amd64'
     _(resource.info).must_equal pkg
   end
 
@@ -81,7 +81,7 @@ describe 'Inspec::Resources::Package' do
         name: 'curl',
         installed: true,
         version: '7.29.0-19.el7',
-        architecture: 'x86_64',
+        arch: 'x86_64',
         type: 'rpm',
       }
     end
@@ -90,23 +90,23 @@ describe 'Inspec::Resources::Package' do
       resource = MockLoader.new(:centos7).load_resource('package', 'curl')
       _(resource.installed?).must_equal true
       _(resource.version).must_equal '7.29.0-19.el7'
-      _(resource.architecture).must_equal 'x86_64'
+      _(resource.arch).must_equal 'x86_64'
       _(resource.info).must_equal pkg
     end
 
-    it 'can parse the correct architecture info whem multiple are present' do
+    it 'can parse the correct arch info whem multiple are present' do
       pkg = {
         name: 'compat-libstdc++-33',
         installed: true,
         version: '3.2.3-72.el7',
-        architecture: ['i686', 'x86_64'],
+        arch: ['i686', 'x86_64'],
         type: 'rpm',
       }
       resource = MockLoader.new(:centos7).load_resource('package', pkg[:name])
       _(resource.installed?).must_equal true
       _(resource.version).must_equal '3.2.3-72.el7'
-      _(resource.architecture).must_include 'i686'
-      _(resource.architecture).must_include 'x86_64'
+      _(resource.arch).must_include 'i686'
+      _(resource.arch).must_include 'x86_64'
       _(resource.info).must_equal pkg
     end
 
@@ -145,7 +145,7 @@ describe 'Inspec::Resources::Package' do
     resource = MockLoader.new(:wrlinux).load_resource('package', 'curl')
     pkg = {
       name: 'curl',
-      architecture: 'x86_64',
+      arch: 'x86_64',
       installed: true,
       version: '7.29.0-19.el7',
       type: 'rpm',
@@ -153,7 +153,7 @@ describe 'Inspec::Resources::Package' do
 
     _(resource.installed?).must_equal true
     _(resource.version).must_equal '7.29.0-19.el7'
-    _(resource.architecture).must_equal 'x86_64'
+    _(resource.arch).must_equal 'x86_64'
     _(resource.info).must_equal pkg
   end
 
@@ -173,12 +173,12 @@ describe 'Inspec::Resources::Package' do
       name: 'SUNWzfsr',
       installed: true,
       version: '11.10.0-2006.05.18.01.46',
-      architecture: 'i386',
+      arch: 'i386',
       type: 'pkg',
     }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal '11.10.0-2006.05.18.01.46'
-    _(resource.architecture).must_equal 'i386'
+    _(resource.arch).must_equal 'i386'
     _(resource.info).must_equal pkg
   end
 


### PR DESCRIPTION
This adds support for `architecture` to the package resource. Example:

```
describe package('curl') do
  its('architecture') { should cmp 'x86_64' }
end
```

This also adds support for multiple architectures. Example:
```
describe package('compat-libstdc++-33') do
  its('architecture') { should include 'i686' }
  its('architecture') { should include 'x86_64' }
end
```

This does not add `architecture` support for the following platforms due
to the query command not providing enough info:
  - AIX
  - HP-UX
  - macOS/Darwin
  - Solaris 11
  - Windows

This closes #2463 