### PR TITLE
virtualization_resource: Fix `NoMethodError` on `nil:NilClass`

### DIFF
--- a/lib/resources/virtualization.rb
+++ b/lib/resources/virtualization.rb
@@ -25,11 +25,14 @@ module Inspec::Resources
     "
 
     def initialize
+      @virtualization_data = Hashie::Mash.new
+
       unless inspec.os.linux?
-        skip_resource 'The `virtualization` resource is not supported on your OS yet.'
-      else
-        collect_data_linux
+        raise Inspec::Exceptions::ResourceSkipped,
+              'The `virtualization` resource is not supported on your OS yet.'
       end
+
+      collect_data_linux
     end
 
     # add helper methods for easy access of properties
@@ -229,8 +232,7 @@ module Inspec::Resources
     end
 
     def collect_data_linux # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
-      # cache data in an instance var to avoid doing multiple detections for a single test
-      @virtualization_data ||= Hashie::Mash.new
+      # This avoids doing multiple detections in a single test
       return unless @virtualization_data.empty?
 
       # each detect method will return true if it matched and was successfully

--- a/lib/resources/virtualization.rb
+++ b/lib/resources/virtualization.rb
@@ -5,7 +5,7 @@ require 'hashie/mash'
 module Inspec::Resources
   class Virtualization < Inspec.resource(1)
     name 'virtualization'
-    supports platform: 'unix'
+    supports platform: 'linux'
     desc 'Use the virtualization InSpec audit resource to test the virtualization platform on which the system is running'
     example "
       describe virtualization do
@@ -26,12 +26,6 @@ module Inspec::Resources
 
     def initialize
       @virtualization_data = Hashie::Mash.new
-
-      unless inspec.os.linux?
-        raise Inspec::Exceptions::ResourceSkipped,
-              'The `virtualization` resource is not supported on your OS yet.'
-      end
-
       collect_data_linux
     end
 

--- a/test/unit/resources/virtualization_test.rb
+++ b/test/unit/resources/virtualization_test.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+require 'helper'
+require 'inspec/resource'
+
+describe 'Inspec::Resources::Virtualization' do
+  let(:resource) { MockLoader.new(:ubuntu).load_resource('virtualization') }
+
+  it 'skips the resource if OS is not Linux' do
+    resource = MockLoader.new(:windows).load_resource('virtualization')
+    resource.resource_skipped?.must_equal true
+  end
+
+  it 'returns nil for all properties if no virutalization platform is found' do
+    resource.system.must_be_nil
+    resource.role.must_be_nil
+  end
+end


### PR DESCRIPTION
This moves the creation of `@virtualization_data` to `initialize`.

Methods for `role` and `system` properties are dynamically generated and return values from the `@virtualization_data` Mash. Therefor, we must ensure `@virtualization_data` exists before calling these methods.

This removes an `author` line since the Git history serves as the authoritative source for who was involved in development.

This adds rudimentary tests. I have created issue https://github.com/chef/inspec/issues/2602 to have more tests added.

This closes #2532.