### PR TITLE
New Resource: MS Message Queue

### DIFF
--- a/lib/resources/ms_message_queue.rb
+++ b/lib/resources/ms_message_queue.rb
@@ -89,26 +89,8 @@ module Inspec::Resources
       end
     end
 
-    # If negating `#allowed?`, use this method instead. A lot may be lost serializing and deserializing the
-    # binary values, so it's best to just have PowerShell handle the comparison.
     def denied?(permission, opts = {})
-      script = allowed_wrapper(permission, opts) + "\n\n"
-      script += 'If (($mask -band $target_perm) -ne $target_perm) { Exit 98; } Else { Exit 99; }'
-
-      cmd = inspec.powershell(script)
-
-      case cmd.exit_status
-      when 98 then return true
-      when 99 then return false
-      else
-        # It should never reach here, but for debugging, this will be left in
-        obj = {
-          code: cmd.exit_status,
-          stderr: cmd.stderr,
-          stdout: cmd.stdout,
-        }
-        raise "Problem with P/Invoke: #{obj.inspect}"
-      end
+      !allowed?(permission, opts)
     end
 
     private

--- a/lib/resources/ms_message_queue.rb
+++ b/lib/resources/ms_message_queue.rb
@@ -1,0 +1,222 @@
+# encoding: utf-8
+
+require 'utils/pinvoke_wrapper'
+
+module Inspec::Resources
+  # NOTE: This resource (currently) only works with private queues on the localhost. It supports Windows 2008r2 up to 2016
+  class MicrosoftMessageQueue < Inspec.resource(1)
+    name 'ms_message_queue'
+    supports platform: 'windows'
+    desc <<-EOH
+      Provides visibility into a Microsoft Message Queue
+    EOH
+
+    example <<-EOH
+      describe ms_message_queue('.\\private$\\MyQueueHere') do
+        it { should exist }
+        its('QueueName') { should eq 'MyQueueHere' }
+        it { should be_allowed('full-control', by_user: 'MyComputerName\\MyAwesomeUser') }
+      end
+    EOH
+
+    PERMISSIONS = {
+      'full-control' => 'MQSEC_QUEUE_GENERIC_ALL',
+      'read' => 'MQSEC_QUEUE_GENERIC_READ',
+      'write' => 'MQSEC_QUEUE_GENERIC_WRITE',
+
+      'take-ownership' => 'MQSEC_TAKE_QUEUE_OWNERSHIP',
+      'delete-queue' => 'MQSEC_DELETE_QUEUE',
+      'delete-journal' => 'MQSEC_DELETE_JOURNAL_MESSAGE',
+      'peek' => 'MQSEC_PEEK_MESSAGE',
+      'read-permission' => 'MQSEC_GET_QUEUE_PERMISSIONS',
+      'change-permission' => 'MQSEC_CHANGE_QUEUE_PERMISSIONS',
+      'read-property' => 'MQSEC_GET_QUEUE_PROPERTiES',
+      'write-property' => 'MQSEC_SET_QUEUE_PROPERTIES',
+      'read-journal' => 'MQSEC_RECEIVE_JOURNAL_MESSAGE',
+      'read-message' => 'MQSEC_RECEIVE_MESSAGE',
+      'write-message' => 'MQSEC_WRITE_MESSAGE',
+      'delete-message' => 'MQSEC_DELETE_MESSAGE',
+    }.freeze
+
+    def initialize(path)
+      @path = path
+      generate_cache
+    end
+
+    def to_s
+      "Message Queue #{@path.inspect}"
+    end
+
+    def method_missing(method, *)
+      if @cache.respond_to?(:keys) && @cache.keys.include?(method.to_s.downcase)
+        return @cache[method.to_s.downcase]
+      end
+
+      super
+    end
+
+    def respond_to_missing?(method, *)
+      if @cache.respond_to?(:keys)
+        return true if @cache.keys.include?(method.to_s.downcase)
+      end
+
+      super
+    end
+
+    def exists?
+      !@cache.nil?
+    end
+
+    # If negating `#denied?`, use this method instead. A lot may be lost serializing and deserializing the
+    # binary values, so it's best to just have PowerShell handle the comparison.
+    def allowed?(permission, opts = {})
+      script = allowed_wrapper(permission, opts) + "\n\n"
+      script += 'If (($mask -band $target_perm) -eq $target_perm) { Exit 98; } Else { Exit 99; }'
+
+      cmd = inspec.powershell(script)
+
+      case cmd.exit_status
+      when 98 then return true
+      when 99 then return false
+      else
+        # It should never reach here, but for debugging, this will be left in
+        obj = {
+          code: cmd.exit_status,
+          stderr: cmd.stderr,
+          stdout: cmd.stdout,
+        }
+        raise "Problem with P/Invoke: #{obj.inspect}"
+      end
+    end
+
+    # If negating `#allowed?`, use this method instead. A lot may be lost serializing and deserializing the
+    # binary values, so it's best to just have PowerShell handle the comparison.
+    def denied?(permission, opts = {})
+      script = allowed_wrapper(permission, opts) + "\n\n"
+      script += 'If (($mask -band $target_perm) -ne $target_perm) { Exit 98; } Else { Exit 99; }'
+
+      cmd = inspec.powershell(script)
+
+      case cmd.exit_status
+      when 98 then return true
+      when 99 then return false
+      else
+        # It should never reach here, but for debugging, this will be left in
+        obj = {
+          code: cmd.exit_status,
+          stderr: cmd.stderr,
+          stdout: cmd.stdout,
+        }
+        raise "Problem with P/Invoke: #{obj.inspect}"
+      end
+    end
+
+    private
+
+    def allowed_wrapper(permission, opts)
+      user = opts.fetch(:by_user) { current_user }.gsub(/^\.\\/) { current_computer_name + '\\' }
+
+      computer_name = @path.split('\\').first
+      queue_name = @path.split('\\').tap(&:shift).join('\\').gsub(/^private\%\\/i, '')
+
+      <<-EOH
+        #{PInvokeWrapper.wrap('MSMQSecurity.cs')}
+        $path = New-Object -TypeName MSMQSecurity.QueuePath -ArgumentList '#{computer_name}','#{queue_name}'
+        $mask = [MSMQSecurity.MSMQSecurity]::GetAccessMask($path, '#{user}')
+        $target_perm = [MSMQSecurity.MQQUEUEACCESSMASK]::#{PERMISSIONS.fetch(permission)}
+      EOH
+    end
+
+    def generate_cache # rubocop:disable Metrics/MethodLength
+      script = <<-EOH
+        Add-Type -AssemblyName 'System.Messaging'
+        If (![System.Messaging.MessageQueue]::Exists("#{@path}")) { Exit 0 }
+        $queues = [System.Messaging.MessageQueue]::GetPrivateQueuesByMachine(".")
+        $out = [PSCustomObject]@{
+          AccessMode = if ($my_queue.AccessMode -eq $null) { $null } else { $my_queue.AccessMode.ToString() }
+          Authenticate = $my_queue.Authenticate
+          BasePriority = $my_queue.BasePriority
+          CanRaiseEvents = $my_queue.CanRaiseEvents
+          CanRead = $my_queue.CanRead
+          CanWrite = $my_queue.CanWrite
+          Container = $my_queue.Container
+          CreateTime = if ($my_queue.CreateTime -eq $null) { $null } else { $my_queue.CreateTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ") }
+          DefaultPropertiesToSend = [PSCustomObject]@{
+            AcknowledgeType = if ($my_queue.DefaultPropertiesToSend.AcknowledgeType -eq $null) { $null } else { $my_queue.DefaultPropertiesToSend.AcknowledgeType.ToString() }
+            AdministrationQueue = $my_queue.DefaultPropertiesToSend.AdministrationQueue
+            AppSpecific = $my_queue.DefaultPropertiesToSend.AppSpecific
+            AttachSenderId = $my_queue.DefaultPropertiesToSend.AttachSenderId
+            EncryptionAlgorithm = if ($my_queue.DefaultPropertiesToSend.EncryptionAlgorithm -eq $null) { $null } else { $my_queue.DefaultPropertiesToSend.EncryptionAlgorithm.ToString() }
+            Extension = $my_queue.DefaultPropertiesToSend.Extension
+            HashAlgorithm = if ($my_queue.DefaultPropertiesToSend.HashAlgorithm -eq $null) { $null } else { $my_queue.DefaultPropertiesToSend.HashAlgorithm.ToString() }
+            Label = $my_queue.DefaultPropertiesToSend.Label
+            Priority = if ($my_queue.DefaultPropertiesToSend.Priority -eq $null) { $null } else { $my_queue.DefaultPropertiesToSend.Priority.ToString() }
+            Recoverable = $my_queue.DefaultPropertiesToSend.Recoverable
+            ResponseQueue = $my_queue.DefaultPropertiesToSend.ResponseQueue
+            TimeToBeReceived = $my_queue.DefaultPropertiesToSend.TimeToBeReceived
+            TimeToReachQueue = $my_queue.DefaultPropertiesToSend.TimeToReachQueue
+            TransactionStatusQueue = $my_queue.DefaultPropertiesToSend.TransactionStatusQueue
+            UseAuthentication = $my_queue.DefaultPropertiesToSend.UseAuthentication
+            UseDeadLetterQueue = $my_queue.DefaultPropertiesToSend.UseDeadLetterQueue
+            UseEncryption = $my_queue.DefaultPropertiesToSend.UseEncryption
+            UseJournalQueue = $my_queue.DefaultPropertiesToSend.UseJournalQueue
+            UseTracing = $my_queue.DefaultPropertiesToSend.UseTracing
+          }
+          DenySharedReceive = $my_queue.DenySharedReceive
+          DesignMode = $my_queue.DesignMode
+          EnableConnectionCache = $my_queue.EnableConnectionCache
+          EncryptionRequired = if ($my_queue.EncryptionRequired -eq $null) { $null } else { $my_queue.EncryptionRequired.ToString() }
+          Events = $my_queue.Events
+          FormatName = $my_queue.FormatName
+          Formatter = $my_queue.Formatter
+          Id = if ($my_queue.Id -eq $null) { $null } else { $my_queue.Id.ToString() }
+          Label = $my_queue.Label
+          LastModifyTime = if ($my_queue.LastModifyTime -eq $null) { $null } else { $my_queue.LastModifyTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ") }
+          MachineName = $my_queue.MachineName
+          MaximumJournalSize = $my_queue.MaximumJournalSize
+          MaximumQueueSize = $my_queue.MaximumQueueSize
+          MessageReadPropertyFilter = $my_queue.MessageReadPropertyFilter
+          MulticastAddress = $my_queue.MulticastAddress
+          Path = $my_queue.Path
+          QueueName = $my_queue.QueueName
+          ReadHandle = $my_queue.ReadHandle
+          Site = $my_queue.Site
+          SynchronizingObject = $my_queue.SynchronizingObject
+          Transactional = $my_queue.Transactional
+          UseJournalQueue = $my_queue.UseJournalQueue
+          WriteHandle = $my_queue.WriteHandle
+        }
+        Write-Host $(ConvertTo-JSON -InputObject $out -Compress)
+      EOH
+
+      @cache = run_cmd(script)
+    end
+
+    def run_cmd(script)
+      cmd = inspec.powershell(script)
+      raise "Unexpected command exit code #{cmd.exit_status.inspect}" unless [nil, 0].include? cmd.exit_status
+      data = {}
+      out = JSON.parse(cmd.stdout)
+
+      if out.respond_to? :fetch
+        out.each do |key, value|
+          data[key.to_s.downcase] = value
+        end
+      else
+        data = out
+      end
+
+      data
+    rescue JSON::ParserError
+      nil
+    end
+
+    def current_user
+      @current_user ||= run_cmd('Write-Host $($env:UserDomain + "\" + $env:UserName | ConvertTo-JSON -Compress)').strip
+    end
+
+    def current_computer_name
+      @current_computer_name ||= inspec.powershell('Write-Host $env:COMPUTERNAME').stdout.strip
+    end
+  end
+end

--- a/lib/utils/pinvoke/MSMQSecurity.cs
+++ b/lib/utils/pinvoke/MSMQSecurity.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+
+// @see https://github.com/jlevitt/MSMQSecurity at commit b6e5946878dce4ed89ee24012cd23b17fcaaf65e
+
+namespace MSMQSecurity {
+    [Flags]
+    public enum MQQUEUEACCESSMASK {
+        MQSEC_DELETE_MESSAGE = 0x00000001,
+        MQSEC_PEEK_MESSAGE = 0x00000002,
+        MQSEC_WRITE_MESSAGE = 0x00000004,
+        MQSEC_DELETE_JOURNAL_MESSAGE = 0x00000008,
+        MQSEC_SET_QUEUE_PROPERTIES = 0x00000010,
+        MQSEC_GET_QUEUE_PROPERTIES = 0x00000020,
+        MQSEC_DELETE_QUEUE = 0x00010000,
+        MQSEC_GET_QUEUE_PERMISSIONS = 0x00020000,
+        MQSEC_CHANGE_QUEUE_PERMISSIONS = 0x00040000,
+        MQSEC_TAKE_QUEUE_OWNERSHIP = 0x00080000,
+        MQSEC_RECEIVE_MESSAGE = (MQSEC_DELETE_MESSAGE
+                               | MQSEC_PEEK_MESSAGE),
+        MQSEC_RECEIVE_JOURNAL_MESSAGE = (MQSEC_DELETE_JOURNAL_MESSAGE
+                                       | MQSEC_PEEK_MESSAGE),
+        MQSEC_QUEUE_GENERIC_READ = (MQSEC_GET_QUEUE_PROPERTIES
+                                  | MQSEC_GET_QUEUE_PERMISSIONS
+                                  | MQSEC_RECEIVE_MESSAGE
+                                  | MQSEC_RECEIVE_JOURNAL_MESSAGE),
+        MQSEC_QUEUE_GENERIC_WRITE = (MQSEC_GET_QUEUE_PROPERTIES
+                                   | MQSEC_GET_QUEUE_PERMISSIONS
+                                   | MQSEC_WRITE_MESSAGE),
+        MQSEC_QUEUE_GENERIC_ALL = (MQSEC_RECEIVE_MESSAGE
+                                 | MQSEC_RECEIVE_JOURNAL_MESSAGE
+                                 | MQSEC_WRITE_MESSAGE
+                                 | MQSEC_SET_QUEUE_PROPERTIES
+                                 | MQSEC_GET_QUEUE_PROPERTIES
+                                 | MQSEC_DELETE_QUEUE
+                                 | MQSEC_GET_QUEUE_PERMISSIONS
+                                 | MQSEC_CHANGE_QUEUE_PERMISSIONS
+                                 | MQSEC_TAKE_QUEUE_OWNERSHIP)
+    };
+
+    [Flags]
+    internal enum SecurityInformation : uint {
+        Owner = 0x00000001,
+        Group = 0x00000002,
+        Dacl = 0x00000004,
+        Sacl = 0x00000008,
+        ProtectedDacl = 0x80000000,
+        ProtectedSacl = 0x40000000,
+        UnprotectedDacl = 0x20000000,
+        UnprotectedSacl = 0x10000000
+    }
+
+    internal enum ACL_INFORMATION_CLASS {
+        AclRevisionInformation = 1,
+        AclSizeInformation
+    }
+
+    [StructLayoutAttribute(LayoutKind.Sequential)]
+    internal class SECURITY_DESCRIPTOR {
+        public byte revision;
+        public byte size;
+        public short control;
+        public IntPtr owner;
+        public IntPtr group;
+        public IntPtr sacl;
+        public IntPtr dacl;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ACL_SIZE_INFORMATION {
+        public uint AceCount;
+        public uint AclBytesInUse;
+        public uint AclBytesFree;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ACE_HEADER {
+        public byte AceType;
+        public byte AceFlags;
+        public short AceSize;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ACCESS_ALLOWED_ACE {
+        public ACE_HEADER Header;
+        public MQQUEUEACCESSMASK Mask;
+        public int SidStart;
+    }
+
+    public class QueuePath {
+        private const string QueuePathFormat = @"Direct=OS:{0}\Private$\{1}";
+
+        private string computerName;
+        private string queueName;
+
+        public QueuePath(string computerName, string queueName) {
+            this.computerName = computerName;
+            this.queueName = queueName;
+        }
+
+        public override string ToString() {
+            return string.Format(QueuePathFormat, computerName, queueName);
+        }
+    }
+
+    public class MSMQSecurity {
+        private const int OWNER_SECURITY_INFORMATION = 0x1;
+        private const int MQ_OK = 0x0;
+        private const uint MQ_ERROR_SECURITY_DESCRIPTOR_TOO_SMALL = 0xC00E0023;
+        private const uint MQ_ERROR_ILLEGAL_FORMATNAME = 0xC00E001E;
+        private const uint MQ_ERROR_ACCESS_DENIED = 0xC00E0025;
+        private const uint MQ_ERROR_NO_DS = 0xC00E0013;
+        private const uint MQ_ERROR_PRIVILEGE_NOT_HELD = 0xC00E0026;
+        private const uint MQ_ERROR_UNSUPPORTED_FORMATNAME_OPERATION = 0xC00E0020;
+        private const uint MQ_ERROR_QUEUE_NOT_FOUND = 0xC00E0003;
+
+        private static readonly Dictionary<uint, string> ErrorMessages = new Dictionary<uint, string> {
+            { MQ_ERROR_ILLEGAL_FORMATNAME, "MQ_ERROR_ILLEGAL_FORMATNAME" },
+            { MQ_ERROR_SECURITY_DESCRIPTOR_TOO_SMALL, "MQ_ERROR_SECURITY_DESCRIPTOR_TOO_SMALL" },
+            { MQ_ERROR_ACCESS_DENIED, "MQ_ERROR_ACCESS_DENIED" },
+            { MQ_ERROR_NO_DS, "MQ_ERROR_NO_DS" },
+            { MQ_ERROR_PRIVILEGE_NOT_HELD, "MQ_ERROR_PRIVILEGE_NOT_HELD" },
+            { MQ_ERROR_UNSUPPORTED_FORMATNAME_OPERATION, "MQ_ERROR_UNSUPPORTED_FORMATNAME_OPERATION" },
+            { MQ_ERROR_QUEUE_NOT_FOUND , "MQ_ERROR_QUEUE_NOT_FOUND " }
+        };
+
+        /// <summary>
+        /// Returns the access control entry flags for the given user on the given queue. Throws if
+        /// user, queue, or ACE are not found.
+        /// </summary>
+        public static MQQUEUEACCESSMASK GetAccessMask(QueuePath queuePath, string username) {
+            var sid = GetSidForUser(username);
+
+            var gcHandleSecurityDescriptor = GetSecurityDescriptorHandle(queuePath);
+            var ace = GetAce(gcHandleSecurityDescriptor.AddrOfPinnedObject(), sid);
+            var aceMask = ace.Mask;
+
+            gcHandleSecurityDescriptor.Free();
+
+            return aceMask;
+        }
+
+        private static string GetErrorMessage(uint errorCode) {
+            return ErrorMessages[errorCode];
+        }
+
+        private static string GetSidForUser(string username) {
+            var account = new NTAccount(username);
+            var sid = (SecurityIdentifier)account.Translate(typeof(SecurityIdentifier));
+
+            return sid.ToString();
+        }
+
+        private static ACCESS_ALLOWED_ACE GetAce(IntPtr pSecurityDescriptor, string sid) {
+            bool daclPresent;
+            bool daclDefaulted;
+            IntPtr pAcl = IntPtr.Zero;
+            MSMQSecurity.GetSecurityDescriptorDacl(pSecurityDescriptor, out daclPresent, ref pAcl, out daclDefaulted);
+
+            if (daclPresent) {
+                ACL_SIZE_INFORMATION AclSize = new ACL_SIZE_INFORMATION();
+                MSMQSecurity.GetAclInformation(pAcl, ref AclSize, (uint)Marshal.SizeOf(typeof(ACL_SIZE_INFORMATION)), ACL_INFORMATION_CLASS.AclSizeInformation);
+
+
+                for (int i = 0; i < AclSize.AceCount; i++) {
+                    IntPtr pAce;
+                    var err = MSMQSecurity.GetAce(pAcl, i, out pAce);
+                    ACCESS_ALLOWED_ACE ace = (ACCESS_ALLOWED_ACE)Marshal.PtrToStructure(pAce, typeof(ACCESS_ALLOWED_ACE));
+
+                    IntPtr iter = (IntPtr)((long)pAce + (long)Marshal.OffsetOf(typeof(ACCESS_ALLOWED_ACE), "SidStart"));
+                    byte[] bSID = null;
+                    int size = (int)MSMQSecurity.GetLengthSid(iter);
+                    bSID = new byte[size];
+                    Marshal.Copy(iter, bSID, 0, size);
+                    IntPtr ptrSid;
+                    MSMQSecurity.ConvertSidToStringSid(bSID, out ptrSid);
+                    string strSID = Marshal.PtrToStringAuto(ptrSid);
+
+                    if (strSID == sid) {
+                        return ace;
+                    }
+                }
+
+                throw new Exception(string.Format("No ACE for SID {0} found in security descriptor", sid));
+            }
+            else {
+                throw new Exception("No DACL found for security descriptor");
+            }
+
+        }
+
+        private static GCHandle GetSecurityDescriptorHandle(QueuePath queuePath) {
+            byte[] securityDescriptorBytes;
+            int length;
+            int lengthNeeded;
+            uint result;
+
+            string formatName = queuePath.ToString();
+
+            //Call MQGetQueueSecurity two times. The first time, set the nLength
+            //parameter to 0. The function then informs you of the size that you need for the
+            //security descriptor in lpnLengthNeeded.
+            result = MSMQSecurity.MQGetQueueSecurity(
+                      formatName
+                    , (int)SecurityInformation.Dacl
+                    , IntPtr.Zero
+                    , 0
+                    , out lengthNeeded);
+
+            if (result != MSMQSecurity.MQ_ERROR_SECURITY_DESCRIPTOR_TOO_SMALL) {
+                //Something went wrong. Display error, and then exit.
+                string message = "There was an error calling MQGetQueueSecurity."
+                    + Environment.NewLine
+                    + "Error Number:  " + result.ToString()
+                    + Environment.NewLine
+                    + "Error Message:  " + MSMQSecurity.GetErrorMessage(result);
+
+                throw new Exception(message);
+            }
+
+            //Now we know how big to make the security descriptor.
+            length = lengthNeeded;
+            securityDescriptorBytes = new byte[length];
+
+            //Get a pointer to the SD
+            IntPtr pSecurityDescriptor = new IntPtr();
+            GCHandle gcHandleSecurityDescriptor = GCHandle.Alloc(securityDescriptorBytes, GCHandleType.Pinned);
+            pSecurityDescriptor = gcHandleSecurityDescriptor.AddrOfPinnedObject();
+
+            //Call MQGetQueueSecurity
+            result = MSMQSecurity.MQGetQueueSecurity(
+                      formatName
+                    , (int)SecurityInformation.Dacl
+                    , pSecurityDescriptor
+                    , length
+                    , out lengthNeeded);
+
+            if (result != MSMQSecurity.MQ_OK) {
+                gcHandleSecurityDescriptor.Free();
+
+                //Something else went wrong. Display error, and then exit.
+                string message = "There was an error calling MQGetQueueSecurity to read the SecurityDescriptor."
+                    + Environment.NewLine
+                    + "Error Number:  " + result.ToString()
+                    + Environment.NewLine
+                    + "Error Message:  " + MSMQSecurity.GetErrorMessage(result);
+
+                throw new Exception(message);
+            }
+
+            var securityDescriptor = new SECURITY_DESCRIPTOR();
+            Marshal.PtrToStructure(pSecurityDescriptor, securityDescriptor);
+
+            return gcHandleSecurityDescriptor;
+        }
+
+        #region p/invoke definitions
+        [DllImport("mqrt.dll", SetLastError = false)]
+        private static extern uint MQGetQueueSecurity(
+            [MarshalAs(UnmanagedType.LPWStr)]string lpwcsFormatName,
+            int SecurityInformation,
+            IntPtr pSecurityDescriptor,
+            int nLength,
+            out int lpnLengthNeeded);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetSecurityDescriptorDacl(
+            IntPtr pSecurityDescriptor,
+            [MarshalAs(UnmanagedType.Bool)] out bool bDaclPresent,
+            ref IntPtr pDacl,
+            [MarshalAs(UnmanagedType.Bool)] out bool bDaclDefaulted
+            );
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetAclInformation(
+            IntPtr pAcl,
+            ref ACL_SIZE_INFORMATION pAclInformation,
+            uint nAclInformationLength,
+            ACL_INFORMATION_CLASS dwAclInformationClass
+         );
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern int GetAce(
+            IntPtr aclPtr,
+            int aceIndex,
+            out IntPtr acePtr
+         );
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern int GetLengthSid(
+            IntPtr pSID
+         );
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool ConvertSidToStringSid(
+            [MarshalAs(UnmanagedType.LPArray)] byte[] pSID,
+            out IntPtr ptrSid
+         );
+
+        [DllImport("netapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern int NetApiBufferFree(
+            IntPtr buffer
+         );
+
+        #endregion
+    }
+}

--- a/lib/utils/pinvoke_wrapper.rb
+++ b/lib/utils/pinvoke_wrapper.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+# author: David Alexander <opensource@thelonelyghost.com>
+
+class PInvokeWrapper
+  # A wrapper for use with PowerShell's P/Invoke capability
+  #
+  # @param script_name : A filename given for something that will be read into a string
+  # @param type : The type of P/Invoke syntax to use. Most common is for C# (:csharp)
+  # @return : The string value of the script wrapped in the appropriate P/Invoke syntax
+  def self.wrap(script_name, type = :csharp)
+    script_path = ::File.join(::File.dirname(__FILE__), 'pinvoke', script_name)
+    contents = ::File.read(script_path)
+    case type
+    when :csharp
+      return <<~EOH
+        $script = @'\n#{contents}'@
+        Add-Type -TypeDefinition $script
+      EOH
+    else
+      raise "Unsupported type #{type.inspect} for using with P/Invoke"
+    end
+  end
+end


### PR DESCRIPTION
This is derived from a custom resource I wrote for internal use. I did my best to convert it from being a custom resource drawing from files in a profile to being part of the inspec standard library, but I'm at a complete loss for how to best add automated tests for it. Help?

---

Here's the theory behind this implementation:

Server 2008r2 does not support any of the later MSMQ APIs exposed in later .NET versions. We need to either backport them or find a more neutral way of getting to the same information. Luckily, there was [someone else on the internet](https://github.com/jlevitt/MSMQSecurity) who had the same issue and decided to open source their solution. It was written in C# which means we can use it with PowerShell via something called P/Invoke.

This C# library calls into some really old DLLs to interact with MSMQ internals at a super low level. It converts them to C# data structures and we can manipulate them from there. That doesn't help us though. We need them in PowerShell.

Here's a deep-dive of how we're traversing the different layers:

```
Ruby (inspec) -> PowerShell -> C# -> C (dll) -> C# -> PowerShell -> Ruby (inspec)
```

Since there's a lot of serialization and deserialization with all of this, there are lower-level accessors for more sensitive checks. This inspec resource provides the `#allowed?` method for digging into binary comparison of the rights that user is allowed for the given queue, but comparing it at the PowerShell level. Same with `#denied?`.

The comparison at the PowerShell level is to reduce the number of conversions before comparing, thereby reducing the number of moving parts. The side effect of it is that we have a winrm call for each check on a user's permissions. This is not cached. This has room for improvement.

---

Yes, it's ugly. Yes, it's a nightmare to maintain. No, I don't want to maintain it long-term. It's the only solution I've found to accomplish what we need for checking MSMQ permissions.