### PR TITLE
Add resource support declarations for Azure

### DIFF
--- a/lib/resources/azure/azure_generic_resource.rb
+++ b/lib/resources/azure/azure_generic_resource.rb
@@ -11,6 +11,8 @@ module Inspec::Resources
       Inspec Resource to interrogate any Resource type in Azure
     '
 
+    supports platform: 'azure'
+
     attr_accessor :filter, :total, :counts, :name, :type, :location, :probes
 
     def initialize(opts = {})

--- a/lib/resources/azure/azure_resource_group.rb
+++ b/lib/resources/azure/azure_resource_group.rb
@@ -10,6 +10,8 @@ module Inspec::Resources
       Inspec Resource to get metadata about a specific Resource Group
     '
 
+    supports platform: 'azure'
+
     attr_reader :name, :location, :id, :total, :counts, :mapping
 
     # Constructor to get the resource group itself and perform some analysis on the

--- a/lib/resources/azure/azure_virtual_machine.rb
+++ b/lib/resources/azure/azure_virtual_machine.rb
@@ -10,6 +10,8 @@ module Inspec::Resources
       Inspec Resource to test Azure Virtual Machines
     '
 
+    supports platform: 'azure'
+
     # Constructor for the resource. This calls the parent constructor to
     # get the generic resource for the specified machine. This will provide
     # static methods that are documented

--- a/lib/resources/azure/azure_virtual_machine_data_disk.rb
+++ b/lib/resources/azure/azure_virtual_machine_data_disk.rb
@@ -11,6 +11,8 @@ module Inspec::Resources
       Inspec Resource to ensure that the data disks attached to a machine are correct
     '
 
+    supports platform: 'azure'
+
     # Create a filter table so that tests on the disk can be performed
     filter = FilterTable.create
     filter.add_accessor(:where)


### PR DESCRIPTION
With the Platforms API, we're able to more clearly restrict resources to appropriate platforms.  This change ensures that Azure resources only run on Azure.

Migrated from https://github.com/chef/inspec-azure/pull/60