### PR TITLE
Fix legacy reporter output to file

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -91,11 +91,18 @@ module Inspec
       }
     end
 
-    def self.parse_reporters(opts) # rubocop:disable Metrics/AbcSize
+    def self.parse_reporters(opts) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       # merge in any legacy formats as reporter
       # this method will only be used for ad-hoc runners
       if !opts['format'].nil? && opts['reporter'].nil?
         warn '[DEPRECATED] The option --format is being is being deprecated and will be removed in inspec 3.0. Please use --reporter'
+
+        # see if we are using the legacy output to write to files
+        if opts['output']
+          opts['format'] = "#{opts['format']}:#{opts['output']}"
+          opts.delete('output')
+        end
+
         opts['reporter'] = Array(opts['format'])
         opts.delete('format')
       end

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -99,6 +99,7 @@ module Inspec
 
         # see if we are using the legacy output to write to files
         if opts['output']
+          warn '[DEPRECATED] The option \'output\' is being is being deprecated and will be removed in inspec 3.0. Please use --reporter name:path'
           opts['format'] = "#{opts['format']}:#{opts['output']}"
           opts.delete('output')
         end

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -137,12 +137,7 @@ module Inspec
     #
     # @return [nil]
     def configure_output
-      if !@conf['output'] || @conf['output'] == '-'
-        RSpec.configuration.output_stream = $stdout
-      else
-        RSpec.configuration.output_stream = @conf['output']
-      end
-
+      RSpec.configuration.output_stream = $stdout
       @formatter = RSpec.configuration.add_formatter(Inspec::Formatters::Base)
       RSpec.configuration.add_formatter(Inspec::Formatters::ShowProgress, $stderr) if @conf[:show_progress]
       set_optional_formatters

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -121,12 +121,14 @@ describe 'BaseCLI' do
     end
 
     it 'parse cli reporters with format and output' do
+      error = "[DEPRECATED] The option --format is being is being deprecated and will be removed in inspec 3.0. Please use --reporter\n"
+      error += "[DEPRECATED] The option 'output' is being is being deprecated and will be removed in inspec 3.0. Please use --reporter name:path\n"
       proc {
         opts = { 'format' => 'json', 'output' => '/tmp/inspec_out.json' }
         parsed = Inspec::BaseCLI.parse_reporters(opts)
         assert = { 'reporter' => { 'json' => { 'file' => '/tmp/inspec_out.json', 'stdout' => false }}}
         parsed.must_equal assert
-      }.must_output nil, "[DEPRECATED] The option --format is being is being deprecated and will be removed in inspec 3.0. Please use --reporter\n"   end
+      }.must_output nil, error end
     end
 
   describe 'validate_reporters' do

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -121,12 +121,13 @@ describe 'BaseCLI' do
     end
 
     it 'parse cli reporters with format and output' do
-      opts = { 'format' => 'json', 'output' => '/tmp/inspec_out.json' }
-      parsed = Inspec::BaseCLI.parse_reporters(opts)
-      assert = { 'reporter' => { 'json' => { 'file' => '/tmp/inspec_out.json', 'stdout' => false }}}
-      parsed.must_equal assert
+      proc {
+        opts = { 'format' => 'json', 'output' => '/tmp/inspec_out.json' }
+        parsed = Inspec::BaseCLI.parse_reporters(opts)
+        assert = { 'reporter' => { 'json' => { 'file' => '/tmp/inspec_out.json', 'stdout' => false }}}
+        parsed.must_equal assert
+      }.must_output nil, "[DEPRECATED] The option --format is being is being deprecated and will be removed in inspec 3.0. Please use --reporter\n"   end
     end
-  end
 
   describe 'validate_reporters' do
     it 'valid reporter' do

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -119,6 +119,13 @@ describe 'BaseCLI' do
       assert = { 'reporter' => { 'json' => { 'stdout' => true }}}
       parsed.must_equal assert
     end
+
+    it 'parse cli reporters with format and output' do
+      opts = { 'format' => 'json', 'output' => '/tmp/inspec_out.json' }
+      parsed = Inspec::BaseCLI.parse_reporters(opts)
+      assert = { 'reporter' => { 'json' => { 'file' => '/tmp/inspec_out.json', 'stdout' => false }}}
+      parsed.must_equal assert
+    end
   end
 
   describe 'validate_reporters' do


### PR DESCRIPTION
This fixes the issue with test-kitchen when trying to output the results to a file. That use to use the old rspec file writer but now it set to use the new format. 

Fixes #2656 

Signed-off-by: Jared Quick <jquick@chef.io>