### PR TITLE
Add resources for aws_billing_report and aws_billing_reports.

### DIFF
--- a/docs/resources/aws_billing_report.md.erb
+++ b/docs/resources/aws_billing_report.md.erb
@@ -18,7 +18,7 @@ Use the `aws_billing_report` InSpec audit resource to test properties of a singl
   end
 
   # Hash Syntax to verify the time_unit used by the 'inspec1' Billing Report.
-  describe aws_billing_report(report_definition: 'inspec1') do
+  describe aws_billing_report(report_name: 'inspec1') do
     its('time_unit') { should cmp 'daily' }
   end
 
@@ -78,7 +78,7 @@ For a full list of available matchers, please visit our [matchers page](https://
 ### be_hourly
 
   describe aws_billing_report('inspec1') do
-    its('time_unit') { should be_hourly }
+    it { should be_hourly }
   end
 
 ### be_daily

--- a/docs/resources/aws_billing_report.md.erb
+++ b/docs/resources/aws_billing_report.md.erb
@@ -14,12 +14,12 @@ Use the `aws_billing_report` InSpec audit resource to test properties of a singl
 
   # Verify the time_unit used by the 'inspec1' Billing Report.
   describe aws_billing_report('inspec1') do
-    its('time_unit') { should cmp 'DAILY' }
+    its('time_unit') { should cmp 'daily' }
   end
 
   # Hash Syntax to verify the time_unit used by the 'inspec1' Billing Report.
   describe aws_billing_report(report_definition: 'inspec1') do
-    its('time_unit') { should cmp 'DAILY' }
+    its('time_unit') { should cmp 'daily' }
   end
 
 ## Properties

--- a/docs/resources/aws_billing_report.md.erb
+++ b/docs/resources/aws_billing_report.md.erb
@@ -1,0 +1,99 @@
+
+---
+title: About the aws_billing_report Resource
+platform: aws
+---
+
+# aws\_billing\_report
+
+Use the `aws_billing_report` InSpec audit resource to test properties of a single AWS Cost and Billing report.
+
+<br>
+
+## Syntax
+
+  # Verify the time_unit used by the 'inspec1' Billing Report.
+  describe aws_billing_report('inspec1') do
+    its('time_unit') { should cmp 'DAILY' }
+  end
+
+  # Hash Syntax to verify the time_unit used by the 'inspec1' Billing Report.
+  describe aws_billing_report(report_definition: 'inspec1') do
+    its('time_unit') { should cmp 'DAILY' }
+  end
+
+## Properties
+
+  `report_name`, `time_unit`, `compression`, `s3_bucket`, `s3_prefix`, `s3_region`, `additional_artifacts`
+
+<br>
+
+## Propery Examples
+
+### report_name
+ The report's name.
+  describe aws_billing_report('inspec1') do
+    its('report_name') { should cmp 'inspec1' }
+  end
+
+### time_unit
+ The interval of time covered by the report. Valid values: hourly, or daily.
+
+  describe aws_billing_report('inspec1') do
+    its('time_unit') { should cmp 'hourly' }
+  end
+
+### compression
+ The reports compression type. Valid values: zip, or gzip.
+
+  describe aws_billing_report('inspec1') do
+    its('compression') { should cmp 'zip' }
+  end
+
+### s3_bucket
+ The s3_bucket the report is stored in.
+
+  describe aws_billing_report('inspec1') do
+    its('s3_bucket') { should cmp 'inspec-s3-bucket' }
+  end
+
+### s3_prefix
+ The prefix that AWS adds to the report when stored.
+
+  describe aws_billing_report('inspec1') do
+    its('s3_prefix') { should cmp 'inspec1' }
+  end
+
+### s3_region
+ The AWS region of the S3 bucket.
+
+  describe aws_billing_report('inspec1') do
+    its('s3_region') { should cmp 'us-east-1' }
+  end
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### be_hourly
+
+  describe aws_billing_report('inspec1') do
+    its('time_unit') { should be_hourly }
+  end
+
+### be_daily
+
+### exist
+
+Indicates that the Billing Report provided was found.  Use `should_not` to test for Billing Reports that should not exist.
+
+  # Verify that the 'inspec1' Billing Report exists.
+  describe aws_billing_report('inspec1') do
+    it { should exist }
+  end
+
+  # Verify that the 'inspec2' Billing Report does not exist.
+  describe aws_billing_report('invalid-inspec') do
+    it { should_not exist }
+  end
+

--- a/docs/resources/aws_billing_report.md.erb
+++ b/docs/resources/aws_billing_report.md.erb
@@ -31,45 +31,52 @@ Use the `aws_billing_report` InSpec audit resource to test properties of a singl
 ## Propery Examples
 
 ### report_name
- The report's name.
-  describe aws_billing_report('inspec1') do
-    its('report_name') { should cmp 'inspec1' }
-  end
+
+The report's name.
+
+    describe aws_billing_report('inspec1') do
+      its('report_name') { should cmp 'inspec1' }
+    end
 
 ### time_unit
- The interval of time covered by the report. Valid values: hourly, or daily.
 
-  describe aws_billing_report('inspec1') do
-    its('time_unit') { should cmp 'hourly' }
-  end
+The interval of time covered by the report. Valid values: hourly or daily.
+
+    describe aws_billing_report('inspec1') do
+      its('time_unit') { should cmp 'hourly' }
+    end
 
 ### compression
- The reports compression type. Valid values: zip, or gzip.
 
-  describe aws_billing_report('inspec1') do
-    its('compression') { should cmp 'zip' }
-  end
+The reports compression type. Valid values: zip, or gzip.
+
+    describe aws_billing_report('inspec1') do
+      its('compression') { should cmp 'zip' }
+    end
 
 ### s3_bucket
- The s3_bucket the report is stored in.
 
-  describe aws_billing_report('inspec1') do
-    its('s3_bucket') { should cmp 'inspec-s3-bucket' }
-  end
+The s3_bucket the report is stored in.
+
+    describe aws_billing_report('inspec1') do
+      its('s3_bucket') { should cmp 'inspec-s3-bucket' }
+    end
 
 ### s3_prefix
- The prefix that AWS adds to the report when stored.
 
-  describe aws_billing_report('inspec1') do
-    its('s3_prefix') { should cmp 'inspec1' }
-  end
+The prefix that AWS adds to the report when stored.
+
+    describe aws_billing_report('inspec1') do
+      its('s3_prefix') { should cmp 'inspec1' }
+    end
 
 ### s3_region
- The AWS region of the S3 bucket.
 
-  describe aws_billing_report('inspec1') do
-    its('s3_region') { should cmp 'us-east-1' }
-  end
+The AWS region of the S3 bucket.
+
+    describe aws_billing_report('inspec1') do
+      its('s3_region') { should cmp 'us-east-1' }
+    end
 
 ## Matchers
 
@@ -87,13 +94,13 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 Indicates that the Billing Report provided was found.  Use `should_not` to test for Billing Reports that should not exist.
 
-  # Verify that the 'inspec1' Billing Report exists.
-  describe aws_billing_report('inspec1') do
-    it { should exist }
-  end
+    # Verify that the 'inspec1' Billing Report exists.
+    describe aws_billing_report('inspec1') do
+      it { should exist }
+    end
 
-  # Verify that the 'inspec2' Billing Report does not exist.
-  describe aws_billing_report('invalid-inspec') do
-    it { should_not exist }
-  end
+    # Verify that the 'inspec2' Billing Report does not exist.
+    describe aws_billing_report('invalid-inspec') do
+      it { should_not exist }
+    end
 

--- a/docs/resources/aws_billing_report.md.erb
+++ b/docs/resources/aws_billing_report.md.erb
@@ -84,11 +84,19 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 ### be_hourly
 
-  describe aws_billing_report('inspec1') do
-    it { should be_hourly }
-  end
+If true, indicates that the report summarizes usage on a per-hour basis.
+
+    describe aws_billing_report('inspec1') do
+      it { should be_hourly }
+    end
 
 ### be_daily
+
+If true, indicates that the report summarizes usage on a per-day basis.
+
+    describe aws_billing_report('inspec1') do
+      it { should be_daily }
+    end
 
 ### exist
 

--- a/docs/resources/aws_billing_reports.md.erb
+++ b/docs/resources/aws_billing_reports.md.erb
@@ -41,7 +41,7 @@ A list of the names of the reports matched by the query.
 
 ### time_units
 
-A list of the time intervals of the reports matched by the query. Valid values: HOURLY, or Daily.
+A list of the time intervals of the reports matched by the query. Valid values: HOURLY, or Daily. This list is de-duplicated, so its count may not match the query count.
 
     describe aws_billing_reports do
       its('time_units') { should_not include 'HOURLY' }
@@ -49,7 +49,7 @@ A list of the time intervals of the reports matched by the query. Valid values: 
 
 ### compressions
 
-A list of the compression types of the reports matched by the query.  Valid values: ZIP, or GZIP.
+A list of the compression types of the reports matched by the query.  Valid values: ZIP, or GZIP. This list is de-duplicated, so its count may not match the query count.
 
     describe aws_billing_reports do
       its('compressions') { should_not include 'ZIP' }
@@ -57,7 +57,7 @@ A list of the compression types of the reports matched by the query.  Valid valu
 
 ### s3_buckets
 
-A list of the S3 buckets the reports matched by the query are stored in.
+A list of the S3 buckets the reports matched by the query are stored in. This list is de-duplicated, so its count may not match the query count.
 
     describe aws_billing_reports do
       its('s3_buckets') { should include 'some-s3-bucket'] }
