### PR TITLE
Remove obsolete mock

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -177,7 +177,6 @@ class MockLoader
       '/etc/postgresql/9.5/main' => mockfile.call('9.5.main'),
       '/var/lib/postgresql/9.5/main' => mockfile.call('var.9.5.main'),
       '/etc/hosts' => mockfile.call('hosts'),
-      '/etc/hosts_empty' => emptyfile.call,
       'C:\windows\system32\drivers\etc\hosts' => mockfile.call('hosts'),
       '/etc/fstab' => mockfile.call('fstab'),
       'fstab_no_home' => mockfile.call('fstab_no_home'),


### PR DESCRIPTION
This mock was a remnant of file reading tests for the etc_hosts resource that became obsolete with the centralization of file reading code to a new FileReader resource.

See: #2863, #2359

Signed-off-by: Trevor Bramble <tbramble@chef.io>