### PR TITLE
Catch cloud exceptions and document connection info

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,11 @@ inspec exec test.rb -t aws://
 # or store your AWS credentials in your ~/.aws/credentials profiles file
 inspec exec test.rb -t aws://us-east-2/my-profile
 
+# run a profile targeting Azure using env vars
+inspec exec test.rb -t azure://
+
+# or store your Azure credentials in your ~/.azure/credentials profiles file
+inspec exec test.rb -t azure://subscription_id
 ```
 
 ### detect

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -4,7 +4,7 @@ New in InSpec 2.0, you may now use certain InSpec resources to audit properties 
 
 In the initial release of InSpec 2.0, support for selected AWS and Azure resources is included.
 
-## AWS Platform Support in InSpec 2.0
+## AWS Platform Support
 
 ### Setting up AWS credentials for InSpec
 
@@ -18,17 +18,40 @@ InSpec uses the standard AWS authentication mechanisms.  Typically, you will cre
 
 You may provide the credentials to InSpec by setting the following environment variables: `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_KEY_ID`.  You may also use `AWS_PROFILE`, or if you are using MFA, `AWS_SESSION_TOKEN`.  See the [AWS Command Line Interface Docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) for details.
 
+Once you have your environment variables set, you can verify your credentials by running:
+
+```bash
+you$ inspec detect -t aws:// 
+
+== Platform Details
+Name:         aws
+Families:     cloud, api
+```
+
 #### Using the InSpec target option to provide credentials
 
-Look for a file in your home directory named `~/.aws/credentials`.  If it does not exist, create it.  Add your credentials as a new profile, in INI format:
+Look for a file in your home directory named `~/.aws/credentials`.  If it does not exist, create it.  Choose a name for your profile; here, we're using the name 'auditing'.  Add your credentials as a new profile, in INI format:
 
 ```
-[my-profile-name]
+[auditing]
 aws_access_key_id = AKIA....
 aws_secret_access_key = 1234....abcd
 ```
 
 You may now run InSpec using the `--target` / `-t` option, using the format `-t aws://region/profile`.  For example, to connect to the Ohio region using a profile named 'auditing', use `-t aws://us-east-2/auditing`.
+
+To verify your credentials, 
+```bash
+you$ inspec detect -t aws:// 
+
+== Platform Details
+Name:         aws
+Families:     cloud, api
+```
+
+#### Verifying your credentials
+
+To verify your credentials
 
 ## Azure Platform Support in InSpec 2.0
 
@@ -46,7 +69,7 @@ The information from the SPN can be specified either in a file `~/.azure/credent
 
 #### Using the Azure Credentials File
 
-The simplest way is to create the file `~/.azure/credentials` with the following format. InSpec is configured to look for this file by default, so no settings are required.
+By default InSpec is configured to look at ~/.azure/credentials, and it should contain:
 
 ```
 [<SUBSCRIPTION_ID>]
