### PR TITLE
Prevent resources from loading if supports check fails

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -258,12 +258,15 @@ module Inspec
 
       return nil if arg.empty?
 
-      if arg[0].respond_to?(:resource_skipped?) && arg[0].resource_skipped?
-        return rspec_skipped_block(arg, opts, arg[0].resource_exception_message)
+      resource = arg[0]
+      # check to see if we are using a filtertable object
+      resource = arg[0].resource if arg[0].class.superclass == FilterTable::Table
+      if resource.respond_to?(:resource_skipped?) && resource.resource_skipped?
+        return rspec_skipped_block(arg, opts, resource.resource_exception_message)
       end
 
-      if arg[0].respond_to?(:resource_failed?) && arg[0].resource_failed?
-        return rspec_failed_block(arg, opts, arg[0].resource_exception_message)
+      if resource.respond_to?(:resource_failed?) && resource.resource_failed?
+        return rspec_failed_block(arg, opts, resource.resource_exception_message)
       end
 
       # If neither skipped nor failed then add the resource

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -110,6 +110,18 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     end
   end
 
+  describe 'with a profile that contains skipped resources' do
+    let(:out) { inspec('exec ' + File.join(profile_path, 'aws-profile') + ' -t azure://') }
+    let(:stdout) { out.stdout.force_encoding(Encoding::UTF_8) }
+    it 'exits with an error' do
+      stdout.must_include 'Resource Aws_iam_users is not supported on platform azure/azure_mgmt_resources-v'
+      stdout.must_include 'Resource Aws_iam_access_keys is not supported on platform azure/azure_mgmt_resources-v'
+      stdout.must_include 'Resource Aws_s3_bucket is not supported on platform azure/azure_mgmt_resources-v'
+      stdout.must_include '3 skipped'
+      out.exit_status.must_equal 101
+    end
+  end
+
   describe 'with a profile that is supported on this version of inspec' do
     let(:out) { inspec('exec ' + File.join(profile_path, 'supported_inspec') + ' --no-create-lockfile') }
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -111,12 +111,12 @@ Test Summary: 0 successful, 0 failures, 0 skipped
   end
 
   describe 'with a profile that contains skipped resources' do
-    let(:out) { inspec('exec ' + File.join(profile_path, 'aws-profile') + ' -t azure://') }
+    let(:out) { inspec('exec ' + File.join(profile_path, 'aws-profile')) }
     let(:stdout) { out.stdout.force_encoding(Encoding::UTF_8) }
     it 'exits with an error' do
-      stdout.must_include 'Resource Aws_iam_users is not supported on platform azure/azure_mgmt_resources-v'
-      stdout.must_include 'Resource Aws_iam_access_keys is not supported on platform azure/azure_mgmt_resources-v'
-      stdout.must_include 'Resource Aws_s3_bucket is not supported on platform azure/azure_mgmt_resources-v'
+      stdout.must_include 'Resource Aws_iam_users is not supported on platform'
+      stdout.must_include 'Resource Aws_iam_access_keys is not supported on platform'
+      stdout.must_include 'Resource Aws_s3_bucket is not supported on platform'
       stdout.must_include '3 skipped'
       out.exit_status.must_equal 101
     end

--- a/test/unit/mock/profiles/aws-profile/controls/aws.rb
+++ b/test/unit/mock/profiles/aws-profile/controls/aws.rb
@@ -1,0 +1,20 @@
+control "Users that have a password but do not have MFA enabled" do
+  impact 0.7
+  describe aws_iam_users.where { has_console_password and not has_mfa_enabled } do
+    it { should_not exist }
+  end
+end 
+
+control "Do not allow access keys older than 90 days" do
+  impact 1.0
+  describe aws_iam_access_keys.where { created_days_ago > 90 } do
+    it { should_not exist }
+  end
+end
+
+control "Check our demo bucket for dangerous settings" do
+  impact 1.0
+  describe aws_s3_bucket('inspec-testing-public-default.chef.io') do
+    it { should_not be_public }
+  end
+end

--- a/test/unit/mock/profiles/aws-profile/inspec.yml
+++ b/test/unit/mock/profiles/aws-profile/inspec.yml
@@ -1,0 +1,9 @@
+name: aws
+title: aws example profile
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
+copyright_email: support@chef.io
+license: Apache-2.0
+summary: Testing stub
+version: 1.0.0
+license: Apache-2.0

--- a/test/unit/plugins/resource_test.rb
+++ b/test/unit/plugins/resource_test.rb
@@ -62,7 +62,8 @@ describe Inspec::Plugins::Resource do
         { os_family: 'windows' },
         { os_family: 'unix' }
       ])
-      m.check_supports.must_be_nil
+      m.check_supports.must_equal true
+      Inspec::Resource.supports['os'] = nil
     end
 
     it 'loads a profile which supports multiple names' do
@@ -70,7 +71,8 @@ describe Inspec::Plugins::Resource do
         { os_family: 'windows', os_name: 'windows_2000'},
         { os_family: 'unix', os_name: 'ubuntu' }
       ])
-      m.check_supports.must_be_nil
+      m.check_supports.must_equal true
+      Inspec::Resource.supports['os'] = nil
     end
 
     it 'reject a profile which supports multiple families' do
@@ -78,8 +80,8 @@ describe Inspec::Plugins::Resource do
         { os_family: 'windows' },
         { os_family: 'redhat' }
       ])
-      expect = 'Resource Os is not supported on platform ubuntu/14.04.'
-      m.check_supports.must_equal expect
+      m.check_supports.must_equal false
+      Inspec::Resource.supports['os'] = nil
     end
   end
 end

--- a/test/unit/resources/filesystem_test.rb
+++ b/test/unit/resources/filesystem_test.rb
@@ -20,14 +20,12 @@ describe 'Inspec::Resources::FileSystemResource' do
   describe 'when loading filesystem in unsupported OS family' do
     it 'fails on Windows' do
       resource_fail = MockLoader.new(:windows).load_resource('filesystem', '/')
-      expect = 'Resource Filesystem is not supported on platform windows/6.2.9200.'
-      resource_fail.check_supports.must_equal expect
+      resource_fail.check_supports.must_equal false
     end
 
     it 'fails on FreeBSD (unix-like)' do
       resource_fail = MockLoader.new(:freebsd10).load_resource('filesystem', '/')
-      expect = 'Resource Filesystem is not supported on platform freebsd/10.'
-      resource_fail.check_supports.must_equal expect
+      resource_fail.check_supports.must_equal false
     end
   end
 end


### PR DESCRIPTION
This change prevents resources from initializing if we are not on a supported platform. This also fixes the issue where resource_fail/skip were not working correctly when using a where clause on a resource.

Fixes #2662 

Signed-off-by: Jared Quick <jquick@chef.io>