### PR TITLE
Updated omnibus `postinst` script to symlink to appbundle created binstubs

### DIFF
--- a/ci/verify-inspec.bat
+++ b/ci/verify-inspec.bat
@@ -1,0 +1,9 @@
+@ECHO OFF
+
+REM ; Set GEM_HOME and GEM_PATH to verify our appbundle inspec shim is correctly
+REM ; removing them from the environment while launching from our embedded ruby.
+SET GEM_HOME=C:\SHOULD_NOT_EXIST
+SET GEM_PATH=C:\SHOULD_NOT_EXIST
+
+cd C:\opscode\inspec\bin
+inspec version

--- a/ci/verify-inspec.sh
+++ b/ci/verify-inspec.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -evx
+
+# Set GEM_HOME and GEM_PATH to verify our appbundle inspec shim is correctly
+# removing them from the environment while launching from our embedded ruby.
+export GEM_HOME=/SHOULD_NOT_EXIST
+export GEM_PATH=/SHOULD_NOT_EXIST
+
+export PATH=$PATH:/usr/local/bin
+inspec version

--- a/omnibus/package-scripts/inspec/postinst
+++ b/omnibus/package-scripts/inspec/postinst
@@ -5,7 +5,7 @@
 #
 
 PROGNAME=`basename $0`
-INSTALLER_DIR=/opt/inspec/embedded
+INSTALLER_DIR=/opt/inspec
 CONFIG_DIR=/etc/inspec
 USAGE="usage: $0"
 


### PR DESCRIPTION
The binstubs created by rubygems, and linked to by our omnibus postinst script error when they encounter GEM_HOME or GEM_PATH set to anything outside of the `/opt/inspec/embedded` directory.

On my laptop with chruby the environment variables GEM_HOME and GEM_PATH are set when I create a new shell.  When I invoke InSpec via `/usr/local/bin/inspec` or `/opt/inspec/embedded/bin/inspec` I get the following error:

```
$ /usr/local/bin/inspec version
/opt/inspec/embedded/lib/ruby/2.4.0/rubygems.rb:271:in `find_spec_for_exe': can't find gem inspec (>= 0.a) (Gem::GemNotFoundException)
	from /opt/inspec/embedded/lib/ruby/2.4.0/rubygems.rb:299:in `activate_bin_path'
	from /usr/local/bin/inspec:23:in `<main>'
```

This error persists until I `unset GEM_HOME` and `unset GEM_PATH`.

```
$ unset GEM_PATH GEM_HOME
$ /usr/local/bin/inspec version
2.0.16
```

The inspec binstub created by appbundler correctly deals with GEM_HOME and GEM_PATH.

```
$ /opt/inspec/bin/inspec version
2.0.16
```

Because our omnibus package already uses [appbundler](https://github.com/chef/appbundler), the fix is to change our symlink to use it rather than the rubygems binstub.

This problem exists in older 1.x packaged releases as well.

Fixes https://github.com/chef/inspec/issues/2727