### PR TITLE
remove release-2.0 branch from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 branches:
   only:
     - master
-    - release-2.0
 language: ruby
 cache: bundler
 dist: trusty


### PR DESCRIPTION
Now that release-2.0 has merged into master you don't need to test it anymore!