@@ -65,7 +65,7 @@ A list of the S3 buckets the reports matched by the query are stored in.
 
 ### s3_prefixes
 
-A list of the S3 prefixes (analogous to a directory on a filesystem) that the reports matched by the query are stored in.
+A list of the S3 prefixes (analogous to a directory on a filesystem) that the reports matched by the query are stored in. This list is de-duplicated, so its count may not match the query count.
 
     describe aws_billing_reports do
       its('s3_prefixes') { should include '/my/path/here' }
@@ -73,7 +73,7 @@ A list of the S3 prefixes (analogous to a directory on a filesystem) that the re
 
 ### s3_regions
 
-A list of the S3 regions that reports matched by the query are stored in.
+A list of the S3 regions that reports matched by the query are stored in. This list is de-duplicated, so its count may not match the query count.
 
     describe aws_billing_reports do
       its('s3_regions') { should_not include 'us-west-1' }

--- a/docs/resources/aws_billing_reports.md.erb
+++ b/docs/resources/aws_billing_reports.md.erb
@@ -41,18 +41,18 @@ A list of the names of the reports matched by the query.
 
 ### time_units
 
-A list of the time intervals of the reports matched by the query. Valid values: HOURLY, or Daily. This list is de-duplicated, so its count may not match the query count.
+A list of the time intervals of the reports matched by the query. Valid values: `hourly` or `daily`. This list is de-duplicated, so its count may not match the query count.
 
     describe aws_billing_reports do
-      its('time_units') { should_not include 'HOURLY' }
+      its('time_units') { should_not include 'hourly' }
     end
 
 ### compressions
 
-A list of the compression types of the reports matched by the query.  Valid values: ZIP, or GZIP. This list is de-duplicated, so its count may not match the query count.
+A list of the compression types of the reports matched by the query.  Valid values: `zip`, or `gzip`. This list is de-duplicated, so its count may not match the query count.
 
     describe aws_billing_reports do
