### PR TITLE
Fix inspec check to work with platforms

### DIFF
--- a/lib/inspec/plugins/resource.rb
+++ b/lib/inspec/plugins/resource.rb
@@ -60,12 +60,8 @@ module Inspec
           supported = true
           supported = check_supports unless @supports.nil?
           test_backend = defined?(Train::Transports::Mock::Connection) && backend.backend.class == Train::Transports::Mock::Connection
-          if test_backend
-            # do not exit out for tests
-          elsif supported == false
-            # do not run resource initalize if we are unsupported
-            return
-          end
+          # do not return if we are supported, or for tests
+          return unless supported || test_backend
 
           # call the resource initializer
           begin

--- a/test/functional/inspec_check_test.rb
+++ b/test/functional/inspec_check_test.rb
@@ -36,4 +36,18 @@ describe 'inspec check' do
       out.exit_status.must_equal 0
     end
   end
+
+  describe 'inspec check with a aws profile' do
+    it 'ignore train connection error' do
+      out = inspec('check ' + File.join(examples_path, 'profile-aws'))
+      out.exit_status.must_equal 0
+    end
+  end
+
+  describe 'inspec check with a azure profile' do
+    it 'ignore train connection error' do
+      out = inspec('check ' + File.join(examples_path, 'profile-azure'))
+      out.exit_status.must_equal 0
+    end
+  end
 end


### PR DESCRIPTION
The InSpec check command uses the mock backend which does not mock a full aws/azure api. Also some of these create methods on the fly depending on the api request. We always skip supports when loading resources for testing (mock backend) which includes inspec check. To get around this issue if we get a NotDefined raise coming from the train connection and we are in a mock backend we will capture and skip.

This allows `inspec check` to check for all its syntax issues accordingly. Without a proper api backend to hit I don't see how we can give more feedback.

Signed-off-by: Jared Quick <jquick@chef.io>