### PR TITLE
Write version_constraints as an array for inspec.lock

### DIFF
--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -80,7 +80,7 @@ module Inspec
       h = {
         'name' => name,
         'resolved_source' => resolved_source,
-        'version_constraints' => version_constraints.to_s,
+        'version_constraints' => Gem::Requirement.new(version_constraints).to_s,
       }
 
       if !dependencies.empty?

--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -80,7 +80,7 @@ module Inspec
       h = {
         'name' => name,
         'resolved_source' => resolved_source,
-        'version_constraints' => Gem::Requirement.new(version_constraints).to_s,
+        'version_constraints' => version_constraints,
       }
 
       if !dependencies.empty?

--- a/test/unit/dependencies/requirement_test.rb
+++ b/test/unit/dependencies/requirement_test.rb
@@ -2,8 +2,9 @@ require 'helper'
 require 'inspec/dependencies/requirement'
 
 describe Inspec::Requirement do
+  let(:req) { Inspec::Requirement.new('foo', constraints, nil, nil, {}) }
+
   describe '#source_satisfies_spec?' do
-    let(:req) { Inspec::Requirement.new('foo', constraints, nil, nil, {}) }
 
     describe 'when there are no version constraints' do
       let(:constraints) { nil }
@@ -70,6 +71,23 @@ describe Inspec::Requirement do
         req.stubs(:profile).returns(profile)
         req.source_satisfies_spec?.must_equal true
       end
+    end
+  end
+
+  describe '#to_hash' do
+    let(:constraints) { nil }
+    it 'returns the correct Hash' do
+      resolved_source = { compliance: 'spam', url: 'eggs', sha256: 'bacon' }
+      req.stubs(:resolved_source).returns(resolved_source)
+      req.stubs(:dependencies).returns({})
+
+      correct_hash = {
+        'name' => 'foo',
+        'resolved_source' => resolved_source,
+        'version_constraints' => '>= 0',
+      }
+
+      req.to_hash.must_equal correct_hash
     end
   end
 end

--- a/test/unit/dependencies/requirement_test.rb
+++ b/test/unit/dependencies/requirement_test.rb
@@ -84,7 +84,7 @@ describe Inspec::Requirement do
       correct_hash = {
         'name' => 'foo',
         'resolved_source' => resolved_source,
-        'version_constraints' => '>= 0',
+        'version_constraints' => [],
       }
 
       req.to_hash.must_equal correct_hash


### PR DESCRIPTION
This fixes #2425

PR https://github.com/chef/inspec/pull/2280 modified how the `version_constraints` field in the `inspec.lock` file was rendered. In the case of no version constraints, that PR made it so an empty Array was rendered as a String (e.g. `'[]'`).

Chef's Compliance product uses an older version of InSpec which tries to parse this field using `Gem::Requirement.new`. This fails as `["[]"]` is not a valid `Gem::Requirement`. See: https://github.com/chef/inspec/blob/8d555bd16054d715ee8471ec98d49118949b85be/lib/inspec/dependencies/requirement.rb#L45

This modifies `Inspec::Requirement#to_hash` to ensure a valid `Gem::Requirement` is written to `inspec.lock`.