### PR TITLE
Remove os checks from initialize

### DIFF
--- a/lib/resources/aide_conf.rb
+++ b/lib/resources/aide_conf.rb
@@ -27,7 +27,6 @@ module Inspec::Resources
     include CommentParser
 
     def initialize(aide_conf_path = nil)
-      return skip_resource 'The `aide_conf` resource is not supported on your OS.' unless inspec.os.linux?
       @conf_path = aide_conf_path || '/etc/aide.conf'
       @content = nil
       @rules = nil

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -45,7 +45,6 @@ module Inspec::Resources
         @user = opts
         @path = nil
       end
-      raise Inspec::Exceptions::ResourceSkipped, 'The `crontab` resource is not supported on your OS.' unless inspec.os.unix?
       @params = read_crontab
     end
 

--- a/lib/resources/etc_fstab.rb
+++ b/lib/resources/etc_fstab.rb
@@ -28,7 +28,6 @@ module Inspec::Resources
     include CommentParser
 
     def initialize(fstab_path = nil)
-      return skip_resource 'The `etc_fstab` resource is not supported on your OS.' unless inspec.os.linux?
       @conf_path      = fstab_path || '/etc/fstab'
       @files_contents = {}
       @content        = nil

--- a/lib/resources/etc_group.rb
+++ b/lib/resources/etc_group.rb
@@ -41,10 +41,6 @@ module Inspec::Resources
     def initialize(path = nil)
       @path = path || '/etc/group'
       @entries = parse_group(@path)
-
-      # skip resource if it is not supported on current OS
-      return skip_resource 'The `etc_group` resource is not supported on your OS.' \
-      unless inspec.os.unix?
     end
 
     def groups(filter = nil)

--- a/lib/resources/etc_hosts.rb
+++ b/lib/resources/etc_hosts.rb
@@ -4,7 +4,9 @@ require 'utils/parser'
 
 class EtcHosts < Inspec.resource(1)
   name 'etc_hosts'
-  supports platform: 'unix'
+  supports platform: 'linux'
+  supports platform: 'bsd'
+  supports platform: 'windows'
   desc 'Use the etc_hosts InSpec audit resource to find an
     ip_address and its associated hosts'
   example "
@@ -20,7 +22,6 @@ class EtcHosts < Inspec.resource(1)
   include CommentParser
 
   def initialize(hosts_path = nil)
-    return skip_resource 'The `etc_hosts` resource is not supported on your OS.' unless inspec.os.bsd? || inspec.os.linux? || inspec.os.windows?
     @conf_path      = hosts_path || default_hosts_file_path
     @content        = nil
     @params         = nil

--- a/lib/resources/etc_hosts_allow_deny.rb
+++ b/lib/resources/etc_hosts_allow_deny.rb
@@ -20,7 +20,6 @@ module Inspec::Resources
     include CommentParser
 
     def initialize(hosts_allow_path = nil)
-      return skip_resource 'The `etc_hosts_allow` resource is not supported on your OS.' unless inspec.os.linux?
       @conf_path      = hosts_allow_path || '/etc/hosts.allow'
       @content        = nil
       @params         = nil

--- a/lib/resources/firewalld.rb
+++ b/lib/resources/firewalld.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     ###
 
     name 'firewalld'
-    supports platform: 'unix'
+    supports platform: 'linux'
     desc 'Use the firewalld resource to check and see if firewalld is configured to grand or deny access to specific hosts or services'
     example "
       describe firewalld do
@@ -38,7 +38,6 @@ module Inspec::Resources
     filter.connect(self, :params)
 
     def initialize
-      return skip_resource 'The `firewalld` resource is not supported on your OS.' unless inspec.os.linux?
       @params = parse_active_zones(active_zones)
     end
 

--- a/lib/resources/iis_app.rb
+++ b/lib/resources/iis_app.rb
@@ -23,9 +23,6 @@ module Inspec::Resources
       @site_name = site_name
       @cache = nil
       @inspec = inspec
-
-      # verify that this resource is only supported on Windows
-      return skip_resource 'The `iis_app` resource is not supported on your OS.' unless inspec.os.windows?
     end
 
     def application_pool

--- a/lib/resources/postgres_hba_conf.rb
+++ b/lib/resources/postgres_hba_conf.rb
@@ -18,7 +18,6 @@ module Inspec::Resources
 
     # @todo add checks to ensure that we have data in our file
     def initialize(hba_conf_path = nil)
-      return skip_resource 'The `postgres_hba_conf` resource is not supported on your OS.' unless inspec.os.linux?
       @conf_file = hba_conf_path || File.expand_path('pg_hba.conf', inspec.postgres.conf_dir)
       @content = ''
       @params = {}

--- a/lib/resources/postgres_ident_conf.rb
+++ b/lib/resources/postgres_ident_conf.rb
@@ -17,12 +17,10 @@ module Inspec::Resources
     attr_reader :params, :conf_file
 
     def initialize(ident_conf_path = nil)
