### PR TITLE
Fix aws-iam-users pagination

### DIFF
--- a/test/unit/resources/aws_iam_users_test.rb
+++ b/test/unit/resources/aws_iam_users_test.rb
@@ -103,7 +103,7 @@ module Maiusb
   #       Empty - No users
   # --------------------------------
   class Empty < AwsBackendBase
-    def list_users
+    def list_users(criteria = {})
       OpenStruct.new({
         users: []
       })
@@ -128,7 +128,7 @@ module Maiusb
   # Carol has a password and MFA device
   class Basic < AwsBackendBase
     # arn, path, user_id omitted
-    def list_users
+    def list_users(criteria = {})
       OpenStruct.new({
         users: [
           OpenStruct.new({


### PR DESCRIPTION
PROBLEM: aws-iam-users resource only retrieves 100 records due to pagination
in the AWS IAM list_users function.

FIX: Iterate over all the pages using the AWS pagination variables `marker`
and `is_truncated`

Fixes #2760 and part of #2582 (which concerns additional resources)

Signed-off-by: Richard Nixon <richard.nixon@btinternet.com>