### PR TITLE
package resource: Fix Windows package detection

### DIFF
--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -267,6 +267,12 @@ module Inspec::Resources
         Select-Object -Property DisplayName,DisplayVersion | ConvertTo-Json
       EOF
 
+      # We cannot rely on `exit_status` since PowerShell always exits 0 from the
+      # above command. Instead, if no package is found the output of the command
+      # will be `''` so we can use that to return `{}` to match the behavior of
+      # other package managers.
+      return {} if cmd.stdout == ''
+
       begin
         package = JSON.parse(cmd.stdout)
       rescue JSON::ParserError => e


### PR DESCRIPTION
PR https://github.com/chef/inspec/pull/2388 modified how the `package` resource handled errors, but in the case of Windows, the handling for when a package was not found was removed.

This adds back that handling.

See: https://github.com/chef/inspec/pull/2388/files#diff-843eb1141523e80b4552e5cc8d178fb4L272

Huge shout out to @frezbo and @abheenasylendran for finding this and assisting in troubleshooting this issue! 