### PR TITLE
Docs: Describe support boundary between RSpec and InSpec

### DIFF
--- a/docs/inspec_and_friends.md
+++ b/docs/inspec_and_friends.md
@@ -40,13 +40,12 @@ control "sshd-11" do
 end
 ```
 
-That said, InSpec is not RSpec. InSpec does not support arbitrary RSpec features. Some key differences:
+That said, InSpec is not RSpec. Some key differences:
 
- * RSpec `describe` blocks are intended to be nested. In InSpec, `describe` 
- blocks should not be nested; instead use `control` blocks to describe a 
- higher-level grouping of tests.
- * RSpec is a tool designed for software engineers. It thus supports a very large range of matchers, to enable testing of software engineering constructs such as exceptions, Object Oriented Programming relationships, and so on. In contrast, InSpec is aimed at compliance practioners and infrastructure testers, so our focus is providing a few, well-supported, easy-to-use universal matchers, such as `cmp`.
- * RSpec is a separate project from InSpec. Its release schedule and feature set are beyond the control of the InSpec team. While you are free to use RSpec-specific features in your InSpec profiles, the InSpec team can only support those features described at [docs.inspec.io](https://docs.inspec.io).
+ * In InSpec, `describe` blocks should not be nested; instead use `control` blocks to describe a higher-level grouping of tests.
+ * The RSpec `shared_example` sonstruct is not suppoerted.  Instead, create a simple custom resource that executes repetitious tasks.
+ * InSpec is aimed at compliance practitioners and infrastructure testers, so our focus is providing a few, well-supported, easy-to-use [universal matchers](https://www.inspec.io/docs/reference/matchers/), such as `cmp`. In contrast, RSpec is a tool designed for software engineers. It thus supports a very large range of matchers, to enable testing of software engineering constructs such as exceptions, Object Oriented Programming relationships, and so on. 
+ * While InSpec uses parts of the RSpec project and codebase, it is a separate project from InSpec. Rspec's release schedule and feature set are beyond the control of the InSpec team. While it is possible to use many of the RSpec core features within InSpec profiles, InSpec can only guarantee that the features described at [docs.inspec.io](https://docs.inspec.io) will function correctly. Some RSpec core functionality may be removed in future versions of InSpec as needed to ensure stability in the InSpec project.
 
 ## Serverspec
 

--- a/docs/inspec_and_friends.md
+++ b/docs/inspec_and_friends.md
@@ -9,7 +9,7 @@ relate to each other.
 
 ## RSpec
 
-RSpec is an awesome framework that is widely used by software engineer to test
+RSpec is an awesome framework that is widely used by software engineers to test
 Ruby code. It enables test-driven development (TDD) and helps developers to write
 better code every day.
 
@@ -40,13 +40,13 @@ control "sshd-11" do
 end
 ```
 
-That said, InSpec is not RSpec.  InSpec does not support arbitrary RSpec features.  Some key differences:
+That said, InSpec is not RSpec. InSpec does not support arbitrary RSpec features. Some key differences:
 
- * RSpec `describe` blocks are intended to be nested.  In InSpec, `describe` 
+ * RSpec `describe` blocks are intended to be nested. In InSpec, `describe` 
  blocks should not be nested; instead use `control` blocks to describe a 
  higher-level grouping of tests.
