### PR TITLE
add systemd service for amazon linux 2

### DIFF
--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -162,7 +162,11 @@ module Inspec::Resources
       elsif %w{aix}.include?(platform)
         SrcMstr.new(inspec)
       elsif %w{amazon}.include?(platform)
-        Upstart.new(inspec, service_ctl)
+        if os[:release].start_with?('2.')
+          Systemd.new(inspec, service_ctl)
+        else
+          Upstart.new(inspec, service_ctl)
+        end
       elsif os.solaris?
         Svcs.new(inspec)
       end

--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -162,10 +162,10 @@ module Inspec::Resources
       elsif %w{aix}.include?(platform)
         SrcMstr.new(inspec)
       elsif %w{amazon}.include?(platform)
-        if os[:release].start_with?('2.')
-          Systemd.new(inspec, service_ctl)
-        else
+        if os[:release].start_with?('20\d\d')
           Upstart.new(inspec, service_ctl)
+        else
+          Systemd.new(inspec, service_ctl)
         end
       elsif os.solaris?
         Svcs.new(inspec)


### PR DESCRIPTION
Right now service Amazon Linux is treated as upstart_service while Amazon Linux 2 is systemd.
It causes issues like https://github.com/chef/inspec/issues/2639

On the Amazon Linux 2 Candidate, os[:release] returns "2.0", so I'm using .start_with?('2.') here in case they'll use something 2.x in the future.
(Amazon Linux 1 returns something like "2016.09")

Signed-off-by: Zakhar Kleyman <zakhar.kleyman@mongodb.com>