### PR TITLE
Add `platform` tags to resource documentation and remove trailing whitespace

### DIFF
--- a/docs/resources/aide_conf.md.erb
+++ b/docs/resources/aide_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: The aide_conf Resource
+platform: linux
 ---
 
 # aide_conf
@@ -40,7 +41,7 @@ Use the where clause to match a selection_line to one rule or a particular set o
 
 ## Property Examples
 
-The following examples show how to use this InSpec audit resource. 
+The following examples show how to use this InSpec audit resource.
 
 ### Test if all selection lines contain the xattr rule
 
@@ -65,13 +66,13 @@ The following examples show how to use this InSpec audit resource.
     describe aide_conf.all_have_rule('sha512') do
       it { should eq true }
     end
-    
+
 <br>
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
-This InSpec audit resource uses the matchers `eq` and `include`. 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource uses the matchers `eq` and `include`.
 
 For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 

--- a/docs/resources/apache.md.erb
+++ b/docs/resources/apache.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the apache Resource
+platform: linux
 ---
 
 # apache

--- a/docs/resources/apache_conf.md.erb
+++ b/docs/resources/apache_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the apache_conf Resource
+platform: linux
 ---
 
 # apache_conf

--- a/docs/resources/apt.md.erb
+++ b/docs/resources/apt.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the apt Resource
+platform: linux
 ---
 
 # apt
@@ -54,7 +55,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 
 ### be_enabled

--- a/docs/resources/audit_policy.md.erb
+++ b/docs/resources/audit_policy.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the audit_policy Resource
+platform: linux
 ---
 
 # audit_policy

--- a/docs/resources/auditd.md.erb
+++ b/docs/resources/auditd.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the auditd Resource
+platform: linux
 ---
 
 # auditd

--- a/docs/resources/auditd_conf.md.erb
+++ b/docs/resources/auditd_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the auditd_conf Resource
+platform: linux
 ---
 
 # auditd_conf
@@ -57,11 +58,11 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### `cmp`
 
-The `cmp` matcher compares values across types. 
+The `cmp` matcher compares values across types.
 
     its('freq') { should cmp 1 }
 

--- a/docs/resources/bash.md.erb
+++ b/docs/resources/bash.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the bash Resource
+platform: linux
 ---
 
 # bash

--- a/docs/resources/bond.md.erb
+++ b/docs/resources/bond.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the bond Resource
+platform: linux
 ---
 
 # bond
@@ -73,7 +74,7 @@ The `params` matcher tests arbitrary parameters for the bonded network interface
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exist
 

--- a/docs/resources/bridge.md.erb
+++ b/docs/resources/bridge.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the bridge Resource
+platform: linux
 ---
 
 # bridge
@@ -19,7 +20,7 @@ A `bridge` resource block declares the bridge to be tested and what interface it
 
 <br>
 
-## Properties 
+## Properties
 
 * On Linux platforms, any value in the `/sys/class/net/{interface}/bridge` directory may be tested
 * On the Windows platform, the `Get-NetAdapter` cmdlet is associated with the `Get-NetAdapterBinding` cmdlet and returns the `ComponentID ms_bridge` value as a JSON object
@@ -38,7 +39,7 @@ The `interfaces` property tests if the named interface is present:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exist
 

--- a/docs/resources/bsd_service.md.erb
+++ b/docs/resources/bsd_service.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the bsd_service Resource
+platform: linux
 ---
 
 # bsd_service
@@ -44,7 +45,7 @@ All properties available to the `service` resource may be used.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_enabled
 

--- a/docs/resources/command.md.erb
+++ b/docs/resources/command.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the command Resource
+platform: os
 ---
 
 # command
