### PR TITLE
Allow ad-hoc runners to use rspec formats.

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -42,13 +42,15 @@ module Inspec
       @ignore_supports = @conf[:ignore_supports]
       @create_lockfile = @conf[:create_lockfile]
       @cache = Inspec::Cache.new(@conf[:vendor_cache])
+
+      # parse any ad-hoc runners reporter formats
+      # this has to happen before we load the test_collector
+      @conf = Inspec::BaseCLI.parse_reporters(@conf) if @conf[:type].nil?
+
       @test_collector = @conf.delete(:test_collector) || begin
         require 'inspec/runner_rspec'
         RunnerRspec.new(@conf)
       end
-
-      # parse any ad-hoc runners reporter formats
-      @conf = Inspec::BaseCLI.parse_reporters(@conf) if @conf[:type].nil?
 
       # list of profile attributes
       @attributes = []

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -94,18 +94,18 @@ module Inspec
     #
     #
     def set_optional_formatters
-      return if @conf[:reporter].nil?
-      if @conf[:reporter].key?('json-rspec')
+      return if @conf['reporter'].nil?
+      if @conf['reporter'].key?('json-rspec')
         # We cannot pass in a nil output path. Rspec only accepts a valid string or a IO object.
-        if @conf[:reporter]['json-rspec']&.[]('file').nil?
+        if @conf['reporter']['json-rspec']&.[]('file').nil?
           RSpec.configuration.add_formatter(Inspec::Formatters::RspecJson)
         else
           RSpec.configuration.add_formatter(Inspec::Formatters::RspecJson, @conf[:reporter]['json-rspec']['file'])
         end
-        @conf[:reporter].delete('json-rspec')
+        @conf['reporter'].delete('json-rspec')
       end
 
-      formats = @conf[:reporter].select { |k, _v| %w{documentation progress html}.include?(k) }
+      formats = @conf['reporter'].select { |k, _v| %w{documentation progress html}.include?(k) }
       formats.each do |k, v|
         # We cannot pass in a nil output path. Rspec only accepts a valid string or a IO object.
         if v&.[]('file').nil?
@@ -113,7 +113,7 @@ module Inspec
         else
           RSpec.configuration.add_formatter(k.to_sym, v['file'])
         end
-        @conf[:reporter].delete(k)
+        @conf['reporter'].delete(k)
       end
     end
 

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -27,6 +27,13 @@ describe Inspec::Runner do
         expected = { 'json' => { 'stdout' => true } }
         config['reporter'].must_equal expected
       end
+
+      it 'delets format if set to a rspec format' do
+        opts = { command_runner: :generic, backend_cache: true, 'format' => 'progress' }
+        runner = Inspec::Runner.new(opts)
+        config = runner.instance_variable_get(:"@conf")
+        config['reporter'].must_equal Hash.new
+      end
     end
 
     describe 'when backend caching is enabled' do


### PR DESCRIPTION
Currently ad-hoc runners cannot use rspec format as the reporter cleaner happens after the runner is initiated. This change re-orders the initialize for the runner, as well as changing symbols to strings for the rspec reporters. 

The thor option does some magic to make some string keys work as symbols. In a future issue we should really look into making everything symbols and unifying it.  

Signed-off-by: Jared Quick <jquick@chef.io>