### PR TITLE
Single quotes cannot go unescaped in a single-quote-wrapped string

### DIFF
--- a/docs/dsl_inspec.md
+++ b/docs/dsl_inspec.md
@@ -107,7 +107,7 @@ The following test shows how to audit machines running PostgreSQL to ensure that
 ```ruby
 control 'postgres-7' do
   impact 1.0
-  title 'Don't allow empty passwords'
+  title "Don't allow empty passwords"
   describe postgres_session('user', 'pass').query("SELECT * FROM pg_shadow WHERE passwd IS NULL;") do
    its('output') { should eq('') }
   end


### PR DESCRIPTION
Obvious fix. Screwed up the formatting of the source code on https://www.inspec.io/docs/reference/dsl_inspec/ under the "Are PostgreSQL passwords empty?" heading, but this addresses the problem.