-      its('compressions') { should_not include 'ZIP' }
+      its('compressions') { should_not include 'zip' }
     end
 
 ### s3_buckets

--- a/docs/resources/aws_billing_reports.md.erb
+++ b/docs/resources/aws_billing_reports.md.erb
@@ -1,0 +1,93 @@
+---
+title: About the aws_billing_reports Resource
+platform: aws
+---
+
+# aws\_billing\_reports
+
+Use the `aws_billing_reports` InSpec audit resource to test properties of a some or all AWS Cost and Billing reports.
+
+<br>
+
+## Syntax
+
+  # Verify the number of Billing Reports in the AWS account.
+  describe aws_billing_reports do
+    its('entries.count') { should cmp 2 }
+  end
+
+  # Use the .where clause to match a property to one or more rules in the available reports.
+  describe aws_billing_reports.where { report_name =~ /inspec.*/ } do
+    its('report_name') { should include 'inspec1' }
+    its('time_unit') { should include 'DAILY' }
+    its('s3_bucket') { should include 'inspec1-s3-bucket' }
+  end
+
+## Properties
+
+  `report_name`, `time_unit`, `compression`, `s3_bucket`, `s3_prefix`, `s3_region`, `additional_artifacts`
+
+<br>
+
+## Propery Examples
+
+### report_name
+ The reports name.
+  describe aws_billing_reports do
+    its('report_name') { should cmp ['inspec1', 'inspec2'] }
+  end
+
+### time_unit
+ The interval of time covered by the report. Valid values: HOURLY, or Daily.
+
+  describe aws_billing_reports do
+    its('time_unit') { should_not include 'HOURLY' }
+  end
+
+### compression
+ The reports compression type. Valid values: ZIP, or GZIP.
+
+  describe aws_billing_reports do
+    its('compression') { should_not include 'ZIP' }
+  end
+
+### s3_bucket
+ A list of the S3 buckets the reports are stored in.
+
+  describe aws_billing_reports do
+    its('s3_bucket') { should cmp ['inspec-s3-bucket', 'example-s3-bucket'] }
+  end
+
+### s3_prefix
+ The prefix that AWS adds to the report when stored.
+
+  describe aws_billing_reports do
+    its('s3_prefix') { should cmp ['inspec1', 'inspec2'] }
+  end
+
+### s3_region
+ The AWS region of the S3 bucket.
+
+  describe aws_billing_reports do
+    its('s3_region') { should cmp ['us-east-1', 'us-west-1'] }
+  end
+
+### additional_artifacts
+ The list of manifests created for the report. Valid values: REDSHIFT, or QUICKSIGHT.
+
+  describe aws_billing_reports do
+    its('additional_artifacts') { should_not include 'QUICKSIGHT' }
+  end
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### exist
+
+Indicates that the Billing Report provided was found.  Use `should_not` to test for Billing Reports that should not exist.
+
+  # Verify that at least one Billing Report exists.
+  describe aws_billing_reports
+    it { should exist }
+  end

--- a/docs/resources/aws_billing_reports.md.erb
+++ b/docs/resources/aws_billing_reports.md.erb
@@ -13,71 +13,71 @@ Use the `aws_billing_reports` InSpec audit resource to test properties of a some
 
   # Verify the number of Billing Reports in the AWS account.
   describe aws_billing_reports do
-    its('entries.count') { should cmp 2 }
+    its('count') { should cmp 2 }
   end
 
   # Use the .where clause to match a property to one or more rules in the available reports.
   describe aws_billing_reports.where { report_name =~ /inspec.*/ } do
-    its('report_name') { should include 'inspec1' }
-    its('time_unit') { should include 'DAILY' }
-    its('s3_bucket') { should include 'inspec1-s3-bucket' }
+    its('report_names') { should include 'inspec1' }
+    its('time_units') { should include 'DAILY' }
+    its('s3_buckets') { should include 'inspec1-s3-bucket' }
   end
 
 ## Properties
 
-  `report_name`, `time_unit`, `compression`, `s3_bucket`, `s3_prefix`, `s3_region`, `additional_artifacts`
+  `report_names`, `time_units`, `compressions`, `s3_buckets`, `s3_prefixs`, `s3_regions`
 
 <br>
 
 ## Propery Examples
 
-### report_name
- The reports name.
-  describe aws_billing_reports do
-    its('report_name') { should cmp ['inspec1', 'inspec2'] }
-  end
+### report_names
 
-### time_unit
- The interval of time covered by the report. Valid values: HOURLY, or Daily.
+A list of the names of the reports matched by the query.
 
-  describe aws_billing_reports do
-    its('time_unit') { should_not include 'HOURLY' }
-  end
+    describe aws_billing_reports do
+      its('report_names') { should include 'myreport' }
+    end
 
-### compression
- The reports compression type. Valid values: ZIP, or GZIP.
+### time_units
 
-  describe aws_billing_reports do
-    its('compression') { should_not include 'ZIP' }
-  end
+A list of the time intervals of the reports matched by the query. Valid values: HOURLY, or Daily.
 
-### s3_bucket
- A list of the S3 buckets the reports are stored in.
+    describe aws_billing_reports do
+      its('time_units') { should_not include 'HOURLY' }
+    end
 
-  describe aws_billing_reports do
-    its('s3_bucket') { should cmp ['inspec-s3-bucket', 'example-s3-bucket'] }
-  end
+### compressions
 
-### s3_prefix
- The prefix that AWS adds to the report when stored.
+A list of the compression types of the reports matched by the query.  Valid values: ZIP, or GZIP.
 
-  describe aws_billing_reports do
-    its('s3_prefix') { should cmp ['inspec1', 'inspec2'] }
-  end
+    describe aws_billing_reports do
+      its('compressions') { should_not include 'ZIP' }
+    end
 
