### PR TITLE
http resource: Make remote worker the default

### DIFF
--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -32,16 +32,6 @@ where
 
 <br>
 
-## Local vs. Remote
-
-By default, the HTTP test runs on the target machine using `curl`.
-
-If you'd like to execute the HTTP test on the machine running InSpec, you can do the following:
-
-    describe http('http://www.example.com', enable_remote_worker: false) do
-      its('body') { should cmp 'awesome' }
-    end
-
 ## Examples
 
 The following examples show how to use this InSpec audit resource.

--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -6,13 +6,6 @@ title: About the http Resource
 
 Use the `http` InSpec audit resource to test an http endpoint.
 
-<p class="warning">In InSpec 1.40 and earlier, this resource always executes on the host on which <code>inspec exec</code> is run, even if you use the <code>--target</code> option to remotely scan a different host.<br>
-<br>
-Beginning with InSpec 1.41, you can enable the ability to have the HTTP test execute on the remote target, provided <code>curl</code> is available. See the "Local vs. Remote" section below.<br>
-<br>
-Executing the HTTP test on the remote target will be the default behavior in InSpec 2.0.
-</p>
-
 <br>
 
 ## Syntax
@@ -38,15 +31,16 @@ where
 * `ssl_verify` may be specified to enable or disable verification of SSL certificates (default to `true`)
 
 <br>
+
 ## Local vs. Remote
 
-Beginning with InSpec 1.41, you can enable the ability to have the HTTP test execute on the remote target:
+By default, the HTTP test runs on the target machine using `curl`.
 
-    describe http('http://www.example.com', enable_remote_worker: true) do
+If you'd like to execute the HTTP test on the machine running InSpec, you can do the following:
+
+    describe http('http://www.example.com', enable_remote_worker: false) do
       its('body') { should cmp 'awesome' }
     end
-
-In InSpec 2.0, the HTTP test will automatically execute remotely whenever InSpec is testing a remote node.
 
 ## Examples
 

--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -41,9 +41,6 @@ module Inspec::Resources
       # Run locally if InSpec is ran locally and remotely if ran remotely
       if inspec.local_transport?
         @worker = Worker::Local.new(http_method, url, opts)
-      elsif !inspec.command('curl').exist?
-        raise Inspec::Exceptions::ResourceSkipped,
-              'curl is not available on the target machine'
       else
         @worker = Worker::Remote.new(inspec, http_method, url, opts)
       end
@@ -150,6 +147,11 @@ module Inspec::Resources
         attr_reader :inspec
 
         def initialize(inspec, http_method, url, opts)
+          unless inspec.command('curl').exist?
+            raise Inspec::Exceptions::ResourceSkipped,
+                  'curl is not available on the target machine'
+          end
+
           @inspec = inspec
           super(http_method, url, opts)
         end

--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -29,7 +29,9 @@ module Inspec::Resources
       @opts = opts
 
       # Prior to InSpec 2.0 the HTTP test had to be instructed to run on the
-      # remote target machine. This warning will be removed.
+      # remote target machine. This warning will be removed after a few months
+      # to give users an opportunity to remove the unused option from their
+      # profiles.
       if opts.key?(:enable_remote_worker) && !inspec.local_transport?
         warn 'Ignoring `enable_remote_worker` option, the `http` resource ',
              'remote worker is enabled by default for remote targets and ',


### PR DESCRIPTION
This makes it so the `http` resource will execute `curl` on the target machine by default.

This does not remove the functionality to make the HTTP call via Ruby on the machine executing InSpec.

This closes #2228 