### PR TITLE
Correct support platform for audit_policy

### DIFF
--- a/lib/resources/audit_policy.rb
+++ b/lib/resources/audit_policy.rb
@@ -24,7 +24,7 @@
 module Inspec::Resources
   class AuditPolicy < Inspec.resource(1)
     name 'audit_policy'
-    supports platform: 'unix'
+    supports platform: 'windows'
     desc 'Use the audit_policy InSpec audit resource to test auditing policies on the Microsoft Windows platform. An auditing policy is a category of security-related events to be audited. Auditing is disabled by default and may be enabled for categories like account management, logon events, policy changes, process tracking, privilege use, system events, or object access. For each enabled auditing category property, the auditing level may be set to No Auditing, Not Specified, Success, Success and Failure, or Failure.'
     example "
       describe audit_policy do


### PR DESCRIPTION
Audity Policy resource is only used on the windows platform and
was incorrectly set to unix.

Fixes #2829

Co-authored-by: Trevor Bramble <tbramble@chef.io>
Co-authored-by: Paul Welch <pwelch@chef.io>