-### s3_region
- The AWS region of the S3 bucket.
+### s3_buckets
 
-  describe aws_billing_reports do
-    its('s3_region') { should cmp ['us-east-1', 'us-west-1'] }
-  end
+A list of the S3 buckets the reports matched by the query are stored in.
 
-### additional_artifacts
- The list of manifests created for the report. Valid values: REDSHIFT, or QUICKSIGHT.
+    describe aws_billing_reports do
+      its('s3_buckets') { should include 'some-s3-bucket'] }
+    end
 
-  describe aws_billing_reports do
-    its('additional_artifacts') { should_not include 'QUICKSIGHT' }
-  end
+### s3_prefixes
+
+A list of the S3 prefixes (analogous to a directory on a filesystem) that the reports matched by the query are stored in.
+
+    describe aws_billing_reports do
+      its('s3_prefixes') { should include '/my/path/here' }
+    end
+
+### s3_regions
+
+A list of the S3 regions that reports matched by the query are stored in.
+
+    describe aws_billing_reports do
+      its('s3_regions') { should_not include 'us-west-1' }
+    end
 
 ## Matchers
 
@@ -85,7 +85,7 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 ### exist
 
-Indicates that the Billing Report provided was found.  Use `should_not` to test for Billing Reports that should not exist.
+Indicates that the query matched at least one report. Use `should_not` to test for Billing Reports that should not exist.
 
   # Verify that at least one Billing Report exists.
   describe aws_billing_reports

--- a/docs/resources/aws_billing_reports.md.erb
+++ b/docs/resources/aws_billing_reports.md.erb
@@ -49,7 +49,7 @@ A list of the time intervals of the reports matched by the query. Valid values: 
 
 ### compressions
 
-A list of the compression types of the reports matched by the query.  Valid values: `zip`, or `gzip`. This list is de-duplicated, so its count may not match the query count.
+A list of the compression types of the reports matched by the query. Valid values: `zip`, or `gzip`. This list is de-duplicated, so its count may not match the query count.
 
     describe aws_billing_reports do
       its('compressions') { should_not include 'zip' }

--- a/lib/resource_support/aws.rb
+++ b/lib/resource_support/aws.rb
@@ -12,6 +12,8 @@ require 'resource_support/aws/aws_backend_base'
 # Load all AWS resources
 # TODO: loop over and load entire directory
 # for f in ls lib/resources/aws/*; do t=$(echo $f | cut -c 5- | cut -f1 -d. ); echo "require '${t}'"; done
+require 'resources/aws/aws_billing_report'
+require 'resources/aws/aws_billing_reports'
 require 'resources/aws/aws_cloudtrail_trail'
 require 'resources/aws/aws_cloudtrail_trails'
 require 'resources/aws/aws_cloudwatch_alarm'

--- a/lib/resources/aws/aws_billing_report.rb
+++ b/lib/resources/aws/aws_billing_report.rb
@@ -59,7 +59,7 @@ class AwsBillingReport < Inspec.resource(1)
     @exists = !report.nil?
     if exists?
       @time_unit = report.time_unit.downcase
-      @format = report.format
+      @format = report.format.downcase
       @compression = report.compression.downcase
       @s3_bucket = report.s3_bucket
       @s3_prefix = report.s3_prefix

--- a/lib/resources/aws/aws_billing_report.rb
+++ b/lib/resources/aws/aws_billing_report.rb
@@ -18,23 +18,23 @@ class AwsBillingReport < Inspec.resource(1)
               :s3_prefix, :s3_region
 
   def to_s
-    "AWS Billing Report #{@report}"
+    "AWS Billing Report #{report_name}"
   end
 
   def hourly?
-    @time_unit.eql?('hourly')
+    exists? ? time_unit.eql?('hourly') : nil
   end
 
   def daily?
-    @time_unit.eql?('daily')
+    exists? ? time_unit.eql?('daily') : nil
   end
 
   def zip?
-    @compression.eql?('zip')
+    exists? ? compression.eql?('zip') : nil
   end
 
   def gzip?
-    @compression.eql?('gzip')
+    exists? ? compression.eql?('gzip') : nil
   end
 
   private
@@ -42,23 +42,22 @@ class AwsBillingReport < Inspec.resource(1)
   def validate_params(raw_params)
     validated_params = check_resource_param_names(
       raw_params: raw_params,
-      allowed_params: [:report],
-      allowed_scalar_name: :report,
+      allowed_params: [:report_name],
+      allowed_scalar_name: :report_name,
       allowed_scalar_type: String,
     )
 
     if validated_params.empty?
-      raise ArgumentError, "You must provide the parameter 'report' to aws_billing_report."
+      raise ArgumentError, "You must provide the parameter 'report_name' to aws_billing_report."
     end
 
     validated_params
   end
 
   def fetch_from_api
-    report = find_report(@report)
+    report = find_report(report_name)
     @exists = !report.nil?
-    if @exists
-      @report_name = report.report_name
+    if exists?
       @time_unit = report.time_unit.downcase
       @format = report.format
       @compression = report.compression.downcase
@@ -92,8 +91,8 @@ class AwsBillingReport < Inspec.resource(1)
       AwsBillingReport::BackendFactory.set_default_backend(self)
       self.aws_client_class = Aws::CostandUsageReportService::Client
 
-      def describe_report_definitions(options = {})
-        aws_service_client.describe_report_definitions(options)
+      def describe_report_definitions(query = {})
+        aws_service_client.describe_report_definitions(query)
       end
     end
   end

