### PR TITLE
Improvements and matcher renaming on aws_iam_password_policy

### DIFF
--- a/docs/resources/aws_iam_password_policy.md
+++ b/docs/resources/aws_iam_password_policy.md
@@ -11,17 +11,17 @@ Use the `aws_iam_password_policy` InSpec audit resource to test properties of th
 
 ## Syntax
 
-An `aws_iam_password_policy` resource block takes no parameters, but uses several matchers.
+An `aws_iam_password_policy` resource block takes no parameters.  Several properties and matchers are available.
 
     describe aws_iam_password_policy do
-      its('requires_lowercase_characters?') { should be true }
+      it { should require_lowercase_characters }
     end
 
 <br>
 
 ## Properties
 
-* `allows_users_to_change_password?`, `expires_passwords`, `max_password_age`,  `minimum_password_length`, `number_of_passwords_to_remember`, `prevents_password_reuse?`, `requires_lowercase_characters` , `requires_uppercase_characters?`, `requires_numbers?`, `requires_symbols?`
+* `max_password_age`,  `minimum_password_length`, `number_of_passwords_to_remember`
 
 ## Examples
 
@@ -30,35 +30,36 @@ The following examples show how to use this InSpec audit resource.
 ### Test that the IAM Password Policy requires lowercase characters, uppercase characters, numbers, symbols, and a minimum length greater than eight
 
     describe aws_iam_password_policy do
-      its('requires_lowercase_characters?') { should be true }
-      its('requires_uppercase_characters?') { should be true }
-      its('requires_numbers?') { should be true }
-      its('requires_symbols?') { should be true }
+      it { should require_lowercase_characters }
+      it { should require_uppercase_characters }
+      it { should require_symbols }
+      it { should require_numbers }
       its('minimum_password_length') { should be > 8 }
     end
 
 ### Test that the IAM Password Policy allows users to change their password
 
     describe aws_iam_password_policy do
-      its('allows_user_to_change_password?') { should be true }
+      it { should allow_users_to_change_passwords }
     end
 
 ### Test that the IAM Password Policy expires passwords
 
     describe aws_iam_password_policy do
-      its('expires_passwords?') { should be true }
+      it { should expire_passwords }
     end
 
 ### Test that the IAM Password Policy has a max password age
 
     describe aws_iam_password_policy do
-      its('max_password_age') { should be > 90 * 86400 }
+      # This value is in days
+      its('max_password_age') { should be 90 }
     end
 
 ### Test that the IAM Password Policy prevents password reuse
 
     describe aws_iam_password_policy do
-      its('prevents_password_reuse?') { should be true }
+      it { should prevent_password_reuse }
     end
 
 ### Test that the IAM Password Policy requires users to remember 3 previous passwords
@@ -71,4 +72,4 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+* `allows_users_to_change_passwords`, `expire_passwords`, `prevent_password_reuse`, `require_lowercase_characters` , `require_uppercase_characters`, `require_numbers`, `require_symbols`

--- a/docs/resources/aws_iam_password_policy.md
+++ b/docs/resources/aws_iam_password_policy.md
@@ -21,7 +21,7 @@ An `aws_iam_password_policy` resource block takes no parameters.  Several proper
 
 ## Properties
 
-* `max_password_age`,  `minimum_password_length`, `number_of_passwords_to_remember`
+* `max_password_age_in_days`,  `minimum_password_length`, `number_of_passwords_to_remember`
 
 ## Examples
 
@@ -52,8 +52,7 @@ The following examples show how to use this InSpec audit resource.
 ### Test that the IAM Password Policy has a max password age
 
     describe aws_iam_password_policy do
-      # This value is in days
-      its('max_password_age') { should be 90 }
+      its('max_password_age_in_days') { should be 90 }
     end
 
 ### Test that the IAM Password Policy prevents password reuse

--- a/lib/resources/aws/aws_iam_password_policy.rb
+++ b/lib/resources/aws/aws_iam_password_policy.rb
@@ -84,19 +84,19 @@ EOX
   end
 
   #-------------------------- Matchers ----------------------------#
-  [ 
+  [
     :require_lowercase_characters,
     :require_uppercase_characters,
     :require_symbols,
     :require_numbers,
     :expire_passwords,
-  ].each do | matcher_stem |
+  ].each do |matcher_stem|
     # Create our predicates (for example, 'require_symbols?')
     stem_with_question_mark = (matcher_stem.to_s + '?').to_sym
