### PR TITLE
Fixes the deprecation warning text for report and output.

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -95,11 +95,11 @@ module Inspec
       # merge in any legacy formats as reporter
       # this method will only be used for ad-hoc runners
       if !opts['format'].nil? && opts['reporter'].nil?
-        warn '[DEPRECATED] The option --format is being is being deprecated and will be removed in inspec 3.0. Please use --reporter'
+        warn '[DEPRECATED] The option --format is being deprecated and will be removed in inspec 3.0. Please use --reporter'
 
         # see if we are using the legacy output to write to files
         if opts['output']
-          warn '[DEPRECATED] The option \'output\' is being is being deprecated and will be removed in inspec 3.0. Please use --reporter name:path'
+          warn '[DEPRECATED] The option \'output\' is being deprecated and will be removed in inspec 3.0. Please use --reporter name:path'
           opts['format'] = "#{opts['format']}:#{opts['output']}"
           opts.delete('output')
         end

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -121,8 +121,8 @@ describe 'BaseCLI' do
     end
 
     it 'parse cli reporters with format and output' do
-      error = "[DEPRECATED] The option --format is being is being deprecated and will be removed in inspec 3.0. Please use --reporter\n"
-      error += "[DEPRECATED] The option 'output' is being is being deprecated and will be removed in inspec 3.0. Please use --reporter name:path\n"
+      error = "[DEPRECATED] The option --format is being deprecated and will be removed in inspec 3.0. Please use --reporter\n"
+      error += "[DEPRECATED] The option 'output' is being deprecated and will be removed in inspec 3.0. Please use --reporter name:path\n"
       proc {
         opts = { 'format' => 'json', 'output' => '/tmp/inspec_out.json' }
         parsed = Inspec::BaseCLI.parse_reporters(opts)


### PR DESCRIPTION
Remove an extra 'is being' from the 'is being is being'

Signed-off-by: Franklin Webber <franklin@chef.io>