--- a/lib/resources/aws/aws_billing_report.rb
+++ b/lib/resources/aws/aws_billing_report.rb
@@ -1,0 +1,90 @@
+class AwsBillingReport < Inspec.resource(1)
+  name 'aws_billing_report'
+  supports platform: 'aws'
+  desc 'Verifies settings for AWS Cost and Billing Reports.'
+  example "
+    describe aws_billing_report('inspec1') do
+      its('report_name') { should cmp 'inspec1' }
+      its('time_unit') { should cmp 'hourly' }
+    end
+
+    describe aws_billing_report(report: 'inspec1') do
+      it { should exist }
+    end"
+
+  include AwsSingularResourceMixin
+
+  attr_reader :report_name, :time_unit, :format, :compression, :s3_bucket,
+              :s3_prefix, :s3_region
+
+  def to_s
+    "AWS Billing Report #{@report}"
+  end
+
+  def hourly?
+    @time_unit.eql?('hourly')
+  end
+
+  def daily?
+    @time_unit.eql?('daily')
+  end
+
+  def zip?
+    @compression.eql?('zip')
+  end
+
+  def gzip?
+    @compression.eql?('gzip')
+  end
+
+  private
+
+  def validate_params(raw_params)
+    validated_params = check_resource_param_names(
+      raw_params: raw_params,
+      allowed_params: [:report],
+      allowed_scalar_name: :report,
+      allowed_scalar_type: String,
+    )
+
+    if validated_params.empty?
+      raise ArgumentError, "You must provide the parameter 'report' to aws_billing_report."
+    end
+
+    validated_params
+  end
+
+  def fetch_from_api
+    r = report
+    @exists = !r.nil?
+    unless r.nil?
+      @report_name = r.report_name
+      @time_unit = r.time_unit.downcase
+      @format = r.format
+      @compression = r.compression.downcase
+      @s3_bucket = r.s3_bucket
+      @s3_prefix = r.s3_prefix
+      @s3_region = r.s3_region
+    end
+  end
+
+  def report
+    definitions = backend.describe_report_definitions.report_definitions
+    definitions.detect { |r| r.report_name.eql?(@report) }
+  end
+
+  def backend
+    BackendFactory.create(inspec_runner)
+  end
+
+  class Backend
+    class AwsClientApi < AwsBackendBase
+      AwsBillingReport::BackendFactory.set_default_backend(self)
+      self.aws_client_class = Aws::CostandUsageReportService::Client
+
+      def describe_report_definitions
+        aws_service_client.describe_report_definitions
+      end
+    end
+  end
+end

--- a/lib/resources/aws/aws_billing_reports.rb
+++ b/lib/resources/aws/aws_billing_reports.rb
@@ -21,12 +21,12 @@ class AwsBillingReports < Inspec.resource(1)
   filtertable = FilterTable.create
   filtertable.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
              .register_column(:report_names, field: :report_name)
-             .register_column(:time_units, field: :time_unit)
-             .register_column(:formats, field: :format)
-             .register_column(:compressions, field: :compression)
-             .register_column(:s3_buckets, field: :s3_bucket)
-             .register_column(:s3_prefixes, field: :s3_prefix)
-             .register_column(:s3_regions, field: :s3_region)
+             .register_column(:time_units, field: :time_unit, style: :simple)
+             .register_column(:formats, field: :format, style: :simple)
+             .register_column(:compressions, field: :compression, style: :simple)
+             .register_column(:s3_buckets, field: :s3_bucket, style: :simple)
+             .register_column(:s3_prefixes, field: :s3_prefix, style: :simple)
+             .register_column(:s3_regions, field: :s3_region, style: :simple)
   filtertable.install_filter_methods_on_resource(self, :table)
 
   def validate_params(resource_params)

--- a/lib/resources/aws/aws_billing_reports.rb
+++ b/lib/resources/aws/aws_billing_reports.rb
@@ -1,0 +1,65 @@
+require 'utils/filter'
+
+class AwsBillingReports < Inspec.resource(1)
+  name 'aws_billing_reports'
+  supports platform: 'aws'
+  desc 'Verifies settings for AWS Cost and Billing Reports.'
+  example "
+      describe aws_billing_reports do
+        its('report_name') { should include 'inspec1' }
+        its('s3_bucket') { should include 'inspec1-s3-bucket' }
+      end
+
+     describe aws_billing_reports.where { report_name =~ /inspec.*/ } do
+       its ('report_name') { should include ['inspec1'] }
+       its ('time_unit') { should include ['DAILY'] }
+       its ('s3_bucket') { should include ['inspec1-s3-bucket'] }
+     end"
+
+  include AwsPluralResourceMixin
+
+  filtertable = FilterTable.create
+  filtertable.add_accessor(:entries)
+             .add_accessor(:where)
+             .add(:exists?) { |x| !x.entries.empty? }
+             .add(:report_name, field: :report_name)
+             .add(:time_unit, field: :time_unit)
+             .add(:format, field: :format)
+             .add(:compression, field: :compression)
+             .add(:s3_bucket, field: :s3_bucket)
+             .add(:s3_prefix, field: :s3_prefix)
+             .add(:s3_region, field: :s3_region)
+             .add(:additional_artifacts, field: :additional_artifacts)
+             .add(:additional_schema_elements, field: :additional_schema_elements)
+  filtertable.connect(self, :table)
+
+  def validate_params(resource_params)
+    unless resource_params.empty?
+      raise ArgumentError, 'aws_billing_reports does not accept resource parameters.'
+    end
+    resource_params
+  end
+
+  def to_s
+    'AWS Billing Reports'
+  end
+
+  def fetch_from_api
+    @table = []
+    backend = BackendFactory.create(inspec_runner)
+    backend.describe_report_definitions.report_definitions.each do |r|
+      @table << r.to_h
+    end
+  end
+
+  class Backend
+    class AwsClientApi < AwsBackendBase
+      AwsBillingReports::BackendFactory.set_default_backend(self)
+      self.aws_client_class = Aws::CostandUsageReportService::Client
+
+      def describe_report_definitions
+        aws_service_client.describe_report_definitions
+      end
+    end
+  end
+end

