### PR TITLE
Fix the /private/var osx issue causing functional tests to fail

### DIFF
--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -26,7 +26,7 @@ describe 'example inheritance profile' do
       out.stderr.must_equal ''
       out.exit_status.must_equal 0
       # this fixes the osx /var symlink to /private/var causing this test to fail
-      out.stdout.gsub!(%r{\/private\/var}, '/var')
+      out.stdout.gsub!('/private/var', '/var')
       out.stdout.must_include "Dependencies for profile #{dir} successfully vendored to #{dir}/vendor"
 
       File.exist?(File.join(dir, 'vendor')).must_equal true

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -25,6 +25,8 @@ describe 'example inheritance profile' do
       out = inspec('vendor --overwrite', "cd #{dir} &&")
       out.stderr.must_equal ''
       out.exit_status.must_equal 0
+      # this fixes the osx /var symlink to /private/var causing this test to fail
+      out.stdout.gsub!(%r{\/private\/var}, '/var')
       out.stdout.must_include "Dependencies for profile #{dir} successfully vendored to #{dir}/vendor"
 
       File.exist?(File.join(dir, 'vendor')).must_equal true


### PR DESCRIPTION
This change fixes the functional changes for osx.
![screen shot 2018-02-12 at 9 39 47 am](https://user-images.githubusercontent.com/574637/36101913-b55db592-0fd8-11e8-85c5-a1c437acaad8.png)


Signed-off-by: Jared Quick <jquick@chef.io>