### PR TITLE
Pw/pip windows bug

### DIFF
--- a/lib/resources/pip.rb
+++ b/lib/resources/pip.rb
@@ -27,7 +27,6 @@ module Inspec::Resources
       @package_name = package_name
       @pip_cmd = pip_path || default_pip_path
 
-      return skip_resource 'python not found' if paths['Python'].nil?
       return skip_resource 'pip not found' if @pip_cmd.nil?
     end
 
@@ -68,7 +67,7 @@ module Inspec::Resources
     end
 
     def cmd_successful?
-      result = inspec.command("#{@pip_cmd} show #{@package_name}")
+      result = cmd
       return true if result.exit_status == 0
 
       if result.exit_status != 0
@@ -84,15 +83,15 @@ module Inspec::Resources
       false
     end
 
-    # Paths of Python and Pip
+    # Paths of Python and Pip on windows
     # {"Pip" => nil, "Python" => "/path/to/python"}
     #
-    # @return [Hash] of paths
-    def paths
-      return @__paths if @__paths
+    # @return [Hash] of windows_paths
+    def windows_paths
+      return @__windows_paths if @__windows_paths
       cmd = inspec.command('New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Pip -Value (Invoke-Command -ScriptBlock {where.exe pip}) -PassThru | Add-Member -MemberType NoteProperty -Name Python -Value (Invoke-Command -ScriptBlock {where.exe python}) -PassThru | ConvertTo-Json')
 
-      @__paths = JSON.parse(cmd.stdout)
+      @__windows_paths = JSON.parse(cmd.stdout)
     end
 
     # Default path of python pip installation
@@ -101,15 +100,18 @@ module Inspec::Resources
     def default_pip_path
       return 'pip' unless inspec.os.windows?
 
+      # If python is not found, return with skip_resource
+      return skip_resource 'python not found' if windows_paths['Python'].nil?
+
       # Pip is not on the default path for Windows, therefore we do some logic
       # to find the binary on Windows
       begin
         # use pip if it on system path
-        pipcmd = paths['Pip']
+        pipcmd = windows_paths['Pip']
         # calculate path on windows
-        if defined?(paths['Python']) && pipcmd.nil?
-          return nil if paths['Pip'].nil?
-          pipdir = paths['Python'].split('\\')
+        if defined?(windows_paths['Python']) && pipcmd.nil?
+          return nil if windows_paths['Pip'].nil?
+          pipdir = windows_paths['Python'].split('\\')
           # remove python.exe
           pipdir.pop
           pipcmd = pipdir.push('Scripts').push('pip.exe').join('/')

--- a/lib/resources/pip.rb
+++ b/lib/resources/pip.rb
@@ -35,7 +35,7 @@ module Inspec::Resources
 
       @info = {}
       @info[:type] = 'pip'
-      return @info if !cmd_successful?
+      return @info unless cmd_successful?
 
       params = SimpleConfig.new(
         cmd.stdout,
@@ -67,15 +67,14 @@ module Inspec::Resources
     end
 
     def cmd_successful?
-      result = cmd
-      return true if result.exit_status == 0
+      return true if cmd.exit_status == 0
 
-      if result.exit_status != 0
+      if cmd.exit_status != 0
         # If pip on windows is not the latest, it will create a stderr value along with stdout
         # Example:
         #   stdout: "Name: Jinja2\r\nVersion: 2.10..."
         #   stderr: "You are using pip version 9.0.1, however version 9.0.3 is available..."
-        if inspec.os.windows? && !result.stdout.empty?
+        if inspec.os.windows? && !cmd.stdout.empty?
           return true
         end
       end
@@ -89,7 +88,12 @@ module Inspec::Resources
     # @return [Hash] of windows_paths
     def windows_paths
       return @__windows_paths if @__windows_paths
-      cmd = inspec.command('New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Pip -Value (Invoke-Command -ScriptBlock {where.exe pip}) -PassThru | Add-Member -MemberType NoteProperty -Name Python -Value (Invoke-Command -ScriptBlock {where.exe python}) -PassThru | ConvertTo-Json')
+      cmd = inspec.command(
+        'New-Object -Type PSObject |
+         Add-Member -MemberType NoteProperty -Name Pip -Value (Invoke-Command -ScriptBlock {where.exe pip}) -PassThru |
+         Add-Member -MemberType NoteProperty -Name Python -Value (Invoke-Command -ScriptBlock {where.exe python}) -PassThru |
+         ConvertTo-Json',
+      )
 
       @__windows_paths = JSON.parse(cmd.stdout)
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -261,6 +261,7 @@ class MockLoader
       "Get-Package -Name 'Mozilla Firefox' | ConvertTo-Json" => cmd.call('get-package-firefox'),
       "Get-Package -Name 'Ruby 2.1.6-p336-x64' | ConvertTo-Json" => cmd.call('get-package-ruby'),
       "New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Service -Value (Get-Service -Name 'dhcp'| Select-Object -Property Name, DisplayName, Status) -PassThru | Add-Member -MemberType NoteProperty -Name WMI -Value (Get-WmiObject -Class Win32_Service | Where-Object {$_.Name -eq 'dhcp' -or $_.DisplayName -eq 'dhcp'} | Select-Object -Property StartMode) -PassThru | ConvertTo-Json" => cmd.call('get-service-dhcp'),
+      "New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Pip -Value (Invoke-Command -ScriptBlock {where.exe pip}) -PassThru | Add-Member -MemberType NoteProperty -Name Python -Value (Invoke-Command -ScriptBlock {where.exe python}) -PassThru | ConvertTo-Json" => cmd.call('get-windows-pip-package'),
       "Get-WindowsFeature | Where-Object {$_.Name -eq 'dhcp' -or $_.DisplayName -eq 'dhcp'} | Select-Object -Property Name,DisplayName,Description,Installed,InstallState | ConvertTo-Json" => cmd.call('get-windows-feature'),
       'lsmod' => cmd.call('lsmod'),
       '/sbin/sysctl -q -n net.ipv4.conf.all.forwarding' => cmd.call('sbin_sysctl'),

--- a/test/unit/mock/cmd/get-windows-pip-package
+++ b/test/unit/mock/cmd/get-windows-pip-package
@@ -1,0 +1,4 @@
+{
+    "Pip":  "C:\\Python36\\Scripts\\pip.exe",
+    "Python":  "C:\\Python36\\python.exe"
+}


### PR DESCRIPTION
When pip on windows has a newer version available it spits out a stderr message along with the results of the `pip show` command. 

This adds logic to ignore the pip message that there is a newer version. 

Fixes #2855 