### PR TITLE
Updates the year to 2018

### DIFF
--- a/lib/bundles/inspec-init/templates/profile/controls/example.rb
+++ b/lib/bundles/inspec-init/templates/profile/controls/example.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-# copyright: 2017, The Authors
+# copyright: 2018, The Authors
 
 title 'sample section'
 


### PR DESCRIPTION
The year for the generator should match the current year.

Signed-off-by: Franklin Webber <franklin@chef.io>