### PR TITLE
Update example resource syntax

### DIFF
--- a/docs/dsl_resource.md
+++ b/docs/dsl_resource.md
@@ -91,7 +91,7 @@ class GordonConfig < Inspec.resource(1)
       f.content
     else
       # If the file doesn't exist, skip all tests that use gordon_config
-      skip_resource "Can't read config from #{@path}."
+      raise Inspec::Exceptions::ResourceSkipped, "Can't read config at #{@path}"
     end
   end
 end

--- a/examples/profile/libraries/gordon_config.rb
+++ b/examples/profile/libraries/gordon_config.rb
@@ -41,9 +41,9 @@ class GordonConfig < Inspec.resource(1)
   end
 
   # Example method called by 'it { should exist }'
-  # Returns true or false from the 'File.exists?' method
+  # Returns true or false from the 'File.exist?' method
   def exists?
-    File.exists?(@path)
+    File.exist?(@path)
   end
 
   # Example matcher for the number of commas in the file

--- a/examples/profile/libraries/gordon_config.rb
+++ b/examples/profile/libraries/gordon_config.rb
@@ -35,8 +35,8 @@ class GordonConfig < Inspec.resource(1)
       @params['file_size'] = @file.size
       @params['file_path'] = @path
       @params['ruby'] = 'RUBY IS HERE TO HELP ME!'
-    rescue StandardError
-      raise Inspec::Exceptions::ResourceSkipped, "#{@file}: #{$!}"
+    rescue StandardError => e
+      raise Inspec::Exceptions::ResourceSkipped, "#{@file}: #{e.message}"
     end
   end
 

--- a/examples/profile/libraries/gordon_config.rb
+++ b/examples/profile/libraries/gordon_config.rb
@@ -43,17 +43,17 @@ class GordonConfig < Inspec.resource(1)
   # Example method called by 'it { should exist }'
   # Returns true or false from the 'File.exists?' method
   def exists?
-    return File.exists?(@path)
+    File.exists?(@path)
   end
 
   # Example matcher for the number of commas in the file
   def comma_count
     text = @file.content
-    return text.count(',')
+    text.count(',')
   end
 
   # Expose all parameters
   def method_missing(name)
-    return @params[name.to_s]
+    @params[name.to_s]
   end
 end

--- a/examples/profile/libraries/gordon_config.rb
+++ b/examples/profile/libraries/gordon_config.rb
@@ -4,6 +4,9 @@ require 'yaml'
 class GordonConfig < Inspec.resource(1)
   name 'gordon_config'
 
+  supports platform: 'unix'
+  supports platform: 'windows'
+
   desc "
     Gordon's resource description ...
   "

--- a/examples/profile/libraries/gordon_config.rb
+++ b/examples/profile/libraries/gordon_config.rb
@@ -20,7 +20,10 @@ class GordonConfig < Inspec.resource(1)
     @params = {}
     @path = '/tmp/gordon/config.yaml'
     @file = inspec.file(@path)
-    return skip_resource "Can't find file \"#{@path}\"" if !@file.file?
+
+    unless @file.file?
+      raise Inspec::Exceptions::ResourceSkipped, "Can't find file `#{@path}`"
+    end
 
     # Protect from invalid YAML content
     begin
@@ -30,7 +33,7 @@ class GordonConfig < Inspec.resource(1)
       @params['file_path'] = @path
       @params['ruby'] = 'RUBY IS HERE TO HELP ME!'
     rescue Exception
-      return skip_resource "#{@file}: #{$!}"
+      raise Inspec::Exceptions::ResourceSkipped, "#{@file}: #{$!}"
     end
   end
 

--- a/examples/profile/libraries/gordon_config.rb
+++ b/examples/profile/libraries/gordon_config.rb
@@ -35,7 +35,7 @@ class GordonConfig < Inspec.resource(1)
       @params['file_size'] = @file.size
       @params['file_path'] = @path
       @params['ruby'] = 'RUBY IS HERE TO HELP ME!'
-    rescue Exception
+    rescue StandardError
       raise Inspec::Exceptions::ResourceSkipped, "#{@file}: #{$!}"
     end
   end

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -58,7 +58,7 @@ describe 'inspec exec with json formatter' do
         "license" => "Apache-2.0",
         "summary" => "Demonstrates the use of InSpec Compliance Profile",
         "version" => "1.0.0",
-        "sha256" => "8eed5154c9fa0174067ab475c0ad4a053f772590d129eb324101fe43ef30794d",
+        "sha256" => "57709d3a3d5cd06f4179be7e6fbe254c09e3af25ce274e474d52623e34487cc4",
         "supports" => [{"os-family" => "unix"}],
         "attributes" => []
       })

--- a/test/functional/inspec_exec_jsonmin_test.rb
+++ b/test/functional/inspec_exec_jsonmin_test.rb
@@ -67,7 +67,7 @@ describe 'inspec exec' do
 
     it 'has a skip_message' do
       ex1['skip_message'].must_be :nil?
-      ex3['skip_message'].must_equal "Can't find file \"/tmp/gordon/config.yaml\""
+      ex3['skip_message'].must_equal "Can't find file `/tmp/gordon/config.yaml`"
     end
   end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -16,7 +16,7 @@ describe 'inspec exec' do
     stdout.must_include "\e[38;5;41m  ✔  tmp-1.0: Create /tmp directory\e[0m\n"
     stdout.must_include "
 \e[38;5;247m  ↺  gordon-1.0: Verify the version number of Gordon (1 skipped)\e[0m
-\e[38;5;247m     ↺  Can't find file \"/tmp/gordon/config.yaml\"\e[0m
+\e[38;5;247m     ↺  Can't find file `/tmp/gordon/config.yaml`\e[0m
 "
     stdout.must_include "\nProfile Summary: \e[38;5;41m2 successful controls\e[0m, 0 control failures, \e[38;5;247m1 control skipped\e[0m\n"
     stdout.must_include "\nTest Summary: \e[38;5;41m4 successful\e[0m, 0 failures, \e[38;5;247m1 skipped\e[0m\n"


### PR DESCRIPTION
This makes the example resource satisfy Rubocop and adds a few other recent changes (e.g. `supports`)