@@ -127,7 +128,7 @@ Wix includes serveral tools -- such as `candle` (preprocesses and compiles sourc
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exist
 

--- a/docs/resources/cpan.md.erb
+++ b/docs/resources/cpan.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the cpan Resource
+platform: linux
 ---
 
 # cpan
@@ -43,7 +44,7 @@ This resource uses package names and perl library paths as resource parameters.
       it { should be_installed }
       its('version') { should eq '3.7.0' }
     end
-    
+
 ### Test if DBD::Pg is installed within a custom PERL5LIB path on the system
 
 Hint: You can pass multiple paths separated with a colon
@@ -69,7 +70,7 @@ The `version` property tests if the named package version is on the system:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_installed
 

--- a/docs/resources/cran.md.erb
+++ b/docs/resources/cran.md.erb
@@ -1,12 +1,13 @@
 ---
 title: About the cran Resource
+platform: linux
 ---
 
 # cran
 
 Use the `cran` InSpec audit resource to test R modules that are installed from CRAN package repository.
 
-<br> 
+<br>
 
 ## Syntax
 

--- a/docs/resources/crontab.md.erb
+++ b/docs/resources/crontab.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the crontab Resource
+platform: linux
 ---
 
 # crontab

--- a/docs/resources/csv.md.erb
+++ b/docs/resources/csv.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the csv Resource
+platform: os
 ---
 
 # csv
@@ -48,6 +49,6 @@ The `name` property tests the value of `name` as read from a CSV file compared t
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 

--- a/docs/resources/dh_params.md.erb
+++ b/docs/resources/dh_params.md.erb
@@ -1,5 +1,6 @@
 ---
 title: The dh_params Resource
+platform: linux
 ---
 
 # dh_params
@@ -198,7 +199,7 @@ Verify via `openssl dhparam` command:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### valid?
 

--- a/docs/resources/directory.md.erb
+++ b/docs/resources/directory.md.erb
@@ -1,10 +1,11 @@
 ---
 title: About the directory Resource
+platform: os
 ---
 
 # directory
 
-Use the `directory` InSpec audit resource to test if the file type is a directory. This is equivalent to using the `file` resource and the `be_directory` matcher, but provides a simpler and more direct way to test directories. 
+Use the `directory` InSpec audit resource to test if the file type is a directory. This is equivalent to using the `file` resource and the `be_directory` matcher, but provides a simpler and more direct way to test directories.
 
 <br>
 

--- a/docs/resources/docker.md.erb
+++ b/docs/resources/docker.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the docker Resource
+platform: linux
 ---
 
 # docker
@@ -109,7 +110,7 @@ Or execute the profile directly via URL:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### containers
 

--- a/docs/resources/docker_container.md.erb
+++ b/docs/resources/docker_container.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the docker_container Resource
+platform: linux
 ---
 
 # docker_container
@@ -23,7 +24,7 @@ A `docker_container` resource block declares the configuration data to be tested
       its('command') { should eq 'nc -ll -p 1234 -e /bin/cat' }
     end
 
-## Resource Parameter Examples 
+## Resource Parameter Examples
 
 ### name
 
@@ -97,5 +98,5 @@ The `command` property tests the value of the container run command:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 

--- a/docs/resources/docker_image.md.erb
+++ b/docs/resources/docker_image.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the docker_image Resource
+platform: linux
 ---
 
 # docker_image
@@ -83,7 +84,7 @@ The `tag` property tests the value of image tag:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exist
 

--- a/docs/resources/docker_service.md.erb
+++ b/docs/resources/docker_service.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the docker_service Resource
+platform: linux
 ---
 
 # docker_service
@@ -102,7 +103,7 @@ The `tag` property tests the value of image tag:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exist
 

--- a/docs/resources/elasticsearch.md.erb
+++ b/docs/resources/elasticsearch.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the Elasticsearch Resource
+platform: linux
 ---
 
 # elasticsearch

--- a/docs/resources/etc_fstab.md.erb
+++ b/docs/resources/etc_fstab.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the etc_fstab Resource
+platform: linux
 ---
 
 # etc_fstab

--- a/docs/resources/etc_group.md.erb
+++ b/docs/resources/etc_group.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the etc_group Resource
+platform: linux
 ---
 
 # etc_group
@@ -70,5 +71,5 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 

--- a/docs/resources/etc_hosts.md.erb
+++ b/docs/resources/etc_hosts.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the etc_hosts Resource
+platform: linux
 ---
 
 # etc_hosts
@@ -72,4 +73,4 @@ where
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/docs/resources/etc_hosts_allow.md.erb
+++ b/docs/resources/etc_hosts_allow.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the etc_hosts_allow Resource
+platform: linux
 ---
 
 # etc\_hosts\_allow

--- a/docs/resources/etc_hosts_deny.md.erb
+++ b/docs/resources/etc_hosts_deny.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the etc_hosts_deny Resource
+platform: linux
 ---
 
 # etc\_hosts\_deny

--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the file Resource
+platform: os
 ---
 
 # file
@@ -28,9 +29,9 @@ where
 
 ### General Properties
 
-content, size, basename, path, owner, group, type 
+content, size, basename, path, owner, group, type
 
-### Unix/Linux Properties 
+### Unix/Linux Properties
 
 symlink, mode, link_path, mtime, size, selinux\_label, md5sum, sha256sum, path, source, source\_path, uid, gid
 
@@ -325,7 +326,7 @@ For example, for the following symlink:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be\_allowed
 

--- a/docs/resources/filesystem.md.erb
+++ b/docs/resources/filesystem.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the filesystem Resource
+platform: linux
 ---
 
 # filesystem

--- a/docs/resources/firewalld.md.erb
+++ b/docs/resources/firewalld.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the firewalld Resource
+platform: linux
 ---
 
 # firewalld
@@ -26,7 +27,7 @@ Use the where clause to test open interfaces, sources, and services in active zo
       its('sources') { should cmp ['192.168.1.0/24', '192.168.1.2'] }
       its('services') { should cmp ['ssh', 'icmp'] }
     end
-    
+
 <br>
 
 ## Properties
@@ -65,7 +66,7 @@ The `default_zone` property displays the default active zone to be used.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### `be_installed`
 

--- a/docs/resources/gem.md.erb
+++ b/docs/resources/gem.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the gem Resource
+platform: os
 ---
 
 # gem
@@ -63,7 +64,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_installed
 

--- a/docs/resources/group.md.erb
+++ b/docs/resources/group.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the group Resource
+platform: os
 ---
 
 # group
@@ -39,7 +40,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_local
 

--- a/docs/resources/grub_conf.md.erb
+++ b/docs/resources/grub_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the grub_conf Resource
+platform: linux
 ---
 
 # grub_conf

--- a/docs/resources/host.md.erb
+++ b/docs/resources/host.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the host Resource
+platform: os
 ---
 
 # host
@@ -56,7 +57,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_reachable
 

--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the http Resource
+platform: linux
 ---
 
 # http

--- a/docs/resources/iis_app.md.erb
+++ b/docs/resources/iis_app.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the iis_app Resource
+platform: windows
 ---
 
 # iis_app
@@ -71,7 +72,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exist
 

--- a/docs/resources/iis_site.md.erb
+++ b/docs/resources/iis_site.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the iis_site Resource
+platform: windows
 ---
 
 # iis_site
@@ -69,7 +70,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_running
 

--- a/docs/resources/inetd_conf.md.erb
+++ b/docs/resources/inetd_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the inetd_conf Resource
+platform: linux
 ---
 
 # inetd_conf
@@ -89,7 +90,7 @@ then the same test will return `false` for `ftp` and the entire test will fail.
 
 ## Matchers
 
- 
+
 
 For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 

--- a/docs/resources/ini.md.erb
+++ b/docs/resources/ini.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the ini Resource
+platform: os
 ---
 
 # ini
@@ -45,7 +46,7 @@ In the event a section or setting name has a period in it, the alternate syntax 
 <br>
 ## Properties
 
-This resource supports any of the settings listed in an INI file as properties. 
+This resource supports any of the settings listed in an INI file as properties.
 
 ## Examples
 

--- a/docs/resources/interface.md.erb
+++ b/docs/resources/interface.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the interface Resource
+platform: os
 ---
 
 # interface
@@ -41,11 +42,11 @@ The `speed` matcher tests the speed of the network interface, in MB/sec:
 
     its('speed') { should eq 1000 }
 
-<br> 
+<br>
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_up
 

--- a/docs/resources/iptables.md.erb
+++ b/docs/resources/iptables.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the iptables Resource
+platform: linux
 ---
 
 # iptables
@@ -54,7 +55,7 @@ Note that the rule specification must exactly match what's in the output of `ipt
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### have_rule
 

--- a/docs/resources/json.md.erb
+++ b/docs/resources/json.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the json Resource
+platform: os
 ---
 
 # json
@@ -52,7 +53,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### name
 

--- a/docs/resources/kernel_module.md.erb
+++ b/docs/resources/kernel_module.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the kernel_module Resource
+platform: linux
 ---
 
 # kernel_module
@@ -91,7 +92,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_loaded
 

--- a/docs/resources/kernel_parameter.md.erb
+++ b/docs/resources/kernel_parameter.md.erb
@@ -1,11 +1,12 @@
 ---
 title: About the kernel_parameter Resource
+platform: linux
 ---
 
 # kernel_parameter
 
 Use the `kernel_parameter` InSpec audit resource to test kernel parameters on Linux platforms.
- These parameters are located under `/proc/cmdline`. 
+ These parameters are located under `/proc/cmdline`.
 <br>
 
 ## Syntax
@@ -49,4 +50,4 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/docs/resources/key_rsa.md.erb
+++ b/docs/resources/key_rsa.md.erb
@@ -1,5 +1,6 @@
 ---
 title: The key_rsa Resource
+platform: os
 ---
 
 # key_rsa
@@ -63,7 +64,7 @@ The `key_length` property allows testing the number of bits in the key pair.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### public?
 

--- a/docs/resources/launchd_service.md.erb
+++ b/docs/resources/launchd_service.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the launchd_service Resource
+platform: linux
 ---
 
 # launchd_service
@@ -35,7 +36,7 @@ The path to the service manager's control may be specified for situations where 
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_enabled
 

--- a/docs/resources/limits_conf.md.erb
+++ b/docs/resources/limits_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the limits_conf Resource
+platform: linux
 ---
 
 # limits_conf
@@ -67,6 +68,6 @@ For example:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 

--- a/docs/resources/login_def.md.erb
+++ b/docs/resources/login_def.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the login_defs Resource
+platform: linux
 ---
 
 # login_defs
@@ -65,6 +66,6 @@ The `name` matcher tests the value of `name` as read from `login.defs` versus th
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 

--- a/docs/resources/mount.md.erb
+++ b/docs/resources/mount.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the mount Resource
+platform: linux
 ---
 
 # mount
@@ -41,7 +42,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_mounted
 

--- a/docs/resources/mssql_session.md.erb
+++ b/docs/resources/mssql_session.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the mssql_session Resource
+platform: windows
 ---
 
 # mssql_session

--- a/docs/resources/mysql_conf.md.erb
+++ b/docs/resources/mysql_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the mysql_conf Resource
+platform: os
 ---
 
 # mysql_conf
@@ -87,7 +88,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### setting
 

--- a/docs/resources/mysql_session.md.erb
+++ b/docs/resources/mysql_session.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the mysql_session Resource
+platform: os
 ---
 
 # mysql_session

--- a/docs/resources/nginx.md.erb
+++ b/docs/resources/nginx.md.erb
@@ -1,5 +1,6 @@
 ---
 title: The Nginx Resource
+platform: linux
 ---
 
 # nginx

--- a/docs/resources/nginx_conf.md.erb
+++ b/docs/resources/nginx_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the nginx_conf Resource
+platform: linux
 ---
 
 # nginx_conf
@@ -50,7 +51,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### http
 

--- a/docs/resources/npm.md.erb
+++ b/docs/resources/npm.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the npm Resource
+platform: os
 ---
 
 # npm
@@ -44,7 +45,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_installed
 

--- a/docs/resources/ntp_conf.md.erb
+++ b/docs/resources/ntp_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the ntp_conf Resource
+platform: linux
 ---
 
 # ntp_conf

--- a/docs/resources/oneget.md.erb
+++ b/docs/resources/oneget.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the oneget Resource
+platform: windows
 ---
 
 # oneget
@@ -37,7 +38,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_installed
 

--- a/docs/resources/oracledb_session.md.erb
+++ b/docs/resources/oracledb_session.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the oracledb_session Resource
+platform: os
 ---
 
 # oracledb_session

--- a/docs/resources/os.md.erb
+++ b/docs/resources/os.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the os Resource
+platform: os
 ---
 
 # os
@@ -52,7 +53,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ## os.family? Helpers
 

--- a/docs/resources/os_env.md.erb
+++ b/docs/resources/os_env.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the os_env Resource
+platform: os
 ---
 
 # os_env
@@ -60,7 +61,7 @@ Habitat uses the `os_env` resource to test environment variables. The environmen
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### content
 

--- a/docs/resources/package.md.erb
+++ b/docs/resources/package.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the package Resource
+platform: os
 ---
 
 # package
@@ -91,7 +92,7 @@ Memcached is an in-memory key-value store that helps improve the performance of 
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_held
 
@@ -116,4 +117,4 @@ You can also use the `cmp OPERATOR` matcher to perform comparisions using the ve
 
     its('version') { should cmp >= '7.35.0-1ubuntu3.10' }
 
-`cmp` understands version numbers using Gem::Version, and can use the operators `==, <, <=, >=, and >`.  It will compare versions by each segment, not as a string - so '7.4' is smaller than '7.30', for example.  
+`cmp` understands version numbers using Gem::Version, and can use the operators `==, <, <=, >=, and >`.  It will compare versions by each segment, not as a string - so '7.4' is smaller than '7.30', for example.

--- a/docs/resources/packages.md.erb
+++ b/docs/resources/packages.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the packages Resource
+platform: linux
 ---
 
 # packages
@@ -45,7 +46,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### statuses
 

--- a/docs/resources/parse_config.md.erb
+++ b/docs/resources/parse_config.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the parse_config Resource
+platform: os
 ---
 
 # parse_config
@@ -41,7 +42,7 @@ where each test
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### assignment_regex
 

--- a/docs/resources/parse_config_file.md.erb
+++ b/docs/resources/parse_config_file.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the parse_config_file Resource
+platform: os
 ---
 
 # parse\_config\_file
@@ -76,7 +77,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### assignment_regex
 

--- a/docs/resources/passwd.md.erb
+++ b/docs/resources/passwd.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the passwd Resource
+platform: linux
 ---
 
 # passwd
@@ -68,7 +69,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### gids
 

--- a/docs/resources/pip.md.erb
+++ b/docs/resources/pip.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the pip Resource
+platform: os
 ---
 
 # pip
@@ -51,7 +52,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_installed
 

--- a/docs/resources/port.md.erb
+++ b/docs/resources/port.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the port Resource
+platform: os
 ---
 
 # port
@@ -99,7 +100,7 @@ or:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### address
 

--- a/docs/resources/postgres_conf.md.erb
+++ b/docs/resources/postgres_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the postgres_conf Resource
+platform: os
 ---
 
 # postgres_conf
@@ -67,7 +68,7 @@ where `unix_socket_group` is set to the PostgreSQL default setting (the group to
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### setting
 

--- a/docs/resources/postgres_hba_conf.md.erb
+++ b/docs/resources/postgres_hba_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the postgres_hba_conf Resource
+platform: linux
 ---
 
 # postgres\_hba\_conf

--- a/docs/resources/postgres_ident_conf.md.erb
+++ b/docs/resources/postgres_ident_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the postgres_ident_conf Resource
+platform: linux
 ---
 
 # postgres\_ident\_conf

--- a/docs/resources/postgres_session.md.erb
+++ b/docs/resources/postgres_session.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the postgres_session Resource
+platform: os
 ---
 
 # postgres_session
@@ -59,7 +60,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### output
 

--- a/docs/resources/powershell.md.erb
+++ b/docs/resources/powershell.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the powershell Resource
+platform: windows
 ---
 
 # powershell
@@ -80,7 +81,7 @@ No newline:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exit_status
 

--- a/docs/resources/processes.md.erb
+++ b/docs/resources/processes.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the processes Resource
+platform: os
 ---
 
 # processes
@@ -98,7 +99,7 @@ Below is a mapping table to help you understand what property the unix field map
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### property_name
 

--- a/docs/resources/rabbitmq_config.md.erb
+++ b/docs/resources/rabbitmq_config.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the rabbitmq_config Resource
+platform: linux
 ---
 
 # rabbitmq_config

--- a/docs/resources/registry_key.md.erb
+++ b/docs/resources/registry_key.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the registry_key Resource
+platform: windows
 ---
 
 # registry_key
@@ -90,7 +91,7 @@ where `'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule'` is the f
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### children
 

--- a/docs/resources/runit_service.md.erb
+++ b/docs/resources/runit_service.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the runit_service Resource
+platform: linux
 ---
 
 # runit_service
@@ -35,7 +36,7 @@ The path to the service manager's control may be specified for situations where 
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_enabled
 

--- a/docs/resources/security_policy.md.erb
+++ b/docs/resources/security_policy.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the security_policy Resource
+platform: windows
 ---
 
 # security_policy
@@ -37,7 +38,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### policy_name
 

--- a/docs/resources/service.md.erb
+++ b/docs/resources/service.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the service Resource
+platform: os
 ---
 
 # service
@@ -99,7 +100,7 @@ This is also possible with `systemd_service`, `runit_service`, `sysv_service`, `
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_enabled
 

--- a/docs/resources/shadow.md.erb
+++ b/docs/resources/shadow.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the shadow Resource
+platform: linux
 ---
 
 # shadow
@@ -78,7 +79,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### count
 

--- a/docs/resources/ssh_config.md.erb
+++ b/docs/resources/ssh_config.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the ssh_config Resource
+platform: linux
 ---
 
 # ssh_config
@@ -66,7 +67,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### name
 

--- a/docs/resources/sshd_config.md.erb
+++ b/docs/resources/sshd_config.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the sshd_config Resource
+platform: linux
 ---
 
 # sshd_config
@@ -69,7 +70,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### name
 

--- a/docs/resources/ssl.md.erb
+++ b/docs/resources/ssl.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the ssl Resource
+platform: os
 ---
 
 # ssl
@@ -85,7 +86,7 @@ Or execute the profile directly via URL:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_enabled
 

--- a/docs/resources/sys_info.md.erb
+++ b/docs/resources/sys_info.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the sys_info Resource
+platform: os
 ---
 
 # sys_info
@@ -32,7 +33,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### hostname
 

--- a/docs/resources/systemd_service.md.erb
+++ b/docs/resources/systemd_service.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the systemd_service Resource
+platform: linux
 ---
 
 # systemd_service
@@ -35,7 +36,7 @@ The path to the service manager's control may be specified for situations where 
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_enabled
 

--- a/docs/resources/sysv_service.md.erb
+++ b/docs/resources/sysv_service.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the sysv_service Resource
+platform: linux
 ---
 
 # sysv_service
@@ -35,7 +36,7 @@ The path to the service manager's control may be specified for situations where 
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_enabled
 

--- a/docs/resources/upstart_service.md.erb
+++ b/docs/resources/upstart_service.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the upstart_service Resource
+platform: linux
 ---
 
 # upstart_service
@@ -35,7 +36,7 @@ The path to the service manager's control may be specified for situations where 
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_enabled
 

--- a/docs/resources/user.md.erb
+++ b/docs/resources/user.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the user Resource
+platform: os
 ---
 
 # user

--- a/docs/resources/users.md.erb
+++ b/docs/resources/users.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the users Resource
+platform: os
 ---
 
 # users
@@ -51,7 +52,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exist
 

--- a/docs/resources/vbscript.md.erb
+++ b/docs/resources/vbscript.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the vbscript Resource
+platform: windows
 ---
 
 # vbscript

--- a/docs/resources/virtualization.md.erb
+++ b/docs/resources/virtualization.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the virtualization Resource
+platform: linux
 ---
 
 # virtualization

--- a/docs/resources/windows_feature.md.erb
+++ b/docs/resources/windows_feature.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the windows_feature Resource
+platform: windows
 ---
 
 # windows_feature
@@ -37,7 +38,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_installed
 

--- a/docs/resources/windows_hotfix.md.erb
+++ b/docs/resources/windows_hotfix.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the windows_hotfix Resource
+platform: windows
 ---
 
 # windows_hotfix
@@ -43,7 +44,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_installed
 

--- a/docs/resources/windows_task.md.erb
+++ b/docs/resources/windows_task.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the windows_task Resource
+platform: windows
 ---
 
 # windows_task

--- a/docs/resources/wmi.md.erb
+++ b/docs/resources/wmi.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the wmi Resource
+platform: windows
 ---
 
 # wmi

--- a/docs/resources/x509_certificate.md.erb
+++ b/docs/resources/x509_certificate.md.erb
@@ -1,5 +1,6 @@
 ---
 title: The x509_certificate Resource
+platform: os
 ---
 
 # x509_certificate

--- a/docs/resources/xinetd_conf.md.erb
+++ b/docs/resources/xinetd_conf.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the xinetd_conf Resource
+platform: linux
 ---
 
 # xinetd_conf
@@ -90,7 +91,7 @@ All three settings can be tested in the same block as well:
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_enabed
 

--- a/docs/resources/xml.md.erb
+++ b/docs/resources/xml.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the xml Resource
+platform: os
 ---
 
 # xml
@@ -75,7 +76,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### name
 

--- a/docs/resources/yaml.md.erb
+++ b/docs/resources/yaml.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the yaml Resource
+platform: os
 ---
 
 # yaml
@@ -59,7 +60,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### name
 

--- a/docs/resources/yum.md.erb
+++ b/docs/resources/yum.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the yum Resource
+platform: linux
 ---
 
 # yum
@@ -60,7 +61,7 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/). 
+For a full list of available matchers please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be_enabled
 

--- a/docs/resources/zfs_dataset.md.erb
+++ b/docs/resources/zfs_dataset.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the zfs_dataset Resource
+platform: linux
 ---
 
 # zfs_dataset

--- a/docs/resources/zfs_pool.md.erb
+++ b/docs/resources/zfs_pool.md.erb
@@ -1,5 +1,6 @@
 ---
 title: About the zfs_pool Resource
+platform: linux
 ---
 
 # zfs_pool


### PR DESCRIPTION
This will allow for sorting of resources in the future.

This also removes trailing whitespace.