### PR TITLE
Fixes partially indented blocks and unescaped underscores

### DIFF
--- a/docs/resources/auditd.md.erb
+++ b/docs/resources/auditd.md.erb
@@ -68,9 +68,9 @@ The where accessor can be used to filter on fields. For example:
 
 The key filter may be useful in evaluating rules with particular key values:
 
-  describe auditd.where { key == "privileged" } do
-    its('permissions') { should include ['x'] }
-  end
+    describe auditd.where { key == "privileged" } do
+      its('permissions') { should include ['x'] }
+    end
 
 <br>
 

--- a/docs/resources/aws_ec2_instance.md.erb
+++ b/docs/resources/aws_ec2_instance.md.erb
@@ -65,7 +65,7 @@ This InSpec audit resource has the following special matchers. For a full list o
 
 ### be\_pending
 
-The `be\_pending` matcher tests if the described EC2 instance state is `pending`. This indicates that an instance is provisioning. This state should be temporary.
+The `be_pending` matcher tests if the described EC2 instance state is `pending`. This indicates that an instance is provisioning. This state should be temporary.
 
     it { should be_pending }
 

--- a/docs/resources/aws_iam_policy.md.erb
+++ b/docs/resources/aws_iam_policy.md.erb
@@ -7,9 +7,9 @@ platform: aws
 
 Use the `aws_iam_policy` InSpec audit resource to test properties of a single managed AWS IAM Policy.
 
-A policy is an entity in AWS that, when attached to an identity or resource, defines their permissions. AWS evaluates these policies when a principal, such as a user, makes a request. Permissions in the policies determine if the request is allowed or denied. 
+A policy is an entity in AWS that, when attached to an identity or resource, defines their permissions. AWS evaluates these policies when a principal, such as a user, makes a request. Permissions in the policies determine if the request is allowed or denied.
 
-Each IAM Policy is uniquely identified by either its policy_name or arn.
+Each IAM Policy is uniquely identified by either its policy\_name or arn.
 
 <br>
 
@@ -142,5 +142,3 @@ The test will pass if the identified policy attached the specified role.
     describe aws_iam_policy('AWSSupportAccess') do
       it { should be_attached_to_role(ROLENAME) }
     end
-
-

--- a/docs/resources/aws_iam_role.md.erb
+++ b/docs/resources/aws_iam_role.md.erb
@@ -11,10 +11,10 @@ Use the `aws_iam_role` InSpec audit resource to test properties of a single IAM 
 
 ## Syntax
 
-  # Ensure that a certain role exists by name
-  describe aws_iam_role('my-role') do
-    it { should exist }
-  end
+    # Ensure that a certain role exists by name
+    describe aws_iam_role('my-role') do
+      it { should exist }
+    end
 
 <br>
 
@@ -24,13 +24,13 @@ Use the `aws_iam_role` InSpec audit resource to test properties of a single IAM 
 
 This resource expects a single parameter that uniquely identifies the IAM Role, the Role Name. You may pass it as a string, or as the value in a hash:
 
-  describe aws_iam_role('my-role') do
-    it { should exist }
-  end
-  # Same
-  describe aws_iam_role(role_name: 'my-role') do
-    it { should exist }
-  end
+    describe aws_iam_role('my-role') do
+      it { should exist }
+    end
+    # Same
+    describe aws_iam_role(role_name: 'my-role') do
+      it { should exist }
+    end
 
 <br>
 
@@ -52,7 +52,7 @@ This InSpec audit resource has the following special matchers. For a full list o
 
 ### exist
 
-Indicates that the Role Name provided was found. Use should_not to test for IAM Roles that should not exist.
+Indicates that the Role Name provided was found. Use `should_not` to test for IAM Roles that should not exist.
 
     describe aws_iam_role('should-be-there') do
       it { should exist }
@@ -61,5 +61,3 @@ Indicates that the Role Name provided was found. Use should_not to test for IAM 
     describe aws_iam_role('should-not-be-there') do
       it { should_not exist }
     end
-
-

--- a/docs/resources/aws_route_table.md.erb
+++ b/docs/resources/aws_route_table.md.erb
@@ -11,10 +11,10 @@ Use the `aws_route_table` InSpec audit resource to test properties of a single R
 
 ## Syntax
 
-  # Ensure that a certain route table exists by name
-  describe aws_route_table('rtb-123abcde') do
-    it { should exist }
-  end
+    # Ensure that a certain route table exists by name
+    describe aws_route_table('rtb-123abcde') do
+      it { should exist }
+    end
 
 ## Resource Parameters
 
@@ -22,13 +22,13 @@ Use the `aws_route_table` InSpec audit resource to test properties of a single R
 
 This resource expects a single parameter that uniquely identifies the Route Table. You may pass it as a string, or as the value in a hash:
 
-  describe aws_route_table('rtb-123abcde') do
-    it { should exist }
-  end
-  # Same
-  describe aws_route_table(route_table_id: 'rtb-123abcde') do
-    it { should exist }
-  end
+    describe aws_route_table('rtb-123abcde') do
+      it { should exist }
+    end
+    # Same
+    describe aws_route_table(route_table_id: 'rtb-123abcde') do
+      it { should exist }
+    end
 
 ## Matchers
 
@@ -36,7 +36,7 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 ### exist
 
