### PR TITLE
Updates README to use function instead of alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,20 +84,19 @@ gem install inspec
 
 ### Usage via Docker
 
-Download the image and define an alias for convenience:
+Download the image and define a function for convenience:
 
 ```
 docker pull chef/inspec
-alias inspec='docker run -it --rm -v $(pwd):/share chef/inspec'
+function inspec { docker run -it --rm -v $(pwd):/share chef/inspec $@; }
 ```
 
-If you call inspec from cli, it automatically mounts the current directory into the work directory. Therefore you can easily use local tests and key files. Note: Only files in the current directory are available to the container.
+If you call `inspec` from your shell, it automatically mounts the current directory into the Docker container. Therefore you can easily use local tests and key files. Note: Only files in the current directory and sub-directories are available within the container.
 
 ```
 $ ls -1
 vagrant
 test.rb
-
 
 $ inspec exec test.rb -t ssh://root@192.168.64.2:11022 -i vagrant
 ..


### PR DESCRIPTION
I really liked the inclusion of the alias for the docker run version
of installing inspec. The instructions tried to make it clear that
when you create the alias that it was for only your current directory
but it sounded more like your current working directory wherever you
were so I thought that it would be better to actually make that work.

By changing it to a function you now can delay the processing of the
$(pwd) subshell so that it will mount your current working directory
when you run it. This makes it really easy to use the InSpec CLI
and the installation this way is on par with the other ways.

Signed-off-by: Franklin Webber <franklin@chef.io>