- * RSpec is a tool designed for software engineers.  It thus supports a very large range of matchers, to enable testing of software engineering constructs such as exceptions, Object Oriented Programming relationships, and so on.  In contrast, InSpec is aimed at compliance practioners and infrastructure testers, so our focus is providing a few, well-supported, easy-to-use universal matchers, such as `cmp`.
- * RSpec is a separate project from InSpec.  Its release schedule and feature set are beyond the control of the InSpec team.  While you are free to use RSpec-specific features in your InSpec profiles, the InSpec team can only support those features described at [docs.inspec.io](https://docs.inspec.io).
+ * RSpec is a tool designed for software engineers. It thus supports a very large range of matchers, to enable testing of software engineering constructs such as exceptions, Object Oriented Programming relationships, and so on. In contrast, InSpec is aimed at compliance practioners and infrastructure testers, so our focus is providing a few, well-supported, easy-to-use universal matchers, such as `cmp`.
+ * RSpec is a separate project from InSpec. Its release schedule and feature set are beyond the control of the InSpec team. While you are free to use RSpec-specific features in your InSpec profiles, the InSpec team can only support those features described at [docs.inspec.io](https://docs.inspec.io).
 
 ## Serverspec
 

--- a/docs/inspec_and_friends.md
+++ b/docs/inspec_and_friends.md
@@ -9,8 +9,8 @@ relate to each other.
 
 ## RSpec
 
-RSpec is an awesome framework that is widely used to test Ruby code. It
-enables test-driven development (TDD) and helps developers to write
+RSpec is an awesome framework that is widely used by software engineer to test
+Ruby code. It enables test-driven development (TDD) and helps developers to write
 better code every day.
 
 InSpec is built on top of RSpec and uses it as the underlying foundation
@@ -39,6 +39,14 @@ control "sshd-11" do
   end
 end
 ```
+
+That said, InSpec is not RSpec.  InSpec does not support arbitrary RSpec features.  Some key differences:
+
+ * RSpec `describe` blocks are intended to be nested.  In InSpec, `describe` 
+ blocks should not be nested; instead use `control` blocks to describe a 
+ higher-level grouping of tests.
+ * RSpec is a tool designed for software engineers.  It thus supports a very large range of matchers, to enable testing of software engineering constructs such as exceptions, Object Oriented Programming relationships, and so on.  In contrast, InSpec is aimed at compliance practioners and infrastructure testers, so our focus is providing a few, well-supported, easy-to-use universal matchers, such as `cmp`.
+ * RSpec is a separate project from InSpec.  Its release schedule and feature set are beyond the control of the InSpec team.  While you are free to use RSpec-specific features in your InSpec profiles, the InSpec team can only support those features described at [docs.inspec.io](https://docs.inspec.io).
 
 ## Serverspec
 

--- a/docs/inspec_and_friends.md
+++ b/docs/inspec_and_friends.md
@@ -43,7 +43,7 @@ end
 That said, InSpec is not RSpec. Some key differences:
 
  * In InSpec, `describe` blocks should not be nested; instead use `control` blocks to describe a higher-level grouping of tests.
- * The RSpec `shared_example` sonstruct is not suppoerted.  Instead, create a simple custom resource that executes repetitious tasks.
+ * The RSpec `shared_example` construct is not supported.  Instead, create a simple custom resource that executes repetitious tasks.
  * InSpec is aimed at compliance practitioners and infrastructure testers, so our focus is providing a few, well-supported, easy-to-use [universal matchers](https://www.inspec.io/docs/reference/matchers/), such as `cmp`. In contrast, RSpec is a tool designed for software engineers. It thus supports a very large range of matchers, to enable testing of software engineering constructs such as exceptions, Object Oriented Programming relationships, and so on. 
  * While InSpec uses parts of the RSpec project and codebase, it is a separate project from InSpec. Rspec's release schedule and feature set are beyond the control of the InSpec team. While it is possible to use many of the RSpec core features within InSpec profiles, InSpec can only guarantee that the features described at [docs.inspec.io](https://docs.inspec.io) will function correctly. Some RSpec core functionality may be removed in future versions of InSpec as needed to ensure stability in the InSpec project.
 


### PR DESCRIPTION
This adds a bullet list to the "InSpec and Friends" document, describing the differences between InSpec and RSpec, and laying out a support boundary (taking docs.inspec.io as the support surface).

My first draft of this generally aligns with my understanding of the team's perspective, though any over-bluntness / misperceptions are my own.  Feedback very welcome.