### PR TITLE
Makes JSON resource enumerable, despite method_missing magic

### DIFF
--- a/lib/resources/json.rb
+++ b/lib/resources/json.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'utils/object_traversal'
+require 'utils/enumerable_delegation'
 require 'utils/file_reader'
 
 module Inspec::Resources
@@ -37,6 +38,9 @@ module Inspec::Resources
       # load the raw content from the source, and then parse it
       @raw_content = load_raw_content(opts)
       @params = parse(@raw_content)
+
+      # If the JSON content is enumerable, make this object enumerable too
+      extend EnumerableDelegation if @params.respond_to?(:each)
     end
 
     # Shorthand to retrieve a parameter name via `#its`.

--- a/lib/utils/enumerable_delegation.rb
+++ b/lib/utils/enumerable_delegation.rb
@@ -1,0 +1,9 @@
+# encoding: utf-8
+
+module EnumerableDelegation
+  include Enumerable
+
+  def each(&block)
+    @params.each(&block)
+  end
+end

--- a/test/unit/resources/json_test.rb
+++ b/test/unit/resources/json_test.rb
@@ -32,6 +32,14 @@ describe 'Inspec::Resources::JSON' do
     it 'doesnt resolve symbol-notation names' do
       _(resource.send(:'x.y.z')).must_be_nil
     end
+
+    it 'is enumerability matches its data' do
+      enum = load_resource('json', content: '["a","b"]')
+      not_enum = load_resource('json', content: '525600')
+
+      _(enum.respond_to?(:each)).must_equal true
+      _(not_enum.respond_to?(:each)).must_equal false
+    end
   end
 
   describe 'when loading a nonexistent file' do


### PR DESCRIPTION
Per Slack discussion:

```ruby
obj = json(content: '[{"Name": "abc"}, {"Name": "def"}]')

obj.each do |node|
  describe node do
    it { should eq nil }
  end
end
```

Above does not respond as expected due to method_missing magic. One expects 2 tests to execute, but each does not iterate over its data. This PR corrects that and includes all of the same enumerable abilities on the `json` (and by extension, `yaml`) resource that its data contains.

Yes, I am aware this could also be accomplished by doing `obj.params.each do` instead of `obj.each do`, but I don't feel this is very intuitive. We're exposing the `:[]` method via method_missing, why not make it react like a hash or array too?