### PR TITLE
Add `release-2.0` target branch to AppVeyor/Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 branches:
   only:
     - master
+    - release-2.0
 language: ruby
 cache: bundler
 dist: trusty

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ skip_tags: true
 branches:
   only:
     - master
+    - release-2.0
 
 cache:
   - vendor/bundle -> appveyor.yml


### PR DESCRIPTION
Leading up to the release of InSpec 2.0 we should be testing both `master` and `release-2.0` branches in AppVeyor/Travis.