### PR TITLE
Remove supports binding for generic resources

### DIFF
--- a/lib/resources/csv.rb
+++ b/lib/resources/csv.rb
@@ -6,10 +6,6 @@
 module Inspec::Resources
   class CsvConfig < JsonConfig
     name 'csv'
-    supports platform: 'unix'
-    supports platform: 'windows'
-    supports platform: 'esx'
-    supports platform: 'cisco'
     desc 'Use the csv InSpec audit resource to test configuration data in a CSV file.'
     example "
       describe csv('example.csv') do

--- a/lib/resources/json.rb
+++ b/lib/resources/json.rb
@@ -5,10 +5,6 @@ require 'utils/object_traversal'
 module Inspec::Resources
   class JsonConfig < Inspec.resource(1)
     name 'json'
-    supports platform: 'unix'
-    supports platform: 'windows'
-    supports platform: 'esx'
-    supports platform: 'cisco'
     desc 'Use the json InSpec audit resource to test data in a JSON file.'
     example "
       describe json('policyfile.lock.json') do

--- a/lib/resources/yaml.rb
+++ b/lib/resources/yaml.rb
@@ -10,10 +10,6 @@ require 'yaml'
 module Inspec::Resources
   class YamlConfig < JsonConfig
     name 'yaml'
-    supports platform: 'unix'
-    supports platform: 'windows'
-    supports platform: 'esx'
-    supports platform: 'cisco'
     desc 'Use the yaml InSpec audit resource to test configuration data in a YAML file.'
     example "
       describe yaml('config.yaml') do


### PR DESCRIPTION
We ran into an issue were the AWS transport was trying to parse some YAML. This resource was previously locked down to only OS's. This change opens up the generic resources(yaml, csv, json) to be able to be used with any transport.

Fixes https://github.com/chef/inspec/issues/2846

Signed-off-by: Jared Quick <jquick@chef.io>