### PR TITLE
Sort library files before loading them so load order is predictable

### DIFF
--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -116,6 +116,7 @@ module Inspec
       lib_prefix = 'libraries' + File::SEPARATOR
       autoloads = []
 
+      libs.sort_by! { |l| l[1] } # Sort on source path so load order is deterministic
       libs.each do |content, source, line|
         path = source
         if source.start_with?(lib_prefix)


### PR DESCRIPTION
Fixes #2474 

This is a one-line fix.  I chose to make the change as close to the problem as possible to minimize impact.  Unit tests and linter passed.