### PR TITLE
Fix bundle exec calls

### DIFF
--- a/lib/bundles/inspec-supermarket/cli.rb
+++ b/lib/bundles/inspec-supermarket/cli.rb
@@ -29,12 +29,20 @@ module Supermarket
     desc 'exec PROFILE', 'execute a Supermarket profile'
     exec_options
     def exec(*tests)
+      o = opts(:exec).dup
+      diagnose(o)
+      configure_logger(o)
+
       # iterate over tests and add compliance scheme
       tests = tests.map { |t| 'supermarket://' + t }
 
-      # execute profile from inspec exec implementation
-      diagnose
-      run_tests(tests, opts)
+      runner = Inspec::Runner.new(o)
+      tests.each { |target| runner.add_target(target) }
+
+      exit runner.run
+    rescue ArgumentError, RuntimeError, Train::UserError => e
+      $stderr.puts e.message
+      exit 1
     end
 
     desc 'info PROFILE', 'display Supermarket profile details'

--- a/test/functional/inspec_supermakert_test.rb
+++ b/test/functional/inspec_supermakert_test.rb
@@ -20,6 +20,7 @@ describe 'inspec supermakert' do
 
   it 'supermarket exec' do
     out = inspec('supermarket exec dev-sec/ssh-baseline')
+    out.exit_status.wont_equal 1
     out.stderr.must_equal ''
     out.stdout.must_include 'Profile Summary'
     out.stdout.must_include 'Test Summary'

--- a/test/functional/inspec_supermakert_test.rb
+++ b/test/functional/inspec_supermakert_test.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+
+require 'functional/helper'
+
+describe 'inspec supermakert' do
+  include FunctionalHelper
+
+  it 'help' do
+    out = inspec('supermarket help')
+    out.exit_status.must_equal 0
+    out.stdout.must_include 'inspec supermarket exec PROFILE'
+  end
+
+  it 'info' do
+    out = inspec('supermarket info dev-sec/ssh-baseline')
+    out.exit_status.must_equal 0
+    out.stderr.must_equal ''
+    out.stdout.must_include "name: \e[0m  ssh-baseline"
+  end
+
+  it 'supermarket exec' do
+    out = inspec('supermarket exec dev-sec/ssh-baseline')
+    out.stderr.must_equal ''
+    out.stdout.must_include 'Profile Summary'
+    out.stdout.must_include 'Test Summary'
+  end
+end


### PR DESCRIPTION
With Inspec 2.0 we have removed parts of the CLI. This PR updates supermarket and compliance to be fully functional again.

Fixes https://github.com/chef/inspec/issues/2668

Signed-off-by: Jared Quick <jquick@chef.io>