### PR TITLE
docs: Enhance `http` resource documentation

### DIFF
--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -13,10 +13,9 @@ Use the `http` InSpec audit resource to test an http endpoint.
 
 An `http` resource block declares the configuration settings to be tested:
 
-    describe http('url', auth: {user: 'user', pass: 'test'}, params: {params}, method: 'method', headers: {headers}, data: data, open_timeout: 60, read_timeout: 60, ssl_verify: true) do
-      its('status') { should eq number }
-      its('body') { should eq 'body' }
-      its('headers.name') { should eq 'header' }
+    describe http('http://www.example.com') do
+      its('body') { should cmp 'awesome' }
+      its('status') { should cmp 200 }
     end
 
 where

--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -13,9 +13,10 @@ Use the `http` InSpec audit resource to test an http endpoint.
 
 An `http` resource block declares the configuration settings to be tested:
 
-    describe http('http://www.example.com') do
-      its('body') { should cmp 'awesome' }
-      its('status') { should cmp 200 }
+    describe http('url', auth: {user: 'user', pass: 'test'}, params: {params}, method: 'method', headers: {headers}, data: data, open_timeout: 60, read_timeout: 60, ssl_verify: true) do
+      its('status') { should eq number }
+      its('body') { should eq 'body' }
+      its('headers.name') { should eq 'header' }
     end
 
 where
@@ -32,27 +33,9 @@ where
 
 <br>
 
-## Local vs. Remote
+## Example
 
-Beginning with InSpec 1.41, you can enable the ability to have the HTTP test execute on the remote target:
-
-    describe http('http://www.example.com', enable_remote_worker: true) do
-      its('body') { should cmp 'awesome' }
-    end
-
-In InSpec 2.0, the HTTP test will automatically execute remotely whenever InSpec is testing a remote node.
-
-<br>
-
-## Properties
-
-body, headers, http_method, status,
-
-<br>
-
-## Property Examples
-
-The following examples show how to use this InSpec audit resource.
+The following examples show how to use this InSpec audit resource. An `http` resource block declares the configuration settings to be tested:
 
 ### Simple http test
 
@@ -77,6 +60,117 @@ For example, a service is listening on default http port can be tested like this
 
 <br>
 
+## Local vs. Remote
+
+Beginning with InSpec 1.41, you can enable the ability to have the HTTP test execute on the remote target:
+
+    describe http('http://www.example.com', enable_remote_worker: true) do
+      its('body') { should cmp 'awesome' }
+    end
+
+In InSpec 2.0, the HTTP test will automatically execute remotely whenever InSpec is testing a remote node.
+
+<br>
+
+## Parameters
+
+* `url`, `auth`, `params`, `method`, `headers`, `data`, `open_timeout`, `read_timeout`, `ssl_verify`
+
+## Parameter Examples
+
+### url
+
+`('url')` is the url to test.
+
+    describe http('http://localhost:8080/ping') do
+      ...
+    end
+
+### auth
+
+`auth: { user: 'user', pass: 'test' }` may be specified for basic auth request.
+
+    describe http('http://localhost:8080/ping',
+                  auth: {user: 'user', pass: 'test'}) do
+      ...
+    end
+
+### params
+
+`{params}` may be specified for http request parameters.
+
+    describe http('http://localhost:8080/ping',
+                  params: {format: 'html'}) do
+      ...
+    end
+
+### method
+
+`'method'` may be specified for http request method (default to 'GET').
+
+    describe http('http://localhost:8080/ping',
+                  method: 'POST') do
+      ...
+    end
+
+### headers 
+
+`{headers}` may be specified for http request headers.
+
+    describe http('http://localhost:8080/ping',
+                  headers: {'Content-Type' => 'application/json'}) do
+      ...
+    end
+
+### data
+
+`data` may be specified for http request body.
+
+        describe http('http://localhost:8080/ping',
+                  data: '{"data":{"a":"1","b":"five"}}') do
+          ...
+        end
+
+### open_timeout
+
+`open_timeout` may be specified for a timeout for opening connections (default to 60)
+
+    describe('http://localhost:8080/ping', 
+                  open_timeout: '90') do
+      ...
+    end
+
+### read_timeout
+
+`read_timeout` may be specified for a timeout for reading connections (default to 60)
+
+    describe('http://localhost:8080/ping', 
+                  read_timeout: '90') do
+      ...
+    end
+
+### ssl_verify
+
+`ssl_verify` may be specified to enable or disable verification of SSL certificates (default to `true`)
+
+    describe('http://localhost:8080/ping', 
+                  ssl_verify: 'true') do
+      ...
+    end
+
+
+<br>
+
+## Properties
+
+* `body`, `headers`, `http_method`, `status`,
+
+<br>
+
+## Property Examples
+
+<br>
+
 ### body
 
 The `body` matcher tests body content of http response:
@@ -98,3 +192,7 @@ Individual headers can be tested via:
 The `status` matcher tests status of the http response:
 
     its('status') { should eq 200 }
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -133,7 +133,7 @@ In InSpec 2.0, the HTTP test will automatically execute remotely whenever InSpec
 
 ### open_timeout
 
-`open_timeout` may be specified for a timeout for opening connections (default to 60)
+`open_timeout` may be specified for a timeout for opening connections (default to 60).
 
     describe('http://localhost:8080/ping', 
                   open_timeout: '90') do
@@ -142,7 +142,7 @@ In InSpec 2.0, the HTTP test will automatically execute remotely whenever InSpec
 
 ### read_timeout
 
-`read_timeout` may be specified for a timeout for reading connections (default to 60)
+`read_timeout` may be specified for a timeout for reading connections (default to 60).
 
     describe('http://localhost:8080/ping', 
                   read_timeout: '90') do
@@ -151,13 +151,12 @@ In InSpec 2.0, the HTTP test will automatically execute remotely whenever InSpec
 
 ### ssl_verify
 
-`ssl_verify` may be specified to enable or disable verification of SSL certificates (default to `true`)
+`ssl_verify` may be specified to enable or disable verification of SSL certificates (default to `true`).
 
     describe('http://localhost:8080/ping', 
                   ssl_verify: 'true') do
       ...
     end
-
 
 <br>
 
@@ -168,8 +167,6 @@ In InSpec 2.0, the HTTP test will automatically execute remotely whenever InSpec
 <br>
 
 ## Property Examples
-
-<br>
 
 ### body
 
@@ -192,6 +189,8 @@ Individual headers can be tested via:
 The `status` matcher tests status of the http response:
 
     its('status') { should eq 200 }
+
+<br>
 
 ## Matchers
 


### PR DESCRIPTION
This modifies the `http` resource documentation to use a simpler example as the first example seen by the reader.