### PR TITLE
Use the version of LicenseScout that comes with the Omnibus gem.

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -11,7 +11,6 @@ source 'https://rubygems.org'
 # gem 'omnibus-software', github: 'chef/omnibus-software', branch: 'ksubrama/ruby23'
 
 # Use entries from chef's Gemfile
-gem 'license_scout', github: 'chef/license_scout'
 gem 'omnibus', github: 'chef/omnibus'
 gem 'omnibus-software', github: 'chef/omnibus-software'
 


### PR DESCRIPTION
LicenseScout is being refactored. We have released a 1.x version that
is pinned within the Omnibus gem.

Signed-off-by: Tom Duffield <tom@chef.io>