### PR TITLE
Add Info about nginx_conf param

### DIFF
--- a/docs/resources/nginx_conf.md.erb
+++ b/docs/resources/nginx_conf.md.erb
@@ -126,3 +126,13 @@ Locations provide access to their parent server entry and raw parameters:
 
     location.params
     => {"_"=>["~", "\\.php$"], "fastcgi_pass"=>[["127.0.0.1:1025"]]}
+
+### configuration file path
+
+If the NGINX configuration file is not located at the default path, `/etc/nginx/nginx.conf`, the path can specified as the first parameter of the describe block:
+
+    describe nginx_conf('/opt/nginx/nginx.conf').params['pid'] do
+      it { should cmp 'logs/nginx.pid' }
+    end
+
+


### PR DESCRIPTION
Add information about setting the path to the NGINX server configuration
file if it is not in the default path.