### PR TITLE
Documentation: `supports` attribute of custom resource DSL

### DIFF
--- a/docs/dsl_resource.md
+++ b/docs/dsl_resource.md
@@ -37,15 +37,25 @@ require a higher version.
 
 The following attributes can be configured:
 
-* name - Identifier of the resource (required)
-* desc - Description of the resource (optional)
-* example - Example usage of the resource (optional)
-* supports - Platform restrictions of the resource. Without specifying anything, it implicitly supports all OS's and releases (optional) (starting in InSpec 2.0)
+<dl>
+  <dt>name</dt>
+  <dd>Identifier of the resource (required)</dd>
+  <dt>desc</dt>
+  <dd>Description of the resource (optional)</dd>
+  <dt>example</dt>
+  <dd>Example usage of the resource (optional)</dd>
+  <dt>supports</dt>
+  <dd><small>(InSpec 2.0+)</small> Platform restrictions of the resource (optional)</dd>
+</dl>
 
 The following methods are available to the resource:
 
-* inspec - Contains a registry of all other resources to interact with the operating system or target in general.
-* skip\_resource - A resource may call this method to indicate that requirements aren't met. All tests that use this resource will be marked as skipped.
+<dl>
+  <dt>inspec</dt>
+  <dd>Contains a registry of all other resources to interact with the operating system or target in general.</dd>
+  <dt>skip_resource</dt>
+  <dd>A resource may call this method to indicate that requirements aren't met. All tests that use this resource will be marked as skipped.</dd>
+</dl>
 
 The following example shows a full resource using attributes and methods
 to provide simple access to a configuration file:
@@ -54,7 +64,7 @@ to provide simple access to a configuration file:
 class GordonConfig < Inspec.resource(1)
   name 'gordon_config'
 
-  # Restrict to only run on the below platforms
+  # Restrict to only run on the below platforms (if none were given, all OS's supported)
   supports platform_family: 'fedora'
   supports platform: 'centos', release: '6.9'
   # Supports `*` for wildcard matcher in the release

--- a/docs/dsl_resource.md
+++ b/docs/dsl_resource.md
@@ -37,25 +37,15 @@ require a higher version.
 
 The following attributes can be configured:
 
-<dl>
-  <dt>name</dt>
-  <dd>Identifier of the resource (required)</dd>
-  <dt>desc</dt>
-  <dd>Description of the resource (optional)</dd>
-  <dt>example</dt>
-  <dd>Example usage of the resource (optional)</dd>
-  <dt>supports</dt>
-  <dd><small>(InSpec 2.0+)</small> Platform restrictions of the resource (optional)</dd>
-</dl>
+- name - Identifier of the resource (required)
+- desc - Description of the resource (optional)
+- example - Example usage of the resource (optional)
+- supports - (InSpec 2.0+) Platform restrictions of the resource (optional)
 
 The following methods are available to the resource:
 
-<dl>
-  <dt>inspec</dt>
-  <dd>Contains a registry of all other resources to interact with the operating system or target in general.</dd>
-  <dt>skip_resource</dt>
-  <dd>A resource may call this method to indicate that requirements aren't met. All tests that use this resource will be marked as skipped.</dd>
-</dl>
+- inspec - Contains a registry of all other resources to interact with the operating system or target in general.
+- skip\_resource - A resource may call this method to indicate that requirements aren't met. All tests that use this resource will be marked as skipped.
 
 The following example shows a full resource using attributes and methods
 to provide simple access to a configuration file:

--- a/docs/dsl_resource.md
+++ b/docs/dsl_resource.md
@@ -40,11 +40,12 @@ The following attributes can be configured:
 * name - Identifier of the resource (required)
 * desc - Description of the resource (optional)
 * example - Example usage of the resource (optional)
+* supports - Platform restrictions of the resource. Without specifying anything, it implicitly supports all OS's and releases (optional) (starting in InSpec 2.0)
 
 The following methods are available to the resource:
 
 * inspec - Contains a registry of all other resources to interact with the operating system or target in general.
-* skip\_resource - A resource may call this method to indicate, that requirements aren't met. All tests that use this resource will be marked as skipped.
+* skip\_resource - A resource may call this method to indicate that requirements aren't met. All tests that use this resource will be marked as skipped.
 
 The following example shows a full resource using attributes and methods
 to provide simple access to a configuration file:
@@ -52,6 +53,12 @@ to provide simple access to a configuration file:
 ```ruby
 class GordonConfig < Inspec.resource(1)
   name 'gordon_config'
+
+  # Restrict to only run on the below platforms
+  supports platform_family: 'fedora'
+  supports platform: 'centos', release: '6.9'
+  # Supports `*` for wildcard matcher in the release
+  supports platform: 'centos', release: '7.*'
 
   desc '
     Resource description ...

--- a/www/source/stylesheets/_layout.scss
+++ b/www/source/stylesheets/_layout.scss
@@ -373,6 +373,11 @@ textarea::placeholder {
 	font-family: $main-font;
 }
 
+// Definition lists
+dl > dd {
+  margin-left: 2em;
+}
+
 // Progress bar
 
 progress { /* Positioning */

--- a/www/source/stylesheets/_layout.scss
+++ b/www/source/stylesheets/_layout.scss
@@ -373,11 +373,6 @@ textarea::placeholder {
 	font-family: $main-font;
 }
 
-// Definition lists
-dl > dd {
-  margin-left: 2em;
-}
-
 // Progress bar
 
 progress { /* Positioning */


### PR DESCRIPTION
I wasn't sure the best way to document this, so I figured I'd give it an initial pass and get some feedback. Thoughts?