### PR TITLE
Fixes docs for file example

### DIFF
--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -51,9 +51,7 @@ The `content` property tests if contents in the file match the value specified i
 
 The following complete example tests the `pg_hba.conf` file in PostgreSQL for MD5 requirements.  The tests look at all `host` and `local` settings in that file, and then compare the MD5 checksums against the values in the test:
 
-    hba_config_file = '/etc/postgresql/9.1/main/pg_hba.conf'
-
-    describe file(hba_config_file) do
+    describe file('/etc/postgresql/9.1/main/pg_hba.conf') do
       its('content') { should match(%r{local\s.*?all\s.*?all\s.*?md5}) }
       its('content') { should match(%r{host\s.*?all\s.*?all\s.*?127.0.0.1\/32\s.*?md5}) }
       its('content') { should match(%r{host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5}) }
@@ -167,9 +165,7 @@ or:
 
 ### Test the contents of a file for MD5 requirements
 
-    hba_config_file = '/etc/postgresql/9.1/main/pg_hba.conf'
-
-    describe file(hba_config_file) do
+    describe file('/etc/postgresql/9.1/main/pg_hba.conf') do
       its('content') { should match /local\s.*?all\s.*?all\s.*?md5/ }
       its('content') { should match %r{/host\s.*?all\s.*?all\s.*?127.0.0.1\/32\s.*?md5/} }
       its('content') { should match %r{/host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5/} }

--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -51,7 +51,7 @@ The `content` property tests if contents in the file match the value specified i
 
 The following complete example tests the `pg_hba.conf` file in PostgreSQL for MD5 requirements.  The tests look at all `host` and `local` settings in that file, and then compare the MD5 checksums against the values in the test:
 
-    hba_config_file = 'pg_hba.conf'
+    hba_config_file = '/etc/postgresql/9.1/main/pg_hba.conf'
 
     describe file(hba_config_file) do
       its('content') { should match(%r{local\s.*?all\s.*?all\s.*?md5}) }
@@ -167,7 +167,7 @@ or:
 
 ### Test the contents of a file for MD5 requirements
 
-    hba_config_file = 'pg_hba.conf'
+    hba_config_file = '/etc/postgresql/9.1/main/pg_hba.conf'
 
     describe file(hba_config_file) do
       its('content') { should match /local\s.*?all\s.*?all\s.*?md5/ }

--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -51,10 +51,12 @@ The `content` property tests if contents in the file match the value specified i
 
 The following complete example tests the `pg_hba.conf` file in PostgreSQL for MD5 requirements.  The tests look at all `host` and `local` settings in that file, and then compare the MD5 checksums against the values in the test:
 
+    hba_config_file = 'pg_hba.conf'
+
     describe file(hba_config_file) do
       its('content') { should match(%r{local\s.*?all\s.*?all\s.*?md5}) }
       its('content') { should match(%r{host\s.*?all\s.*?all\s.*?127.0.0.1\/32\s.*?md5}) }
-      its('content') { should match(%r{host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5})
+      its('content') { should match(%r{host\s.*?all\s.*?all\s.*?::1\/128\s.*?md5}) }
     end
 
 ### file_version
@@ -109,7 +111,7 @@ The `owner` property tests if the owner of the file matches the specified value.
 
 The `product_version` property tests if a Windows file's product version matches the specified value. The difference between a file's "file version" and "product version" is that the file version is the version number of the file itself, whereas the product version is the version number associated with the application from which that file originates.
 
-    its('product_version') { should eq 2.3.4 }
+    its('product_version') { should eq '2.3.4' }
 
 ### selinux_label
 
@@ -164,6 +166,8 @@ or:
     its('type') { should cmp 'socket' }
 
 ### Test the contents of a file for MD5 requirements
+
+    hba_config_file = 'pg_hba.conf'
 
     describe file(hba_config_file) do
       its('content') { should match /local\s.*?all\s.*?all\s.*?md5/ }
@@ -512,4 +516,3 @@ The `exist` matcher tests if the named file exists:
 The `have_mode` matcher tests if a file has a mode assigned to it:
 
     it { should have_mode }
-


### PR DESCRIPTION
* The version test should be a string
* There was a missing closing brace in the regex examples
* Some white-spaced got cleaned up
* I added the file name into the variable for the pg examples

Signed-off-by: Franklin Webber <franklin@chef.io>