-      return skip_resource 'The `postgres_ident_conf` resource is not supported on your OS.' unless inspec.os.linux?
       @conf_file = ident_conf_path || File.expand_path('pg_ident.conf', inspec.postgres.conf_dir)
       @content = nil
       @params = nil
       read_content
-      return skip_resource '`pg_ident_conf` is not yet supported on your OS' if inspec.os.windows?
     end
 
     filter = FilterTable.create

--- a/lib/resources/powershell.rb
+++ b/lib/resources/powershell.rb
@@ -17,10 +17,6 @@ module Inspec::Resources
     "
 
     def initialize(script)
-      unless inspec.os.windows?
-        super('')
-        return skip_resource 'The `script` resource is not supported on your OS yet.'
-      end
       # since WinRM 2.0 and the default use of powershell for local execution in
       # train, we do not need to wrap the script here anymore
       super(script)

--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -40,7 +40,6 @@ module Inspec::Resources
       @raw_content = opts[:content] || inspec.file(@path).content
       @lines = @raw_content.to_s.split("\n")
       @filters = opts[:filters] || ''
-      raise Inspec::Exceptions::ResourceSkipped, 'The `shadow` resource is not supported on your OS.' unless inspec.os.unix?
       @params = @lines.map { |l| parse_shadow_line(l) }
     end
 

--- a/lib/resources/vbscript.rb
+++ b/lib/resources/vbscript.rb
@@ -34,7 +34,6 @@ module Inspec::Resources
     "
 
     def initialize(vbscript)
-      return skip_resource 'The `vbscript` resource is not supported on your OS yet.' unless inspec.os.windows?
       @seperator = SecureRandom.uuid
       cmd = <<~EOH
         $vbscript = @"

--- a/lib/resources/windows_task.rb
+++ b/lib/resources/windows_task.rb
@@ -28,9 +28,6 @@ module Inspec::Resources
     def initialize(taskuri)
       @taskuri = taskuri
       @cache = nil
-
-      # verify that this resource is only supported on Windows
-      return skip_resource 'The `windows_task` resource is not supported on your OS.' unless inspec.os.windows?
     end
 
     def exists?

--- a/lib/resources/wmi.rb
+++ b/lib/resources/wmi.rb
@@ -25,9 +25,6 @@ module Inspec::Resources
     attr_accessor :content
 
     def initialize(wmiclass = nil, opts = nil)
-      # verify that this resource is only supported on Windows
-      return skip_resource 'The `wmi` resource is not supported on your OS.' unless inspec.os.windows?
-
       @options = opts || {}
       # if wmiclass is not a hash, we have to handle deprecation behavior
       if wmiclass.is_a?(Hash)

--- a/test/unit/resources/crontab_test.rb
+++ b/test/unit/resources/crontab_test.rb
@@ -158,7 +158,8 @@ describe 'Inspec::Resources::Crontab' do
     it 'raises error on unsupported os' do
       resource = MockLoader.new(:windows).load_resource('crontab', { user: 'special' })
       _(resource.resource_skipped?).must_equal true
-      _(resource.resource_exception_message).must_equal 'The `crontab` resource is not supported on your OS.'
+      _(resource.resource_exception_message)
+        .must_equal 'Resource Crontab is not supported on platform windows/6.2.9200.'
     end
 
     it 'raises error when no user or path supplied' do

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -114,7 +114,8 @@ describe 'Inspec::Resources::Shadow' do
     it 'raises error on unsupported os' do
       resource = MockLoader.new(:windows).load_resource('shadow')
       _(resource.resource_skipped?).must_equal true
-      _(resource.resource_exception_message).must_equal 'The `shadow` resource is not supported on your OS.'
+      _(resource.resource_exception_message)
+        .must_equal 'Resource Shadow is not supported on platform windows/6.2.9200.'
     end
   end
 

--- a/test/unit/resources/wmi_test.rb
+++ b/test/unit/resources/wmi_test.rb
@@ -25,18 +25,8 @@ describe 'Inspec::Resources::WMI' do
   # ubuntu 14.04 with upstart
   it 'fail wmi on ubuntu' do
     resource = MockLoader.new(:ubuntu1404).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
-    _(resource.send('DisplayName')).must_be_nil
-  end
-
-  # centos 7 with systemd
-  it 'fail wmi on centos' do
-    resource = MockLoader.new(:centos7).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
-    _(resource.send('DisplayName')).must_be_nil
-  end
-
-  # unknown OS
-  it 'fail wmi on unknown os' do
-    resource = MockLoader.new(:undefined).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
-    _(resource.send('DisplayName')).must_be_nil
+    _(resource.resource_skipped?).must_equal true
+    _(resource.resource_exception_message)
+      .must_equal 'Resource Wmi is not supported on platform ubuntu/14.04.'
   end
 end


### PR DESCRIPTION
Removes `skip_resource` and `raise .. if InSpec.os` stuff from initialize as this is covered by platform support.

Signed-off-by: Miah Johnson <miah@chia-pet.org>

Fixes https://github.com/chef/inspec/issues/2714