### PR TITLE
aws_cloudtrail_trail feature: test how many days ago logs were delivered

### DIFF
--- a/docs/resources/aws_cloudtrail_trail.md.erb
+++ b/docs/resources/aws_cloudtrail_trail.md.erb
@@ -108,6 +108,15 @@ Specifies the region in which the trail was created.
     describe aws_cloudtrail_trail('trail-name') do
       its('home_region') { should include "us-east-1" }
     end
+    
+### delivered\_logs\_days\_ago
+
+Specifies the number of days ago the CloudTrail delivered logs to CloudWatch Logs.
+    
+    # Ensure the latest delivery time was recent
+    describe aws_cloudtrail_trail('trail-name') do
+      its('delivered_logs_days_ago') { should eq 0 }
+    end
 
 <br>
 

--- a/lib/resources/aws/aws_cloudtrail_trail.rb
+++ b/lib/resources/aws/aws_cloudtrail_trail.rb
@@ -28,14 +28,16 @@ class AwsCloudTrailTrail < Inspec.resource(1)
   def encrypted?
     !kms_key_id.nil?
   end
-  
+
   def delivered_logs_days_ago
     query = { name: @trail_name }
     catch_aws_errors do
-      resp = BackendFactory.create(inspec_runner).get_trail_status(query).to_h
-      ((Time.now - resp[:latest_cloud_watch_logs_delivery_time])/(24*60*60)).to_i unless resp[:latest_cloud_watch_logs_delivery_time].nil?
-    rescue Aws::CloudTrail::Errors::TrailNotFoundException
-      nil
+      begin
+        resp = BackendFactory.create(inspec_runner).get_trail_status(query).to_h
+        ((Time.now - resp[:latest_cloud_watch_logs_delivery_time])/(24*60*60)).to_i unless resp[:latest_cloud_watch_logs_delivery_time].nil?
+      rescue Aws::CloudTrail::Errors::TrailNotFoundException
+        nil
+      end
     end
   end
 
@@ -82,7 +84,7 @@ class AwsCloudTrailTrail < Inspec.resource(1)
       def describe_trails(query)
         aws_service_client.describe_trails(query)
       end
-      
+
       def get_trail_status(query)
         aws_service_client.get_trail_status(query)
       end

--- a/lib/resources/aws/aws_cloudtrail_trail.rb
+++ b/lib/resources/aws/aws_cloudtrail_trail.rb
@@ -28,6 +28,16 @@ class AwsCloudTrailTrail < Inspec.resource(1)
   def encrypted?
     !kms_key_id.nil?
   end
+  
+  def delivered_logs_days_ago
+    query = { name: @trail_name }
+    catch_aws_errors do
+      resp = BackendFactory.create(inspec_runner).get_trail_status(query).to_h
+      ((Time.now - resp[:latest_cloud_watch_logs_delivery_time])/(24*60*60)).to_i unless resp[:latest_cloud_watch_logs_delivery_time].nil?
+    rescue Aws::CloudTrail::Errors::TrailNotFoundException
+      nil
+    end
+  end
 
   private
 
@@ -71,6 +81,10 @@ class AwsCloudTrailTrail < Inspec.resource(1)
 
       def describe_trails(query)
         aws_service_client.describe_trails(query)
+      end
+      
+      def get_trail_status(query)
+        aws_service_client.get_trail_status(query)
       end
     end
   end

--- a/test/integration/aws/default/verify/controls/aws_cloudtrail_trail.rb
+++ b/test/integration/aws/default/verify/controls/aws_cloudtrail_trail.rb
@@ -38,6 +38,7 @@ control "aws_cloudtrail_trail properties" do
     its('cloud_watch_logs_role_arn') { should eq fixtures['cloudtrail_trail_1_cloud_watch_logs_role_arn'] }
     its('cloud_watch_logs_log_group_arn') { should eq fixtures['cloudtrail_trail_1_cloud_watch_logs_group_arn']}
     its('kms_key_id') { should eq fixtures['cloudtrail_trail_1_key_arn'] }
+    its('delivered_logs_days_ago') { should eq 0 }
   end
   describe aws_cloudtrail_trail(fixtures['cloudtrail_trail_2_name']) do
     its('s3_bucket_name') { should eq fixtures['cloudtrail_trail_2_s3_bucket_name'] }

--- a/test/unit/resources/aws_cloudtrail_trail_test.rb
+++ b/test/unit/resources/aws_cloudtrail_trail_test.rb
@@ -3,7 +3,6 @@ require 'helper'
 # MACTTSB = MockAwsCloudTrailTrailSingularBackend
 # Abbreviation not used outside this file
 
-TIME_NOW = Time.now
 #=============================================================================#
 #                            Constructor Tests
 #=============================================================================#
@@ -177,14 +176,11 @@ module MACTTSB
       fixtures = [
         OpenStruct.new({
           name: "test-trail-1",
-          latest_cloud_watch_logs_delivery_time: TIME_NOW
+          latest_cloud_watch_logs_delivery_time: Time.now
         })
       ]
       
-      selected = fixtures.detect do |fixture|
-        fixture.name == query[:name]
-      end
-      selected
+      fixtures.detect { |f| f.name == query[:name] }
     end
   end
 end

--- a/test/unit/resources/aws_cloudtrail_trail_test.rb
+++ b/test/unit/resources/aws_cloudtrail_trail_test.rb
@@ -3,6 +3,7 @@ require 'helper'
 # MACTTSB = MockAwsCloudTrailTrailSingularBackend
 # Abbreviation not used outside this file
 
+TIME_NOW = Time.now
 #=============================================================================#
 #                            Constructor Tests
 #=============================================================================#
@@ -90,6 +91,11 @@ class AwsCloudTrailTrailPropertiesTest < Minitest::Test
     assert_equal("us-east-1", AwsCloudTrailTrail.new('test-trail-1').home_region)
     assert_nil(AwsCloudTrailTrail.new(trail_name: 'non-existant').home_region)
   end
+  
+  def test_property_delivered_logs_days_ago
+    assert_equal(0, AwsCloudTrailTrail.new('test-trail-1').delivered_logs_days_ago)
+    assert_nil(AwsCloudTrailTrail.new(trail_name: 'non-existant').delivered_logs_days_ago)
+  end
 end
 
 
@@ -165,6 +171,20 @@ module MACTTSB
         fixture.name == query[:trail_name_list].first
       end
       OpenStruct.new({ trail_list: [selected] })
+    end
+    
+    def get_trail_status(query)
+      fixtures = [
+        OpenStruct.new({
+          name: "test-trail-1",
+          latest_cloud_watch_logs_delivery_time: TIME_NOW
+        })
+      ]
+      
+      selected = fixtures.detect do |fixture|
+        fixture.name == query[:name]
+      end
+      selected
     end
   end
 end


### PR DESCRIPTION
* Adds new property to test how many days ago the CloudTrail delivered logs to the CloudWatch Logs.
* This feature is needed in order to complete the cis aws benchmark

Fixes #2587 

Signed-off-by: Matthew Dromazos <dromazmj@dukes.jmu.edu>