### PR TITLE
Add AWS hardware MFA matcher

### DIFF
--- a/docs/resources/aws_iam_root_user.md.erb
+++ b/docs/resources/aws_iam_root_user.md.erb
@@ -51,6 +51,18 @@ The `have_mfa_enabled` matcher tests if the AWS root user has Multi-Factor Authe
 
     it { should have_mfa_enabled }
 
+### have\_hardware\_mfa\_enabled
+
+The `have_hardware_mfa_enabled` matcher tests if the AWS root user has Hardware Multi-Factor Authentication device enabled, requiring them to enter a secondary code when they login to the web console.
+
+    it { should have_hardware_mfa_enabled }
+
+### have\_virtual\_mfa\_enabled
+
+The `have_virtual_mfa_enabled` matcher tests if the AWS root user has Virtual Multi-Factor Authentication device enabled, requiring them to enter a secondary code when they login to the web console.
+
+    it { should have_virtual_mfa_enabled }
+
 ### have\_access\_key
 
 The `have_access_key` matcher tests if the AWS root user has at least one access key.

--- a/lib/resources/aws/aws_iam_root_user.rb
+++ b/lib/resources/aws/aws_iam_root_user.rb
@@ -46,8 +46,10 @@ class AwsIamRootUser < Inspec.resource(1)
     summary_account['AccountMFAEnabled'] == 1
   end
 
-  def has_virtual_mfa_devices?
+  def has_virtual_mfa_enabled?
     virtual_mfa_devices.each do |device|
+      # if the root account has a Virtual MFA device then
+      # it will have a special serial number ending in 'root-account-mfa-device'
       if %r{arn:aws:iam::\d{12}:mfa\/root-account-mfa-device} =~
         device['serial_number']
         return true
@@ -56,8 +58,8 @@ class AwsIamRootUser < Inspec.resource(1)
     false
   end
 
-  def has_hardware_mfa_devices?
-    @__hardware_devices ||= !@client.list_mfa_devices.mfa_devices.empty?
+  def has_hardware_mfa_enabled?
+    has_mfa_enabled? && !has_virtual_mfa_enabled?
   end
 
   def to_s
@@ -73,6 +75,8 @@ class AwsIamRootUser < Inspec.resource(1)
   end
 
   def virtual_mfa_devices
-    @__virtual_devices ||= @client.list_virtual_mfa_devices.virtual_mfa_devices
+    catch_aws_errors do
+      @__virtual_devices ||= @client.list_virtual_mfa_devices.virtual_mfa_devices
+    end
   end
 end

--- a/lib/resources/aws/aws_iam_root_user.rb
+++ b/lib/resources/aws/aws_iam_root_user.rb
@@ -46,6 +46,20 @@ class AwsIamRootUser < Inspec.resource(1)
     summary_account['AccountMFAEnabled'] == 1
   end
 
+  def has_virtual_mfa_devices?
+    virtual_mfa_devices.each do |device|
+      if %r{arn:aws:iam::\d{12}:mfa\/root-account-mfa-device} =~
+        device['serial_number']
+        return true
+      end
+    end
+    false
+  end
+
+  def has_hardware_mfa_devices?
+    @__hardware_devices ||= !@client.list_mfa_devices.mfa_devices.empty?
+  end
+
   def to_s
     'AWS Root-User'
   end
@@ -56,5 +70,9 @@ class AwsIamRootUser < Inspec.resource(1)
     catch_aws_errors do
       @summary_account ||= @client.get_account_summary.summary_map
     end
+  end
+
+  def virtual_mfa_devices
+    @__virtual_devices ||= @client.list_virtual_mfa_devices.virtual_mfa_devices
   end
 end

--- a/lib/resources/aws/aws_iam_root_user.rb
+++ b/lib/resources/aws/aws_iam_root_user.rb
@@ -46,16 +46,12 @@ class AwsIamRootUser < Inspec.resource(1)
     summary_account['AccountMFAEnabled'] == 1
   end
 
+  # if the root account has a Virtual MFA device then it will have a special
+  # serial number ending in 'root-account-mfa-device'
   def has_virtual_mfa_enabled?
