### PR TITLE
Wrong matcher name in example for aws_config_recorder

### DIFF
--- a/docs/resources/aws_config_recorder.md.erb
+++ b/docs/resources/aws_config_recorder.md.erb
@@ -61,7 +61,7 @@ Provides a list of AWS resource types for which the AWS Config records configura
 
 Indicates if the ConfigurationRecorder will record changes for all resources, regardless of type. If this is true, resource_types is ignored.
 
-      it { should be_recording\_all_resource_types }
+      it { should be_recording_all_resource_types }
       
 ### be\_recording\_all\_global\_types
 

--- a/docs/resources/aws_config_recorder.md.erb
+++ b/docs/resources/aws_config_recorder.md.erb
@@ -61,7 +61,7 @@ Provides a list of AWS resource types for which the AWS Config records configura
 
 Indicates if the ConfigurationRecorder will record changes for all resources, regardless of type. If this is true, resource_types is ignored.
 
-      it { should be_all_supported }
+      it { should be_recording\_all_resource_types }
       
 ### be\_recording\_all\_global\_types
 


### PR DESCRIPTION
It's a one-line docs correction.  The matcher was renamed during PR feedback, and the doc example didn't get updated.