### PR TITLE
apache resource: document and deprecate

### DIFF
--- a/docs/resources/apache.md.erb
+++ b/docs/resources/apache.md.erb
@@ -1,0 +1,71 @@
+---
+title: About the apache Resource
+---
+
+# apache
+
+Use the `apache` InSpec audit resource to test the state of the Apache server on Linux/Unix systems. 
+
+<br>
+
+## Syntax
+
+An `apache` InSpec audit resource block declares settings that should be tested:
+
+    describe apache do
+      its('setting_name') { should cmp 'value' }
+    end
+
+where
+
+* `'setting_name'` is description of the Apache configuration file
+* `{ should cmp 'value' }` is the value that is expected
+
+<br>
+
+## Supported Properties 
+
+* 'service', 'conf_dir', 'conf_path', 'user'
+
+<br>
+
+## Property Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that Apache exists.
+
+    describe apache do
+      it { should exist }
+    end
+
+### Test the service name.
+
+    describe apache do
+      its ( 'service' ) { should cmp 'apache2' }
+    end
+
+### Test the configuration location
+
+    describe apache do
+      its ( 'conf_dir' ) { should cmp '/etc/apache2' }
+    end
+
+### Test the path of the configuration file
+
+    describe apache do
+      its ( 'conf_path' ) { should cmp 'etc/apache2/apache2.conf' }
+    end
+
+### Test the apache user
+
+    describe apache do
+      its ( 'user' ) { should cmp 'www-data' }
+    end
+
+
+<br>
+
+## Matchers
+
+This InSpec audit resource uses the following matchers: `should exist` and `cmp`. For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/docs/resources/apache.md.erb
+++ b/docs/resources/apache.md.erb
@@ -4,7 +4,9 @@ title: About the apache Resource
 
 # apache
 
-Use the `apache` InSpec audit resource to test the state of the Apache server on Linux/Unix systems. 
+Use the `apache` InSpec audit resource to test the state of the Apache server on Linux/Unix systems.
+
+<p class="warning">This resource is deprecated and should not be used. It will be removed in InSpec 3.0.</p>
 
 <br>
 
@@ -23,7 +25,7 @@ where
 
 <br>
 
-## Supported Properties 
+## Supported Properties
 
 * 'service', 'conf_dir', 'conf_path', 'user'
 
@@ -33,39 +35,32 @@ where
 
 The following examples show how to use this InSpec audit resource.
 
-### Test that Apache exists.
-
-    describe apache do
-      it { should exist }
-    end
-
 ### Test the service name.
 
     describe apache do
-      its ( 'service' ) { should cmp 'apache2' }
+      its ('service') { should cmp 'apache2' }
     end
 
 ### Test the configuration location
 
     describe apache do
-      its ( 'conf_dir' ) { should cmp '/etc/apache2' }
+      its ('conf_dir') { should cmp '/etc/apache2' }
     end
 
 ### Test the path of the configuration file
 
     describe apache do
-      its ( 'conf_path' ) { should cmp 'etc/apache2/apache2.conf' }
+      its ('conf_path') { should cmp '/etc/apache2/apache2.conf' }
     end
 
 ### Test the apache user
 
     describe apache do
-      its ( 'user' ) { should cmp 'www-data' }
+      its ('user') { should cmp 'www-data' }
     end
-
 
 <br>
 
 ## Matchers
 
-This InSpec audit resource uses the following matchers: `should exist` and `cmp`. For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/lib/resources/aide_conf.rb
+++ b/lib/resources/aide_conf.rb
@@ -3,7 +3,6 @@
 
 require 'utils/filter'
 require 'utils/parser'
-
 module Inspec::Resources
   class AideConf < Inspec.resource(1)
     name 'aide_conf'

--- a/lib/resources/aide_conf.rb
+++ b/lib/resources/aide_conf.rb
@@ -3,6 +3,7 @@
 
 require 'utils/filter'
 require 'utils/parser'
+
 module Inspec::Resources
   class AideConf < Inspec.resource(1)
     name 'aide_conf'

--- a/lib/resources/apache.rb
+++ b/lib/resources/apache.rb
@@ -6,6 +6,12 @@
 module Inspec::Resources
   class Apache < Inspec.resource(1)
     name 'apache'
+    desc 'Use the apache InSpec audit resource to test if Apache is installed.'
+    example "
+      describe apache do
+        it { should exist }
+      end
+    "
 
     attr_reader :service, :conf_dir, :conf_path, :user
     def initialize

--- a/lib/resources/apache.rb
+++ b/lib/resources/apache.rb
@@ -6,15 +6,29 @@
 module Inspec::Resources
   class Apache < Inspec.resource(1)
     name 'apache'
-    desc 'Use the apache InSpec audit resource to test if Apache is installed.'
+    desc 'Use the apache InSpec audit resource to retrieve Apache environment settings.'
     example "
       describe apache do
-        it { should exist }
+        its ('service') { should cmp 'apache2' }
+      end
+
+      describe apache do
+        its ('conf_dir') { should cmp '/etc/apache2' }
+      end
+
+      describe apache do
+        its ('conf_path') { should cmp '/etc/apache2/apache2.conf' }
+      end
+
+      describe apache do
+        its ('user') { should cmp 'www-data' }
       end
     "
 
     attr_reader :service, :conf_dir, :conf_path, :user
     def initialize
