### PR TITLE
Pin to new Train version and update InSpec defaults

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'train', '~> 1.1'
+  spec.add_dependency 'train', '~> 1.2'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'method_source', '~> 0.8'

--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -65,6 +65,7 @@ module Inspec
         connection.disable_cache(:command)
       else
         Inspec::Log.debug 'Option backend_cache is disabled'
+        connection.disable_cache(:file)
         connection.disable_cache(:command)
       end
 

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -76,7 +76,7 @@ module Inspec
       option :create_lockfile, type: :boolean,
         desc: 'Write out a lockfile based on this execution (unless one already exists)'
       option :backend_cache, type: :boolean,
-        desc: 'Allow caching for backend command output.'
+        desc: 'Allow caching for backend command output. (default: true)'
       option :show_progress, type: :boolean,
         desc: 'Show progress while executing tests.'
     end
@@ -88,7 +88,7 @@ module Inspec
           'show_progress' => false,
           'color' => true,
           'create_lockfile' => true,
-          'backend_cache' => false,
+          'backend_cache' => true,
         },
         shell: {
           'reporter' => ['cli'],

--- a/test/unit/resources/platform_test.rb
+++ b/test/unit/resources/platform_test.rb
@@ -21,7 +21,7 @@ describe 'Inspec::Resources::Platform' do
   end
 
   it 'verify platform families' do
-    expect = ["debian", "linux", "unix"]
+    expect = ["debian", "linux", "unix", "os"]
     _(resource.families).must_equal expect
   end
 


### PR DESCRIPTION
Sets the backend_cache to default to true, also pins to a new version of train.

Notable Train changes:
Force 64bit powershell if using ruby32 on a 64bit os [\#265](https://github.com/chef/train/issues/265)
Master OS detect family [\#260](https://github.com/chef/train/issues/260)

Fixes https://github.com/chef/inspec/issues/2814

Signed-off-by: Jared Quick <jquick@chef.io>