### PR TITLE
Revert download button

### DIFF
--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -26,6 +26,9 @@ header.bg-gradient.margin-top-offset.short-bg.relative
     .box-white.shadow.z-20
       h3 What's new in InSpec 2.0?
       p See into the cloud for continuous compliance everywhere.
+      a.button.btn-lg.btn-purple.shadow-dark.z-20 href="/downloads"
+        i.fa.fa-cloud-download
+        span download inspec 2.0
       .margin-top-sm.brdr-left.large-11.medium-11
         .margin-left-sm.slide-left
           h4.t-purple cloud
@@ -47,9 +50,6 @@ header.bg-gradient.margin-top-offset.short-bg.relative
           .margin-left-sm.slide-left
             h4.t-purple Ease
             p It’s now easier to write and debug custom resources you create using InSpec Shell.
-        a.button.btn-lg.btn-purple.shadow-dark.z-20.margin-top-xs href="/downloads"
-          i.fa.fa-cloud-download
-          span download inspec 2.0
       .margin-top-xs
         a#expandBtn Show all new features
   /!  canvas elements


### PR DESCRIPTION
I don’t agree with pushing the download button down for the new features - mainly because it’s very unlikely that most users will click the “show all new features” button and now we have hid a primary CTA under secondary content