### PR TITLE
Update `inspec detect` to support APIs/Families

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -178,17 +178,27 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :format, type: :string
   def detect
     o = opts(:detect).dup
-    o[:command] = 'os.params'
+    o[:command] = 'platform.params'
     (_, res) = run_command(o)
     if o['format'] == 'json'
       puts res.to_json
     else
-      headline('Operating System Details')
-      %w{name family release arch}.each { |item|
-        puts format('%-10s %s', item.to_s.capitalize + ':',
-                    mark_text(res[item.to_sym]))
+      headline('Platform Details')
+      %w{name families release arch}.each { |item|
+        data = res[item.to_sym]
+
+        # Format Array for better output if applicable
+        data = data.join(', ') if data.is_a?(Array)
+
+        # Do not output fields of data is missing ('unknown' is fine)
+        next if data.nil?
+
+        puts format('%-10s %s', item.to_s.capitalize + ':', mark_text(data))
       }
     end
+  rescue ArgumentError, RuntimeError, Train::UserError => e
+    $stderr.puts e.message
+    exit 1
   rescue StandardError => e
     pretty_handle_exception(e)
   end

--- a/lib/resources/os.rb
+++ b/lib/resources/os.rb
@@ -29,16 +29,6 @@ module Inspec::Resources
       end
     end
 
-    # helper to collect a hash object easily
-    def params
-      {
-        name: name,
-        family: @platform[:family],
-        release: @platform[:release],
-        arch: @platform[:arch],
-      }
-    end
-
     def to_s
       'Operating System Detection'
     end

--- a/lib/resources/platform.rb
+++ b/lib/resources/platform.rb
@@ -25,6 +25,10 @@ module Inspec::Resources
       end
     end
 
+    def families
+      @platform.family_hierarchy
+    end
+
     def name
       @platform.name
     end
@@ -46,8 +50,19 @@ module Inspec::Resources
       @platform.family_hierarchy.include?(family)
     end
 
-    def families
-      @platform.family_hierarchy
+    def params
+      h = {
+        name: name,
+        families: families,
+      }
+
+      # Avoid adding Release/Arch for APIs
+      unless in_family?('api')
+        h[:release] = release
+        h[:arch] = arch
+      end
+
+      h
     end
 
     def supported?(supports)

--- a/lib/resources/platform.rb
+++ b/lib/resources/platform.rb
@@ -54,11 +54,11 @@ module Inspec::Resources
       h = {
         name: name,
         families: families,
+        release: release,
       }
 
-      # Avoid adding Release/Arch for APIs
+      # Avoid adding Arch for APIs (not applicable)
       unless in_family?('api')
-        h[:release] = release
         h[:arch] = arch
       end
 

--- a/test/functional/inspec_detect_test.rb
+++ b/test/functional/inspec_detect_test.rb
@@ -16,19 +16,7 @@ describe 'inspec detect' do
     stdout.must_include "\nRelease:   \e[0;36m"
   end
 
-  it 'outputs the correct data when `--format json` is used' do
-    res = inspec('detect --format json')
-    res.stderr.must_equal ''
-    res.exit_status.must_equal 0
-
-    json = JSON.parse(res.stdout)
-    json.keys.must_include 'name'
-    json.keys.must_include 'families'
-    json.keys.must_include 'arch'
-    json.keys.must_include 'release'
-  end
-
-  it 'outputs the correct data when target is an api' do
+  it 'outputs the correct data when target the target an API' do
     res = inspec('detect -t aws://')
     res.stderr.must_equal ''
     res.exit_status.must_equal 0
@@ -37,8 +25,35 @@ describe 'inspec detect' do
     stdout.must_include "\n== Platform Details\n\n"
     stdout.must_include "\nName:      \e[0;36m"
     stdout.must_include "\nFamilies:  \e[0;36m"
+    stdout.must_include "\nRelease:   \e[0;36m"
 
     stdout.wont_include "\nArch:"
-    stdout.wont_include "\nRelease:"
+  end
+
+  describe 'when `--format json` is used`' do
+    it 'outputs the correct JSON data' do
+      res = inspec('detect --format json')
+      res.stderr.must_equal ''
+      res.exit_status.must_equal 0
+
+      json = JSON.parse(res.stdout)
+      json.keys.must_include 'name'
+      json.keys.must_include 'families'
+      json.keys.must_include 'arch'
+      json.keys.must_include 'release'
+    end
+
+    it 'outputs the correct JSON data when the target an API' do
+      res = inspec('detect -t aws:// --format json')
+      res.stderr.must_equal ''
+      res.exit_status.must_equal 0
+
+      json = JSON.parse(res.stdout)
+      json.keys.must_include 'name'
+      json.keys.must_include 'families'
+      json.keys.must_include 'release'
+
+      json.keys.wont_include 'arch'
+    end
   end
 end

--- a/test/functional/inspec_detect_test.rb
+++ b/test/functional/inspec_detect_test.rb
@@ -1,0 +1,44 @@
+require 'functional/helper'
+
+describe 'inspec detect' do
+  include FunctionalHelper
+
+  it 'outputs the correct data' do
+    res = inspec('detect')
+    res.stderr.must_equal ''
+    res.exit_status.must_equal 0
+
+    stdout = res.stdout
+    stdout.must_include "\n== Platform Details\n\n"
+    stdout.must_include "\nName:      \e[0;36m"
+    stdout.must_include "\nFamilies:  \e[0;36m"
+    stdout.must_include "\nArch:      \e[0;36m"
+    stdout.must_include "\nRelease:   \e[0;36m"
+  end
+
+  it 'outputs the correct data when `--format json` is used' do
+    res = inspec('detect --format json')
+    res.stderr.must_equal ''
+    res.exit_status.must_equal 0
+
+    json = JSON.parse(res.stdout)
+    json.keys.must_include 'name'
+    json.keys.must_include 'families'
+    json.keys.must_include 'arch'
+    json.keys.must_include 'release'
+  end
+
+  it 'outputs the correct data when target is an api' do
+    res = inspec('detect -t aws://')
+    res.stderr.must_equal ''
+    res.exit_status.must_equal 0
+
+    stdout = res.stdout
+    stdout.must_include "\n== Platform Details\n\n"
+    stdout.must_include "\nName:      \e[0;36m"
+    stdout.must_include "\nFamilies:  \e[0;36m"
+
+    stdout.wont_include "\nArch:"
+    stdout.wont_include "\nRelease:"
+  end
+end

--- a/test/functional/inspec_shell_test.rb
+++ b/test/functional/inspec_shell_test.rb
@@ -58,10 +58,10 @@ describe 'inspec shell tests' do
     end
 
     it 'retrieves resources (json output)' do
-      out = do_shell_c('os.params', 0, true)
+      out = do_shell_c('platform.params', 0, true)
       j = JSON.load(out.stdout)
       j.keys.must_include 'name'
-      j.keys.must_include 'family'
+      j.keys.must_include 'families'
       j.keys.must_include 'arch'
       j.keys.must_include 'release'
     end
@@ -69,7 +69,7 @@ describe 'inspec shell tests' do
     it 'retrieves resources' do
       out = do_shell_c('os.params', 0)
       out.stdout.must_include 'name'
-      out.stdout.must_include 'family'
+      out.stdout.must_include 'families'
       out.stdout.must_include 'arch'
       out.stdout.must_include 'release'
     end

--- a/test/functional/inspec_test.rb
+++ b/test/functional/inspec_test.rb
@@ -1,38 +1,9 @@
 # encoding: utf-8
-# author: Dominik Richter
-# author: Christoph Hartmann
 
 require 'functional/helper'
 
 describe 'command tests' do
   include FunctionalHelper
-
-  describe 'detect with json' do
-    it 'runs well on all nodes' do
-      out = inspec('detect --format json')
-      out.stderr.must_equal ''
-      out.exit_status.must_equal 0
-      j = JSON.load(out.stdout)
-      j.keys.must_include 'name'
-      j.keys.must_include 'family'
-      j.keys.must_include 'arch'
-      j.keys.must_include 'release'
-    end
-  end
-
-  describe 'detect without json' do
-    it 'runs well on all nodes' do
-      out = inspec('detect')
-      out.stderr.must_equal ''
-      out.exit_status.must_equal 0
-      std = out.stdout
-      std.must_include "\n== Operating System Details\n\n"
-      std.must_include "\nName:      \e[0;36m"
-      std.must_include "\nFamily:    \e[0;36m"
-      std.must_include "\nArch:      \e[0;36m"
-      std.must_include "\nRelease:   \e[0;36m"
-    end
-  end
 
   describe 'version' do
     it 'provides the version number on stdout' do


### PR DESCRIPTION
This closes #2611 

This does the following to `inspec detect`:
  - Modifies it to use the `platform` resource
  - Changes the output to mention Platform and show the family hierarchy
  - Changes the JSON output by changing `family` to `families`
  - Adds better error messaging (no more stacktraces!)
  - Adds support for APIs such as AWS/Azure
  - Hides Arch from API platforms output (not applicable)