@@ -55,7 +78,7 @@ client_secret = "<CLIENT_SECRET>"
 tenant_id = "<TENANT_ID>"
 ```
 
-So to run InSpec now it is as simple as running:
+With the credentials are in place you may now execute InSpec:
 
 ```bash
 inspec exec my-inspec-profile -t azure://

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -80,3 +80,9 @@ AZURE_TENANT_ID="6ad89b58-df2e-11e6-bf01-fe55135034f3" inspec exec my-profile -t
 ```
 
 #### Using InSpec Target Syntax
+
+If you have created a `~/.azure/credentials` file as above, you may also use the InSpec command line `--target` / `-t` option to select a subscription ID.  For example:
+
+```bash
+inspec exec my-profile -t azure://2fbdbb02-df2e-11e6-bf01-fe55135034f3
+```

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -1,0 +1,82 @@
+# Using InSpec 2.0 with Platforms
+
+New in InSpec 2.0, you may now use certain InSpec resources to audit properties of things that aren't individual machines - for example, an Amazon Web Services S3 bucket.
+
+In the initial release of InSpec 2.0, support for selected AWS and Azure resources is included.
+
+## AWS Platform Support in InSpec 2.0
+
+### Setting up AWS credentials for InSpec
+
+InSpec uses the standard AWS authentication mechanisms.  Typically, you will create an IAM user which will be used for auditing activities.
+
+1. Create an IAM user in the AWS console, with your choice of username.  Check the box marked "Programmatic Access."
+2. On the Permissions screen, choose Direct Attach.  Select the AWS-managed IAM Profile named "ReadOnlyAccess."  If you wish to restrict the user further, you may do so; see individual InSpec resources to identify which permissions are required.
+3. After the key is generated, record the Access Key ID and Secret Key.
+
+#### Using Environment Variables to provide credentials
+
+You may provide the credentials to InSpec by setting the following environment variables: `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_KEY_ID`.  You may also use `AWS_PROFILE`, or if you are using MFA, `AWS_SESSION_TOKEN`.  See the [AWS Command Line Interface Docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) for details.
+
+#### Using the InSpec target option to provide credentials
+
+Look for a file in your home directory named `~/.aws/credentials`.  If it does not exist, create it.  Add your credentials as a new profile, in INI format:
+
+```
+[my-profile-name]
+aws_access_key_id = AKIA....
+aws_secret_access_key = 1234....abcd
+```
+
+You may now run InSpec using the `--target` / `-t` option, using the format `-t aws://region/profile`.  For example, to connect to the Ohio region using a profile named 'auditing', use `-t aws://us-east-2/auditing`.
+
+## Azure Platform Support in InSpec 2.0
+
+### Setting up Azure credentials for InSpec
+
+To use InSpec Azure resources, you will need a Service Principal Name (SPN) to be created in the Azure subscription that is being audited.
+
+This can be done on the command line or from the Azure Portal:
+
+- Azure CLI: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authenticate-service-principal-cli
+- PowerShell: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authenticate-service-principal
+- Azure Portal: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal
+
+The information from the SPN can be specified either in a file `~/.azure/credentials`, as environment variables, or using InSpec target URIs.
+
+#### Using the Azure Credentials File
+
+The simplest way is to create the file `~/.azure/credentials` with the following format. InSpec is configured to look for this file by default, so no settings are required.
+
+```
+[<SUBSCRIPTION_ID>]
+client_id = "<CLIENT_ID>"
+client_secret = "<CLIENT_SECRET>"
+tenant_id = "<TENANT_ID>"
+```
+
+So to run InSpec now it is as simple as running:
+
+```bash
+inspec exec my-inspec-profile -t azure://
+```
+
+#### Using Environment variables
+
+You may also set the Azure credentials via environment variables:
+
+- `AZURE_SUBSCRIPTION_ID`
+- `AZURE_CLIENT_ID`
+- `AZURE_CLIENT_SECRET`
+- `AZURE_TENANT_ID`
+
+For example:
+
+```bash
+AZURE_SUBSCRIPTION_ID="2fbdbb02-df2e-11e6-bf01-fe55135034f3" \
+AZURE_CLIENT_ID="58dc4f6c-df2e-11e6-bf01-fe55135034f3" \
+AZURE_CLIENT_SECRET="Jibr4iwwaaZwBb6W" \
+AZURE_TENANT_ID="6ad89b58-df2e-11e6-bf01-fe55135034f3" inspec exec my-profile -t azure://
+```
+
+#### Using InSpec Target Syntax

--- a/lib/resource_support/aws/aws_resource_mixin.rb
+++ b/lib/resource_support/aws/aws_resource_mixin.rb
@@ -50,15 +50,13 @@ module AwsResourceMixin
 
   # Intercept AWS exceptions
   def catch_aws_errors
