### PR TITLE
aws_iam_group feature: test users in an iam group

### DIFF
--- a/docs/resources/aws_iam_group.md.erb
+++ b/docs/resources/aws_iam_group.md.erb
@@ -35,6 +35,18 @@ As this is the initial release of `aws_iam_group`, its limited functionality pre
 
 <br>
 
+## Properties
+
+### users
+
+Provides a list of the users that are attached to the group
+
+    describe aws_iam_group('mygroup')
+      its('users') { should include 'iam_user_name' }
+    end
+
+<br>
+
 ## Matchers
 
 ### exists

--- a/lib/resources/aws/aws_iam_group.rb
+++ b/lib/resources/aws/aws_iam_group.rb
@@ -9,7 +9,7 @@ class AwsIamGroup < Inspec.resource(1)
   supports platform: 'aws'
 
   include AwsSingularResourceMixin
-  attr_reader :group_name
+  attr_reader :group_name, :users
 
   def to_s
     "IAM Group #{group_name}"
@@ -36,8 +36,10 @@ class AwsIamGroup < Inspec.resource(1)
     backend = AwsIamGroup::BackendFactory.create(inspec_runner)
 
     begin
-      @aws_group_struct = backend.get_group(group_name: group_name)[:group]
+      resp = backend.get_group(group_name: group_name)
       @exists = true
+      @aws_group_struct = resp[:group]
+      @users = resp[:users].map(&:user_name)
     rescue Aws::IAM::Errors::NoSuchEntity
       @exists = false
     end

--- a/test/integration/aws/default/build/iam.tf
+++ b/test/integration/aws/default/build/iam.tf
@@ -115,3 +115,17 @@ resource "aws_iam_group" "administrators" {
 output "iam_group_administrators" {
   value = "${aws_iam_group.administrators.name}"
 }
+
+#======================================================#
+#                    IAM Group Memberships
+#======================================================#
+
+resource "aws_iam_group_membership" "administrators_membership" {
+  name = "administrators_membership"
+
+  users = [
+    "${aws_iam_user.recall_hit.name}",
+  ]
+
+  group = "${aws_iam_group.administrators.name}"
+}

--- a/test/integration/aws/default/verify/controls/aws_iam_group.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_group.rb
@@ -1,6 +1,7 @@
 fixtures = {}
 [
   'iam_group_administrators',
+  'iam_user_recall_hit'
 ].each do |fixture_name|
   fixtures[fixture_name] = attribute(
     fixture_name,
@@ -16,5 +17,11 @@ control "aws_iam_group recall" do
 
   describe aws_iam_group('fakegroup') do
     it { should_not exist }
+  end
+end
+
+control "aws_iam_group properties test" do
+  describe aws_iam_group(fixtures['iam_group_administrators']) do
+    its('users') { should include fixtures['iam_user_recall_hit'] }
   end
 end

--- a/test/unit/resources/aws_iam_group_test.rb
+++ b/test/unit/resources/aws_iam_group_test.rb
@@ -53,6 +53,21 @@ class AwsIamGroupRecallTest < Minitest::Test
 end
 
 #=============================================================================#
+#                               Properties
+#=============================================================================#
+class AwsIamGroupRecallTest < Minitest::Test
+
+  def setup
+    AwsIamGroup::BackendFactory.select(MAIGSB::Basic)
+  end
+
+  def test_property_users
+    assert_equal(['user1', 'user2'], AwsIamGroup.new('Administrator').users)
+    assert_nil(AwsIamGroup.new('nonexistent').users)
+  end
+end
+
+#=============================================================================#
 #                               Test Fixtures
 #=============================================================================#
 module MAIGSB
@@ -70,7 +85,15 @@ module MAIGSB
           group_name: 'Administrator',
           group_id: 'AGPAQWERQWERQWERQWERQ',
           arn: 'arn:aws:iam::111111111111:group/Administrator',
-          create_date: DateTime.parse('2017-12-14 05:29:57 UTC')
+          create_date: DateTime.parse('2017-12-14 05:29:57 UTC'),
+          users: [
+            OpenStruct.new({
+              user_name: 'user1',
+            }),
+            OpenStruct.new({
+              user_name: 'user2',
+            }),
+          ]
         }),
         OpenStruct.new({
           path: '/',
@@ -89,7 +112,7 @@ module MAIGSB
         raise Aws::IAM::Errors::NoSuchEntity.new(nil,nil)
       end
 
-      OpenStruct.new({ group: selected[0] })
+      OpenStruct.new({ group: selected[0], users: selected[0].users })
     end
   end
 


### PR DESCRIPTION
* Adds new property to test the users in an aws_iam_grouo
* Adds terraform code to include the recall_hit IAM user into the administrator IAM group
* This feature is needed in order to complete the cis aws benchmark

Signed-off-by: Matthew Dromazos <dromazmj@dukes.jmu.edu>