### PR TITLE
mssql_session -  Handling cases where the data is nil

### DIFF
--- a/lib/utils/database_helpers.rb
+++ b/lib/utils/database_helpers.rb
@@ -10,7 +10,7 @@ module DatabaseHelper
     end
 
     def value
-      @row[@name.downcase]
+      @row.nil? ? '' : @row[@name.downcase]
     end
 
     def to_s

--- a/test/unit/utils/database_helpers_test.rb
+++ b/test/unit/utils/database_helpers_test.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+require 'helper'
+
+describe DatabaseHelper do
+  describe DatabaseHelper::SQLColumn do
+    def column(row = { 'test' => 'value' })
+      DatabaseHelper::SQLColumn.new(row, 'test')
+    end
+
+    it 'has a valid column value' do
+      column.value.must_equal 'value'
+    end
+
+    it 'returns empty when nil' do
+      column(nil).value.must_equal ''
+    end
+  end
+end


### PR DESCRIPTION
same o/p where the code failed:
```
inspec> sql = mssql_session()
=> MSSQL session
inspec> data = sql.query("SELECT who.name AS [Principal Name] FROM sys.server_permissions what INNER JOIN sys.server_principals who ON who.principal_id = what.grantee_principal_id WHERE what.permission_name = 'Alter any endpoint' AND who.name NOT LIKE '##MS%##' AND who.type_desc <> 'SERVER_ROLE'  ORDER BY  who.name  ;")
=> SQL ResultSet
inspec> s = data.row(0).column('Principal Name')
=> #<DatabaseHelper::SQLColumn:0x00005566f360da10 @name="Principal Name", @row=nil>
inspec> s.value
NoMethodError: undefined method `[]' for nil:NilClass
from /home/frezbo/.gem/ruby/gems/inspec-2.0.17/lib/utils/database_helpers.rb:13:in `value'
inspec> 

```