### PR TITLE
Create reporter output directory if it does not exist

### DIFF
--- a/lib/inspec/reporters.rb
+++ b/lib/inspec/reporters.rb
@@ -25,6 +25,10 @@ module Inspec::Reporters
     output = reporter.rendered_output
 
     if config['file']
+      # create destination directory if it does not exist
+      dirname = File.dirname(config['file'])
+      FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
+
       File.write(config['file'], output)
     elsif config['stdout'] == true
       print output

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -37,6 +37,15 @@ Test Summary: 0 successful, 0 failures, 0 skipped
 "
   end
 
+  it 'can execute the profile and write to directory' do
+    outpath = Dir.tmpdir
+    out = inspec("exec #{example_profile} --no-create-lockfile --reporter json:#{outpath}/foo/bar/test.json")
+    out.stderr.must_equal ''
+    out.exit_status.must_equal 101
+    File.exist?("#{outpath}/foo/bar/test.json").must_equal true
+    File.stat("#{outpath}/foo/bar/test.json").size.must_be :>, 0
+  end
+
   it 'executes a metadata-only profile' do
     out = inspec('exec ' + File.join(profile_path, 'complete-metadata') + ' --no-create-lockfile')
     out.stderr.must_equal ''


### PR DESCRIPTION
This PR creates the output directory for a report if it does not exist.

Fixes #2771 
Fixes #2660 

Signed-off-by: Jared Quick <jquick@chef.io>