### PR TITLE
Require a key attribute for the key_rsa resource

### DIFF
--- a/lib/resources/key_rsa.rb
+++ b/lib/resources/key_rsa.rb
@@ -28,7 +28,6 @@ module Inspec::Resources
     def initialize(keypath, passphrase = nil)
       @key_path = keypath
       @passphrase = passphrase
-      default_attribute?(passphrase)
       @key = read_pkey(read_file_content(@key_path, allow_empty: true), @passphrase)
     end
 

--- a/lib/resources/key_rsa.rb
+++ b/lib/resources/key_rsa.rb
@@ -3,6 +3,7 @@
 require 'openssl'
 require 'hashie/mash'
 require 'utils/file_reader'
+require 'utils/pkey_reader'
 
 module Inspec::Resources
   class RsaKey < Inspec.resource(1)
@@ -22,18 +23,13 @@ module Inspec::Resources
     "
 
     include FileReader
+    include PkeyReader
 
     def initialize(keypath, passphrase = nil)
       @key_path = keypath
       @passphrase = passphrase
-      if @passphrase.is_a? Inspec::Attribute::DEFAULT_ATTRIBUTE
-        return fail_resource 'Please provide default value for attribute'
-      end
-      begin
-        @key = OpenSSL::PKey.read(read_file_content(@key_path, allow_empty: true), @passphrase)
-      rescue OpenSSL::PKey::PKeyError
-        return fail_resource 'passphrase Error'
-      end
+      default_attribute?(passphrase)
+      @key = read_pkey(read_file_content(@key_path, allow_empty: true), @passphrase)
     end
 
     def public?

--- a/lib/resources/key_rsa.rb
+++ b/lib/resources/key_rsa.rb
@@ -26,7 +26,14 @@ module Inspec::Resources
     def initialize(keypath, passphrase = nil)
       @key_path = keypath
       @passphrase = passphrase
-      @key = OpenSSL::PKey.read(read_file_content(@key_path, allow_empty: true), @passphrase)
+      if @passphrase.is_a? Inspec::Attribute::DEFAULT_ATTRIBUTE
+        return fail_resource "Please provide default value for attribute"
+      end
+      begin
+        @key = OpenSSL::PKey.read(read_file_content(@key_path, allow_empty: true), @passphrase)
+      rescue OpenSSL::PKey::PKeyError
+        return fail_resource 'passphrase Error'
+      end
     end
 
     def public?

--- a/lib/resources/key_rsa.rb
+++ b/lib/resources/key_rsa.rb
@@ -27,7 +27,7 @@ module Inspec::Resources
       @key_path = keypath
       @passphrase = passphrase
       if @passphrase.is_a? Inspec::Attribute::DEFAULT_ATTRIBUTE
-        return fail_resource "Please provide default value for attribute"
+        return fail_resource 'Please provide default value for attribute'
       end
       begin
         @key = OpenSSL::PKey.read(read_file_content(@key_path, allow_empty: true), @passphrase)

--- a/lib/utils/pkey_reader.rb
+++ b/lib/utils/pkey_reader.rb
@@ -1,15 +1,13 @@
 module PkeyReader
   def read_pkey(filecontent, passphrase)
-    default_attribute?(passphrase)
-    begin
-      key = OpenSSL::PKey.read(filecontent, passphrase)
-    rescue OpenSSL::PKey::PKeyError
-      raise Inspec::Exceptions::ResourceFailed, 'passphrase Error'
-    end
-    key
+    raise_if_default(passphrase)
+    
+    OpenSSL::PKey.read(filecontent, passphrase)
+  rescue OpenSSL::PKey::PKeyError
+    raise Inspec::Exceptions::ResourceFailed, 'passphrase error'
   end
 
-  def default_attribute?(passphrase)
+  def raise_if_default(passphrase)
     if passphrase.is_a? Inspec::Attribute::DEFAULT_ATTRIBUTE
       raise Inspec::Exceptions::ResourceFailed, 'Please provide default value for attribute'
     end

--- a/lib/utils/pkey_reader.rb
+++ b/lib/utils/pkey_reader.rb
@@ -1,0 +1,17 @@
+module PkeyReader
+  def read_pkey(filecontent, passphrase)
+    default_attribute?(passphrase)
+    begin
+      key = OpenSSL::PKey.read(filecontent, passphrase)
+    rescue OpenSSL::PKey::PKeyError
+      raise Inspec::Exceptions::ResourceFailed, 'passphrase Error'
+    end
+    key
+  end
+
+  def default_attribute?(passphrase)
+    if passphrase.is_a? Inspec::Attribute::DEFAULT_ATTRIBUTE
+      raise Inspec::Exceptions::ResourceFailed, 'Please provide default value for attribute'
+    end
+  end
+end

--- a/lib/utils/pkey_reader.rb
+++ b/lib/utils/pkey_reader.rb
@@ -1,7 +1,7 @@
 module PkeyReader
   def read_pkey(filecontent, passphrase)
     raise_if_default(passphrase)
-    
+
     OpenSSL::PKey.read(filecontent, passphrase)
   rescue OpenSSL::PKey::PKeyError
     raise Inspec::Exceptions::ResourceFailed, 'passphrase error'


### PR DESCRIPTION
Checking that passphrase is not of type Attribute::DEFAULT_ATTRIBUTE before calling OpenSSL::PKey.read.
Also added a catch to exception OpenSSL::PKey::PKeyError to prevent a stack trace error if the passphrase was incorrect.
