### PR TITLE
Changes indented code blocks to code fences adds style

### DIFF
--- a/docs/dsl_inspec.md
+++ b/docs/dsl_inspec.md
@@ -107,7 +107,7 @@ The following test shows how to audit machines running PostgreSQL to ensure that
 ```ruby
 control 'postgres-7' do
   impact 1.0
-  title 'Don't allow empty passwords'
+  title "Don't allow empty passwords"
   describe postgres_session('user', 'pass').query("SELECT * FROM pg_shadow WHERE passwd IS NULL;") do
    its('output') { should eq('') }
   end

--- a/docs/dsl_resource.md
+++ b/docs/dsl_resource.md
@@ -12,7 +12,7 @@ profiles.
 
 Resources may be added to profiles in the libraries folder:
 
-```bash
+```shell
 $ tree examples/profile
 examples/profile
 ...

--- a/docs/habitat.md
+++ b/docs/habitat.md
@@ -16,20 +16,14 @@ To learn more about Habitat and try our demos and tutorials, visit [https://www.
 
 After creating a Habitat package for an InSpec profile (see CLI commands below) and uploading the package to a Habitat Depot or manually distributing to a host, start the Habitat Supervisor with your package:
 
-```bash
-hab start adamleff/inspec-profile-frontend1
+```shell
+$ hab start adamleff/inspec-profile-frontend1
 ```
 
 The Habitat Supervisor will install InSpec and execute your profile in a loop. By default, the loop runs every 300 seconds but can be changed via the `sleep_time` configuration value:
 
-```bash
-HAB_INSPEC_PROFILE_FRONTEND1="sleep_time = 60" hab start adamleff/inspec-profile-frontend1
-```
-
-The Habitat Supervisor will display output like this:
-
-```
-hab start adamleff/inspec-profile-frontend1
+```shell
+$ HAB_INSPEC_PROFILE_FRONTEND1="sleep_time = 60" hab start adamleff/inspec-profile-frontend1
 ∵ Missing package for core/hab-sup/0.17.0
 » Installing core/hab-sup/0.17.0
 ↓ Downloading core/hab-sup/0.17.0/20170214235450
@@ -86,14 +80,14 @@ adamleff-inspec-profile-frontend1-0.1.0-20170328173005-x86_64-linux.hart
 
 #### Syntax
 
-```bash
-inspec habitat profile create PROFILE_DIRECTORY
+```shell
+$ inspec habitat profile create PROFILE_DIRECTORY
 ```
 
 Example:
 
-```bash
-inspec habitat profile create ~/profiles/frontend1
+```shell
+$ inspec habitat profile create ~/profiles/frontend1
 ```
 
 ### inspec habitat profile create
@@ -116,19 +110,19 @@ adamleff-inspec-profile-frontend1-0.1.0-20170328173005-x86_64-linux.hart
 
 #### Syntax
 
-```bash
-inspec habitat profile create PROFILE_DIRECTORY
+```shell
+$ inspec habitat profile create PROFILE_DIRECTORY
 ```
 
 #### Example
 
-```bash
-inspec habitat profile create ~/profiles/frontend1
+```shell
+$ inspec habitat profile create ~/profiles/frontend1
 ```
 
 #### Example Output
 
-```
+```shell
 $ habitat profile create ~/profiles/frontend1
 [2017-03-28T13:29:32-04:00] INFO: Creating a Habitat artifact for profile: /Users/aleff/profiles/frontend1
 [2017-03-28T13:29:32-04:00] INFO: Checking to see if Habitat is installed...
@@ -157,18 +151,19 @@ Create and then upload a Habitat package for an InSpec profile. Like the `inspec
 
 #### Syntax
 
-```bash
-inspec habitat profile upload PROFILE_DIRECTORY
+```shell
+$ inspec habitat profile upload PROFILE_DIRECTORY
 ```
 
 #### Example
 
-```bash
-inspec habitat profile upload ~/profiles/frontend1
+```shell
+$ inspec habitat profile upload ~/profiles/frontend1
 ```
 
 #### Example Output
-```
+
+```shell
 [2017-03-28T13:29:32-04:00] INFO: Creating a Habitat artifact for profile: /Users/aleff/profiles/frontend1
 [2017-03-28T13:29:32-04:00] INFO: Checking to see if Habitat is installed...
 [2017-03-28T13:29:32-04:00] INFO: Copying profile contents to the work directory...

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -90,7 +90,7 @@ In addition InSpec provides additional [resources](https://www.inspec.io/docs/re
 
 For most cases, the migration to InSpec is pretty straight forward. First, replace the current verifier in `kitchen.yml` configuration with:
 
-```
+```yaml
 verifier:
   name: inspec
 ```
@@ -100,7 +100,7 @@ Second, rename the directory `test/integration/default/serverspec` to
 
 Third, remove the Serverspec-specific code from the test files.
 
-```
+```ruby
 require 'serverspec'
 
 # Required by serverspec
@@ -109,7 +109,7 @@ set :backend, :exec
 
 InSpec is now configured with Test-Kitchen:
 
-```
+```shell
 kitchen verify package-install-centos-72
 -----> Starting Kitchen (v1.14.2)
 -----> Verifying <package-install-centos-72>...
@@ -145,7 +145,7 @@ Some general recommendations:
 
 InSpec does not attach backend information to test files. All tests are defined independently of any backend. Therefore a Serverspec test file:
 
-```
+```ruby
 require 'serverspec'
 
 # Required by serverspec
@@ -168,7 +168,7 @@ end
 
 will become the following InSpec test file:
 
-```
+```ruby
 describe 'PHP' do
   it 'has php' do
     expect(command('php -v').exit_status).to eq(0)
@@ -190,7 +190,7 @@ As you can see, the InSpec test files just focuses on tests and tries to avoid a
 
 Serverspec and RSpec allow you to define nested describe blocks. We did a survey and found out that most users use nested describe blocks only to improve their output report. We believe the code structure should not change to improve the output of a report. Nevertheless we understand that nested describe blocks help you to structure test code. A sample code block looks like:
 
-```
+```ruby
 describe 'chef-server-directories' do
   describe file('/etc/opscode') do
     it { should be_directory }
@@ -218,7 +218,7 @@ end
 
 In InSpec you would split up groups into files.
 
-```
+```shell
 tests
 ├── server-directories.rb
 ├── other-tests.rb
@@ -227,7 +227,7 @@ tests
 
 Each file can have a top-level description of its content:
 
-```
+```ruby
 title "Chef Server Directories"
 
 describe file('/etc/opscode') do
@@ -260,7 +260,7 @@ Of course. We still prefer the `should` syntax for UX reasons. We did surveys wi
 
 ### `should` syntax with InSpec
 
-```
+```ruby
 describe command('php -v') do
   its('exit_status') { should eq 0 }
 end
@@ -276,7 +276,7 @@ end
 
 ### `expect` syntax with InSpec
 
-```
+```ruby
 describe 'PHP' do
   it 'has php' do
     expect(command('php -v').exit_status).to eq(0)

--- a/docs/plugin_kitchen_inspec.md
+++ b/docs/plugin_kitchen_inspec.md
@@ -8,42 +8,51 @@ Use InSpec as a Kitchen verifier with `kitchen-inspec`.
 
 Add the InSpec verifier to the `.kitchen.yml` file:
 
-    verifier:
-      name: inspec
+```yaml
+verifier:
+  name: inspec
+```
 
 Use a compliance profile from the Chef Compliance server:
 
-    suites:
-      - name: compliance
-        run_list:
-          - recipe[ssh-hardening::default]
-        verifier:
-          inspec_tests:
-            - compliance://base/ssh
+```yaml
+suites:
+  - name: compliance
+    run_list:
+      - recipe[ssh-hardening::default]
+    verifier:
+      inspec_tests:
+        - compliance://base/ssh
+```
 
 and then run the following command:
 
-    $ inspec compliance login https://compliance.test --user admin --insecure --token ''
+```shell
+$ inspec compliance login https://compliance.test --user admin --insecure --token ''
+```
 
 where `--insecure` is required when using self-signed certificates.
 
 Use a compliance profile from the Chef Supermarket:
 
-    suites:
-      - name: supermarket
-        run_list:
-          - recipe[ssh-hardening::default]
-        verifier:
-          inspec_tests:
-            - supermarket://dev-sec/ssh-baseline
+```yaml
+suites:
+  - name: supermarket
+    run_list:
+      - recipe[ssh-hardening::default]
+    verifier:
+      inspec_tests:
+        - supermarket://dev-sec/ssh-baseline
+```
 
 Use InSpec tests from the local file system:
 
-    suites:
-      - name: local
-        run_list:
-          - recipe[my_cookbook::default]
-        verifier:
-          inspec_tests:
-            - test/integration/default
-
+```yaml
+suites:
+  - name: local
+    run_list:
+      - recipe[my_cookbook::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+```

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -49,63 +49,76 @@ Each profile must have an `inspec.yml` file that defines the following informati
 
 `name` is required; all other profile settings are optional. For example:
 
-    name: ssh
-    title: Basic SSH
-    maintainer: Chef Software, Inc.
-    copyright: Chef Software, Inc.
-    copyright_email: support@chef.io
-    license: Proprietary, All rights reserved
-    summary: Verify that SSH Server and SSH Client are configured securely
-    version: 1.0.0
-    supports:
-      - os-family: linux
-    depends:
-      - name: profile
-        path: ../path/to/profile
+```yaml
+name: ssh
+title: Basic SSH
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
+copyright_email: support@chef.io
+license: Proprietary, All rights reserved
+summary: Verify that SSH Server and SSH Client are configured securely
+version: 1.0.0
+supports:
+  - os-family: linux
+depends:
+  - name: profile
+    path: ../path/to/profile
+```
 
 ## Verify Profiles
 
 Use the `inspec check` command to verify the implementation of a profile:
 
-    $ inspec check examples/profile
+```shell
+$ inspec check examples/profile
+```
 
 # Platform Support
 
 Use the `supports` setting in the `inspec.yml` file to specify one (or more) platforms for which a profile is targeting. The list of supported platforms may contain simple names, names and versions, or detailed flags, and may be combined arbitrarily. For example, to target anything running Debian Linux:
 
-    name: ssh
-    supports:
-      - os-name: debian
+```yaml
+name: ssh
+supports:
+  - os-name: debian
+```
 
 and to target only Ubuntu version 14.04
 
-    name: ssh
-    supports:
-      - os-name: ubuntu
-        release: 14.04
+```yaml
+name: ssh
+supports:
+  - os-name: ubuntu
+    release: 14.04
+```
 
 and to target the entire RedHat platform (including CentOS and Oracle Linux):
 
-    name: ssh
-    supports:
-      - os-family: redhat
+```yaml
+name: ssh
+supports:
+  - os-family: redhat
+```
 
 and to target anything running on Amazon AWS:
 
-    name: ssh
-    supports:
-      - platform: aws
+```yaml
+name: ssh
+supports:
+  - platform: aws
+```
 
 and to target all of these examples in a single `inspec.yml` file:
 
-    name: ssh
-    supports:
-      - os-name: debian
-      - os-name: ubuntu
-        release: 14.04
-      - os-family: redhat
-      - platform: aws
-
+```yaml
+name: ssh
+supports:
+  - os-name: debian
+  - os-name: ubuntu
+    release: 14.04
+  - os-family: redhat
+  - platform: aws
+```
 
 # Profile Dependencies
 
@@ -115,11 +128,13 @@ An InSpec profile can bring in the controls and custom resources from another In
 
 Before a profile can use controls from another profile, the to-be-included profile needs to be specified in the including profile’s `inspec.yml` file in the `depends` section. For each profile to be included, a location for the profile from where to be fetched and a name for the profile should be included. For example:
 
-    depends:
-    - name: linux-baseline
-      url: https://github.com/dev-sec/linux-baseline/archive/master.tar.gz
-    - name: ssh-baseline
-      url: https://github.com/dev-sec/ssh-baseline/archive/master.tar.gz
+```yaml
+depends:
+- name: linux-baseline
+  url: https://github.com/dev-sec/linux-baseline/archive/master.tar.gz
+- name: ssh-baseline
+  url: https://github.com/dev-sec/ssh-baseline/archive/master.tar.gz
+```
 
 InSpec supports a number of dependency sources.
 
@@ -127,21 +142,25 @@ InSpec supports a number of dependency sources.
 
 The `path` setting defines a profile that is located on disk. This setting is typically used during development of profiles and when debugging profiles.
 
-    depends:
-    - name: my-profile
-      path: /absolute/path
-    - name: another
-      path: ../relative/path
+```yaml
+depends:
+- name: my-profile
+  path: /absolute/path
+- name: another
+  path: ../relative/path
+```
 
 ### url
 
 The `url` setting specifies a profile that is located at an HTTP- or HTTPS-based URL. The profile must be accessible via a HTTP GET operation and must be a valid profile archive (zip, tar, or tar.gz format).
 
-    depends:
-    - name: my-profile
-      url: https://my.domain/path/to/profile.tgz
-    - name: profile-via-git
-      url: https://github.com/myusername/myprofile-repo/archive/master.tar.gz
+```yaml
+depends:
+- name: my-profile
+  url: https://my.domain/path/to/profile.tgz
+- name: profile-via-git
+  url: https://github.com/myusername/myprofile-repo/archive/master.tar.gz
+```
 
 ### git
 
@@ -149,13 +168,15 @@ A `git` setting specifies a profile that is located in a git repository, with op
 
 For example:
 
-    depends:
-    - name: git-profile
-      git: http://url/to/repo
-      branch:  desired_branch
-      tag:     desired_version
-      commit:  pinned_commit
-      version: semver_via_tags
+```yaml
+depends:
+- name: git-profile
+  git: http://url/to/repo
+  branch:  desired_branch
+  tag:     desired_version
+  commit:  pinned_commit
+  version: semver_via_tags
+```
 
 ### supermarket
 
@@ -163,9 +184,11 @@ A `supermarket` setting specifies a profile that is located in a cookbook hosted
 
 For example:
 
-    depends:
-    - name: supermarket-profile
-      supermarket: supermarket-username/supermarket-profile
+```yaml
+depends:
+- name: supermarket-profile
+  supermarket: supermarket-username/supermarket-profile
+```
 
 Available Supermarket profiles can be listed with `inspec supermarket profiles`.
 
@@ -175,9 +198,11 @@ A `compliance` setting specifies a profile that is located on the Chef Automate 
 
 For example:
 
-    depends:
-      - name: linux
-        compliance: base/linux
+```yaml
+depends:
+  - name: linux
+    compliance: base/linux
+```
 
 ## Vendoring Dependencies
 
@@ -253,8 +278,10 @@ for use in your profile. If two of your dependencies provide a resource with
 the same name, you can use the `require_resource` DSL function to
 disambiguate the two:
 
-    require_resource(profile: 'my_dep', resource: 'my_res',
-                     as: 'my_res2')
+```ruby
+require_resource(profile: 'my_dep', resource: 'my_res',
+                 as: 'my_res2')
+```
 
 This will allow you to reference the resource `my_res` from the
 profile `my_dep` using the name `my_res2`.
@@ -265,34 +292,40 @@ Attributes may be used in profiles to define secrets, such as user names and pas
 
 For example, a control:
 
-    # define these attributes on the top-level of your file and re-use them across all tests!
-    val_user = attribute('user', default: 'alice', description: 'An identification for the user')
-    val_password = attribute('password', description: 'A value for the password')
+```ruby
+# define these attributes on the top-level of your file and re-use them across all tests!
+val_user = attribute('user', default: 'alice', description: 'An identification for the user')
+val_password = attribute('password', description: 'A value for the password')
 
-    control 'system-users' do
-      impact 0.8
-      desc '
-        This test assures that the user "Bob" has a user installed on the system, along with a
-        specified password.
-      '
+control 'system-users' do
+  impact 0.8
+  desc '
+    This test assures that the user "Bob" has a user installed on the system, along with a
+    specified password.
+  '
 
-      describe val_user do
-        it { should eq 'bob' }
-      end
+  describe val_user do
+    it { should eq 'bob' }
+  end
 
-      describe val_password do
-        it { should eq 'secret' }
-      end
-    end
+  describe val_password do
+    it { should eq 'secret' }
+  end
+end
+```
 
-And a Yaml file named `profile-attribute.yml`:
+And a YAML file named `profile-attribute.yml`:
 
-    user: bob
-    password: secret
+```yaml
+user: bob
+password: secret
+```
 
 The following command runs the tests and applies the secrets specified in `profile-attribute.yml`:
 
-    $ inspec exec examples/profile-attribute --attrs examples/profile-attribute.yml
+```shell
+$ inspec exec examples/profile-attribute --attrs examples/profile-attribute.yml
+```
 
 See the full example in the InSpec open source repository: https://github.com/chef/inspec/tree/master/examples/profile-attribute
 
@@ -304,33 +337,39 @@ To access these files, they must be stored in the `files` directory at the root 
 
 Here is an example for reading and testing a list of ports. The folder structure is:
 
-    examples/profile
-    ├── controls
-    │   ├── example.rb
-    |── files
-    │   └── services.yml
-    └── inspec.yml
+```shell
+examples/profile
+├── controls
+│   ├── example.rb
+|── files
+│   └── services.yml
+└── inspec.yml
+```
 
 With `services.yml` containing:
 
-    - service_name: httpd-alpha
-      port: 80
-    - service_name: httpd-beta
-      port: 8080
+```yaml
+- service_name: httpd-alpha
+  port: 80
+- service_name: httpd-beta
+  port: 8080
+```
 
 The tests in `example.rb` can now access this file:
 
-    my_services = yaml(content: inspec.profile.file('services.yml')).params
+```ruby
+my_services = yaml(content: inspec.profile.file('services.yml')).params
 
-    my_services.each do |s|
-      describe service(s['service_name']) do
-        it { should be_running }
-      end
+my_services.each do |s|
+  describe service(s['service_name']) do
+    it { should be_running }
+  end
 
-      describe port(s['port']) do
-        it { should be_listening }
-      end
-    end
+  describe port(s['port']) do
+    it { should be_listening }
+  end
+end
+```
 
 # "should" vs. "expect" syntax
 
@@ -338,33 +377,42 @@ Users familiar with the RSpec testing framework may know that there are two ways
 
 InSpec will continue to support both methods of writing tests. Consider this `file` test:
 
-    describe file('/tmp/test.txt') do
-      it { should be_file }
-    end
+```ruby
+describe file('/tmp/test.txt') do
+  it { should be_file }
+end
+```
 
 This can be re-written with `expect` syntax
 
-    describe file('/tmp/test.txt') do
-      it 'should be a file' do
-        expect(subject).to(be_file)
-      end
-    end
+```ruby
+describe file('/tmp/test.txt') do
+  it 'should be a file' do
+    expect(subject).to(be_file)
+  end
+end
+```
 
 The output of both of the above examples looks like this:
 
-    File /tmp/test.txt
-       ✔  should be a file
-
+```shell
+File /tmp/test.txt
+   ✔  should be a file
+```
 In addition, you can make use of the `subject` keyword to further control your output if you choose:
 
-    describe 'test file' do
-      subject { file('/tmp/test.txt') }
-      it 'should be a file' do
-        expect(subject).to(be_file)
-      end
-    end
+```ruby
+describe 'test file' do
+  subject { file('/tmp/test.txt') }
+  it 'should be a file' do
+    expect(subject).to(be_file)
+  end
+end
+```
 
 ... which will render the following output:
 
-    test file
-      ✔  should be a file
+```shell
+test file
+  ✔  should be a file
+```

--- a/docs/resources/aide_conf.md.erb
+++ b/docs/resources/aide_conf.md.erb
@@ -13,9 +13,11 @@ Use the `aide_conf` InSpec audit resource to test the rules established for the 
 
 An `aide_conf` resource block can be used to determine if the selection lines contain one (or more) directories whose files should be added to the aide database:
 
-    describe aide_conf('path') do
-      its('selection_lines') { should include '/sbin' }
-    end
+```ruby
+describe aide_conf('path') do
+  its('selection_lines') { should include '/sbin' }
+end
+```
 
 where
 
@@ -25,13 +27,17 @@ where
 
 Use the where clause to match a selection_line to one rule or a particular set of rules found in the aide.conf file:
 
-    describe aide_conf.where { selection_line == '/bin' } do
-      its('rules.flatten') { should include 'r' }
-    end
+```ruby
+describe aide_conf.where { selection_line == '/bin' } do
+  its('rules.flatten') { should include 'r' }
+end
+```
 
-    describe aide_conf.where { selection_line == '/sbin' } do
-      its('rules') { should include ['p', 'i', 'l', 'n', 'u', 'g', 'sha512'] }
-    end
+```ruby
+describe aide_conf.where { selection_line == '/sbin' } do
+  its('rules') { should include ['p', 'i', 'l', 'n', 'u', 'g', 'sha512'] }
+end
+```
 
 <br>
 
@@ -47,28 +53,35 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if all selection lines contain the xattr rule
 
-    describe aide_conf.all_have_rule('xattr') do
-      it { should eq true }
-    end
+```ruby
+describe aide_conf.all_have_rule('xattr') do
+  it { should eq true }
+end
+```
 
 ### Test whether selection line for /bin contains a particular rule
 
-    describe aide_conf.where { selection_line == '/bin' } do
-      its('rules.flatten') { should include 'r' }
-    end
+```ruby
+describe aide_conf.where { selection_line == '/bin' } do
+  its('rules.flatten') { should include 'r' }
+end
+```
 
 ### Test whether selection line for /sbin consists of a particular set of rules
 
-    describe aide_conf.where { selection_line == '/sbin' } do
-      its('rules') { should include ['r', 'sha512'] }
-    end
+```ruby
+describe aide_conf.where { selection_line == '/sbin' } do
+  its('rules') { should include ['r', 'sha512'] }
+end
+```
 
 ### The usage of all\_have\_rule will return whether or not all selection lines in audit.conf contain a particular rule:
 
-    describe aide_conf.all_have_rule('sha512') do
-      it { should eq true }
-    end
-
+```ruby
+describe aide_conf.all_have_rule('sha512') do
+  it { should eq true }
+end
+```
 <br>
 
 ## Matchers

--- a/docs/resources/apache.md.erb
+++ b/docs/resources/apache.md.erb
@@ -15,9 +15,11 @@ Use the `apache` InSpec audit resource to test the state of the Apache server on
 
 An `apache` InSpec audit resource block declares settings that should be tested:
 
-    describe apache do
-      its('setting_name') { should cmp 'value' }
-    end
+```ruby
+describe apache do
+  its('setting_name') { should cmp 'value' }
+end
+```
 
 where
 
@@ -38,27 +40,35 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test the service name.
 
-    describe apache do
-      its ('service') { should cmp 'apache2' }
-    end
+```ruby
+describe apache do
+  its ('service') { should cmp 'apache2' }
+end
+```
 
 ### Test the configuration location
 
-    describe apache do
-      its ('conf_dir') { should cmp '/etc/apache2' }
-    end
+```ruby
+describe apache do
+  its ('conf_dir') { should cmp '/etc/apache2' }
+end
+```
 
 ### Test the path of the configuration file
 
-    describe apache do
-      its ('conf_path') { should cmp '/etc/apache2/apache2.conf' }
-    end
+```ruby
+describe apache do
+  its ('conf_path') { should cmp '/etc/apache2/apache2.conf' }
+end
+```
 
 ### Test the apache user
 
-    describe apache do
-      its ('user') { should cmp 'www-data' }
-    end
+```ruby
+describe apache do
+  its ('user') { should cmp 'www-data' }
+end
+```
 
 <br>
 

--- a/docs/resources/apache_conf.md.erb
+++ b/docs/resources/apache_conf.md.erb
@@ -13,9 +13,11 @@ Use the `apache_conf` InSpec audit resource to test the configuration settings f
 
 An `apache_conf` InSpec audit resource block declares configuration settings that should be tested:
 
-    describe apache_conf('path') do
-      its('setting_name') { should eq 'value' }
-    end
+```ruby
+describe apache_conf('path') do
+  its('setting_name') { should eq 'value' }
+end
+```
 
 where
 
@@ -31,21 +33,27 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test for blocking .htaccess files on CentOS
 
-    describe apache_conf do
-      its('AllowOverride') { should cmp 'None' }
-    end
+```ruby
+describe apache_conf do
+  its('AllowOverride') { should cmp 'None' }
+end
+```
 
 ### Test ports for SSL
 
-    describe apache_conf do
-      its('Listen') { should cmp '443' }
-    end
+```ruby
+describe apache_conf do
+  its('Listen') { should cmp '443' }
+end
+```
 
 ### Test multiple ports are listening
 
-    describe apache_conf do
-      its('Listen') { should =~ [ '80', '443' ] }
-    end
+```ruby
+describe apache_conf do
+  its('Listen') { should =~ [ '80', '443' ] }
+end
+```
 
 <br>
 
@@ -54,15 +62,21 @@ The following examples show how to use this InSpec audit resource.
 For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 This InSpec audit resource matches any service that is listed in the Apache configuration file:
 
-    its('PidFile') { should_not eq '/var/run/httpd.pid' }
+```ruby
+its('PidFile') { should_not eq '/var/run/httpd.pid' }
+```
 
 or:
 
-    its('Timeout') { should cmp '300' }
+```ruby
+its('Timeout') { should cmp '300' }
+```
 
 For example:
 
-    describe apache_conf do
-      its('MaxClients') { should cmp '100' }
-      its('Listen') { should cmp '443' }
-    end
+```ruby
+describe apache_conf do
+  its('MaxClients') { should cmp '100' }
+  its('Listen') { should cmp '443' }
+end
+```

--- a/docs/resources/apt.md.erb
+++ b/docs/resources/apt.md.erb
@@ -13,10 +13,12 @@ Use the `apt` InSpec audit resource to verify Apt repositories on the Debian and
 
 An `apt` resource block tests the contents of Apt and PPA repositories:
 
-    describe apt('path') do
-      it { should exist }
-      it { should be_enabled }
-    end
+```ruby
+describe apt('path') do
+  it { should exist }
+  it { should be_enabled }
+end
+```
 
 where
 
@@ -32,24 +34,30 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if apt repository exists and is enabled
 
-    describe apt('http://ppa.launchpad.net/juju/stable/ubuntu') do
-      it { should exist }
-      it { should be_enabled }
-    end
+```ruby
+describe apt('http://ppa.launchpad.net/juju/stable/ubuntu') do
+  it { should exist }
+  it { should be_enabled }
+end
+```
 
 ### Verify that a PPA repository exists and is enabled
 
-    describe apt('ppa:nginx/stable') do
-      it { should exist }
-      it { should be_enabled }
-    end
+```ruby
+describe apt('ppa:nginx/stable') do
+  it { should exist }
+  it { should be_enabled }
+end
+```
 
 ### Verify that a repository is not present
 
-    describe apt('ubuntu-wine/ppa') do
-      it { should_not exist }
-      it { should_not be_enabled }
-    end
+```ruby
+describe apt('ubuntu-wine/ppa') do
+  it { should_not exist }
+  it { should_not be_enabled }
+end
+```
 
 <br>
 
@@ -62,10 +70,14 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_enabled` matcher tests if a package exists in the repository:
 
-    it { should be_enabled }
+```ruby
+it { should be_enabled }
+```
 
 ### exist
 
 The `exist` matcher tests if a package exists on the system:
 
-    it { should exist }
+```ruby
+it { should exist }
+```

--- a/docs/resources/audit_policy.md.erb
+++ b/docs/resources/audit_policy.md.erb
@@ -13,9 +13,11 @@ Use the `audit_policy` InSpec audit resource to test auditing policies on the Wi
 
 An `audit_policy` resource block declares a parameter that belongs to an audit policy category or subcategory:
 
-    describe audit_policy do
-      its('parameter') { should eq 'value' }
-    end
+```ruby
+describe audit_policy do
+  its('parameter') { should eq 'value' }
+end
+```
 
 where
 
@@ -30,15 +32,19 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test that a parameter is not set to "No Auditing"
 
-    describe audit_policy do
-      its('Other Account Logon Events') { should_not eq 'No Auditing' }
-    end
+```ruby
+describe audit_policy do
+  its('Other Account Logon Events') { should_not eq 'No Auditing' }
+end
+```
 
 ### Test that a parameter is set to "Success"
 
-    describe audit_policy do
-      its('User Account Management') { should eq 'Success' }
-    end
+```ruby
+describe audit_policy do
+  its('User Account Management') { should eq 'Success' }
+end
+```
 
 <br>
 

--- a/docs/resources/auditd.md.erb
+++ b/docs/resources/auditd.md.erb
@@ -13,16 +13,20 @@ Use the `auditd` InSpec audit resource to test the rules for logging that exist 
 
 An `auditd` resource block declares one (or more) rules to be tested, and then what that rule should do:
 
-    describe auditd do
-      its('lines') { should include %r(-w /etc/ssh/sshd_config) }
-    end
+```ruby
+describe auditd do
+  its('lines') { should include %r(-w /etc/ssh/sshd_config) }
+end
+```
 
 or test that multiple individual rules are defined:
 
-    describe auditd do
-      its('lines') { should include %r(-a always,exit -F arch=.* -S init_module,delete_module -F key=modules) }
-      its('lines') { should include %r(-a always,exit -F arch=.* -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=-1 -F key=.+) }
-    end
+```ruby
+describe auditd do
+  its('lines') { should include %r(-a always,exit -F arch=.* -S init_module,delete_module -F key=modules) }
+  its('lines') { should include %r(-a always,exit -F arch=.* -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=-1 -F key=.+) }
+end
+```
 
 where each test must declare one (or more) rules to be tested.
 
@@ -36,40 +40,52 @@ The following examples show how to use this InSpec audit resource.
 
 For `audit` >= 2.3:
 
-    describe auditd do
-      its('lines') { should include %r(-a always,exit -F arch=.* -S chown.* -F auid>=1000 -F auid!=-1 -F key=perm_mod) }
-    end
+```ruby
+describe auditd do
+  its('lines') { should include %r(-a always,exit -F arch=.* -S chown.* -F auid>=1000 -F auid!=-1 -F key=perm_mod) }
+end
+```
 
 ### Query the audit daemon status
 
-    describe auditd.status('backlog') do
-      it { should cmp 0 }
-    end
+```ruby
+describe auditd.status('backlog') do
+  it { should cmp 0 }
+end
+```
 
 ### Query properties of rules targeting specific syscalls or files - uniq is used to handle multiple rules for the same syscall with redundant field values
 
-    describe auditd.syscall('open') do
-      its('action.uniq') { should eq ['always'] }
-      its('list.uniq') { should eq ['exit'] }
-    end
+```ruby
+describe auditd.syscall('open') do
+  its('action.uniq') { should eq ['always'] }
+  its('list.uniq') { should eq ['exit'] }
+end
+```
 
-    describe auditd.file('/etc/sudoers') do
-      its('permissions') { should include ['x'] }
-    end
+```ruby
+describe auditd.file('/etc/sudoers') do
+  its('permissions') { should include ['x'] }
+end
+```
 
 The where accessor can be used to filter on fields. For example:
 
-    describe auditd.syscall('chown').where { arch == "b32" } do
-      its('action') { should eq ['always'] }
-      its('list') { should eq ['exit'] }
-      its('exit') { should include ['-EACCES'] }
-      its('exit') { should include ['-EPERM'] }
-    end
+```ruby
+describe auditd.syscall('chown').where { arch == "b32" } do
+  its('action') { should eq ['always'] }
+  its('list') { should eq ['exit'] }
+  its('exit') { should include ['-EACCES'] }
+  its('exit') { should include ['-EPERM'] }
+end
+```
 
 The key filter may be useful in evaluating rules with particular key values:
 
   describe auditd.where { key == "privileged" } do
-    its('permissions') { should include ['x'] }
+```ruby
+its('permissions') { should include ['x'] }
+```
   end
 
 <br>

--- a/docs/resources/auditd_conf.md.erb
+++ b/docs/resources/auditd_conf.md.erb
@@ -13,9 +13,11 @@ Use the `auditd_conf` InSpec audit resource to test the configuration settings f
 
 A `auditd_conf` resource block declares configuration settings that should be tested:
 
-    describe auditd_conf('path') do
-      its('keyword') { should cmp 'value' }
-    end
+```ruby
+describe auditd_conf('path') do
+  its('keyword') { should cmp 'value' }
+end
+```
 
 where
 
@@ -37,22 +39,24 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test the auditd.conf file
 
-    describe auditd_conf do
-      its('log_file') { should cmp '/full/path/to/file' }
-      its('log_format') { should cmp 'raw' }
-      its('flush') { should cmp 'none' }
-      its('freq') { should cmp 1 }
-      its('num_logs') { should cmp 0 }
-      its('max_log_file') { should cmp 6 }
-      its('max_log_file_action') { should cmp 'email' }
-      its('space_left') { should cmp 2 }
-      its('action_mail_acct') { should cmp 'root' }
-      its('space_left_action') { should cmp 'email' }
-      its('admin_space_left') { should cmp 1 }
-      its('admin_space_left_action') { should cmp 'halt' }
-      its('disk_full_action') { should cmp 'halt' }
-      its('disk_error_action') { should cmp 'halt' }
-    end
+```ruby
+describe auditd_conf do
+  its('log_file') { should cmp '/full/path/to/file' }
+  its('log_format') { should cmp 'raw' }
+  its('flush') { should cmp 'none' }
+  its('freq') { should cmp 1 }
+  its('num_logs') { should cmp 0 }
+  its('max_log_file') { should cmp 6 }
+  its('max_log_file_action') { should cmp 'email' }
+  its('space_left') { should cmp 2 }
+  its('action_mail_acct') { should cmp 'root' }
+  its('space_left_action') { should cmp 'email' }
+  its('admin_space_left') { should cmp 1 }
+  its('admin_space_left_action') { should cmp 'halt' }
+  its('disk_full_action') { should cmp 'halt' }
+  its('disk_error_action') { should cmp 'halt' }
+end
+```
 
 <br>
 
@@ -64,5 +68,7 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `cmp` matcher compares values across types.
 
-    its('freq') { should cmp 1 }
+```ruby
+its('freq') { should cmp 1 }
+```
 

--- a/docs/resources/bash.md.erb
+++ b/docs/resources/bash.md.erb
@@ -13,10 +13,12 @@ Use the `bash` InSpec audit resource to test an arbitrary command that is run on
 
 A `command` resource block declares a command to be run, one (or more) expected outputs, and the location to which that output is sent:
 
-    describe bash('command') do
-      it { should exist }
-      its('property') { should eq 'expected value' }
-    end
+```ruby
+describe bash('command') do
+  it { should exist }
+  its('property') { should eq 'expected value' }
+end
+```
 
 where
 
@@ -26,11 +28,13 @@ where
 
 For example:
 
-    describe bash('ls -al /') do
-      its('stdout') { should match /bin/ }
-      its('stderr') { should eq '' }
-      its('exit_status') { should eq 0 }
-    end
+```ruby
+describe bash('ls -al /') do
+  its('stdout') { should match /bin/ }
+  its('stderr') { should eq '' }
+  its('exit_status') { should eq 0 }
+end
+```
 
 <br>
 
@@ -46,19 +50,25 @@ For example:
 
 The `exit_status` property tests the exit status for the command:
 
-    its('exit_status') { should eq 0 }
+```ruby
+its('exit_status') { should eq 0 }
+```
 
 ### stderr
 
 The `stderr` property tests results of the command as returned in standard error (stderr):
 
-    its('stderr') { should eq '' }
+```ruby
+its('stderr') { should eq '' }
+```
 
 ### stdout
 
 The `stdout` property tests results of the command as returned in standard output (stdout).
 
-    its('stdout') { should match /bin/ }
+```ruby
+its('stdout') { should match /bin/ }
+```
 
 <br>
 
@@ -70,6 +80,8 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 If an absolute path is provided, the `exist` matcher tests if the command exists on the filesystem at the specified location. Otherwise, the `exist` matcher tests if the command is found in the PATH.
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 

--- a/docs/resources/bond.md.erb
+++ b/docs/resources/bond.md.erb
@@ -13,9 +13,11 @@ Use the `bond` InSpec audit resource to test a logical, bonded network interface
 
 A `bond` resource block declares a bonded network interface, and then specifies the properties of that bonded network interface to be tested:
 
-    describe bond('name') do
-      it { should exist }
-    end
+```ruby
+describe bond('name') do
+  it { should exist }
+end
+```
 
 where
 
@@ -32,43 +34,55 @@ The following examples show how to use this InSpec audit resource.
 
 The `content` matcher tests if contents in the file that defines the bonded network interface match the value specified in the test. The values of the `content` matcher are arbitrary.
 
-    its('content') { should match('value') }
+```ruby
+its('content') { should match('value') }
+```
 
 ### interfaces
 
 The `interfaces` matcher tests if the named secondary interfaces are available.
 
-    its('interfaces') { should eq ['eth0', 'eth1', ...] }
+```ruby
+its('interfaces') { should eq ['eth0', 'eth1', ...] }
+```
 
 ### mode
 
 The `mode` matcher tests the Bonding Mode.
 
-    its('mode') { should eq 'IEEE 802.3ad Dynamic link aggregation' }
+```ruby
+its('mode') { should eq 'IEEE 802.3ad Dynamic link aggregation' }
+```
 
 ### params
 
 The `params` matcher tests arbitrary parameters for the bonded network interface.
 
-    its('params') { should eq 'value' }
+```ruby
+its('params') { should eq 'value' }
+```
 
 ### Test if eth0 is a secondary interface for bond0
 
-    describe bond('bond0') do
-      it { should exist }
-      it { should have_interface 'eth0' }
-    end
+```ruby
+describe bond('bond0') do
+  it { should exist }
+  it { should have_interface 'eth0' }
+end
+```
 
 ### Test parameters for bond0
 
-    describe bond('bond0') do
-      its('mode') { should eq 'IEEE 802.3ad Dynamic link aggregation' }
-      its('Transmit Hash Policy') { should eq 'layer3+4 (1)' }
-      its('MII Status') { should eq 'up' }
-      its('MII Polling Interval (ms)') { should eq '100' }
-      its('Up Delay (ms)') { should eq '0' }
-      its('Down Delay (ms)') { should eq '0' }
-    end
+```ruby
+describe bond('bond0') do
+  its('mode') { should eq 'IEEE 802.3ad Dynamic link aggregation' }
+  its('Transmit Hash Policy') { should eq 'layer3+4 (1)' }
+  its('MII Status') { should eq 'up' }
+  its('MII Polling Interval (ms)') { should eq '100' }
+  its('Up Delay (ms)') { should eq '0' }
+  its('Down Delay (ms)') { should eq '0' }
+end
+```
 
 <br>
 
@@ -80,11 +94,15 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `exist` matcher tests if the bonded network interface is available:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 ### have_interface
 
 The `have_interface` matcher tests if the bonded network interface has one (or more) secondary interfaces:
 
-    it { should have_interface }
+```ruby
+it { should have_interface }
+```
 

--- a/docs/resources/bridge.md.erb
+++ b/docs/resources/bridge.md.erb
@@ -13,10 +13,12 @@ Use the `bridge` InSpec audit resource to test basic network bridge properties, 
 
 A `bridge` resource block declares the bridge to be tested and what interface it should be associated with:
 
-    describe bridge('br0') do
-      it { should exist }
-      it { should have_interface 'eth0' }
-    end
+```ruby
+describe bridge('br0') do
+  it { should exist }
+  it { should have_interface 'eth0' }
+end
+```
 
 <br>
 
@@ -33,9 +35,11 @@ A `bridge` resource block declares the bridge to be tested and what interface it
 
 The `interfaces` property tests if the named interface is present:
 
-    its('interfaces') { should eq 'foo' }
-    its('interfaces') { should eq 'bar' }
-    its('interfaces') { should include('foo') }
+```ruby
+its('interfaces') { should eq 'foo' }
+its('interfaces') { should eq 'bar' }
+its('interfaces') { should include('foo') }
+```
 
 <br>
 
@@ -47,11 +51,15 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `exist` matcher tests if the network bridge is available:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 ### have_interface
 
 The `have_interface` matcher tests if the named interface is defined for the network bridge:
 
-    it { should have_interface 'eth0' }
+```ruby
+it { should have_interface 'eth0' }
+```
 

--- a/docs/resources/bsd_service.md.erb
+++ b/docs/resources/bsd_service.md.erb
@@ -13,11 +13,13 @@ Use the `bsd_service` InSpec audit resource to test a service using a Berkeley O
 
 A `bsd_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
-    describe bsd_service('service_name') do
-      it { should be_installed }
-      it { should be_enabled }
-      it { should be_running }
-    end
+```ruby
+describe bsd_service('service_name') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+```
 
 where
 
@@ -30,11 +32,13 @@ where
 
 The path to the service manager's control may be specified for situations where the path isn't available in the current `PATH`. For example:
 
-    describe bsd_service('service_name', '/path/to/control') do
-      it { should be_enabled }
-      it { should be_installed }
-      it { should be_running }
-    end
+```ruby
+describe bsd_service('service_name', '/path/to/control') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end
+```
 
 <br>
 
@@ -52,16 +56,22 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_enabled` matcher tests if the named service is enabled:
 
-    it { should be_enabled }
+```ruby
+it { should be_enabled }
+```
 
 ### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### be_running
 
 The `be_running` matcher tests if the named service is running:
 
-    it { should be_running }
+```ruby
+it { should be_running }
+```

--- a/docs/resources/command.md.erb
+++ b/docs/resources/command.md.erb
@@ -13,10 +13,12 @@ Use the `command` InSpec audit resource to test an arbitrary command that is run
 
 A `command` resource block declares a command to be run, one (or more) expected values, and the location to which that output is sent:
 
-    describe command('command') do
-      it { should exist }
-      its('property') { should eq 'value' }
-    end
+```ruby
+describe command('command') do
+  it { should exist }
+  its('property') { should eq 'value' }
+end
+```
 
 where
 
@@ -34,95 +36,121 @@ The following examples show how to use this InSpec audit resource.
 
 The `exit_status` property tests the exit status for the command:
 
-    its('exit_status') { should eq 123 }
+```ruby
+its('exit_status') { should eq 123 }
+```
 
 ### stderr
 
 The `stderr` property tests results of the command as returned in standard error (stderr):
 
-    its('stderr') { should eq 'error' }
+```ruby
+its('stderr') { should eq 'error' }
+```
 
 ### stdout
 
 The `stdout` property tests results of the command as returned in standard output (stdout). The following example shows matching output using a regular expression:
 
-    describe command('echo 1') do
-       its('stdout') { should match (/[0-9]/) }
-    end
+```ruby
+describe command('echo 1') do
+   its('stdout') { should match (/[0-9]/) }
+end
+```
 
 ### Test standard output (stdout)
 
-    describe command('echo hello') do
-      its('stdout') { should eq "hello\n" }
-      its('stderr') { should eq '' }
-      its('exit_status') { should eq 0 }
-    end
+```ruby
+describe command('echo hello') do
+  its('stdout') { should eq "hello\n" }
+  its('stderr') { should eq '' }
+  its('exit_status') { should eq 0 }
+end
+```
 
 ### Test standard error (stderr)
 
-    describe command('>&2 echo error') do
-      its('stdout') { should eq '' }
-      its('stderr') { should eq "error\n" }
-      its('exit_status') { should eq 0 }
-    end
+```ruby
+describe command('>&2 echo error') do
+  its('stdout') { should eq '' }
+  its('stderr') { should eq "error\n" }
+  its('exit_status') { should eq 0 }
+end
+```
 
 ### Test an exit status code
 
-    describe command('exit 123') do
-      its('stdout') { should eq '' }
-      its('stderr') { should eq '' }
-      its('exit_status') { should eq 123 }
-    end
+```ruby
+describe command('exit 123') do
+  its('stdout') { should eq '' }
+  its('stderr') { should eq '' }
+  its('exit_status') { should eq 123 }
+end
+```
 
 ### Test if the command shell exists
 
-    describe command('/bin/sh').exist? do
-      it { should eq true }
-    end
+```ruby
+describe command('/bin/sh').exist? do
+  it { should eq true }
+end
+```
 
 ### Test for a command that should not exist
 
-    describe command('this is not existing').exist? do
-      it { should eq false }
-    end
+```ruby
+describe command('this is not existing').exist? do
+  it { should eq false }
+end
+```
 
 ### Test for PostgreSQL database running a RC, development, or beta release
 
-    describe command('psql -V') do
-      its('stdout') { should eq '/RC/' }
-      its('stdout') { should_not eq '/DEVEL/' }
-      its('stdout') { should_not eq '/BETA/' }
-    end
+```ruby
+describe command('psql -V') do
+  its('stdout') { should eq '/RC/' }
+  its('stdout') { should_not eq '/DEVEL/' }
+  its('stdout') { should_not eq '/BETA/' }
+end
+```
 
 ### Verify NTP
 
 The following example shows how to use the `file` audit resource to verify if the `ntp.conf` and `leap-seconds` files are present, and then the `command` resource to verify if NTP is installed and running:
 
-    describe file('/etc/ntp.conf') do
-       it { should be_file }
-    end
+```ruby
+describe file('/etc/ntp.conf') do
+   it { should be_file }
+end
+```
 
-    describe file('/etc/ntp.leapseconds') do
-      it { should be_file }
-    end
+```ruby
+describe file('/etc/ntp.leapseconds') do
+  it { should be_file }
+end
+```
 
-    describe command('pgrep ntp') do
-       its('exit_status') { should eq 0 }
-    end
+```ruby
+describe command('pgrep ntp') do
+   its('exit_status') { should eq 0 }
+end
+```
 
 ### Verify WiX
 
 Wix includes serveral tools -- such as `candle` (preprocesses and compiles source files into object files), `light` (links and binds object files to an installer database), and `heat` (harvests files from various input formats). The following example uses a whitespace array and the `file` audit resource to verify if these three tools are present:
 
-    %w(
-      candle.exe
-      heat.exe
-      light.exe
-    ).each do |utility|
-      describe file("C:/wix/##{utility}") do
-        it { should be_file }
-      end
-    end
+```ruby
+%w(
+  candle.exe
+  heat.exe
+  light.exe
+).each do |utility|
+  describe file("C:/wix/##{utility}") do
+    it { should be_file }
+  end
+end
+```
 
 <br>
 
@@ -134,5 +162,7 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `exist` matcher tests if a command may be run on the system:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 

--- a/docs/resources/cpan.md.erb
+++ b/docs/resources/cpan.md.erb
@@ -13,9 +13,11 @@ Use the `cpan` InSpec audit resource to test Perl modules that are installed by 
 
 A `cpan` resource block declares a package and (optionally) a package version:
 
-    describe cpan('package_name') do
-      it { should be_installed }
-    end
+```ruby
+describe cpan('package_name') do
+  it { should be_installed }
+end
+```
 
 where
 
@@ -34,25 +36,31 @@ This resource uses package names and perl library paths as resource parameters.
 
 ### Test if DBD::Pg is installed on the system
 
-    describe cpan('DBD:Pg') do
-      it { should be_installed }
-    end
+```ruby
+describe cpan('DBD:Pg') do
+  it { should be_installed }
+end
+```
 
 ### Test if DBD::Pg 3.7.0 is installed on the system
 
-    describe cpan('DBD::Pg') do
-      it { should be_installed }
-      its('version') { should eq '3.7.0' }
-    end
+```ruby
+describe cpan('DBD::Pg') do
+  it { should be_installed }
+  its('version') { should eq '3.7.0' }
+end
 
+```
 ### Test if DBD::Pg is installed within a custom PERL5LIB path on the system
 
 Hint: You can pass multiple paths separated with a colon
 `/path/to/perl5/lib:/usr/share/perl5/vendor_perl/lib/perl5`
 
-    describe cpan('DBD::Pg', '/home/jdoe/perl5/lib/perl5') do
-      it { should be_installed }
-    end
+```ruby
+describe cpan('DBD::Pg', '/home/jdoe/perl5/lib/perl5') do
+  it { should be_installed }
+end
+```
 
 <br>
 
@@ -64,7 +72,9 @@ The following examples show how to use this InSpec audit resource.
 
 The `version` property tests if the named package version is on the system:
 
-    its('version') { should eq '1.2.3' }
+```ruby
+its('version') { should eq '1.2.3' }
+```
 
 <br>
 
@@ -76,4 +86,6 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_installed` matcher tests if the named package is installed on the system:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```

--- a/docs/resources/cran.md.erb
+++ b/docs/resources/cran.md.erb
@@ -13,9 +13,11 @@ Use the `cran` InSpec audit resource to test R modules that are installed from C
 
 A `cran` resource block declares a package and (optionally) a package version:
 
-    describe cran('package_name') do
-      it { should be_installed }
-    end
+```ruby
+describe cran('package_name') do
+  it { should be_installed }
+end
+```
 
 where
 
@@ -30,16 +32,20 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if DBI is installed on the system
 
-    describe cran('DBI') do
-      it { should be_installed }
-    end
+```ruby
+describe cran('DBI') do
+  it { should be_installed }
+end
+```
 
 ### Test if DBI 0.5.1 is installed on the system
 
-    describe cran('DBI') do
-      it { should be_installed }
-      its('version') { should eq '0.5.1' }
-    end
+```ruby
+describe cran('DBI') do
+  it { should be_installed }
+  its('version') { should eq '0.5.1' }
+end
+```
 
 <br>
 
@@ -49,7 +55,9 @@ The following examples show how to use this InSpec audit resource.
 
 The `version` property tests if the named package version is on the system:
 
-    its('version') { should eq '1.2.3' }
+```ruby
+its('version') { should eq '1.2.3' }
+```
 
 <br>
 
@@ -61,4 +69,6 @@ This InSpec audit resource has the following matchers:
 
 The `be_installed` matcher tests if the named package is installed on the system:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```

--- a/docs/resources/crontab.md.erb
+++ b/docs/resources/crontab.md.erb
@@ -13,9 +13,11 @@ Use the `crontab` InSpec audit resource to test the crontab entries for a partic
 
 A `crontab` resource block declares a user (which defaults to the current user, if not specified), and then the details to be tested, such as the schedule elements for each crontab entry or the commands itself:
 
-    describe crontab do
-      its('commands') { should include '/some/scheduled/task.sh' }
-    end
+```ruby
+describe crontab do
+  its('commands') { should include '/some/scheduled/task.sh' }
+end
+```
 
 <br>
 
@@ -25,44 +27,56 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test that root's crontab has a particular command
 
-    describe crontab('root') do
-      its('commands') { should include '/path/to/some/script' }
-    end
+```ruby
+describe crontab('root') do
+  its('commands') { should include '/path/to/some/script' }
+end
+```
 
 ### Test that myuser's crontab entry for command '/home/myuser/build.sh' runs every minute
 
-    describe crontab('myuser').commands('/home/myuser/build.sh') do
-      its('hours') { should cmp '*' }
-      its('minutes') { should cmp '*' }
-    end
+```ruby
+describe crontab('myuser').commands('/home/myuser/build.sh') do
+  its('hours') { should cmp '*' }
+  its('minutes') { should cmp '*' }
+end
+```
 
 ### Test that the logged-in user's crontab has no tasks set to run on every hour and every minute
 
-    describe crontab.where({'hour' => '*', 'minute' => '*'}) do
-      its('entries.length') { should cmp '0' }
-    end
+```ruby
+describe crontab.where({'hour' => '*', 'minute' => '*'}) do
+  its('entries.length') { should cmp '0' }
+end
+```
 
 ### Test that the logged-in user's crontab contains a single command that matches a mattern
 
-    describe crontab.where { command =~ /a partial command string/ } do
-      its('entries.length') { should cmp 1 }
-    end
+```ruby
+describe crontab.where { command =~ /a partial command string/ } do
+  its('entries.length') { should cmp 1 }
+end
+```
 
 ### Test a special time string (i.e., @yearly /root/anual_report.sh)
 
-    describe crontab.commands('/root/anual_report.sh') do
-      its('hours') { should cmp '0' }
-      its('minutes') { should cmp '0' }
-      its('days') { should cmp '1' }
-      its('months') { should cmp '1' }
-    end
+```ruby
+describe crontab.commands('/root/anual_report.sh') do
+  its('hours') { should cmp '0' }
+  its('minutes') { should cmp '0' }
+  its('days') { should cmp '1' }
+  its('months') { should cmp '1' }
+end
+```
 
 ### Test @reboot case
 
-    describe crontab.commands('/root/reboot.sh') do
-      its('hours') { should cmp '-1' }
-      its('minutes') { should cmp '-1' }
-    end
+```ruby
+describe crontab.commands('/root/reboot.sh') do
+  its('hours') { should cmp '-1' }
+  its('minutes') { should cmp '-1' }
+end
+```
 
 <br>
 
@@ -70,14 +84,16 @@ The following examples show how to use this InSpec audit resource.
 
   ### Test a special time string
 
-    describe crontab do
-      its('minutes') { should cmp '0' }
-      its('hours') { should cmp '0' }
-      its('days') { should cmp '1' }
-      its('weekdays') { should cmp '1' }
-      its('user') { should include 'username'}
-      its('commands') { should include '/some/scheduled/task.sh' }
-    end
+```ruby
+describe crontab do
+  its('minutes') { should cmp '0' }
+  its('hours') { should cmp '0' }
+  its('days') { should cmp '1' }
+  its('weekdays') { should cmp '1' }
+  its('user') { should include 'username'}
+  its('commands') { should include '/some/scheduled/task.sh' }
+end
+```
 
 InSpec will automatically interpret crontab-supported special time strings. For example, a crontab entry set to run `@yearly` can be tested as if the entry was manually configured to run on January 1, 12 AM.
 

--- a/docs/resources/csv.md.erb
+++ b/docs/resources/csv.md.erb
@@ -13,9 +13,11 @@ Use the `csv` InSpec audit resource to test configuration data in a CSV file.
 
 A `csv` resource block declares the configuration data to be tested:
 
-    describe csv('file') do
-      its('name') { should cmp 'foo' }
-    end
+```ruby
+describe csv('file') do
+  its('name') { should cmp 'foo' }
+end
+```
 
 where
 
@@ -31,9 +33,11 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test a CSV file
 
-    describe csv('some_file.csv') do
-      its('setting') { should eq 1 }
-    end
+```ruby
+describe csv('some_file.csv') do
+  its('setting') { should eq 1 }
+end
+```
 
 <br>
 
@@ -43,7 +47,9 @@ The following examples show how to use this InSpec audit resource.
 
 The `name` property tests the value of `name` as read from a CSV file compared to the value declared in the test.
 
-    its('name') { should cmp 'foo' }
+```ruby
+its('name') { should cmp 'foo' }
+```
 
 <br>
 

--- a/docs/resources/dh_params.md.erb
+++ b/docs/resources/dh_params.md.erb
@@ -13,15 +13,17 @@ Use the `dh_params` InSpec audit resource to test Diffie-Hellman (DH) parameters
 
 A `dh_params` resource block declares a parameter file to be tested.
 
-    describe dh_params('/path/to/file.dh_pem') do
-      it { should be_dh_params }
-      it { should be_valid }
-      its('generator') { should eq 2 }
-      its('modulus') { should eq '00:91:a0:15:89:e5:bc:38:93:12:02:fc:...' }
-      its('prime_length') { should eq 2048 }
-      its('pem') { should eq '-----BEGIN DH PARAMETERS...' }
-      its('text') { should eq 'PKCS#3 DH Parameters: (2048 bit)...' }
-    end
+```ruby
+describe dh_params('/path/to/file.dh_pem') do
+  it { should be_dh_params }
+  it { should be_valid }
+  its('generator') { should eq 2 }
+  its('modulus') { should eq '00:91:a0:15:89:e5:bc:38:93:12:02:fc:...' }
+  its('prime_length') { should eq 2048 }
+  its('pem') { should eq '-----BEGIN DH PARAMETERS...' }
+  its('text') { should eq 'PKCS#3 DH Parameters: (2048 bit)...' }
+end
+```
 
 <br>
 
@@ -31,9 +33,11 @@ A `dh_params` resource block declares a parameter file to be tested.
 
 Verify whether file contains DH parameters:
 
-    describe dh_params('/path/to/file.dh_pem') do
-      it { should be_dh_params }
-    end
+```ruby
+describe dh_params('/path/to/file.dh_pem') do
+  it { should be_dh_params }
+end
+```
 
 <br>
 
@@ -49,81 +53,78 @@ generator, modulus, prime_length, pem, text
 
 Verify generator used for the Diffie-Hellman operation:
 
-    describe dh_params('/path/to/file.dh_pem') do
-      its('generator') { should eq 2 }
-    end
+```ruby
+describe dh_params('/path/to/file.dh_pem') do
+  its('generator') { should eq 2 }
+end
+```
 
 ### modulus (String)
 
 Verify prime modulus used for the Diffie-Hellman operation:
 
-    describe dh_params('/path/to/file.dh_pem') do
-      its('modulus') { should eq '00:91:a0:15:89:e5:bc:38:93:12:02:fc:...' }
-    end
+```ruby
+describe dh_params('/path/to/file.dh_pem') do
+  its('modulus') { should eq '00:91:a0:15:89:e5:bc:38:93:12:02:fc:...' }
+end
+```
 
 Example using multi-line string:
 
-    describe dh_params('/path/to/file.dh_pem') do
-      its('modulus') do
-        # regex removes all whitespace
-        should eq <<-EOF.gsub(/[[:space:]]+/, '')
-          00:91:a0:15:89:e5:bc:38:93:12:02:fc:91:a2:85:
-          f7:f7:29:63:2e:d3:4e:7a:86:f7:ee:84:fe:42:d0:
-          48:bc:9c:91:d5:54:f8:78:1d:c0:41:78:a2:c4:ac:
-          1a:24:8b:9d:88:55:98:0b:ac:a7:23:eb:c2:aa:2b:
-          2e:a9:f9:af:d4:8e:4e:11:bc:7f:35:a2:ac:da:3a:
-          ef:f0:25:6c:9a:a4:fd:00:28:76:86:2c:57:87:67:
-          30:5d:b1:d6:5b:22:8f:72:a1:ea:de:8b:ef:9e:33:
-          1a:40:92:68:85:02:54:02:09:fa:c0:60:c1:3c:4e:
-          28:26:db:ed:25:8e:38:21:56:40:dc:c0:c0:66:1f:
-          2b:32:c3:b4:78:a9:26:94:ea:f7:41:28:b2:f5:5b:
-          01:38:0c:46:09:85:26:4d:69:12:8d:95:0f:35:e2:
-          e6:4e:47:3a:86:dd:8a:b2:fe:45:15:27:d8:59:c2:
-          3c:f4:62:ff:5f:74:e9:77:92:50:47:36:2b:05:57:
-          60:ee:7b:a1:60:cc:1c:7a:2b:77:18:8a:37:f7:c7:
-          31:3e:15:cb:15:7f:7b:66:96:fb:c6:be:7d:d6:03:
-          5e:0d:60:75:2b:5b:62:2a:a3:37:b6:34:f9:fe:96:
-          4c:f6:c5:e3:a1:52:af:01:c1:4f:c7:42:a0:be:ed:
-          cd:13
-        EOF
-      end
-    end
+```ruby
+describe dh_params('/path/to/file.dh_pem') do
+  its('modulus') do
+    # regex removes all whitespace
+    should eq <<-EOF.gsub(/[[:space:]]+/, '')
+      00:91:a0:15:89:e5:bc:38:93:12:02:fc:91:a2:85:
+      f7:f7:29:63:2e:d3:4e:7a:86:f7:ee:84:fe:42:d0:
+      48:bc:9c:91:d5:54:f8:78:1d:c0:41:78:a2:c4:ac:
+      1a:24:8b:9d:88:55:98:0b:ac:a7:23:eb:c2:aa:2b:
+      2e:a9:f9:af:d4:8e:4e:11:bc:7f:35:a2:ac:da:3a:
+      ef:f0:25:6c:9a:a4:fd:00:28:76:86:2c:57:87:67:
+      30:5d:b1:d6:5b:22:8f:72:a1:ea:de:8b:ef:9e:33:
+      1a:40:92:68:85:02:54:02:09:fa:c0:60:c1:3c:4e:
+      28:26:db:ed:25:8e:38:21:56:40:dc:c0:c0:66:1f:
+      2b:32:c3:b4:78:a9:26:94:ea:f7:41:28:b2:f5:5b:
+      01:38:0c:46:09:85:26:4d:69:12:8d:95:0f:35:e2:
+      e6:4e:47:3a:86:dd:8a:b2:fe:45:15:27:d8:59:c2:
+      3c:f4:62:ff:5f:74:e9:77:92:50:47:36:2b:05:57:
+      60:ee:7b:a1:60:cc:1c:7a:2b:77:18:8a:37:f7:c7:
+      31:3e:15:cb:15:7f:7b:66:96:fb:c6:be:7d:d6:03:
+      5e:0d:60:75:2b:5b:62:2a:a3:37:b6:34:f9:fe:96:
+      4c:f6:c5:e3:a1:52:af:01:c1:4f:c7:42:a0:be:ed:
+      cd:13
+    EOF
+  end
+end
+```
 
 ### prime_length (Integer)
 
 Verify length of prime modulus used for the Diffie-Hellman operation:
 
-    describe dh_params('/path/to/file.dh_pem') do
-      its('prime_length') { should eq 2048 }
-    end
+```ruby
+describe dh_params('/path/to/file.dh_pem') do
+  its('prime_length') { should eq 2048 }
+end
+```
 
 ### pem (String)
 
 Verify `pem` output of DH parameters:
 
-    describe dh_params('/path/to/file.dh_pem') do
-      its('pem') { should eq '-----BEGIN DH PARAMETERS...' }
-    end
+```ruby
+describe dh_params('/path/to/file.dh_pem') do
+  its('pem') { should eq '-----BEGIN DH PARAMETERS...' }
+end
+```
 
 Example using multi-line string:
 
-    its('pem') do
-      # regex removes all leading spaces
-      should eq <<-EOF.gsub(/^[[:blank:]]+/, '')
-        -----BEGIN DH PARAMETERS-----
-        MIIBCAKCAQEAkaAVieW8OJMSAvyRooX39yljLtNOeob37oT+QtBIvJyR1VT4eB3A
-        QXiixKwaJIudiFWYC6ynI+vCqisuqfmv1I5OEbx/NaKs2jrv8CVsmqT9ACh2hixX
-        h2cwXbHWWyKPcqHq3ovvnjMaQJJohQJUAgn6wGDBPE4oJtvtJY44IVZA3MDAZh8r
-        MsO0eKkmlOr3QSiy9VsBOAxGCYUmTWkSjZUPNeLmTkc6ht2Ksv5FFSfYWcI89GL/
-        X3Tpd5JQRzYrBVdg7nuhYMwceit3GIo398cxPhXLFX97Zpb7xr591gNeDWB1K1ti
-        KqM3tjT5/pZM9sXjoVKvAcFPx0Kgvu3NEwIBAg==
-        -----END DH PARAMETERS-----
-      EOF
-    end
-
-Verify via `openssl dhparam` command:
-
-    $ openssl dhparam -in /path/to/file.dh_pem
+```ruby
+its('pem') do
+  # regex removes all leading spaces
+  should eq <<-EOF.gsub(/^[[:blank:]]+/, '')
     -----BEGIN DH PARAMETERS-----
     MIIBCAKCAQEAkaAVieW8OJMSAvyRooX39yljLtNOeob37oT+QtBIvJyR1VT4eB3A
     QXiixKwaJIudiFWYC6ynI+vCqisuqfmv1I5OEbx/NaKs2jrv8CVsmqT9ACh2hixX
@@ -132,47 +133,40 @@ Verify via `openssl dhparam` command:
     X3Tpd5JQRzYrBVdg7nuhYMwceit3GIo398cxPhXLFX97Zpb7xr591gNeDWB1K1ti
     KqM3tjT5/pZM9sXjoVKvAcFPx0Kgvu3NEwIBAg==
     -----END DH PARAMETERS-----
+  EOF
+end
+```
+
+Verify via `openssl dhparam` command:
+
+```ruby
+$ openssl dhparam -in /path/to/file.dh_pem
+-----BEGIN DH PARAMETERS-----
+MIIBCAKCAQEAkaAVieW8OJMSAvyRooX39yljLtNOeob37oT+QtBIvJyR1VT4eB3A
+QXiixKwaJIudiFWYC6ynI+vCqisuqfmv1I5OEbx/NaKs2jrv8CVsmqT9ACh2hixX
+h2cwXbHWWyKPcqHq3ovvnjMaQJJohQJUAgn6wGDBPE4oJtvtJY44IVZA3MDAZh8r
+MsO0eKkmlOr3QSiy9VsBOAxGCYUmTWkSjZUPNeLmTkc6ht2Ksv5FFSfYWcI89GL/
+X3Tpd5JQRzYrBVdg7nuhYMwceit3GIo398cxPhXLFX97Zpb7xr591gNeDWB1K1ti
+KqM3tjT5/pZM9sXjoVKvAcFPx0Kgvu3NEwIBAg==
+-----END DH PARAMETERS-----
+```
 
 ### text (String)
 
 Verify human-readable text output of DH parameters:
 
-    describe dh_params('/path/to/file.dh_pem') do
-      its('text') { should eq 'PKCS#3 DH Parameters: (2048 bit)...' }
-    end
+```ruby
+describe dh_params('/path/to/file.dh_pem') do
+  its('text') { should eq 'PKCS#3 DH Parameters: (2048 bit)...' }
+end
+```
 
 Example using multi-line string:
 
-    its('text') do
-      # regex removes 2 leading spaces
-      should eq <<-EOF.gsub(/^[[:blank:]]{2}/, '')
-        PKCS#3 DH Parameters: (2048 bit)
-            prime:
-                00:91:a0:15:89:e5:bc:38:93:12:02:fc:91:a2:85:
-                f7:f7:29:63:2e:d3:4e:7a:86:f7:ee:84:fe:42:d0:
-                48:bc:9c:91:d5:54:f8:78:1d:c0:41:78:a2:c4:ac:
-                1a:24:8b:9d:88:55:98:0b:ac:a7:23:eb:c2:aa:2b:
-                2e:a9:f9:af:d4:8e:4e:11:bc:7f:35:a2:ac:da:3a:
-                ef:f0:25:6c:9a:a4:fd:00:28:76:86:2c:57:87:67:
-                30:5d:b1:d6:5b:22:8f:72:a1:ea:de:8b:ef:9e:33:
-                1a:40:92:68:85:02:54:02:09:fa:c0:60:c1:3c:4e:
-                28:26:db:ed:25:8e:38:21:56:40:dc:c0:c0:66:1f:
-                2b:32:c3:b4:78:a9:26:94:ea:f7:41:28:b2:f5:5b:
-                01:38:0c:46:09:85:26:4d:69:12:8d:95:0f:35:e2:
-                e6:4e:47:3a:86:dd:8a:b2:fe:45:15:27:d8:59:c2:
-                3c:f4:62:ff:5f:74:e9:77:92:50:47:36:2b:05:57:
-                60:ee:7b:a1:60:cc:1c:7a:2b:77:18:8a:37:f7:c7:
-                31:3e:15:cb:15:7f:7b:66:96:fb:c6:be:7d:d6:03:
-                5e:0d:60:75:2b:5b:62:2a:a3:37:b6:34:f9:fe:96:
-                4c:f6:c5:e3:a1:52:af:01:c1:4f:c7:42:a0:be:ed:
-                cd:13
-            generator: 2 (0x2)
-        EOF
-    end
-
-Verify via `openssl dhparam` command:
-
-    $ openssl dhparam -in /path/to/file.dh_pem -noout -text
+```ruby
+its('text') do
+  # regex removes 2 leading spaces
+  should eq <<-EOF.gsub(/^[[:blank:]]{2}/, '')
     PKCS#3 DH Parameters: (2048 bit)
         prime:
             00:91:a0:15:89:e5:bc:38:93:12:02:fc:91:a2:85:
@@ -194,6 +188,36 @@ Verify via `openssl dhparam` command:
             4c:f6:c5:e3:a1:52:af:01:c1:4f:c7:42:a0:be:ed:
             cd:13
         generator: 2 (0x2)
+    EOF
+end
+```
+
+Verify via `openssl dhparam` command:
+
+```ruby
+$ openssl dhparam -in /path/to/file.dh_pem -noout -text
+PKCS#3 DH Parameters: (2048 bit)
+    prime:
+        00:91:a0:15:89:e5:bc:38:93:12:02:fc:91:a2:85:
+        f7:f7:29:63:2e:d3:4e:7a:86:f7:ee:84:fe:42:d0:
+        48:bc:9c:91:d5:54:f8:78:1d:c0:41:78:a2:c4:ac:
+        1a:24:8b:9d:88:55:98:0b:ac:a7:23:eb:c2:aa:2b:
+        2e:a9:f9:af:d4:8e:4e:11:bc:7f:35:a2:ac:da:3a:
+        ef:f0:25:6c:9a:a4:fd:00:28:76:86:2c:57:87:67:
+        30:5d:b1:d6:5b:22:8f:72:a1:ea:de:8b:ef:9e:33:
+        1a:40:92:68:85:02:54:02:09:fa:c0:60:c1:3c:4e:
+        28:26:db:ed:25:8e:38:21:56:40:dc:c0:c0:66:1f:
+        2b:32:c3:b4:78:a9:26:94:ea:f7:41:28:b2:f5:5b:
+        01:38:0c:46:09:85:26:4d:69:12:8d:95:0f:35:e2:
+        e6:4e:47:3a:86:dd:8a:b2:fe:45:15:27:d8:59:c2:
+        3c:f4:62:ff:5f:74:e9:77:92:50:47:36:2b:05:57:
+        60:ee:7b:a1:60:cc:1c:7a:2b:77:18:8a:37:f7:c7:
+        31:3e:15:cb:15:7f:7b:66:96:fb:c6:be:7d:d6:03:
+        5e:0d:60:75:2b:5b:62:2a:a3:37:b6:34:f9:fe:96:
+        4c:f6:c5:e3:a1:52:af:01:c1:4f:c7:42:a0:be:ed:
+        cd:13
+    generator: 2 (0x2)
+```
 
 <br>
 
@@ -205,13 +229,17 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 Verify whether DH parameters are valid:
 
-    describe dh_params('/path/to/file.dh_pem') do
-      it { should be_valid }
-    end
+```ruby
+describe dh_params('/path/to/file.dh_pem') do
+  it { should be_valid }
+end
+```
 
 ### be\_dh\_params
 
-    describe dh_params('/path/to/file.dh_pem') do
-        it { should be_dh_params}
-    end
+```ruby
+describe dh_params('/path/to/file.dh_pem') do
+    it { should be_dh_params}
+end
+```
 

--- a/docs/resources/directory.md.erb
+++ b/docs/resources/directory.md.erb
@@ -13,9 +13,11 @@ Use the `directory` InSpec audit resource to test if the file type is a director
 
 A `directory` resource block declares the location of the directory to be tested, and then one (or more) matchers.
 
-    describe directory('path') do
-      its('property') { should cmp 'value' }
-    end
+```ruby
+describe directory('path') do
+  its('property') { should cmp 'value' }
+end
+```
 
 <br>
 

--- a/docs/resources/docker.md.erb
+++ b/docs/resources/docker.md.erb
@@ -13,15 +13,19 @@ Use the `docker` InSpec audit resource to test configuration data for docker dae
 
 A `docker` resource block declares allows you to write test for many containers:
 
-    describe docker.containers do
-      its('images') { should_not include 'u12:latest' }
-    end
+```ruby
+describe docker.containers do
+  its('images') { should_not include 'u12:latest' }
+end
+```
 
 or:
 
-    describe docker.containers.where { names == 'flamboyant_colden' } do
-      it { should be_running }
-    end
+```ruby
+describe docker.containers.where { names == 'flamboyant_colden' } do
+  it { should be_running }
+end
+```
 
 where
 
@@ -30,15 +34,19 @@ where
 
 The `docker` resource block also declares allows you to write test for many images:
 
-    describe docker.images do
-      its('repositories') { should_not include 'inssecure_image' }
-    end
+```ruby
+describe docker.images do
+  its('repositories') { should_not include 'inssecure_image' }
+end
+```
 
 or if you want to query specific images:
 
-    describe docker.images.where { repository == 'ubuntu' && tag == '12.04' } do
-      it { should_not exist }
-    end
+```ruby
+describe docker.images.where { repository == 'ubuntu' && tag == '12.04' } do
+  it { should_not exist }
+end
+```
 
 where
 
@@ -53,42 +61,52 @@ The following examples show how to use this InSpec audit resource.
 
 ### Return all running containers
 
-    docker.containers.running?.ids.each do |id|
-      describe docker.object(id) do
-        its('State.Health.Status') { should eq 'healthy' }
-      end
-    end
+```ruby
+docker.containers.running?.ids.each do |id|
+  describe docker.object(id) do
+    its('State.Health.Status') { should eq 'healthy' }
+  end
+end
+```
 
 ### Verify a Docker Server and Client version
 
-    describe docker.version do
-      its('Server.Version') { should cmp >= '1.12'}
-      its('Client.Version') { should cmp >= '1.12'}
-    end
+```ruby
+describe docker.version do
+  its('Server.Version') { should cmp >= '1.12'}
+  its('Client.Version') { should cmp >= '1.12'}
+end
+```
 
 ### Iterate over all containers to verify host coniguration
 
-    docker.containers.ids.each do |id|
-      # call docker inspect for a specific container id
-      describe docker.object(id) do
-        its(%w(HostConfig Privileged)) { should cmp false }
-        its(%w(HostConfig Privileged)) { should_not cmp true }
-      end
-    end
+```ruby
+docker.containers.ids.each do |id|
+  # call docker inspect for a specific container id
+  describe docker.object(id) do
+    its(%w(HostConfig Privileged)) { should cmp false }
+    its(%w(HostConfig Privileged)) { should_not cmp true }
+  end
+end
+```
 
 ### Iterate over all images to verify the container was built without ADD instruction
 
-    docker.images.ids.each do |id|
-      describe command("docker history #{id}| grep 'ADD'") do
-        its('stdout') { should eq '' }
-      end
-    end
+```ruby
+docker.images.ids.each do |id|
+  describe command("docker history #{id}| grep 'ADD'") do
+    its('stdout') { should eq '' }
+  end
+end
+```
 
 ### Verify that health-checks are enabled for a container
 
-    describe docker.object('71b5df59442b') do
-      its(%w(Config Healthcheck)) { should_not eq nil }
-    end
+```ruby
+describe docker.object('71b5df59442b') do
+  its(%w(Config Healthcheck)) { should_not eq nil }
+end
+```
 
 ### Run the DevSec docker baseline  profile
 
@@ -96,15 +114,21 @@ There are two ways to run the `docker-baseline` profile to test Docker via the `
 
 Clone the profile:
 
-    $ git clone https://github.com/dev-sec/cis-docker-benchmark.git
+```ruby
+$ git clone https://github.com/dev-sec/cis-docker-benchmark.git
+```
 
 and then run:
 
-    $ inspec exec cis-docker-benchmark
+```ruby
+$ inspec exec cis-docker-benchmark
+```
 
 Or execute the profile directly via URL:
 
-    $ inspec exec https://github.com/dev-sec/cis-docker-benchmark
+```ruby
+$ inspec exec https://github.com/dev-sec/cis-docker-benchmark
+```
 
 <br>
 
@@ -116,49 +140,59 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 `containers` returns information about containers as returned by [docker ps -a](https://docs.docker.com/engine/reference/commandline/ps/). You can determine specific information about
 
-    describe docker.containers do
-      its('ids') { should include 'sha:71b5df59...442b' }
-      its('commands') { should_not include '/bin/sh' }
-      its('images') { should_not include 'u12:latest' }
-      its('ports') { should include '0.0.0.0:1234->1234/tcp' }
-      its('labels') { should include 'License=GPLv2,Vendor=CentOS' }
-    end
+```ruby
+describe docker.containers do
+  its('ids') { should include 'sha:71b5df59...442b' }
+  its('commands') { should_not include '/bin/sh' }
+  its('images') { should_not include 'u12:latest' }
+  its('ports') { should include '0.0.0.0:1234->1234/tcp' }
+  its('labels') { should include 'License=GPLv2,Vendor=CentOS' }
+end
+```
 
 
 ### images
 
 `images` returns information about docker image as returned by [docker images](https://docs.docker.com/engine/reference/commandline/images/). You can determine specific information about
 
-    describe docker.images do
-      its('ids') { should include 'sha:12b5df59...442b' }
-      its('repositories') { should_not include 'my_image' }
-      its('tags') { should_not include 'unwanted_tag' }
-      its('sizes') { should_not include "1.41 GB" }
-    end
+```ruby
+describe docker.images do
+  its('ids') { should include 'sha:12b5df59...442b' }
+  its('repositories') { should_not include 'my_image' }
+  its('tags') { should_not include 'unwanted_tag' }
+  its('sizes') { should_not include "1.41 GB" }
+end
+```
 
 ### version
 
 `info` returns the parsed result of [docker version](https://docs.docker.com/engine/reference/commandline/version/)
 
-    describe docker.version do
-      its('Server.Version') { should cmp >= '1.12'}
-      its('Client.Version') { should cmp >= '1.12'}
-    end
+```ruby
+describe docker.version do
+  its('Server.Version') { should cmp >= '1.12'}
+  its('Client.Version') { should cmp >= '1.12'}
+end
+```
 
 
 ### info
 
 `info` returns the parsed result of [docker info](https://docs.docker.com/engine/reference/commandline/info/)
 
-    describe docker.info do
-      its('Configuration.Path') { should eq 'value' }
-    end
+```ruby
+describe docker.info do
+  its('Configuration.Path') { should eq 'value' }
+end
+```
 
 
 ### object('id')
 
 `object` returns low-level information about docker objects. It is calling [docker inspect](https://docs.docker.com/engine/reference/commandline/info/) under the hood.
 
-    describe docker.object(id) do
-      its('Configuration.Path') { should eq 'value' }
-    end
+```ruby
+describe docker.object(id) do
+  its('Configuration.Path') { should eq 'value' }
+end
+```

--- a/docs/resources/docker_container.md.erb
+++ b/docs/resources/docker_container.md.erb
@@ -13,16 +13,18 @@ Use the `docker_container` InSpec audit resource to test a docker container.
 
 A `docker_container` resource block declares the configuration data to be tested:
 
-    describe docker_container('container') do
-      it { should exist }
-      it { should be_running }
-      its('id') { should_not eq '' }
-      its('image') { should eq 'busybox:latest' }
-      its('repo') { should eq 'busybox' }
-      its('tag') { should eq 'latest' }
-      its('ports') { should eq [] }
-      its('command') { should eq 'nc -ll -p 1234 -e /bin/cat' }
-    end
+```ruby
+describe docker_container('container') do
+  it { should exist }
+  it { should be_running }
+  its('id') { should_not eq '' }
+  its('image') { should eq 'busybox:latest' }
+  its('repo') { should eq 'busybox' }
+  its('tag') { should eq 'latest' }
+  its('ports') { should eq [] }
+  its('command') { should eq 'nc -ll -p 1234 -e /bin/cat' }
+end
+```
 
 <br>
 
@@ -32,19 +34,23 @@ A `docker_container` resource block declares the configuration data to be tested
 
 The container name can also be passed with the `name` resource parameter:
 
-    describe docker_container(name: 'an-echo-server') do
-      it { should exist }
-      it { should be_running }
-    end
+```ruby
+describe docker_container(name: 'an-echo-server') do
+  it { should exist }
+  it { should be_running }
+end
+```
 
 ### id
 
 Alternatively, you can pass in the container id:
 
-    describe docker_container(id: '71b5df59442b') do
-      it { should exist }
-      it { should be_running }
-    end
+```ruby
+describe docker_container(id: '71b5df59442b') do
+  it { should exist }
+  it { should be_running }
+end
+```
 
 <br>
 
@@ -56,45 +62,57 @@ The following examples show how to use this InSpec resource.
 
 The `id` property tests the container id:
 
-    its('id') { should eq 'sha:71b5df59...442b' }
+```ruby
+its('id') { should eq 'sha:71b5df59...442b' }
+```
 
 ### repo
 
 The `repo` property tests the value of the image repository:
 
-    its('repo') { should eq 'busybox' }
+```ruby
+its('repo') { should eq 'busybox' }
+```
 
 ### tag
 
 The `tag` property tests the value of the image tag:
 
-    its('tag') { should eq 'latest' }
+```ruby
+its('tag') { should eq 'latest' }
+```
 
 ### ports
 
 The `ports` property tests the value the docker ports:
 
-    its('ports') { should eq '0.0.0.0:1234->1234/tcp' }
+```ruby
+its('ports') { should eq '0.0.0.0:1234->1234/tcp' }
+```
 
 ### command
 
 The `command` property tests the value of the container run command:
 
-    its('command') { should eq 'nc -ll -p 1234 -e /bin/cat' }
+```ruby
+its('command') { should eq 'nc -ll -p 1234 -e /bin/cat' }
+```
 
 
 ### Verify a running container:
 
-    describe docker_container('an-echo-server') do
-      it { should exist }
-      it { should be_running }
-      its('id') { should_not eq '' }
-      its('image') { should eq 'busybox:latest' }
-      its('repo') { should eq 'busybox' }
-      its('tag') { should eq 'latest' }
-      its('ports') { should eq [] }
-      its('command') { should eq 'nc -ll -p 1234 -e /bin/cat' }
-    end
+```ruby
+describe docker_container('an-echo-server') do
+  it { should exist }
+  it { should be_running }
+  its('id') { should_not eq '' }
+  its('image') { should eq 'busybox:latest' }
+  its('repo') { should eq 'busybox' }
+  its('tag') { should eq 'latest' }
+  its('ports') { should eq [] }
+  its('command') { should eq 'nc -ll -p 1234 -e /bin/cat' }
+end
+```
 
 <br>
 

--- a/docs/resources/docker_image.md.erb
+++ b/docs/resources/docker_image.md.erb
@@ -13,12 +13,14 @@ Use the `docker_image` InSpec audit resource to verify a docker image.
 
 A `docker_image` resource block declares the image:
 
-    describe docker_image('alpine:latest') do
-      it { should exist }
-      its('id') { should eq 'sha256:4a415e...a526' }
-      its('repo') { should eq 'alpine' }
-      its('tag') { should eq 'latest' }
-    end
+```ruby
+describe docker_image('alpine:latest') do
+  it { should exist }
+  its('id') { should eq 'sha256:4a415e...a526' }
+  its('repo') { should eq 'alpine' }
+  its('tag') { should eq 'latest' }
+end
+```
 
 <br>
 
@@ -26,21 +28,27 @@ A `docker_image` resource block declares the image:
 
 The resource allows you to pass in an image id:
 
-    describe docker_image(id: alpine_id) do
-      ...
-    end
+```ruby
+describe docker_image(id: alpine_id) do
+  ...
+end
+```
 
 If the tag is missing for an image, `latest` is assumed as default:
 
-    describe docker_image('alpine') do
-      ...
-    end
+```ruby
+describe docker_image('alpine') do
+  ...
+end
+```
 
 You can also pass in repository and tag as separate values
 
-    describe docker_image(repo: 'alpine', tag: 'latest') do
-      ...
-    end
+```ruby
+describe docker_image(repo: 'alpine', tag: 'latest') do
+  ...
+end
+```
 
 <br>
 
@@ -50,35 +58,45 @@ You can also pass in repository and tag as separate values
 
 The `id` property returns the full image id:
 
-    its('id') { should eq 'sha256:4a415e3663882fbc554ee830889c68a33b3585503892cc718a4698e91ef2a526' }
+```ruby
+its('id') { should eq 'sha256:4a415e3663882fbc554ee830889c68a33b3585503892cc718a4698e91ef2a526' }
+```
 
 ### image
 
 The `image` property tests the value of the image. It is a combination of `repository/tag`:
 
-    its('image') { should eq 'alpine:latest' }
+```ruby
+its('image') { should eq 'alpine:latest' }
+```
 
 ### repo
 
 The `repo` property tests the value of the repository name:
 
-    its('repo') { should eq 'alpine' }
+```ruby
+its('repo') { should eq 'alpine' }
+```
 
 ### tag
 
 The `tag` property tests the value of image tag:
 
-    its('tag') { should eq 'latest' }
+```ruby
+its('tag') { should eq 'latest' }
+```
 
 ### Test a docker image
 
-    describe docker_image('alpine:latest') do
-      it { should exist }
-      its('id') { should eq 'sha256:4a415e...a526' }
-      its('image') { should eq 'alpine:latest' }
-      its('repo') { should eq 'alpine' }
-      its('tag') { should eq 'latest' }
-    end
+```ruby
+describe docker_image('alpine:latest') do
+  it { should exist }
+  its('id') { should eq 'sha256:4a415e...a526' }
+  its('image') { should eq 'alpine:latest' }
+  its('repo') { should eq 'alpine' }
+  its('tag') { should eq 'latest' }
+end
+```
 
 <br>
 
@@ -90,5 +108,7 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `exist` matcher tests if the image is available on the node:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 

--- a/docs/resources/docker_service.md.erb
+++ b/docs/resources/docker_service.md.erb
@@ -13,12 +13,14 @@ Use the `docker_service` InSpec audit resource to verify a docker swarm service.
 
 A `docker_service` resource block declares the service by name:
 
-    describe docker_service('foo') do
-      it { should exist }
-      its('id') { should eq '2ghswegspre1' }
-      its('repo') { should eq 'alpine' }
-      its('tag') { should eq 'latest' }
-    end
+```ruby
+describe docker_service('foo') do
+  it { should exist }
+  its('id') { should eq '2ghswegspre1' }
+  its('repo') { should eq 'alpine' }
+  its('tag') { should eq 'latest' }
+end
+```
 
 <br>
 
@@ -26,15 +28,19 @@ A `docker_service` resource block declares the service by name:
 
 The resource allows you to pass in a service id:
 
-    describe docker_service(id: '2ghswegspre1') do
-      ...
-    end
+```ruby
+describe docker_service(id: '2ghswegspre1') do
+  ...
+end
+```
 
 You can also pass in the fully-qualified image:
 
-    describe docker_service(image: 'localhost:5000/alpine:latest') do
-      ...
-    end
+```ruby
+describe docker_service(image: 'localhost:5000/alpine:latest') do
+  ...
+end
+```
 
 <br>
 
@@ -46,58 +52,76 @@ The following examples show how to use InSpec `docker_service` resource.
 
 The `id` property returns the service id:
 
-    its('id') { should eq '2ghswegspre1' }
+```ruby
+its('id') { should eq '2ghswegspre1' }
+```
 
 ### image
 
 The `image` property tests the value of the image. It is a combination of `repository:tag`:
 
-    its('image') { should eq 'alpine:latest' }
+```ruby
+its('image') { should eq 'alpine:latest' }
+```
 
 ### mode
 
 The `mode` property tests the value of the service mode:
 
-    its('mode') { should eq 'replicated' }
+```ruby
+its('mode') { should eq 'replicated' }
+```
 
 ### name
 
 The `name` property tests the value of the service name:
 
-    its('name') { should eq 'foo' }
+```ruby
+its('name') { should eq 'foo' }
+```
 
 ### ports
 
 The `ports` property tests the value of the service's published ports:
 
-    its('ports') { should include '*:8000->8000/tcp' }
+```ruby
+its('ports') { should include '*:8000->8000/tcp' }
+```
 
 ### repo
 
 The `repo` property tests the value of the repository name:
 
-    its('repo') { should eq 'alpine' }
+```ruby
+its('repo') { should eq 'alpine' }
+```
 
 ### replicas
 
 The `replicas` property tests the value of the service's replica count:
 
-    its('replicas') { should eq '3/3' }
+```ruby
+its('replicas') { should eq '3/3' }
+```
 
 ### tag
 
 The `tag` property tests the value of image tag:
 
-    its('tag') { should eq 'latest' }
+```ruby
+its('tag') { should eq 'latest' }
+```
 
 ### Test a docker service
 
-    describe docker_service('foo') do
-      it { should exist }
-      its('id') { should eq '2ghswegspre1' }
-      its('repo') { should eq 'alpine' }
-      its('tag') { should eq 'latest' }
-    end
+```ruby
+describe docker_service('foo') do
+  it { should exist }
+  its('id') { should eq '2ghswegspre1' }
+  its('repo') { should eq 'alpine' }
+  its('tag') { should eq 'latest' }
+end
+```
 
 <br>
 
@@ -109,6 +133,8 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `exist` matcher tests if the image is available on the node:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 

--- a/docs/resources/elasticsearch.md.erb
+++ b/docs/resources/elasticsearch.md.erb
@@ -14,9 +14,11 @@ a variety of settings and statuses.
 
 ## Syntax
 
-    describe elasticsearch do
-      its('property') { should cmp 'value' }
-    end
+```ruby
+describe elasticsearch do
+  its('property') { should cmp 'value' }
+end
+```
 
 <br>
 
@@ -31,19 +33,25 @@ The `elasticsearch` resource accepts a number of optional resource parameters:
 
 In addition, the `elasticsearch` resource allows for filtering the nodes returned by property before executing the tests:
 
-    describe elasticsearch.where { node_name == 'one-off-node' } do
-      its('version') { should eq '1.2.3' }
-    end
+```ruby
+describe elasticsearch.where { node_name == 'one-off-node' } do
+  its('version') { should eq '1.2.3' }
+end
+```
 
-    describe elasticsearch.where { process.mlockall == false } do
-      its('count') { should cmp 0 }
-    end
+```ruby
+describe elasticsearch.where { process.mlockall == false } do
+  its('count') { should cmp 0 }
+end
+```
 
 To simply check if nodes exist that match the criteria, use the `exist` matcher:
 
-    describe elasticsearch.where { cluster_name == 'my_cluster' } do
-      it { should exist }
-    end
+```ruby
+describe elasticsearch.where { cluster_name == 'my_cluster' } do
+  it { should exist }
+end
+```
 
 <br>
 
@@ -63,177 +71,223 @@ Since the `elasticsearch` resource is meant for use on a cluster, each property 
 
 Returns the build hash for each of the nodes.
 
-    describe elasticsearch do
-      its('build_hash') { should cmp 'b2f0c09' }
-    end
+```ruby
+describe elasticsearch do
+  its('build_hash') { should cmp 'b2f0c09' }
+end
+```
 
 ### cluster_name
 
 Returns the cluster names of each of the nodes.
 
-    describe elasticsearch do
-      its('cluster_name') { should cmp 'my_cluster' }
-    end
+```ruby
+describe elasticsearch do
+  its('cluster_name') { should cmp 'my_cluster' }
+end
+```
 
 ### host
 
 Returns the hostname of each of the nodes. This may return an IP address, if the node is improperly performing DNS resolution or has no hostname set.
 
-    describe elasticsearch do
-      its('host') { should cmp 'my.hostname.mycompany.biz' }
-    end
+```ruby
+describe elasticsearch do
+  its('host') { should cmp 'my.hostname.mycompany.biz' }
+end
+```
 
 ### http
 
 Returns a hash of HTTP-related settings for each of the nodes. In this example, the `first` method is used to grab only the first node's HTTP-related info and is a way of removing the item from the Array if only one node is being queried.
 
-    describe elasticsearch do
-      its('http.first.max_content_length_in_bytes') { should cmp 123456 }
-    end
+```ruby
+describe elasticsearch do
+  its('http.first.max_content_length_in_bytes') { should cmp 123456 }
+end
+```
 
 ### ingest
 
 Returns ingest-related settings and capabilities, such as available processors.
 
-    describe elasticsearch do
-      its('ingest.first.processors.count') { should be >= 1 }
-    end
+```ruby
+describe elasticsearch do
+  its('ingest.first.processors.count') { should be >= 1 }
+end
+```
 
 ### ip
 
 Returns the IP address of each of the nodes.
 
-    describe elasticsearch do
-      its('ip') { should cmp '192.168.1.100' }
-    end
+```ruby
+describe elasticsearch do
+  its('ip') { should cmp '192.168.1.100' }
+end
+```
 
 ### jvm
 
 Returns Java Virtual Machine related parameters for each of the nodes.
 
-    describe elasticsearch do
-      its('jvm.first.version') { should cmp '1.8.0_141' }
-    end
+```ruby
+describe elasticsearch do
+  its('jvm.first.version') { should cmp '1.8.0_141' }
+end
+```
 
 ### module_list
 
 Returns a list of enabled modules for each node in the cluster. For more additional information about each module, use the `modules` property.
 
-    describe elasticsearch do
-      its('module_list.first') { should include 'my_module' }
-    end
+```ruby
+describe elasticsearch do
+  its('module_list.first') { should include 'my_module' }
+end
+```
 
 ### modules
 
 Returns detailed information about each enabled module for each node in the cluster. For a succint list of the names of each of the modules enabled, use the `module_list` property. This example uses additional Ruby to find a specific module and assert a value.
 
-    modules = elasticsearch.modules.first
-    lang_groovy_module = modules.find { |mod| mod.name == 'lang-groovy' }
+```ruby
+modules = elasticsearch.modules.first
+lang_groovy_module = modules.find { |mod| mod.name == 'lang-groovy' }
+```
 
-    describe 'lang-groovy module version' do
-      subject { lang_groovy_module }
-      its('version') { should cmp '5.5.2' }
-    end
+```ruby
+describe 'lang-groovy module version' do
+  subject { lang_groovy_module }
+  its('version') { should cmp '5.5.2' }
+end
+```
 
 ### node_name
 
 Returns the node name for each node in the cluster.
 
-    describe elasticsearch do
-      its('node_name') { should cmp 'node1' }
-    end
+```ruby
+describe elasticsearch do
+  its('node_name') { should cmp 'node1' }
+end
+```
 
 ### node_id
 
 Returns the node IDs of each of the nodes in the cluster.
 
-    describe elasticsearch do
-      its('node_id') { should include 'my_node_id' }
-    end
+```ruby
+describe elasticsearch do
+  its('node_id') { should include 'my_node_id' }
+end
+```
 
 ### os
 
 Returns OS-related information about each node in the cluster.
 
-    describe elasticsearch do
-      its('os.first.arch') { should cmp 'amd64' }
-    end
+```ruby
+describe elasticsearch do
+  its('os.first.arch') { should cmp 'amd64' }
+end
+```
 
 ### plugin_list
 
 Returns a list of enabled plugins for each node in the cluster. For more additional information about each plugin, use the `plugins` property.
 
-    describe elasticsearch do
-      its('plugin_list.first') { should include 'my_plugin' }
-    end
+```ruby
+describe elasticsearch do
+  its('plugin_list.first') { should include 'my_plugin' }
+end
+```
 
 ### plugins
 
 Returns detailed information about each enabled plugin for each node in the cluster. For a succint list of the names of each of the plugins enabled, use the `plugin_list` property. This example uses additional Ruby to find a specific plugin and assert a value.
 
-    plugins = elasticsearch.plugins.first
-    my_plugin = plugins.find { |plugin| plugin.name == 'my_plugin' }
+```ruby
+plugins = elasticsearch.plugins.first
+my_plugin = plugins.find { |plugin| plugin.name == 'my_plugin' }
+```
 
-    describe 'my_plugin plugin version' do
-      subject { my_plugin }
-      its('version') { should cmp '1.2.3' }
-    end
+```ruby
+describe 'my_plugin plugin version' do
+  subject { my_plugin }
+  its('version') { should cmp '1.2.3' }
+end
+```
 
 ### process
 
 Returns process information for each node in the cluster, such as the process ID.
 
-    describe elasticsearch do
-      its('process.first.mlockall') { should cmp true }
-    end
+```ruby
+describe elasticsearch do
+  its('process.first.mlockall') { should cmp true }
+end
+```
 
 ### roles
 
 Returns the role for each of the nodes in the cluster.
 
-    describe elasticsearch.where { node_name == 'my_master_node' } do
-      it { should include 'master' }
-    end
+```ruby
+describe elasticsearch.where { node_name == 'my_master_node' } do
+  it { should include 'master' }
+end
+```
 
 ### settings
 
 Returns all the configuration settings for each node in the cluster. These settings usually include those set in the elasticsearch.yml as well as those set via `-Des.` or `-E` flags at startup. Use the `inspec shell` to explore the various setting keys that are available.
 
-    describe elasticsearch do
-      its('settings.first.path.home') { should cmp '/usr/share/elasticsearch' }
-    end
+```ruby
+describe elasticsearch do
+  its('settings.first.path.home') { should cmp '/usr/share/elasticsearch' }
+end
+```
 
 ### total_indexing_buffer
 
 Returns the total indexing buffer for each node in the cluster.
 
-    describe elasticsearch do
-      its('total_indexing_buffer') { should cmp 123456 }
-    end
+```ruby
+describe elasticsearch do
+  its('total_indexing_buffer') { should cmp 123456 }
+end
+```
 
 ### transport
 
 Returns transport-related settings for each node in the cluster, such as the bound and published addresses.
 
-    describe elasticsearch do
-      its('transport.first.bound_address') { should cmp '1.2.3.4:9200' }
-    end
+```ruby
+describe elasticsearch do
+  its('transport.first.bound_address') { should cmp '1.2.3.4:9200' }
+end
+```
 
 ### transport_address
 
 Returns the bound transport address for each node in the cluster.
 
-    describe elasticsearch do
-      its('transport_address') { should cmp '1.2.3.4:9200' }
-    end
+```ruby
+describe elasticsearch do
+  its('transport_address') { should cmp '1.2.3.4:9200' }
+end
+```
 
 ### version
 
 Returns the version of Elasticsearch running on each node of the cluster.
 
-    describe elasticsearch do
-      its('version') { should cmp '5.5.2' }
-    end
+```ruby
+describe elasticsearch do
+  its('version') { should cmp '5.5.2' }
+end
+```
 
 <br>
 

--- a/docs/resources/etc_fstab.md.erb
+++ b/docs/resources/etc_fstab.md.erb
@@ -16,23 +16,27 @@ its dump options, and the order the files system should be checked.
 
 Use the where clause to match a property to one or more rules in the fstab file:
 
-    describe etc_fstab.where { device_name == 'value' } do
-      its('mount_point') { should cmp 'hostname' }
-      its('file_system_type') { should cmp 'list' }
-      its('mount_options') { should cmp 'list' }
-      its('dump_options') { should cmp 'list' }
-      its('file_system_options') { should cmp 'list' }
-    end
+```ruby
+describe etc_fstab.where { device_name == 'value' } do
+  its('mount_point') { should cmp 'hostname' }
+  its('file_system_type') { should cmp 'list' }
+  its('mount_options') { should cmp 'list' }
+  its('dump_options') { should cmp 'list' }
+  its('file_system_options') { should cmp 'list' }
+end
+```
 
 Use the optional constructor parameter to give an alternative path to fstab file:
 
-    describe etc_fstab(hosts_path).where { device_name == 'value' } do
-      its('mount_point') { should cmp 'hostname' }
-      its('file_system_type') { should cmp 'list' }
-      its('mount_options') { should cmp 'list' }
-      its('dump_options') { should cmp 'list' }
-      its('file_system_options') { should cmp 'list ' }
-    end
+```ruby
+describe etc_fstab(hosts_path).where { device_name == 'value' } do
+  its('mount_point') { should cmp 'hostname' }
+  its('file_system_type') { should cmp 'list' }
+  its('mount_options') { should cmp 'list' }
+  its('dump_options') { should cmp 'list' }
+  its('file_system_options') { should cmp 'list ' }
+end
+```
 
 <br>
 
@@ -53,70 +57,88 @@ Use the optional constructor parameter to give an alternative path to fstab file
 
 `device_name` returns a string array of device names mounted on the system.
 
-    describe etc_fstab.where { mount_point == '/mnt/sr0' } do
-      its('device_name') { should cmp '/dev/sr0' }
-    end
+```ruby
+describe etc_fstab.where { mount_point == '/mnt/sr0' } do
+  its('device_name') { should cmp '/dev/sr0' }
+end
+```
 
 ### mount_point
 
 `mount_point` returns a string array of directorys at which filesystems are configured to be mounted.
 
-    describe etc_fstab.where { device_name == '/dev/sr0' } do
-      its('mount_point') { should cmp '/mnt/sr0' }
-    end
+```ruby
+describe etc_fstab.where { device_name == '/dev/sr0' } do
+  its('mount_point') { should cmp '/mnt/sr0' }
+end
+```
 
 ### file\_system_type
 
 `file_system_type` returns a String array of each partitions file system type.
 
-    describe etc_fstab.where { device_name == '/dev/sr0' } do
-      its('file_system_type') { should cmp 'iso9660' }
-    end
+```ruby
+describe etc_fstab.where { device_name == '/dev/sr0' } do
+  its('file_system_type') { should cmp 'iso9660' }
+end
+```
 
 ### mount_options
 
 `mount_options` returns a two dimensional array of each partitions mount options.
 
-    describe etc_fstab.where { mount_point == '/' } do
-      its('mount_options') { should eq [['defaults', 'x-systemd.device-timeout=0']] }
-    end
+```ruby
+describe etc_fstab.where { mount_point == '/' } do
+  its('mount_options') { should eq [['defaults', 'x-systemd.device-timeout=0']] }
+end
+```
 
 ### dump_options
 
 `dump_options` returns a integer array of each partitions dump option.
 
-    describe etc_fstab.where { device_name == '/dev/sr0' } do
-      its('dump_options') { should cmp 0 }
-    end
+```ruby
+describe etc_fstab.where { device_name == '/dev/sr0' } do
+  its('dump_options') { should cmp 0 }
+end
+```
 
 ### file_system_options
 
 `file_system_options` returns a integer array of each partitions file system option.
 
-    describe etc_fstab.where { device_name == '/dev/sr0' } do
-      its('file_system_options') { should cmp 0 }
-    end
+```ruby
+describe etc_fstab.where { device_name == '/dev/sr0' } do
+  its('file_system_options') { should cmp 0 }
+end
+```
 
 ### Check all partitions that have type of 'nfs'
 
-    nfs_systems = etc_fstab.nfs_file_systems.entries
-    nfs_systems.each do |partition|
-      describe partition do
-        its('mount_options') { should include 'nosuid' }
-      end
-    end
+```ruby
+nfs_systems = etc_fstab.nfs_file_systems.entries
+nfs_systems.each do |partition|
+  describe partition do
+    its('mount_options') { should include 'nosuid' }
+  end
+end
+```
 
 ### Check the partition mounted at /home contains 'nosuid' in its mount_options
 
-    describe etc_fstab do
-      its('home_mount_options') { should include 'nosuid' }
-    end
+```ruby
+describe etc_fstab do
+  its('home_mount_options') { should include 'nosuid' }
+end
+```
 
 ### Check if a partition is mounted at a point
 
-    describe etc_fstab.where { mount_point == '/home' } do
-      it { should be_configured }
-    end
+```ruby
+describe etc_fstab.where { mount_point == '/home' } do
+  it { should be_configured }
+end
+```
 
 <br>
 

--- a/docs/resources/etc_group.md.erb
+++ b/docs/resources/etc_group.md.erb
@@ -13,24 +13,30 @@ Use the `etc_group` InSpec audit resource to test groups that are defined on Lin
 
 A `etc_group` resource block declares a collection of properties to be tested:
 
-    describe etc_group('path') do
-      its('property') { should eq 'some_value' }
-    end
+```ruby
+describe etc_group('path') do
+  its('property') { should eq 'some_value' }
+end
+```
 
 or:
 
-    describe etc_group.where(item: 'value', item: 'value') do
-      its('gids') { should_not contain_duplicates }
-      its('groups') { should include 'user_name' }
-      its('users') { should include 'user_name' }
-    end
+```ruby
+describe etc_group.where(item: 'value', item: 'value') do
+  its('gids') { should_not contain_duplicates }
+  its('groups') { should include 'user_name' }
+  its('users') { should include 'user_name' }
+end
+```
 
 where
 
 * `('path')` is the non-default path to the `inetd.conf` file
 * `.where()` filters for a specific item and value, to which the parameter are compared
 * `.where` filter may be one or more of:
-    * `name: 'name'`, `group_name: 'group_name'`, `password: 'password'`, `gid: 'gid'`, `group_id: 'gid'`, `users: 'user_name'`, `members: 'member_name'`
+```ruby
+* `name: 'name'`, `group_name: 'group_name'`, `password: 'password'`, `gid: 'gid'`, `group_id: 'gid'`, `users: 'user_name'`, `members: 'member_name'`
+```
 <br>
 
 ## Properties
@@ -45,27 +51,35 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test group identifiers (GIDs) for duplicates
 
-    describe etc_group do
-      its('gids') { should_not contain_duplicates }
-    end
+```ruby
+describe etc_group do
+  its('gids') { should_not contain_duplicates }
+end
+```
 
 ### Test all groups to see if a specific user belongs to one (or more) groups
 
-    describe etc_group do
-      its('groups') { should include 'my_group' }
-    end
+```ruby
+describe etc_group do
+  its('groups') { should include 'my_group' }
+end
+```
 
 ### Test all groups for a specific user name
 
-    describe etc_group do
-      its('users') { should include 'my_user' }
-    end
+```ruby
+describe etc_group do
+  its('users') { should include 'my_user' }
+end
+```
 
 ### Filter a list of groups for a specific user
 
-    describe etc_group.where(name: 'my_group') do
-      its('users') { should include 'my_user' }
-    end
+```ruby
+describe etc_group.where(name: 'my_group') do
+  its('users') { should include 'my_user' }
+end
+```
 
 <br>
 

--- a/docs/resources/etc_hosts.md.erb
+++ b/docs/resources/etc_hosts.md.erb
@@ -19,17 +19,21 @@ An etc/hosts rule specifies an IP address and what its hostname is along with op
 
 Use the `.where` clause to match a property to one or more rules in the hosts file:
 
-    describe etc_hosts.where { ip_address == 'value' } do
-      its('primary_name') { should cmp 'hostname' }
-      its('all_host_names') { should cmp 'list' }
-    end
+```ruby
+describe etc_hosts.where { ip_address == 'value' } do
+  its('primary_name') { should cmp 'hostname' }
+  its('all_host_names') { should cmp 'list' }
+end
+```
 
 Use the optional resource parameter to give an alternative path to the hosts file:
 
-    describe etc_hosts('path/to/hosts').where { ip_address == 'value' } do
-      its('primary_name') { should cmp 'hostname' }
-      its('all_host_names') { should cmp 'list' }
-    end
+```ruby
+describe etc_hosts('path/to/hosts').where { ip_address == 'value' } do
+  its('primary_name') { should cmp 'hostname' }
+  its('all_host_names') { should cmp 'list' }
+end
+```
 
 where
 
@@ -41,7 +45,9 @@ where
 
 ## Properties
 
-    'ip_address', 'primary_name', 'all_host_names'
+```ruby
+'ip_address', 'primary_name', 'all_host_names'
+```
 
 <br>
 
@@ -51,25 +57,31 @@ where
 
 `ip_address` returns a string array of ip addresses specified in the etc/hosts file.
 
-    describe etc_hosts.where { primary_name == 'localhost' } do
-      its('ip_address') { should cmp '127.0.1.154' }
-    end
+```ruby
+describe etc_hosts.where { primary_name == 'localhost' } do
+  its('ip_address') { should cmp '127.0.1.154' }
+end
+```
 
 ### primary_name
 
 `primary_name` returns a string array of primary_names specified in the etc/hosts file.
 
-    describe etc_hosts.where { ip_address == '::1' } do
-      its('primary_name') { should cmp 'localhost' }
-    end
+```ruby
+describe etc_hosts.where { ip_address == '::1' } do
+  its('primary_name') { should cmp 'localhost' }
+end
+```
 
 ### all\_host_names
 
 `all_host_names` returns a two dimensional string array where each entry has the primary_name first followed by any aliases.
 
-    describe etc_hosts.where { ip_address == '127.0.1.154' } do
-      its('all_host_names') { should eq [['localhost', 'localhost.localdomain', 'localhost4', 'localhost4.localdomain4'],  ['localhost', 'localhost.localdomain', 'localhost6', 'localhost6.localdomain6']] }
-    end
+```ruby
+describe etc_hosts.where { ip_address == '127.0.1.154' } do
+  its('all_host_names') { should eq [['localhost', 'localhost.localdomain', 'localhost4', 'localhost4.localdomain4'],  ['localhost', 'localhost.localdomain', 'localhost6', 'localhost6.localdomain6']] }
+end
+```
 
 <br>
 

--- a/docs/resources/etc_hosts_allow.md.erb
+++ b/docs/resources/etc_hosts_allow.md.erb
@@ -15,17 +15,21 @@ An etc/hosts.allow rule specifies one or more daemons mapped to one or more clie
 
 Use the where clause to match a property to one or more rules in the hosts.allow file.
 
-    describe etc_hosts_allow.where { daemon == 'value' } do
-      its ('client_list') { should include ['values'] }
-      its ('options') { should include ['values'] }
-    end
+```ruby
+describe etc_hosts_allow.where { daemon == 'value' } do
+  its ('client_list') { should include ['values'] }
+  its ('options') { should include ['values'] }
+end
+```
 
 Use the optional constructor parameter to give an alternative path to hosts.allow
 
-    describe etc_hosts_allow(hosts_path).where { daemon == 'value' } do
-      its ('client_list') { should include ['values'] }
-      its ('options') { should include ['values'] }
-    end
+```ruby
+describe etc_hosts_allow(hosts_path).where { daemon == 'value' } do
+  its ('client_list') { should include ['values'] }
+  its ('options') { should include ['values'] }
+end
+```
 
 where
 
@@ -37,7 +41,9 @@ where
 
 ## Properties
 
-    'daemon', 'client_list', 'options'
+```ruby
+'daemon', 'client_list', 'options'
+```
 
 <br>
 
@@ -47,25 +53,31 @@ where
 
 `daemon` returns a string containing the daemon that is allowed in the rule.
 
-    describe etc_hosts_allow.where { client_list == ['127.0.1.154',  '[:fff:fAb0::]'] } do
-      its('daemon') { should eq ['vsftpd', 'sshd'] }
-    end
+```ruby
+describe etc_hosts_allow.where { client_list == ['127.0.1.154',  '[:fff:fAb0::]'] } do
+  its('daemon') { should eq ['vsftpd', 'sshd'] }
+end
+```
 
 ### client_list
 
 `client_list` returns a 2d string array where each entry contains the clients specified for the rule.
 
-    describe etc_hosts_allow.where { daemon == 'sshd' } do
-      its('client_list') { should include ['192.168.0.0/16', '[abcd::0000:1234]'] }
-    end
+```ruby
+describe etc_hosts_allow.where { daemon == 'sshd' } do
+  its('client_list') { should include ['192.168.0.0/16', '[abcd::0000:1234]'] }
+end
+```
 
 ### options
 
 `options` returns a 2d string array where each entry contains any options specified for the rule.
 
-    describe etc_hosts_allow.where { daemon == 'sshd' } do
-      its('options') { should include ['deny', 'echo "REJECTED"'] }
-    end
+```ruby
+describe etc_hosts_allow.where { daemon == 'sshd' } do
+  its('options') { should include ['deny', 'echo "REJECTED"'] }
+end
+```
 
 <br>
 

--- a/docs/resources/etc_hosts_deny.md.erb
+++ b/docs/resources/etc_hosts_deny.md.erb
@@ -15,17 +15,21 @@ An etc/hosts.deny rule specifies one or more daemons mapped to one or more clien
 
 Use the where clause to match a property to one or more rules in the hosts.deny file:
 
-    describe etc_hosts_deny.where { daemon == 'value' } do
-      its ('client_list') { should include ['values'] }
-      its ('options') { should include ['values'] }
-    end
+```ruby
+describe etc_hosts_deny.where { daemon == 'value' } do
+  its ('client_list') { should include ['values'] }
+  its ('options') { should include ['values'] }
+end
+```
 
 Use the optional constructor parameter to give an alternative path to hosts.deny:
 
-    describe etc_hosts_deny(hosts_path).where { daemon == 'value' } do
-      its ('client_list') { should include ['values'] }
-      its ('options') { should include ['values'] }
-    end
+```ruby
+describe etc_hosts_deny(hosts_path).where { daemon == 'value' } do
+  its ('client_list') { should include ['values'] }
+  its ('options') { should include ['values'] }
+end
+```
 
 where
 
@@ -37,7 +41,9 @@ where
 
 ## Properties
 
-    'daemon', 'client_list', 'options'
+```ruby
+'daemon', 'client_list', 'options'
+```
 
 <br>
 
@@ -47,25 +53,31 @@ where
 
 `daemon` returns a string containing the daemon that is allowed in the rule.
 
-    describe etc_hosts_deny.where { client_list == ['127.0.1.154',  '[:fff:fAb0::]'] } do
-      its('daemon') { should eq ['vsftpd', 'sshd'] }
-    end
+```ruby
+describe etc_hosts_deny.where { client_list == ['127.0.1.154',  '[:fff:fAb0::]'] } do
+  its('daemon') { should eq ['vsftpd', 'sshd'] }
+end
+```
 
 ### client_list
 
 `client_list` returns a 2d string array where each entry contains the clients specified for the rule.
 
-    describe etc_hosts_deny.where { daemon == 'sshd' } do
-      its('client_list') { should include ['192.168.0.0/16', '[abcd::0000:1234]'] }
-    end
+```ruby
+describe etc_hosts_deny.where { daemon == 'sshd' } do
+  its('client_list') { should include ['192.168.0.0/16', '[abcd::0000:1234]'] }
+end
+```
 
 ### options
 
 `options` returns a 2d string array where each entry contains any options specified for the rule.
 
-    describe etc_hosts_deny.where { daemon == 'sshd' } do
-      its('options') { should include ['deny', 'echo "REJECTED"'] }
-    end
+```ruby
+describe etc_hosts_deny.where { daemon == 'sshd' } do
+  its('options') { should include ['deny', 'echo "REJECTED"'] }
+end
+```
 
 <br>
 

--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -13,9 +13,11 @@ Use the `file` InSpec audit resource to test all system file types, including fi
 
 A `file` resource block declares the location of the file type to be tested, the expected file type  (if required), and one (or more) resource properties.
 
-    describe file('path') do
-      it { should PROPERTY 'value' }
-    end
+```ruby
+describe file('path') do
+  it { should PROPERTY 'value' }
+end
+```
 
 where
 
@@ -47,27 +49,35 @@ file\_version, product\_version
 
 The `content` property tests if contents in the file match the value specified in a regular expression. The values of the `content` property are arbitrary and depend on the file type being tested and also the type of information that is expected to be in that file:
 
-    its('content') { should match REGEX }
+```ruby
+its('content') { should match REGEX }
+```
 
 The following complete example tests the `pg_hba.conf` file in PostgreSQL for MD5 requirements.  The tests look at all `host` and `local` settings in that file, and then compare the MD5 checksums against the values in the test:
 
-    describe file(hba_config_file) do
-      its('content') { should match(%r{local\s.*?all\s.*?all\s.*?md5}) }
-      its('content') { should match(%r{host\s.*?all\s.*?all\s.*?127.0.0.1\/32\s.*?md5}) }
-      its('content') { should match(%r{host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5})
-    end
+```ruby
+describe file(hba_config_file) do
+  its('content') { should match(%r{local\s.*?all\s.*?all\s.*?md5}) }
+  its('content') { should match(%r{host\s.*?all\s.*?all\s.*?127.0.0.1\/32\s.*?md5}) }
+  its('content') { should match(%r{host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5})
+end
+```
 
 ### file_version
 
 The `file_version` property tests if a Windows file's version matches the specified value. The difference between a file's "file version" and "product version" is that the file version is the version number of the file itself, whereas the product version is the version number associated with the application from which that file originates:
 
-    its('file_version') { should eq '1.2.3' }
+```ruby
+its('file_version') { should eq '1.2.3' }
+```
 
 ### group
 
 The `group` property tests if the group to which a file belongs matches the specified value.
 
-    its('group') { should eq 'admins' }
+```ruby
+its('group') { should eq 'admins' }
+```
 
 The following examples show how to use this InSpec audit resource.
 
@@ -76,66 +86,88 @@ The following examples show how to use this InSpec audit resource.
 The `link_path` property tests if the file exists at the specified path. If the file is a symlink,
 InSpec will resolve the symlink and return the ultimate linked file.
 
-    its('link_path') { should eq '/some/path/to/file' }
+```ruby
+its('link_path') { should eq '/some/path/to/file' }
+```
 
 ### md5sum
 
 The `md5sum` property tests if the MD5 checksum for a file matches the specified value.
 
-    its('md5sum') { should eq '3329x3hf9130gjs9jlasf2305mx91s4j' }
+```ruby
+its('md5sum') { should eq '3329x3hf9130gjs9jlasf2305mx91s4j' }
+```
 
 ### mode
 
 The `mode` property tests if the mode assigned to the file matches the specified value.
 
-    its('mode') { should cmp '0644' }
+```ruby
+its('mode') { should cmp '0644' }
+```
 
 ### mtime
 
 The `mtime` property tests if the file modification time for the file matches the specified value. The mtime, where supported, is returned as the number of seconds since the epoch.
 
-    describe file('/') do
-      its('mtime') { should <= Time.now.to_i }
-      its('mtime') { should >= Time.now.to_i - 1000 }
-    end
+```ruby
+describe file('/') do
+  its('mtime') { should <= Time.now.to_i }
+  its('mtime') { should >= Time.now.to_i - 1000 }
+end
+```
 
 ### owner
 
 The `owner` property tests if the owner of the file matches the specified value.
 
-    its('owner') { should eq 'root' }
+```ruby
+its('owner') { should eq 'root' }
+```
 
 ### product_version
 
 The `product_version` property tests if a Windows file's product version matches the specified value. The difference between a file's "file version" and "product version" is that the file version is the version number of the file itself, whereas the product version is the version number associated with the application from which that file originates.
 
-    its('product_version') { should eq 2.3.4 }
+```ruby
+its('product_version') { should eq 2.3.4 }
+```
 
 ### selinux_label
 
 The `selinux_label` property tests if the SELinux label for a file matches the specified value.
 
-    its('selinux_label') { should eq 'system_u:system_r:httpd_t:s0' }
+```ruby
+its('selinux_label') { should eq 'system_u:system_r:httpd_t:s0' }
+```
 
 ### sha256sum
 
 The `sha256sum` property tests if the SHA-256 checksum for a file matches the specified value.
 
-    its('sha256sum') { should eq 'b837ch38lh19bb8eaopl8jvxwd2e4g58jn9lkho1w3ed9jbkeicalplaad9k0pjn' }
+```ruby
+its('sha256sum') { should eq 'b837ch38lh19bb8eaopl8jvxwd2e4g58jn9lkho1w3ed9jbkeicalplaad9k0pjn' }
+```
 
 ### size
 
 The `size` property tests if a file's size matches, is greater than, or is less than the specified value. For example, equal:
 
-    its('size') { should eq 32375 }
+```ruby
+its('size') { should eq 32375 }
+```
 
 Greater than:
 
-    its('size') { should > 64 }
+```ruby
+its('size') { should > 64 }
+```
 
 Less than:
 
-    its('size') { should < 10240 }
+```ruby
+its('size') { should < 10240 }
+```
 
 ### type
 
@@ -155,152 +187,202 @@ either by symbol or string.
 
 For example:
 
-    its('type') { should eq :file }
-    its('type') { should cmp 'file' }
+```ruby
+its('type') { should eq :file }
+its('type') { should cmp 'file' }
+```
 
 or:
 
-    its('type') { should eq :socket }
-    its('type') { should cmp 'socket' }
+```ruby
+its('type') { should eq :socket }
+its('type') { should cmp 'socket' }
+```
 
 ### Test the contents of a file for MD5 requirements
 
-    describe file(hba_config_file) do
-      its('content') { should match /local\s.*?all\s.*?all\s.*?md5/ }
-      its('content') { should match %r{/host\s.*?all\s.*?all\s.*?127.0.0.1\/32\s.*?md5/} }
-      its('content') { should match %r{/host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5/} }
-    end
+```ruby
+describe file(hba_config_file) do
+  its('content') { should match /local\s.*?all\s.*?all\s.*?md5/ }
+  its('content') { should match %r{/host\s.*?all\s.*?all\s.*?127.0.0.1\/32\s.*?md5/} }
+  its('content') { should match %r{/host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5/} }
+end
+```
 
 ### Test if a file exists
 
-    describe file('/tmp') do
-     it { should exist }
-    end
+```ruby
+describe file('/tmp') do
+ it { should exist }
+end
+```
 
 ### Test that a file does not exist
 
-    describe file('/tmpest') do
-     it { should_not exist }
-    end
+```ruby
+describe file('/tmpest') do
+ it { should_not exist }
+end
+```
 
 ### Test if a path is a directory
 
-    describe file('/tmp') do
-     its('type') { should eq :directory }
-     it { should be_directory }
-    end
+```ruby
+describe file('/tmp') do
+ its('type') { should eq :directory }
+ it { should be_directory }
+end
+```
 
 ### Test if a path is a file and not a directory
 
-    describe file('/proc/version') do
-      its('type') { should cmp 'file' }
-      it { should be_file }
-      it { should_not be_directory }
-    end
+```ruby
+describe file('/proc/version') do
+  its('type') { should cmp 'file' }
+  it { should be_file }
+  it { should_not be_directory }
+end
+```
 
 ### Test if a file is a symbolic link
 
-    describe file('/dev/stdout') do
-      its('type') { should cmp 'symlink' }
-      it { should be_symlink }
-      it { should_not be_file }
-      it { should_not be_directory }
-    end
+```ruby
+describe file('/dev/stdout') do
+  its('type') { should cmp 'symlink' }
+  it { should be_symlink }
+  it { should_not be_file }
+  it { should_not be_directory }
+end
+```
 
 ### Test if a file is a character device
 
-    describe file('/dev/zero') do
-      its('type') { should cmp 'character' }
-      it { should be_character_device }
-      it { should_not be_file }
-      it { should_not be_directory }
-    end
+```ruby
+describe file('/dev/zero') do
+  its('type') { should cmp 'character' }
+  it { should be_character_device }
+  it { should_not be_file }
+  it { should_not be_directory }
+end
+```
 
 ### Test if a file is a block device
 
-    describe file('/dev/zero') do
-      its('type') { should cmp 'block' }
-      it { should be_character_device }
-      it { should_not be_file }
-      it { should_not be_directory }
-    end
+```ruby
+describe file('/dev/zero') do
+  its('type') { should cmp 'block' }
+  it { should be_character_device }
+  it { should_not be_file }
+  it { should_not be_directory }
+end
+```
 
 ### Test the mode for a file
 
-    describe file('/dev') do
-     its('mode') { should cmp '00755' }
-    end
+```ruby
+describe file('/dev') do
+ its('mode') { should cmp '00755' }
+end
+```
 
 ### Test the owner of a file
 
-    describe file('/root') do
-      its('owner') { should eq 'root' }
-    end
+```ruby
+describe file('/root') do
+  its('owner') { should eq 'root' }
+end
+```
 
 ### Test if a file is owned by the root user
 
-    describe file('/dev') do
-      it { should be_owned_by 'root' }
-    end
+```ruby
+describe file('/dev') do
+  it { should be_owned_by 'root' }
+end
+```
 
 ### Test the mtime for a file
 
-    describe file('/') do
-      its('mtime') { should <= Time.now.to_i }
-      its('mtime') { should >= Time.now.to_i - 1000 }
-    end
+```ruby
+describe file('/') do
+  its('mtime') { should <= Time.now.to_i }
+  its('mtime') { should >= Time.now.to_i - 1000 }
+end
+```
 
 ### Test that a file's size is between 64 and 10240
 
-    describe file('/') do
-      its('size') { should be > 64 }
-      its('size') { should be < 10240 }
-    end
+```ruby
+describe file('/') do
+  its('size') { should be > 64 }
+  its('size') { should be < 10240 }
+end
+```
 
 ### Test that a file's size is zero
 
-    describe file('/proc/cpuinfo') do
-      its('size') { should be 0 }
-    end
+```ruby
+describe file('/proc/cpuinfo') do
+  its('size') { should be 0 }
+end
+```
 
 
 ### Test an MD5 checksum
 
-    require 'digest'
-    cpuinfo = file('/proc/cpuinfo').content
+```ruby
+require 'digest'
+cpuinfo = file('/proc/cpuinfo').content
+```
 
-    md5sum = Digest::MD5.hexdigest(cpuinfo)
+```ruby
+md5sum = Digest::MD5.hexdigest(cpuinfo)
+```
 
-    describe file('/proc/cpuinfo') do
-      its('md5sum') { should eq md5sum }
-    end
+```ruby
+describe file('/proc/cpuinfo') do
+  its('md5sum') { should eq md5sum }
+end
+```
 
 ### Test an SHA-256 checksum
 
-    require 'digest'
-    cpuinfo = file('/proc/cpuinfo').content
+```ruby
+require 'digest'
+cpuinfo = file('/proc/cpuinfo').content
+```
 
-    sha256sum = Digest::SHA256.hexdigest(cpuinfo)
+```ruby
+sha256sum = Digest::SHA256.hexdigest(cpuinfo)
+```
 
-    describe file('/proc/cpuinfo') do
-      its('sha256sum') { should eq sha256sum }
-    end
+```ruby
+describe file('/proc/cpuinfo') do
+  its('sha256sum') { should eq sha256sum }
+end
+```
 
 ### Verify NTP
 
 The following example shows how to use the `file` audit resource to verify if the `ntp.conf` and `leap-seconds` files are present, and then the `command` resource to verify if NTP is installed and running:
 
-    describe file('/etc/ntp.conf') do
-       it { should be_file }
-    end
+```ruby
+describe file('/etc/ntp.conf') do
+   it { should be_file }
+end
+```
 
-    describe file('/etc/ntp.leapseconds') do
-      it { should be_file }
-    end
+```ruby
+describe file('/etc/ntp.leapseconds') do
+  it { should be_file }
+end
+```
 
-    describe command('pgrep ntp') do
-       its('exit_status') { should eq 0 }
-    end
+```ruby
+describe command('pgrep ntp') do
+   its('exit_status') { should eq 0 }
+end
+```
 
 ### Test parameters of symlinked file
 
@@ -308,21 +390,27 @@ If you need to test the parameters of the target file for a symlink, you can use
 
 For example, for the following symlink:
 
-    lrwxrwxrwx. 1 root root 11 03-10 17:56 /dev/virtio-ports/com.redhat.rhevm.vdsm -> ../vport2p1
+```ruby
+lrwxrwxrwx. 1 root root 11 03-10 17:56 /dev/virtio-ports/com.redhat.rhevm.vdsm -> ../vport2p1
+```
 
 ... you can write controls for both the link and the target.
 
-    describe file('/dev/virtio-ports/com.redhat.rhevm.vdsm') do
-      it { should be_symlink }
-    end
+```ruby
+describe file('/dev/virtio-ports/com.redhat.rhevm.vdsm') do
+  it { should be_symlink }
+end
+```
 
-    virito_port_vdsm = file('/dev/virtio-ports/com.redhat.rhevm.vdsm').link_path
-    describe file(virito_port_vdsm) do
-      it { should exist }
-      it { should be_character_device }
-      it { should be_owned_by 'ovirtagent' }
-      it { should be_grouped_into 'ovirtagent' }
-    end
+```ruby
+virito_port_vdsm = file('/dev/virtio-ports/com.redhat.rhevm.vdsm').link_path
+describe file(virito_port_vdsm) do
+  it { should exist }
+  it { should be_character_device }
+  it { should be_owned_by 'ovirtagent' }
+  it { should be_grouped_into 'ovirtagent' }
+end
+```
 
 <br>
 
@@ -334,182 +422,252 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_allowed` matcher tests if the file contains a certain permission set, such as `execute` or `write` in Unix and [`full-control` or `modify` in Windows](https://www.codeproject.com/Reference/871338/AccessControl-FileSystemRights-Permissions-Table).
 
-    it { should be_allowed('read') }
+```ruby
+it { should be_allowed('read') }
+```
 
 Just like with `be_executable` and other permissions, one can check for the permission with respect to the specific user or group.
 
-    it { should be_allowed('full-control', by_user: 'MyComputerName\Administrator') }
+```ruby
+it { should be_allowed('full-control', by_user: 'MyComputerName\Administrator') }
+```
 
 OR
 
-    it { should be_allowed('write', by: 'root') }
+```ruby
+it { should be_allowed('write', by: 'root') }
+```
 
 ### be\_block\_device
 
 The `be_block_device` matcher tests if the file exists as a block device, such as `/dev/disk0` or `/dev/disk0s9`:
 
-    it { should be_block_device }
+```ruby
+it { should be_block_device }
+```
 
 ### be\_character\_device
 
 The `be_character_device` matcher tests if the file exists as a character device (that corresponds to a block device), such as `/dev/rdisk0` or `/dev/rdisk0s9`:
 
-    it { should be_character_device }
+```ruby
+it { should be_character_device }
+```
 
 ### be_directory
 
 The `be_directory` matcher tests if the file exists as a directory, such as `/etc/passwd`, `/etc/shadow`, or `/var/log/httpd`:
 
-    it { should be_directory }
+```ruby
+it { should be_directory }
+```
 
 ### be_executable
 
 The `be_executable` matcher tests if the file exists as an executable:
 
-    it { should be_executable }
+```ruby
+it { should be_executable }
+```
 
 The `be_executable` matcher may also test if the file is executable by a specific owner, group, or user. For example, a group:
 
-    it { should be_executable.by('group') }
+```ruby
+it { should be_executable.by('group') }
+```
 
 an owner:
 
-    it { should be_executable.by('owner') }
+```ruby
+it { should be_executable.by('owner') }
+```
 
 any user other than the owner or members of the file's group:
 
-    it { should be_executable.by('others') }
+```ruby
+it { should be_executable.by('others') }
+```
 
 a user:
 
-    it { should be_executable.by_user('user') }
+```ruby
+it { should be_executable.by_user('user') }
+```
 
 ### be_file
 
 The `be_file` matcher tests if the file exists as a file. This can be useful with configuration files like `/etc/passwd` where there typically is not an associated file extension---`passwd.txt`:
 
-    it { should be_file }
+```ruby
+it { should be_file }
+```
 
 ### be\_grouped\_into
 
 The `be_grouped_into` matcher tests if the file exists as part of the named group:
 
-    it { should be_grouped_into 'group' }
+```ruby
+it { should be_grouped_into 'group' }
+```
 
 ### be_immutable
 
 The `be_immutable` matcher tests if the file is immutable, i.e. "cannot be changed":
 
-    it { should be_immutable }
+```ruby
+it { should be_immutable }
+```
 
 ### be\_linked\_to
 
 The `be_linked_to` matcher tests if the file is linked to the named target:
 
-    it { should be_linked_to '/etc/target-file' }
+```ruby
+it { should be_linked_to '/etc/target-file' }
+```
 
 
 ### be\_owned\_by
 
 The `be_owned_by` matcher tests if the file is owned by the named user, such as `root`:
 
-    it { should be_owned_by 'root' }
+```ruby
+it { should be_owned_by 'root' }
+```
 
 ### be_pipe
 
 The `be_pipe` matcher tests if the file exists as first-in, first-out special file (`.fifo`) that is typically used to define a named pipe, such as `/var/log/nginx/access.log.fifo`:
 
-    it { should be_pipe }
+```ruby
+it { should be_pipe }
+```
 
 ### be_readable
 
 The `be_readable` matcher tests if the file is readable:
 
-    it { should be_readable }
+```ruby
+it { should be_readable }
+```
 
 The `be_readable` matcher may also test if the file is readable by a specific owner, group, or user. For example, a group:
 
-    it { should be_readable.by('group') }
+```ruby
+it { should be_readable.by('group') }
+```
 
 an owner:
 
-    it { should be_readable.by('owner') }
+```ruby
+it { should be_readable.by('owner') }
+```
 
 any user other than the owner or members of the file's group:
 
-    it { should be_readable.by('others') }
+```ruby
+it { should be_readable.by('others') }
+```
 
 a user:
 
-    it { should be_readable.by_user('user') }
+```ruby
+it { should be_readable.by_user('user') }
+```
 
 ### be_setgid
 
 The `be_setgid` matcher tests if the 'setgid' permission is set on the file or directory.  On executable files, this causes the process to be started owned by the group that owns the file, rather than the primary group of the invocating user.  This can result in escalation of privilege.  On Linux, when setgid is set on directories, setgid causes newly created files and directories to be owned by the group that owns the setgid parent directory; additionally, newly created subdirectories will have the setgid bit set.  To use this matcher:
 
-    it { should be_setgid }
+```ruby
+it { should be_setgid }
+```
 
 ### be_socket
 
 The `be_socket` matcher tests if the file exists as socket (`.sock`), such as `/var/run/php-fpm.sock`:
 
-    it { should be_socket }
+```ruby
+it { should be_socket }
+```
 
 ### be_sticky
 
 The `be_sticky` matcher tests if the 'sticky bit' permission is set on the directory.  On directories, this restricts file deletion to the owner of the file, even if the permission of the parent directory would normally permit deletion by others.  This is commonly used on /tmp filesystems.  To use this matcher:
 
-    it { should be_sticky }
+```ruby
+it { should be_sticky }
+```
 
 ### be_setuid
 
 The `be_setuid` matcher tests if the 'setuid' permission is set on the file.  On executable files, this causes the process to be started owned by the user that owns the file, rather than invocating user.  This can result in escalation of privilege.  To use this matcher:
 
-    it { should be_setuid }
+```ruby
+it { should be_setuid }
+```
 
 ### be_symlink
 
 The `be_symlink` matcher tests if the file exists as a symbolic, or soft link that contains an absolute or relative path reference to another file:
 
-    it { should be_symlink }
+```ruby
+it { should be_symlink }
+```
 
 ### be_version
 
 The `be_version` matcher tests the version of the file:
 
-    it { should be_version '1.2.3' }
+```ruby
+it { should be_version '1.2.3' }
+```
 
 ### be_writable
 
 The `be_writable` matcher tests if the file is writable:
 
-    it { should be_writable }
+```ruby
+it { should be_writable }
+```
 
 The `be_writable` matcher may also test if the file is writable by a specific owner, group, or user. For example, a group:
 
-    it { should be_writable.by('group') }
+```ruby
+it { should be_writable.by('group') }
+```
 
 an owner:
 
-    it { should be_writable.by('owner') }
+```ruby
+it { should be_writable.by('owner') }
+```
 
 any user other than the owner or members of the file's group:
 
-    it { should be_writable.by('others') }
+```ruby
+it { should be_writable.by('others') }
+```
 
 a user:
 
-    it { should be_writable.by_user('user') }
+```ruby
+it { should be_writable.by_user('user') }
+```
 
 ### exist
 
 The `exist` matcher tests if the named file exists:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 ### have_mode
 
 The `have_mode` matcher tests if a file has a mode assigned to it:
 
-    it { should have_mode }
+```ruby
+it { should have_mode }
+```
 

--- a/docs/resources/filesystem.md.erb
+++ b/docs/resources/filesystem.md.erb
@@ -13,9 +13,11 @@ Use the `filesystem` InSpec resource to audit filesystem disk space usage.
 
 A `filesystem` resource block declares tests for disk space in a partion:
 
-    describe filesystem('/') do
-      its('size') { should be >= 32000 }
-    end
+```ruby
+describe filesystem('/') do
+  its('size') { should be >= 32000 }
+end
+```
 
 where
 
@@ -30,9 +32,11 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if the root partition is greater thank 32000 MB
 
-    describe filesystem('/') do
-      its('size') { should be >= 32000 }
-    end
+```ruby
+describe filesystem('/') do
+  its('size') { should be >= 32000 }
+end
+```
 
 <br>
 

--- a/docs/resources/firewalld.md.erb
+++ b/docs/resources/firewalld.md.erb
@@ -13,21 +13,24 @@ A firewalld has a number of zones that can be configured to allow and deny acces
 
 ## Syntax
 
-    describe firewalld do
-      it { should be_running }
-      its('default_zone') { should eq 'public' }
-      it { should have_service_enabled_in_zone('ssh', 'public') }
-      it { should have_rule_enabled('family=ipv4 source address=192.168.0.14 accept', 'public') }
-    end
+```ruby
+describe firewalld do
+  it { should be_running }
+  its('default_zone') { should eq 'public' }
+  it { should have_service_enabled_in_zone('ssh', 'public') }
+  it { should have_rule_enabled('family=ipv4 source address=192.168.0.14 accept', 'public') }
+end
+```
 
 Use the where clause to test open interfaces, sources, and services in active zones.
 
-    describe firewalld.where { zone == 'public' } do
-      its('interfaces') { should cmp ['enp0s3', 'eno2'] }
-      its('sources') { should cmp ['192.168.1.0/24', '192.168.1.2'] }
-      its('services') { should cmp ['ssh', 'icmp'] }
-    end
-
+```ruby
+describe firewalld.where { zone == 'public' } do
+  its('interfaces') { should cmp ['enp0s3', 'eno2'] }
+  its('sources') { should cmp ['192.168.1.0/24', '192.168.1.2'] }
+  its('services') { should cmp ['ssh', 'icmp'] }
+end
+```
 <br>
 
 ## Properties
@@ -36,31 +39,39 @@ Use the where clause to test open interfaces, sources, and services in active zo
 
 The `interfaces` property is used in conjunction with the where class to display open interfaces in an active zone.
 
-    describe firewalld.where { zone == 'public' } do
-      its('interfaces') { should cmp ['enp0s3', 'eno2'] }
-    end
+```ruby
+describe firewalld.where { zone == 'public' } do
+  its('interfaces') { should cmp ['enp0s3', 'eno2'] }
+end
+```
 
 ### sources
 
 The `sources` property is used in conjunction with the where class to display open sources in an active zone.
 
-    describe firewalld.where { zone == 'public' } do
-      its('sources') { should cmp ['192.168.1.0/24', '192.168.1.2'] }
-    end
+```ruby
+describe firewalld.where { zone == 'public' } do
+  its('sources') { should cmp ['192.168.1.0/24', '192.168.1.2'] }
+end
+```
 
 ### services
 
 The `services` property is used in conjunction with the where class to display open services in an active zone.
 
-    describe firewalld.where { zone == 'public' } do
-      its('services') { should cmp ['ssh', 'icmp'] }
-    end
+```ruby
+describe firewalld.where { zone == 'public' } do
+  its('services') { should cmp ['ssh', 'icmp'] }
+end
+```
 
 ### default_zone
 
 The `default_zone` property displays the default active zone to be used.
 
-    its('default_zone') { should eq 'public' }
+```ruby
+its('default_zone') { should eq 'public' }
+```
 
 <br>
 
@@ -72,36 +83,48 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_installed` matcher tests if the firewalld service is installed:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### `be_running`
 
 The `be_running` matcher tests if the firewalld service is running:
 
-    it { should be_running }
+```ruby
+it { should be_running }
+```
 
 ### have_zone
 
 `have_zone` returns true or false if the zone is set on firewalld. It does not mean the zone is active.
 
-    it { should have_zone('public') }
+```ruby
+it { should have_zone('public') }
+```
 
 ### `have_service_enabled_in_zone`
 
 `have_service_enabled_in_zone` returns true or false if the service is allowed in the specified zone.
 
-    it { should have_service_enabled_in_zone('ssh', 'public') }
+```ruby
+it { should have_service_enabled_in_zone('ssh', 'public') }
+```
 
 ### `have_port_enabled_in_zone`
 
 `have_port_enabled_in_zone` returns true or false if the port is allowed in the specified zone.
 
-    it { should have_port_enabled_in_zone('22/tcp', 'public') }
+```ruby
+it { should have_port_enabled_in_zone('22/tcp', 'public') }
+```
 
 ### `have_rule_enabled`
 
 `have_rule_enabled` returns true or false if the rich-rule has been specified in the zone.
 
-    it { should have_rule_enabled('family=ipv4 source address=192.168.0.14 accept', 'public') }
+```ruby
+it { should have_rule_enabled('family=ipv4 source address=192.168.0.14 accept', 'public') }
+```
 
 It is not necessary to add the "rule" string, and you can start with the optional flags that are used in firewalld and end with the action

--- a/docs/resources/gem.md.erb
+++ b/docs/resources/gem.md.erb
@@ -13,9 +13,11 @@ Use the `gem` InSpec audit resource to test if a global Gem package is installed
 
 A `gem` resource block declares a package and (optionally) a package version:
 
-    describe gem('gem_package_name', 'gem_binary') do
-      it { should be_installed }
-    end
+```ruby
+describe gem('gem_package_name', 'gem_binary') do
+  it { should be_installed }
+end
+```
 
 where
 
@@ -31,34 +33,44 @@ The following examples show how to use this InSpec audit resource.
 
 ### Verify that a gem package is installed, with a specific version
 
-    describe gem('rubocop') do
-      it { should be_installed }
-      its('version') { should eq '0.33.0' }
-    end
+```ruby
+describe gem('rubocop') do
+  it { should be_installed }
+  its('version') { should eq '0.33.0' }
+end
+```
 
 ### Verify that a gem package is not installed
 
-    describe gem('rubocop') do
-      it { should_not be_installed }
-    end
+```ruby
+describe gem('rubocop') do
+  it { should_not be_installed }
+end
+```
 
 ### Verify that a gem package is installed in an omnibus environment
 
-    describe gem('pry', '/opt/ruby-2.3.1/embedded/bin/gem') do
-      it { should be_installed }
-    end
+```ruby
+describe gem('pry', '/opt/ruby-2.3.1/embedded/bin/gem') do
+  it { should be_installed }
+end
+```
 
 ### Verify that a gem package is installed in a chef omnibus environment
 
-    describe gem('chef-sugar', :chef) do
-      it { should be_installed }
-    end
+```ruby
+describe gem('chef-sugar', :chef) do
+  it { should be_installed }
+end
+```
 
 ### Verify that a gem package is installed in a chef-server omnibus environment
 
-    describe gem('knife-backup', :chef_server) do
-      it { should be_installed }
-    end
+```ruby
+describe gem('knife-backup', :chef_server) do
+  it { should be_installed }
+end
+```
 
 <br>
 
@@ -70,10 +82,14 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_installed` matcher tests if the named Gem package is installed:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### version
 
 The `version` matcher tests if the named package version is on the system:
 
-    its('version') { should eq '0.33.0' }
+```ruby
+its('version') { should eq '0.33.0' }
+```

--- a/docs/resources/group.md.erb
+++ b/docs/resources/group.md.erb
@@ -13,10 +13,12 @@ Use the `group` InSpec audit resource to test groups on the system.
 
 A `group` resource block declares a group, and then the details to be tested, such as if the group is a local group, the group identifier, or if the group exists:
 
-    describe group('group_name') do
-      it { should exist }
-      its('gid') { should eq 0 }
-    end
+```ruby
+describe group('group_name') do
+  it { should exist }
+  its('gid') { should eq 0 }
+end
+```
 
 where
 
@@ -31,10 +33,12 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test the group identifier for the root group
 
-    describe group('root') do
-      it { should exist }
-      its('gid') { should eq 0 }
-    end
+```ruby
+describe group('root') do
+  it { should exist }
+  its('gid') { should eq 0 }
+end
+```
 
 <br>
 
@@ -46,16 +50,22 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_local` matcher tests if the group is a local group:
 
-    it { should be_local }
+```ruby
+it { should be_local }
+```
 
 ### exist
 
 The `exist` matcher tests if the named user exists:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 ### gid
 
 The `gid` matcher tests the named group identifier:
 
-    its('gid') { should eq 1234 }
+```ruby
+its('gid') { should eq 1234 }
+```

--- a/docs/resources/grub_conf.md.erb
+++ b/docs/resources/grub_conf.md.erb
@@ -13,16 +13,20 @@ Grub is a boot loader on the Linux platform used to load and then transfer contr
 
 A `grub_conf` resource block declares a list of settings in a `grub.conf` file:
 
-    describe grub_conf('path', 'kernel') do
-      its('setting') { should eq 'value' }
-    end
+```ruby
+describe grub_conf('path', 'kernel') do
+  its('setting') { should eq 'value' }
+end
+```
 
 or:
 
-    describe grub_conf('path') do
-      its('default') { should eq '0' } #
-      its('setting') { should eq 'value' }
-    end
+```ruby
+describe grub_conf('path') do
+  its('default') { should eq '0' } #
+  its('setting') { should eq 'value' }
+end
+```
 
 where
 
@@ -66,33 +70,41 @@ This file defines two versions of RedHat Enterprise Linux, with version `2.6.32-
 
 The following test verifies the kernel, ensures that kernel is the default kernel, its initial RAM disk (`initrd`), and the timeout:
 
-    describe grub_conf('/etc/grub.conf',  'default') do
-      its('kernel') { should include '/vmlinuz-2.6.32-573.7.1.el6.x86_64' }
-      its('initrd') { should include '/initrd-2.6.32-573.7.1.el6.x86_64.img' }
-      its('default') { should_not eq '1' }
-      its('timeout') { should eq '10' }
-    end
+```ruby
+describe grub_conf('/etc/grub.conf',  'default') do
+  its('kernel') { should include '/vmlinuz-2.6.32-573.7.1.el6.x86_64' }
+  its('initrd') { should include '/initrd-2.6.32-573.7.1.el6.x86_64.img' }
+  its('default') { should_not eq '1' }
+  its('timeout') { should eq '10' }
+end
+```
 
 The following test verifies the `ramdisk_size` for the non-deault kernel:
 
-    describe grub_conf('/etc/grub.conf',  'Red Hat Enterprise Linux ES (2.6.32-358.14.1.el6.x86_64)') do
-       its('kernel') { should include 'ramdisk_size=400000' }
-     end
+```ruby
+describe grub_conf('/etc/grub.conf',  'Red Hat Enterprise Linux ES (2.6.32-358.14.1.el6.x86_64)') do
+   its('kernel') { should include 'ramdisk_size=400000' }
+ end
+```
 
 ### Test a configuration file and boot configuration
 
-    describe grub_conf('/etc/grub.conf',  'default') do
-      its('kernel') { should include '/vmlinuz-2.6.32-573.7.1.el6.x86_64' }
-      its('initrd') { should include '/initramfs-2.6.32-573.el6.x86_64.img=1' }
-      its('default') { should_not eq '1' }
-      its('timeout') { should eq '5' }
-    end
+```ruby
+describe grub_conf('/etc/grub.conf',  'default') do
+  its('kernel') { should include '/vmlinuz-2.6.32-573.7.1.el6.x86_64' }
+  its('initrd') { should include '/initramfs-2.6.32-573.el6.x86_64.img=1' }
+  its('default') { should_not eq '1' }
+  its('timeout') { should eq '5' }
+end
+```
 
 ### Test a specific kernel
 
-    grub_conf('/etc/grub.conf',  'CentOS (2.6.32-573.12.1.el6.x86_64)') do
-      its('kernel') { should include 'audit=1' }
-    end
+```ruby
+grub_conf('/etc/grub.conf',  'CentOS (2.6.32-573.12.1.el6.x86_64)') do
+  its('kernel') { should include 'audit=1' }
+end
+```
 
 <br>
 

--- a/docs/resources/host.md.erb
+++ b/docs/resources/host.md.erb
@@ -13,11 +13,13 @@ Use the `host` InSpec audit resource to test the name used to refer to a specifi
 
 A `host` resource block declares a host name, and then (depending on what is to be tested) a port and/or a protocol:
 
-    describe host('example.com', port: 80, protocol: 'tcp') do
-      it { should be_reachable }
-      it { should be_resolvable }
-      its('ipaddress') { should include '12.34.56.78' }
-    end
+```ruby
+describe host('example.com', port: 80, protocol: 'tcp') do
+  it { should be_reachable }
+  it { should be_resolvable }
+  its('ipaddress') { should include '12.34.56.78' }
+end
+```
 
 where
 
@@ -34,24 +36,30 @@ The following examples show how to use this InSpec audit resource.
 
 ### Verify host name is reachable over a specific protocol and port number
 
-    describe host('example.com', port: 80, protocol: 'tcp') do
-      it { should be_reachable }
-    end
+```ruby
+describe host('example.com', port: 80, protocol: 'tcp') do
+  it { should be_reachable }
+end
+```
 
 ### Verify that a specific IP address can be resolved
 
-    describe host('example.com') do
-      it { should be_resolvable }
-      its('ipaddress') { should include '192.168.1.1' }
-    end
+```ruby
+describe host('example.com') do
+  it { should be_resolvable }
+  its('ipaddress') { should include '192.168.1.1' }
+end
+```
 
 ### Review the connection setup and socket contents when checking reachability
 
-    describe host('example.com', port: 12345, protocol: 'tcp') do
-      it { should be_reachable }
-      its('connection') { should_not match /connection refused/ }
-      its('socket') { should match /STATUS_OK/ }
-    end
+```ruby
+describe host('example.com', port: 12345, protocol: 'tcp') do
+  it { should be_reachable }
+  its('connection') { should_not match /connection refused/ }
+  its('socket') { should match /STATUS_OK/ }
+end
+```
 
 <br>
 
@@ -63,16 +71,22 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_reachable` matcher tests if the host name is available:
 
-    it { should be_reachable }
+```ruby
+it { should be_reachable }
+```
 
 ### be_resolvable
 
 The `be_resolvable` matcher tests for host name resolution, i.e. "resolvable to an IP address":
 
-    it { should be_resolvable }
+```ruby
+it { should be_resolvable }
+```
 
 ### ipaddress
 
 The `ipaddress` matcher tests if a host name is resolvable to a specific IP address:
 
-    its('ipaddress') { should include '93.184.216.34' }
+```ruby
+its('ipaddress') { should include '93.184.216.34' }
+```

--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -13,11 +13,13 @@ Use the `http` InSpec audit resource to test an http endpoint.
 
 An `http` resource block declares the configuration settings to be tested:
 
-    describe http('url', auth: {user: 'user', pass: 'test'}, params: {params}, method: 'method', headers: {headers}, data: data, open_timeout: 60, read_timeout: 60, ssl_verify: true) do
-      its('status') { should eq number }
-      its('body') { should eq 'body' }
-      its('headers.name') { should eq 'header' }
-    end
+```ruby
+describe http('url', auth: {user: 'user', pass: 'test'}, params: {params}, method: 'method', headers: {headers}, data: data, open_timeout: 60, read_timeout: 60, ssl_verify: true) do
+  its('status') { should eq number }
+  its('body') { should eq 'body' }
+  its('headers.name') { should eq 'header' }
+end
+```
 
 where
 
@@ -37,9 +39,11 @@ where
 
 Beginning with InSpec 1.41, you can enable the ability to have the HTTP test execute on the remote target:
 
-    describe http('http://www.example.com', enable_remote_worker: true) do
-      its('body') { should cmp 'awesome' }
-    end
+```ruby
+describe http('http://www.example.com', enable_remote_worker: true) do
+  its('body') { should cmp 'awesome' }
+end
+```
 
 In InSpec 2.0, the HTTP test will automatically execute remotely whenever InSpec is testing a remote node.
 
@@ -59,22 +63,26 @@ The following examples show how to use this InSpec audit resource.
 
 For example, a service is listening on default http port can be tested like this:
 
-    describe http('http://localhost') do
-      its('status') { should cmp 200 }
-    end
+```ruby
+describe http('http://localhost') do
+  its('status') { should cmp 200 }
+end
+```
 
 ### Complex http test
 
-    describe http('http://localhost:8080/ping',
-                  auth: {user: 'user', pass: 'test'},
-                  params: {format: 'html'},
-                  method: 'POST',
-                  headers: {'Content-Type' => 'application/json'},
-                  data: '{"data":{"a":"1","b":"five"}}') do
-      its('status') { should cmp 200 }
-      its('body') { should cmp 'pong' }
-      its('headers.Content-Type') { should cmp 'text/html' }
-    end
+```ruby
+describe http('http://localhost:8080/ping',
+              auth: {user: 'user', pass: 'test'},
+              params: {format: 'html'},
+              method: 'POST',
+              headers: {'Content-Type' => 'application/json'},
+              data: '{"data":{"a":"1","b":"five"}}') do
+  its('status') { should cmp 200 }
+  its('body') { should cmp 'pong' }
+  its('headers.Content-Type') { should cmp 'text/html' }
+end
+```
 
 <br>
 
@@ -82,20 +90,28 @@ For example, a service is listening on default http port can be tested like this
 
 The `body` matcher tests body content of http response:
 
-   its('body') { should eq 'hello\n' }
+```ruby
+ts('body') { should eq 'hello\n' }
+```
 
 ### headers
 
 The `headers` matcher returns an hash of all http headers:
 
-    its('headers') { should eq {} }
+```ruby
+its('headers') { should eq {} }
+```
 
 Individual headers can be tested via:
 
-    its('headers.Content-Type') { should cmp 'text/html' }
+```ruby
+its('headers.Content-Type') { should cmp 'text/html' }
+```
 
 ### status
 
 The `status` matcher tests status of the http response:
 
-    its('status') { should eq 200 }
+```ruby
+its('status') { should eq 200 }
+```

--- a/docs/resources/iis_app.md.erb
+++ b/docs/resources/iis_app.md.erb
@@ -13,14 +13,16 @@ Use the `iis_app` InSpec audit resource to test the state of IIS on Windows Serv
 
 An `iis_app` resource block declares details about the named site:
 
-    describe iis_app('application_path', 'site_name') do
-      it { should exist }
-      it { should have_application_pool('application_pool') }
-      it { should have_protocols('protocol') }
-      it { should have_site_name('site') }
-      it { should have_physical_path('physical_path') }
-      it { should have_path('application_path') }
-    end
+```ruby
+describe iis_app('application_path', 'site_name') do
+  it { should exist }
+  it { should have_application_pool('application_pool') }
+  it { should have_protocols('protocol') }
+  it { should have_site_name('site') }
+  it { should have_physical_path('physical_path') }
+  it { should have_path('application_path') }
+end
+```
 
 where
 
@@ -32,14 +34,16 @@ where
 
 For example:
 
-    describe iis_app('/myapp', 'Default Web Site') do
-      it { should exist }
-      it { should have_application_pool('MyAppPool') }
-      it { should have_protocols('http') }
-      it { should have_site_name('Default Web Site') }
-      it { should have_physical_path('C:\\inetpub\\wwwroot\\myapp') }
-      it { should have_path('\\My Application') }
-    end
+```ruby
+describe iis_app('/myapp', 'Default Web Site') do
+  it { should exist }
+  it { should have_application_pool('MyAppPool') }
+  it { should have_protocols('http') }
+  it { should have_site_name('Default Web Site') }
+  it { should have_physical_path('C:\\inetpub\\wwwroot\\myapp') }
+  it { should have_path('\\My Application') }
+end
+```
 
 <br>
 
@@ -54,20 +58,24 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test a default IIS web application
 
-    describe iis_app('Default Web Site') do
-      it { should exist }
-      it { should be_running }
-      it { should have_app_pool('DefaultAppPool') }
-      it { should have_binding('http *:80:') }
-      it { should have_path('%SystemDrive%\\inetpub\\wwwroot') }
-    end
+```ruby
+describe iis_app('Default Web Site') do
+  it { should exist }
+  it { should be_running }
+  it { should have_app_pool('DefaultAppPool') }
+  it { should have_binding('http *:80:') }
+  it { should have_path('%SystemDrive%\\inetpub\\wwwroot') }
+end
+```
 
 ### Test if IIS service is running
 
-    describe service('W3SVC') do
-      it { should be_installed }
-      it { should be_running }
-    end
+```ruby
+describe service('W3SVC') do
+  it { should be_installed }
+  it { should be_running }
+end
+```
 
 <br>
 
@@ -79,23 +87,31 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `exist` matcher tests if the site exists:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 ### have\_application\_pool
 
 The `have_application_pool` matcher tests if the named application pool exists for the web application:
 
-    it { should have_application_pool('DefaultAppPool') }
+```ruby
+it { should have_application_pool('DefaultAppPool') }
+```
 
 ### have_protocol
 
 The `have_protocol` matcher tests if the specified protocol exists for the web application:
 
-    it { should have_protocol('http') }
+```ruby
+it { should have_protocol('http') }
+```
 
 or:
 
-    it { should have_protocol('https') }
+```ruby
+it { should have_protocol('https') }
+```
 
 A web application may have multiple bindings; use a `have_protocol` matcher for each unique web application binding to be tested.
 
@@ -103,20 +119,28 @@ A web application may have multiple bindings; use a `have_protocol` matcher for 
 
 The `have_protocol` matcher can also test attributes that are defined for a web application enabledProtocols.
 
-    it { should have_protocol('http') }
+```ruby
+it { should have_protocol('http') }
+```
 
 For example, testing a site that doesn't have https enabled:
 
-    it { should_not have_protocol('https') }
-    it { should have_protocol('http') }
+```ruby
+it { should_not have_protocol('https') }
+it { should have_protocol('http') }
+```
 
 Testing a web application with https enabled and http enabled:
 
-    it { should have_protocol('https') }
-    it { should have_protocol('http') }
+```ruby
+it { should have_protocol('https') }
+it { should have_protocol('http') }
+```
 
 ### have\_physical\_path
 
 The `have_physical_path` matcher tests if the named path is defined for the web application:
 
-    it { should have_physical_path('C:\\inetpub\\wwwroot') }
+```ruby
+it { should have_physical_path('C:\\inetpub\\wwwroot') }
+```

--- a/docs/resources/iis_site.md.erb
+++ b/docs/resources/iis_site.md.erb
@@ -13,13 +13,15 @@ Use the `iis_site` InSpec audit resource to test the state of IIS on Windows Ser
 
 An `iis_site` resource block declares details about the named site:
 
-    describe iis_site('site_name') do
-      it { should exist }
-      it { should be_running }
-      it { should have_app_pool('app_pool_name') }
-      it { should have_binding('binding_details') }
-      it { should have_path('path_to_site') }
-    end
+```ruby
+describe iis_site('site_name') do
+  it { should exist }
+  it { should be_running }
+  it { should have_app_pool('app_pool_name') }
+  it { should have_binding('binding_details') }
+  it { should have_path('path_to_site') }
+end
+```
 
 where
 
@@ -30,14 +32,16 @@ where
 
 For example:
 
-    describe iis_site('Default Web Site') do
-      it { should exist }
-      it { should be_running }
-      it { should have_app_pool('DefaultAppPool') }
-      it { should have_binding('https :443:www.contoso.com sslFlags=0') }
-      it { should have_binding('net.pipe *') }
-      it { should have_path('C:\\inetpub\\wwwroot') }
-    end
+```ruby
+describe iis_site('Default Web Site') do
+  it { should exist }
+  it { should be_running }
+  it { should have_app_pool('DefaultAppPool') }
+  it { should have_binding('https :443:www.contoso.com sslFlags=0') }
+  it { should have_binding('net.pipe *') }
+  it { should have_path('C:\\inetpub\\wwwroot') }
+end
+```
 
 <br>
 
@@ -53,20 +57,24 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test a default IIS site
 
-    describe iis_site('Default Web Site') do
-      it { should exist }
-      it { should be_running }
-      it { should have_app_pool('DefaultAppPool') }
-      it { should have_binding('http *:80:') }
-      it { should have_path('%SystemDrive%\\inetpub\\wwwroot') }
-    end
+```ruby
+describe iis_site('Default Web Site') do
+  it { should exist }
+  it { should be_running }
+  it { should have_app_pool('DefaultAppPool') }
+  it { should have_binding('http *:80:') }
+  it { should have_path('%SystemDrive%\\inetpub\\wwwroot') }
+end
+```
 
 ### Test if IIS service is running
 
-    describe service('W3SVC') do
-      it { should be_installed }
-      it { should be_running }
-    end
+```ruby
+describe service('W3SVC') do
+  it { should be_installed }
+  it { should be_running }
+end
+```
 
 <br>
 
@@ -78,33 +86,45 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_running` matcher tests if the site is running:
 
-    it { should be_running }
+```ruby
+it { should be_running }
+```
 
 ### exist
 
 The `exist` matcher tests if the site exists:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 ### have\_app\_pool
 
 The `have_app_pool` matcher tests if the named application pool exists for the site:
 
-    it { should have_app_pool('DefaultAppPool') }
+```ruby
+it { should have_app_pool('DefaultAppPool') }
+```
 
 For example, testing if a site's application pool inherits the settings of the parent application pool:
 
-    it { should have_app_pool('/') }
+```ruby
+it { should have_app_pool('/') }
+```
 
 ### have_binding
 
 The `have_binding` matcher tests if the specified binding exists for the site:
 
-    it { should have_binding('http :80:*') }
+```ruby
+it { should have_binding('http :80:*') }
+```
 
 or:
 
-    it { should have_binding('net.pipe *') }
+```ruby
+it { should have_binding('net.pipe *') }
+```
 
 A site may have multiple bindings; use a `have_binding` matcher for each unique site binding to be tested.
 
@@ -114,22 +134,32 @@ The `have_binding` matcher can also test attributes that are defined for a site 
 
 Testing a site with SSL disabled:
 
-    it { should have_binding('https :443:www.contoso.com sslFlags=0') }
+```ruby
+it { should have_binding('https :443:www.contoso.com sslFlags=0') }
+```
 
 Testing a site with SSL enabled:
 
-    it { should have_binding('https :443:www.contoso.com sslFlags=Ssl') }
+```ruby
+it { should have_binding('https :443:www.contoso.com sslFlags=Ssl') }
+```
 
 Testing a site with certificate mapping authentication enabled:
 
-    it { should have_binding('https :443:www.contoso.com sslFlags=SslMapCert') }
+```ruby
+it { should have_binding('https :443:www.contoso.com sslFlags=SslMapCert') }
+```
 
 Testing a site with 128-bit SSL enabled:
 
-    it { should have_binding('https :443:www.contoso.com sslFlags=Ssl128') }
+```ruby
+it { should have_binding('https :443:www.contoso.com sslFlags=Ssl128') }
+```
 
 ### have_path
 
 The `have_path` matcher tests if the named path is defined for the site:
 
-    it { should have_path('C:\\inetpub\\wwwroot') }
+```ruby
+it { should have_path('C:\\inetpub\\wwwroot') }
+```

--- a/docs/resources/inetd_conf.md.erb
+++ b/docs/resources/inetd_conf.md.erb
@@ -13,9 +13,11 @@ Use the `inetd_conf` InSpec audit resource to test if a service is listed in the
 
 An `inetd_conf` resource block declares the list of services that are enabled in the `inetd.conf` file:
 
-    describe inetd_conf('path') do
-      its('service_name') { should eq 'value' }
-    end
+```ruby
+describe inetd_conf('path') do
+  its('service_name') { should eq 'value' }
+end
+```
 
 where
 
@@ -59,36 +61,45 @@ For example:
 
 The contents if the `inetd.conf` file contain the following:
 
-    #ftp      stream   tcp   nowait   root   /usr/sbin/tcpd   in.ftpd -l -a
-    #telnet   stream   tcp   nowait   root   /usr/sbin/tcpd   in.telnetd
+```ruby
+#ftp      stream   tcp   nowait   root   /usr/sbin/tcpd   in.ftpd -l -a
+#telnet   stream   tcp   nowait   root   /usr/sbin/tcpd   in.telnetd
+```
 
 and the following test is defined:
 
-    describe inetd_conf do
-      its('ftp') { should eq nil }
-      its('telnet') { should eq nil }
-    end
+```ruby
+describe inetd_conf do
+  its('ftp') { should eq nil }
+  its('telnet') { should eq nil }
+end
+```
 
 Because both the `ftp` and `telnet` Internet services are commented out (`#`), both services are disabled. Consequently, both tests will return `true`. However, if the `inetd.conf` file is set as follows:
 
-    ftp       stream   tcp   nowait   root   /usr/sbin/tcpd   in.ftpd -l -a
-    #telnet   stream   tcp   nowait   root   /usr/sbin/tcpd   in.telnetd
+```ruby
+ftp       stream   tcp   nowait   root   /usr/sbin/tcpd   in.ftpd -l -a
+#telnet   stream   tcp   nowait   root   /usr/sbin/tcpd   in.telnetd
+```
 
 then the same test will return `false` for `ftp` and the entire test will fail.
 
 ### Test if telnet is installed
 
-    describe package('telnetd') do
-      it { should_not be_installed }
-    end
+```ruby
+describe package('telnetd') do
+  it { should_not be_installed }
+end
+```
 
-    describe inetd_conf do
-      its('telnet') { should eq nil }
-    end
+```ruby
+describe inetd_conf do
+  its('telnet') { should eq nil }
+end
+```
 
 <br>
 
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
-

--- a/docs/resources/ini.md.erb
+++ b/docs/resources/ini.md.erb
@@ -13,9 +13,11 @@ Use the `ini` InSpec audit resource to test settings in an INI file.
 
 An `ini` resource block declares the configuration settings to be tested:
 
-    describe ini('path') do
-      its('setting_name') { should eq 'value' }
-    end
+```ruby
+describe ini('path') do
+  its('setting_name') { should eq 'value' }
+end
+```
 
 where
 
@@ -25,23 +27,31 @@ where
 
 For example:
 
-    describe ini('path/to/ini_file.ini') do
-      its('port') { should eq '143' }
-      its('server') { should eq '192.0.2.62' }
-    end
+```ruby
+describe ini('path/to/ini_file.ini') do
+  its('port') { should eq '143' }
+  its('server') { should eq '192.0.2.62' }
+end
+```
 
 Settings inside of sections, such as the following:
 
-    [section_name]
-    setting_name = 123
+```ruby
+[section_name]
+setting_name = 123
+```
 
 ... can be retrieved by prefixing the setting_name with the section.
 
-    its('section_name.setting_name') { should cmp 123 }
+```ruby
+its('section_name.setting_name') { should cmp 123 }
+```
 
 In the event a section or setting name has a period in it, the alternate syntax can be used:
 
-    its(['section.with.a.dot.in.it', 'setting.name.with.dots']) { should cmp 'lotsadots' }
+```ruby
+its(['section.with.a.dot.in.it', 'setting.name.with.dots']) { should cmp 'lotsadots' }
+```
 
 <br>
 
@@ -59,15 +69,19 @@ The following examples show how to use this InSpec audit resource.
 
 For example, a PHP INI file located at contains the following settings:
 
-    [mail function]
-    SMTP = smtp.gmail.com
-    smtp_port = 465
+```ruby
+[mail function]
+SMTP = smtp.gmail.com
+smtp_port = 465
+```
 
 and can be tested like this:
 
-    describe ini('/etc/php5/apache2/php.ini') do
-      its('mail function.smtp_port') { should eq('465') }
-    end
+```ruby
+describe ini('/etc/php5/apache2/php.ini') do
+  its('mail function.smtp_port') { should eq('465') }
+end
+```
 
 <br>
 

--- a/docs/resources/interface.md.erb
+++ b/docs/resources/interface.md.erb
@@ -16,11 +16,13 @@ Use the `interface` InSpec audit resource to test basic network adapter properti
 
 An `interface` resource block declares network interface properties to be tested:
 
-    describe interface('eth0') do
-      it { should be_up }
-      its('speed') { should eq 1000 }
-      its('name') { should eq eth0 }
-    end
+```ruby
+describe interface('eth0') do
+  it { should be_up }
+  its('speed') { should eq 1000 }
+  its('name') { should eq eth0 }
+end
+```
 
 <br>
 
@@ -36,13 +38,17 @@ An `interface` resource block declares network interface properties to be tested
 
 The `name` matcher tests if the named network interface exists:
 
-    its('name') { should eq eth0 }
+```ruby
+its('name') { should eq eth0 }
+```
 
 ### speed
 
 The `speed` matcher tests the speed of the network interface, in MB/sec:
 
-    its('speed') { should eq 1000 }
+```ruby
+its('speed') { should eq 1000 }
+```
 
 <br>
 
@@ -55,4 +61,3 @@ For a full list of available matchers, please visit our [matchers page](https://
 The `be_up` matcher tests if the network interface is available:
 
     it { should be_up }
-

--- a/docs/resources/iptables.md.erb
+++ b/docs/resources/iptables.md.erb
@@ -13,9 +13,11 @@ Use the `iptables` InSpec audit resource to test rules that are defined in `ipta
 
 A `iptables` resource block declares tests for rules in IP tables:
 
-    describe iptables(rule:'name', table:'name', chain: 'name') do
-      it { should have_rule('RULE') }
-    end
+```ruby
+describe iptables(rule:'name', table:'name', chain: 'name') do
+  it { should have_rule('RULE') }
+end
+```
 
 where
 
@@ -33,21 +35,27 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if the INPUT chain is in default ACCEPT mode
 
-    describe iptables do
-      it { should have_rule('-P INPUT ACCEPT') }
-    end
+```ruby
+describe iptables do
+  it { should have_rule('-P INPUT ACCEPT') }
+end
+```
 
 ### Test if the INPUT chain from the mangle table is in ACCEPT mode
 
-    describe iptables(table:'mangle', chain: 'INPUT') do
-      it { should have_rule('-P INPUT ACCEPT') }
-    end
+```ruby
+describe iptables(table:'mangle', chain: 'INPUT') do
+  it { should have_rule('-P INPUT ACCEPT') }
+end
+```
 
 ### Test if there is a rule allowing Postgres (5432/TCP) traffic
 
-    describe iptables do
-      it { should have_rule('-A INPUT -p tcp -m tcp -m multiport --dports 5432 -m comment --comment "postgres" -j ACCEPT') }
-    end
+```ruby
+describe iptables do
+  it { should have_rule('-A INPUT -p tcp -m tcp -m multiport --dports 5432 -m comment --comment "postgres" -j ACCEPT') }
+end
+```
 
 Note that the rule specification must exactly match what's in the output of `iptables -S INPUT`, which will depend on how you've built your rules.
 
@@ -61,4 +69,6 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `have_rule` matcher tests the named rule against the information in the `iptables` file:
 
-    it { should have_rule('RULE') }
+```ruby
+it { should have_rule('RULE') }
+```

--- a/docs/resources/json.md.erb
+++ b/docs/resources/json.md.erb
@@ -13,24 +13,28 @@ Use the `json` InSpec audit resource to test data in a JSON file.
 
 A `json` resource block declares the data to be tested. Assume the following JSON file:
 
-    {
-      "name" : "hello",
-      "meta" : {
-        "creator" : "John Doe"
-      },
-      "array": [
-        "zero",
-        "one"
-      ]
-    }
+```ruby
+{
+  "name" : "hello",
+  "meta" : {
+    "creator" : "John Doe"
+  },
+  "array": [
+    "zero",
+    "one"
+  ]
+}
+```
 
 This file can be queried using:
 
-    describe json('/path/to/name.json') do
-      its('name') { should eq 'hello' }
-      its(['meta','creator']) { should eq 'John Doe' }
-      its(['array', 1]) { should eq 'one' }
-    end
+```ruby
+describe json('/path/to/name.json') do
+  its('name') { should eq 'hello' }
+  its(['meta','creator']) { should eq 'John Doe' }
+  its(['array', 1]) { should eq 'one' }
+end
+```
 
 where
 
@@ -45,9 +49,11 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test a cookbook version in a policyfile.lock.json file
 
-    describe json('policyfile.lock.json') do
-      its(['cookbook_locks', 'omnibus', 'version']) { should eq('2.2.0') }
-    end
+```ruby
+describe json('policyfile.lock.json') do
+  its(['cookbook_locks', 'omnibus', 'version']) { should eq('2.2.0') }
+end
+```
 
 <br>
 
@@ -59,4 +65,6 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `name` matcher tests the value of `name` as read from a JSON file versus the value declared in the test:
 
-    its('name') { should eq 'foo' }
+```ruby
+its('name') { should eq 'foo' }
+```

--- a/docs/resources/kernel_module.md.erb
+++ b/docs/resources/kernel_module.md.erb
@@ -21,11 +21,13 @@ A `kernel_module` resource block declares a module name, and then tests if that
 module is a loadable kernel module, if it is enabled, disabled or if it is
 blacklisted:
 
-    describe kernel_module('module_name') do
-      it { should be_loaded }
-      it { should_not be_disabled }
-      it { should_not be_blacklisted }
-    end
+```ruby
+describe kernel_module('module_name') do
+  it { should be_loaded }
+  it { should_not be_disabled }
+  it { should_not be_blacklisted }
+end
+```
 
 where
 
@@ -42,51 +44,65 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test a modules 'version'
 
-      describe kernel_module('bridge') do
-        it { should be_loaded }
-        its(:version) { should cmp >= '2.2.2' }
-      end
+```ruby
+  describe kernel_module('bridge') do
+    it { should be_loaded }
+    its(:version) { should cmp >= '2.2.2' }
+  end
+```
 
 ### Test if a module is loaded, not disabled and not blacklisted
 
-      describe kernel_module('video') do
-        it { should be_loaded }
-        it { should_not be_disabled }
-        it { should_not be_blacklisted }
-      end
+```ruby
+  describe kernel_module('video') do
+    it { should be_loaded }
+    it { should_not be_disabled }
+    it { should_not be_blacklisted }
+  end
+```
 
 ### Check if a module is blacklisted
 
-      describe kernel_module('floppy') do
-        it { should be_blacklisted }
-      end
+```ruby
+  describe kernel_module('floppy') do
+    it { should be_blacklisted }
+  end
+```
 
 ### Ensure a module is *not* blacklisted and it is loaded
 
-      describe kernel_module('video') do
-        it { should_not be_blacklisted }
-        it { should be_loaded }
-      end
+```ruby
+  describe kernel_module('video') do
+    it { should_not be_blacklisted }
+    it { should be_loaded }
+  end
+```
 
 ### Ensure a module is disabled via 'bin_false'
 
-      describe kernel_module('sstfb') do
-        it { should_not be_loaded }
-        it { should be_disabled }
-      end
+```ruby
+  describe kernel_module('sstfb') do
+    it { should_not be_loaded }
+    it { should be_disabled }
+  end
+```
 
 ### Ensure a module is 'blacklisted'/'disabled' via 'bin_true'
 
-      describe kernel_module('nvidiafb') do
-        it { should_not be_loaded }
-        it { should be_blacklisted }
-      end
+```ruby
+  describe kernel_module('nvidiafb') do
+    it { should_not be_loaded }
+    it { should be_blacklisted }
+  end
+```
 
 ### Ensure a module is not loaded
 
-      describe kernel_module('dhcp') do
-        it { should_not be_loaded }
-      end
+```ruby
+  describe kernel_module('dhcp') do
+    it { should_not be_loaded }
+  end
+```
 
 <br>
 
@@ -98,10 +114,14 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_loaded` matcher tests if the module is a loadable kernel module:
 
-    it { should be_loaded }
+```ruby
+it { should be_loaded }
+```
 
 ### version
 
 The `version` matcher tests if the named module version is on the system:
 
-    its(:version) { should eq '3.2.2' }
+```ruby
+its(:version) { should eq '3.2.2' }
+```

--- a/docs/resources/kernel_parameter.md.erb
+++ b/docs/resources/kernel_parameter.md.erb
@@ -13,9 +13,11 @@ Use the `kernel_parameter` InSpec audit resource to test kernel parameters on Li
 
 A `kernel_parameter` resource block declares a parameter and then a value to be tested:
 
-    describe kernel_parameter('path.to.parameter') do
-      its('value') { should eq 0 }
-    end
+```ruby
+describe kernel_parameter('path.to.parameter') do
+  its('value') { should eq 0 }
+end
+```
 
 where
 
@@ -30,21 +32,27 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if global forwarding is enabled for an IPv4 address
 
-    describe kernel_parameter('net.ipv4.conf.all.forwarding') do
-      its('value') { should eq 1 }
-    end
+```ruby
+describe kernel_parameter('net.ipv4.conf.all.forwarding') do
+  its('value') { should eq 1 }
+end
+```
 
 ### Test if global forwarding is disabled for an IPv6 address
 
-    describe kernel_parameter('net.ipv6.conf.all.forwarding') do
-      its('value') { should eq 0 }
-    end
+```ruby
+describe kernel_parameter('net.ipv6.conf.all.forwarding') do
+  its('value') { should eq 0 }
+end
+```
 
 ### Test if an IPv6 address accepts redirects
 
-    describe kernel_parameter('net.ipv6.conf.interface.accept_redirects') do
-      its('value') { should cmp 'true' }
-    end
+```ruby
+describe kernel_parameter('net.ipv6.conf.interface.accept_redirects') do
+  its('value') { should cmp 'true' }
+end
+```
 
 <br>
 

--- a/docs/resources/key_rsa.md.erb
+++ b/docs/resources/key_rsa.md.erb
@@ -15,18 +15,22 @@ This resource is mainly useful when used in conjunction with the x509_certificat
 
 An `key_rsa` resource block declares a `key file` to be tested.
 
-    describe key_rsa('mycertificate.key') do
-      it { should be_private }
-      it { should be_public }
-      its('public_key') { should match "-----BEGIN PUBLIC KEY-----\n3597459df9f3982" }
-      its('key_length') { should eq 2048 }
-    end
+```ruby
+describe key_rsa('mycertificate.key') do
+  it { should be_private }
+  it { should be_public }
+  its('public_key') { should match "-----BEGIN PUBLIC KEY-----\n3597459df9f3982" }
+  its('key_length') { should eq 2048 }
+end
+```
 
 You can use an optional passphrase with `key_rsa`
 
-    describe key_rsa('mycertificate.key', 'passphrase') do
-      it { should be_private }
-    end
+```ruby
+describe key_rsa('mycertificate.key', 'passphrase') do
+  it { should be_private }
+end
+```
 
 <br>
 
@@ -42,25 +46,31 @@ You can use an optional passphrase with `key_rsa`
 
 The `public_key` property returns the public part of the RSA key pair
 
-    describe key_rsa('/etc/pki/www.mywebsite.com.key') do
-      its('public_key') { should match "-----BEGIN PUBLIC KEY-----\n3597459df9f3982......" }
-    end
+```ruby
+describe key_rsa('/etc/pki/www.mywebsite.com.key') do
+  its('public_key') { should match "-----BEGIN PUBLIC KEY-----\n3597459df9f3982......" }
+end
+```
 
 ### private_key (String)
 
 The `private_key` property returns the private key or the RSA key pair.
 
-    describe key_rsa('/etc/pki/www.mywebsite.com.key') do
-      its('private_key') { should match "-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAK......" }
-    end
+```ruby
+describe key_rsa('/etc/pki/www.mywebsite.com.key') do
+  its('private_key') { should match "-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAK......" }
+end
+```
 
 ### key_length
 
 The `key_length` property allows testing the number of bits in the key pair.
 
-    describe key_rsa('/etc/pki/www.mywebsite.com.key') do
-      its('key_length') { should eq 2048 }
-    end
+```ruby
+describe key_rsa('/etc/pki/www.mywebsite.com.key') do
+  its('key_length') { should eq 2048 }
+end
+```
 
 <br>
 
@@ -72,14 +82,18 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 To verify if a key is public use the following:
 
-    describe key_rsa('/etc/pki/www.mywebsite.com.key') do
-      it { should be_public }
-    end
+```ruby
+describe key_rsa('/etc/pki/www.mywebsite.com.key') do
+  it { should be_public }
+end
+```
 
 ### private?
 
 This property verifies that the key includes a private key:
 
-    describe key_rsa('/etc/pki/www.mywebsite.com.key') do
-      it { should be_private }
-    end
+```ruby
+describe key_rsa('/etc/pki/www.mywebsite.com.key') do
+  it { should be_private }
+end
+```

--- a/docs/resources/launchd_service.md.erb
+++ b/docs/resources/launchd_service.md.erb
@@ -13,11 +13,13 @@ Use the ``launchd_service`` InSpec audit resource to test a service using Launch
 
 A ``launchd_service`` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
-    describe launchd_service('service_name') do
-      it { should be_installed }
-      it { should be_enabled }
-      it { should be_running }
-    end
+```ruby
+describe launchd_service('service_name') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+```
 
 where
 
@@ -26,11 +28,13 @@ where
 
 The path to the service manager's control may be specified for situations where the path isn't available in the current ``PATH``. For example:
 
-    describe launchd_service('service_name', '/path/to/control') do
-      it { should be_enabled }
-      it { should be_installed }
-      it { should be_running }
-    end
+```ruby
+describe launchd_service('service_name', '/path/to/control') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end
+```
 
 <br>
 
@@ -42,16 +46,22 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_enabled` matcher tests if the named service is enabled:
 
-    it { should be_enabled }
+```ruby
+it { should be_enabled }
+```
 
 ### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### be_running
 
 The `be_running` matcher tests if the named service is running:
 
-    it { should be_running }
+```ruby
+it { should be_running }
+```

--- a/docs/resources/limits_conf.md.erb
+++ b/docs/resources/limits_conf.md.erb
@@ -12,11 +12,15 @@ Use the `limits_conf` InSpec audit resource to test configuration settings in th
 
 Entries in the `limits.conf` file are similar to:
 
-    grantmc     soft   nofile   4096
-    grantmc     hard   nofile   63536
+```ruby
+grantmc     soft   nofile   4096
+grantmc     hard   nofile   63536
+```
 
-    ^^^^^^^^^   ^^^^   ^^^^^^   ^^^^^
-    domain      type    item    value
+```ruby
+^^^^^^^^^   ^^^^   ^^^^^^   ^^^^^
+domain      type    item    value
+```
 
 <br>
 
@@ -24,10 +28,12 @@ Entries in the `limits.conf` file are similar to:
 
 A `limits_conf` resource block declares a domain to be tested, along with associated type, item, and value:
 
-    describe limits_conf('path') do
-      its('domain') { should include ['type', 'item', 'value'] }
-      its('domain') { should eq ['type', 'item', 'value'] }
-    end
+```ruby
+describe limits_conf('path') do
+  its('domain') { should include ['type', 'item', 'value'] }
+  its('domain') { should eq ['type', 'item', 'value'] }
+end
+```
 
 where
 
@@ -61,15 +67,15 @@ For example:
 
 ### Test limits
 
-    describe limits_conf('path') do
-      its('*') { should include ['soft', 'core', '0'], ['hard', 'rss', '10000'] }
-      its('ftp') { should eq ['hard', 'nproc', '0'] }
-    end
+```ruby
+describe limits_conf('path') do
+  its('*') { should include ['soft', 'core', '0'], ['hard', 'rss', '10000'] }
+  its('ftp') { should eq ['hard', 'nproc', '0'] }
+end
+```
 
 <br>
 
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
-
-

--- a/docs/resources/login_def.md.erb
+++ b/docs/resources/login_def.md.erb
@@ -13,9 +13,11 @@ Use the `login_defs` InSpec audit resource to test configuration settings in the
 
 A `login_defs` resource block declares the `login.defs` configuration data to be tested:
 
-    describe login_defs do
-      its('name') { should include('foo') }
-    end
+```ruby
+describe login_defs do
+  its('name') { should include('foo') }
+end
+```
 
 where
 
@@ -42,30 +44,34 @@ The `name` matcher tests the value of `name` as read from `login.defs` versus th
 
 ### Test password expiration settings
 
-    describe login_defs do
-      its('PASS_MAX_DAYS') { should eq '180' }
-      its('PASS_MIN_DAYS') { should eq '1' }
-      its('PASS_MIN_LEN') { should eq '15' }
-      its('PASS_WARN_AGE') { should eq '30' }
-    end
+```ruby
+describe login_defs do
+  its('PASS_MAX_DAYS') { should eq '180' }
+  its('PASS_MIN_DAYS') { should eq '1' }
+  its('PASS_MIN_LEN') { should eq '15' }
+  its('PASS_WARN_AGE') { should eq '30' }
+end
+```
 
 ### Test the encryption method
 
-    describe login_defs do
-      its('ENCRYPT_METHOD') { should eq 'SHA512' }
-    end
+```ruby
+describe login_defs do
+  its('ENCRYPT_METHOD') { should eq 'SHA512' }
+end
+```
 
 ### Test umask setting
 
-    describe login_def do
-      its('UMASK') { should eq '077' }
-      its('PASS_MAX_DAYS') { should eq '90' }
-    end
+```ruby
+describe login_def do
+  its('UMASK') { should eq '077' }
+  its('PASS_MAX_DAYS') { should eq '90' }
+end
+```
 
 <br>
 
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
-
-

--- a/docs/resources/mount.md.erb
+++ b/docs/resources/mount.md.erb
@@ -13,9 +13,11 @@ Use the `mount` InSpec audit resource to test the mount points on FreeBSD and Li
 
 An `mount` resource block declares the synchronization settings that should be tested:
 
-    describe mount('path') do
-      it { should MATCHER 'value' }
-    end
+```ruby
+describe mount('path') do
+  it { should MATCHER 'value' }
+end
+```
 
 where
 
@@ -31,12 +33,14 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test a the mount point on '/'
 
-    describe mount('/') do
-      it { should be_mounted }
-      its('device') { should eq  '/dev/mapper/VolGroup-lv_root' }
-      its('type') { should eq  'ext4' }
-      its('options') { should eq ['rw', 'mode=620'] }
-    end
+```ruby
+describe mount('/') do
+  it { should be_mounted }
+  its('device') { should eq  '/dev/mapper/VolGroup-lv_root' }
+  its('type') { should eq  'ext4' }
+  its('options') { should eq ['rw', 'mode=620'] }
+end
+```
 
 <br>
 
@@ -48,22 +52,30 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_mounted` matcher tests if the file is accessible from the file system:
 
-    it { should be_mounted }
+```ruby
+it { should be_mounted }
+```
 
 ### device
 
 The `device` matcher tests the device from the `fstab` table:
 
-    its('device') { should eq  '/dev/mapper/VolGroup-lv_root' }
+```ruby
+its('device') { should eq  '/dev/mapper/VolGroup-lv_root' }
+```
 
 ### options
 
 The `options` matcher tests the mount options for the file system from the `fstab` table:
 
-    its('options') { should eq ['rw', 'mode=620'] }
+```ruby
+its('options') { should eq ['rw', 'mode=620'] }
+```
 
 ### type
 
 The `type` matcher tests the file system type:
 
-    its('type') { should eq  'ext4' }
+```ruby
+its('type') { should eq  'ext4' }
+```

--- a/docs/resources/mssql_session.md.erb
+++ b/docs/resources/mssql_session.md.erb
@@ -13,9 +13,11 @@ Use the `mssql_session` InSpec audit resource to test SQL commands run against a
 
 A `mssql_session` resource block declares the username and password to use for the session, and then the command to be run:
 
-    describe mssql_session(user: 'username', password: 'password').query('QUERY').row(0).column('result') do
-      its('value') { should eq('') }
-    end
+```ruby
+describe mssql_session(user: 'username', password: 'password').query('QUERY').row(0).column('result') do
+  its('value') { should eq('') }
+end
+```
 
 where
 
@@ -31,27 +33,39 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test for matching databases
 
-    sql = mssql_session(user: 'my_user', password: 'password')
+```ruby
+sql = mssql_session(user: 'my_user', password: 'password')
+```
 
-    describe sql.query("SELECT SERVERPROPERTY('ProductVersion') as result").row(0).column('result') do
-      its("value") { should cmp > '12.00.4457' }
-    end
+```ruby
+describe sql.query("SELECT SERVERPROPERTY('ProductVersion') as result").row(0).column('result') do
+  its("value") { should cmp > '12.00.4457' }
+end
+```
 
 ### Test using Windows authentication
 
-    sql = mssql_session
+```ruby
+sql = mssql_session
+```
 
-    describe sql.query("SELECT SERVERPROPERTY('ProductVersion') as result").row(0).column('result') do
-      its("value") { should cmp > '12.00.4457' }
-    end
+```ruby
+describe sql.query("SELECT SERVERPROPERTY('ProductVersion') as result").row(0).column('result') do
+  its("value") { should cmp > '12.00.4457' }
+end
+```
 
 ### Test a specific host and instance
 
-    sql = mssql_session(user: 'my_user', password: 'password', host: 'mssqlserver', instance: 'foo')
+```ruby
+sql = mssql_session(user: 'my_user', password: 'password', host: 'mssqlserver', instance: 'foo')
+```
 
-    describe sql.query("SELECT SERVERPROPERTY('ProductVersion') as result").row(0).column('result') do
-      its("value") { should cmp > '12.00.4457' }
-    end
+```ruby
+describe sql.query("SELECT SERVERPROPERTY('ProductVersion') as result").row(0).column('result') do
+  its("value") { should cmp > '12.00.4457' }
+end
+```
 
 <br>
 

--- a/docs/resources/mysql_conf.md.erb
+++ b/docs/resources/mysql_conf.md.erb
@@ -13,19 +13,25 @@ Use the `mysql_conf` InSpec audit resource to test the contents of the configura
 
 A `mysql_conf` resource block declares one (or more) settings in the `my.cnf` file, and then compares the setting in the configuration file to the value stated in the test:
 
-    describe mysql_conf('path') do
-      its('setting') { should eq 'value' }
-    end
+```ruby
+describe mysql_conf('path') do
+  its('setting') { should eq 'value' }
+end
+```
 
-    # Test a parameter set within the [mysqld] section
-    describe mysql_conf do
-      its('mysqld.port') { should cmp 3306 }
-    end
+```ruby
+# Test a parameter set within the [mysqld] section
+describe mysql_conf do
+  its('mysqld.port') { should cmp 3306 }
+end
+```
 
-    # Test a parameter set within the [mariadb] section using array notation
-    describe mysql_conf do
-      its(['mariadb', 'max-connections']) { should_not be_nil }
-    end
+```ruby
+# Test a parameter set within the [mariadb] section using array notation
+describe mysql_conf do
+  its(['mariadb', 'max-connections']) { should_not be_nil }
+end
+```
 
 where
 
@@ -42,47 +48,57 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test the maximum number of allowed connections
 
-    describe mysql_conf do
-      its('max_connections') { should eq '505' }
-      its('max_user_connections') { should eq '500' }
-    end
+```ruby
+describe mysql_conf do
+  its('max_connections') { should eq '505' }
+  its('max_user_connections') { should eq '500' }
+end
+```
 
 ### Test slow query logging**
 
-    describe mysql_conf do
-      its('slow_query_log_file') { should eq 'hostname_slow.log' }
-      its('slow_query_log') { should eq '0' }
-      its('log_queries_not_using_indexes') { should eq '1' }
-      its('long_query_time') { should eq '0.5' }
-      its('min_examined_row_limit') { should eq '100' }
-    end
+```ruby
+describe mysql_conf do
+  its('slow_query_log_file') { should eq 'hostname_slow.log' }
+  its('slow_query_log') { should eq '0' }
+  its('log_queries_not_using_indexes') { should eq '1' }
+  its('long_query_time') { should eq '0.5' }
+  its('min_examined_row_limit') { should eq '100' }
+end
+```
 
 ### Test the port and socket on which MySQL listens
 
-    describe mysql_conf do
-      its('port') { should eq '3306' }
-      its('socket') { should eq '/var/run/mysqld/mysql.sock' }
-    end
+```ruby
+describe mysql_conf do
+  its('port') { should eq '3306' }
+  its('socket') { should eq '/var/run/mysqld/mysql.sock' }
+end
+```
 
 ### Test connection and thread variables
 
-    describe mysql_conf do
-      its('port') { should eq '3306' }
-      its('socket') { should eq '/var/run/mysqld/mysql.sock' }
-      its('max_allowed_packet') { should eq '12M' }
-      its('default_storage_engine') { should eq 'InnoDB' }
-      its('character_set_server') { should eq 'utf8' }
-      its('collation_server') { should eq 'utf8_general_ci' }
-      its('max_connections') { should eq '505' }
-      its('max_user_connections') { should eq '500' }
-      its('thread_cache_size') { should eq '505' }
-    end
+```ruby
+describe mysql_conf do
+  its('port') { should eq '3306' }
+  its('socket') { should eq '/var/run/mysqld/mysql.sock' }
+  its('max_allowed_packet') { should eq '12M' }
+  its('default_storage_engine') { should eq 'InnoDB' }
+  its('character_set_server') { should eq 'utf8' }
+  its('collation_server') { should eq 'utf8_general_ci' }
+  its('max_connections') { should eq '505' }
+  its('max_user_connections') { should eq '500' }
+  its('thread_cache_size') { should eq '505' }
+end
+```
 
 ### Test the safe-user-create parameter
 
-    describe mysql_conf.params('mysqld') do
-      its('safe-user-create') { should eq('1') }
-    end
+```ruby
+describe mysql_conf.params('mysqld') do
+  its('safe-user-create') { should eq('1') }
+end
+```
 
 <br>
 
@@ -94,6 +110,8 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `setting` matcher tests specific, named settings in the `my.cnf` file:
 
-    its('setting') { should eq 'value' }
+```ruby
+its('setting') { should eq 'value' }
+```
 
 Use a `setting` matcher for each setting to be tested.

--- a/docs/resources/mysql_session.md.erb
+++ b/docs/resources/mysql_session.md.erb
@@ -13,9 +13,11 @@ Use the `mysql_session` InSpec audit resource to test SQL commands run against a
 
 A `mysql_session` resource block declares the username and password to use for the session, and then the command to be run:
 
-    describe mysql_session('username', 'password').query('QUERY') do
-      its('stdout') { should match(/expected-result/) }
-    end
+```ruby
+describe mysql_session('username', 'password').query('QUERY') do
+  its('stdout') { should match(/expected-result/) }
+end
+```
 
 where
 
@@ -31,41 +33,57 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test for matching databases
 
-    sql = mysql_session('my_user','password')
+```ruby
+sql = mysql_session('my_user','password')
+```
 
-    describe sql.query('show databases like \'test\';') do
-      its('stdout') { should_not match(/test/) }
-    end
+```ruby
+describe sql.query('show databases like \'test\';') do
+  its('stdout') { should_not match(/test/) }
+end
+```
 
 ### Alternate Connection: Different Host
 
-    sql = mysql_session('my_user','password','db.example.com')
+```ruby
+sql = mysql_session('my_user','password','db.example.com')
+```
 
 ### Alternate Connection: Different Port
 
-    sql = mysql_session('my_user','password','localhost',3307)
+```ruby
+sql = mysql_session('my_user','password','localhost',3307)
+```
 
 ### Alternate Connection: Using a socket
 
-    sql = mysql_session('my_user','password', nil, nil, '/var/lib/mysql-default/mysqld.sock')
+```ruby
+sql = mysql_session('my_user','password', nil, nil, '/var/lib/mysql-default/mysqld.sock')
+```
 
 ### Test for a successful query
 
-    describe mysql_session('my_user','password').query('show tables in existing_database;') do
-      its('exit_status') { should eq(0) }
-    end
+```ruby
+describe mysql_session('my_user','password').query('show tables in existing_database;') do
+  its('exit_status') { should eq(0) }
+end
+```
 
 ### Test for a failing query
 
-    describe mysql_session('my_user','password').query('show tables in non_existent_database;') do
-      its('exit_status') { should_not eq(0) }
-    end
+```ruby
+describe mysql_session('my_user','password').query('show tables in non_existent_database;') do
+  its('exit_status') { should_not eq(0) }
+end
+```
 
 ### Test for specific error message
 
-    describe mysql_session('my_user','password').query('show tables in non_existent_database;') do
-      its('stderr') { should match(/Unknown database/) }
-    end
+```ruby
+describe mysql_session('my_user','password').query('show tables in non_existent_database;') do
+  its('stderr') { should match(/Unknown database/) }
+end
+```
 
 <br>
 

--- a/docs/resources/nginx.md.erb
+++ b/docs/resources/nginx.md.erb
@@ -15,13 +15,17 @@ Nginx resource extracts and exposes data reported by the command 'nginx -V'
 
 An `nginx` InSpec audit resource block extracts configuration settings that should be tested:
 
-    describe nginx do
-      its('attribute') { should eq 'value' }
-    end
+```ruby
+describe nginx do
+  its('attribute') { should eq 'value' }
+end
+```
 
-    describe nginx('path to nginx') do
-      its('attribute') { should eq 'value' }
-    end
+```ruby
+describe nginx('path to nginx') do
+  its('attribute') { should eq 'value' }
+end
+```
 
 where
 
@@ -42,38 +46,48 @@ where
 
 `version` returns a string of the version of the running nginx instance
 
-    describe nginx do
-      its('version') { should eq '1.12.0' }
-    end
+```ruby
+describe nginx do
+  its('version') { should eq '1.12.0' }
+end
+```
 
 ### modules(String)
 
 `modules` returns a array modules in the running nginx instance
 
-    describe nginx do
-      its('modules') { should include 'my_module' }
-    end
+```ruby
+describe nginx do
+  its('modules') { should include 'my_module' }
+end
+```
 
 ### openssl_version(Hash)
 
 `openssl_version ` returns a hash with 'version' and 'date' as keys
 
-    describe nginx do
-      its('openssl_version.date') { should eq '11 Feb 2013' }
-    end
+```ruby
+describe nginx do
+  its('openssl_version.date') { should eq '11 Feb 2013' }
+end
+```
 
 ### compiler_info(Hash)
 
 `compiler_info ` returns a hash with 'compiler' , version' and 'date' as keys
 
-    describe nginx do
-      its('compiler_info.compiler') { should eq 'gcc' }
-    end
+```ruby
+describe nginx do
+  its('compiler_info.compiler') { should eq 'gcc' }
+end
+```
 
 ### support_info(String)
 
 `support_info ` returns a string containing supported protocols
 
-    describe nginx do
-      its('support_info') { should match /TLS/ }
-    end
+```ruby
+describe nginx do
+  its('support_info') { should match /TLS/ }
+end
+```

--- a/docs/resources/nginx_conf.md.erb
+++ b/docs/resources/nginx_conf.md.erb
@@ -15,9 +15,11 @@ Use the `nginx_conf` InSpec resource to test configuration data for the NGINX se
 
 An `nginx_conf` resource block declares the client NGINX configuration data to be tested:
 
-    describe nginx_conf.params['pid'] do
-      it { should cmp 'logs/nginx.pid' }
-    end
+```ruby
+describe nginx_conf.params['pid'] do
+  it { should cmp 'logs/nginx.pid' }
+end
+```
 
 where
 
@@ -34,18 +36,22 @@ The following examples show how to use this InSpec audit resource.
 
 ### Find a specific server
 
-    servers = nginx_conf.servers
-    domain2 = servers.find { |s| s.params['server_name'].flatten.include? 'domain2.com' }
-    describe 'No server serves domain2' do
-      subject { domain2 }
-      it { should be_nil }
-    end
+```ruby
+servers = nginx_conf.servers
+domain2 = servers.find { |s| s.params['server_name'].flatten.include? 'domain2.com' }
+describe 'No server serves domain2' do
+  subject { domain2 }
+  it { should be_nil }
+end
+```
 
 ### Test a raw parameter
 
-    describe nginx_conf.params['worker_processes'].flatten do
-      it { should cmp 5 }
-    end
+```ruby
+describe nginx_conf.params['worker_processes'].flatten do
+  it { should cmp 5 }
+end
+```
 
 <br>
 
@@ -57,19 +63,27 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 Retrieves all `http` entries in the configuration file.
 
-    nginx_conf.http
-    => nginx_conf /etc/nginx/nginx.conf, http entries
+```ruby
+nginx_conf.http
+=> nginx_conf /etc/nginx/nginx.conf, http entries
+```
 
 It provides further access to all individual entries, servers, and locations.
 
-    nginx_conf.http.entries
-    => [nginx_conf /etc/nginx/nginx.conf, http entry ...]
+```ruby
+nginx_conf.http.entries
+=> [nginx_conf /etc/nginx/nginx.conf, http entry ...]
+```
 
-    nginx_conf.http.servers
-    => [nginx_conf /etc/nginx/nginx.conf, server entry ...]
+```ruby
+nginx_conf.http.servers
+=> [nginx_conf /etc/nginx/nginx.conf, server entry ...]
+```
 
-    nginx_conf.http.locations
-    => [nginx_conf /etc/nginx/nginx.conf, location entry ...]
+```ruby
+nginx_conf.http.locations
+=> [nginx_conf /etc/nginx/nginx.conf, location entry ...]
+```
 
 You can access each of these from the array and inspect it further (see below).
 
@@ -77,52 +91,76 @@ You can access each of these from the array and inspect it further (see below).
 
 Retrieve all `servers` entries in the configuration:
 
-    # all servers across all configs aggregated:
-    nginx_conf.servers
-    => [nginx_conf /etc/nginx/nginx.conf, server entry ...]
+```ruby
+# all servers across all configs aggregated:
+nginx_conf.servers
+=> [nginx_conf /etc/nginx/nginx.conf, server entry ...]
+```
 
-    # servers that belong to a specific http entry:
-    nginx_conf.http.entries[0].servers
-    => [nginx_conf /etc/nginx/nginx.conf, server entry ...]
+```ruby
+# servers that belong to a specific http entry:
+nginx_conf.http.entries[0].servers
+=> [nginx_conf /etc/nginx/nginx.conf, server entry ...]
+```
 
 Servers provide access to all their locations, parent http entry, and raw parameters:
 
-    server = nginx_conf.servers[0]
+```ruby
+server = nginx_conf.servers[0]
+```
 
-    server.locations
-    => [nginx_conf /etc/nginx/nginx.conf, location entry ...]
+```ruby
+server.locations
+=> [nginx_conf /etc/nginx/nginx.conf, location entry ...]
+```
 
-    server.parent
-    => nginx_conf /etc/nginx/nginx.conf, http entry
+```ruby
+server.parent
+=> nginx_conf /etc/nginx/nginx.conf, http entry
+```
 
-    server.params
-    => {"listen"=>[["85"]],
-       "server_name"=>[["domain1.com", "www.domain1.com"]],
-       "root"=>[["html"]],
-       "location"=>[{"_"=>["~", "\\.php$"], "fastcgi_pass"=>[["127.0.0.1:1025"]]}]}
+```ruby
+server.params
+=> {"listen"=>[["85"]],
+   "server_name"=>[["domain1.com", "www.domain1.com"]],
+   "root"=>[["html"]],
+   "location"=>[{"_"=>["~", "\\.php$"], "fastcgi_pass"=>[["127.0.0.1:1025"]]}]}
+```
 
 ### locations
 
 Retrieve all `location` entries in the configuration:
 
-    # all locations across all configs aggregated:
-    nginx_conf.locations
-    => [nginx_conf /etc/nginx/nginx.conf, location entry ...]
+```ruby
+# all locations across all configs aggregated:
+nginx_conf.locations
+=> [nginx_conf /etc/nginx/nginx.conf, location entry ...]
+```
 
-    # locations of a http entry aggregated:
-    nginx_conf.http.entries[0].locations
-    => [nginx_conf /etc/nginx/nginx.conf, location entry ...]
+```ruby
+# locations of a http entry aggregated:
+nginx_conf.http.entries[0].locations
+=> [nginx_conf /etc/nginx/nginx.conf, location entry ...]
+```
 
-    # locations of a specific server:
-    nginx_conf.servers[0].locations
-    => [nginx_conf /etc/nginx/nginx.conf, location entry ...]
+```ruby
+# locations of a specific server:
+nginx_conf.servers[0].locations
+=> [nginx_conf /etc/nginx/nginx.conf, location entry ...]
+```
 
 Locations provide access to their parent server entry and raw parameters:
 
-    location = nginx_conf.locations[0]
+```ruby
+location = nginx_conf.locations[0]
+```
 
-    location.parent
-    => nginx_conf /etc/nginx/nginx.conf, server entry
+```ruby
+location.parent
+=> nginx_conf /etc/nginx/nginx.conf, server entry
+```
 
-    location.params
-    => {"_"=>["~", "\\.php$"], "fastcgi_pass"=>[["127.0.0.1:1025"]]}
+```ruby
+location.params
+=> {"_"=>["~", "\\.php$"], "fastcgi_pass"=>[["127.0.0.1:1025"]]}
+```

--- a/docs/resources/npm.md.erb
+++ b/docs/resources/npm.md.erb
@@ -13,9 +13,11 @@ Use the `npm` InSpec audit resource to test if a global NPM package is installed
 
 A `npm` resource block declares a package and (optionally) a package version:
 
-    describe npm('npm_package_name') do
-      it { should be_installed }
-    end
+```ruby
+describe npm('npm_package_name') do
+  it { should be_installed }
+end
+```
 
 where
 
@@ -30,16 +32,20 @@ The following examples show how to use this InSpec audit resource.
 
 ### Verify that bower is installed, with a specific version
 
-    describe npm('bower') do
-      it { should be_installed }
-      its('version') { should eq '1.4.1' }
-    end
+```ruby
+describe npm('bower') do
+  it { should be_installed }
+  its('version') { should eq '1.4.1' }
+end
+```
 
 ### Verify that statsd is not installed
 
-    describe npm('statsd') do
-      it { should_not be_installed }
-    end
+```ruby
+describe npm('statsd') do
+  it { should_not be_installed }
+end
+```
 
 <br>
 
@@ -51,10 +57,14 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_installed` matcher tests if the named Gem package and package version (if specified) is installed:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### version
 
 The `version` matcher tests if the named package version is on the system:
 
-    its('version') { should eq '1.2.3' }
+```ruby
+its('version') { should eq '1.2.3' }
+```

--- a/docs/resources/ntp_conf.md.erb
+++ b/docs/resources/ntp_conf.md.erb
@@ -13,9 +13,11 @@ Use the `ntp_conf` InSpec audit resource to test the synchronization settings de
 
 An `ntp_conf` resource block declares the synchronization settings that should be tested:
 
-    describe ntp_conf('path') do
-      its('setting_name') { should eq 'value' }
-    end
+```ruby
+describe ntp_conf('path') do
+  its('setting_name') { should eq 'value' }
+end
+```
 
 where
 
@@ -31,14 +33,16 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test for clock drift against named servers
 
-    describe ntp_conf do
-      its('driftfile') { should eq '/var/lib/ntp/ntp.drift' }
-      its('server') { should eq [
-        0.ubuntu.pool.ntp.org,
-        1.ubuntu.pool.ntp.org,
-        2.ubuntu.pool.ntp.org
-      ] }
-    end
+```ruby
+describe ntp_conf do
+  its('driftfile') { should eq '/var/lib/ntp/ntp.drift' }
+  its('server') { should eq [
+    0.ubuntu.pool.ntp.org,
+    1.ubuntu.pool.ntp.org,
+    2.ubuntu.pool.ntp.org
+  ] }
+end
+```
 
 <br>
 
@@ -46,15 +50,21 @@ The following examples show how to use this InSpec audit resource.
 
 This resource matches any service that is listed in the `ntp.conf` file. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
-    its('server') { should_not eq nil }
+```ruby
+its('server') { should_not eq nil }
+```
 
 or:
 
-    its('restrict') { should include '-4 default kod notrap nomodify nopeer noquery'}
+```ruby
+its('restrict') { should include '-4 default kod notrap nomodify nopeer noquery'}
+```
 
 For example:
 
-    describe ntp_conf do
-      its('server') { should_not eq nil }
-      its('restrict') { should include '-4 default kod notrap nomodify nopeer noquery'}
-    end
+```ruby
+describe ntp_conf do
+  its('server') { should_not eq nil }
+  its('restrict') { should include '-4 default kod notrap nomodify nopeer noquery'}
+end
+```

--- a/docs/resources/oneget.md.erb
+++ b/docs/resources/oneget.md.erb
@@ -13,9 +13,11 @@ Use the `oneget` InSpec audit resource to test if the named package and/or packa
 
 A `oneget` resource block declares a package and (optionally) a package version:
 
-    describe oneget('name') do
-      it { should be_installed }
-    end
+```ruby
+describe oneget('name') do
+  it { should be_installed }
+end
+```
 
 where
 
@@ -30,9 +32,11 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if VLC is installed
 
-    describe oneget('VLC') do
-      it { should be_installed }
-    end
+```ruby
+describe oneget('VLC') do
+  it { should be_installed }
+end
+```
 
 <br>
 
@@ -44,10 +48,14 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_installed` matcher tests if the named package is installed on the system:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### version
 
 The `version` matcher tests if the named package version is on the system:
 
-    its('version') { should eq '1.2.3' }
+```ruby
+its('version') { should eq '1.2.3' }
+```

--- a/docs/resources/oracledb_session.md.erb
+++ b/docs/resources/oracledb_session.md.erb
@@ -13,9 +13,11 @@ Use the `oracledb_session` InSpec audit resource to test SQL commands run agains
 
 A `oracledb_session` resource block declares the username and password to use for the session with an optional service to connect to, and then the command to be run:
 
-    describe oracledb_session(user: 'username', password: 'password', service: 'ORCL.localdomain').query('QUERY').row(0).column('result') do
-      its('value') { should eq('') }
-    end
+```ruby
+describe oracledb_session(user: 'username', password: 'password', service: 'ORCL.localdomain').query('QUERY').row(0).column('result') do
+  its('value') { should eq('') }
+end
+```
 
 where
 
@@ -31,19 +33,27 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test for matching databases
 
-    sql = oracledb_session(user: 'my_user', pass: 'password')
+```ruby
+sql = oracledb_session(user: 'my_user', pass: 'password')
+```
 
-    describe sql.query('SELECT NAME AS VALUE FROM v$database;').row(0).column('value') do
-      its('value') { should cmp 'ORCL' }
-    end
+```ruby
+describe sql.query('SELECT NAME AS VALUE FROM v$database;').row(0).column('value') do
+  its('value') { should cmp 'ORCL' }
+end
+```
 
 ### Test for matching databases with custom host, SID and sqlplus binary location
 
-    sql = oracledb_session(user: 'my_user', pass: 'password', host: 'oraclehost', sid: 'mysid', sqlplus_bin: '/u01/app/oracle/product/12.1.0/dbhome_1/bin/sqlplus')
+```ruby
+sql = oracledb_session(user: 'my_user', pass: 'password', host: 'oraclehost', sid: 'mysid', sqlplus_bin: '/u01/app/oracle/product/12.1.0/dbhome_1/bin/sqlplus')
+```
 
-    describe sql.query('SELECT NAME FROM v$database;').row(0).column('name') do
-      its('value') { should cmp 'ORCL' }
-    end
+```ruby
+describe sql.query('SELECT NAME FROM v$database;').row(0).column('name') do
+  its('value') { should cmp 'ORCL' }
+end
+```
 
 <br>
 

--- a/docs/resources/os.md.erb
+++ b/docs/resources/os.md.erb
@@ -13,9 +13,11 @@ Use the `os` InSpec audit resource to test the platform on which the system is r
 
 An `os` resource block declares the platform to be tested. The platform may specified via matcher or control block name. For example, using a matcher:
 
-    describe os[:family] do
-      it { should eq 'platform_family_name' }
-    end
+```ruby
+describe os[:family] do
+  it { should eq 'platform_family_name' }
+end
+```
 
 * `'platform_family_name'` (a string) is one of `aix`, `bsd`, `darwin`, `debian`, `hpux`, `linux`, `redhat`, `solaris`, `suse`,  `unix`, or `windows`
 
@@ -33,21 +35,27 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test for RedHat
 
-    describe os[:family] do
-      it { should eq 'redhat' }
-    end
+```ruby
+describe os[:family] do
+  it { should eq 'redhat' }
+end
+```
 
 ### Test for Ubuntu
 
-    describe os[:family] do
-      it { should eq 'debian' }
-    end
+```ruby
+describe os[:family] do
+  it { should eq 'debian' }
+end
+```
 
 ### Test for Microsoft Windows
 
-    describe os[:family] do
-      it { should eq 'windows' }
-    end
+```ruby
+describe os[:family] do
+  it { should eq 'windows' }
+end
+```
 
 <br>
 
@@ -73,35 +81,47 @@ The `os` audit resource includes a collection of helpers that enable more granul
 
 For example, to test for Darwin use:
 
-    describe os.bsd? do
-       it { should eq true }
-    end
+```ruby
+describe os.bsd? do
+   it { should eq true }
+end
+```
 
 To test for Windows use:
 
-    describe os.windows? do
-       it { should eq true }
-    end
+```ruby
+describe os.windows? do
+   it { should eq true }
+end
+```
 
 and to test for Redhat use:
 
-    describe os.redhat? do
-       it { should eq true }
-    end
+```ruby
+describe os.redhat? do
+   it { should eq true }
+end
+```
 
 Use the following helpers to test for operating system names, releases, and architectures:
 
-    describe os.name do
-       it { should eq 'foo' }
-    end
+```ruby
+describe os.name do
+   it { should eq 'foo' }
+end
+```
 
-    describe os.release do
-       it { should eq 'foo' }
-    end
+```ruby
+describe os.release do
+   it { should eq 'foo' }
+end
+```
 
-    describe os.arch do
-       it { should eq 'foo' }
-    end
+```ruby
+describe os.arch do
+   it { should eq 'foo' }
+end
+```
 
 ### os[:family] Symbols
 
@@ -120,22 +140,26 @@ Use `os[:family]` to enable more granular testing of platforms, platform names, 
 
 For example, both of the following tests should have the same result:
 
-    if os[:family] == 'debian'
-      describe port(69) do
-        its('processes') { should include 'in.tftpd' }
-      end
-    elsif os[:family] == 'redhat'
-      describe port(69) do
-        its('processes') { should include 'xinetd' }
-      end
-    end
+```ruby
+if os[:family] == 'debian'
+  describe port(69) do
+    its('processes') { should include 'in.tftpd' }
+  end
+elsif os[:family] == 'redhat'
+  describe port(69) do
+    its('processes') { should include 'xinetd' }
+  end
+end
+```
 
-    if os.debian?
-      describe port(69) do
-        its('processes') { should include 'in.tftpd' }
-      end
-    elsif os.redhat?
-      describe port(69) do
-        its('processes') { should include 'xinetd' }
-      end
-    end
+```ruby
+if os.debian?
+  describe port(69) do
+    its('processes') { should include 'in.tftpd' }
+  end
+elsif os.redhat?
+  describe port(69) do
+    its('processes') { should include 'xinetd' }
+  end
+end
+```

--- a/docs/resources/os_env.md.erb
+++ b/docs/resources/os_env.md.erb
@@ -13,9 +13,11 @@ Use the `os_env` InSpec audit resource to test the environment variables for the
 
 A `os_env` resource block declares an environment variable, and then declares its value:
 
-    describe os_env('VARIABLE') do
-      its('property') { should eq 1 }
-    end
+```ruby
+describe os_env('VARIABLE') do
+  its('property') { should eq 1 }
+end
+```
 
 where
 
@@ -30,32 +32,38 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test the PATH environment variable
 
-    describe os_env('PATH') do
-      its('split') { should_not include('') }
-      its('split') { should_not include('.') }
-    end
+```ruby
+describe os_env('PATH') do
+  its('split') { should_not include('') }
+  its('split') { should_not include('.') }
+end
+```
 
 ### Test Habitat environment variables
 
 Habitat uses the `os_env` resource to test environment variables. The environment variables are first defined in a whitespace array, after which each environment variable is tested:
 
-    hab_env_vars = %w(HAB_AUTH_TOKEN
-                      HAB_CACHE_KEY_PATH
-                      HAB_DEPOT_URL
-                      HAB_ORG
-                      HAB_ORIGIN
-                      HAB_ORIGIN_KEYS
-                      HAB_RING
-                      HAB_RING_KEY
-                      HAB_STUDIOS_HOME
-                      HAB_STUDIO_ROOT
-                      HAB_USER)
+```ruby
+hab_env_vars = %w(HAB_AUTH_TOKEN
+                  HAB_CACHE_KEY_PATH
+                  HAB_DEPOT_URL
+                  HAB_ORG
+                  HAB_ORIGIN
+                  HAB_ORIGIN_KEYS
+                  HAB_RING
+                  HAB_RING_KEY
+                  HAB_STUDIOS_HOME
+                  HAB_STUDIO_ROOT
+                  HAB_USER)
+```
 
-    hab_env_vars.each do |e|
-      describe os_env(e) do
-        its('content') { should eq nil }
-      end
-    end
+```ruby
+hab_env_vars.each do |e|
+  describe os_env(e) do
+    its('content') { should eq nil }
+  end
+end
+```
 
 <br>
 
@@ -67,12 +75,16 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `content` matcher return the value of the environment variable:
 
-    its('content') { should eq '/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin' }
+```ruby
+its('content') { should eq '/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin' }
+```
 
 ### split
 
 The `split` matcher splits the value of the environment variable with the `:` deliminator (use the `;` deliminator if Windows):
 
-    its('split') { should include ('/usr/bin') }
+```ruby
+its('split') { should include ('/usr/bin') }
+```
 
 Note: the `split` matcher returns an array including `""` for cases where there is a trailing colon (`:`), such as `dir1::dir2:`

--- a/docs/resources/package.md.erb
+++ b/docs/resources/package.md.erb
@@ -13,9 +13,11 @@ Use the `package` InSpec audit resource to test if the named package and/or pack
 
 A `package` resource block declares a package and (optionally) a package version:
 
-    describe package('name') do
-      it { should be_installed }
-    end
+```ruby
+describe package('name') do
+  it { should be_installed }
+end
+```
 
 where
 
@@ -30,63 +32,83 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if NGINX version 1.9.5 is installed
 
-    describe package('nginx') do
-      it { should be_installed }
-      its('version') { should eq '1.9.5' }
-    end
+```ruby
+describe package('nginx') do
+  it { should be_installed }
+  its('version') { should eq '1.9.5' }
+end
+```
 
 ### Test that a package is not installed
 
-    describe package('some_package') do
-      it { should_not be_installed }
-    end
+```ruby
+describe package('some_package') do
+  it { should_not be_installed }
+end
+```
 
 ### Test if telnet is installed
 
-    describe package('telnetd') do
-      it { should_not be_installed }
-    end
+```ruby
+describe package('telnetd') do
+  it { should_not be_installed }
+end
+```
 
-    describe inetd_conf do
-      its('telnet') { should eq nil }
-    end
+```ruby
+describe inetd_conf do
+  its('telnet') { should eq nil }
+end
+```
 
 ### Test if ClamAV (an antivirus engine) is installed and running
 
-    describe package('clamav') do
-      it { should be_installed }
-      its('version') { should eq '0.98.7' }
-    end
+```ruby
+describe package('clamav') do
+  it { should be_installed }
+  its('version') { should eq '0.98.7' }
+end
+```
 
-    describe service('clamd') do
-      it { should_not be_enabled }
-      it { should_not be_installed }
-      it { should_not be_running }
-    end
+```ruby
+describe service('clamd') do
+  it { should_not be_enabled }
+  it { should_not be_installed }
+  it { should_not be_running }
+end
+```
 
 ### Verify if some_package is installed according to my_rpmdb
 
-   describe package('some_package', rpm_dbpath: '/var/lib/my_rpmdb') do
-     it { should be_installed }
-   end
+```ruby
+escribe package('some_package', rpm_dbpath: '/var/lib/my_rpmdb') do
+ it { should be_installed }
+nd
+```
 
 ### Verify if Memcached is installed, enabled, and running
 
 Memcached is an in-memory key-value store that helps improve the performance of database-driven websites and can be installed, maintained, and tested using the `memcached` cookbook (maintained by Chef). The following example is from the `memcached` cookbook and shows how to use a combination of the `package`, `service`, and `port` InSpec audit resources to test if Memcached is installed, enabled, and running:
 
-    describe package('memcached') do
-      it { should be_installed }
-    end
+```ruby
+describe package('memcached') do
+  it { should be_installed }
+end
+```
 
-    describe service('memcached') do
-      it { should be_installed }
-      it { should be_enabled }
-      it { should be_running }
-    end
+```ruby
+describe service('memcached') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+```
 
-    describe port(11_211) do
-      it { should be_listening }
-    end
+```ruby
+describe port(11_211) do
+  it { should be_listening }
+end
+```
 
 <br>
 
@@ -99,22 +121,30 @@ For a full list of available matchers, please visit our [matchers page](https://
 The `be_held` matcher tests if the named package is "held". On dpkg platforms, a "held" package
 will not be upgraded to a later version.
 
-    it { should be_held }
+```ruby
+it { should be_held }
+```
 
 ### be_installed
 
 The `be_installed` matcher tests if the named package is installed on the system:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### version
 
 The `version` matcher tests if the named package version is on the system:
 
-    its('version') { should eq '1.2.3' }
+```ruby
+its('version') { should eq '1.2.3' }
+```
 
 You can also use the `cmp OPERATOR` matcher to perform comparisions using the version attribute:
 
-    its('version') { should cmp >= '7.35.0-1ubuntu3.10' }
+```ruby
+its('version') { should cmp >= '7.35.0-1ubuntu3.10' }
+```
 
 `cmp` understands version numbers using Gem::Version, and can use the operators `==, <, <=, >=, and >`.  It will compare versions by each segment, not as a string - so '7.4' is smaller than '7.30', for example.

--- a/docs/resources/packages.md.erb
+++ b/docs/resources/packages.md.erb
@@ -13,9 +13,11 @@ Use the `packages` InSpec audit resource to test the properties of multiple pack
 
 A `packages` resource block declares a regular expression search to select packages
 
-    describe packages(/name/) do
-      its('statuses') { should cmp 'installed' }
-    end
+```ruby
+describe packages(/name/) do
+  its('statuses') { should cmp 'installed' }
+end
+```
 
 <br>
 
@@ -25,22 +27,28 @@ The following examples show how to use this InSpec audit resource.
 
 ### Verify that no `xserver` packages are installed
 
-    describe package(/xserver/) do
-      its('statuses') { should_not cmp 'installed' }
-    end
+```ruby
+describe package(/xserver/) do
+  its('statuses') { should_not cmp 'installed' }
+end
+```
 
 ### Verify all `openssl` packages match a certain version
 
-    describe package(/openssl/) do
-      its('versions') { should cmp '1.0.1e-42.el7' }
-    end
+```ruby
+describe package(/openssl/) do
+  its('versions') { should cmp '1.0.1e-42.el7' }
+end
+```
 
 ### Verify that both the `i686` and `x86_64` versions of `libgcc` are installed
 
-    describe package(/libgcc/) do
-      its('architectures') { should include 'x86_64' }
-      its('architectures') { should include 'i686' }
-    end
+```ruby
+describe package(/libgcc/) do
+  its('architectures') { should include 'x86_64' }
+  its('architectures') { should include 'i686' }
+end
+```
 
 <br>
 
@@ -52,16 +60,22 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `statuses` matcher tests if packages are installed on the system
 
-    its('statuses') { should cmp 'installed' }
+```ruby
+its('statuses') { should cmp 'installed' }
+```
 
 ### versions
 
 The `versions` matcher tests the versions of the packages installed on the system
 
-    its('versions') { should cmp '3.4.0.2-4.el7' }
+```ruby
+its('versions') { should cmp '3.4.0.2-4.el7' }
+```
 
 ### architectures
 
 The `architectures` matcher tests the architecture of packages installed on the system
 
-    its('architectures') { should include 'i686' }
+```ruby
+its('architectures') { should include 'i686' }
+```

--- a/docs/resources/parse_config.md.erb
+++ b/docs/resources/parse_config.md.erb
@@ -13,23 +13,31 @@ Use the `parse_config` InSpec audit resource to test arbitrary configuration fil
 
 A `parse_config` resource block declares the location of the configuration setting to be tested, and then what value is to be tested. Because this resource relies on arbitrary configuration files, the test itself is often arbitrary and relies on custom Ruby code:
 
-    output = command('some-command').stdout
+```ruby
+output = command('some-command').stdout
+```
 
-    describe parse_config(output, { data_config_option: value } ) do
-      its('setting') { should eq 1 }
-    end
+```ruby
+describe parse_config(output, { data_config_option: value } ) do
+  its('setting') { should eq 1 }
+end
+```
 
 or:
 
-    audit = command('/sbin/auditctl -l').stdout
-      options = {
-        assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
-        multiple_values: true
-      }
+```ruby
+audit = command('/sbin/auditctl -l').stdout
+  options = {
+    assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
+    multiple_values: true
+  }
+```
 
-    describe parse_config(audit, options) do
-      its('setting') { should eq 1 }
-    end
+```ruby
+describe parse_config(audit, options) do
+  its('setting') { should eq 1 }
+end
+```
 
 where each test
 
@@ -48,56 +56,74 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 Use `assignment_regex` to test a key value using a regular expression:
 
-    'key = value'
+```ruby
+'key = value'
+```
 
 may be tested using the following regular expression, which determines assignment from key to value:
 
-    assignment_regex: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/
+```ruby
+assignment_regex: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/
+```
 
 ### comment_char
 
 Use `comment_char` to test for comments in a configuration file:
 
-    comment_char: '#'
+```ruby
+comment_char: '#'
+```
 
 ### key_values
 
 Use `key_values` to test how many values a key contains:
 
-    key = a b c
+```ruby
+key = a b c
+```
 
 contains three values. To test that value to ensure it only contains one, use:
 
-    key_values: 1
+```ruby
+key_values: 1
+```
 
 ### multiple_values
 
 Use `multiple_values` if the source file uses the same key multiple times. All values will be aggregated in an array:
 
-    # # file structure:
-    # key = a
-    # key = b
-    # key2 = c
-    params['key'] = ['a', 'b']
-    params['key2'] = ['c']
+```ruby
+# # file structure:
+# key = a
+# key = b
+# key2 = c
+params['key'] = ['a', 'b']
+params['key2'] = ['c']
+```
 
 To use plain key value mapping, use `multiple_values: false`:
 
-    # # file structure:
-    # key = a
-    # key = b
-    # key2 = c
-    params['key'] = 'b'
-    params['key2'] = 'c'
+```ruby
+# # file structure:
+# key = a
+# key = b
+# key2 = c
+params['key'] = 'b'
+params['key2'] = 'c'
+```
 
 ### standalone_comments
 
 Use `standalone_comments` to parse comments as a line, otherwise inline comments are allowed:
 
-    'key = value # comment'
-    params['key'] = 'value # comment'
+```ruby
+'key = value # comment'
+params['key'] = 'value # comment'
+```
 
 Use `standalone_comments: false`, to parse the following:
 
-    'key = value # comment'
-    params['key'] = 'value'
+```ruby
+'key = value # comment'
+params['key'] = 'value'
+```

--- a/docs/resources/parse_config_file.md.erb
+++ b/docs/resources/parse_config_file.md.erb
@@ -13,20 +13,26 @@ Use the `parse_config_file` InSpec audit resource to test arbitrary configuratio
 
 A `parse_config_file` InSpec audit resource block declares the location of the configuration file to be tested, and then which settings in that file are to be tested.
 
-    describe parse_config_file('/path/to/file', { data_config_option: value } ) do
-      its('setting') { should eq 1 }
-    end
+```ruby
+describe parse_config_file('/path/to/file', { data_config_option: value } ) do
+  its('setting') { should eq 1 }
+end
+```
 
 or:
 
-    options = {
-      assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
-      multiple_values: true
-    }
+```ruby
+options = {
+  assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
+  multiple_values: true
+}
+```
 
-    describe parse_config_file('path/to/file', options) do
-      its('setting') { should eq 1 }
-    end
+```ruby
+describe parse_config_file('path/to/file', options) do
+  its('setting') { should eq 1 }
+end
+```
 
 where each test
 
@@ -41,13 +47,15 @@ where each test
 
 This resource supports the following options for parsing configuration data. Use them in an `options` block stated outside of (and immediately before) the actual test:
 
-    options = {
-        assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
-        multiple_values: true
-      }
-    describe parse_config_file('path/to/file',  options) do
-      its('setting') { should eq 1 }
-    end
+```ruby
+options = {
+    assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
+    multiple_values: true
+  }
+describe parse_config_file('path/to/file',  options) do
+  its('setting') { should eq 1 }
+end
+```
 
 <br>
 
@@ -57,21 +65,27 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test a configuration setting
 
-    describe parse_config_file('/path/to/file.conf') do
-     its('PARAM_X') { should eq 'Y' }
-    end
+```ruby
+describe parse_config_file('/path/to/file.conf') do
+ its('PARAM_X') { should eq 'Y' }
+end
+```
 
 ### Use options, and then test a configuration setting
 
-    describe parse_config_file('/path/to/file.conf', { multiple_values: true }) do
-     its('PARAM_X') { should include 'Y' }
-    end
+```ruby
+describe parse_config_file('/path/to/file.conf', { multiple_values: true }) do
+ its('PARAM_X') { should include 'Y' }
+end
+```
 
 ### Test a file with an ini-like structure (such as a yum.conf)
 
-    describe parse_config_file('/path/to/yum.conf') do
-     its('main') { should include('gpgcheck' => '1') }
-    end
+```ruby
+describe parse_config_file('/path/to/yum.conf') do
+ its('main') { should include('gpgcheck' => '1') }
+end
+```
 
 <br>
 
@@ -83,56 +97,74 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 Use `assignment_regex` to test a key value using a regular expression:
 
-    'key = value'
+```ruby
+'key = value'
+```
 
 may be tested using the following regular expression, which determines assignment from key to value:
 
-    assignment_regex: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/
+```ruby
+assignment_regex: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/
+```
 
 ### comment_char
 
 Use `comment_char` to test for comments in a configuration file:
 
-    comment_char: '#'
+```ruby
+comment_char: '#'
+```
 
 ### key_values
 
 Use `key_values` to test how many values a key contains:
 
-    key = a b c
+```ruby
+key = a b c
+```
 
 contains three values. To test that value to ensure it only contains one, use:
 
-    key_values: 1
+```ruby
+key_values: 1
+```
 
 ### multiple_values
 
 Use `multiple_values` if the source file uses the same key multiple times. All values will be aggregated in an array:
 
-    # # file structure:
-    # key = a
-    # key = b
-    # key2 = c
-    params['key'] = ['a', 'b']
-    params['key2'] = ['c']
+```ruby
+# # file structure:
+# key = a
+# key = b
+# key2 = c
+params['key'] = ['a', 'b']
+params['key2'] = ['c']
+```
 
 To use plain key value mapping, use `multiple_values: false`:
 
-    # # file structure:
-    # key = a
-    # key = b
-    # key2 = c
-    params['key'] = 'b'
-    params['key2'] = 'c'
+```ruby
+# # file structure:
+# key = a
+# key = b
+# key2 = c
+params['key'] = 'b'
+params['key2'] = 'c'
+```
 
 ### standalone_comments
 
 Use `standalone_comments` to parse comments as a line, otherwise inline comments are allowed:
 
-    'key = value # comment'
-    params['key'] = 'value # comment'
+```ruby
+'key = value # comment'
+params['key'] = 'value # comment'
+```
 
 Use `standalone_comments: false`, to parse the following:
 
-    'key = value # comment'
-    params['key'] = 'value'
+```ruby
+'key = value # comment'
+params['key'] = 'value'
+```

--- a/docs/resources/passwd.md.erb
+++ b/docs/resources/passwd.md.erb
@@ -17,7 +17,9 @@ Use the `passwd` InSpec audit resource to test the contents of `/etc/passwd`, wh
 
 These entries are defined as a colon-delimited row in the file, one row per user:
 
-    root:x:1234:5678:additional_info:/home/dir/:/bin/bash
+```ruby
+root:x:1234:5678:additional_info:/home/dir/:/bin/bash
+```
 
 <br>
 
@@ -25,14 +27,18 @@ These entries are defined as a colon-delimited row in the file, one row per user
 
 A `passwd` resource block declares one (or more) users and associated user information to be tested:
 
-    describe passwd do
-      its('users') { should_not include 'forbidden_user' }
-    end
+```ruby
+describe passwd do
+  its('users') { should_not include 'forbidden_user' }
+end
+```
 
-    describe passwd.uid(filter) do
-      its('users') { should cmp 'root' }
-      its('count') { should eq 1 }
-    end
+```ruby
+describe passwd.uid(filter) do
+  its('users') { should cmp 'root' }
+  its('count') { should eq 1 }
+end
+```
 
 where
 
@@ -48,22 +54,28 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test usernames and UIDs
 
-    describe passwd do
-      its('users') { should eq ['root', 'www-data'] }
-      its('uids') { should eq [0, 33] }
-    end
+```ruby
+describe passwd do
+  its('users') { should eq ['root', 'www-data'] }
+  its('uids') { should eq [0, 33] }
+end
+```
 
 ### Select one user and test for multiple occurrences
 
-    describe passwd.uids(0) do
-      its('users') { should cmp 'root' }
-      its('count') { should eq 1 }
-    end
+```ruby
+describe passwd.uids(0) do
+  its('users') { should cmp 'root' }
+  its('count') { should eq 1 }
+end
+```
 
-    describe passwd.where { user == 'www-data' } do
-      its('uids') { should cmp 33 }
-      its('count') { should eq 1 }
-    end
+```ruby
+describe passwd.where { user == 'www-data' } do
+  its('uids') { should cmp 33 }
+  its('count') { should eq 1 }
+end
+```
 
 <br>
 
@@ -75,26 +87,34 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `gids` matcher tests if the group indentifiers in the test match group identifiers in `/etc/passwd`:
 
-    its('gids') { should include 1234 }
-    its('gids') { should cmp 0 }
+```ruby
+its('gids') { should include 1234 }
+its('gids') { should cmp 0 }
+```
 
 ### homes
 
 The `homes` matcher tests the absolute path to a user's home directory:
 
-    its('home') { should eq '/' }
+```ruby
+its('home') { should eq '/' }
+```
 
 ### length
 
 The `length` matcher tests the length of a password that appears in `/etc/passwd`:
 
-    its('length') { should be <= 32 }
+```ruby
+its('length') { should be <= 32 }
+```
 
 This matcher is best used in conjunction with filters. For example:
 
-    describe passwd.users('highlander') do
-       its('length') { should_not be < 16 }
-    end
+```ruby
+describe passwd.users('highlander') do
+   its('length') { should_not be < 16 }
+end
+```
 
 ### passwords
 
@@ -106,36 +126,48 @@ The `passwords` matcher tests if passwords are
 
 For example:
 
-    its('passwords') { should eq ['x'] }
-    its('passwords') { should cmp '*' }
+```ruby
+its('passwords') { should eq ['x'] }
+its('passwords') { should cmp '*' }
+```
 
 ### shells
 
 The `shells` matcher tests the absolute path of a shell (or command) to which a user has access:
 
-    its('shells') { should_not include 'user' }
+```ruby
+its('shells') { should_not include 'user' }
+```
 
 or to find all users with the nologin shell:
 
-    describe passwd.shells(/nologin/) do
-      its('users') { should_not include 'my_login_user' }
-    end
+```ruby
+describe passwd.shells(/nologin/) do
+  its('users') { should_not include 'my_login_user' }
+end
+```
 
 ### uids
 
 The `uids` matcher tests if the user indentifiers in the test match user identifiers in `/etc/passwd`:
 
-    its('uids') { should eq ['1234', '1235'] }
+```ruby
+its('uids') { should eq ['1234', '1235'] }
+```
 
 or:
 
-    describe passwd.uids(0) do
-      its('users') { should cmp 'root' }
-      its('count') { should eq 1 }
-    end
+```ruby
+describe passwd.uids(0) do
+  its('users') { should cmp 'root' }
+  its('count') { should eq 1 }
+end
+```
 
 ### users
 
 The `users` matcher tests if the user names in the test match user names in `/etc/passwd`:
 
-    its('users') { should eq ['root', 'www-data'] }
+```ruby
+its('users') { should eq ['root', 'www-data'] }
+```

--- a/docs/resources/pip.md.erb
+++ b/docs/resources/pip.md.erb
@@ -13,9 +13,11 @@ Use the `pip` InSpec audit resource to test packages that are installed using th
 
 A `pip` resource block declares a package and (optionally) a package version:
 
-    describe pip('package_name') do
-      it { should be_installed }
-    end
+```ruby
+describe pip('package_name') do
+  it { should be_installed }
+end
+```
 
 where
 
@@ -30,23 +32,29 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if Jinja2 is installed on the system
 
-    describe pip('Jinja2') do
-      it { should be_installed }
-    end
+```ruby
+describe pip('Jinja2') do
+  it { should be_installed }
+end
+```
 
 ### Test if Jinja2 2.8 is installed on the system
 
-    describe pip('Jinja2') do
-      it { should be_installed }
-      its('version') { should eq '2.8' }
-    end
+```ruby
+describe pip('Jinja2') do
+  it { should be_installed }
+  its('version') { should eq '2.8' }
+end
+```
 
 ### Test packages installed into a non-default location (e.g. virtualenv) by passing a custom path to pip executable
 
-    describe pip('Jinja2', '/path/to/bin/pip') do
-      it { should be_installed }
-      its('version') { should eq '2.8' }
-    end
+```ruby
+describe pip('Jinja2', '/path/to/bin/pip') do
+  it { should be_installed }
+  its('version') { should eq '2.8' }
+end
+```
 
 <br>
 
@@ -58,10 +66,14 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_installed` matcher tests if the named package is installed on the system:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### version
 
 The `version` matcher tests if the named package version is on the system:
 
-    its('version') { should eq '1.2.3' }
+```ruby
+its('version') { should eq '1.2.3' }
+```

--- a/docs/resources/port.md.erb
+++ b/docs/resources/port.md.erb
@@ -13,18 +13,22 @@ Use the `port` InSpec audit resource to test basic port properties, such as port
 
 A `port` resource block declares a port, and then depending on what needs to be tested, a process, protocol, process identifier, and its state (is it listening?):
 
-    describe port(514) do
-      it { should be_listening }
-      its('processes') {should include 'syslog'}
-    end
+```ruby
+describe port(514) do
+  it { should be_listening }
+  its('processes') {should include 'syslog'}
+end
+```
 
 where the `processes` returns the processes listening on port 514.
 
 A filter may specify an attribute:
 
-    describe port.where { protocol =~ /tcp/ && port > 22 && port < 80 } do
-      it { should_not be_listening }
-    end
+```ruby
+describe port.where { protocol =~ /tcp/ && port > 22 && port < 80 } do
+  it { should_not be_listening }
+end
+```
 
 where
 
@@ -32,11 +36,13 @@ where
 
 For example, to test if the SSH daemon is available on a Linux machine via the default port (22):
 
-    describe port(22) do
-      its('processes') { should include 'sshd' }
-      its('protocols') { should include 'tcp' }
-      its('addresses') { should include '0.0.0.0' }
-    end
+```ruby
+describe port(22) do
+  its('processes') { should include 'sshd' }
+  its('protocols') { should include 'tcp' }
+  its('addresses') { should include '0.0.0.0' }
+end
+```
 
 <br>
 
@@ -46,55 +52,71 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test port 80, listening with the TCP protocol
 
-    describe port(80) do
-      it { should be_listening }
-      its('protocols') { should cmp 'tcp' }
-    end
+```ruby
+describe port(80) do
+  it { should be_listening }
+  its('protocols') { should cmp 'tcp' }
+end
+```
 
 ### Test port 80, on a specific address
 
 A specific port address may be checked using either of the following examples:
 
-    describe port(80) do
-      it { should be_listening }
-      its('addresses') {should include '0.0.0.0'}
-    end
+```ruby
+describe port(80) do
+  it { should be_listening }
+  its('addresses') {should include '0.0.0.0'}
+end
+```
 
 or:
 
-    describe port('0.0.0.0', 80) do
-      it { should be_listening }
-    end
+```ruby
+describe port('0.0.0.0', 80) do
+  it { should be_listening }
+end
+```
 
 ### Test port 80, listening with TCP version IPv6 protocol
 
-    describe port(80) do
-      it { should be_listening }
-      its('protocols') { should cmp 'tcp6' }
-    end
+```ruby
+describe port(80) do
+  it { should be_listening }
+  its('protocols') { should cmp 'tcp6' }
+end
+```
 
 ### Test that only secure ports accept requests
 
-    describe port(80) do
-      it { should_not be_listening }
-    end
+```ruby
+describe port(80) do
+  it { should_not be_listening }
+end
+```
 
-    describe port(443) do
-      it { should be_listening }
-      its('protocols') { should cmp 'tcp' }
-    end
+```ruby
+describe port(443) do
+  it { should be_listening }
+  its('protocols') { should cmp 'tcp' }
+end
+```
 
 ### Verify port 65432 is not listening
 
-    describe port(22) do
-      it { should be_listening }
-      its('protocols') { should include('tcp') }
-      its('protocols') { should_not include('udp') }
-    end
+```ruby
+describe port(22) do
+  it { should be_listening }
+  its('protocols') { should include('tcp') }
+  its('protocols') { should_not include('udp') }
+end
+```
 
-    describe port(65432) do
-      it { should_not be_listening }
-    end
+```ruby
+describe port(65432) do
+  it { should_not be_listening }
+end
+```
 
 <br>
 
@@ -106,32 +128,44 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `addresses` matcher tests if the specified address is associated with a port:
 
-    its('addresses') { should include '0.0.0.0' }
+```ruby
+its('addresses') { should include '0.0.0.0' }
+```
 
 ### be_listening
 
 The `be_listening` matcher tests if the port is listening for traffic:
 
-    it { should be_listening }
+```ruby
+it { should be_listening }
+```
 
 ### pids
 
 The `pids` matcher tests the process identifiers (PIDs):
 
-    its('pids') { should cmp 27808 }
+```ruby
+its('pids') { should cmp 27808 }
+```
 
 ### processes
 
 The `processes` matcher tests if the named process is running on the system:
 
-    its('processes') { should cmp 'syslog' }
+```ruby
+its('processes') { should cmp 'syslog' }
+```
 
 ### protocols
 
 The `protocols` matcher tests the Internet protocol: ICMP (`'icmp'`), TCP (`'tcp'` or `'tcp6'`), or UDP (`'udp'` or `'udp6'`):
 
-    its('protocols') { should include 'tcp' }
+```ruby
+its('protocols') { should include 'tcp' }
+```
 
 or for the IPv6 protocol:
 
-    its('protocols') { should include 'tcp6' }
+```ruby
+its('protocols') { should include 'tcp6' }
+```

--- a/docs/resources/postgres_conf.md.erb
+++ b/docs/resources/postgres_conf.md.erb
@@ -13,9 +13,11 @@ Use the `postgres_conf` InSpec audit resource to test the contents of the config
 
 A `postgres_conf` resource block declares one (or more) settings in the `postgresql.conf` file, and then compares the setting in the configuration file to the value stated in the test:
 
-    describe postgres_conf('path') do
-      its('setting') { should eq 'value' }
-    end
+```ruby
+describe postgres_conf('path') do
+  its('setting') { should eq 'value' }
+end
+```
 
 
 where
@@ -32,35 +34,43 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test the maximum number of allowed client connections
 
-    describe postgres_conf do
-      its('max_connections') { should eq '5' }
-    end
+```ruby
+describe postgres_conf do
+  its('max_connections') { should eq '5' }
+end
+```
 
 ### Test system logging
 
-    describe postgres_conf do
-      its('logging_collector') { should eq 'on' }
-      its('log_connections') { should eq 'on' }
-      its('log_disconnections') { should eq 'on' }
-      its('log_duration') { should eq 'on' }
-      its('log_hostname') { should eq 'on' }
-      its('log_line_prefix') { should eq '%t %u %d %h' }
-      its(['pgaudit.log_parameter']) { should cmp 'on' }
-    end
+```ruby
+describe postgres_conf do
+  its('logging_collector') { should eq 'on' }
+  its('log_connections') { should eq 'on' }
+  its('log_disconnections') { should eq 'on' }
+  its('log_duration') { should eq 'on' }
+  its('log_hostname') { should eq 'on' }
+  its('log_line_prefix') { should eq '%t %u %d %h' }
+  its(['pgaudit.log_parameter']) { should cmp 'on' }
+end
+```
 
 ### Test the port on which PostgreSQL listens
 
-    describe postgres_conf do
-      its('port') { should eq '5432' }
-    end
+```ruby
+describe postgres_conf do
+  its('port') { should eq '5432' }
+end
+```
 
 ### Test the Unix socket settings
 
-    describe postgres_conf do
-      its('unix_socket_directories') { should eq '.s.PGSQL.5432' }
-      its('unix_socket_group') { should eq nil }
-      its('unix_socket_permissions') { should eq '0770' }
-    end
+```ruby
+describe postgres_conf do
+  its('unix_socket_directories') { should eq '.s.PGSQL.5432' }
+  its('unix_socket_group') { should eq nil }
+  its('unix_socket_permissions') { should eq '0770' }
+end
+```
 
 where `unix_socket_group` is set to the PostgreSQL default setting (the group to which the server user belongs).
 
@@ -74,6 +84,8 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `setting` matcher tests specific, named settings in the `postgresql.conf` file:
 
-    its('setting') { should eq 'value' }
+```ruby
+its('setting') { should eq 'value' }
+```
 
 Use a `setting` matcher for each setting to be tested.

--- a/docs/resources/postgres_hba_conf.md.erb
+++ b/docs/resources/postgres_hba_conf.md.erb
@@ -13,9 +13,11 @@ Use the `postgres_hba_conf` InSpec audit resource to test the client authenticat
 
 An `postgres_hba_conf` InSpec audit resource block declares client authentication data that should be tested:
 
-    describe postgres_hba_conf.where { type == 'local' } do
-     its('auth_method') { should eq ['peer'] }
-    end
+```ruby
+describe postgres_hba_conf.where { type == 'local' } do
+ its('auth_method') { should eq ['peer'] }
+end
+```
 
 where
 
@@ -27,7 +29,9 @@ where
 
 ## Properties
 
-    'address', 'auth_method', 'auth_params', 'conf_dir' , 'conf_file' , 'database', 'params' ,'type', 'user'
+```ruby
+'address', 'auth_method', 'auth_params', 'conf_dir' , 'conf_file' , 'database', 'params' ,'type', 'user'
+```
 
 <br>
 
@@ -37,41 +41,51 @@ where
 
 `address` returns a an array of strings that matches the where condition of the filter table
 
-    describe postgres_hba_conf.where { type == 'local' } do
-      its('address') { should cmp 'value' }
-    end
+```ruby
+describe postgres_hba_conf.where { type == 'local' } do
+  its('address') { should cmp 'value' }
+end
+```
 
 ### auth_method([String])
 
 `auth_method` returns a an array of strings that matches the where condition of the filter table
 
-    describe postgres_hba_conf.where { type == 'local' } do
-      its('auth_method') { should cmp 'value' }
-    end
+```ruby
+describe postgres_hba_conf.where { type == 'local' } do
+  its('auth_method') { should cmp 'value' }
+end
+```
 
 ### database([String])
 
 `database` returns a an array of strings that matches the where condition of the filter table
 
-    describe postgres_hba_conf.where { type == 'local' } do
-      its('database') { should cmp 'value' }
-    end
+```ruby
+describe postgres_hba_conf.where { type == 'local' } do
+  its('database') { should cmp 'value' }
+end
+```
 
 ### type([String])
 
 `type` returns a an array of strings that matches the where condition of the filter table
 
-    describe postgres_hba_conf.where { database == 'acme_test_db' } do
-      its('type') { should cmp 'value' }
-    end
+```ruby
+describe postgres_hba_conf.where { database == 'acme_test_db' } do
+  its('type') { should cmp 'value' }
+end
+```
 
 ### user([String])
 
 `user` returns a an array of strings that matches the where condition of the filter table
 
-    describe postgres_hba_conf.where { database == 'acme_test_db' } do
-      its('user') { should cmp 'value' }
-    end
+```ruby
+describe postgres_hba_conf.where { database == 'acme_test_db' } do
+  its('user') { should cmp 'value' }
+end
+```
 
 <br>
 
@@ -79,15 +93,21 @@ where
 
 This InSpec audit resource matches any service that is listed in the HBA configuration file. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
-    its('auth_method') { should_not cmp 'peer' }
+```ruby
+its('auth_method') { should_not cmp 'peer' }
+```
 
 or:
 
-    its('auth_method') { should cmp 'peer' }
+```ruby
+its('auth_method') { should cmp 'peer' }
+```
 
 For example:
 
-    describe postgres_hba_conf.where { type == 'type' } do
-      its('auth_method') { should cmp 'value' }
-      its('user') { should cmp 'value' }
-    end
+```ruby
+describe postgres_hba_conf.where { type == 'type' } do
+  its('auth_method') { should cmp 'value' }
+  its('user') { should cmp 'value' }
+end
+```

--- a/docs/resources/postgres_ident_conf.md.erb
+++ b/docs/resources/postgres_ident_conf.md.erb
@@ -13,9 +13,11 @@ Use the `postgres_ident_conf` InSpec audit resource to test the client authentic
 
 An `postgres_ident_conf` InSpec audit resource block declares client authentication data that should be tested:
 
-    describe postgres_ident_conf.where { pg_username == 'filter_value' } do
-      its('attribute') { should eq ['value'] }
-    end
+```ruby
+describe postgres_ident_conf.where { pg_username == 'filter_value' } do
+  its('attribute') { should eq ['value'] }
+end
+```
 
 where
 
@@ -27,7 +29,9 @@ where
 
 ## Properties
 
-    'conf_file', 'map_name', 'params', 'pg_username', 'system_username'
+```ruby
+'conf_file', 'map_name', 'params', 'pg_username', 'system_username'
+```
 
 <br>
 
@@ -37,24 +41,30 @@ where
 
 `address` returns a an array of strings that matches the where condition of the filter table
 
-    describe pg_hba_conf.where { pg_username == 'name' } do
-      its('map_name') { should eq ['value'] }
-    end
+```ruby
+describe pg_hba_conf.where { pg_username == 'name' } do
+  its('map_name') { should eq ['value'] }
+end
+```
 ### pg_username([String])
 
 `pg_username` returns a an array of strings that matches the where condition of the filter table
 
-    describe pg_hba_conf.where { pg_username == 'name' } do
-      its('pg_username') { should eq ['value'] }
-    end
+```ruby
+describe pg_hba_conf.where { pg_username == 'name' } do
+  its('pg_username') { should eq ['value'] }
+end
+```
 
 ### system_username([String])
 
 `system_username` returns a an array of strings that matches the where condition of the filter table
 
-    describe pg_hba_conf.where { pg_username == 'name' } do
-      its('system_username') { should eq ['value'] }
-    end
+```ruby
+describe pg_hba_conf.where { pg_username == 'name' } do
+  its('system_username') { should eq ['value'] }
+end
+```
 
 <br>
 
@@ -62,15 +72,21 @@ where
 
 This InSpec audit resource matches any service that is listed in the pg ident configuration file. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
-    its('pg_username') { should_not eq ['peer'] }
+```ruby
+its('pg_username') { should_not eq ['peer'] }
+```
 
 or:
 
-    its('map_name') { should eq ['value'] }
+```ruby
+its('map_name') { should eq ['value'] }
+```
 
 For example:
 
-    describe postgres_ident_conf.where { pg_username == 'name' } do
-      its('system_username') { should eq ['value'] }
-      its('map_name') { should eq ['value'] }
-    end
+```ruby
+describe postgres_ident_conf.where { pg_username == 'name' } do
+  its('system_username') { should eq ['value'] }
+  its('map_name') { should eq ['value'] }
+end
+```

--- a/docs/resources/postgres_session.md.erb
+++ b/docs/resources/postgres_session.md.erb
@@ -13,22 +13,30 @@ Use the `postgres_session` InSpec audit resource to test SQL commands run agains
 
 A `postgres_session` resource block declares the username and password to use for the session, and then the command to be run:
 
-    # Create a PostgreSQL session:
-    sql = postgres_session('username', 'password', 'host')
+```ruby
+# Create a PostgreSQL session:
+sql = postgres_session('username', 'password', 'host')
+```
 
-    # default values:
-    #   username: 'postgres'
-    #   host: 'localhost'
+```ruby
+# default values:
+#   username: 'postgres'
+#   host: 'localhost'
+```
 
-    # Run an SQL query with an optional database to execute
-    sql.query('sql_query', ['database_name'])`
+```ruby
+# Run an SQL query with an optional database to execute
+sql.query('sql_query', ['database_name'])`
+```
 
 A full example is:
 
-    sql = postgres_session('username', 'password', 'host')
-    describe sql.query('SELECT * FROM pg_shadow WHERE passwd IS NULL;') do
-      its('output') { should eq '' }
-    end
+```ruby
+sql = postgres_session('username', 'password', 'host')
+describe sql.query('SELECT * FROM pg_shadow WHERE passwd IS NULL;') do
+  its('output') { should eq '' }
+end
+```
 
 where `its('output') { should eq '' }` compares the results of the query against the expected result in the test
 
@@ -40,21 +48,27 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test the PostgreSQL shadow password
 
-    sql = postgres_session('my_user', 'password', '192.168.1.2')
+```ruby
+sql = postgres_session('my_user', 'password', '192.168.1.2')
+```
 
-    describe sql.query('SELECT * FROM pg_shadow WHERE passwd IS NULL;', ['testdb']) do
-      its('output') { should eq('') }
-    end
+```ruby
+describe sql.query('SELECT * FROM pg_shadow WHERE passwd IS NULL;', ['testdb']) do
+  its('output') { should eq('') }
+end
+```
 
 ### Test for risky database entries
 
-    describe postgres_session('my_user', 'password').query('SELECT count (*)
-                  FROM pg_language
-                  WHERE lanpltrusted = \'f\'
-                  AND lanname!=\'internal\'
-                  AND lanname!=\'c\';', ['postgres']) do
-      its('output') { should eq '0' }
-    end
+```ruby
+describe postgres_session('my_user', 'password').query('SELECT count (*)
+              FROM pg_language
+              WHERE lanpltrusted = \'f\'
+              AND lanname!=\'internal\'
+              AND lanname!=\'c\';', ['postgres']) do
+  its('output') { should eq '0' }
+end
+```
 
 <br>
 
@@ -66,4 +80,6 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `output` matcher tests the results of the query:
 
-    its('output') { should eq(/^0/) }
+```ruby
+its('output') { should eq(/^0/) }
+```

--- a/docs/resources/powershell.md.erb
+++ b/docs/resources/powershell.md.erb
@@ -13,13 +13,17 @@ Use the `powershell` InSpec audit resource to test a Powershell script on the Wi
 
 A `powershell` resource block declares a Powershell script to be tested, and then compares the output of that command to the matcher in the test:
 
-    script = <<-EOH
-      # a PowerShell script
-    EOH
+```ruby
+script = <<-EOH
+  # a PowerShell script
+EOH
+```
 
-    describe powershell(script) do
-      its('property') { should eq 'output' }
-    end
+```ruby
+describe powershell(script) do
+  its('property') { should eq 'output' }
+end
+```
 
 where
 
@@ -35,47 +39,59 @@ The following examples show how to use this InSpec audit resource.
 
 ### Get all groups of Administrator user
 
-    script = <<-EOH
-      # find user
-      $user = Get-WmiObject Win32_UserAccount -filter "Name = 'Administrator'"
-      # get related groups
-      $groups = $user.GetRelated('Win32_Group') | Select-Object -Property Caption, Domain, Name, LocalAccount, SID, SIDType, Status
-      $groups | ConvertTo-Json
-    EOH
+```ruby
+script = <<-EOH
+  # find user
+  $user = Get-WmiObject Win32_UserAccount -filter "Name = 'Administrator'"
+  # get related groups
+  $groups = $user.GetRelated('Win32_Group') | Select-Object -Property Caption, Domain, Name, LocalAccount, SID, SIDType, Status
+  $groups | ConvertTo-Json
+EOH
+```
 
-    describe powershell(script) do
-      its('stdout') { should_not eq '' }
-    end
+```ruby
+describe powershell(script) do
+  its('stdout') { should_not eq '' }
+end
+```
 
 ### Write-Output 'hello'
 
 The following Powershell script:
 
-    script = <<-EOH
-      Write-Output 'hello'
-    EOH
+```ruby
+script = <<-EOH
+  Write-Output 'hello'
+EOH
+```
 
 can be tested in the following ways.
 
 For a newline:
 
-    describe powershell(script) do
-      its('stdout') { should eq "hello\r\n" }
-      its('stderr') { should eq '' }
-    end
+```ruby
+describe powershell(script) do
+  its('stdout') { should eq "hello\r\n" }
+  its('stderr') { should eq '' }
+end
+```
 
 Removing whitespace `\r\n` from `stdout`:
 
-    describe powershell(script) do
-      its('strip') { should eq "hello" }
-    end
+```ruby
+describe powershell(script) do
+  its('strip') { should eq "hello" }
+end
+```
 
 No newline:
 
-    describe powershell("'hello' | Write-Host -NoNewLine") do
-      its('stdout') { should eq 'hello' }
-      its('stderr') { should eq '' }
-    end
+```ruby
+describe powershell("'hello' | Write-Host -NoNewLine") do
+  its('stdout') { should eq 'hello' }
+  its('stderr') { should eq '' }
+end
+```
 
 <br>
 
@@ -87,16 +103,22 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `exit_status` matcher tests the exit status for the command:
 
-    its('exit_status') { should eq 123 }
+```ruby
+its('exit_status') { should eq 123 }
+```
 
 ### stderr
 
 The `stderr` matcher tests results of the command as returned in standard error (stderr):
 
-    its('stderr') { should eq 'error' }
+```ruby
+its('stderr') { should eq 'error' }
+```
 
 ### stdout
 
 The `stdout` matcher tests results of the command as returned in standard output (stdout):
 
-    its('stdout') { should eq '/^1$/' }
+```ruby
+its('stdout') { should eq '/^1$/' }
+```

--- a/docs/resources/processes.md.erb
+++ b/docs/resources/processes.md.erb
@@ -13,9 +13,11 @@ Use the `processes` InSpec audit resource to test properties for programs that a
 
 A `processes` resource block declares the name of the process to be tested, and then declares one (or more) property/value pairs:
 
-    describe processes('process_name') do
-      its('property_name') { should eq ['property_value'] }
-    end
+```ruby
+describe processes('process_name') do
+  its('property_name') { should eq ['property_value'] }
+end
+```
 
 where
 
@@ -30,36 +32,48 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if the list length for the mysqld process is 1
 
-    describe processes('mysqld') do
-      its('list.length') { should eq 1 }
-    end
+```ruby
+describe processes('mysqld') do
+  its('list.length') { should eq 1 }
+end
+```
 
 ### Test if the process is owned by a specifc user
 
-    describe processes('init') do
-      its('users') { should eq ['root'] }
-    end
+```ruby
+describe processes('init') do
+  its('users') { should eq ['root'] }
+end
+```
 
-    describe processes('winlogon') do
-      its('users') { should cmp "NT AUTHORITY\\SYSTEM" }
-    end
+```ruby
+describe processes('winlogon') do
+  its('users') { should cmp "NT AUTHORITY\\SYSTEM" }
+end
+```
 
 
 ### Test if a high-priority process is running
 
-    describe processes('linux_process') do
-      its('states') { should eq ['R<'] }
-    end
+```ruby
+describe processes('linux_process') do
+  its('states') { should eq ['R<'] }
+end
+```
 
-    describe processes('windows_process') do
-      its('labels') { should cmp "High" }
-    end
+```ruby
+describe processes('windows_process') do
+  its('labels') { should cmp "High" }
+end
+```
 
 ### Test if a process exists on the system
 
-    describe processes('some_process') do
-      it { should exist }
-    end
+```ruby
+describe processes('some_process') do
+  it { should exist }
+end
+```
 
 ### Test for a process using a specific Regexp
 
@@ -67,9 +81,11 @@ If the process name is too common for a string to uniquely find it,
 you may use a regexp. Inclusion of whitespace characters may be
 needed.
 
-    describe processes(Regexp.new("/usr/local/bin/swap -d")) do
-      its('list.length') { should eq 1 }
-    end
+```ruby
+describe processes(Regexp.new("/usr/local/bin/swap -d")) do
+  its('list.length') { should eq 1 }
+end
+```
 
 ### Notes for auditing Windows systems
 
@@ -106,4 +122,6 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `property_name` matcher tests the named property for the specified value:
 
-    its('property_name') { should eq ['property_value'] }
+```ruby
+its('property_name') { should eq ['property_value'] }
+```

--- a/docs/resources/rabbitmq_config.md.erb
+++ b/docs/resources/rabbitmq_config.md.erb
@@ -13,9 +13,11 @@ Use the `rabbitmq_config` InSpec audit resource to test configuration data for t
 
 A `rabbitmq_config` resource block declares the RabbitMQ configuration data to be tested:
 
-    describe rabbitmq_config.params('rabbit', 'ssl_listeners') do
-      it { should cmp 5671 }
-    end
+```ruby
+describe rabbitmq_config.params('rabbit', 'ssl_listeners') do
+  it { should cmp 5671 }
+end
+```
 
 where
 
@@ -30,9 +32,11 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test the list of TCP listeners
 
-    describe rabbitmq_config.params('rabbit', 'tcp_listeners') do
-      it { should eq [5672] }
-    end
+```ruby
+describe rabbitmq_config.params('rabbit', 'tcp_listeners') do
+  it { should eq [5672] }
+end
+```
 
 <br>
 

--- a/docs/resources/registry_key.md.erb
+++ b/docs/resources/registry_key.md.erb
@@ -15,54 +15,68 @@ A `registry_key` resource block declares the item in the Windows registry, the p
 
 Use a registry key name and path:
 
-    describe registry_key('Task Scheduler','HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule') do
-      its('Start') { should eq 2 }
-    end
+```ruby
+describe registry_key('Task Scheduler','HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule') do
+  its('Start') { should eq 2 }
+end
+```
 
 Use only a registry key path:
 
-    describe registry_key('Task Scheduler','HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule') do
-      its('Start') { should eq 2 }
-    end
+```ruby
+describe registry_key('Task Scheduler','HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule') do
+  its('Start') { should eq 2 }
+end
+```
 
 Or use a Ruby Hash:
 
-    describe registry_key({
-      name: 'Task Scheduler',
-      hive: 'HKEY_LOCAL_MACHINE',
-      key: '\SYSTEM\CurrentControlSet\services\Schedule'
-    }) do
-      its('Start') { should eq 2 }
-    end
+```ruby
+describe registry_key({
+  name: 'Task Scheduler',
+  hive: 'HKEY_LOCAL_MACHINE',
+  key: '\SYSTEM\CurrentControlSet\services\Schedule'
+}) do
+  its('Start') { should eq 2 }
+end
+```
 
 
 ### Registry Key Path Separators
 
 A Windows registry key can be used as a string in Ruby code, such as when a registry key is used as the name of a recipe. In Ruby, when a registry key is enclosed in a double-quoted string (`" "`), the same backslash character (`\`) that is used to define the registry key path separator is also used in Ruby to define an escape character. Therefore, the registry key path separators must be escaped when they are enclosed in a double-quoted string. For example, the following registry key:
 
-    HKCU\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Themes
+```ruby
+HKCU\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Themes
+```
 
 may be encloused in a single-quoted string with a single backslash:
 
-    'HKCU\SOFTWARE\path\to\key\Themes'
+```ruby
+'HKCU\SOFTWARE\path\to\key\Themes'
+```
 
 or may be enclosed in a double-quoted string with an extra backslash as an escape character:
 
-    "HKCU\\SOFTWARE\\path\\to\\key\\Themes"
+```ruby
+"HKCU\\SOFTWARE\\path\\to\\key\\Themes"
+```
 
 
 <p class="warning">
 Please make sure that you use backslashes instead of forward slashes. Forward slashes will not work for registry keys.
 </p>
 
-    # The following will not work:
-    # describe registry_key('HKLM/SOFTWARE/Microsoft/NET Framework Setup/NDP/v4/Full/1033') do
-    #   its('Release') { should eq 378675 }
-    # end
-    # You should use:
-    describe registry_key('HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\1033') do
-      its('Release') { should eq 378675 }
-    end
+```ruby
+# The following will not work:
+# describe registry_key('HKLM/SOFTWARE/Microsoft/NET Framework Setup/NDP/v4/Full/1033') do
+#   its('Release') { should eq 378675 }
+# end
+# You should use:
+describe registry_key('HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\1033') do
+  its('Release') { should eq 378675 }
+end
+```
 
 <br>
 
@@ -72,20 +86,24 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test the start time for the Schedule service
 
-    describe registry_key('Task Scheduler','HKEY_LOCAL_MACHINE\...\Schedule') do
-      its('Start') { should eq 2 }
-    end
+```ruby
+describe registry_key('Task Scheduler','HKEY_LOCAL_MACHINE\...\Schedule') do
+  its('Start') { should eq 2 }
+end
+```
 
 where `'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule'` is the full path to the setting.
 
 ### Use a regular expression in responses
 
-    describe registry_key({
-      hive: 'HKEY_LOCAL_MACHINE',
-      key: 'SOFTWARE\Microsoft\Windows NT\CurrentVersion'
-    }) do
-      its('ProductName') { should match /^[a-zA-Z0-9\(\)\s]*2012\s[rR]2[a-zA-Z0-9\(\)\s]*$/ }
-    end
+```ruby
+describe registry_key({
+  hive: 'HKEY_LOCAL_MACHINE',
+  key: 'SOFTWARE\Microsoft\Windows NT\CurrentVersion'
+}) do
+  its('ProductName') { should match /^[a-zA-Z0-9\(\)\s]*2012\s[rR]2[a-zA-Z0-9\(\)\s]*$/ }
+end
+```
 
 <br>
 
@@ -97,62 +115,80 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `children` matcher return all of the child items of a registry key. A regular expression may be used to filter child items:
 
-    describe registry_key('Key Name', '\path\to\key').children(regex)
-      ...
-    end
+```ruby
+describe registry_key('Key Name', '\path\to\key').children(regex)
+  ...
+end
+```
 
 For example, to get all child items for a registry key:
 
-    describe registry_key('Task Scheduler','HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet').children do
-      it { should_not eq [] }
-    end
+```ruby
+describe registry_key('Task Scheduler','HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet').children do
+  it { should_not eq [] }
+end
+```
 
 The following example shows how find a property that may exist against multiple registry keys, and then test that property for every registry key in which that property is located:
 
-    describe registry_key({
-      hive: 'HKEY_USERS'
-    }).children(/^S-1-5-21-[0-9]+-[0-9]+-[0-9]+-[0-9]{3,}\\Software\\Policies\\Microsoft\\Windows\\Installer/).each { |key|
-        describe registry_key(key) do
-          its('AlwaysInstallElevated') { should eq 'value' }
-        end
-      }
+```ruby
+describe registry_key({
+  hive: 'HKEY_USERS'
+}).children(/^S-1-5-21-[0-9]+-[0-9]+-[0-9]+-[0-9]{3,}\\Software\\Policies\\Microsoft\\Windows\\Installer/).each { |key|
+    describe registry_key(key) do
+      its('AlwaysInstallElevated') { should eq 'value' }
+    end
+  }
+```
 
 ### exist
 
 The `exist` matcher tests if the registry key is present:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 ### have_property
 
 The `have_property` matcher tests if a property exists for a registry key:
 
-    it { should have_property 'value' }
+```ruby
+it { should have_property 'value' }
+```
 
 ### have\_property\_value
 
 The `have_property_value` matcher tests if a property value exists for a registry key:
 
-    it { should have_property_value 'value' }
+```ruby
+it { should have_property_value 'value' }
+```
 
 ### have_value
 
 The `have_value` matcher tests if a value exists for a registry key:
 
-    it { should have_value 'value' }
+```ruby
+it { should have_value 'value' }
+```
 
 ### name
 
 The `name` matcher tests the value for the specified registry setting:
 
-    its('name') { should eq 'value' }
+```ruby
+its('name') { should eq 'value' }
+```
 
 
 <p class="warning">
 Any name with a dot will not work as expected: <code>its('explorer.exe') { should eq 'test' }</code>. This issue is tracked in <a href="https://github.com/chef/inspec/issues/1281">https://github.com/chef/inspec/issues/1281</a>
 </p>
 
-    # instead of:
-    # its('explorer.exe') { should eq 'test' }
-    # use the following solution:
-    it { should have_property_value('explorer.exe', :string, 'test') }
+```ruby
+# instead of:
+# its('explorer.exe') { should eq 'test' }
+# use the following solution:
+it { should have_property_value('explorer.exe', :string, 'test') }
+```

--- a/docs/resources/runit_service.md.erb
+++ b/docs/resources/runit_service.md.erb
@@ -13,11 +13,13 @@ Use the `runit_service` InSpec audit resource to test a service using runit.
 
 A `runit_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
-    describe runit_service('service_name') do
-      it { should be_installed }
-      it { should be_enabled }
-      it { should be_running }
-    end
+```ruby
+describe runit_service('service_name') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+```
 
 where
 
@@ -26,11 +28,13 @@ where
 
 The path to the service manager's control may be specified for situations where the path isn't available in the current `PATH`. For example:
 
-    describe runit_service('service_name', '/path/to/control') do
-      it { should be_enabled }
-      it { should be_installed }
-      it { should be_running }
-    end
+```ruby
+describe runit_service('service_name', '/path/to/control') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end
+```
 
 <br>
 
@@ -42,16 +46,22 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_enabled` matcher tests if the named service is enabled:
 
-    it { should be_enabled }
+```ruby
+it { should be_enabled }
+```
 
 ### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### be_running
 
 The `be_running` matcher tests if the named service is running:
 
-    it { should be_running }
+```ruby
+it { should be_running }
+```

--- a/docs/resources/security_policy.md.erb
+++ b/docs/resources/security_policy.md.erb
@@ -13,9 +13,11 @@ Use the `security_policy` InSpec audit resource to test security policies on the
 
 A `security_policy` resource block declares the name of a security policy and the value to be tested:
 
-    describe security_policy do
-      its('policy_name') { should eq 'value' }
-    end
+```ruby
+describe security_policy do
+  its('policy_name') { should eq 'value' }
+end
+```
 
 where
 
@@ -30,9 +32,11 @@ The following examples show how to use this InSpec audit resource.
 
 ### Verify that only the Administrators group has remote access
 
-    describe security_policy do
-      its('SeRemoteInteractiveLogonRight') { should eq '*S-1-5-32-544' }
-    end
+```ruby
+describe security_policy do
+  its('SeRemoteInteractiveLogonRight') { should eq '*S-1-5-32-544' }
+end
+```
 
 <br>
 
@@ -44,4 +48,6 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `policy_name` matcher must be the name of a security policy:
 
-    its('SeNetworkLogonRight') { should eq '*S-1-5-11' }
+```ruby
+its('SeNetworkLogonRight') { should eq '*S-1-5-11' }
+```

--- a/docs/resources/service.md.erb
+++ b/docs/resources/service.md.erb
@@ -15,11 +15,13 @@ Under some circumstances, it may be necessary to specify the service manager by 
 
 A `service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
-    describe service('service_name') do
-      it { should be_installed }
-      it { should be_enabled }
-      it { should be_running }
-    end
+```ruby
+describe service('service_name') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+```
 
 where
 
@@ -34,67 +36,85 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if the postgresql service is both running and enabled
 
-    describe service('postgresql') do
-      it { should be_enabled }
-      it { should be_running }
-    end
+```ruby
+describe service('postgresql') do
+  it { should be_enabled }
+  it { should be_running }
+end
+```
 
 ### Test if the mysql service is both running and enabled
 
-    describe service('mysqld') do
-      it { should be_enabled }
-      it { should be_running }
-    end
+```ruby
+describe service('mysqld') do
+  it { should be_enabled }
+  it { should be_running }
+end
+```
 
 ### Test if ClamAV (an antivirus engine) is installed and running
 
-    describe package('clamav') do
-      it { should be_installed }
-      its('version') { should eq '0.98.7' }
-    end
+```ruby
+describe package('clamav') do
+  it { should be_installed }
+  its('version') { should eq '0.98.7' }
+end
+```
 
-    describe service('clamd') do
-      it { should_not be_enabled }
-      it { should_not be_installed }
-      it { should_not be_running }
-    end
+```ruby
+describe service('clamd') do
+  it { should_not be_enabled }
+  it { should_not be_installed }
+  it { should_not be_running }
+end
+```
 
 ### Test Unix System V run levels
 
 On targets that are using SystemV services, the existing run levels can also be checked:
 
-    describe service('sshd').runlevels do
-      its('keys') { should include(2) }
-    end
+```ruby
+describe service('sshd').runlevels do
+  its('keys') { should include(2) }
+end
+```
 
-    describe service('sshd').runlevels(2,4) do
-      it { should be_enabled }
-    end
+```ruby
+describe service('sshd').runlevels(2,4) do
+  it { should be_enabled }
+end
+```
 
 ### Override the service manager
 
 Under some circumstances, it may be required to override the logic in place to select the right service manager. For example, to check a service managed by Upstart:
 
-    describe upstart_service('service') do
-      it { should_not be_enabled }
-      it { should be_installed }
-      it { should be_running }
-    end
+```ruby
+describe upstart_service('service') do
+  it { should_not be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end
+```
 
 This is also possible with `systemd_service`, `runit_service`, `sysv_service`, `bsd_service`, and `launchd_service`. Provide the control command when it is not to be found at the default location. For example, if the `sv` command for services managed by runit is not in the `PATH`:
 
-    describe runit_service('service', '/opt/chef/embedded/sbin/sv') do
-      it { should be_enabled }
-      it { should be_installed }
-      it { should be_running }
-    end
+```ruby
+describe runit_service('service', '/opt/chef/embedded/sbin/sv') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end
+```
 
 ### Verify that IIS is running
 
-    describe service('W3SVC') do
-      it { should be_installed }
-      it { should be_running }
-    end
+```ruby
+describe service('W3SVC') do
+  it { should be_installed }
+  it { should be_running }
+end
+```
 
 <br>
 
@@ -106,16 +126,22 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_enabled` matcher tests if the named service is enabled:
 
-    it { should be_enabled }
+```ruby
+it { should be_enabled }
+```
 
 ### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### be_running
 
 The `be_running` matcher tests if the named service is running:
 
-    it { should be_running }
+```ruby
+it { should be_running }
+```

--- a/docs/resources/shadow.md.erb
+++ b/docs/resources/shadow.md.erb
@@ -18,7 +18,9 @@ Use the `shadow` InSpec audit resource to test the contents of `/etc/shadow`, wh
 
 These entries are defined as a colon-delimited row in the file, one row per user:
 
-    dannos:Gb7crrO5CDF.:10063:0:99999:7:::
+```ruby
+dannos:Gb7crrO5CDF.:10063:0:99999:7:::
+```
 
 <br>
 
@@ -26,21 +28,27 @@ These entries are defined as a colon-delimited row in the file, one row per user
 
 A `shadow` resource block declares one (or more) users and associated user information to be tested:
 
-    describe shadow do
-      its('users') { should_not include 'forbidden_user' }
-    end
+```ruby
+describe shadow do
+  its('users') { should_not include 'forbidden_user' }
+end
+```
 
 or with a single query:
 
-    describe shadow.users('root') do
-      its('count') { should eq 1 }
-    end
+```ruby
+describe shadow.users('root') do
+  its('count') { should eq 1 }
+end
+```
 
 or with a filter:
 
-    describe shadow.filter(min_days: '0', max_days: '99999') do
-      its('count') { should eq 1 }
-    end
+```ruby
+describe shadow.filter(min_days: '0', max_days: '99999') do
+  its('count') { should eq 1 }
+end
+```
 
 The following properties are available:
 
@@ -64,16 +72,20 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test for a forbidden user
 
-    describe shadow do
-      its('users') { should_not include 'forbidden_user' }
-    end
+```ruby
+describe shadow do
+  its('users') { should_not include 'forbidden_user' }
+end
+```
 
 ### Test that a user appears one time
 
-    describe shadow.users('bin') do
-      its('passwords') { should cmp 'x' }
-      its('count') { should eq 1 }
-    end
+```ruby
+describe shadow.users('bin') do
+  its('passwords') { should cmp 'x' }
+  its('count') { should eq 1 }
+end
+```
 
 <br>
 
@@ -85,43 +97,57 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `count` matcher tests the number of times the named user appears in `/etc/shadow`:
 
-    its('count') { should eq 1 }
+```ruby
+its('count') { should eq 1 }
+```
 
 This matcher is best used in conjunction with filters. For example:
 
-    describe shadow.users('dannos') do
-       its('count') { should eq 1 }
-    end
+```ruby
+describe shadow.users('dannos') do
+   its('count') { should eq 1 }
+end
+```
 
 ### expiry_dates
 
 The `expiry_dates` matcher tests the number of days a user account has been disabled:
 
-    its('expiry_dates') { should eq '' }
+```ruby
+its('expiry_dates') { should eq '' }
+```
 
 ### inactive_days
 
 The `inactive_days` matcher tests the number of days a user must be inactive before the user account is disabled:
 
-    its('inactive_days') { should eq '' }
+```ruby
+its('inactive_days') { should eq '' }
+```
 
 ### last_changes
 
 The `last_changes` matcher tests the last time a password was changed:
 
-    its('last_changes') { should eq '' }
+```ruby
+its('last_changes') { should eq '' }
+```
 
 ### max_days
 
 The `max_days` matcher tests the maximum number of days after which a password must be changed:
 
-    its('max_days') { should eq 90 }
+```ruby
+its('max_days') { should eq 90 }
+```
 
 ### min_days
 
 The `min_days` matcher tests the minimum number of days a password must exist, before it may be changed:
 
-    its('min_days') { should eq 0 }
+```ruby
+its('min_days') { should eq 0 }
+```
 
 ### passwords
 
@@ -129,16 +155,22 @@ The `passwords` matcher returns the encrypted password string from the shadow fi
 
 For example:
 
-    its('passwords') { should cmp '*' }
+```ruby
+its('passwords') { should cmp '*' }
+```
 
 ### users
 
 The `users` matcher tests if the user name exists `/etc/shadow`:
 
-    its('users') { should eq 'root' }
+```ruby
+its('users') { should eq 'root' }
+```
 
 ### warn_days
 
 The `warn_days` matcher tests the number of days a user is warned about an expiring password:
 
-    its('warn_days') { should eq 7 }
+```ruby
+its('warn_days') { should eq 7 }
+```

--- a/docs/resources/ssh_config.md.erb
+++ b/docs/resources/ssh_config.md.erb
@@ -13,9 +13,11 @@ Use the `ssh_config` InSpec audit resource to test OpenSSH client configuration 
 
 An `ssh_config` resource block declares the client OpenSSH configuration data to be tested:
 
-    describe ssh_config('path') do
-      its('name') { should include('foo') }
-    end
+```ruby
+describe ssh_config('path') do
+  its('name') { should include('foo') }
+end
+```
 
 where
 
@@ -31,37 +33,47 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test SSH configuration settings
 
-    describe ssh_config do
-      its('cipher') { should contain '3des' }
-      its('port') { should eq '22' }
-      its('hostname') { should include('example.com') }
-    end
+```ruby
+describe ssh_config do
+  its('cipher') { should contain '3des' }
+  its('port') { should eq '22' }
+  its('hostname') { should include('example.com') }
+end
+```
 
 ### Test which variables from the local environment are sent to the server
 
-    only_if do
-      command('sshd').exist? or command('ssh').exists?
-    end
+```ruby
+only_if do
+  command('sshd').exist? or command('ssh').exists?
+end
+```
 
-    describe ssh_config do
-      its('SendEnv') { should include('GORDON_CLIENT') }
-    end
+```ruby
+describe ssh_config do
+  its('SendEnv') { should include('GORDON_CLIENT') }
+end
+```
 
 ### Test owner and group permissions
 
-    describe ssh_config do
-      its('owner') { should eq 'root' }
-      its('mode') { should cmp '0644' }
-    end
+```ruby
+describe ssh_config do
+  its('owner') { should eq 'root' }
+  its('mode') { should cmp '0644' }
+end
+```
 
 ### Test SSH configuration
 
-    describe ssh_config do
-      its('Host') { should eq '*' }
-      its('Tunnel') { should eq nil }
-      its('SendEnv') { should eq 'LANG LC_*' }
-      its('HashKnownHosts') { should eq 'yes' }
-    end
+```ruby
+describe ssh_config do
+  its('Host') { should eq '*' }
+  its('Tunnel') { should eq nil }
+  its('SendEnv') { should eq 'LANG LC_*' }
+  its('HashKnownHosts') { should eq 'yes' }
+end
+```
 
 <br>
 
@@ -73,8 +85,12 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `name` matcher tests the value of `name` as read from `ssh_config` versus the value declared in the test:
 
-    its('name') { should eq 'foo' }
+```ruby
+its('name') { should eq 'foo' }
+```
 
 or:
 
-    its('name') { should include('bar') }
+```ruby
+its('name') { should include('bar') }
+```

--- a/docs/resources/sshd_config.md.erb
+++ b/docs/resources/sshd_config.md.erb
@@ -13,9 +13,11 @@ Use the `sshd_config` InSpec audit resource to test configuration data for the O
 
 An `sshd_config` resource block declares the client OpenSSH configuration data to be tested:
 
-    describe sshd_config('path') do
-      its('name') { should include('foo') }
-    end
+```ruby
+describe sshd_config('path') do
+  its('name') { should include('foo') }
+end
+```
 
 where
 
@@ -31,40 +33,50 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test which variables may be sent to the server
 
-    describe sshd_config do
-      its('AcceptEnv') { should include('GORDON_SERVER') }
-    end
+```ruby
+describe sshd_config do
+  its('AcceptEnv') { should include('GORDON_SERVER') }
+end
+```
 
 ### Test for IPv6-only addresses
 
-    describe sshd_config do
-      its('AddressFamily') { should cmp 'inet6' }
-    end
+```ruby
+describe sshd_config do
+  its('AddressFamily') { should cmp 'inet6' }
+end
+```
 
 ### Test the Protocol setting
 
-    describe sshd_config do
-      its('Protocol') { should cmp 2 }
-    end
+```ruby
+describe sshd_config do
+  its('Protocol') { should cmp 2 }
+end
+```
 
 ### Test for approved, strong ciphers
 
-    describe sshd_config do
-      its('Ciphers') { should cmp('chacha20-poly1305@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr') }
-    end
+```ruby
+describe sshd_config do
+  its('Ciphers') { should cmp('chacha20-poly1305@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr') }
+end
+```
 
 ### Test SSH protocols
 
-    describe sshd_config do
-      its('Port') { should cmp  22 }
-      its('UsePAM') { should eq 'yes' }
-      its('ListenAddress') { should eq nil }
-      its('HostKey') { should eq [
-          '/etc/ssh/ssh_host_rsa_key',
-          '/etc/ssh/ssh_host_dsa_key',
-          '/etc/ssh/ssh_host_ecdsa_key',
-        ] }
-    end
+```ruby
+describe sshd_config do
+  its('Port') { should cmp  22 }
+  its('UsePAM') { should eq 'yes' }
+  its('ListenAddress') { should eq nil }
+  its('HostKey') { should eq [
+      '/etc/ssh/ssh_host_rsa_key',
+      '/etc/ssh/ssh_host_dsa_key',
+      '/etc/ssh/ssh_host_ecdsa_key',
+    ] }
+end
+```
 
 <br>
 
@@ -76,8 +88,12 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `name` matcher tests the value of `name` as read from `sshd_config` versus the value declared in the test:
 
-    its('name') { should cmp 'foo' }
+```ruby
+its('name') { should cmp 'foo' }
+```
 
 or:
 
-    its('name') {should include('bar') }
+```ruby
+its('name') {should include('bar') }
+```

--- a/docs/resources/ssl.md.erb
+++ b/docs/resources/ssl.md.erb
@@ -13,15 +13,19 @@ Use the `ssl` InSpec audit resource to test SSL settings for the named port.
 
 An `ssl` resource block declares an SSL port, and then other properties of the test like cipher and/or protocol:
 
-    describe ssl(port: #) do
-      it { should be_enabled }
-    end
+```ruby
+describe ssl(port: #) do
+  it { should be_enabled }
+end
+```
 
 or:
 
-    describe ssl(port: #).filter('value') do
-      it { should be_enabled }
-    end
+```ruby
+describe ssl(port: #).filter('value') do
+  it { should be_enabled }
+end
+```
 
 where
 
@@ -38,49 +42,67 @@ The following examples show how to use this InSpec audit resource.
 
 The following shows how to use the `ssl` InSpec audit resource to find all TCP ports on the system, including IPv4 and IPv6. (This is a partial example based on the `ssl_text.rb` file in the `ssl-benchmark` profile on GitHub.)
 
-    ...
+```ruby
+...
+```
 
-    control 'tls1.2' do
-      title 'Run TLS 1.2 whenever SSL is active on a port'
-      impact 0.5
+```ruby
+control 'tls1.2' do
+  title 'Run TLS 1.2 whenever SSL is active on a port'
+  impact 0.5
+```
 
-      sslports.each do |socket|
-        proc_desc = "on node == #{command('hostname').stdout.strip} running #{socket.process.inspect} (#{socket.pid})"
-        describe ssl(port: socket.port).protocols('tls1.2') do
-          it(proc_desc) { should be_enabled }
-          it { should be_enabled }
-        end
-      end
+```ruby
+  sslports.each do |socket|
+    proc_desc = "on node == #{command('hostname').stdout.strip} running #{socket.process.inspect} (#{socket.pid})"
+    describe ssl(port: socket.port).protocols('tls1.2') do
+      it(proc_desc) { should be_enabled }
+      it { should be_enabled }
     end
+  end
+end
+```
 
-    ...
+```ruby
+...
+```
 
-    control 'rc4' do
-      title 'Disable RC4 ciphers from all exposed SSL/TLS ports and versions.'
-      impact 0.5
+```ruby
+control 'rc4' do
+  title 'Disable RC4 ciphers from all exposed SSL/TLS ports and versions.'
+  impact 0.5
+```
 
-      sslports.each do |socket|
-        proc_desc = "on node == #{command('hostname').stdout.strip} running #{socket.process.inspect} (#{socket.pid})"
-        describe ssl(port: socket.port).ciphers(/rc4/i) do
-          it(proc_desc) { should_not be_enabled }
-          it { should_not be_enabled }
-        end
-      end
+```ruby
+  sslports.each do |socket|
+    proc_desc = "on node == #{command('hostname').stdout.strip} running #{socket.process.inspect} (#{socket.pid})"
+    describe ssl(port: socket.port).ciphers(/rc4/i) do
+      it(proc_desc) { should_not be_enabled }
+      it { should_not be_enabled }
     end
+  end
+end
+```
 
 There are two ways to run the `ssl-benchmark` example profile to test SSL via the `ssl` resource.
 
 Clone the profile:
 
-    $ git clone https://github.com/dev-sec/ssl-benchmark
+```ruby
+$ git clone https://github.com/dev-sec/ssl-benchmark
+```
 
 and then run:
 
-    $ inspec exec ssl-benchmark
+```ruby
+$ inspec exec ssl-benchmark
+```
 
 Or execute the profile directly via URL:
 
-    $ inspec exec https://github.com/dev-sec/ssl-benchmark
+```ruby
+$ inspec exec https://github.com/dev-sec/ssl-benchmark
+```
 
 <br>
 
@@ -92,28 +114,38 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_enabled` matcher tests if SSL is enabled:
 
-    it { should be_enabled }
+```ruby
+it { should be_enabled }
+```
 
 ### ciphers
 
 The `ciphers` matcher tests the named cipher:
 
-    its('ciphers') { should_not eq '/rc4/i' }
+```ruby
+its('ciphers') { should_not eq '/rc4/i' }
+```
 
 or:
 
-    describe ssl(port: 443).ciphers(/rc4/i) do
-      it { should_not be_enabled }
-    end
+```ruby
+describe ssl(port: 443).ciphers(/rc4/i) do
+  it { should_not be_enabled }
+end
+```
 
 ### protocols
 
 The `protocols` matcher tests what protocol versions (SSLv3, TLSv1.1, etc) are enabled:
 
-    its('protocols') { should eq 'ssl2' }
+```ruby
+its('protocols') { should eq 'ssl2' }
+```
 
 or:
 
-    describe ssl(port: 443).protocols('ssl2') do
-      it { should_not be_enabled }
-    end
+```ruby
+describe ssl(port: 443).protocols('ssl2') do
+  it { should_not be_enabled }
+end
+```

--- a/docs/resources/sys_info.md.erb
+++ b/docs/resources/sys_info.md.erb
@@ -13,9 +13,11 @@ Use the `sys_info` InSpec audit resource to test for operating system properties
 
 An `sys_info` resource block declares the hostname to be tested:
 
-    describe sys_info do
-      its('hostname') { should eq 'value' }
-    end
+```ruby
+describe sys_info do
+  its('hostname') { should eq 'value' }
+end
+```
 
 <br>
 
@@ -25,9 +27,11 @@ The following examples show how to use this InSpec audit resource.
 
 ### Get system information for example.com
 
-    describe sys_info do
-      its('hostname') { should eq 'example.com' }
-    end
+```ruby
+describe sys_info do
+  its('hostname') { should eq 'example.com' }
+end
+```
 
 <br>
 
@@ -39,4 +43,6 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `hostname` matcher tests the host for which standard output is returned:
 
-    its('hostname') { should eq 'value' }
+```ruby
+its('hostname') { should eq 'value' }
+```

--- a/docs/resources/systemd_service.md.erb
+++ b/docs/resources/systemd_service.md.erb
@@ -13,11 +13,13 @@ Use the `systemd_service` InSpec audit resource to test a service using SystemD.
 
 A `systemd_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
-    describe systemd_service('service_name') do
-      it { should be_installed }
-      it { should be_enabled }
-      it { should be_running }
-    end
+```ruby
+describe systemd_service('service_name') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+```
 
 where
 
@@ -26,11 +28,13 @@ where
 
 The path to the service manager's control may be specified for situations where the path isn't available in the current `PATH`. For example:
 
-    describe systemd_service('service_name', '/path/to/control') do
-      it { should be_enabled }
-      it { should be_installed }
-      it { should be_running }
-    end
+```ruby
+describe systemd_service('service_name', '/path/to/control') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end
+```
 
 <br>
 
@@ -42,16 +46,22 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_enabled` matcher tests if the named service is enabled:
 
-    it { should be_enabled }
+```ruby
+it { should be_enabled }
+```
 
 ### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### be_running
 
 The `be_running` matcher tests if the named service is running:
 
-    it { should be_running }
+```ruby
+it { should be_running }
+```

--- a/docs/resources/sysv_service.md.erb
+++ b/docs/resources/sysv_service.md.erb
@@ -13,11 +13,13 @@ Use the `sysv_service` InSpec audit resource to test a service using SystemV.
 
 A `sysv_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
-    describe sysv_service('service_name') do
-      it { should be_installed }
-      it { should be_enabled }
-      it { should be_running }
-    end
+```ruby
+describe sysv_service('service_name') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+```
 
 where
 
@@ -26,11 +28,13 @@ where
 
 The path to the service manager's control may be specified for situations where the path isn't available in the current `PATH`. For example:
 
-    describe sysv_service('service_name', '/path/to/control') do
-      it { should be_enabled }
-      it { should be_installed }
-      it { should be_running }
-    end
+```ruby
+describe sysv_service('service_name', '/path/to/control') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end
+```
 
 <br>
 
@@ -42,16 +46,22 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_enabled` matcher tests if the named service is enabled:
 
-    it { should be_enabled }
+```ruby
+it { should be_enabled }
+```
 
 ### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### be_running
 
 The `be_running` matcher tests if the named service is running:
 
-    it { should be_running }
+```ruby
+it { should be_running }
+```

--- a/docs/resources/upstart_service.md.erb
+++ b/docs/resources/upstart_service.md.erb
@@ -13,11 +13,13 @@ Use the `upstart_service` InSpec audit resource to test a service using Upstart.
 
 An `upstart_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
 
-    describe upstart_service('service_name') do
-      it { should be_installed }
-      it { should be_enabled }
-      it { should be_running }
-    end
+```ruby
+describe upstart_service('service_name') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+```
 
 where
 
@@ -26,11 +28,13 @@ where
 
 The path to the service manager's control may be specified for situations where the path isn't available in the current `PATH`. For example:
 
-    describe upstart_service('service_name', '/path/to/control') do
-      it { should be_enabled }
-      it { should be_installed }
-      it { should be_running }
-    end
+```ruby
+describe upstart_service('service_name', '/path/to/control') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end
+```
 
 <br>
 
@@ -42,16 +46,22 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_enabled` matcher tests if the named service is enabled:
 
-    it { should be_enabled }
+```ruby
+it { should be_enabled }
+```
 
 ### be_installed
 
 The `be_installed` matcher tests if the named service is installed:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```
 
 ### be_running
 
 The `be_running` matcher tests if the named service is running:
 
-    it { should be_running }
+```ruby
+it { should be_running }
+```

--- a/docs/resources/user.md.erb
+++ b/docs/resources/user.md.erb
@@ -13,18 +13,20 @@ Use the `user` InSpec audit resource to test user profiles for a single, known/e
 
 A `user` resource block declares a user name, and then one (or more) matchers:
 
-    describe user('root') do
-      it { should exist }
-      its('uid') { should eq 1234 }
-      its('gid') { should eq 1234 }
-      its('group') { should eq 'root' }
-      its('groups') { should eq ['root', 'other']}
-      its('home') { should eq '/root' }
-      its('shell') { should eq '/bin/bash' }
-      its('mindays') { should eq 0 }
-      its('maxdays') { should eq 90 }
-      its('warndays') { should eq 8 }
-    end
+```ruby
+describe user('root') do
+  it { should exist }
+  its('uid') { should eq 1234 }
+  its('gid') { should eq 1234 }
+  its('group') { should eq 'root' }
+  its('groups') { should eq ['root', 'other']}
+  its('home') { should eq '/root' }
+  its('shell') { should eq '/bin/bash' }
+  its('mindays') { should eq 0 }
+  its('maxdays') { should eq 90 }
+  its('warndays') { should eq 8 }
+end
+```
 
 where
 
@@ -40,26 +42,32 @@ The following examples show how to use this InSpec audit resource.
 
 ### Verify available users for the MySQL server
 
-    describe user('root') do
-      it { should exist }
-      its('uid') { should eq 0 }
-      its('groups') { should eq ['root'] }
-    end
+```ruby
+describe user('root') do
+  it { should exist }
+  its('uid') { should eq 0 }
+  its('groups') { should eq ['root'] }
+end
 
-    describe user('mysql') do
-     it { should_not exist }
-    end
+describe user('mysql') do
+ it { should_not exist }
+end
+```
 
 ### Test users on multiple platforms
 
 The `nginx` user is typically `www-data`, but on CentOS it's `nginx`. The following example shows how to test for the `nginx` user with a single test, but accounting for all platforms:
 
-    web_user = 'www-data'
-    web_user = 'nginx' if os[:family] == 'centos'
+```ruby
+web_user = 'www-data'
+web_user = 'nginx' if os[:family] == 'centos'
+```
 
-    describe user(web_user) do
-      it { should exist }
-    end
+```ruby
+describe user(web_user) do
+  it { should exist }
+end
+```
 
 <br>
 
@@ -71,13 +79,17 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `exist` matcher tests if the named user exists:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 ### gid
 
 The `gid` matcher tests the group identifier:
 
-    its('gid') { should eq 1234 }
+```ruby
+its('gid') { should eq 1234 }
+```
 
 where `1234` represents the user identifier.
 
@@ -85,7 +97,9 @@ where `1234` represents the user identifier.
 
 The `group` matcher tests the group to which the user belongs:
 
-    its('group') { should eq 'root' }
+```ruby
+its('group') { should eq 'root' }
+```
 
 where `root` represents the group.
 
@@ -93,19 +107,25 @@ where `root` represents the group.
 
 The `groups` matcher tests two (or more) groups to which the user belongs:
 
-    its('groups') { should eq ['root', 'other'] }
+```ruby
+its('groups') { should eq ['root', 'other'] }
+```
 
 ### home
 
 The `home` matcher tests the home directory path for the user:
 
-    its('home') { should eq '/root' }
+```ruby
+its('home') { should eq '/root' }
+```
 
 ### maxdays
 
 The `maxdays` matcher tests the maximum number of days between password changes:
 
-    its('maxdays') { should eq 99 }
+```ruby
+its('maxdays') { should eq 99 }
+```
 
 where `99` represents the maximum number of days.
 
@@ -113,7 +133,9 @@ where `99` represents the maximum number of days.
 
 The `mindays` matcher tests the minimum number of days between password changes:
 
-    its('mindays') { should eq 0 }
+```ruby
+its('mindays') { should eq 0 }
+```
 
 where `0` represents the maximum number of days.
 
@@ -121,13 +143,17 @@ where `0` represents the maximum number of days.
 
 The `shell` matcher tests the path to the default shell for the user:
 
-    its('shell') { should eq '/bin/bash' }
+```ruby
+its('shell') { should eq '/bin/bash' }
+```
 
 ### uid
 
 The `uid` matcher tests the user identifier:
 
-    its('uid') { should eq 1234 }
+```ruby
+its('uid') { should eq 1234 }
+```
 
 where `1234` represents the user identifier.
 
@@ -135,6 +161,8 @@ where `1234` represents the user identifier.
 
 The `warndays` matcher tests the number of days a user is warned before a password must be changed:
 
-    its('warndays') { should eq 5 }
+```ruby
+its('warndays') { should eq 5 }
+```
 
 where `5` represents the number of days a user is warned.

--- a/docs/resources/users.md.erb
+++ b/docs/resources/users.md.erb
@@ -13,11 +13,13 @@ Use the `users` InSpec audit resource to look up all local users available on th
 
 A `users` resource block declares a user name, and then one (or more) matchers:
 
-    describe users.where(uid: 0).entries do
-      it { should eq ['root'] }
-      its('uids') { should eq [1234] }
-      its('gids') { should eq [1234] }
-    end
+```ruby
+describe users.where(uid: 0).entries do
+  it { should eq ['root'] }
+  its('uids') { should eq [1234] }
+  its('gids') { should eq [1234] }
+end
+```
 
 where
 
@@ -26,15 +28,19 @@ where
 
 For example:
 
-    describe users.where { username =~ /.*/ } do
-      it { should exist }
-    end
+```ruby
+describe users.where { username =~ /.*/ } do
+  it { should exist }
+end
+```
 
 or:
 
-    describe users.where { uid =~ /^S-1-5-[0-9-]+-501$/ } do
-      it { should exist }
-    end
+```ruby
+describe users.where { uid =~ /^S-1-5-[0-9-]+-501$/ } do
+  it { should exist }
+end
+```
 
 <br>
 
@@ -44,9 +50,11 @@ The following examples show how to use this InSpec audit resource.
 
 ### Use a regular expression to find users
 
-    describe users.where { uid =~ /S\-1\-5\-21\-\d+\-\d+\-\d+\-500/ } do
-      it { should exist }
-    end
+```ruby
+describe users.where { uid =~ /S\-1\-5\-21\-\d+\-\d+\-\d+\-500/ } do
+  it { should exist }
+end
+```
 
 <br>
 
@@ -58,13 +66,17 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `exist` matcher tests if the named user exists:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 ### gid
 
 The `gid` matcher tests the group identifier:
 
-    its('gid') { should eq 1234 } }
+```ruby
+its('gid') { should eq 1234 } }
+```
 
 where `1234` represents the user identifier.
 
@@ -72,7 +84,9 @@ where `1234` represents the user identifier.
 
 The `group` matcher tests the group to which the user belongs:
 
-    its('group') { should eq 'root' }
+```ruby
+its('group') { should eq 'root' }
+```
 
 where `root` represents the group.
 
@@ -80,19 +94,25 @@ where `root` represents the group.
 
 The `groups` matcher tests two (or more) groups to which the user belongs:
 
-    its('groups') { should eq ['root', 'other']}
+```ruby
+its('groups') { should eq ['root', 'other']}
+```
 
 ### home
 
 The `home` matcher tests the home directory path for the user:
 
-    its('home') { should eq '/root' }
+```ruby
+its('home') { should eq '/root' }
+```
 
 ### maxdays
 
 The `maxdays` matcher tests the maximum number of days between password changes:
 
-    its('maxdays') { should eq 99 }
+```ruby
+its('maxdays') { should eq 99 }
+```
 
 where `99` represents the maximum number of days.
 
@@ -100,7 +120,9 @@ where `99` represents the maximum number of days.
 
 The `mindays` matcher tests the minimum number of days between password changes:
 
-    its('mindays') { should eq 0 }
+```ruby
+its('mindays') { should eq 0 }
+```
 
 where `0` represents the maximum number of days.
 
@@ -108,13 +130,17 @@ where `0` represents the maximum number of days.
 
 The `shell` matcher tests the path to the default shell for the user:
 
-    its('shell') { should eq '/bin/bash' }
+```ruby
+its('shell') { should eq '/bin/bash' }
+```
 
 ### uid
 
 The `uid` matcher tests the user identifier:
 
-    its('uid') { should eq 1234 } }
+```ruby
+its('uid') { should eq 1234 } }
+```
 
 where `1234` represents the user identifier.
 
@@ -122,6 +148,8 @@ where `1234` represents the user identifier.
 
 The `warndays` matcher tests the number of days a user is warned before a password must be changed:
 
-    its('warndays') { should eq 5 }
+```ruby
+its('warndays') { should eq 5 }
+```
 
 where `5` represents the number of days a user is warned.

--- a/docs/resources/vbscript.md.erb
+++ b/docs/resources/vbscript.md.erb
@@ -13,9 +13,11 @@ Use the `vbscript` InSpec audit resource to test a VBScript on the Windows platf
 
 A `vbscript` resource block tests the output of a VBScript on the Windows platform:
 
-    describe vbscript('script contents') do
-      its('stdout') { should eq 'output' }
-    end
+```ruby
+describe vbscript('script contents') do
+  its('stdout') { should eq 'output' }
+end
+```
 
 where
 
@@ -32,21 +34,27 @@ The following examples show how to use this InSpec audit resource.
 
 A VBScript file similar to:
 
-    script = <<-EOH
-      WScript.Echo "hello"
-    EOH
+```ruby
+script = <<-EOH
+  WScript.Echo "hello"
+EOH
+```
 
 may be tested for multiple lines:
 
-    describe vbscript(script) do
-      its('stdout') { should eq "hello\r\n" }
-    end
+```ruby
+describe vbscript(script) do
+  its('stdout') { should eq "hello\r\n" }
+end
+```
 
 and tested for whitespace removal from standard output:
 
-    describe vbscript(script) do
-      its('strip') { should eq "hello" }
-    end
+```ruby
+describe vbscript(script) do
+  its('strip') { should eq "hello" }
+end
+```
 
 <br>
 

--- a/docs/resources/virtualization.md.erb
+++ b/docs/resources/virtualization.md.erb
@@ -13,9 +13,11 @@ Use the `virtualization` InSpec audit resource to test the virtualization platfo
 
 An `virtualization` resource block declares the virtualization platform that should be tested:
 
-    describe virtualization do
-      its('system') { should MATCHER 'value' }
-    end
+```ruby
+describe virtualization do
+  its('system') { should MATCHER 'value' }
+end
+```
 
 where
 
@@ -31,24 +33,30 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test for Docker
 
-    describe virtualization do
-      its('system') { should eq 'docker' }
-    end
+```ruby
+describe virtualization do
+  its('system') { should eq 'docker' }
+end
+```
 
 ### Test for VirtualBox
 
-    describe virtualization do
-      its('system') { should eq 'vbox' }
-      its('role') { should eq 'guest' }
-    end
+```ruby
+describe virtualization do
+  its('system') { should eq 'vbox' }
+  its('role') { should eq 'guest' }
+end
+```
 
 ### Detect the virtualization platform
 
-    if virtualization.system == 'vbox'
-      describe package('name') do
-        it { should be_installed }
-      end
-    end
+```ruby
+if virtualization.system == 'vbox'
+  describe package('name') do
+    it { should be_installed }
+  end
+end
+```
 
 <br>
 

--- a/docs/resources/windows_feature.md.erb
+++ b/docs/resources/windows_feature.md.erb
@@ -13,9 +13,11 @@ Use the `windows_feature` InSpec audit resource to test features on Windows via 
 
 A `windows_feature` resource block declares the name of the Windows feature, tests if that feature is installed, and then returns information about that feature:
 
-    describe windows_feature('feature_name') do
-      it { should be_installed }
-    end
+```ruby
+describe windows_feature('feature_name') do
+  it { should be_installed }
+end
+```
 
 where
 
@@ -30,9 +32,11 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test the DHCP Server feature
 
-    describe windows_feature('DHCP Server') do
-      it{ should be_installed }
-    end
+```ruby
+describe windows_feature('DHCP Server') do
+  it{ should be_installed }
+end
+```
 
 <br>
 
@@ -44,4 +48,6 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_installed` matcher tests if the named Windows feature is installed:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```

--- a/docs/resources/windows_hotfix.md.erb
+++ b/docs/resources/windows_hotfix.md.erb
@@ -13,9 +13,11 @@ Use the `windows_hotfix` InSpec audit resource to test if the hotfix has been in
 
 A `windows_hotfix` resource block declares a hotfix to validate:
 
-    describe windows_hotfix('name') do
-      it { should be_installed }
-    end
+```ruby
+describe windows_hotfix('name') do
+  it { should be_installed }
+end
+```
 
 where
 
@@ -30,15 +32,19 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if KB4012213 is installed
 
-    describe windows_hotfix('KB4012213') do
-      it { should be_installed }
-    end
+```ruby
+describe windows_hotfix('KB4012213') do
+  it { should be_installed }
+end
+```
 
 ### Test that a hotfix is not installed
 
-    describe windows_hotfix('KB9999999') do
-      it { should_not be_installed }
-    end
+```ruby
+describe windows_hotfix('KB9999999') do
+  it { should_not be_installed }
+end
+```
 
 <br>
 
@@ -50,4 +56,6 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_installed` matcher tests if the named hotfix is installed on the system:
 
-    it { should be_installed }
+```ruby
+it { should be_installed }
+```

--- a/docs/resources/windows_task.md.erb
+++ b/docs/resources/windows_task.md.erb
@@ -14,10 +14,12 @@ Microsoft and application vendors use scheduled tasks to perform a variety of sy
 
 A `windows_task` resource block declares the name of the task (as its full path) and tests its configuration:
 
-    describe windows_task('task name uri') do
-      its('parameter') { should eq 'value' }
-      it { should be_enabled }
-    end
+```ruby
+describe windows_task('task name uri') do
+  its('parameter') { should eq 'value' }
+  it { should be_enabled }
+end
+```
 
 where
 

--- a/docs/resources/wmi.md.erb
+++ b/docs/resources/wmi.md.erb
@@ -13,14 +13,16 @@ Use the `wmi` InSpec audit resource to test WMI settings on the Windows platform
 
 A `wmi` resource block tests WMI settings on the Windows platform:
 
-    describe wmi({
-      class: 'class_name'
-      namespace: 'path\\to\\setting'
-      filter: 'filter'
-      query: 'query'
-    }) do
-      its('setting_name') { should eq '' }
-    end
+```ruby
+describe wmi({
+  class: 'class_name'
+  namespace: 'path\\to\\setting'
+  filter: 'filter'
+  query: 'query'
+}) do
+  its('setting_name') { should eq '' }
+end
+```
 
 where
 
@@ -33,21 +35,25 @@ where
 
 For example, both of the following tests will verify if WinRM is present on the target node. The first tests if WinRM belongs to the list of services running under the `win32_service` class:
 
-    describe wmi({class: 'win32_service'}) do
-      its('DisplayName') { should include 'Windows Remote Management (WS-Management)'}
-    end
+```ruby
+describe wmi({class: 'win32_service'}) do
+  its('DisplayName') { should include 'Windows Remote Management (WS-Management)'}
+end
+```
 
 and the second uses a filter in the Ruby Hash to first identify WinRM, and then perform additional tests:
 
-    describe wmi({
-      class: 'win32_service',
-      filter: "name like '%winrm%'"
-    }) do
-      its('Status') { should cmp 'ok' }
-      its('State') { should cmp 'Running' }
-      its('ExitCode') { should cmp 0 }
-      its('DisplayName') { should eq 'Windows Remote Management (WS-Management)'}
-    end
+```ruby
+describe wmi({
+  class: 'win32_service',
+  filter: "name like '%winrm%'"
+}) do
+  its('Status') { should cmp 'ok' }
+  its('State') { should cmp 'Running' }
+  its('ExitCode') { should cmp 0 }
+  its('DisplayName') { should eq 'Windows Remote Management (WS-Management)'}
+end
+```
 
 <br>
 
@@ -57,22 +63,26 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test a password expiration policy
 
-    describe wmi({
-      class: 'RSOP_SecuritySettingNumeric',
-      namespace: 'root\\rsop\\computer',
-      filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
-    }) do
-       its('Setting') { should eq 1 }
-    end
+```ruby
+describe wmi({
+  class: 'RSOP_SecuritySettingNumeric',
+  namespace: 'root\\rsop\\computer',
+  filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
+}) do
+   its('Setting') { should eq 1 }
+end
+```
 
 ### Test if an anonymous user can query the Local Security Authority (LSA)
 
-    describe wmi({
-      namespace: 'root\rsop\computer',
-      query: "SELECT Setting FROM RSOP_SecuritySettingBoolean WHERE KeyName='LSAAnonymousNameLookup' AND Precedence=1"
-    }) do
-      its('Setting') { should eq false }
-    end
+```ruby
+describe wmi({
+  namespace: 'root\rsop\computer',
+  query: "SELECT Setting FROM RSOP_SecuritySettingBoolean WHERE KeyName='LSAAnonymousNameLookup' AND Precedence=1"
+}) do
+  its('Setting') { should eq false }
+end
+```
 
 <br>
 

--- a/docs/resources/x509_certificate.md.erb
+++ b/docs/resources/x509_certificate.md.erb
@@ -19,9 +19,11 @@ certificates.
 
 An `x509_certificate` resource block declares a certificate `key file` to be tested.
 
-    describe x509_certificate('mycertificate.pem') do
-      its('validity_in_days') { should be > 30 }
-    end
+```ruby
+describe x509_certificate('mycertificate.pem') do
+  its('validity_in_days') { should be > 30 }
+end
+```
 
 <br>
 
@@ -31,9 +33,11 @@ An `x509_certificate` resource block declares a certificate `key file` to be tes
 
 `subject` property makes it easier to access individual subject elements.
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      its('subject.CN') { should eq "www.mywebsite.com" }
-    end
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  its('subject.CN') { should eq "www.mywebsite.com" }
+end
+```
 
 ### subject_dn (String)
 
@@ -41,17 +45,21 @@ The `subject_dn` string returns the distinguished name of the subject field. It 
 
 e.g. `/C=US/L=Seattle/O=Chef Software Inc/OU=Chefs/CN=Richard Nixon`
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      its('subject_dn') { should match "CN=www.mywebsite.com" }
-    end
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  its('subject_dn') { should match "CN=www.mywebsite.com" }
+end
+```
 
 ### issuer.XX
 
 `issuer` makes it easier to access individual issuer elements.
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      its('issuer.CN') { should eq "Acme Trust CA" }
-    end
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  its('issuer.CN') { should eq "Acme Trust CA" }
+end
+```
 
 ### issuer_dn (String)
 
@@ -61,35 +69,43 @@ identity of our certificate.
 
 e.g. `/C=US/L=Seattle/CN=Acme Trust CA/emailAddress=support@acmetrust.org`
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      its('issuer_cn') { should match "CN=Acme Trust CA" }
-    end
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  its('issuer_cn') { should match "CN=Acme Trust CA" }
+end
+```
 
 ### public_key (String)
 
 The `public_key` property returns a base64 encoded public key in PEM format.
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      its('public_key') { should match "-----BEGIN PUBLIC KEY-----\nblah blah blah..." }
-    end
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  its('public_key') { should match "-----BEGIN PUBLIC KEY-----\nblah blah blah..." }
+end
+```
 
 ### key_length (Integer)
 
 The `key_length` property calculates the number of bits in the public key.
 More bits increase security, but at the cost of speed and in extreme cases, compatibility.
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      its('key_length') { should be 2048 }
-    end
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  its('key_length') { should be 2048 }
+end
+```
 
 ### signature_algorithm (String)
 
 The `signature_algorithm` property describes which hash function was used by the CA to
 sign the certificate.
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      its('signature_algorithm') { should be 'sha256WithRSAEncryption' }
-    end
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  its('signature_algorithm') { should be 'sha256WithRSAEncryption' }
+end
+```
 
 
 ### validity_in_days (Float)
@@ -97,55 +113,71 @@ sign the certificate.
 The `validity_in_days` property can be used to check that certificates are not in
 danger of expiring soon.
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      its('validity_in_days') { should be > 30 }
-    end
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  its('validity_in_days') { should be > 30 }
+end
+```
 
 ### not_before and not_after (Time)
 
 The `not_before` and `not_after` properties expose the start and end dates of certificate
 validity. They are exposed as ruby Time class so that date arithmetic can be easily performed.
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      its('not_before') { should be <= Time.utc.now }
-      its('not_after')  { should be >= Time.utc.now }
-    end
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  its('not_before') { should be <= Time.utc.now }
+  its('not_after')  { should be >= Time.utc.now }
+end
+```
 
 ### serial (Integer)
 
 The `serial` property exposes the serial number of the certificate. The serial number is set by the CA during the signing process and should be unique within that CA.
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      its('serial') { should eq 9623283588743302433 }
-    end
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  its('serial') { should eq 9623283588743302433 }
+end
+```
 
 ### version (Integer)
 
 The `version` property exposes the certificate version.
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      its('version') { should eq 2 }
-    end
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  its('version') { should eq 2 }
+end
+```
 
 ### extensions (Hash)
 
 The `extensions` hash property is mainly used to determine what the certificate can be used for.
 
-    describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
-      # Check what extension categories we have
-      its('extensions') { should include 'keyUsage' }
-      its('extensions') { should include 'extendedKeyUsage' }
-      its('extensions') { should include 'subjectAltName' }
+```ruby
+describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
+  # Check what extension categories we have
+  its('extensions') { should include 'keyUsage' }
+  its('extensions') { should include 'extendedKeyUsage' }
+  its('extensions') { should include 'subjectAltName' }
+```
 
-      # Check examples of basic 'keyUsage'
-      its('extensions.keyUsage') { should include 'Digital Signature' }
-      its('extensions.keyUsage') { should include 'Non Repudiation' }
-      its('extensions.keyUsage') { should include 'Data Encipherment' }
+```ruby
+  # Check examples of basic 'keyUsage'
+  its('extensions.keyUsage') { should include 'Digital Signature' }
+  its('extensions.keyUsage') { should include 'Non Repudiation' }
+  its('extensions.keyUsage') { should include 'Data Encipherment' }
+```
 
-      # Check examples of newer 'extendedKeyUsage'
-      its('extensions.extendedKeyUsage') { should include 'TLS Web Server Authentication' }
-      its('extensions.extendedKeyUsage') { should include 'Code Signing' }
+```ruby
+  # Check examples of newer 'extendedKeyUsage'
+  its('extensions.extendedKeyUsage') { should include 'TLS Web Server Authentication' }
+  its('extensions.extendedKeyUsage') { should include 'Code Signing' }
+```
 
-      # Check examples of 'subjectAltName'
-      its('extensions.subjectAltName') { should include 'email:support@chef.io' }
-    end
+```ruby
+  # Check examples of 'subjectAltName'
+  its('extensions.subjectAltName') { should include 'email:support@chef.io' }
+end
+```

--- a/docs/resources/xinetd_conf.md.erb
+++ b/docs/resources/xinetd_conf.md.erb
@@ -13,10 +13,12 @@ Use the `xinetd_conf` InSpec audit resource to test services under `/etc/xinet.d
 
 An `xinetd_conf` resource block declares settings found in a `xinetd.conf` file for the named service:
 
-    describe xinetd_conf('service_name') do
-      it { should be_enabled } # or be_disabled
-      its('setting') { should eq 'value' }
-    end
+```ruby
+describe xinetd_conf('service_name') do
+  it { should be_enabled } # or be_disabled
+  its('setting') { should eq 'value' }
+end
+```
 
 where
 
@@ -34,58 +36,72 @@ The following examples show how to use this InSpec audit resource.
 
 The network socket type: `dgram` (a datagram-based service), `raw` (a service that requires direct access to an IP address), `stream` (a stream-based service), or `seqpacket` (a service that requires a sequenced packet).
 
-    describe xinetd_conf.services('service_name') do
-       its('socket_types') { should include 'dgram' }
-    end
+```ruby
+describe xinetd_conf.services('service_name') do
+   its('socket_types') { should include 'dgram' }
+end
+```
 
 ### Test a service type
 
 The type of service: `INTERNAL` (a service provided by xinetd), `RPC` (an RPC-based service), `TCPMUX` (a service that is started on a well-known TPCMUX port), or `UNLISTED` (a service that is not listed in a standard system file location).
 
-    describe xinetd_conf.services('service_name') do
-       its('type') { should include 'RPC' }
-    end
+```ruby
+describe xinetd_conf.services('service_name') do
+   its('type') { should include 'RPC' }
+end
+```
 
 ### Test the telnet service
 
 For example, a `telnet` file under `/etc/xinet.d` contains the following settings:
 
-    service telnet
-    {
-      disable         = yes
-      flags           = REUSE
-      socket_type     = stream
-      wait            = no
-      user            = root
-      server          = /usr/sbin/in.telnetd
-      log_on_failure  += USERID
-    }
+```ruby
+service telnet
+{
+  disable         = yes
+  flags           = REUSE
+  socket_type     = stream
+  wait            = no
+  user            = root
+  server          = /usr/sbin/in.telnetd
+  log_on_failure  += USERID
+}
+```
 
 Some examples of tests that can be run against that file include:
 
-    describe xinetd_conf.services('telnet') do
-      it { should be_disabled }
-    end
+```ruby
+describe xinetd_conf.services('telnet') do
+  it { should be_disabled }
+end
+```
 
 and
 
-    describe xinetd_conf.services('telnet') do
-      its('socket_type') { should include 'stream' }
-    end
+```ruby
+describe xinetd_conf.services('telnet') do
+  its('socket_type') { should include 'stream' }
+end
+```
 
 and
 
-    describe xinetd_conf.services('telnet') do
-      its('wait') { should eq 'no' }
-    end
+```ruby
+describe xinetd_conf.services('telnet') do
+  its('wait') { should eq 'no' }
+end
+```
 
 All three settings can be tested in the same block as well:
 
-    describe xinetd_conf.services('telnet') do
-      it { should be_disabled }
-      its('socket_type') { should include 'stream' }
-      its('wait') { should eq 'no' }
-    end
+```ruby
+describe xinetd_conf.services('telnet') do
+  it { should be_disabled }
+  its('socket_type') { should include 'stream' }
+  its('wait') { should eq 'no' }
+end
+```
 
 <br>
 
@@ -97,47 +113,65 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_enabled` matcher tests if a service listed under `/etc/xinet.d` is enabled:
 
-    it { should be_enabled }
+```ruby
+it { should be_enabled }
+```
 
 ### ids
 
 The `ids` matcher tests if the named service is located under `/etc/xinet.d`:
 
-    its('ids') { should include 'service_name' }
+```ruby
+its('ids') { should include 'service_name' }
+```
 
 For example:
 
-    its('ids') { should include 'chargen-stream chargen-dgram'}
+```ruby
+its('ids') { should include 'chargen-stream chargen-dgram'}
+```
 
 ### services
 
 The `services` matcher tests if the named service is listed under `/etc/xinet.d`:
 
-    its('services') { should include 'service_name' }
+```ruby
+its('services') { should include 'service_name' }
+```
 
 ### socket_types
 
 The `socket_types` matcher tests if a service listed under `/etc/xinet.d` is configured to use the named socket type:
 
-    its('socket_types') { should eq 'socket' }
+```ruby
+its('socket_types') { should eq 'socket' }
+```
 
 where `socket` is one of `dgram`, `raw`, or `stream`. For a UDP-based service:
 
-    its('socket_types') { should eq 'dgram' }
+```ruby
+its('socket_types') { should eq 'dgram' }
+```
 
 For a raw socket (such as a service using a non-standard protocol or a service that requires direct access to IP):
 
-    its('socket_types') { should eq 'raw' }
+```ruby
+its('socket_types') { should eq 'raw' }
+```
 
 For a TCP-based service:
 
-    its('socket_types') { should eq 'stream' }
+```ruby
+its('socket_types') { should eq 'stream' }
+```
 
 ### types
 
 The `types` matcher tests the service type:
 
-    its('type') { should eq 'TYPE' }
+```ruby
+its('type') { should eq 'TYPE' }
+```
 
 where `'TYPE'` is `INTERNAL` (for a service provided by xinetd), `RPC` (for a service based on remote procedure call), or `UNLISTED` (for services not under `/etc/services` or `/etc/rpc`).
 
@@ -147,10 +181,14 @@ The `wait` matcher tests how a service handles incoming connections.
 
 For UDP (`dgram`) socket types the `wait` matcher should test for `yes`:
 
-    its('socket_types') { should eq 'dgram' }
-    its('wait') { should eq 'yes' }
+```ruby
+its('socket_types') { should eq 'dgram' }
+its('wait') { should eq 'yes' }
+```
 
 For TCP (`stream`) socket types the `wait` matcher should test for `no`:
 
-    its('socket_types') { should eq 'stream' }
-    its('wait') { should eq 'no' }
+```ruby
+its('socket_types') { should eq 'stream' }
+its('wait') { should eq 'no' }
+```

--- a/docs/resources/xml.md.erb
+++ b/docs/resources/xml.md.erb
@@ -13,36 +13,42 @@ Use the `xml` InSpec audit resource to test data in an XML file.
 
 An `xml` resource block declares the data to be tested. Assume the following XML file:
 
-    <root>
-      <name>hello</name>
-      <meta>
-        <creator>John Doe</creator>
-      </meta>
-      <array>
-        <element>one</element>
-        <element>two</element>
-      </array>
-      <array>
-        <element value="one"></element>
-        <element value="two"></element>
-      </array>
-    </root>
+```ruby
+<root>
+  <name>hello</name>
+  <meta>
+    <creator>John Doe</creator>
+  </meta>
+  <array>
+    <element>one</element>
+    <element>two</element>
+  </array>
+  <array>
+    <element value="one"></element>
+    <element value="two"></element>
+  </array>
+</root>
+```
 
 This file can be queried for elements using:
 
-    describe xml('/path/to/name.xml') do
-      its('root/name') { should eq ['hello'] }
-      its('root/meta/creator') { should eq ['John Doe'] }
-      its('root/array[2]/element') { should eq ['two'] }
-    end
+```ruby
+describe xml('/path/to/name.xml') do
+  its('root/name') { should eq ['hello'] }
+  its('root/meta/creator') { should eq ['John Doe'] }
+  its('root/array[2]/element') { should eq ['two'] }
+end
+```
 
 This file can be queried for attributes using:
 
-    describe xml('/path/to/name.xml') do
-      its('root/array[2]/element/@value') { should eq ['one', 'two'] }
-      its('root/array[2]/element/attribute::value') { should eq ['one', 'two'] }
-      its('root/array[2]/element[2]/attribute::value') { should eq ['two'] }
-    end
+```ruby
+describe xml('/path/to/name.xml') do
+  its('root/array[2]/element/@value') { should eq ['one', 'two'] }
+  its('root/array[2]/element/attribute::value') { should eq ['one', 'two'] }
+  its('root/array[2]/element[2]/attribute::value') { should eq ['two'] }
+end
+```
 
 where
 
@@ -53,7 +59,9 @@ In the above example, you see the use of `@` and `attribute::` which are both me
 
 In the event the path contains an element which contains periods, the alternate syntax can be used:
 
-    its(['root/name.with.a.period']) { should cmp 'so_many_dots' }
+```ruby
+its(['root/name.with.a.period']) { should cmp 'so_many_dots' }
+```
 
 <br>
 
@@ -63,14 +71,18 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test an AppPool's presence in an applicationHost.config file or the default site under applicationHost.sites
 
-    describe xml('applicationHost.config') do
-      # using the alternate syntax as described above because of the . in the key name
-      its(['configuration/system.applicationHost/applicationPools/add@name']) { should contain('my_pool') }
-    end
+```ruby
+describe xml('applicationHost.config') do
+  # using the alternate syntax as described above because of the . in the key name
+  its(['configuration/system.applicationHost/applicationPools/add@name']) { should contain('my_pool') }
+end
+```
 
-    describe xml('applicationHost.sites') do
-      its('site[@name="Default Web Site"]/application/virtualDirectory/@path') { should eq ['/'] }
-    end
+```ruby
+describe xml('applicationHost.sites') do
+  its('site[@name="Default Web Site"]/application/virtualDirectory/@path') { should eq ['/'] }
+end
+```
 
 <br>
 
@@ -82,4 +94,6 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `name` matcher tests the value of `name` as read from a JSON file versus the value declared in the test:
 
-    its('name') { should eq 'foo' }
+```ruby
+its('name') { should eq 'foo' }
+```

--- a/docs/resources/yaml.md.erb
+++ b/docs/resources/yaml.md.erb
@@ -13,17 +13,21 @@ Use the `yaml` InSpec audit resource to test configuration data in a Yaml file.
 
 A `yaml` resource block declares the configuration data to be tested. Assume the following Yaml file:
 
-    name: foo
-    array:
-      - zero
-      - one
+```ruby
+name: foo
+array:
+  - zero
+  - one
+```
 
 This file can be queried using:
 
-    describe yaml('filename.yml') do
-      its('name') { should eq 'foo' }
-      its(['array', 1]) { should eq 'one' }
-    end
+```ruby
+describe yaml('filename.yml') do
+  its('name') { should eq 'foo' }
+  its(['array', 1]) { should eq 'one' }
+end
+```
 
 where
 
@@ -32,17 +36,23 @@ where
 
 Like the `json` resource, the `yaml` resource can read a file, run a command, or accept content inline:
 
-    describe yaml('config.yaml') do
-      its(['driver', 'name']) { should eq 'vagrant' }
-    end
+```ruby
+describe yaml('config.yaml') do
+  its(['driver', 'name']) { should eq 'vagrant' }
+end
+```
 
-    describe yaml({ command: 'retrieve_data.py --yaml' }) do
-      its('state') { should eq 'open' }
-    end
+```ruby
+describe yaml({ command: 'retrieve_data.py --yaml' }) do
+  its('state') { should eq 'open' }
+end
+```
 
-    describe yaml({ content: \"key1: value1\nkey2: value2\" }) do
-      its('key2') { should cmp 'value2' }
-    end
+```ruby
+describe yaml({ content: \"key1: value1\nkey2: value2\" }) do
+  its('key2') { should cmp 'value2' }
+end
+```
 
 <br>
 
@@ -52,9 +62,11 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test a kitchen.yml file driver
 
-    describe yaml('.kitchen.yaml') do
-      its('driver.name') { should eq('vagrant') }
-    end
+```ruby
+describe yaml('.kitchen.yaml') do
+  its('driver.name') { should eq('vagrant') }
+end
+```
 
 <br>
 
@@ -66,4 +78,6 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `name` matcher tests the value of `name` as read from a Yaml file versus the value declared in the test:
 
-    its('name') { should eq 'foo' }
+```ruby
+its('name') { should eq 'foo' }
+```

--- a/docs/resources/yum.md.erb
+++ b/docs/resources/yum.md.erb
@@ -13,10 +13,12 @@ Use the `yum` InSpec audit resource to test packages in the Yum repository.
 
 A `yum` resource block declares a package repo, tests if the package repository is present, and if it that package repository is a valid package source (i.e. "is enabled"):
 
-    describe yum.repo('name') do
-      it { should exist }
-      it { should be_enabled }
-    end
+```ruby
+describe yum.repo('name') do
+  it { should exist }
+  it { should be_enabled }
+end
+```
 
 where
 
@@ -30,32 +32,40 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test if the yum repo exists
 
-    describe yum do
-      its('repos') { should exist }
-    end
+```ruby
+describe yum do
+  its('repos') { should exist }
+end
+```
 
 ### Test if the 'base/7/x86_64' repo exists and is enabled
 
-    describe yum do
-      its('repos') { should include 'base/7/x86_64' }
-      its('epel') { should exist }
-      its('epel') { should be_enabled }
-    end
+```ruby
+describe yum do
+  its('repos') { should include 'base/7/x86_64' }
+  its('epel') { should exist }
+  its('epel') { should be_enabled }
+end
+```
 
 ### Test if a specific yum repo exists
 
-    describe yum.repo('epel') do
-      it { should exist }
-      it { should be_enabled }
-    end
+```ruby
+describe yum.repo('epel') do
+  it { should exist }
+  it { should be_enabled }
+end
+```
 
 ### Test a particular repository configuration, such as its Base URL
 
-    describe yum.repo('mycompany-artifacts') do
-      it { should exist }
-      it { should be_enabled }
-      its('baseurl') { should include 'mycompany.biz' }
-    end
+```ruby
+describe yum.repo('mycompany-artifacts') do
+  it { should exist }
+  it { should be_enabled }
+  its('baseurl') { should include 'mycompany.biz' }
+end
+```
 
 <br>
 
@@ -67,32 +77,42 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `be_enabled` matcher tests if the package repository is a valid package source:
 
-    it { should be_enabled }
+```ruby
+it { should be_enabled }
+```
 
 ### exist
 
 The `exist` matcher tests if the package repository exists:
 
-    it { should exist }
+```ruby
+it { should exist }
+```
 
 ### repo('name')
 
 The `repo('name')` matcher names a specific package repository:
 
-    describe yum.repo('epel') do
-      ...
-    end
+```ruby
+describe yum.repo('epel') do
+  ...
+end
+```
 
 ### repos
 
 The `repos` matcher tests if a named repo, using either a full identifier (`'updates/7/x86_64'`) or a short identifier (`'updates'`), is included in the Yum repo:
 
-    its('repos') { should include 'some_repo' }
+```ruby
+its('repos') { should include 'some_repo' }
+```
 
 ### shortname
 
 The `shortname` matcher names a specific package repository's group identifier. For example, if a repository's group name is "Directory Server", the corresponding group idenfier is typically "directory-server":
 
-    describe yum.repo('Directory Server') do
-      its('shortname') { should eq 'directory-server' }
-    end
+```ruby
+describe yum.repo('Directory Server') do
+  its('shortname') { should eq 'directory-server' }
+end
+```

--- a/docs/resources/zfs_dataset.md.erb
+++ b/docs/resources/zfs_dataset.md.erb
@@ -13,9 +13,11 @@ Use the `zfs_dataset` InSpec audit resource to test the ZFS datasets on FreeBSD 
 
 A `zfs_dataset` resource block declares the ZFS dataset properties that should be tested:
 
-    describe zfs_dataset('dataset') do
-      it { should MATCHER 'value' }
-    end
+```ruby
+describe zfs_dataset('dataset') do
+  it { should MATCHER 'value' }
+end
+```
 
 where
 
@@ -31,14 +33,16 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test a dataset of 'tank/tmp'
 
-    describe zfs_dataset('tank/tmp') do
-      it { should be_mounted }
-      its('atime') { should eq  'on' }
-      its('compression') { should eq  'lz4' }
-      its('exec') { should eq  'off' }
-      its('readonly') { should eq  'off' }
-      its('setuid') { should eq  'off' }
-    end
+```ruby
+describe zfs_dataset('tank/tmp') do
+  it { should be_mounted }
+  its('atime') { should eq  'on' }
+  its('compression') { should eq  'lz4' }
+  its('exec') { should eq  'off' }
+  its('readonly') { should eq  'off' }
+  its('setuid') { should eq  'off' }
+end
+```
 
 <br>
 
@@ -50,4 +54,6 @@ This InSpec audit resource has the matchers listed below, in addition to dynamic
 
 The `be_mounted` matcher tests if the dataset is accessible from the file system:
 
-    it { should be_mounted }
+```ruby
+it { should be_mounted }
+```

--- a/docs/resources/zfs_pool.md.erb
+++ b/docs/resources/zfs_pool.md.erb
@@ -13,9 +13,11 @@ Use the `zfs_pool` InSpec audit resource to test the ZFS pools on FreeBSD system
 
 A `zfs_pool` resource block declares the ZFS pool properties that should be tested:
 
-    describe zfs_pool('pool') do
-      it { should MATCHER 'value' }
-    end
+```ruby
+describe zfs_pool('pool') do
+  it { should MATCHER 'value' }
+end
+```
 
 where
 
@@ -31,14 +33,16 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test a pool of 'tank'
 
-    describe zfs_pool('tank') do
-      its('autoexpand') { should eq  'off' }
-      its('failmode') { should eq  'continue' }
-      its('feature@lz4_compress') { should eq  'active' }
-      its('health') { should eq  'ONLINE' }
-      its('listsnapshots') { should eq  'off' }
-      its('readonly') { should eq  'off' }
-    end
+```ruby
+describe zfs_pool('tank') do
+  its('autoexpand') { should eq  'off' }
+  its('failmode') { should eq  'continue' }
+  its('feature@lz4_compress') { should eq  'active' }
+  its('health') { should eq  'ONLINE' }
+  its('listsnapshots') { should eq  'off' }
+  its('readonly') { should eq  'off' }
+end
+```
 
 <br>
 

--- a/docs/ruby_usage.md
+++ b/docs/ruby_usage.md
@@ -106,7 +106,7 @@ commented out the `require 'pry'; binding.pry;` line. If you remove the
 give you a `pry` shell. Use that to troubleshoot, print variables, see
 methods available, etc. For the above example:
 
-```ruby
+```shell
 [1] pry> perl_out.exit_status
 => 0
 [2] pry> perl_out.stderr
@@ -127,7 +127,7 @@ You can use `pry` inside both the controls DSL and resources. Similarly,
 for dev and test, you can use `inspec shell` which is based on `pry`,
 for example:
 
-```ruby
+```shell
 $ inspec shell
 Welcome to the interactive InSpec Shell
 To find out how to use it, type: help
@@ -159,7 +159,7 @@ However, the `command` resource has a `.stdout` method that will allow you to ma
 Using the above example, you could check the writes on several subdirectories.
 
 ### Example 1:
-```ruby
+```shell
 $ inspec shell
 Welcome to the interactive InSpec Shell
 To find out how to use it, type: help
@@ -180,7 +180,7 @@ Test Summary: 1 successful, 0 failures, 0 skipped
 ```
 
 ### Example 2:
-```ruby
+```shell
 $ inspec shell
 Welcome to the interactive InSpec Shell
 To find out how to use it, type: help

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -19,7 +19,7 @@ etc.) or from a chef prepared shell in ChefDK, you can directly launch
 InSpec shell against your local machine using the following. See
 <https://docs.chef.io/install_dk.html#set-system-ruby> for details.
 
-```bash
+```shell
 $ inspec shell
 $ inspec help shell # This will describe inspec shell usage
 ```
@@ -33,7 +33,7 @@ and the `--sudo*` commands for requesting a privilege escalation after
 logging in. For a WinRM connection, use `--path` to change the login
 path, `--ssl` to use SSL for transport layer encryption.
 
-```bash
+```shell
 $ inspec shell -t ssh://root@192.168.64.2:11022  # Login to remote machine using ssh as root.
 $ inspec shell -t ssh://user@hostname:1234 -i /path/to/user_key  # Login to hostname on port 1234 as user using given ssh key.
 $ inspec shell -t winrm://UserName:Password@windowsmachine:1234  # Login to windowsmachine over WinRM as UserName.
@@ -52,13 +52,13 @@ them as a dependency.
 To use the `gordon_config` resource that is provided in the `examples/profile`
 in the InSpec repo you can run the following:
 
-```bash
-inspec shell --depends examples/profile
+```shell
+$ inspec shell --depends examples/profile
 ```
 
 Once inside the shell your resource will be available:
 
-```ruby
+```shell
 inspec> gordon_config
 ```
 
@@ -70,7 +70,7 @@ them. Source high-lighting, automatic indentation and command history
 (using the up and down arrow keys) are available to make your experience
 more delightful. You can exit the shell using `exit`.
 
-```bash
+```shell
 $ inspec shell
 Welcome to the interactive InSpec Shell
 To find out how to use it, type: help
@@ -92,7 +92,7 @@ You may also access the resource contents or other matchers that they
 define. Run `help <resource>` to get more help on using a particular
 resource or see the InSpec resources documentation online.
 
-```bash
+```shell
 $ inspec shell
 Welcome to the interactive InSpec Shell
 To find out how to use it, type: help
@@ -108,7 +108,7 @@ inspec> exit
 
 InSpec tests are immediately executed.
 
-```bash
+```shell
 inspec> describe file('/Users')     # Empty test.
 Summary: 0 successful, 0 failures, 0 skipped
 inspec> describe file('/Users') do  # Test with one check.
@@ -123,7 +123,7 @@ All tests in a control are immediately executed as well. If a control is
 redefined in the shell, the old control's tests are destroyed and
 replaced with the redefinition and the control is re-run.
 
-```bash
+```shell
 inspec> control 'my_control' do
 inspec>   describe os_env('HOME') do
 inspec>     its('content') { should eq '/Users/ksubramanian' }
@@ -136,7 +136,7 @@ inspec> end
 
 Syntax errors are illegal tests are also detected and reported.
 
-```bash
+```shell
 inspec> control 'foo' do
 inspec>   thisisnonsense
 inspec> end
@@ -155,9 +155,9 @@ inspec> end
 ## Running a single InSpec command
 
 If you wish to run a single InSpec command and fetch its results, you
-may use the `-c` flag. This is similar to using `bash -c`.
+may use the `-c` flag. This is similar to using `shell -c`.
 
-```bash
+```shell
 $ inspec shell -c 'describe file("/Users/ksubramanian") do it { should exist } end'}
 Target:  local://
 
@@ -166,7 +166,7 @@ Target:  local://
 Summary: 1 successful, 0 failures, 0 skipped
 ```
 
-```bash
+```shell
 $ inspec shell --format json -c 'describe file("/Users/ksubramanian") do it { should exist } end'
 {"version":"0.30.0","profiles":{"":{"supports":[],"controls":{"(generated from in_memory.rb:1 5aab65c33fb1f133d9244017958eef64)":{"title":null,"desc":null,"impact":0.5,"refs":[],"tags":{},"code":"          rule = rule_class.new(id, profile_id, {}) do\n            res = describe(*args, &block)\n          end\n","source_location":{"ref":"/Users/ksubramanian/repo/chef/inspec/lib/inspec/profile_context.rb","line":184},"results":[{"status":"passed","code_desc":"File /Users/ksubramanian should exist","run_time":0.000747,"start_time":"2016-08-16 11:41:40 -0400"}]}},"groups":{"in_memory.rb":{"title":null,"controls":["(generated from in_memory.rb:1 5aab65c33fb1f133d9244017958eef64)"]}},"attributes":[]}},"other_checks":[],"summary":{"duration":0.001078,"example_count":1,"failure_count":0,"skip_count":0}}}
 ```

--- a/www/source/stylesheets/_code_blocks.scss
+++ b/www/source/stylesheets/_code_blocks.scss
@@ -1,0 +1,235 @@
+$solarized: 'light';
+
+$solar-base03:        #002b36; //darkest blue
+$solar-base02:        #073642; //dark blue
+$solar-base01:        #586e75; //darkest gray
+$solar-base00:        #657b83; //dark gray
+$solar-base0:         #839496; //medium gray
+$solar-base1:         #93a1a1; //medium light gray
+$solar-base2:         #f2f2f2; //very light gray
+$solar-base3:         #ffffff; //white
+$solar-yellow:        #b58900;
+$solar-orange:        #cb4b16;
+$solar-red:           #dc322f;
+$solar-magenta:       #d33682;
+$solar-violet:        #6c71c4;
+$solar-blue:          #268bd2;
+$solar-cyan:          #2aa198;
+$solar-green:         #859900;
+
+$pre-marker:              rgba(#00baff, .5) !default;
+$pre-marker-border:       rgba($pre-marker, .13) !default;
+$pre-marker-border-left:  $pre-marker;
+
+$code-bg:                 rgba(#ddd, .7);
+$code-border:             rgba(#000, .1);
+
+
+$pre-line-padding:  .8em !default;
+$pre-font-family:   "Source Code Pro", Inconsolata-dz, Inconsolata, Menlo, Monaco, Consolas, "Liberation Mono", Courier, monospace !default;
+$code-font-family:  $pre-font-family;
+
+%octopress-diff-bg {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  left: 0; right: 0; top: 0; bottom: 0;
+}
+
+@mixin octopress-diff-bg($bg) {
+  &:after {
+    background: $bg;
+    @extend %octopress-diff-bg;
+  }
+}
+
+@mixin solarized-theme($s: dark) {
+  // Core colors
+  $base03:  if($s == light, $solar-base3, $solar-base03);
+  $base02:  if($s == light, $solar-base2, $solar-base02);
+  $base01:  if($s == light, $solar-base1, $solar-base01);
+  $base00:  if($s == light, $solar-base0, $solar-base00);
+  $base0:   if($s == light, $solar-base00, $solar-base0);
+  $base1:   if($s == light, $solar-base01, $solar-base1);
+  $base2:   if($s == light, $solar-base02, $solar-base2);
+  $base3:   if($s == light, $solar-base03, $solar-base3);
+
+  $pre-marker-bg: if($s == light, rgba($pre-marker, .05), rgba($pre-marker, .13));
+
+  $pre-bg: $base03;
+  $pre-color: $base1;
+  $pre-border: darken($base02, 5);
+  $code-highlight-border: $pre-border;
+
+  .code-highlight-pre {
+    background: darken($base03, 1);
+  }
+
+  .code-highlight-row.numbered:before {
+    color: $base01;
+    @if $solarized == light {
+      background: lighten($base03, 1);
+      border-right: 1px solid darken($base02, 2);
+      text-shadow: lighten($base02, 2) 0 -1px;
+    } @else {
+      background: $base02;
+      border-right: 1px solid darken($base03, 2);
+      box-shadow: lighten($base02, 2) -1px 0 inset;
+      text-shadow: darken($base02, 10) 0 -1px;
+    }
+  }
+
+  .marked-line {
+    .code-highlight-line:before {
+      background: $pre-marker-bg;
+    }
+
+    &.numbered:before {
+      background: $pre-marker-bg;
+      border-right-color: darken($pre-marker-bg, 20);
+    }
+  }
+
+  .highlight code {
+    background: none;
+    color: $color_paragraph;
+  }
+
+  .highlight pre,
+  pre:not(.code-highlight-pre),
+  .code-highlight {
+    border: 1px solid $code-highlight-border;
+    background: $pre-bg;
+    color: $base1;
+  }
+
+  pre {
+    span { color: $base1; }
+
+    .c      { color: $base01; font-style: italic; }                      /* Comment */
+    .cm     { color: $base01; font-style: italic; }                      /* Comment.Multiline */
+    .cp     { color: $base01; font-style: italic;  }                     /* Comment.Preproc */
+    .c1     { color: $base01; font-style: italic; }                      /* Comment.Single */
+    .cs     {                                                            /* Comment.Special */
+              color: $base01;
+              font-weight: bold;
+              font-style: italic; }
+    .err    { color: $solar-red; background: none; }                     /* Error */
+    .k      { color: $solar-orange; }                                    /* Keyword */
+    .o      { color: $base1; font-weight: bold; }                        /* Operator */
+    .p      { color: $base1; }                                           /* Operator */
+    .ow     { color: $solar-cyan; font-weight: bold; }                   /* Operator.Word */
+    .gd     {
+              color: $base1;                                             /* Generic.Deleted */
+              @include octopress-diff-bg(mix($solar-red, $base03, 25%));
+            }
+    .gd .x  {                                                            /* Generic.Deleted.Specific */
+              color: $base1;
+              @include octopress-diff-bg(mix($solar-red, $base03, 35%));
+            }
+    .ge     {                                                            /* Generic.Emph */
+              color: $base1;
+              font-style: italic; }
+    //.gr     { color: #aa0000 }                                         /* Generic.Error */
+    .gh     { color: $base01; }                                          /* Generic.Heading */
+    .gi     {                                                            /* Generic.Inserted */
+              color: $base1;
+              @include octopress-diff-bg(mix($solar-green, $base03, 20%));
+            }
+    .gi .x  {                                                            /* Generic.Inserted.Specific */
+              color: $base1;
+              @include octopress-diff-bg(mix($solar-green, $base03, 40%));
+            }
+    .go     { color: $base0; }                                           /* Generic.Output */
+    .gp     { color: $solar-cyan; }                                      /* Generic.Prompt */
+    .gs     { color: $base1; font-weight: bold; }                        /* Generic.Strong */
+    .gu     { color: $solar-violet; }                                    /* Generic.Subheading */
+    .gt     { color: $solar-red; }                                       /* Generic.Traceback */
+    .kc     { color: $solar-green; font-weight: bold; }                  /* Keyword.Constant */
+    .kd     { color: $solar-blue; }                                      /* Keyword.Declaration */
+    .kp     { color: $solar-orange; font-weight: bold; }                 /* Keyword.Pseudo */
+    .kr     { color: $solar-magenta; font-weight: bold; }                /* Keyword.Reserved */
+    .kt     { color: $solar-cyan; }                                      /* Keyword.Type */
+    .n      { color: $solar-blue; }
+    .na     { color: $solar-blue; }                                      /* Name.Attribute */
+    .nb     { color: $solar-green; }                                     /* Name.Builtin */
+    .nc     { color: $solar-magenta;}                                    /* Name.Class */
+    .no     { color: $solar-yellow; }                                    /* Name.Constant */
+    .ni     { color: $solar-magenta; }                                   /* Name.Entity */
+    .nl     { color: $solar-green; }
+    .ne     { color: $solar-blue; font-weight: bold; }                   /* Name.Exception */
+    .nf     { color: $solar-blue; font-weight: bold; }                   /* Name.Function */
+    .nn     { color: $solar-yellow; }                                    /* Name.Namespace */
+    .nt     { color: $solar-blue; font-weight: bold; }                   /* Name.Tag */
+    .nx     { color: $solar-yellow; }
+    .bp     { color: $base1;  }                                          /* Name.Builtin.Pseudo */
+    .vc     { color: $solar-green; }                                     /* Name.Variable.Class */
+    .vg     { color: $solar-blue; }                                      /* Name.Variable.Global */
+    .vi     { color: $solar-blue; }                                      /* Name.Variable.Instance */
+    .nv     { color: $solar-blue; }                                      /* Name.Variable */
+    .w      { color: $base00; }                                          /* Text.Whitespace */
+    .mf     { color: $solar-cyan; }                                      /* Literal.Number.Float */
+    .m      { color: $solar-cyan; }                                      /* Literal.Number */
+    .mh     { color: $solar-cyan; }                                      /* Literal.Number.Hex */
+    .mi     { color: $solar-cyan; }                                      /* Literal.Number.Integer */
+    .mo     { color: $solar-cyan; }                                      /* Literal.Number.Oct */
+    .s      { color: $solar-cyan; }                                      /* Literal.String */
+    .sb     { color: $solar-green; }                                     /* Literal.String.Backtick */
+    .sc     { color: $solar-green; }                                     /* Literal.String.Char */
+    .sd     { color: $solar-cyan; }                                      /* Literal.String.Doc */
+    .s2     { color: $solar-cyan; }                                      /* Literal.String.Double */
+    .se     { color: $solar-red; }                                       /* Literal.String.Escape */
+    .sh     { color: $solar-green; }                                     /* Literal.String.Heredoc */
+    .si     { color: $solar-blue; }                                      /* Literal.String.Interpol */
+    .sx     { color: $solar-green; }                                     /* Literal.String.Other */
+    .sr     { color: $solar-cyan; }                                      /* Literal.String.Regex */
+    .s1     { color: $solar-cyan; }                                      /* Literal.String.Single */
+    .ss     { color: $solar-orange; }                                    /* Literal.String.Symbol */
+    .il     { color: $solar-yellow; }                                    /* Literal.Number.Integer.Long */
+  }
+}
+
+
+@include solarized-theme($solarized);
+
+// Inline <code> element styles
+//
+code,
+kbd,
+samp,
+tt {
+  color: inherit;
+  background-color: $code-bg;
+  border: 1px solid $code-border;
+  border-radius: 3px;
+  &:before, &:after {
+    content: "\00a0";
+    letter-spacing: -0.2em;
+  }
+  padding: 0.215rem 0 0;
+}
+
+// Overide <code> styles beneath <pre>
+//
+pre code {
+  &:before, &:after {
+    content: none;
+  }
+  border: none;
+  background: none;
+  border-raidus: 0;
+  font-size: inherit;
+}
+
+// Styles for pre's which aren't highlighted by Octopress's highlighter
+//
+.highlight pre,
+pre:not(.code-highlight-pre),
+.code-highlight {
+  span { font-style: normal; }
+
+  overflow: scroll;
+  overflow-y: hidden;
+  overflow-x: auto;
+  background: $code-bg;
+}

--- a/www/source/stylesheets/site.css.scss
+++ b/www/source/stylesheets/site.css.scss
@@ -14,4 +14,5 @@
 @import "homepage";
 @import "tutorials-page";
 @import "code";
+@import "code_blocks";
 @import "search";


### PR DESCRIPTION
* Fixed a small typo with a single quoted string
* Added `$` prompt where I saw it was needed
* Changed some inspec shell code blocks to use `shell`. It's not right but `irb` is not currently supported in the gem. We can talk if you want to add an inspec shell lexer they aren't too hard to make.
* Ran a script to change over all the indented code blocks in the resources doc to become code fences with the ruby language specified.
* Added a stylesheet and took a stab at picking some colors that would look appealing on the site. I don't know if there were some guidelines that I should have been aware of or used.

Signed-off-by: Franklin Webber <franklin@chef.io>

## Example of final rendering

The view 'docs/reference/dsl_inspec'

![image](https://user-images.githubusercontent.com/244426/35979563-415b8836-0cae-11e8-9822-b86dd8fc25de.png)

An example of the poor rendering of inspec shell: 

![image](https://user-images.githubusercontent.com/244426/35979855-ff60ffbe-0cae-11e8-86e8-ab2e337a0580.png)

## Color Commentary

![will-smith-i-make-this-look-good-men-in-black](https://user-images.githubusercontent.com/244426/35979528-317c3d8e-0cae-11e8-99a7-0c33c8210e49.gif)

https://www.youtube.com/watch?v=AjPau5QYtYs