--- a/test/unit/resources/aws_billing_backend.rb
+++ b/test/unit/resources/aws_billing_backend.rb
@@ -1,0 +1,95 @@
+module MockAwsBillingReports
+  class Empty < AwsBackendBase
+    def describe_report_definitions(_query)
+      Aws::CostandUsageReportService::Types::DescribeReportDefinitionsResponse.new(report_definitions: [])
+    end
+  end
+
+  class Basic < AwsBackendBase
+    def describe_report_definitions(_query)
+      Aws::CostandUsageReportService::Types::DescribeReportDefinitionsResponse
+        .new(report_definitions:
+      [
+        Aws::CostandUsageReportService::Types::ReportDefinition.new(
+          report_name: 'inspec1',
+          time_unit: 'HOURLY',
+          format: 'textORcsv',
+          compression: 'ZIP',
+          s3_bucket: 'inspec1-s3-bucket',
+          s3_prefix: 'inspec1/accounting',
+          s3_region: 'us-east-1',
+        ),
+        Aws::CostandUsageReportService::Types::ReportDefinition.new(
+          report_name: 'inspec2',
+          time_unit: 'DAILY',
+          format: 'textORcsv',
+          compression: 'GZIP',
+          s3_bucket: 'inspec2-s3-bucket',
+          s3_prefix: 'inspec2/accounting',
+          s3_region: 'us-west-1',
+        ),
+      ])
+    end
+  end
+
+  # Paginated backend to provide an environment similar to what exists in the real world.
+  # The aws-sdk provides stub and mock facilities, but they do not emulate paging.
+  # This backend will always repond with 5 reports, as if the `max_results` option was passed to
+  # `#describe_report_definitions`. I chose 5 because when using `max_results` in the real world
+  # it seems to only accept a value of 5.
+  #
+  # == Returns:
+  # A Aws::CostandUsageReportService::Types::DescribeReportDefinitionsRespons object with two instance
+  # attributes:
+  # `report_definitions` An Array that includes a single page of 5 Reports.
+  # `next_token` A String set to the start of the next page. When `next_token` is nil, there are no more pages.
+  #
+  class Paginated < AwsBackendBase
+    def describe_report_definitions(options = {})
+      definitions = []
+
+      definitions << Aws::CostandUsageReportService::Types::ReportDefinition.new(
+        report_name: 'inspec1',
+        time_unit: 'HOURLY',
+        format: 'textORcsv',
+        compression: 'ZIP',
+        s3_bucket: 'inspec1-s3-bucket',
+        s3_prefix: 'inspec1/accounting',
+        s3_region: 'us-east-1')
+      definitions << Aws::CostandUsageReportService::Types::ReportDefinition.new(
+        report_name: 'inspec2',
+        time_unit: 'DAILY',
+        format: 'textORcsv',
+        compression: 'GZIP',
+        s3_bucket: 'inspec2-s3-bucket',
+        s3_prefix: 'inspec2/accounting',
+        s3_region: 'us-west-1')
+
+      (3..12).each do |i|
+        definitions <<
+        Aws::CostandUsageReportService::Types::ReportDefinition.new(
+          report_name: "inspec#{i}",
+          time_unit: %w{HOURLY DAILY}.sample,
+          format: 'textORcsv',
+          compression: %w{ZIP GZIP}.sample,
+          s3_bucket: "inspec#{i}-s3-bucket",
+          s3_prefix: "inspec#{i}",
+          s3_region: 'us-east-1'
+        )
+      end
+
+      @definitions ||= definitions.shuffle!
+
+      token = options.fetch(:next_token, nil)
+
+      starting_position = token.nil? ? 0 : @definitions.find_index { |i| i[:report_name].eql?(token) }
+      selected_definitions = @definitions.slice(starting_position, 5)
+      next_token = @definitions[starting_position + 5].eql?(nil) ? nil : @definitions[starting_position + 5][:report_name]
+
+      response = Aws::CostandUsageReportService::Types::DescribeReportDefinitionsResponse
+      .new(report_definitions: selected_definitions)
+      response.next_token = next_token
+      response
+    end
+  end
+end

--- a/test/unit/resources/aws_billing_report_test.rb
+++ b/test/unit/resources/aws_billing_report_test.rb
@@ -25,11 +25,11 @@ class BasicAwsBillingReportTest < Minitest::Test
   end
 
   def test_search_hit_via_hash_works
-    assert AwsBillingReport.new(report: 'inspec1').exists?
+    assert AwsBillingReport.new(report_name: 'inspec1').exists?
   end
 
   def test_search_miss_is_not_an_exception
-    refute AwsBillingReport.new(report: 'non-existent').exists?
+    refute AwsBillingReport.new(report_name: 'non-existent').exists?
   end
 
   def test_search_hit_properties

