### PR TITLE
Added a description to steer people to correct resource

### DIFF
--- a/lib/resources/mysql.rb
+++ b/lib/resources/mysql.rb
@@ -5,6 +5,7 @@ module Inspec::Resources
   class Mysql < Inspec.resource(1)
     name 'mysql'
     supports platform: 'unix'
+    desc 'The \'mysql\' resource is a helper for the \'mysql_conf\' & \'mysql_session\' resources.  Please use those instead.'
 
     attr_reader :package, :service, :conf_dir, :conf_path, :data_dir, :log_dir, :log_path, :log_group, :log_dir_group
     def initialize

--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -5,6 +5,7 @@ module Inspec::Resources
   class Postgres < Inspec.resource(1)
     name 'postgres'
     supports platform: 'unix'
+    desc 'The \'postgres\' resource is a helper for the \'postgres_conf\', \'postgres_hba_conf\', \'postgres_ident_conf\' & \'postgres_session\' resources.  Please use those instead.'
 
     attr_reader :service, :data_dir, :conf_dir, :conf_path, :version, :cluster
     def initialize


### PR DESCRIPTION
Whilst revising for my inspec exam I noticed that these two resources didn't have a description.  I appreciate they are just helper resources but they are still listed when running `help resources` within an inspec shell.

So I added a description to steer people in the right direction.

Signed-off-by: DigitalGaz <digitalgaz@hotmail.com>