### PR TITLE
Ensure we have a proper exit code and report data for ad-hoc runners

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -129,8 +129,9 @@ module Inspec
     end
 
     def run_tests(with = nil)
-      run_data = @test_collector.run(with)
-      render_output(run_data)
+      @run_data = @test_collector.run(with)
+      # dont output anything if we want a report
+      render_output(@run_data) unless @conf['report']
       @test_collector.exit_code
     end
 

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -82,6 +82,7 @@ module Inspec
     #
     # @return [int] exit code
     def exit_code
+      return @rspec_exit_code if @formatter.results.empty?
       stats = @formatter.results[:statistics][:controls]
       if stats[:failed][:total] == 0 && stats[:skipped][:total] == 0
         0

--- a/test/functional/inspec_report_test.rb
+++ b/test/functional/inspec_report_test.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+
+require 'functional/helper'
+
+describe 'inspec report tests' do
+  include FunctionalHelper
+
+  describe 'report' do
+    it 'loads a json report' do
+      o = { 'reporter' => ['json'], 'report' => true }
+      runner = ::Inspec::Runner.new(o)
+      runner.add_target(example_profile)
+      runner.run
+      runner.report.count.must_equal 4
+      runner.report.inspect.must_include ':title=>"InSpec Example Profile"'
+      runner.report.inspect.must_include ':status=>"passed"'
+    end
+
+    # Due to the way we require/use rspec, you can only run one runner.
+    # You have to reload rspec to run another.
+  end
+end


### PR DESCRIPTION
This PR confirms we have the proper @run_data for a ad-hoc report call. It also ensures we pass the rspec error code back if no data was returned.

Signed-off-by: Jared Quick <jquick@chef.io>