-    begin
-      yield
-    rescue Aws::Errors::MissingCredentialsError => e
-      # The AWS error here is unhelpful:
-      # "unable to sign request without credentials set"
-      Inspec::Log.error "It appears that you have not set your AWS credentials.  You may set them using environment variables, or using the 'aws://region/aws_credentials_profile' target.  See https://www.inspec.io/docs/reference/platforms for details."
-      fail_resource("No AWS credentials available")
-    rescue Aws::Errors::ServiceError => e
-      fail_resource e.message
-    end
+    yield
+  rescue Aws::Errors::MissingCredentialsError
+    # The AWS error here is unhelpful:
+    # "unable to sign request without credentials set"
+    Inspec::Log.error "It appears that you have not set your AWS credentials.  You may set them using environment variables, or using the 'aws://region/aws_credentials_profile' target.  See https://www.inspec.io/docs/reference/platforms for details."
+    fail_resource('No AWS credentials available')
+  rescue Aws::Errors::ServiceError => e
+    fail_resource e.message
   end
 end

--- a/lib/resource_support/aws/aws_resource_mixin.rb
+++ b/lib/resource_support/aws/aws_resource_mixin.rb
@@ -3,7 +3,9 @@ module AwsResourceMixin
     validate_params(resource_params).each do |param, value|
       instance_variable_set(:"@#{param}", value)
     end
-    fetch_from_api
+    catch_aws_errors do
+      fetch_from_api
+    end
   end
 
   # Default implementation of validate params accepts everything.
@@ -44,5 +46,19 @@ module AwsResourceMixin
     # (nil is OK) to the backend.
     # TODO: remove with https://github.com/chef/inspec-aws/issues/216
     inspec if respond_to?(:inspec)
+  end
+
+  # Intercept AWS exceptions
+  def catch_aws_errors
+    begin
+      yield
+    rescue Aws::Errors::MissingCredentialsError => e
+      # The AWS error here is unhelpful:
+      # "unable to sign request without credentials set"
+      Inspec::Log.error "It appears that you have not set your AWS credentials.  You may set them using environment variables, or using the 'aws://region/aws_credentials_profile' target.  See https://www.inspec.io/docs/reference/platforms for details."
+      fail_resource("No AWS credentials available")
+    rescue Aws::Errors::ServiceError => e
+      fail_resource e.message
+    end
   end
 end

--- a/lib/resources/aws/aws_ec2_instance.rb
+++ b/lib/resources/aws/aws_ec2_instance.rb
@@ -25,6 +25,21 @@ EOX
     @iam_resource = conn ? conn.iam_resource : inspec_runner.backend.aws_resource(Aws::IAM::Resource, {})
   end
 
+  # TODO: DRY up, see https://github.com/chef/inspec/issues/2633
+  # Copied from resource_support/aws/aws_resource_mixin.rb
+  def catch_aws_errors
+    yield
+  rescue Aws::Errors::MissingCredentialsError
+    # The AWS error here is unhelpful:
+    # "unable to sign request without credentials set"
+    Inspec::Log.error "It appears that you have not set your AWS credentials.  You may set them using environment variables, or using the 'aws://region/aws_credentials_profile' target.  See https://www.inspec.io/docs/reference/platforms for details."
+    fail_resource('No AWS credentials available')
+  rescue Aws::Errors::ServiceError => e
+    fail_resource e.message
+  end
+
+  # TODO: DRY up, see https://github.com/chef/inspec/issues/2633
+  # Copied from resource_support/aws/aws_singular_resource_mixin.rb
   def inspec_runner
     # When running under inspec-cli, we have an 'inspec' method that
     # returns the runner. When running under unit tests, we don't
@@ -37,19 +52,21 @@ EOX
 
   def id
     return @instance_id if defined?(@instance_id)
-    if @opts.is_a?(Hash)
-      first = @ec2_resource.instances(
-        {
-          filters: [{
-            name: 'tag:Name',
-            values: [@opts[:name]],
-          }],
-        },
-      ).first
-      # catch case where the instance is not known
-      @instance_id = first.id unless first.nil?
-    else
-      @instance_id = @opts
+    catch_aws_errors do
+      if @opts.is_a?(Hash)
+        first = @ec2_resource.instances(
+          {
+            filters: [{
+              name: 'tag:Name',
+              values: [@opts[:name]],
+            }],
+          },
+        ).first
+        # catch case where the instance is not known
+        @instance_id = first.id unless first.nil?
+      else
+        @instance_id = @opts
+      end
     end
   end
   alias instance_id id
