### PR TITLE
registry_key resource was returning an incorrect value

### DIFF
--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -163,10 +163,11 @@ module Inspec::Resources
         $properties = New-Object -Type PSObject
         $reg.Property | ForEach-Object {
             $key = $_
-            if ("(default)".Equals($key)) { $key = '' }
+            $keytype = $key
+            if ("(default)".Equals($key)) { $keytype = '' }
             $value = New-Object psobject -Property @{
               "value" =  $(Get-ItemProperty ('Registry::' + $path)).$key;
-              "type"  = $reg.GetValueKind($key);
+              "type"  = $reg.GetValueKind($keytype);
             }
             $properties | Add-Member NoteProperty $_ $value
         }

--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -165,7 +165,7 @@ module Inspec::Resources
             $key = $_
             if ("(default)".Equals($key)) { $key = '' }
             $value = New-Object psobject -Property @{
-              "value" =  $reg.GetValue($key);
+              "value" =  $(Get-ItemProperty ('Registry::' + $path)).$key;
               "type"  = $reg.GetValueKind($key);
             }
             $properties | Add-Member NoteProperty $_ $value

--- a/test/cookbooks/os_prepare/recipes/registry_key.rb
+++ b/test/cookbooks/os_prepare/recipes/registry_key.rb
@@ -24,6 +24,10 @@ if node['platform_family'] == 'windows'
       :type => :dword,
       :data => 0
     },{
+      :name => 'big dword value',
+      :type => :dword,
+      :data => 2147483648
+    },{
       :name => 'qword value',
       :type => :qword,
       :data => 0

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -229,7 +229,7 @@ class MockLoader
       'env' => cmd.call('env'),
       '${Env:PATH}'  => cmd.call('$env-PATH'),
       # registry key test using winrm 2.0
-      '85dc50ecbb6cec70544174a31c8aa3aa7cb3c4dc96553c478c2c3e86715557d5' => cmd.call('reg_schedule'),
+      'e5f668e7130ed40b18a0686b76dac9be5ede33421eb3d125aafd43bcd7b565a6' => cmd.call('reg_schedule'),
       'Auditpol /get /subcategory:\'User Account Management\' /r' => cmd.call('auditpol'),
       '/sbin/auditctl -l' => cmd.call('auditctl'),
       '/sbin/auditctl -s' => cmd.call('auditctl-s'),

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -229,7 +229,7 @@ class MockLoader
       'env' => cmd.call('env'),
       '${Env:PATH}'  => cmd.call('$env-PATH'),
       # registry key test using winrm 2.0
-      'e5f668e7130ed40b18a0686b76dac9be5ede33421eb3d125aafd43bcd7b565a6' => cmd.call('reg_schedule'),
+      '9417f24311a9dcd90f1b1734080a2d4c6516ec8ff2d452a2328f68eb0ed676cf' => cmd.call('reg_schedule'),
       'Auditpol /get /subcategory:\'User Account Management\' /r' => cmd.call('auditpol'),
       '/sbin/auditctl -l' => cmd.call('auditctl'),
       '/sbin/auditctl -s' => cmd.call('auditctl-s'),

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -229,7 +229,7 @@ class MockLoader
       'env' => cmd.call('env'),
       '${Env:PATH}'  => cmd.call('$env-PATH'),
       # registry key test using winrm 2.0
-      'bd15a11a4b07de0224c4d1ab16c49ad78dd6147650c6ef629152c7093a5ac95e' => cmd.call('reg_schedule'),
+      '85dc50ecbb6cec70544174a31c8aa3aa7cb3c4dc96553c478c2c3e86715557d5' => cmd.call('reg_schedule'),
       'Auditpol /get /subcategory:\'User Account Management\' /r' => cmd.call('auditpol'),
       '/sbin/auditctl -l' => cmd.call('auditctl'),
       '/sbin/auditctl -s' => cmd.call('auditctl-s'),

--- a/test/integration/default/controls/registry_key_spec.rb
+++ b/test/integration/default/controls/registry_key_spec.rb
@@ -133,6 +133,7 @@ end
 describe registry_key('HKLM\System\Test') do
   it { should exist }
   its('super\/escape') { should eq '\/value/\\' }
+  its('big dword value') { should eq 2147483648}
 
   # its('key.with.dot') { should eq 'value.with.dot' }
   # does not work due to the . inside the its block


### PR DESCRIPTION
When key value was greater than 2147483647 the registry_key resource was returning an incorrect value failing the test even though the expected value and the actual value in the registry were the same.