-    virtual_mfa_devices.each do |device|
-      # if the root account has a Virtual MFA device then
-      # it will have a special serial number ending in 'root-account-mfa-device'
-      if %r{arn:aws:iam::\d{12}:mfa\/root-account-mfa-device} =~
-        device['serial_number']
-        return true
-      end
-    end
-    false
+    mfa_device_pattern = %r{arn:aws:iam::\d{12}:mfa\/root-account-mfa-device}
+
+    virtual_mfa_devices.any? { |d| mfa_device_pattern =~ d['serial_number'] }
   end
 
   def has_hardware_mfa_enabled?

--- a/test/integration/aws/default/verify/controls/aws_iam_root_user.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_root_user.rb
@@ -18,6 +18,14 @@ control "aws_iam_root_user has_mfa_enabled property" do
   end
 end
 
+#---------- Property - has_virtual_mfa_enabled ----------#
+# Negative test in 'minimal' test set.
+control "aws_iam_root_user has_virtual_mfa_enabled property" do
+  describe aws_iam_root_user do
+    it { should have_virtual_mfa_enabled }
+  end
+end
+
 #------------- Property - has_access_key -------------#
 # Positive test in 'minimal' test set
 control "aws_iam_root_user has_access_key property" do

--- a/test/integration/aws/minimal/verify/controls/aws_iam_root_user.rb
+++ b/test/integration/aws/minimal/verify/controls/aws_iam_root_user.rb
@@ -18,6 +18,22 @@ control "aws_iam_root_user has_mfa_enabled property" do
   end
 end
 
+#---------- Property - has_virtual_mfa_enabled ----------#
+# Positive test in 'default' test set
+control "aws_iam_root_user has_virtual_mfa_enabled property" do
+  describe aws_iam_root_user do
+    it { should_not have_virtual_mfa_enabled }
+  end
+end
+
+#---------- Property - has_hardware_mfa_enabled ----------#
+# Positive test in 'default' test set
+control "aws_iam_root_user has_hardware_mfa_enabled property" do
+  describe aws_iam_root_user do
+    it { should_not have_hardware_mfa_enabled }
+  end
+end
+
 #------------- Property - has_access_key -------------#
 # Negative test in 'default' test set
 control "aws_iam_root_user has_access_key property" do

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -57,7 +57,7 @@ class AwsIamRootUserTest < Minitest::Test
     )
     @mock_client.expect :list_virtual_mfa_devices, test_list_virtual_mfa_devices
 
-    assert_equal true, AwsIamRootUser.new(@mock_conn).has_virtual_mfa_devices?
+    assert_equal true, AwsIamRootUser.new(@mock_conn).has_virtual_mfa_enabled?
   end
 
   def test_has_virtual_mfa_enabled_returns_false_when_account_vmfa_devices_is_zero
@@ -66,30 +66,32 @@ class AwsIamRootUserTest < Minitest::Test
     )
     @mock_client.expect :list_virtual_mfa_devices, test_list_virtual_mfa_devices
 
-    assert_equal false, AwsIamRootUser.new(@mock_conn).has_virtual_mfa_devices?
+    assert_equal false, AwsIamRootUser.new(@mock_conn).has_virtual_mfa_enabled?
   end
 
   def test_has_hardware_mfa_enabled_returns_true_when_account_hardware_devices_is_one
