### PR TITLE
Fixes the paths for assets loading for javascript and stylesheets

### DIFF
--- a/www/source/layouts/layout.slim
+++ b/www/source/layouts/layout.slim
@@ -10,8 +10,8 @@ html
 
     title = current_page.data.title || "InSpec"
 
-    link rel='stylesheet' type='text/css' href='css/inspec_tutorial.css'
-    link rel='stylesheet' type='text/css' href='stylesheets/vendor/fontawesome.min.css'
+    link rel='stylesheet' type='text/css' href='/css/inspec_tutorial.css'
+    link rel='stylesheet' type='text/css' href='/stylesheets/vendor/fontawesome.min.css'
 
     == stylesheet_link_tag :site
 
@@ -26,11 +26,11 @@ html
 
     = partial "layouts/footer"
 
-    script src='https://s3.amazonaws.com/menumaker/menumaker.min.js'
     script src='https://buttons.github.io/buttons.js'
-    script src='scripts/inspec_tutorial.js'
-    script src='dist/inspec_tutorial.js'
-    script src='javascripts/vendor/jquery.min.js'
+    script src='/scripts/inspec_tutorial.js'
+    script src='/dist/inspec_tutorial.js'
+    script src='/javascripts/vendor/jquery.min.js'
+    script src='https://s3.amazonaws.com/menumaker/menumaker.min.js'
     div inspec-tutorial="true" class="inspec-tutorial" hidden="true"
       = "Loading"
 
@@ -125,7 +125,7 @@ html
             $(this).html($(this).html() == 'Collapse new features' ? 'Show all new features' : 'Collapse new features');
          });
       });
-      
+
       // tutorial content slider
 
       $(function() {
@@ -146,8 +146,8 @@ html
             }
          });
       });
-      
-      
+
+
 
       // scroll spy animations
 
@@ -241,11 +241,11 @@ html
           $('html, body').animate({scrollTop : 0},800);
           return false;
         });
-        
+
         // scrolling to resource sections
         $(".resources-button").click(function() {
           var dst = $(this).attr("href")
-          $(".resources-button").removeClass("btn-purple").addClass("btn-purple-o") 
+          $(".resources-button").removeClass("btn-purple").addClass("btn-purple-o")
           $(this).addClass("btn-purple").removeClass("btn-purple-o")
           $("html, body").animate({
               scrollTop: $(dst).offset().top - 105
@@ -261,7 +261,7 @@ html
           var pos = div.scrollTop();
           div.scrollTop(pos + 2);
       }, 200);
-      
+
       //Animating progress bar for header
 
       $(document).ready(function(){


### PR DESCRIPTION
When viewing a non-index page like tutorials I was getting a lot of errors:

![image](https://user-images.githubusercontent.com/244426/36409592-f6d50030-15d1-11e8-83e7-4967e2531341.png)

* The paths were relative and that was causing problems on non-index pages.
* jquery apparently needs to be loaded before the menumaker.

I can't get the demo to generate those stylesheets/javascript so I can't
verify if the `script/inspec_tutorial.js` and `dist/inspect_tutorial.js` are the
same/similar from the web as one is minified and the other is not.

Signed-off-by: Franklin Webber <franklin@chef.io>