### PR TITLE
iptables resource: Add support for other bin paths

### DIFF
--- a/lib/resources/iptables.rb
+++ b/lib/resources/iptables.rb
@@ -52,8 +52,9 @@ module Inspec::Resources
       return @iptables_cache if defined?(@iptables_cache)
 
       # construct iptables command to read all rules
+      bin = find_iptables_or_error
       table_cmd = "-t #{@table}" if @table
-      iptables_cmd = format('iptables %s -S %s', table_cmd, @chain).strip
+      iptables_cmd = format('%s %s -S %s', bin, table_cmd, @chain).strip
 
       cmd = inspec.command(iptables_cmd)
       return [] if cmd.exit_status.to_i != 0
@@ -64,6 +65,16 @@ module Inspec::Resources
 
     def to_s
       format('Iptables %s %s', @table && "table: #{@table}", @chain && "chain: #{@chain}").strip
+    end
+
+    private
+
+    def find_iptables_or_error
+      ['/usr/sbin/iptables', '/sbin/iptables', 'iptables'].each do |cmd|
+        return cmd if inspec.command(cmd).exist?
+      end
+
+      raise Inspec::Exceptions::ResourceFailed, 'Could not find `iptables`'
     end
   end
 end

--- a/lib/resources/iptables.rb
+++ b/lib/resources/iptables.rb
@@ -70,7 +70,7 @@ module Inspec::Resources
     private
 
     def find_iptables_or_error
-      ['/usr/sbin/iptables', '/sbin/iptables', 'iptables'].each do |cmd|
+      %w{/usr/sbin/iptables /sbin/iptables iptables}.each do |cmd|
         return cmd if inspec.command(cmd).exist?
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -339,7 +339,8 @@ class MockLoader
       # apt
       "find /etc/apt/ -name *.list -exec sh -c 'cat {} || echo -n' \\;" => cmd.call('etc-apt'),
       # iptables
-      'iptables  -S' => cmd.call('iptables-s'),
+      '/usr/sbin/iptables  -S' => cmd.call('iptables-s'),
+      %{bash -c 'type "/usr/sbin/iptables"'} => empty.call,
       # apache_conf
       "sh -c 'find /etc/apache2/ports.conf -type f -maxdepth 1'" => cmd.call('find-apache2-ports-conf'),
       "sh -c 'find /etc/httpd/conf.d/*.conf -type f -maxdepth 1'" => cmd.call('find-httpd-ssl-conf'),


### PR DESCRIPTION
The location of `iptables` can vary from OS to OS and it is not guaranteed it will be in the PATH based on how `sudo` + SSH works. See: https://github.com/chef/inspec/issues/450#issuecomment-317076814

This adds the most common paths and selects the first one that exists.

This fixes #2777 
