### PR TITLE
Remove incorrect example from documentation

### DIFF
--- a/docs/resources/ssh_config.md.erb
+++ b/docs/resources/ssh_config.md.erb
@@ -47,13 +47,6 @@ The following examples show how to use this InSpec audit resource.
       its('SendEnv') { should include('GORDON_CLIENT') }
     end
 
-### Test owner and group permissions
-
-    describe ssh_config do
-      its('owner') { should eq 'root' }
-      its('mode') { should cmp '0644' }
-    end
-
 ### Test SSH configuration
 
     describe ssh_config do


### PR DESCRIPTION
Owner and mode are provided by the file resource, not ssh_config.

Fixes #2471

Co-authored-by: Trevor Bramble tbramble@chef.io
Co-authored-by: Paul Welch pwelch@chef.io

Signed-off-by: Paul Welch <pwelch@chef.io>