### PR TITLE
Refine deprecated methods to be consistent with supported fields in shadow file.

### DIFF
--- a/docs/resources/shadow.md.erb
+++ b/docs/resources/shadow.md.erb
@@ -27,12 +27,12 @@ These entries are defined as a colon-delimited row in the file, one row per user
 A `shadow` resource block declares one (or more) users and associated user information to be tested:
 
     describe shadow do
-      its('users') { should_not include 'forbidden_user' }
+      its('user') { should_not include 'forbidden_user' }
     end
 
 or with a single query:
 
-    describe shadow.users('root') do
+    describe shadow.user('root') do
       its('count') { should eq 1 }
     end
 
@@ -44,9 +44,9 @@ or with a filter:
 
 The following properties are available:
 
-* `users`
-* `passwords`
-* `last_changes`
+* `user`
+* `password`
+* `last_change`
 * `min_days`
 * `max_days`
 * `warn_days`
@@ -65,13 +65,13 @@ The following examples show how to use this InSpec audit resource.
 ### Test for a forbidden user
 
     describe shadow do
-      its('users') { should_not include 'forbidden_user' }
+      its('user') { should_not include 'forbidden_user' }
     end
 
 ### Test that a user appears one time
 
-    describe shadow.users('bin') do
-      its('passwords') { should cmp 'x' }
+    describe shadow.user('bin') do
+      its('password') { should cmp 'x' }
       its('count') { should eq 1 }
     end
 
