### PR TITLE
Capture ArgumentErrors from aws.

### DIFF
--- a/lib/resource_support/aws/aws_resource_mixin.rb
+++ b/lib/resource_support/aws/aws_resource_mixin.rb
@@ -6,6 +6,10 @@ module AwsResourceMixin
     catch_aws_errors do
       fetch_from_api
     end
+  rescue ArgumentError => e
+    # continue with ArgumentError if testing
+    raise unless respond_to?(:inspec)
+    raise Inspec::Exceptions::ResourceFailed, e.message
   end
 
   # Default implementation of validate params accepts everything.

--- a/test/unit/resource_supports/aws/aws_resource_mixin_test.rb
+++ b/test/unit/resource_supports/aws/aws_resource_mixin_test.rb
@@ -1,0 +1,39 @@
+# encoding: utf-8
+# copyright: 2017, Chef Software Inc.
+
+require 'helper'
+
+describe 'AwsResourceMixin' do
+  describe 'initialize' do
+    class AwsResourceMixinError
+      include AwsResourceMixin
+      def validate_params(_resource_params)
+        raise ArgumentError, 'this param is not right'
+      end
+    end
+
+    it 'confirm ArgumentError is raised when testing' do
+      proc {
+        mixin = AwsResourceMixinError.new({})
+      }.must_raise ArgumentError
+    end
+
+    class AwsResourceMixinLive
+      include AwsResourceMixin
+      def validate_params(_resource_params)
+        raise ArgumentError, 'this param is not right'
+      end
+
+      # if inspec is defined we are a live test
+      def inspec
+        # live
+      end
+    end
+
+    it 'confirm ResourceFailed is raised when live' do
+      proc {
+        mixin = AwsResourceMixinLive.new({})
+      }.must_raise Inspec::Exceptions::ResourceFailed
+    end
+  end
+end


### PR DESCRIPTION
This PR captures ArgumentErrors from aws and converts them to ResourceFailed so we can continue testing accordingly.

Ex:
![screen shot 2018-02-16 at 4 39 00 pm](https://user-images.githubusercontent.com/574637/36330521-ecda0252-1337-11e8-859f-f721adc93446.png)

Fixes https://github.com/chef/inspec/issues/2666

Signed-off-by: Jared Quick <jquick@chef.io>