--- a/test/unit/resources/aws_billing_report_test.rb
+++ b/test/unit/resources/aws_billing_report_test.rb
@@ -1,0 +1,99 @@
+require 'helper'
+
+class EmptyAwsBillingReportTest < Minitest::Test
+  def setup
+    AwsBillingReport::BackendFactory.select(MockAwsBillingReport::Empty)
+  end
+
+  def test_empty_query
+    assert_raises(ArgumentError) { AwsBillingReport.new }
+  end
+end
+
+class BasicAwsBillingReportTest < Minitest::Test
+  def setup
+    AwsBillingReport::BackendFactory.select(MockAwsBillingReport::Basic)
+  end
+
+  def test_search_hit_via_scalar
+    assert AwsBillingReport.new('inspec1').exists?
+  end
+
+  def test_search_miss_via_scalar
+    refute AwsBillingReport.new('non-existant').exists?
+  end
+
+  def test_search_hit_via_hash_works
+    assert AwsBillingReport.new(report: 'inspec1').exists?
+  end
+
+  def test_search_miss_is_not_an_exception
+    refute AwsBillingReport.new(report: 'non-existant').exists?
+  end
+
+  def test_search_hit_properties
+    r = AwsBillingReport.new('inspec1')
+    assert_equal('inspec1', r.report_name)
+    assert_equal('hourly', r.time_unit)
+    assert_equal('textORcsv', r.format)
+    assert_equal('zip', r.compression)
+    assert_equal('inspec1-s3-bucket', r.s3_bucket)
+    assert_equal('inspec1/accounting', r.s3_prefix)
+    assert_equal('us-east-1', r.s3_region)
+  end
+
+  def test_hourly?
+    assert AwsBillingReport.new('inspec1').hourly?
+    refute AwsBillingReport.new('inspec2').hourly?
+  end
+
+  def test_daily?
+    assert AwsBillingReport.new('inspec2').daily?
+    refute AwsBillingReport.new('inspec1').daily?
+  end
+
+  def test_zip?
+    assert AwsBillingReport.new('inspec1').zip?
+    refute AwsBillingReport.new('inspec2').zip?
+  end
+
+  def test_gzip?
+    assert AwsBillingReport.new('inspec2').gzip?
+    refute AwsBillingReport.new('inspec1').gzip?
+  end
+end
+
+module MockAwsBillingReport
+  class Empty < AwsBackendBase
+    def describe_report_definitions
+      OpenStruct.new(report_definitions: [])
+    end
+  end
+
+  class Basic < AwsBackendBase
+    def describe_report_definitions
+      OpenStruct.new(
+        report_definitions: [
+          Aws::CostandUsageReportService::Types::ReportDefinition.new(
+            report_name: 'inspec1',
+            time_unit: 'HOURLY',
+            format: 'textORcsv',
+            compression: 'ZIP',
+            s3_bucket: 'inspec1-s3-bucket',
+            s3_prefix: 'inspec1/accounting',
+            s3_region: 'us-east-1',
+          ),
+          Aws::CostandUsageReportService::Types::ReportDefinition.new(
+            report_name: 'inspec2',
+            time_unit: 'DAILY',
+            format: 'textORcsv',
+            compression: 'GZIP',
+            s3_bucket: 'inspec2-s3-bucket',
+            s3_prefix: 'inspec2/accounting',
+            s3_region: 'us-west-1',
+          ),
+        ],
+      )
+    end
+  end
+end

--- a/test/unit/resources/aws_billing_report_test.rb
+++ b/test/unit/resources/aws_billing_report_test.rb
@@ -1,8 +1,9 @@
 require 'helper'
+require_relative 'aws_billing_backend'
 
 class EmptyAwsBillingReportTest < Minitest::Test
   def setup
-    AwsBillingReport::BackendFactory.select(MockAwsBillingReport::Empty)
+    AwsBillingReport::BackendFactory.select(MockAwsBillingReports::Empty)
   end
 
   def test_empty_query
@@ -12,7 +13,7 @@ end
 
 class BasicAwsBillingReportTest < Minitest::Test
   def setup
-    AwsBillingReport::BackendFactory.select(MockAwsBillingReport::Basic)
+    AwsBillingReport::BackendFactory.select(MockAwsBillingReports::Basic)
   end
 
   def test_search_hit_via_scalar
@@ -20,7 +21,7 @@ class BasicAwsBillingReportTest < Minitest::Test
   end
 
   def test_search_miss_via_scalar
-    refute AwsBillingReport.new('non-existant').exists?
+    refute AwsBillingReport.new('non-existent').exists?
   end
 
   def test_search_hit_via_hash_works
@@ -28,7 +29,7 @@ class BasicAwsBillingReportTest < Minitest::Test
   end
 
   def test_search_miss_is_not_an_exception
-    refute AwsBillingReport.new(report: 'non-existant').exists?
+    refute AwsBillingReport.new(report: 'non-existent').exists?
   end
 
   def test_search_hit_properties
@@ -63,37 +64,16 @@ class BasicAwsBillingReportTest < Minitest::Test
   end
 end
 
-module MockAwsBillingReport
-  class Empty < AwsBackendBase
-    def describe_report_definitions
-      OpenStruct.new(report_definitions: [])
-    end
+class PaginatedAwsBillingReportTest < Minitest::Test
+  def setup
+    AwsBillingReport::BackendFactory.select(MockAwsBillingReports::Paginated)
   end
 
-  class Basic < AwsBackendBase
-    def describe_report_definitions
-      OpenStruct.new(
-        report_definitions: [
-          Aws::CostandUsageReportService::Types::ReportDefinition.new(
-            report_name: 'inspec1',
-            time_unit: 'HOURLY',
-            format: 'textORcsv',
-            compression: 'ZIP',
-            s3_bucket: 'inspec1-s3-bucket',
-            s3_prefix: 'inspec1/accounting',
-            s3_region: 'us-east-1',
-          ),
-          Aws::CostandUsageReportService::Types::ReportDefinition.new(
-            report_name: 'inspec2',
-            time_unit: 'DAILY',
-            format: 'textORcsv',
-            compression: 'GZIP',
-            s3_bucket: 'inspec2-s3-bucket',
-            s3_prefix: 'inspec2/accounting',
-            s3_region: 'us-west-1',
-          ),
-        ],
-      )
-    end
+  def test_paginated_search_hit_via_scalar
+    assert AwsBillingReport.new('inspec8').exists?
+  end
+
+  def test_paginated_search_miss_via_scalar
+    refute AwsBillingReport.new('non-existent').exists?
   end
 end

--- a/test/unit/resources/aws_billing_report_test.rb
+++ b/test/unit/resources/aws_billing_report_test.rb
@@ -36,7 +36,6 @@ class BasicAwsBillingReportTest < Minitest::Test
     r = AwsBillingReport.new('inspec1')
     assert_equal('inspec1', r.report_name)
     assert_equal('hourly', r.time_unit)
