### PR TITLE
Docs: Clarify Matchers page to speak about Universal matchers

### DIFF
--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -4,9 +4,9 @@ title: InSpec Universal Matchers Reference
 
 # InSpec Universal Matchers Reference
 
-Inspec uses matchers to help compare resource values to expectations.  Matchers may be dedicated to a specific resource (such as the `aws_iam_root_user` resource's [`have_mfa_enabled`](https://www.inspec.io/docs/reference/resources/aws_iam_root_user/#have_mfa_enabled) matcher).  If a matcher may be used on any resource type, it is _universal_.
+InSpec uses matchers to help compare resource values to expectations. Matchers may be dedicated to a specific resource (such as the `aws_iam_root_user` resource's [`have_mfa_enabled`](https://www.inspec.io/docs/reference/resources/aws_iam_root_user/#have_mfa_enabled) matcher). If a matcher may be used on any resource type, it is _universal_.
 
-You may also use any matcher provided by [RSpec::Expectations](https://relishapp.com/rspec/rspec-expectations/docs), but those matchers are outside the [scope of support](https://www.inspec.io/docs/reference/inspec_and_friends/#rspec) for InSpec.
+You may also use any matcher provided by [RSpec::Expectations](https://relishapp.com/rspec/rspec-expectations/docs), but those matchers are outside of InSpec's [scope of support](https://www.inspec.io/docs/reference/inspec_and_friends/#rspec).
 
 The following InSpec-supported universal matchers are available:
 
@@ -35,7 +35,7 @@ end
 
 ## cmp
 
-Unlike `eq`, cmp is a matcher for less-restrictive comparisons. It will
+Unlike `eq`, `cmp` is a matcher for less-restrictive comparisons. It will
 try to fit the actual value to the type you are comparing it to. This is
 meant to relieve the user from having to write type-casts and
 resolutions.
@@ -119,7 +119,7 @@ describe sshd_config do
 end
 ```
 
-It fails if types don't match. Please keep this in mind, when comparing
+`eq` fails if types don't match. Please keep this in mind, when comparing
 configuration entries that are numbers:
 
 ```ruby

--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -1,11 +1,12 @@
 ---
-title: InSpec Matchers Reference
+title: InSpec Universal Matchers Reference
 ---
 
-# InSpec Matchers Reference
+# InSpec Universal Matchers Reference
 
-Inspec uses matchers to help compare resource values to expectations.
-The following matchers are available:
+Inspec uses matchers to help compare resource values to expectations.  Matchers may be dedicated to a specific resource (such as the `aws_iam_root_user` resource's [`have_mfa_enabled`](https://www.inspec.io/docs/reference/resources/aws_iam_root_user/#have_mfa_enabled) matcher).  If a matcher may be used on any resource type, it is _universal_.
+
+The following universal matchers are available:
 
 * `be`
 * `be_in`

--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -8,12 +8,12 @@ Inspec uses matchers to help compare resource values to expectations.  Matchers 
 
 The following universal matchers are available:
 
-* `be`
-* `be_in`
-* `cmp`
-* `eq`
-* `include`
-* `match`
+* [`be`](#be) - make numeric comparisons
+* [`be_in`](#be_in) - look for the property value in a list
+* [`cmp`](#cmp) - general-use equality (try this first)
+* [`eq`](#eq) - type-specific equality
+* [`include`](#include) - look for an expected value in a list-valued property
+* [`match`](#match) - look for patterns in text using regular expressions
 
 <br>
 

--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -6,7 +6,9 @@ title: InSpec Universal Matchers Reference
 
 Inspec uses matchers to help compare resource values to expectations.  Matchers may be dedicated to a specific resource (such as the `aws_iam_root_user` resource's [`have_mfa_enabled`](https://www.inspec.io/docs/reference/resources/aws_iam_root_user/#have_mfa_enabled) matcher).  If a matcher may be used on any resource type, it is _universal_.
 
-The following universal matchers are available:
+You may also use any matcher provided by [RSpec::Expectations](https://relishapp.com/rspec/rspec-expectations/docs), but those matchers are outside the [scope of support](https://www.inspec.io/docs/reference/inspec_and_friends/#rspec) for InSpec.
+
+The following InSpec-supported universal matchers are available:
 
 * [`be`](#be) - make numeric comparisons
 * [`be_in`](#be_in) - look for the property value in a list


### PR DESCRIPTION
Three small changes to the Matchers website page:

* Indicate that it refers to "universal" matchers (a term I just made up).  Just trying to clarify that you can use these on any resource, while many resources also provide specialized matchers.
* Linkify the table of contents
* Add a note that RSpec offers matchers, too, but we don't support them.  This probably needs some massaging.