### PR TITLE
http resource: Support OPTIONS method

### DIFF
--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -137,7 +137,7 @@ module Inspec::Resources
           conn.options.timeout      = read_timeout  # open/read timeout in seconds
           conn.options.open_timeout = open_timeout  # connection open timeout in seconds
 
-          @response = conn.send(http_method.downcase) do |req|
+          @response = conn.run_request(http_method.downcase.to_sym, nil, nil, nil) do |req|
             req.body = request_body
           end
         end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -482,6 +482,7 @@ class MockLoader
       "curl -i -X GET --connect-timeout 60 --max-time 120 -H 'accept: application/json' -H 'foo: bar' 'http://www.example.com'" => cmd.call('http-remote-headers'),
       "curl -i -X GET --connect-timeout 60 --max-time 120 'http://www.example.com?a=b&c=d'" => cmd.call('http-remote-params'),
       "curl -i --head --connect-timeout 60 --max-time 120 'http://www.example.com'" => cmd.call('http-remote-head-request'),
+      "curl -i -X OPTIONS --connect-timeout 60 --max-time 120 -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: origin, x-requested-with' -H 'Origin: http://www.example.com' 'http://www.example.com'" => cmd.call('http-remote-options-request'),
 
       # elasticsearch resource
       "curl -H 'Content-Type: application/json' http://localhost:9200/_nodes" => cmd.call('elasticsearch-cluster-nodes-default'),

--- a/test/unit/mock/cmd/http-remote-options-request
+++ b/test/unit/mock/cmd/http-remote-options-request
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Length: 0
+Connection: keep-alive
+Access-Control-Allow-Origin: http://www.example.com
+Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE
+Access-Control-Max-Age: 86400

--- a/test/unit/resources/http_test.rb
+++ b/test/unit/resources/http_test.rb
@@ -65,6 +65,25 @@ describe 'Inspec::Resources::Http' do
         _(worker.body).must_equal 'params ok'
       end
     end
+
+    describe 'an OPTIONS request' do
+      let(:http_method) { 'OPTIONS' }
+      let(:opts) { { headers: { 'Access-Control-Request-Method' => 'GET',
+                                'Access-Control-Request-Headers' => 'origin, x-requested-with',
+                                'Origin' => 'http://www.example.com' } } }
+
+      it 'returns correct data' do
+        stub_request(:options, "http://www.example.com/").
+          with(:headers => {'Access-Control-Request-Headers'=>'origin, x-requested-with', 'Access-Control-Request-Method'=>'GET', 'Origin'=>'http://www.example.com'}).
+          to_return(:status => 200, :body => "", :headers => { 'mock' => 'ok', 'Access-Control-Allow-Origin' => 'http://www.example.com', 'Access-Control-Allow-Methods' => 'POST, GET, OPTIONS, DELETE', 'Access-Control-Max-Age' => '86400' })
+
+        _(worker.status).must_equal 200
+        _(worker.response_headers['mock']).must_equal 'ok'
+        _(worker.response_headers['access-control-allow-origin']).must_equal 'http://www.example.com'
+        _(worker.response_headers['access-control-allow-methods']).must_equal 'POST, GET, OPTIONS, DELETE'
+        _(worker.response_headers['access-control-max-age']).must_equal '86400'
+      end
+    end
   end
 
   describe 'Inspec::Resource::Http::Worker::Remote' do
@@ -125,6 +144,20 @@ describe 'Inspec::Resources::Http' do
       it 'returns correct data' do
         _(worker.status).must_equal 301
         _(worker.response_headers['Location']).must_equal 'http://www.google.com/'
+      end
+    end
+
+    describe 'an OPTIONS request' do
+      let(:http_method) { 'OPTIONS' }
+      let(:opts) { { headers: { 'Access-Control-Request-Method' => 'GET',
+                                'Access-Control-Request-Headers' => 'origin, x-requested-with',
+                                'Origin' => 'http://www.example.com' } } }
+
+      it 'returns correct data' do
+        _(worker.status).must_equal 200
+        _(worker.response_headers['Access-Control-Allow-Origin']).must_equal 'http://www.example.com'
+        _(worker.response_headers['Access-Control-Allow-Methods']).must_equal 'POST, GET, OPTIONS, DELETE'
+        _(worker.response_headers['Access-Control-Max-Age']).must_equal '86400'
       end
     end
   end


### PR DESCRIPTION
This patchset adds support for the HTTP OPTIONS method by using `run_request` since Faraday does not support an `options` method.
See https://github.com/lostisland/faraday/issues/305 for background.