### PR TITLE
Change route_table_id Regular Expression for correctness

### DIFF
--- a/lib/resources/aws/aws_route_table.rb
+++ b/lib/resources/aws/aws_route_table.rb
@@ -26,9 +26,11 @@ class AwsRouteTable < Inspec.resource(1)
       allowed_scalar_type: String,
     )
 
-    if validated_params.key?(:route_table_id) && validated_params[:route_table_id] !~ /^rtb\-[0-9a-f]{8}/
-      raise ArgumentError, 'aws_route_table Route Table ID must be in the' \
-       ' format "rtb-" followed by 8 hexadecimal characters.'
+    if validated_params.key?(:route_table_id) &&
+       validated_params[:route_table_id] !~ /^rtb\-[0-9a-f]{8}$/
+      raise ArgumentError,
+            'aws_route_table Route Table ID must be in the' \
+            ' format "rtb-" followed by 8 hexadecimal characters.'
     end
 
     validated_params

--- a/test/unit/resources/aws_route_table_test.rb
+++ b/test/unit/resources/aws_route_table_test.rb
@@ -22,6 +22,16 @@ class BasicAwsRouteTableTest2 < Minitest::Test
   def test_search_hit
     assert AwsRouteTable.new('rtb-2c60ec44').exists?
     assert AwsRouteTable.new('rtb-58508630').exists?
+
+    # not hexadecimal
+    assert_raises(ArgumentError) do
+      AwsRouteTable.new('rtb-xyzxyzxy')
+    end
+
+    # not within length constraint
+    assert_raises(ArgumentError) do
+      AwsRouteTable.new('rtb-abcdef012')
+    end
   end
 end
 


### PR DESCRIPTION
Without the terminating character ($), it just accepted any characters
at all after the initial matching set.

Also add some tests to assure we're raising appropriately.

Fixes #2741.

Co-authored-by: Trevor Bramble <tbramble@chef.io>
Co-authored-by: Joshua Padgett <jpadgett@chef.io>

Signed-off-by: Trevor Bramble <tbramble@chef.io>