### PR TITLE
Various small fixes/adjustments to the integration tests for AWS and Azure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ profile-1.0.0.tar.gz
 .terraform/
 terraform.tfstate*
 terraform.tfstate.backup
-
+inspec-azure.plan

--- a/test/integration/aws/default/build/ec2.tf
+++ b/test/integration/aws/default/build/ec2.tf
@@ -198,6 +198,10 @@ output "ec2_security_group_alpha_group_id" {
   value = "${aws_security_group.alpha.id}"
 }
 
+output "ec2_security_group_alpha_group_name" {
+  value = "${aws_security_group.alpha.name}"
+}
+
 #============================================================#
 #                      VPC Subnets
 #============================================================#
@@ -206,12 +210,14 @@ resource "aws_subnet" "subnet_01" {
   cidr_block = "172.31.96.0/20"
 }
 
-output "ec2_default_vpc_subnet_01_id" {
-  value = "${aws_subnet.subnet_01.id}"
+# Re-output any VPC ID for subnet listings
+output "subnet_vpc_id" {
+  # Use the default VPC since it is gaurenteed
+  value = "${data.aws_vpc.default.id}"
 }
 
-output "ec2_security_group_alpha_group_name" {
-  value = "${aws_security_group.alpha.name}"
+output "subnet_01_id" {
+  value = "${aws_subnet.subnet_01.id}"
 }
 
 output "subnet_01_az" {

--- a/test/integration/aws/default/build/ec2.tf
+++ b/test/integration/aws/default/build/ec2.tf
@@ -213,3 +213,7 @@ output "ec2_default_vpc_subnet_01_id" {
 output "ec2_security_group_alpha_group_name" {
   value = "${aws_security_group.alpha.name}"
 }
+
+output "subnet_01_az" {
+  value = "${aws_subnet.subnet_01.availability_zone}"
+}

--- a/test/integration/aws/default/verify/controls/aws_iam_user.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_user.rb
@@ -14,33 +14,38 @@ fixtures = {}
 end
 
 #-------------------  Recall / Miss -------------------#
-describe aws_iam_user(username: fixtures['iam_user_recall_hit']) do
-  it { should exist }
-end
-
-describe aws_iam_user(username: fixtures['iam_user_recall_miss']) do
-  it { should_not exist }
-end
-
-#------------- Property - has_mfa_enabled -------------#
-
-# TODO: fixture and test for has_mfa_enabled
-
-describe aws_iam_user(username: fixtures['iam_user_no_mfa_enabled']) do
-  it { should_not have_mfa_enabled }
-  it { should_not have_console_password } # TODO: this is working by accident, we should have a dedicated fixture
-end
-
-#---------- Property - has_console_password -----------#
-
-describe aws_iam_user(username: fixtures['iam_user_has_console_password']) do
-  it { should have_console_password }
-end
-
-#------------- Property - access_keys -------------#
-
-aws_iam_user(username: fixtures['iam_user_with_access_key']).access_keys.each { |access_key|
-  describe access_key do
-   its('status') { should eq 'Active' }
+control "aws_iam_user recall" do
+  describe aws_iam_user(username: fixtures['iam_user_recall_hit']) do
+    it { should exist }
   end
-}
+
+  describe aws_iam_user(username: fixtures['iam_user_recall_miss']) do
+    it { should_not exist }
+  end
+end
+
+control "aws_iam_user properties" do
+  #------------- Property - has_mfa_enabled -------------#
+
+  # TODO: fixture and test for has_mfa_enabled
+
+  describe aws_iam_user(username: fixtures['iam_user_no_mfa_enabled']) do
+    it { should_not have_mfa_enabled }
+    it { should_not have_console_password } # TODO: this is working by accident, we should have a dedicated fixture
+  end
+
+  #---------- Property - has_console_password -----------#
+
+  describe aws_iam_user(username: fixtures['iam_user_has_console_password']) do
+    it { should have_console_password }
+  end
+
+  #------------- Property - access_keys -------------#
+
+  aws_iam_user(username: fixtures['iam_user_with_access_key']).access_keys.each { |access_key|
+    describe access_key.access_key_id do
+      subject { access_key }
+     its('status') { should eq 'Active' }
+    end
+  }
+end

--- a/test/integration/aws/default/verify/controls/aws_iam_users.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_users.rb
@@ -1,4 +1,7 @@
-describe aws_iam_users.where(has_console_password?: true)
-                      .where(has_mfa_enabled?: false) do
-  it { should exist }
+
+control "aws_iam_users filtering" do
+  describe aws_iam_users.where(has_console_password?: true)
+                        .where(has_mfa_enabled?: false) do
+    it { should exist }
+  end
 end

--- a/test/integration/aws/default/verify/controls/aws_subnet.rb
+++ b/test/integration/aws/default/verify/controls/aws_subnet.rb
@@ -2,6 +2,7 @@ fixtures = {}
 [
   'ec2_security_group_default_vpc_id',
   'ec2_default_vpc_subnet_01_id',
+  'subnet_01_az',
 ].each do |fixture_name|
   fixtures[fixture_name] = attribute(
     fixture_name,
@@ -32,7 +33,7 @@ control "aws_subnet properties of subnet_01" do
     its('subnet_id') { should eq fixtures['ec2_default_vpc_subnet_01_id'] }
     its('cidr_block') { should eq '172.31.96.0/20' }
     its('available_ip_address_count') { should eq 4091 }
-    its('availability_zone') { should eq 'us-east-1c' }
+    its('availability_zone') { should eq fixtures['subnet_01_az'] }
     its('ipv_6_cidr_block_association_set') { should eq [] }
   end
 end

--- a/test/integration/aws/default/verify/controls/aws_subnets.rb
+++ b/test/integration/aws/default/verify/controls/aws_subnets.rb
@@ -1,7 +1,7 @@
 fixtures = {}
 [
-  'ec2_security_group_default_vpc_id',
-  'ec2_default_vpc_subnet_id',
+  'subnet_01_id',
+  'subnet_vpc_id',
 ].each do |fixture_name|
   fixtures[fixture_name] = attribute(
     fixture_name,
@@ -14,12 +14,12 @@ control "aws_subnets recall" do
   all_subnets = aws_subnets
   
   # You should be able to get a specific subnet given its id
-  describe all_subnets.where(subnet_id: fixtures['ec2_default_vpc_subnet_id']) do
+  describe all_subnets.where(subnet_id: fixtures['subnet_01_id']) do
     it { should exist }
   end
 
   # You should be able to get subnets given a vpc_id
-  describe all_subnets.where(vpc_id: fixtures['ec2_security_group_default_vpc_id']) do
+  describe all_subnets.where(vpc_id: fixtures['subnet_vpc_id']) do
     it { should exist }
   end
 
@@ -32,17 +32,17 @@ control "aws_subnets recall" do
   end
 end
 
-control "aws_subnets properties of default VPC subnet" do
+control "aws_subnets properties by subnet id" do
   # you should be able to test the cidr_block of a subnet
-  describe aws_subnets.where(subnet_id: fixtures['ec2_default_vpc_subnet_id']) do
+  describe aws_subnets.where(subnet_id: fixtures['subnet_01_id']) do
     its('cidr_blocks') { should include '172.31.96.0/20' }
     its('states') { should_not include 'pending' }
   end
 end
 
-control "aws_subnets properties of default VPC" do
+control "aws_subnets properties by vpc_id" do
   # you should be able to test the cidr_block of a subnet
-  describe aws_subnets.where(vpc_id: fixtures['ec2_security_group_default_vpc_id']) do
+  describe aws_subnets.where(vpc_id: fixtures['subnet_vpc_id']) do
     its('cidr_blocks') { should include '172.31.96.0/20' }
     its('states') { should include 'available' }
   end

--- a/test/integration/azure/build/azure.tf
+++ b/test/integration/azure/build/azure.tf
@@ -15,6 +15,11 @@ variable "location" {
   default = "West Europe"
 }
 
+# Output the sub ID so the fixture system has something to chew on
+output "subscription_id" {
+  value = "${var.subscription_id}"
+}
+
 # Configure the Azure RM provider
 provider "azurerm" {
   subscription_id = "${var.subscription_id}"


### PR DESCRIPTION
A few simple changes to the integration tests for Azure and AWS, to make them easier to work with and keep them passing.

- Modifies the Azure task list to allow setting up and tearing down the Terraform-driven infrastructure separately from the actual integration tests.  This allows faster development, since you can cleanly re-run the tests.  It is also more closely aligned to the AWS integration testing approach.
- Fixes #2578 by placing `aws_iam_user` and `aws_iam_users` tests inside a control.
- Fixes https://github.com/chef/inspec-aws/issues/229 by parameterizing the AWS region and updating the name of a fixture.