@@ -89,33 +89,29 @@ The `count` matcher tests the number of times the named user appears in `/etc/sh
 
 This matcher is best used in conjunction with filters. For example:
 
-    describe shadow.users('dannos') do
+    describe shadow.user('dannos') do
        its('count') { should eq 1 }
     end
 
-### expiry_date
+### user
 
-The `expiry_date` matcher tests the number of days a user account has been disabled:
+The `user` matcher tests if the username exists `/etc/shadow`:
 
-    its('expiry_date') { should eq '' }
+    its('user') { should eq 'root' }
 
-### inactive_days
+### password
 
-The `inactive_days` matcher tests the number of days a user must be inactive before the user account is disabled:
+The `password` matcher returns the encrypted password string from the shadow file. The returned string may not be an encrypted password, but rather a `*` or similar which indicates that direct logins are not allowed.
 
-    its('inactive_days') { should eq '' }
+For example:
 
-### last_changes
+    its('password') { should cmp '*' }
 
-The `last_changes` matcher tests the last time a password was changed:
+### last_change
 
-    its('last_changes') { should eq '' }
+The `last_change` matcher tests the last time a password was changed:
 
-### max_days
-
-The `max_days` matcher tests the maximum number of days after which a password must be changed:
-
-    its('max_days') { should eq 90 }
+    its('last_change') { should be_empty }
 
 ### min_days
 
@@ -123,22 +119,28 @@ The `min_days` matcher tests the minimum number of days a password must exist, b
 
     its('min_days') { should eq 0 }
 
-### passwords
+### max_days
 
-The `passwords` matcher returns the encrypted password string from the shadow file. The returned string may not be an encrypted password, but rather a `*` or similar which indicates that direct logins are not allowed.
+The `max_days` matcher tests the maximum number of days after which a password must be changed:
 
-For example:
-
-    its('passwords') { should cmp '*' }
-
-### users
-
-The `users` matcher tests if the user name exists `/etc/shadow`:
-
-    its('users') { should eq 'root' }
+    its('max_days') { should eq 90 }
 
 ### warn_days
 
 The `warn_days` matcher tests the number of days a user is warned about an expiring password:
 
     its('warn_days') { should eq 7 }
+
+### inactive_days
+
+The `inactive_days` matcher tests the number of days a user must be inactive before the user account is disabled:
+
+    its('inactive_days') { should be_empty }
+
+### expiry_date
+
+The `expiry_date` matcher tests the number of days a user account has been disabled:
+
+    its('expiry_date') { should be_empty }
+
+

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -11,16 +11,16 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   it 'retrieve users via field' do
-    _(shadow.users).must_equal %w{root www-data}
+    _(shadow.user).must_equal %w{root www-data}
     _(shadow.count).must_equal 2
   end
 
   it 'retrieve passwords via field' do
-    _(shadow.passwords).must_equal %w{x !!}
+    _(shadow.password).must_equal %w{x !!}
   end
 
   it 'retrieve last password change via field' do
-    _(shadow.last_changes).must_equal %w{1 10}
+    _(shadow.last_change).must_equal %w{1 10}
   end
 
   it 'retrieve min password days via field' do
@@ -56,21 +56,21 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   it 'returns deprecation notice on user property' do
-    proc { _(shadow.user).must_equal %w{root www-data} }.must_output nil,
-      '[DEPRECATION] The shadow `user` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `users` instead.\n"
+    proc { _(shadow.users).must_equal %w{root www-data} }.must_output nil,
+      '[DEPRECATION] The shadow `users` property is deprecated and will' \
+      " be removed in InSpec 3.0.  Please use `user` instead.\n"
   end
 
   it 'returns deprecatation notice on password property' do
-    proc { _(shadow.password).must_equal %w{x !!} }.must_output nil,
-      '[DEPRECATION] The shadow `password` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `passwords` instead.\n"
+    proc { _(shadow.passwords).must_equal %w{x !!} }.must_output nil,
+      '[DEPRECATION] The shadow `passwords` property is deprecated and will' \
+      " be removed in InSpec 3.0.  Please use `password` instead.\n"
   end
 
   it 'returns deprecation notice on last_change property' do
-    proc { _(shadow.last_change).must_equal %w{1 10} }.must_output nil,
-      '[DEPRECATION] The shadow `last_change` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `last_changes` instead.\n"
+    proc { _(shadow.last_changes).must_equal %w{1 10} }.must_output nil,
+      '[DEPRECATION] The shadow `last_changes` property is deprecated and will' \
+      " be removed in InSpec 3.0.  Please use `last_change` instead.\n"
   end
 
   it 'returns deprecation notice on expiry_dates property' do
@@ -79,11 +79,18 @@ describe 'Inspec::Resources::Shadow' do
       " be removed in InSpec 3.0.  Please use `expiry_date` instead.\n"
   end
 
+  describe 'multiple filters' do
+    it 'filters with min_days and max_days' do
+      _(shadow.filter(min_days: 20, max_days: 30).user).must_equal ['www-data']
+      _(shadow.filter(last_change: 1, min_days: 2).user).must_equal ['root']
+    end
+  end
+
   describe 'filter via name =~ /^www/' do
-    let(:child) { shadow.users(/^www/) }
+    let(:child) { shadow.user(/^www/) }
 
     it 'filters by user via name (regex)' do
-      _(child.users).must_equal ['www-data']
+      _(child.user).must_equal ['www-data']
       _(child.count).must_equal 1
     end
 
@@ -93,10 +100,10 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   describe 'filter via name = root' do
-    let(:child) { shadow.users('root') }
+    let(:child) { shadow.user('root') }
 
     it 'filters by user name' do
-      _(child.users).must_equal %w{root}
+      _(child.user).must_equal %w{root}
       _(child.count).must_equal 1
     end
   end
@@ -105,7 +112,7 @@ describe 'Inspec::Resources::Shadow' do
     let(:child) { shadow.min_days('20') }
 
     it 'filters by property' do
-      _(child.users).must_equal %w{www-data}
+      _(child.user).must_equal %w{www-data}
       _(child.count).must_equal 1
     end
   end
@@ -118,5 +125,4 @@ describe 'Inspec::Resources::Shadow' do
         .must_equal 'Resource Shadow is not supported on platform windows/6.2.9200.'
     end
   end
-
 end


### PR DESCRIPTION
After much thought the deprecations from #2642  were for the wrong methods.

Plural method names feel much more natural when working with this
resource because you can have more than a single result.

Consider a match like `shadow.user(/^www/)`, this could return multiple
users, so `shadow.users` feels more natural here.

The problem is that the fields we're matching in the shadow file itself
are singular. Each entry is for a user, which has a password, and some
other fields. A user never has `passwords` in the shadow file, only a
`password`.

This is made more obvious when you use the `filter` method.

When we use this filter: `shadow.filter(min_days: 20, max_days: 30)` we
are matching fields in the shadow file and not using our matcher
methods. This means that if there is a discrepancy between our matcher
methods, and the shadow fields the user could end up confused. Like I did =)

This PR changes:

Changed matchers to match shadow fields.
Updated documentation to reflect changes.
Updated tests to reflect changes.
Re-add `filter` method, and add a test for it.
Renamed variable for FilterTable to be less confusing.
Renamed query argument for methods to be consistent.

Signed-off-by: Miah Johnson <miah@chia-pet.org>