-    assert_equal('textORcsv', r.format)
     assert_equal('zip', r.compression)
     assert_equal('inspec1-s3-bucket', r.s3_bucket)
     assert_equal('inspec1/accounting', r.s3_prefix)

--- a/test/unit/resources/aws_billing_reports_test.rb
+++ b/test/unit/resources/aws_billing_reports_test.rb
@@ -35,14 +35,14 @@ class BasicAwsBillingReportsTest < Minitest::Test
   end
 
   def test_search_hit_properties
-    assert AwsBillingReports.new.report_name.include?('inspec1')
+    assert AwsBillingReports.new.report_names.include?('inspec1')
   end
 
   def test_where_hit
     abr = AwsBillingReports.new.where { report_name =~ /inspec.*/ }
-    assert_includes abr.time_unit, 'daily'
-    assert_includes abr.compression, 'zip'
-    assert_includes abr.s3_bucket, 'inspec1-s3-bucket'
+    assert_includes abr.time_units, 'daily'
+    assert_includes abr.compressions, 'zip'
+    assert_includes abr.s3_buckets, 'inspec1-s3-bucket'
   end
 end
 
@@ -52,10 +52,10 @@ class PaginatedAwsBillingReportsTest < Minitest::Test
   end
 
   def test_paginated_search_hit_via_scalar
-    assert AwsBillingReports.new.report_name.include?('inspec12')
+    assert AwsBillingReports.new.report_names.include?('inspec12')
   end
 
   def test_paginated_search_miss_via_scalar
-    refute AwsBillingReports.new.report_name.include?('non-existent')
+    refute AwsBillingReports.new.report_names.include?('non-existent')
   end
 end

--- a/test/unit/resources/aws_billing_reports_test.rb
+++ b/test/unit/resources/aws_billing_reports_test.rb
@@ -1,0 +1,82 @@
+require 'helper'
+
+class ConstructorAwsBillingReportsTest < Minitest::Test
+  def setup
+    AwsBillingReports::BackendFactory.select(MockAwsBillingReports::Empty)
+  end
+
+  def test_empty_params_ok
+    assert AwsBillingReports.new
+  end
+
+  def test_rejects_unrecognized_params
+    assert_raises(ArgumentError) { AwsBillingReports.new(unrecognized_param: 1) }
+  end
+end
+
+class EmptyAwsBillingReportsTest < Minitest::Test
+  def setup
+    AwsBillingReports::BackendFactory.select(MockAwsBillingReports::Empty)
+  end
+
+  def test_search_miss_reports_empty
+    refute AwsBillingReports.new.exists?
+  end
+end
+
+class BasicAwsBillingReportsTest < Minitest::Test
+  def setup
+    AwsBillingReports::BackendFactory.select(MockAwsBillingReports::Basic)
+  end
+
+  def test_search_hit_via_empty_filter
+    assert AwsBillingReports.new.exists?
+  end
+
+  def test_search_hit_properties
+    assert AwsBillingReports.new.report_name.include?('inspec1')
+  end
+
+  def test_where_hit
+    abr = AwsBillingReports.new.where { report_name =~ /inspec.*/ }
+    assert_includes abr.compression, 'ZIP'
+    assert_includes abr.s3_bucket, 'inspec-s3-bucket'
+  end
+end
+
+module MockAwsBillingReports
+  class Empty < AwsBackendBase
+    def describe_report_definitions
+      OpenStruct.new(report_definitions: [])
+    end
+  end
+
+  class Basic < AwsBackendBase
+    def describe_report_definitions
+      OpenStruct.new(report_definitions: [
+        Aws::CostandUsageReportService::Types::ReportDefinition.new(
+          report_name: 'inspec1',
+          time_unit: 'HOURLY',
+          format: 'textORcsv',
+          compression: 'ZIP',
+          additional_schema_elements: ['RESOURCES'],
+          s3_bucket: 'inspec-s3-bucket',
+          s3_prefix: 'inspec1',
+          s3_region: 'us-east-1',
+          additional_artifacts: ['REDSHIFT'],
+        ),
+        Aws::CostandUsageReportService::Types::ReportDefinition.new(
+          report_name: 'inspec2',
+          time_unit: 'DAILY',
+          format: 'textORcsv',
+          compression: 'GZIP',
+          additional_schema_elements: ['RESOURCES'],
+          s3_bucket: 'inspec-s3-bucket',
+          s3_prefix: 'inspec2',
+          s3_region: 'us-west-1',
+          additional_artifacts: ['QUICKSIGHT'],
+        ),
+      ])
+    end
+  end
+end


### PR DESCRIPTION
This PR adds two resources, `aws_billing_report` and `aws_billing_reports`, tests, and documentation.

With `aws_billing_report` you can search for specific reports and test its properties.

```
describe aws_billing_report('inspec1') do
  its('report_name') { should cmp 'inspec1' }
  its('time_unit') { should cmp 'DAILY' }
end
```

`aws_billing_reports` uses a FilterTable to store all reports and their properties. 
```
describe aws_billing_reports do
  its('report_name') { should include 'inspec1' }
  its('s3_bucket') { should include 'inspec1-s3-bucket' }
end
```

You can also use `.where` to match multiple entries.
```
describe aws_billing_reports.where { report_name =~ /inspec.*/ } do
  its('time_unit') { should_not include 'DAILY' }
  its('s3_bucket') { should include 'inspec1-s3-bucket' }
end
```

I was not able to add integration testing through Terraform as it lacks the resources to create billing reports.

Signed-off-by: Miah Johnson <miah@chia-pet.org>

Fixes https://github.com/chef/inspec/issues/2720