### PR TITLE
Fix travis-ci bundler issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ bundler_args: "--without integration tools maintenance deploy"
 before_install:
 - gem update --system
 - gem --version
-- rvm @global do gem uninstall bundler -a -x
 - rvm @global do gem install bundler
 - bundle --version
 matrix:


### PR DESCRIPTION
Bundler is now included in ruby and set as a default gem. As such we need to remove the force uninstall bundler command (as you cannot remove a default gem). Leaving in the install command will confirm its always there.

Signed-off-by: Jared Quick <jquick@chef.io>