### PR TITLE
Add unf_ext configuration to omnibus to allow building against our forked unf_ext.

### DIFF
--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -24,6 +24,7 @@ dependency 'rubygems'
 dependency 'bundler'
 dependency 'rb-readline'
 dependency 'appbundler'
+dependency 'unf_ext'
 
 license :project_license
 

--- a/omnibus/config/software/unf_ext.rb
+++ b/omnibus/config/software/unf_ext.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+# override for unf_ext until
+# https://github.com/knu/ruby-unf_ext/pull/39
+# is merged and released
+
+name 'unf_ext'
+
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'bundler'
+dependency 'appbundler'
+
+license :project_license
+default_version 'b5a0ee7725cb7d3cb8e068c8cab0f8627b2b1225'
+source git: 'https://github.com/jquick/ruby-unf_ext.git'
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  delete "#{name}-*.gem"
+  gem "build #{name}.gemspec", env: env
+  gem "install #{name}-*.gem --no-document", env: env
+end


### PR DESCRIPTION
Installing the InSpec gem on Solaris is currently failing, because of a new dependency on unf_ext which was brought in when we added Azure to Train. We have submitted a PR upstream to get unf_ext fixed, but until then hope to provide a solution through omnibus. When upstream is merged we can remove our fork, and undo this change but still provide omnibus for Solaris and AIX.

Unfortunately, we do not currently release omnibus builds of InSpec for Solaris or AIX. I have another PR opened to add Solaris and AIX to our InSpec omnibus build matrix.

Until https://github.com/knu/ruby-unf_ext/pull/39 is merged we have a fork of unf_ext living at https://github.com/jquick/ruby-unf_ext.

Signed-off-by: Miah Johnson <miah@chia-pet.org>