### PR TITLE
packages resource: Add `architectures` support

### DIFF
--- a/docs/resources/packages.md.erb
+++ b/docs/resources/packages.md.erb
@@ -1,0 +1,66 @@
+---
+title: About the packages Resource
+---
+
+# packages
+
+Use the `packages` InSpec audit resource to test the properties of multiple packages on the system.
+
+<br>
+
+## Syntax
+
+A `packages` resource block declares a regular expression search to select packages
+
+    describe packages(/name/) do
+      its('statuses') { should cmp 'installed' }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Verify that no `xserver` packages are installed
+
+    describe package(/xserver/) do
+      its('statuses') { should_not cmp 'installed' }
+    end
+
+### Verify all `openssl` packages match a certain version
+
+    describe package(/openssl/) do
+      its('versions') { should cmp '1.0.1e-42.el7' }
+    end
+
+### Verify that both the `i686` and `x86_64` versions of `libgcc` are installed
+
+    describe package(/libgcc/) do
+      its('architectures') { should include 'x86_64' }
+      its('architectures') { should include 'i686' }
+    end
+
+<br>
+
+## Matchers
+
+This InSpec audit resource has the following matchers. For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### statuses
+
+The `statuses` matcher tests if packages are installed on the system
+
+    its('statuses') { should cmp 'installed' }
+
+### versions
+
+The `versions` matcher tests the versions of the packages installed on the system
+
+    its('versions') { should cmp '3.4.0.2-4.el7' }
+
+### architectures
+
+The `architectures` matcher tests the architecture of packages installed on the system
+
+    its('architectures') { should include 'i686' }

--- a/lib/resources/packages.rb
+++ b/lib/resources/packages.rb
@@ -48,6 +48,7 @@ module Inspec::Resources
           .add(:statuses,  field: 'status', style: :simple)
           .add(:names,     field: 'name')
           .add(:versions,  field: 'version')
+          .add(:architectures, field: 'architecture')
           .connect(self, :filtered_packages)
 
     private
@@ -69,7 +70,7 @@ module Inspec::Resources
   end
 
   class PkgsManagement
-    PackageStruct = Struct.new(:status, :name, :version)
+    PackageStruct = Struct.new(:status, :name, :version, :architecture)
     attr_reader :inspec
     def initialize(inspec)
       @inspec = inspec
@@ -80,7 +81,7 @@ module Inspec::Resources
   class Debs < PkgsManagement
     def build_package_list
       # use two spaces as delimiter in case any of the fields has a space in it
-      command = "dpkg-query -W -f='${db:Status-Abbrev}  ${Package}  ${Version}\\n'"
+      command = "dpkg-query -W -f='${db:Status-Abbrev}  ${Package}  ${Version}  ${Architecture}\\n'"
       cmd = inspec.command(command)
       all = cmd.stdout.split("\n")
       return [] if all.nil?
@@ -97,7 +98,7 @@ module Inspec::Resources
   class Rpms < PkgsManagement
     def build_package_list
       # use two spaces as delimiter in case any of the fields has a space in it
-      command = "rpm -qa --queryformat '%{NAME}  %{VERSION}-%{RELEASE}\\n'" # rubocop:disable Style/FormatStringToken
+      command = "rpm -qa --queryformat '%{NAME}  %{VERSION}-%{RELEASE}  %{ARCH}\\n'" # rubocop:disable Style/FormatStringToken
       cmd = inspec.command(command)
       all = cmd.stdout.split("\n")
       return [] if all.nil?

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -351,9 +351,9 @@ class MockLoader
       # solaris 11 package manager
       'pkg info system/file-system/zfs' => cmd.call('pkg-info-system-file-system-zfs'),
       # dpkg-query all packages
-      "dpkg-query -W -f='${db:Status-Abbrev}  ${Package}  ${Version}\\n'" => cmd.call('dpkg-query-W'),
+      "dpkg-query -W -f='${db:Status-Abbrev}  ${Package}  ${Version}  ${Architecture}\\n'" => cmd.call('dpkg-query-W'),
       # rpm query all packages
-      "rpm -qa --queryformat '%{NAME}  %{VERSION}-%{RELEASE}\\n'" => cmd.call('rpm-qa-queryformat'),
+      "rpm -qa --queryformat '%{NAME}  %{VERSION}-%{RELEASE}  %{ARCH}\\n'" => cmd.call('rpm-qa-queryformat'),
       # port netstat on solaris 10 & 11
       'netstat -an -f inet -f inet6' => cmd.call('s11-netstat-an-finet-finet6'),
       # xinetd configuration

