### PR TITLE
Fix infrastructure code example and typo in parse_config_file reference

### DIFF
--- a/lib/resources/parse_config.rb
+++ b/lib/resources/parse_config.rb
@@ -97,7 +97,7 @@ module Inspec::Resources
 
   class PConfigFile < PConfig
     name 'parse_config_file'
-    desc 'Use the parse_config_file InSpec audit resource to test arbitrary configuration files. It works identiacal to parse_config. Instead of using a command output, this resource works with files.'
+    desc 'Use the parse_config_file InSpec resource to test arbitrary configuration files. It works identically to parse_config. Instead of using a command output, this resource works with files.'
     example "
       describe parse_config_file('/path/to/file') do
         its('setting') { should eq 1 }

--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -243,8 +243,8 @@ header.bg-gradient.margin-top-offset.short-bg.relative
                 code   its('mode') { should cmp 0644 }
                 code end
                 br
-                code describe parse_config_file('/etc/myapp.conf') do
-                code   its('port') { should cmp 8080 }
+                code describe apache_conf do
+                code   its('Listen') { should cmp 8080 }
                 code end
                 br
                 code describe port(8080) do

--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -243,7 +243,7 @@ header.bg-gradient.margin-top-offset.short-bg.relative
                 code   its('mode') { should cmp 0644 }
                 code end
                 br
-                code describe myapp.conf do
+                code describe parse_config_file('/etc/myapp.conf') do
                 code   its('port') { should cmp 8080 }
                 code end
                 br


### PR DESCRIPTION
On the website I think you meant to use `parse_config_file` in the example. I also found a typo in the help text while looking this up.