### PR TITLE
Pin concurrent-ruby to version 1.0 to fix kitchen-ansible example

### DIFF
--- a/examples/kitchen-ansible/Gemfile
+++ b/examples/kitchen-ansible/Gemfile
@@ -15,5 +15,5 @@ group :integration do
   gem 'kitchen-ansible'
   gem 'kitchen-vagrant'
   gem 'kitchen-inspec'
-  gem 'concurrent-ruby', '~> 0.9'
+  gem 'concurrent-ruby', '~> 1.0'
 end


### PR DESCRIPTION
When I tried to install the dependencies with bundle I bumped into a dependency issue with the concurrent-ruby gem. 

By pointing the version to 1.0 instead of 0.9 in the Gemfile the dependencies installed fine using bundle. 

```bash
$ bundle install --path vendor/bundle
Fetching gem metadata from https://rubygems.org/.......
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "concurrent-ruby":
  In Gemfile:
    concurrent-ruby (~> 0.9)

    inspec was resolved to 2.1.11, which depends on
      train (~> 1.2) was resolved to 1.2.0, which depends on
        azure_mgmt_resources (~> 0.15) was resolved to 0.15.1, which depends on
          ms_rest_azure (~> 0.9.0) was resolved to 0.9.0, which depends on
            concurrent-ruby (~> 1.0)

Bundler could not find compatible versions for gem "test-kitchen":
  In Gemfile:
    kitchen-inspec was resolved to 0.23.1, which depends on
      test-kitchen (~> 1.6)

    kitchen-vagrant was resolved to 1.3.1, which depends on
      test-kitchen (~> 1.4)
```