--- a/test/unit/mock/cmd/dpkg-query-W
+++ b/test/unit/mock/cmd/dpkg-query-W
@@ -1,12 +1,14 @@
-ii   bash  4.3-14ubuntu1.1
-rc   fakeroot  1.20.2-1ubuntu1
-rc   libfakeroot  1.20.2-1ubuntu1
-ii   overlayroot  0.27ubuntu1.2
-ii   vim  2:7.4.1689-3ubuntu1.2
-ii   vim-common  2:7.4.1689-3ubuntu1.2
-ii   xorg  1:7.7+13ubuntu3
-ii   xorg-docs-core  1:1.7.1-1ubuntu1
-ii   xserver-common  2:1.18.4-0ubuntu0.2
-ii   xserver-xorg  1:7.7+13ubuntu3
-ii   xserver-xorg-core  2:1.18.4-0ubuntu0.2
-ii   xserver-xorg-input-all  1:7.7+13ubuntu3
+ii   bash  4.3-14ubuntu1.1  amd64
+ii   libc6  2.19-0ubuntu6.14  amd64
+ii   libc6  2.19-0ubuntu6.14  i386
+rc   fakeroot  1.20.2-1ubuntu1  amd64
+rc   libfakeroot  1.20.2-1ubuntu0 amd64
+ii   overlayroot  0.27ubuntu1.2  amd64
+ii   vim  2:7.4.1689-3ubuntu1.2  amd64
+ii   vim-common  2:7.4.1689-3ubuntu1.2  amd64
+ii   xorg  1:7.7+13ubuntu3  amd64
+ii   xorg-docs-core  1:1.7.1-1ubuntu1  amd64
+ii   xserver-common  2:1.18.4-0ubuntu0.2  amd64
+ii   xserver-xorg  1:7.7+13ubuntu3  amd64
+ii   xserver-xorg-core  2:1.18.4-0ubuntu0.2  amd64
+ii   xserver-xorg-input-all  1:7.7+13ubuntu3  amd64

--- a/test/unit/mock/cmd/rpm-qa-queryformat
+++ b/test/unit/mock/cmd/rpm-qa-queryformat
@@ -1,10 +1,12 @@
-attr  2.4.44-7.el6
-perl-Pod-Escapes  1.04-141.el6_7.1
-perl-version  0.77-141.el6_7.1
-perl-Pod-Simple  3.13-141.el6_7.1
-vim-filesystem  7.4.629-5.el6
-gpm-libs  1.20.6-12.el6
-mlocate  0.22.2-6.el6
-ntpdate  4.2.6p5-10.el6.centos.1
-chef-compliance  1.3.1-1.el6
-nc  1.84-24.el6
+attr  2.4.44-7.el6  x86_64
+perl-Pod-Escapes  1.04-141.el6_7.1  x86_64
+perl-version  0.77-141.el6_7.1  x86_64
+perl-Pod-Simple  3.13-141.el6_7.1  x86_64
+vim-filesystem  7.4.629-5.el6  x86_64
+gpm-libs  1.20.6-12.el6  x86_64
+mlocate  0.22.2-6.el6  x86_64
+ntpdate  4.2.6p5-10.el6.centos.1  x86_64
+chef-compliance  1.3.1-1.el6  x86_64
+compat-libstdc++-33  3.2.3-72.el7  x86_64
+compat-libstdc++-33  3.2.3-72.el7  i686
+nc  1.84-24.el6  x86_64

--- a/test/unit/resources/packages_test.rb
+++ b/test/unit/resources/packages_test.rb
@@ -12,6 +12,7 @@ describe 'Inspec::Resources::Packages' do
       status: 'installed',
       name: 'vim',
       version: '7.4.1689-3ubuntu1.2',
+      architecture: 'amd64',
     })
   end
 
@@ -28,6 +29,7 @@ describe 'Inspec::Resources::Packages' do
       status: "installed",
       name: "overlayroot",
       version: "0.27ubuntu1.2",
+      architecture: 'amd64',
     })
   end
 
@@ -44,12 +46,24 @@ describe 'Inspec::Resources::Packages' do
 
   it 'all packages on Ubuntu' do
     resource = MockLoader.new(:ubuntu1604).load_resource('packages', /.+/)
-    _(resource.entries.length).must_equal 12
+    _(resource.entries.length).must_equal 14
+  end
+
+  it 'can find packages with same name but different architectures on Ubuntu' do
+    resource = MockLoader.new(:ubuntu1604).load_resource('packages', /libc6/)
+    _(resource.architectures).must_include 'amd64'
+    _(resource.architectures).must_include 'i386'
+  end
+
+  it 'can find packages with same name but different architectures on CentOS' do
+    resource = MockLoader.new(:centos6).load_resource('packages', /libstdc/)
+    _(resource.architectures).must_include 'x86_64'
+    _(resource.architectures).must_include 'i686'
   end
 
   it 'all packages on CentOS' do
     resource = MockLoader.new(:centos6).load_resource('packages', /.+/)
-    _(resource.entries.length).must_equal 10
+    _(resource.entries.length).must_equal 12
   end
 
   it 'packages on CentOS' do
@@ -60,6 +74,7 @@ describe 'Inspec::Resources::Packages' do
       status: "installed",
       name: "chef-compliance",
       version: "1.3.1-1.el6",
+      architecture: "x86_64",
     })
   end
 


### PR DESCRIPTION
This adds support for `architectures` to the `packages` resource.

Example:

```
describe packages(/compat-libstdc++-33/) do
  its('architectures') { should include 'x86_64' }
  its('architectures') { should include 'i686' }
end
```

This also adds documentation for the `packages` resource and closes #2463 