### PR TITLE
Add Cisco IOS `enable_password` support

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'train', '~> 1.3'
+  spec.add_dependency 'train', '~> 1.4'
   spec.add_dependency 'thor', '~> 0.20'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'method_source', '~> 0.8'

--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -40,7 +40,7 @@ module Inspec
     #
     # @param [Hash] config for the transport backend
     # @return [TransportBackend] enriched transport instance
-    def self.create(config) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def self.create(config) # rubocop:disable Metrics/AbcSize
       conf = Train.target_config(config)
       name = Train.validate_backend(conf)
       transport = Train.create(name, conf)
@@ -51,14 +51,6 @@ module Inspec
       connection = transport.connection
       if connection.nil?
         raise "Can't connect to transport backend '#{name}'."
-      end
-
-      # Cisco IOS requires a special implementation of `Net:SSH`. This uses the
-      # SSH transport to identify the platform, but then replaces that transport
-      # with the CiscoIOS transport in order to behave as expected later.
-      if name == 'ssh' && connection.platform.cisco_ios?
-        transport = Train.create('cisco_ios', conf)
-        connection = transport.connection
       end
 
       # Set caching settings. We always want to enable caching for

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -26,6 +26,8 @@ module Inspec
         desc: 'The login user for a remote scan.'
       option :password, type: :string, lazy_default: -1,
         desc: 'Login password for a remote scan, if required.'
+      option :enable_password, type: :string, lazy_default: -1,
+        desc: 'Password for enable mode on Cisco IOS devices.'
       option :key_files, aliases: :i, type: :array,
         desc: 'Login key or certificate file for a remote scan.'
       option :path, type: :string,


### PR DESCRIPTION
This adds support for using the `ssh://` URI with Cisco IOS devices via swapping the transport after platform detection.

This also adds support for passing the IOS enable password via the CLI.