### PR TITLE
New attribute JUnit reporter - target

### DIFF
--- a/lib/inspec/reporters/junit.rb
+++ b/lib/inspec/reporters/junit.rb
@@ -43,6 +43,7 @@ module Inspec::Reporters
       result_xml = REXML::Element.new('testcase')
       result_xml.add_attribute('name', result[:code_desc])
       result_xml.add_attribute('classname', control[:title].nil? ? "#{profile_name}.Anonymous" : "#{profile_name}.#{control[:id]}")
+      result_xml.add_attribute('target', run_data[:platform][:target].nil? ? '' : run_data[:platform][:target].to_s)
       result_xml.add_attribute('time', result[:run_time])
 
       if result[:status] == 'failed'

--- a/test/unit/mock/reporters/junit_output
+++ b/test/unit/mock/reporters/junit_output
@@ -1,11 +1,11 @@
 <?xml version='1.0'?>
 <testsuites>
   <testsuite name='long_commands' tests='4' failed='1'>
-    <testcase name='File /tmp should be directory' classname='long_commands.Anonymous' time='0.002058'/>
-    <testcase name='File /tmp should be directory' classname='long_commands.tmp-1.0' time='0.000102'/>
-    <testcase name='gem package rubocop should be installed' classname='long_commands.Anonymous' time='0.000168'>
+    <testcase name='File /tmp should be directory' classname='long_commands.Anonymous' target='local://' time='0.002058'/>
+    <testcase name='File /tmp should be directory' classname='long_commands.tmp-1.0' target='local://' time='0.000102'/>
+    <testcase name='gem package rubocop should be installed' classname='long_commands.Anonymous' target='local://' time='0.000168'>
       <failure message='rubocop is not installed'/>
     </testcase>
-    <testcase name='Command whoami stdout should eq &quot;jquick\n&quot;' classname='long_commands.Anonymous' time='0.034938'/>
+    <testcase name='Command whoami stdout should eq &quot;jquick\n&quot;' classname='long_commands.Anonymous' target='local://' time='0.034938'/>
   </testsuite>
 </testsuites>

--- a/test/unit/reporters/junit_test.rb
+++ b/test/unit/reporters/junit_test.rb
@@ -2,9 +2,9 @@
 
 require 'helper'
 
-describe Inspec::Reporters::Json do
+describe Inspec::Reporters::Junit do
   let(:path) { File.expand_path(File.dirname(__FILE__)) }
-  let(:report) do 
+  let(:report) do
     data = JSON.parse(File.read(path + '/../mock/reporters/run_data.json'), symbolize_names: true)
     Inspec::Reporters::Junit.new({ run_data: data })
   end


### PR DESCRIPTION
Append target for JUnit reporter, so that it's easier to find which host actually failed, when running the same set of controls across multiple nodes.

Fixes https://github.com/chef/inspec/issues/2840