-    test_list_hardware_mfa_devices = OpenStruct.new(
-      mfa_devices: [Aws::IAM::Types::MFADevice.new(
-        serial_number: "arn:aws:iam::123456789000:mfa/root-account-mfa-device",
-        user_name: Aws::IAM::Types::User.new(
-          user_id: "123456789000",
-          arn:     "arn:aws:iam::123456789000:root",
-        )
-      )]
+    test_list_virtual_mfa_devices = OpenStruct.new(
+      virtual_mfa_devices: []
     )
-    @mock_client.expect :list_mfa_devices, test_list_hardware_mfa_devices
+    test_summary_map = OpenStruct.new(
+      summary_map: { 'AccountMFAEnabled' => 1 },
+    )
+    @mock_client.expect :list_virtual_mfa_devices, test_list_virtual_mfa_devices
+    @mock_client.expect :get_account_summary, test_summary_map
 
-    assert_equal true, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_devices?
+    assert_equal true, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_enabled?
   end
 
   def test_has_hardware_mfa_enabled_returns_false_when_account_hardware_devices_is_zero
-    test_list_hardware_mfa_devices = OpenStruct.new(
-      mfa_devices: []
+    test_list_virtual_mfa_devices = OpenStruct.new(
+      virtual_mfa_devices: []
     )
-    @mock_client.expect :list_mfa_devices, test_list_hardware_mfa_devices
+    test_summary_map = OpenStruct.new(
+      summary_map: { 'AccountMFAEnabled' => 0 },
+    )
+    @mock_client.expect :get_account_summary, test_summary_map
+    @mock_client.expect :list_virtual_mfa_devices, test_list_virtual_mfa_devices
 
-    assert_equal false, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_devices?
+    assert_equal false, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_enabled?
   end
 end

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -48,10 +48,10 @@ class AwsIamRootUserTest < Minitest::Test
   def test_has_virtual_mfa_enabled_returns_true_when_account_vmfa_devices_is_one
     test_list_virtual_mfa_devices = OpenStruct.new(
       virtual_mfa_devices: [Aws::IAM::Types::VirtualMFADevice.new(
-        serial_number: "arn:aws:iam::123456789011:mfa/root-account-mfa-device",
+        serial_number: 'arn:aws:iam::123456789011:mfa/root-account-mfa-device',
         user: Aws::IAM::Types::User.new(
-          user_id: "123456789011",
-          arn:     "arn:aws:iam::123456789011:root",
+          user_id: '123456789011',
+          arn:     'arn:aws:iam::123456789011:root',
         )
       )]
     )

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -44,4 +44,52 @@ class AwsIamRootUserTest < Minitest::Test
 
     assert_equal false, AwsIamRootUser.new(@mock_conn).has_mfa_enabled?
   end
+
+  def test_has_virtual_mfa_enabled_returns_true_when_account_vmfa_devices_is_one
+    test_list_virtual_mfa_devices = OpenStruct.new(
+      virtual_mfa_devices: [Aws::IAM::Types::VirtualMFADevice.new(
+        serial_number: "arn:aws:iam::123456789011:mfa/root-account-mfa-device",
+        user: Aws::IAM::Types::User.new(
+          user_id: "123456789011",
+          arn:     "arn:aws:iam::123456789011:root",
+        )
+      )]
+    )
+    @mock_client.expect :list_virtual_mfa_devices, test_list_virtual_mfa_devices
+
+    assert_equal true, AwsIamRootUser.new(@mock_conn).has_virtual_mfa_devices?
+  end
+
+  def test_has_virtual_mfa_enabled_returns_false_when_account_vmfa_devices_is_zero
+    test_list_virtual_mfa_devices = OpenStruct.new(
+      virtual_mfa_devices: []
+    )
+    @mock_client.expect :list_virtual_mfa_devices, test_list_virtual_mfa_devices
+
+    assert_equal false, AwsIamRootUser.new(@mock_conn).has_virtual_mfa_devices?
+  end
+
+  def test_has_hardware_mfa_enabled_returns_true_when_account_hardware_devices_is_one
+    test_list_hardware_mfa_devices = OpenStruct.new(
+      mfa_devices: [Aws::IAM::Types::MFADevice.new(
+        serial_number: "arn:aws:iam::123456789000:mfa/root-account-mfa-device",
+        user_name: Aws::IAM::Types::User.new(
+          user_id: "123456789000",
+          arn:     "arn:aws:iam::123456789000:root",
+        )
+      )]
+    )
+    @mock_client.expect :list_mfa_devices, test_list_hardware_mfa_devices
+
+    assert_equal true, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_devices?
+  end
+
+  def test_has_hardware_mfa_enabled_returns_false_when_account_hardware_devices_is_zero
+    test_list_hardware_mfa_devices = OpenStruct.new(
+      mfa_devices: []
+    )
+    @mock_client.expect :list_mfa_devices, test_list_hardware_mfa_devices
+
+    assert_equal false, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_devices?
+  end
 end


### PR DESCRIPTION
Adding a hardware as well as a virtual MFA matcher for aws_iam_root_user
resource

Fixes #2750

Signed-off-by: Paul Welch <pwelch@chef.io>