### PR TITLE
Update audit_policy supports to 'windows'

### DIFF
--- a/lib/resources/audit_policy.rb
+++ b/lib/resources/audit_policy.rb
@@ -24,7 +24,7 @@
 module Inspec::Resources
   class AuditPolicy < Inspec.resource(1)
     name 'audit_policy'
-    supports platform: 'unix'
+    supports platform: 'windows'
     desc 'Use the audit_policy InSpec audit resource to test auditing policies on the Microsoft Windows platform. An auditing policy is a category of security-related events to be audited. Auditing is disabled by default and may be enabled for categories like account management, logon events, policy changes, process tracking, privilege use, system events, or object access. For each enabled auditing category property, the auditing level may be set to No Auditing, Not Specified, Success, Success and Failure, or Failure.'
     example "
       describe audit_policy do

--- a/test/unit/resources/audit_policy_test.rb
+++ b/test/unit/resources/audit_policy_test.rb
@@ -8,6 +8,7 @@ require 'inspec/resource'
 describe 'Inspec::Resources::AuditPolicy' do
   it 'check audit policy parsing' do
     resource = MockLoader.new(:windows).load_resource('audit_policy')
+    _(resource.resource_skipped?).must_equal false
     _(resource.send('User Account Management')).must_equal 'Success'
   end
 end


### PR DESCRIPTION
This updates the supports from `unix` to `windows` for the audit_policy resource.

Fixes #2829 

Signed-off-by: Jared Quick <jquick@chef.io>