### PR TITLE
Sort file list for unit tests

### DIFF
--- a/test/unit/dsl/other_keywords_test.rb
+++ b/test/unit/dsl/other_keywords_test.rb
@@ -47,7 +47,7 @@ describe 'inspec keyword' do
     end
 
     it 'lists all profile files when calling #files' do
-      load_in_profile('inspec.profile.files').must_equal %w{a_sub_dir/sub_items.conf items.conf}
+      load_in_profile('inspec.profile.files').sort.must_equal %w{a_sub_dir/sub_items.conf items.conf}
     end
   end
 

--- a/test/unit/source_readers/inspec_test.rb
+++ b/test/unit/source_readers/inspec_test.rb
@@ -36,7 +36,7 @@ describe SourceReaders::InspecReader do
     end
 
     it 'retrieves all extra files' do
-      _(res.data_files.keys).must_equal %w{files/a_sub_dir/sub_items.conf files/items.conf}
+      _(res.data_files.keys.sort).must_equal %w{files/a_sub_dir/sub_items.conf files/items.conf}
       _(res.data_files['files/items.conf']).must_equal "one\ntwo\nthree\n"
       _(res.data_files['files/a_sub_dir/sub_items.conf']).must_equal "[section]\nkey = value\n"
     end


### PR DESCRIPTION
When testing on a filesystem used for a long time or built on a small sized partition, the actual file order may be different from the expected file order as below:

```
    1) Failure:
  inspec keyword::inspec.profile.files#test_0002_lists all profile files when calling #files [/work/git/inspec/test/unit/dsl/other_keywords_test.rb:50]:
  --- expected
  +++ actual
  @@ -1 +1 @@
  -["a_sub_dir/sub_items.conf", "items.conf"]
  +["items.conf", "a_sub_dir/sub_items.conf"]

    2) Failure:
  SourceReaders::InspecReader::with a valid profile#test_0005_retrieves all extra files [/work/git/inspec/test/unit/source_readers/inspec_test.rb:39]:
  --- expected
  +++ actual
  @@ -1 +1 @@
  -["files/a_sub_dir/sub_items.conf", "files/items.conf"]
  +["files/items.conf", "files/a_sub_dir/sub_items.conf"]
```

Signed-off-by: ERAMOTO Masaya <eramoto.masaya@jp.fujitsu.com>