### PR TITLE
AWS API Pagination fixes

### DIFF
--- a/lib/resources/aws/aws_iam_access_keys.rb
+++ b/lib/resources/aws/aws_iam_access_keys.rb
@@ -85,9 +85,14 @@ class AwsIamAccessKeys < Inspec.resource(1)
             # Swallow - a miss on search results should return an empty table
           end
         else
-          # TODO: pagination check and resume
-          iam_client.list_users.users.each do |info|
-            user_details[info.user_name] = info
+          pagination_opts = {}
+          loop do
+            api_result = iam_client.list_users(pagination_opts)
+            api_result.users.each do |info|
+              user_details[info.user_name] = info
+            end
+            break unless api_result.is_truncated
+            pagination_opts[:marker] = api_result.marker
           end
         end
 

--- a/lib/resources/aws/aws_iam_groups.rb
+++ b/lib/resources/aws/aws_iam_groups.rb
@@ -35,7 +35,7 @@ class AwsIamGroups < Inspec.resource(1)
       api_result = backend.list_groups(pagination_opts)
       @table += api_result.groups.map(&:to_h)
       pagination_opts = { marker: api_result.marker }
-      break unless api_result.is_truncated 
+      break unless api_result.is_truncated
     end
   end
 

--- a/lib/resources/aws/aws_iam_groups.rb
+++ b/lib/resources/aws/aws_iam_groups.rb
@@ -29,7 +29,14 @@ class AwsIamGroups < Inspec.resource(1)
 
   def fetch_from_api
     backend = BackendFactory.create(inspec_runner)
-    @table = backend.list_groups.to_h[:groups]
+    @table = []
+    pagination_opts = {}
+    loop do
+      api_result = backend.list_groups(pagination_opts)
+      @table += api_result.groups.map(&:to_h)
+      pagination_opts = { marker: api_result.marker }
+      break unless api_result.is_truncated 
+    end
   end
 
   class Backend

--- a/lib/resources/aws/aws_iam_policies.rb
+++ b/lib/resources/aws/aws_iam_policies.rb
@@ -30,7 +30,14 @@ class AwsIamPolicies < Inspec.resource(1)
 
   def fetch_from_api
     backend = BackendFactory.create(inspec_runner)
-    @table = backend.list_policies({}).to_h[:policies]
+    @table = []
+    pagination_opts = {}
+    loop do
+      api_result = backend.list_policies(pagination_opts)
+      @table += api_result.policies.map(&:to_h)
+      pagination_opts = { marker: api_result.marker }
+      break unless api_result.is_truncated
+    end
   end
 
   class Backend

--- a/lib/resources/aws/aws_kms_keys.rb
+++ b/lib/resources/aws/aws_kms_keys.rb
@@ -35,7 +35,7 @@ class AwsKmsKeys < Inspec.resource(1)
     loop do
       api_result = backend.list_keys(pagination_opts)
       @table += api_result.keys.map(&:to_h)
-      break unless api_result.truncated    
+      break unless api_result.truncated
       pagination_opts = { marker: api_result.next_marker }
     end
   end

--- a/lib/resources/aws/aws_kms_keys.rb
+++ b/lib/resources/aws/aws_kms_keys.rb
@@ -30,7 +30,14 @@ class AwsKmsKeys < Inspec.resource(1)
 
   def fetch_from_api
     backend = BackendFactory.create(inspec_runner)
-    @table = backend.list_keys({ limit: 1000 }).to_h[:keys] # max value for limit is 1000
+    @table = []
+    pagination_opts = { limit: 1000 }
+    loop do
+      api_result = backend.list_keys(pagination_opts)
+      @table += api_result.keys.map(&:to_h)
+      break unless api_result.truncated    
+      pagination_opts = { marker: api_result.next_marker }
+    end
   end
 
   class Backend


### PR DESCRIPTION
Fixes #2582 for most current resources (#2761 fixes `aws_iam_users`, and this PR fixes all others).  Uses a simple loop, sending the token back to AWS when needed.  Unit tests and integration tests are happy.  