### PR TITLE
Force a default reporter for ad-hoc runners

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -93,7 +93,7 @@ module Inspec
       }
     end
 
-    def self.parse_reporters(opts)
+    def self.parse_reporters(opts) # rubocop:disable Metrics/AbcSize
       # merge in any legacy formats as reporter
       # this method will only be used for ad-hoc runners
       if !opts['format'].nil? && opts['reporter'].nil?
@@ -101,6 +101,9 @@ module Inspec
         opts['reporter'] = Array(opts['format'])
         opts.delete('format')
       end
+
+      # default to cli report for ad-hoc runners
+      opts['reporter'] = ['cli'] if opts['reporter'].nil?
 
       # parse out cli to proper report format
       if opts['reporter'].is_a?(Array)

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -19,6 +19,14 @@ describe Inspec::Runner do
         expected = { 'cli' => { 'stdout' => true } }
         config['reporter'].must_equal expected
       end
+
+      it 'does not default when format is set' do
+        opts = { command_runner: :generic, backend_cache: true, 'format' => 'json' }
+        runner = Inspec::Runner.new(opts)
+        config = runner.instance_variable_get(:"@conf")
+        expected = { 'json' => { 'stdout' => true } }
+        config['reporter'].must_equal expected
+      end
     end
 
     describe 'when backend caching is enabled' do

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -11,6 +11,16 @@ describe Inspec::Runner do
       Inspec::Runner.any_instance.stubs(:validate_attributes_file_readability!)
     end
 
+    describe 'confirm reporter defaults to cli' do
+      it 'defaults to cli when format and reporter not set' do
+        opts = { command_runner: :generic, backend_cache: true }
+        runner = Inspec::Runner.new(opts)
+        config = runner.instance_variable_get(:"@conf")
+        expected = { 'cli' => { 'stdout' => true } }
+        config['reporter'].must_equal expected
+      end
+    end
+
     describe 'when backend caching is enabled' do
       it 'returns a backend with caching' do
         opts = { command_runner: :generic, backend_cache: true }


### PR DESCRIPTION
There is a potential issue with ad-hoc runners if they do not set a format or reporter. If this happens no reporters run. This change forces a cli report in that case.

Signed-off-by: Jared Quick <jquick@chef.io>