-    define_method stem_with_question_mark do 
+    define_method stem_with_question_mark do
       @policy.send(matcher_stem)
     end
-    # RSpec will expose that as (for example) `be_require_symbols`.  
+    # RSpec will expose that as (for example) `be_require_symbols`.
     # To undo that, we have to make a matcher alias.
     stem_with_be = ('be_' + matcher_stem.to_s).to_sym
     RSpec::Matchers.alias_matcher matcher_stem, stem_with_be
@@ -113,5 +113,4 @@ EOX
     !@policy.password_reuse_prevention.nil?
   end
   RSpec::Matchers.alias_matcher :prevent_password_reuse, :be_prevent_password_reuse
-
 end

--- a/lib/resources/aws/aws_iam_password_policy.rb
+++ b/lib/resources/aws/aws_iam_password_policy.rb
@@ -17,11 +17,20 @@ EOX
   # TODO: rewrite to avoid direct injection, match other resources, use AwsSingularResourceMixin
   def initialize(conn = nil)
     catch_aws_errors do
-      iam_resource = conn ? conn.iam_resource : inspec_runner.backend.aws_resource(Aws::IAM::Resource, {})
-      @policy = iam_resource.account_password_policy
+      begin
+        if conn
+          # We're in a mocked unit test.
+          @policy = conn.iam_resource.account_password_policy
+        else
+          # Don't use the resource approach.  It's a CRUD operation
+          # - if the policy does not exist, you get back a blank object to  populate and save.
+          # Using the Client will throw an exception if no policy exists.
+          @policy = inspec_runner.backend.aws_client(Aws::IAM::Client).get_account_password_policy.password_policy
+        end
+      rescue Aws::IAM::Errors::NoSuchEntity
+        @policy = nil
+      end
     end
-  rescue Aws::IAM::Errors::NoSuchEntity
-    @policy = nil
   end
 
   # TODO: DRY up, see https://github.com/chef/inspec/issues/2633

--- a/lib/resources/aws/aws_iam_password_policy.rb
+++ b/lib/resources/aws/aws_iam_password_policy.rb
@@ -72,7 +72,7 @@ EOX
     @policy.minimum_password_length
   end
 
-  def max_password_age
+  def max_password_age_in_days
     raise 'this policy does not expire passwords' unless expire_passwords?
     @policy.max_password_age
   end

--- a/test/aws/default/build/iam.tf
+++ b/test/aws/default/build/iam.tf
@@ -7,6 +7,21 @@ variable "login_profile_pgp_key" {
 }
 
 #======================================================#
+#               Accoount Password Policy
+#======================================================#
+# Only one of these is allowed
+resource "aws_iam_account_password_policy" "fixture" {
+  minimum_password_length        = 10
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_uppercase_characters   = true
+  require_symbols                = true
+  allow_users_to_change_password = true
+  max_password_age               = 365
+  password_reuse_prevention      = 7
+}
+
+#======================================================#
 #                    IAM Users
 #======================================================#
 

--- a/test/aws/default/verify/controls/aws_iam_password_policy.rb
+++ b/test/aws/default/verify/controls/aws_iam_password_policy.rb
@@ -1,0 +1,33 @@
+# There are other tests in the "minimal" test account.
+
+#---------------------- Recall ------------------------#
+# Password policy is a per-account singleton.  If it's been configured, it exists.
+control "aws_iam_password_policy existence" do
+  describe aws_iam_password_policy do
+    it { should exist }
+  end
+end
+
+#------------- Properties -------------#
+
+control "aws_iam_password_policy properties" do
+  describe aws_iam_password_policy do
+    its('max_password_age') { should cmp 365 }
+    its('number_of_passwords_to_remember') { should cmp 7 }
+  end
+end
+
+#------------- Matchers - Positive Case -------------#
+
+control "aws_iam_password_policy matchers" do
+  describe aws_iam_password_policy do
+    it { should be_requires_lowercase_characters }
+    it { should be_requires_uppercase_characters }
+    it { should be_requires_numbers }
+    it { should be_requires_symbols }
+    it { should be_allows_users_to_change_password }
+    it { should be_expires_passwords }
+    it { should be_prevents_password_reuse }
+  end
+end
+