@@ -61,7 +78,9 @@ EOX
 
   # returns the instance state
   def state
-    instance&.state&.name
+    catch_aws_errors do
+      instance&.state&.name
+    end
   end
 
   # helper methods for each state
@@ -82,18 +101,24 @@ EOX
     instance_type image_id vpc_id
   }.each do |attribute|
     define_method attribute do
-      instance.send(attribute) if instance
+      catch_aws_errors do
+       instance.send(attribute) if instance
+      end
     end
   end
 
   def security_groups
-    @security_groups ||= instance.security_groups.map { |sg|
-      { id: sg.group_id, name: sg.group_name }
-    }
+    catch_aws_errors do
+      @security_groups ||= instance.security_groups.map { |sg|
+        { id: sg.group_id, name: sg.group_name }
+      }
+    end
   end
 
   def tags
-    @tags ||= instance.tags.map { |tag| { key: tag.key, value: tag.value } }
+    catch_aws_errors do
+      @tags ||= instance.tags.map { |tag| { key: tag.key, value: tag.value } }
+    end
   end
 
   def to_s
@@ -101,25 +126,27 @@ EOX
   end
 
   def has_roles?
-    instance_profile = instance.iam_instance_profile
+    catch_aws_errors do
+      instance_profile = instance.iam_instance_profile
 
-    if instance_profile
-      roles = @iam_resource.instance_profile(
-        instance_profile.arn.gsub(%r{^.*\/}, ''),
-      ).roles
-    else
-      roles = nil
+      if instance_profile
+        roles = @iam_resource.instance_profile(
+          instance_profile.arn.gsub(%r{^.*\/}, ''),
+        ).roles
+      else
+        roles = nil
+      end
+
+      roles && !roles.empty?
     end
-
-    roles && !roles.empty?
   end
 
   private
 
   def instance
-    @instance ||= @ec2_resource.instance(id)
+    catch_aws_errors { @instance ||= @ec2_resource.instance(id) }   
   end
-end
+end 
 
 # Deprecated
 class AwsEc2 < AwsEc2Instance

--- a/lib/resources/aws/aws_ec2_instance.rb
+++ b/lib/resources/aws/aws_ec2_instance.rb
@@ -102,7 +102,7 @@ EOX
   }.each do |attribute|
     define_method attribute do
       catch_aws_errors do
-       instance.send(attribute) if instance
+        instance.send(attribute) if instance
       end
     end
   end
@@ -144,9 +144,9 @@ EOX
   private
 
   def instance
-    catch_aws_errors { @instance ||= @ec2_resource.instance(id) }   
+    catch_aws_errors { @instance ||= @ec2_resource.instance(id) }
   end
-end 
+end
 
 # Deprecated
 class AwsEc2 < AwsEc2Instance

--- a/lib/resources/aws/aws_iam_access_key.rb
+++ b/lib/resources/aws/aws_iam_access_key.rb
@@ -54,7 +54,9 @@ class AwsIamAccessKey < Inspec.resource(1)
     return nil unless exists?
     return @last_used_date if defined? @last_used_date
     backend = BackendFactory.create(inspec_runner)
-    @last_used_date = backend.get_access_key_last_used({ access_key_id: access_key_id }).access_key_last_used.last_used_date
+    catch_aws_errors do
+      @last_used_date = backend.get_access_key_last_used({ access_key_id: access_key_id }).access_key_last_used.last_used_date
+    end
   end
 
   def fetch_from_api

--- a/lib/resources/aws/aws_iam_password_policy.rb
+++ b/lib/resources/aws/aws_iam_password_policy.rb
@@ -16,12 +16,29 @@ EOX
 
   # TODO: rewrite to avoid direct injection, match other resources, use AwsSingularResourceMixin
   def initialize(conn = nil)
-    iam_resource = conn ? conn.iam_resource : inspec_runner.backend.aws_resource(Aws::IAM::Resource, {})
-    @policy = iam_resource.account_password_policy
+    catch_aws_errors do
+      iam_resource = conn ? conn.iam_resource : inspec_runner.backend.aws_resource(Aws::IAM::Resource, {})
+      @policy = iam_resource.account_password_policy
+    end
   rescue Aws::IAM::Errors::NoSuchEntity
     @policy = nil
   end
 
