### PR TITLE
Add 1.x and 2.x release branches

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -23,10 +23,10 @@ github:
     - "Version: Bump Minor"
   version_tag_format: v{{version}}
   release_branch:
-  - master:
-      version_constraint: 2.*
-  - 1-stable:
-      version_constraint: 1.*
+    - master:
+        version_constraint: 2.*
+    - 1-stable:
+        version_constraint: 1.*
 
 changelog:
   categories:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -22,6 +22,11 @@ github:
   minor_bump_labels:
     - "Version: Bump Minor"
   version_tag_format: v{{version}}
+  release_branch:
+  - master:
+      version_constraint: 2.*
+  - 1-stable:
+      version_constraint: 1.*
 
 changelog:
   categories:


### PR DESCRIPTION
This is here to prep Expeditor to do the right things. When this is merged, we will create the 1-stable branch and update the versions accordingly.

Signed-off-by: Jared Quick <jquick@chef.io>