--- a/test/aws/default/verify/controls/aws_iam_password_policy.rb
+++ b/test/aws/default/verify/controls/aws_iam_password_policy.rb
@@ -21,13 +21,13 @@ end
 
 control "aws_iam_password_policy matchers" do
   describe aws_iam_password_policy do
-    it { should be_requires_lowercase_characters }
-    it { should be_requires_uppercase_characters }
-    it { should be_requires_numbers }
-    it { should be_requires_symbols }
-    it { should be_allows_users_to_change_password }
-    it { should be_expires_passwords }
-    it { should be_prevents_password_reuse }
+    it { should require_lowercase_characters }
+    it { should require_uppercase_characters }
+    it { should require_numbers }
+    it { should require_symbols }
+    it { should allow_users_to_change_passwords }
+    it { should expire_passwords }
+    it { should prevent_password_reuse }
   end
 end
 

--- a/test/aws/default/verify/controls/aws_iam_password_policy.rb
+++ b/test/aws/default/verify/controls/aws_iam_password_policy.rb
@@ -12,7 +12,7 @@ end
 
 control "aws_iam_password_policy properties" do
   describe aws_iam_password_policy do
-    its('max_password_age') { should cmp 365 }
+    its('max_password_age_in_days') { should cmp 365 }
     its('number_of_passwords_to_remember') { should cmp 7 }
   end
 end

--- a/test/aws/minimal/verify/controls/aws_iam_password_policy.rb
+++ b/test/aws/minimal/verify/controls/aws_iam_password_policy.rb
@@ -1,0 +1,14 @@
+
+#---------------------- Recall ------------------------#
+# Password policy is a per-account singleton.  If it's been configured, it exists.
+control "aws_iam_password_policy properties" do
+  describe aws_iam_password_policy do
+    it { should_not exist }
+  end
+end
+
+#------------- Properties - Negative Case -------------#
+# No negative tests yet - we'd need a third account
+
+#------------- Matchers - Negative Case -------------#
+# No negative tests yet - we'd need a third account

--- a/test/unit/resources/aws_iam_password_policy_test.rb
+++ b/test/unit/resources/aws_iam_password_policy_test.rb
@@ -30,7 +30,7 @@ class AwsIamPasswordPolicyTest < Minitest::Test
     @mock_resource.expect :account_password_policy, @mock_policy
 
     e = assert_raises Exception do
-      AwsIamPasswordPolicy.new(@mock_conn).max_password_age
+      AwsIamPasswordPolicy.new(@mock_conn).max_password_age_in_days
     end
 
     assert_equal e.message, 'this policy does not expire passwords'

--- a/test/unit/resources/aws_iam_password_policy_test.rb
+++ b/test/unit/resources/aws_iam_password_policy_test.rb
@@ -39,13 +39,13 @@ class AwsIamPasswordPolicyTest < Minitest::Test
   def test_prevents_password_reuse_returns_true_when_not_nil
     configure_policy_password_reuse_prevention(value: Object.new)
 
-    assert AwsIamPasswordPolicy.new(@mock_conn).prevents_password_reuse?
+    assert AwsIamPasswordPolicy.new(@mock_conn).prevent_password_reuse?
   end
 
   def test_prevents_password_reuse_returns_false_when_nil
     configure_policy_password_reuse_prevention(value: nil)
 
-    refute AwsIamPasswordPolicy.new(@mock_conn).prevents_password_reuse?
+    refute AwsIamPasswordPolicy.new(@mock_conn).prevent_password_reuse?
   end
 
   def test_number_of_passwords_to_remember_throws_when_nil


### PR DESCRIPTION
This PR:
1. Fixes a bug, in which aws_iam_password_policy.exists?  always returned true
2. Adds integration tests, which were wholly absent
3. Renames all matchers to read more fluently (see below)
4. Renames max_password_age to max_password_Age_in_days for clarity (the docs had an incorrect second-based example)
5. Updates old markdown-format docs accordingly (ping @kagarmoe )

```
describe aws_iam_password_policy do
  # Previous "matchers as properties" approach that was documented
  its('requires_symbols?') { should eq true }
  # Un-fluent existing matcher syntax
  it { should be_requires_symbols }
  # New, more fluent syntax
  it { should require_symbols }
end
```
Refs #2588 