### PR TITLE
Mitigate trivial warning output on test

### DIFF
--- a/lib/bundles/inspec-habitat/profile.rb
+++ b/lib/bundles/inspec-habitat/profile.rb
@@ -31,6 +31,7 @@ module Habitat
     def initialize(path, options = {})
       @path    = path
       @options = options
+      @cli_config = nil
 
       log_level = options.fetch('log_level', 'info')
       Habitat::Log.level(log_level.to_sym)

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -115,6 +115,9 @@ module Inspec
       @runner_context =
         options[:profile_context] ||
         Inspec::ProfileContext.for_profile(self, @backend, @attr_values)
+
+      @supports_platform = metadata.supports_platform?(@backend)
+      @supports_runtime = metadata.supports_runtime?
     end
 
     def name

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -38,6 +38,7 @@ module Inspec
       # in the transitive dependency tree of the loaded profile.
       @resource_registry = Inspec::Resource.new_registry
       @library_eval_context = Inspec::LibraryEvalContext.create(@resource_registry, @require_loader)
+      @current_load = nil
     end
 
     def dependencies

--- a/lib/resources/azure/azure_virtual_machine_data_disk.rb
+++ b/lib/resources/azure/azure_virtual_machine_data_disk.rb
@@ -17,8 +17,6 @@ module Inspec::Resources
     filter = FilterTable.create
     filter.add_accessor(:where)
           .add_accessor(:entries)
-          .add_accessor(:has_data_disks?)
-          .add_accessor(:count)
           .add(:exists?) { |x| !x.entries.empty? }
           .add(:disk, field: :disk)
           .add(:number, field: :number)

--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -74,6 +74,7 @@ module Inspec::Resources
           @http_method = http_method
           @url = url
           @opts = opts
+          @response = nil
         end
 
         private
@@ -152,6 +153,7 @@ module Inspec::Resources
                   'curl is not available on the target machine'
           end
 
+          @ran_curl = false
           @inspec = inspec
           super(http_method, url, opts)
         end

--- a/lib/resources/nginx.rb
+++ b/lib/resources/nginx.rb
@@ -34,7 +34,7 @@ module Inspec::Resources
       read_content
     end
 
-    %w{compiler_info error_log_path http_client_body_temp_path http_fastcgi_temp_path http_log_path http_proxy_temp_path http_scgi_temp_path http_uwsgi_temp_path lock_path modules_path openssl_version prefix sbin_path service support_info version}.each do |property|
+    %w{error_log_path http_client_body_temp_path http_fastcgi_temp_path http_log_path http_proxy_temp_path http_scgi_temp_path http_uwsgi_temp_path lock_path modules_path prefix sbin_path service version}.each do |property|
       define_method(property.to_sym) do
         @params[property.to_sym]
       end

--- a/lib/resources/os_env.rb
+++ b/lib/resources/os_env.rb
@@ -22,7 +22,6 @@ module Inspec::Resources
       end
     "
 
-    attr_reader :content
     def initialize(env = nil)
       @osenv = env
     end

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -180,6 +180,7 @@ module FilterTable
     def initialize
       @accessors = []
       @connectors = {}
+      @resource = nil
     end
 
     def connect(resource, table_accessor) # rubocop:disable Metrics/AbcSize

--- a/test/unit/reporters/cli_test.rb
+++ b/test/unit/reporters/cli_test.rb
@@ -230,7 +230,7 @@ describe Inspec::Reporters::CLI do
     it 'confirm controls' do
       result = report.send(:anonymous_controls_from_profile, profile)
       result.count.must_equal 3
-      result.first[:id].must_match /generated/
+      result.first[:id].must_match(/generated/)
     end
   end
 

--- a/test/unit/resources/aws_s3_bucket_test.rb
+++ b/test/unit/resources/aws_s3_bucket_test.rb
@@ -29,14 +29,14 @@ class AwsS3BucketConstructor < Minitest::Test
   end
 end
 
-#=============================================================================#
-#                               Search / Recall
-#=============================================================================#
 class AwsS3BucketPropertiesTest < Minitest::Test
   def setup
     AwsS3Bucket::BackendFactory.select(AwsMSBSB::Basic)
   end
 
+  #===========================================================================#
+  #                               Search / Recall
+  #===========================================================================#
   def test_recall_no_match_is_no_exception
     refute AwsS3Bucket.new('NonExistentBucket').exists?
   end
@@ -46,17 +46,10 @@ class AwsS3BucketPropertiesTest < Minitest::Test
   end
 
   # No need to handle multiple hits; S3 bucket names are globally unique.
-end
 
