### PR TITLE
powershell resource: Add support other OSs

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -215,6 +215,7 @@ class MockLoader
       'bash -c \'type "/test/path/pip"\'' => empty.call,
       'bash -c \'type "Rscript"\'' => empty.call,
       'bash -c \'type "perl"\'' => empty.call,
+      'type "pwsh"' => empty.call,
       'type "netstat"' => empty.call,
       'sh -c \'find /etc/apache2/ports.conf -type l -maxdepth 1\'' => empty.call,
       'sh -c \'find /etc/httpd/conf.d/*.conf -type l -maxdepth 1\'' => empty.call,

--- a/test/unit/resources/powershell_test.rb
+++ b/test/unit/resources/powershell_test.rb
@@ -5,28 +5,27 @@
 require 'helper'
 require 'inspec/resource'
 
-describe 'Inspec::Resources::Powershell' do
+describe 'Inspec::Resources::PowershellScript' do
+  let(:base64_command) {
+    # Encoded version of `$ProgressPreference='SilentlyContinue';Get-Help`
+    'JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwA' \
+    'ZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsARwBlAHQALQBIAGUAbABwAA=='
+  }
 
-  ps1_script = <<-EOH
-    # call help for get command
-    Get-Help Get-Command
-  EOH
+  it 'properly generates command' do
+    resource = MockLoader.new(:windows).load_resource('powershell', 'Get-Help')
+    _(resource.command).must_equal 'Get-Help'
 
-  it 'check if `powershell` for windows is properly generated ' do
-    resource = MockLoader.new(:windows).load_resource('powershell', ps1_script)
-    # string should be the same
-    _(resource.command.to_s).must_equal ps1_script
+    resource = MockLoader.new(:osx104).load_resource('powershell', 'Get-Help')
+    _(resource.command).must_equal("pwsh -encodedCommand '#{base64_command}'")
   end
 
-  it 'check if legacy `script` for windows is properly generated ' do
-    resource = MockLoader.new(:windows).load_resource('script', ps1_script)
-    # string should be the same
-    _(resource.command.to_s).must_equal ps1_script
-  end
+  it 'properly generates command if deprecated `script` is used on Windows' do
+    Inspec::Resources::LegacyPowershellScript.any_instance.stubs(:deprecated)
+    resource = MockLoader.new(:windows).load_resource('script', 'Get-Help')
+    _(resource.command).must_equal 'Get-Help'
 
-  it 'will return an empty array when called on a non-supported OS with children' do
-    resource = MockLoader.new.load_resource('powershell', '...')
-    # string should be the same
-    _(resource.stdout).must_equal ''
+    resource = MockLoader.new(:osx104).load_resource('script', 'Get-Help')
+    _(resource.command).must_equal("pwsh -encodedCommand '#{base64_command}'")
   end
 end


### PR DESCRIPTION
This adds `powershell` resource support for non-Windows OSs via `pwsh` and Base64 encoded commands.