+      warn '[DEPRECATED] The `apache` resource is deprecated and will be removed in InSpec 3.0.'
+
       if inspec.os.debian?
         @service = 'apache2'
         @conf_dir = '/etc/apache2/'

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -129,6 +129,18 @@ module Inspec::Resources
       @files_contents[path] ||= inspec.file(path).content
     end
 
+    def conf_dir
+      if inspec.os.debian?
+        File.dirname(conf_path)
+      else
+        # On RHEL-based systems, the configuration is usually in a /conf directory
+        # that contains the primary config file. We assume the "config path" is the
+        # directory that contains the /conf directory, such as /etc/httpd, so that
+        # the conf.d directory can be properly located.
+        File.expand_path(File.join(File.dirname(conf_path), '..'))
+      end
+    end
+
     def to_s
       "Apache Config #{conf_path}"
     end
@@ -140,18 +152,6 @@ module Inspec::Resources
         '/etc/apache2/apache2.conf'
       else
         '/etc/httpd/conf/httpd.conf'
-      end
-    end
-
-    def conf_dir
-      if inspec.os.debian?
-        File.dirname(conf_path)
-      else
-        # On RHEL-based systems, the configuration is usually in a /conf directory
-        # that contains the primary config file. We assume the "config path" is the
-        # directory that contains the /conf directory, such as /etc/httpd, so that
-        # the conf.d directory can be properly located.
-        File.expand_path(File.join(File.dirname(conf_path), '..'))
       end
     end
   end

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -137,7 +137,7 @@ module Inspec::Resources
         # that contains the primary config file. We assume the "config path" is the
         # directory that contains the /conf directory, such as /etc/httpd, so that
         # the conf.d directory can be properly located.
-        File.expand_path(File.join(File.dirname(conf_path), '..'))
+        Pathname.new(File.dirname(conf_path)).parent.to_s
       end
     end
 

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -9,6 +9,8 @@ require 'utils/find_files'
 module Inspec::Resources
   class ApacheConf < Inspec.resource(1)
     name 'apache_conf'
+    supports os_family: 'linux'
+    supports os_family: 'debian'
     desc 'Use the apache_conf InSpec audit resource to test the configuration settings for Apache. This file is typically located under /etc/apache2 on the Debian and Ubuntu platforms and under /etc/httpd on the Fedora, CentOS, Red Hat Enterprise Linux, and Arch Linux platforms. The configuration settings may vary significantly from platform to platform.'
     example "
       describe apache_conf do
@@ -18,9 +20,10 @@ module Inspec::Resources
 
     include FindFiles
 
+    attr_reader :conf_path
+
     def initialize(conf_path = nil)
-      @conf_path = conf_path || inspec.apache.conf_path
-      @conf_dir = conf_path ? File.dirname(@conf_path) : inspec.apache.conf_dir
+      @conf_path = conf_path || default_conf_path
       @files_contents = {}
       @content = nil
       @params = nil
@@ -63,17 +66,17 @@ module Inspec::Resources
       @params = {}
 
       # skip if the main configuration file doesn't exist
-      file = inspec.file(@conf_path)
+      file = inspec.file(conf_path)
       if !file.file?
-        return skip_resource "Can't find file \"#{@conf_path}\""
+        return skip_resource "Can't find file \"#{conf_path}\""
       end
 
       raw_conf = file.content
       if raw_conf.empty? && !file.empty?
-        return skip_resource("Can't read file \"#{@conf_path}\"")
+        return skip_resource("Can't read file \"#{conf_path}\"")
       end
 
-      to_read = [@conf_path]
+      to_read = [conf_path]
       until to_read.empty?
         raw_conf = read_file(to_read[0])
         @content += raw_conf
@@ -111,7 +114,7 @@ module Inspec::Resources
 
       includes = []
       (include_files + include_files_optional).each do |f|
-        id    = Pathname.new(f).absolute? ? f : File.join(@conf_dir, f)
+        id    = Pathname.new(f).absolute? ? f : File.join(conf_dir, f)
         files = find_files(id, depth: 1, type: 'file')
         files += find_files(id, depth: 1, type: 'link')
 
@@ -127,7 +130,29 @@ module Inspec::Resources
     end
 
     def to_s
-      "Apache Config #{@conf_path}"
+      "Apache Config #{conf_path}"
+    end
+
+    private
+
+    def default_conf_path
+      if inspec.os.debian?
+        '/etc/apache2/apache2.conf'
+      else
+        '/etc/httpd/conf/httpd.conf'
+      end
+    end
+
+    def conf_dir
+      if inspec.os.debian?
+        File.dirname(conf_path)
+      else
+        # On RHEL-based systems, the configuration is usually in a /conf directory
+        # that contains the primary config file. We assume the "config path" is the
+        # directory that contains the /conf directory, such as /etc/httpd, so that
+        # the conf.d directory can be properly located.
+        File.expand_path(File.join(File.dirname(conf_path), '..'))
+      end
     end
   end
 end


### PR DESCRIPTION
The `apache` resource only serves as a way to surface sane per-OS defaults for
a standard Apache install. Internally, this is only used by the `apache_conf`
resource and doesn't actually perform any inspection.

This PR adopts the documentation work in #2489, deprecates the `apache` resource,
and updates `apache_conf` to remove its reliance on the deprecated `apache` resource.

Supersedes #2489