-#=============================================================================#
-#                               Properties
-#=============================================================================#
-
-class AwsS3BucketPropertiesTest < Minitest::Test
-  def setup
-    AwsS3Bucket::BackendFactory.select(AwsMSBSB::Basic)
-  end
-
+  #===========================================================================#
+  #                               Properties
+  #===========================================================================#
   #---------------------Bucket Name----------------------------#  
   def test_property_bucket_name
     assert_equal('public', AwsS3Bucket.new('public').bucket_name)
@@ -143,17 +136,9 @@ class AwsS3BucketPropertiesTest < Minitest::Test
     assert_empty(bucket_policy)
   end
 
-end
-
-#=============================================================================#
-#                               Test Matchers
-#=============================================================================#
-
-class AwsS3BucketPropertiesTest < Minitest::Test
-  def setup
-    AwsS3Bucket::BackendFactory.select(AwsMSBSB::Basic)
-  end
-
+  #===========================================================================#
+  #                               Test Matchers
+  #===========================================================================#
   def test_be_public_public_acl
     assert(AwsS3Bucket.new('public').public?)
   end
@@ -162,9 +147,6 @@ class AwsS3BucketPropertiesTest < Minitest::Test
   end
   def test_be_public_private_acl
     refute(AwsS3Bucket.new('private').public?)
-  end
-  def test_be_public_public_acl
-    assert(AwsS3Bucket.new('public').public?)
   end
 
   def test_has_access_logging_enabled_positive


### PR DESCRIPTION
To be easier to find out any problem when testing, mitigates that trivial warnings are output due to initializing arguments and removing redundant methods. 

Changes to mitigate each warning on this PR are described in detail below:

* Sets the initial value to the variables in initialize method.
  ```
  lib/bundles/inspec-habitat/profile.rb:290: warning: instance variable @cli_config not initialized
  lib/inspec/profile.rb:143: warning: instance variable @supports_platform not initialized
  lib/inspec/profile.rb:150: warning: instance variable @supports_runtime not initialized
  lib/inspec/profile_context.rb:169: warning: instance variable @current_load not initialized
  lib/resources/http.rb:130: warning: instance variable @response not initialized
  lib/resources/http.rb:177: warning: instance variable @ran_curl not initialized
  lib/utils/filter.rb:236: warning: instance variable @resource not initialized
  lib/utils/filter.rb:244: warning: instance variable @resource not initialized
  ```

* Fixes passing a ambiguous argument.
  ```
  test/unit/reporters/cli_test.rb:233: warning: ambiguous first argument; put parentheses or a space even after `/' operator
  ```

* Since `has_data_disks` and `count` method are defined as method in azure_virtual_machine_data_disk.rb after being added as accessor, removes the accessors
  ```
  lib/resources/azure/azure_virtual_machine_data_disk.rb:66: warning: method redefined; discarding old has_data_disks?
  lib/utils/filter.rb:223: warning: previous definition of has_data_disks? was here
  lib/resources/azure/azure_virtual_machine_data_disk.rb:71: warning: method redefined; discarding old count
  lib/utils/filter.rb:223: warning: previous definition of count was here 
  ```

* Since `openssl_version/compiler_info/support_info` method are redefined as unique method after being defined by define_method method, removes previous definitions.
  ```
  lib/resources/nginx.rb:43: warning: method redefined; discarding old openssl_version
  lib/resources/nginx.rb:38: warning: previous definition of openssl_version was here
  lib/resources/nginx.rb:48: warning: method redefined; discarding old compiler_info 
  lib/resources/nginx.rb:38: warning: previous definition of compiler_info was here
  lib/resources/nginx.rb:53: warning: method redefined; discarding old support_info
  lib/resources/nginx.rb:38: warning: previous definition of support_info was here
  ```

* Since `content` method is defined as method after being defined as attribute reader, removes the reader.
  ```
  lib/resources/os_env.rb:39: warning: method redefined; discarding old content
  ```

* Since `setup` method is multiply defined in the same class name, organizes to remove them.
  ```
  test/unit/resources/aws_s3_bucket_test.rb:56: warning: method redefined; discarding old setup
  test/unit/resources/aws_s3_bucket_test.rb:36: warning: previous definition of setup was here
  test/unit/resources/aws_s3_bucket_test.rb:153: warning: method redefined; discarding old setup
  test/unit/resources/aws_s3_bucket_test.rb:56: warning: previous definition of setup was here 
  ```

* Since `test_be_public_public_acl` method is defined twice and is the same in content, removes one.
  ```
  test/unit/resources/aws_s3_bucket_test.rb:166: warning: method redefined; discarding old test_be_public_public_acl
  test/unit/resources/aws_s3_bucket_test.rb:157: warning: previous definition of test_be_public_public_acl was here
  ```