-Indicates that the Route Table provided was found.  Use should_not to test for Route Tables that should not exist.
+Indicates that the Route Table provided was found.  Use `should_not` to test for Route Tables that should not exist.
 
     describe aws_route_table('should-be-there') do
       it { should exist }

--- a/docs/resources/aws_security_group.md.erb
+++ b/docs/resources/aws_security_group.md.erb
@@ -44,7 +44,7 @@ This InSpec resource accepts the following parameters, which are used to search 
 
 The Security Group ID of the Security Group. This is of the format `sg-` followed by 8 hexadecimal characters.  The ID is unique within your AWS account; using ID ensures that you will never match more than one SG. The ID is also the default resource parameter, so you may omit the hash syntax.
 
-    # Using Hash syntax 
+    # Using Hash syntax
     describe aws_security_group(id: 'sg-12345678') do
       it { should exist }
     end
@@ -79,7 +79,7 @@ A string identifying the VPC that contains the security group. Since VPCs common
 
     # This will error if there is more than the default SG
     describe aws_security_group(vpc_id: 'vpc-12345678') do
-      it { should exist }    
+      it { should exist }
     end
 
 <br>
@@ -138,15 +138,14 @@ This InSpec audit resource has the following special matchers. For a full list o
 
 ### exists
 
-The control will pass if the specified SG was found.  Use should_not if you want to verify that the specified SG does not exist.
+The control will pass if the specified SG was found.  Use `should_not` if you want to verify that the specified SG does not exist.
 
     # You will always have at least one SG, the VPC default SG
     describe aws_security_group(group_name: 'default')
       it { should exist }
-    end   
+    end
 
     # Make sure we don't have any security groups with the name 'nogood'
     describe aws_security_group(group_name: 'nogood')
       it { should_not exist }
-    end 
-
+    end

--- a/docs/resources/aws_security_groups.md.erb
+++ b/docs/resources/aws_security_groups.md.erb
@@ -54,7 +54,7 @@ A string identifying a group. Since groups are contained in VPCs, group names ar
 
 ## Properties
 
-* `entries`, `group\_ids`
+* `entries`, `group_ids`
 
 <br>
 
@@ -88,5 +88,4 @@ The control will pass if the filter returns at least one result. Use `should_not
     # You will always have at least one SG, the VPC default SG
     describe aws_security_groups
       it { should exist }
-    end   
-
+    end

--- a/docs/resources/aws_sns_topic.md.erb
+++ b/docs/resources/aws_sns_topic.md.erb
@@ -10,16 +10,16 @@ Use the `aws_sns_topic` InSpec audit resource to test properties of a single AWS
 
 ## Syntax
 
-  # Ensure that a topic exists and has at least one subscription
-  describe aws_sns_topic('arn:aws:sns:*::my-topic-name') do
-    it { should exist }
-    its('confirmed_subscription_count') { should_not be_zero }
-  end
+    # Ensure that a topic exists and has at least one subscription
+    describe aws_sns_topic('arn:aws:sns:*::my-topic-name') do
+      it { should exist }
+      its('confirmed_subscription_count') { should_not be_zero }
+    end
 
-  # You may also use has syntax to pass the ARN
-  describe aws_sns_topic(arn: 'arn:aws:sns:*::my-topic-name') do
-    it { should exist }
-  end
+    # You may also use has syntax to pass the ARN
+    describe aws_sns_topic(arn: 'arn:aws:sns:*::my-topic-name') do
+      it { should exist }
+    end
 
 ## Resource Parameters
 
@@ -27,7 +27,7 @@ Use the `aws_sns_topic` InSpec audit resource to test properties of a single AWS
 
 This resource expects a single parameter that uniquely identifes the SNS Topic, an ARN. Amazon Resource Names for SNS topics have the format `arn:aws:sns:region:account-id:topicname`.  AWS requires a fully-specified ARN for looking up an SNS topic.  The account ID and region are required.  Wildcards are not permitted.
 
-See also the (AWS documentation on ARNs)[http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html].
+See also the [AWS documentation on ARNs](http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
 
 <br>
 
@@ -50,7 +50,7 @@ This InSpec audit resource has the following special matchers. For a full list o
 
 ### exist
 
-Indicates that the ARN provided was found.  Use should_not to test for SNS topics that should not exist.
+Indicates that the ARN provided was found.  Use `should_not` to test for SNS topics that should not exist.
 
     # Expect good news
     describe aws_sns_topic('arn:aws:sns:*::good-news') do

--- a/docs/resources/crontab.md.erb
+++ b/docs/resources/crontab.md.erb
@@ -68,7 +68,8 @@ The following examples show how to use this InSpec audit resource.
 
 ## Property Examples
 
-  ### Test a special time string
+
+### Test a special time string
 
     describe crontab do
       its('minutes') { should cmp '0' }


### PR DESCRIPTION
> Using docs to build a profile, 
> when I spot a typo,
> hard time letting go,
> hard time letting go.
> I see the food chain
> dive in and drive the change
> add, commit push and pull
> make it better as I go,
> make it better as I go.

* Moved 2 space examples 2 more spaces in. Don't be shy, show the world your code the way it was meant to be seen.
* Underscores in markdown must be escaped otherwise the world goes crooked.
* Underscores in backticks cannot escape!
* `should_not` should appear with backticks. Or at least that was the standard on some pages.

Signed-off-by: Franklin Webber <franklin@chef.io>