### PR TITLE
Doc fixes the apache_conf properties returns an array

### DIFF
--- a/docs/resources/apache_conf.md.erb
+++ b/docs/resources/apache_conf.md.erb
@@ -37,7 +37,7 @@ The following examples show how to use this InSpec audit resource.
 ### Test ports for SSL
 
     describe apache_conf do
-      its('Listen') { should eq '443'}
+      its('Listen') { should include '443' }
     end
 
 <br>
@@ -57,5 +57,5 @@ For example:
 
     describe apache_conf do
       its('MaxClients') { should eq 100 }
-      its('Listen') { should eq '443'}
+      its('Listen') { should include '443' }
     end

--- a/docs/resources/apache_conf.md.erb
+++ b/docs/resources/apache_conf.md.erb
@@ -31,7 +31,7 @@ The following examples show how to use this InSpec audit resource.
 ### Test for blocking .htaccess files on CentOS
 
     describe apache_conf do
-      its('AllowOverride') { should eq 'None' }
+      its('AllowOverride') { should include 'None' }
     end
 
 ### Test ports for SSL
@@ -51,11 +51,11 @@ This InSpec audit resource matches any service that is listed in the Apache conf
 
 or:
 
-    its('Timeout') { should eq 300 }
+    its('Timeout') { should include '300' }
 
 For example:
 
     describe apache_conf do
-      its('MaxClients') { should eq 100 }
+      its('MaxClients') { should include '100' }
       its('Listen') { should include '443' }
     end

--- a/docs/resources/apache_conf.md.erb
+++ b/docs/resources/apache_conf.md.erb
@@ -31,13 +31,19 @@ The following examples show how to use this InSpec audit resource.
 ### Test for blocking .htaccess files on CentOS
 
     describe apache_conf do
-      its('AllowOverride') { should include 'None' }
+      its('AllowOverride') { should cmp 'None' }
     end
 
 ### Test ports for SSL
 
     describe apache_conf do
-      its('Listen') { should include '443' }
+      its('Listen') { should cmp '443' }
+    end
+
+### Test multiple ports are listening
+
+    describe apache_conf do
+      its('Listen') { should =~ [ '80', '443' ] }
     end
 
 <br>
@@ -51,11 +57,11 @@ This InSpec audit resource matches any service that is listed in the Apache conf
 
 or:
 
-    its('Timeout') { should include '300' }
+    its('Timeout') { should cmp '300' }
 
 For example:
 
     describe apache_conf do
-      its('MaxClients') { should include '100' }
-      its('Listen') { should include '443' }
+      its('MaxClients') { should cmp '100' }
+      its('Listen') { should cmp '443' }
     end


### PR DESCRIPTION
Updates the `apache_conf`'s attributes: `timeout`, `allowoverride`, `maxclients`, `Listen`

Signed-off-by: Franklin Webber <franklin@chef.io>