+  # TODO: DRY up, see https://github.com/chef/inspec/issues/2633
+  # Copied from resource_support/aws/aws_resource_mixin.rb
+  def catch_aws_errors
+    yield
+  rescue Aws::Errors::MissingCredentialsError
+    # The AWS error here is unhelpful:
+    # "unable to sign request without credentials set"
+    Inspec::Log.error "It appears that you have not set your AWS credentials.  You may set them using environment variables, or using the 'aws://region/aws_credentials_profile' target.  See https://www.inspec.io/docs/reference/platforms for details."
+    fail_resource('No AWS credentials available')
+  rescue Aws::Errors::ServiceError => e
+    fail_resource e.message
+  end
+
+  # TODO: DRY up, see https://github.com/chef/inspec/issues/2633
+  # Copied from resource_support/aws/aws_singular_resource_mixin.rb
   def inspec_runner
     # When running under inspec-cli, we have an 'inspec' method that
     # returns the runner. When running under unit tests, we don't

--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -93,7 +93,10 @@ class AwsIamPolicy < Inspec.resource(1)
     end
     backend = AwsIamPolicy::BackendFactory.create(inspec_runner)
     criteria = { policy_arn: arn }
-    resp = backend.list_entities_for_policy(criteria)
+    resp = nil
+    catch_aws_errors do
+      resp = backend.list_entities_for_policy(criteria)
+    end
     @attached_groups = resp.policy_groups.map(&:group_name)
     @attached_users  = resp.policy_users.map(&:user_name)
     @attached_roles  = resp.policy_roles.map(&:role_name)

--- a/lib/resources/aws/aws_iam_user.rb
+++ b/lib/resources/aws/aws_iam_user.rb
@@ -82,6 +82,8 @@ class AwsIamUser < Inspec.resource(1)
 
     # TODO: consider returning Inspec AwsIamAccessKey objects
     @access_keys = backend.list_access_keys(user_name: username).access_key_metadata
+    # If the above call fails, we get nil here; but we promise access_keys will be an array.
+    @access_keys ||= []
   end
 
   class Backend

--- a/lib/resources/azure/azure_resource_group.rb
+++ b/lib/resources/azure/azure_resource_group.rb
@@ -132,6 +132,7 @@ module Inspec::Resources
     # @author Russell Seymour
     # @private
     def create_has_methods
+      return if failed_resource?
       # Create the has methods for each of the mappings
       # This is a quick test to show that the resource group has at least one of these things
       mapping.each do |name, type|

--- a/lib/resources/azure/azure_virtual_machine_data_disk.rb
+++ b/lib/resources/azure/azure_virtual_machine_data_disk.rb
@@ -54,6 +54,7 @@ module Inspec::Resources
     #
     # @author Russell Seymour
     def datadisk_details
+      return if failed_resource?
       # Iterate around the data disks on the machine
       properties.storageProfile.dataDisks.each_with_index.map do |datadisk, index|
         # Call function to parse the data disks and return an object based on the parameters


### PR DESCRIPTION
Adds a document describing the credentials setup for AWS and Azure, fixes #2612 

Adds a method, `catch_aws_errors`, to the AwsResourceMixin.  Intercepts connection exceptions and provides a friendlier error message.  Intercepts all other AWS errors and calls `fail_resource`, allowing the inspec run to continue while marking the test/control failed.  Added wrapper around lazy-fetched properties, and copy-pasted the code to get three more resources covered (#2633 logged as tech debt).  

Adds a method, `catch_azure_errors`, to AzureResourceBase.  Catches Azure exceptions (there appears to only be one class; they are otherwise distinguished by a JSON structure).  Due to how properties are dynamically generated, it was necessary to add an instance variable as a sentinel for whether the resource had failed, and then treat any unknown property as nil, which is ugly. 

The AWS and Azure changes together fix #2613.