### PR TITLE
Policy Statement Search capability for aws_iam_policy

### DIFF
--- a/docs/resources/aws_iam_policy.md.erb
+++ b/docs/resources/aws_iam_policy.md.erb
@@ -5,9 +5,9 @@ platform: aws
 
 # aws\_iam\_policy
 
-Use the `aws_iam_policy` InSpec audit resource to test properties of a single managed AWS IAM Policy.
+Use the `aws_iam_policy` InSpec audit resource to test detailed properties of a single managed AWS IAM Policy.  Use `aws_iam_policies` to audit IAM policies in bulk.
 
-A policy is an entity in AWS that, when attached to an identity or resource, defines their permissions. AWS evaluates these policies when a principal, such as a user, makes a request. Permissions in the policies determine if the request is allowed or denied.
+A policy is an entity in AWS that, when attached to an identity or resource, defines their permissions. AWS evaluates these policies when a principal, such as a user, makes a request. Permissions (known as Statements) in the policies determine if the request is allowed or denied.
 
 Each IAM Policy is uniquely identified by either its policy\_name or arn.
 
@@ -50,11 +50,22 @@ The following examples show how to use this InSpec audit resource.
       it { should be_attached }
     end
 
+### Examine the policy statements
+
+    describe aws_iam_policy('my-policy') do
+      # Verify that there is at least one statement allowing access to S3
+      it { should have_statement(Action: 's3:PutObject', Effect: 'allow') }
+
+      # have_statement does not expand wildcards.  If you want to verify 
+      # they are absent, an explicit check is required.
+      it { should_not have_statement(Action: 's3:*') }
+    end
+
 <br>
 
 ## Properties
 
-* `arn`, `attachment_count`, `attached_groups`, `attached_roles`,`attached_users`, `default_version_id`
+* `arn`, `attachment_count`, `attached_groups`, `attached_roles`,`attached_users`, `default_version_id`, `policy`, `statement_count`
 
 ## Property Examples
 
@@ -106,10 +117,31 @@ The 'default_version_id' value of the specified policy.
       its('default_version_id') { should cmp "v1" }
     end
 
+### policy
+
+A low-level property that returns a Ruby Hash structure reflecting the decoded contents of the default version of the policy's policy document. This structure contains the statements that the policy enforces and is useful for performing checks that cannot be expressed using higher-level matchers like `have_statement`.
+
+For details regarding the contents of this structure, refer to the [AWS IAM Policy JSON Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html).  A set of examples is [also available](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_examples.html).
+
+Example: 
+
+    describe aws_iam_policy('my-policy') do
+      # TODO - example?
+      its('policy') { should }
+    end
+
+### statement\_count
+
+Returns the number of Statements present in the `policy`.
+
+    # Make sure there are exactly two statements.
+    describe aws_iam_policy('my-policy') do
+      its('statement_count') { should cmp 2 }
+    end
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
 
 ### be\_attached
 
@@ -141,4 +173,83 @@ The test will pass if the identified policy attached the specified role.
 
     describe aws_iam_policy('AWSSupportAccess') do
       it { should be_attached_to_role(ROLENAME) }
+    end
+
+### have\_statement
+
+Examines the list of statements contained in the policy, and passes if at least one of the statements matches. Note that this does _not_ interpret the policy in a request authorization context, as AWS does when a request processed. Rather, `have_statement` examines the literal contents of the IAM policy, and reports on what is present (or absent, when used with `should_not`).
+
+`have_statement` accepts the following criteria to search for matching statements. If any statement matches all the criteria, the test is successful.
+
+* `Action` - Expresses the operation being requested. Acceptable literal values are any AWS operation name, including the '*' wildcard character. `Action` may also be a list of such values.
+* `Effect` - Expresses whether the operation is permitted. Acceptable values are 'Deny' and 'Allow'.
+* `Id` - A user-provided string identifier for the statement.
+* `Principal` - Refers to the actor making the request. May be an ARN, a service identifier, or a wildcard. `Principal` may also be a list of such values.
+* `Resource` - Expresses the target of the operation. Acceptable values are ARNs, including the '*' wildcard. `Resource` may also be a list of such values.
+
+Please note the following about the behavior of `have_statement`:
+* `Action`, `Id`, `Principal`, and `Resource` allow using a regular expression instead of a string literal as the search criteria.
+* it does not support wildcard expansion; if you wish to check for a wildcard value, you must check for it explicitly. For example, if the policy includes a statement with `"Action": "s3:*"` and you write a test checking for `Action: "s3:PutObject"`, your test _will not match_.  You must write an additional test checking for the wildcard case. 
+* it does support searching list values.  For example, if a statement contains a list of 3 resources, and you write a `have_statement` test specifying one of those resources, it will match.
+* `Action`, `Principal`, and `Resource` allow providing a list of string literals or regular expressions, in which case _all_ must match on the _same_ statement for the test to match. Order is ignored.
+* it does not currently support the `Conditional` key, nor any of `NotAction`, `NotPrincipal`, or `NotResource`.
+
+Examples:
+
+    # Verify there is no full-admin statement
+    describe aws_iam_policy('kryptonite') do
+      it { should_not have_statement(Effect: 'Allow', Resource: '*', Action: '*')}
+    end
+
+    # Verify bob is allowed to manage things on S3 buckets that start with bobs-stuff
+    describe aws_iam_policy('bob-is-a-packrat') do
+      it { should have_statement(Effect: 'Allow',
+                                 Principal: 'arn:aws:iam::123456789101:user/bob'
+                                 # Using the AWS wildcard - this must match exactly 
+                                 Resource: 'arn:aws:s3:::bobs-stuff*',
+                                 # Specify a list of actions - all must match, no others, order isn't important
+                                 Action: ['s3:PutObject', 's3:GetObject', 's3:DeleteObject'])}
+
+      # Bob would make new buckets constantly if we let him.
+      it { should_not have_statement(Effect: 'Allow', Action: 's3:CreateBucket')}
+      it { should_not have_statement(Effect: 'Allow', Action: 's3:*')}
+      it { should_not have_statement(Effect: 'Allow', Action: '*')}
+
+      # An alternative to checking for wildcards is to specify the 
+      # statements you expect, then restrict statement count
+      its('statement_count') { should cmp 1 }
+    end
+
+    # Use regular expressions to examine the policy
+    describe aws_iam_policy('regex-demo') do
+      # Check to see if anything mentions RDS at all.
+      # This catches `rds:CreateDBinstance` and `rds:*`, but would not catch '*'.
+      it { should_not have_statement(Action: /^rds:/)}
+      
+      # This policy should refer to both sally and kim's s3 buckets.
+      # This will only match if there is a statement that refers to both resources.
+      it { should have_statement(Resource: [/arn:aws:s3.+:sally/, /arn:aws:s3.+:kim/]) }
+      # This isn't quite the same; it would also match on a statement that only mentions one of them
+      it { should have_statement(Resource: /arn:aws:s3.+:(sally|kim)/) }
+    end
+
+
+### grant_full_admin
+
+This high-level matcher detects whether the policy contains a statement that grants "full admin" permissions on the AWS account.  More precisely, the matcher looks for any statement with:
+
+* Effect: 'Allow'
+* Resource: '*'
+* Action: '*'
+
+Examples:
+
+    # Allow full admin for the 'admins' policy
+    describe aws_iam_policy('admins') do
+      it { should grant_full_admin }
+    end
+
+    # Peons should not have admin.
+    describe aws_iam_policy('peons') do
+      it { should_not grant_full_admin }
     end

--- a/docs/resources/aws_iam_policy.md.erb
+++ b/docs/resources/aws_iam_policy.md.erb
@@ -7,7 +7,7 @@ platform: aws
 
 Use the `aws_iam_policy` InSpec audit resource to test properties of a single managed AWS IAM Policy. Use `aws_iam_policies` to audit IAM policies in bulk.
 
-A policy defines the permissions of an identity or resource within AWA. AWS evaluates these policies when a principal, such as a user, makes a request. Policy permissions, also called "policy statements" in AWS, determine if a request authorized -- and allow or deny it accordingly.
+A policy defines the permissions of an identity or resource within AWS. AWS evaluates these policies when a principal, such as a user, makes a request. Policy permissions, also called "policy statements" in AWS, determine if a request is authorized -- and allow or deny it accordingly.
 
 Each IAM Policy is uniquely identified by either its policy\_name or arn.
 

--- a/docs/resources/aws_iam_policy.md.erb
+++ b/docs/resources/aws_iam_policy.md.erb
@@ -5,9 +5,9 @@ platform: aws
 
 # aws\_iam\_policy
 
-Use the `aws_iam_policy` InSpec audit resource to test detailed properties of a single managed AWS IAM Policy.  Use `aws_iam_policies` to audit IAM policies in bulk.
+Use the `aws_iam_policy` InSpec audit resource to test properties of a single managed AWS IAM Policy. Use `aws_iam_policies` to audit IAM policies in bulk.
 
-A policy is an entity in AWS that, when attached to an identity or resource, defines their permissions. AWS evaluates these policies when a principal, such as a user, makes a request. Permissions (known as Statements) in the policies determine if the request is allowed or denied.
+A policy defines the permissions of an identity or resource within AWA. AWS evaluates these policies when a principal, such as a user, makes a request. Policy permissions, also called "policy statements" in AWS, determine if a request authorized -- and allow or deny it accordingly.
 
 Each IAM Policy is uniquely identified by either its policy\_name or arn.
 
@@ -56,7 +56,7 @@ The following examples show how to use this InSpec audit resource.
       # Verify that there is at least one statement allowing access to S3
       it { should have_statement(Action: 's3:PutObject', Effect: 'allow') }
 
-      # have_statement does not expand wildcards.  If you want to verify 
+      # have_statement does not expand wildcards. If you want to verify 
       # they are absent, an explicit check is required.
       it { should_not have_statement(Action: 's3:*') }
     end
@@ -119,7 +119,7 @@ The 'default_version_id' value of the specified policy.
 
 ### policy
 
-A low-level property that returns a Ruby Hash structure reflecting the decoded contents of the default version of the policy's policy document. This structure contains the statements that the policy enforces and is useful for performing checks that cannot be expressed using higher-level matchers like `have_statement`.
+Returns the default version of a policy document as a Ruby hash. This hash contains the enforced policy statements and is useful for performing checks that cannot be expressed using higher-level matchers like `have_statement`.
 
 For details regarding the contents of this structure, refer to the [AWS IAM Policy JSON Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html).  A set of examples is [also available](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_examples.html).
 
@@ -127,12 +127,13 @@ Example:
 
     describe aws_iam_policy('my-policy') do
       # TODO - example?
-      its('policy') { should }
+      # !!Check this sytax!!
+      its('policy') { should have_action 'codecommit:GitPull' }
     end
 
 ### statement\_count
 
-Returns the number of Statements present in the `policy`.
+Returns the number of statements present in the `policy`.
 
     # Make sure there are exactly two statements.
     describe aws_iam_policy('my-policy') do
@@ -177,21 +178,21 @@ The test will pass if the identified policy attached the specified role.
 
 ### have\_statement
 
-Examines the list of statements contained in the policy and passes if at least one of the statements matches. Note that this does _not_ interpret the policy in a request authorization context, as AWS does when a request processed. Rather, `have_statement` examines the literal contents of the IAM policy, and reports on what is present (or absent, when used with `should_not`).
+Examines the list of statements contained in the policy and passes if at least one of the statements matches. This matcher does _not_ interpret the policy in a request authorization context, as AWS does when a request processed. Rather, `have_statement` examines the literal contents of the IAM policy, and reports on what is present (or absent, when used with `should_not`).
 
 `have_statement` accepts the following criteria to search for matching statements. If any statement matches all the criteria, the test is successful.
 
-* `Action` - Expresses the operation being requested. Acceptable literal values are any AWS operation name, including the '*' wildcard character. `Action` may also be a list of such values.
-* `Effect` - Expresses whether the operation is permitted. Acceptable values are 'Deny' and 'Allow'.
+* `Action` - Expresses the requested operation. Acceptable literal values are any AWS operation name, including the '*' wildcard character. `Action` may also use a list of AWS operation names.
+* `Effect` - Expresses if the operation is permitted. Acceptable values are 'Deny' and 'Allow'.
 * `Sid` - A user-provided string identifier for the statement.
-* `Resource` - Expresses the target of the operation. Acceptable values are ARNs, including the '*' wildcard. `Resource` may also be a list of such values.
+* `Resource` - Expresses the operation's target. Acceptable values are ARNs, including the '*' wildcard. `Resource` may also use a list of ARN values.
 
 Please note the following about the behavior of `have_statement`:
-* `Action`, `Sid`, and `Resource` allow using a regular expression instead of a string literal as the search criteria.
-* it does not support wildcard expansion; if you wish to check for a wildcard value, you must check for it explicitly. For example, if the policy includes a statement with `"Action": "s3:*"` and you write a test checking for `Action: "s3:PutObject"`, your test _will not match_.  You must write an additional test checking for the wildcard case. 
-* it does support searching list values.  For example, if a statement contains a list of 3 resources, and you write a `have_statement` test specifying one of those resources, it will match.
-* `Action` and `Resource` allow providing a list of string literals or regular expressions, in which case _all_ must match on the _same_ statement for the test to match. Order is ignored.
-* it does not currently support the `Principal` nor `Conditional` key, nor any of `NotAction`, `NotPrincipal`, or `NotResource`.
+* `Action`, `Sid`, and `Resource` allow using a regular expression as the search critera instead of a string literal.
+* it does not support wildcard expansion; to check for a wildcard value, check for it explicitly. For example, if the policy includes a statement with `"Action": "s3:*"` and the test checks for `Action: "s3:PutObject"`, the test _will not match_. You must write an additional test checking for the wildcard case. 
+* it supports searching list values. For example, if a statement contains a list of 3 resources, and a `have_statement` test specifes _one_ of those resources, it will match.
+* `Action` and `Resource` allow using a list of string literals or regular expressions in a test, in which case _all_ must match on the _same_ statement for the test to match. Order is ignored.
+* it does not support the `Principal` nor `Conditional` key, nor any of `NotAction`, `NotPrincipal`, or `NotResource`.
 
 Examples:
 
@@ -227,6 +228,6 @@ Examples:
       # This policy should refer to both sally and kim's s3 buckets.
       # This will only match if there is a statement that refers to both resources.
       it { should have_statement(Resource: [/arn:aws:s3.+:sally/, /arn:aws:s3.+:kim/]) }
-      # This isn't quite the same; it would also match on a statement that only mentions one of them
+      # It also matches on a statement mentioning only one of them
       it { should have_statement(Resource: /arn:aws:s3.+:(sally|kim)/) }
     end

--- a/docs/resources/aws_iam_policy.md.erb
+++ b/docs/resources/aws_iam_policy.md.erb
@@ -125,10 +125,14 @@ For details regarding the contents of this structure, refer to the [AWS IAM Poli
 
 Example: 
 
-    describe aws_iam_policy('my-policy') do
-      # TODO - example?
-      # !!Check this sytax!!
-      its('policy') { should have_action 'codecommit:GitPull' }
+    # Fetch the policy structure as a Ruby object
+    policy_struct = aws_iam_policy('my-policy').policy
+    # Write a manually-constructed test to check that the policy 
+    # has an IP constraint on the first statement
+    # ( Based on https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_deny-ip.html )
+    describe 'Check that we are restricting IP access' do
+      subject { policy_struct['Statement'].first['Condition'] }
+      it { should include 'NotIpAddress' }
     end
 
 ### statement\_count

--- a/docs/resources/aws_iam_policy.md.erb
+++ b/docs/resources/aws_iam_policy.md.erb
@@ -177,18 +177,18 @@ The test will pass if the identified policy attached the specified role.
 
 ### have\_statement
 
-Examines the list of statements contained in the policy, and passes if at least one of the statements matches. Note that this does _not_ interpret the policy in a request authorization context, as AWS does when a request processed. Rather, `have_statement` examines the literal contents of the IAM policy, and reports on what is present (or absent, when used with `should_not`).
+Examines the list of statements contained in the policy and passes if at least one of the statements matches. Note that this does _not_ interpret the policy in a request authorization context, as AWS does when a request processed. Rather, `have_statement` examines the literal contents of the IAM policy, and reports on what is present (or absent, when used with `should_not`).
 
 `have_statement` accepts the following criteria to search for matching statements. If any statement matches all the criteria, the test is successful.
 
 * `Action` - Expresses the operation being requested. Acceptable literal values are any AWS operation name, including the '*' wildcard character. `Action` may also be a list of such values.
 * `Effect` - Expresses whether the operation is permitted. Acceptable values are 'Deny' and 'Allow'.
-* `Id` - A user-provided string identifier for the statement.
+* `Sid` - A user-provided string identifier for the statement.
 * `Principal` - Refers to the actor making the request. May be an ARN, a service identifier, or a wildcard. `Principal` may also be a list of such values.
 * `Resource` - Expresses the target of the operation. Acceptable values are ARNs, including the '*' wildcard. `Resource` may also be a list of such values.
 
 Please note the following about the behavior of `have_statement`:
-* `Action`, `Id`, `Principal`, and `Resource` allow using a regular expression instead of a string literal as the search criteria.
+* `Action`, `Sid`, `Principal`, and `Resource` allow using a regular expression instead of a string literal as the search criteria.
 * it does not support wildcard expansion; if you wish to check for a wildcard value, you must check for it explicitly. For example, if the policy includes a statement with `"Action": "s3:*"` and you write a test checking for `Action: "s3:PutObject"`, your test _will not match_.  You must write an additional test checking for the wildcard case. 
 * it does support searching list values.  For example, if a statement contains a list of 3 resources, and you write a `have_statement` test specifying one of those resources, it will match.
 * `Action`, `Principal`, and `Resource` allow providing a list of string literals or regular expressions, in which case _all_ must match on the _same_ statement for the test to match. Order is ignored.
@@ -224,7 +224,7 @@ Examples:
     describe aws_iam_policy('regex-demo') do
       # Check to see if anything mentions RDS at all.
       # This catches `rds:CreateDBinstance` and `rds:*`, but would not catch '*'.
-      it { should_not have_statement(Action: /^rds:/)}
+      it { should_not have_statement(Action: /^rds:.+$/)}
       
       # This policy should refer to both sally and kim's s3 buckets.
       # This will only match if there is a statement that refers to both resources.

--- a/docs/resources/aws_iam_policy.md.erb
+++ b/docs/resources/aws_iam_policy.md.erb
@@ -184,15 +184,14 @@ Examines the list of statements contained in the policy and passes if at least o
 * `Action` - Expresses the operation being requested. Acceptable literal values are any AWS operation name, including the '*' wildcard character. `Action` may also be a list of such values.
 * `Effect` - Expresses whether the operation is permitted. Acceptable values are 'Deny' and 'Allow'.
 * `Sid` - A user-provided string identifier for the statement.
-* `Principal` - Refers to the actor making the request. May be an ARN, a service identifier, or a wildcard. `Principal` may also be a list of such values.
 * `Resource` - Expresses the target of the operation. Acceptable values are ARNs, including the '*' wildcard. `Resource` may also be a list of such values.
 
 Please note the following about the behavior of `have_statement`:
-* `Action`, `Sid`, `Principal`, and `Resource` allow using a regular expression instead of a string literal as the search criteria.
+* `Action`, `Sid`, and `Resource` allow using a regular expression instead of a string literal as the search criteria.
 * it does not support wildcard expansion; if you wish to check for a wildcard value, you must check for it explicitly. For example, if the policy includes a statement with `"Action": "s3:*"` and you write a test checking for `Action: "s3:PutObject"`, your test _will not match_.  You must write an additional test checking for the wildcard case. 
 * it does support searching list values.  For example, if a statement contains a list of 3 resources, and you write a `have_statement` test specifying one of those resources, it will match.
-* `Action`, `Principal`, and `Resource` allow providing a list of string literals or regular expressions, in which case _all_ must match on the _same_ statement for the test to match. Order is ignored.
-* it does not currently support the `Conditional` key, nor any of `NotAction`, `NotPrincipal`, or `NotResource`.
+* `Action` and `Resource` allow providing a list of string literals or regular expressions, in which case _all_ must match on the _same_ statement for the test to match. Order is ignored.
+* it does not currently support the `Principal` nor `Conditional` key, nor any of `NotAction`, `NotPrincipal`, or `NotResource`.
 
 Examples:
 
@@ -204,7 +203,6 @@ Examples:
     # Verify bob is allowed to manage things on S3 buckets that start with bobs-stuff
     describe aws_iam_policy('bob-is-a-packrat') do
       it { should have_statement(Effect: 'Allow',
-                                 Principal: 'arn:aws:iam::123456789101:user/bob'
                                  # Using the AWS wildcard - this must match exactly 
                                  Resource: 'arn:aws:s3:::bobs-stuff*',
                                  # Specify a list of actions - all must match, no others, order isn't important

--- a/docs/resources/aws_iam_policy.md.erb
+++ b/docs/resources/aws_iam_policy.md.erb
@@ -192,7 +192,7 @@ Please note the following about the behavior of `have_statement`:
 * it does not support wildcard expansion; to check for a wildcard value, check for it explicitly. For example, if the policy includes a statement with `"Action": "s3:*"` and the test checks for `Action: "s3:PutObject"`, the test _will not match_. You must write an additional test checking for the wildcard case. 
 * it supports searching list values. For example, if a statement contains a list of 3 resources, and a `have_statement` test specifes _one_ of those resources, it will match.
 * `Action` and `Resource` allow using a list of string literals or regular expressions in a test, in which case _all_ must match on the _same_ statement for the test to match. Order is ignored.
-* it does not support the `Principal` nor `Conditional` key, nor any of `NotAction`, `NotPrincipal`, or `NotResource`.
+* it does not support the `Principal` or `Conditional` key, or any of `NotAction`, `NotPrincipal`, or `NotResource`.
 
 Examples:
 

--- a/docs/resources/aws_iam_policy.md.erb
+++ b/docs/resources/aws_iam_policy.md.erb
@@ -230,24 +230,3 @@ Examples:
       # This isn't quite the same; it would also match on a statement that only mentions one of them
       it { should have_statement(Resource: /arn:aws:s3.+:(sally|kim)/) }
     end
-
-
-### grant_full_admin
-
-This high-level matcher detects whether the policy contains a statement that grants "full admin" permissions on the AWS account.  More precisely, the matcher looks for any statement with:
-
-* Effect: 'Allow'
-* Resource: '*'
-* Action: '*'
-
-Examples:
-
-    # Allow full admin for the 'admins' policy
-    describe aws_iam_policy('admins') do
-      it { should grant_full_admin }
-    end
-
-    # Peons should not have admin.
-    describe aws_iam_policy('peons') do
-      it { should_not grant_full_admin }
-    end

--- a/docs/resources/aws_iam_policy.md.erb
+++ b/docs/resources/aws_iam_policy.md.erb
@@ -119,7 +119,9 @@ The 'default_version_id' value of the specified policy.
 
 ### policy
 
-Returns the default version of a policy document as a Ruby hash. This hash contains the enforced policy statements and is useful for performing checks that cannot be expressed using higher-level matchers like `have_statement`.
+This is a low-level, unsupported property.
+
+Returns the default version of the policy document after decoding as a Ruby hash. This hash contains the policy statements and is useful for performing checks that cannot be expressed using higher-level matchers like `have_statement`.
 
 For details regarding the contents of this structure, refer to the [AWS IAM Policy JSON Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html).  A set of examples is [also available](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_examples.html).
 
@@ -232,6 +234,6 @@ Examples:
       # This policy should refer to both sally and kim's s3 buckets.
       # This will only match if there is a statement that refers to both resources.
       it { should have_statement(Resource: [/arn:aws:s3.+:sally/, /arn:aws:s3.+:kim/]) }
-      # It also matches on a statement mentioning only one of them
+      # The following also matches on a statement mentioning only one of them
       it { should have_statement(Resource: /arn:aws:s3.+:(sally|kim)/) }
     end

--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -65,6 +65,11 @@ class AwsIamPolicy < Inspec.resource(1)
     @policy
   end
 
+  def statement_count
+    return nil unless exists?
+    policy['Statement'].count
+  end
+
   private
 
   def validate_params(raw_params)

--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -76,7 +76,7 @@ class AwsIamPolicy < Inspec.resource(1)
     catch_aws_errors do
       backend = BackendFactory.create(inspec_runner)
       gpv_response = backend.get_policy_version(policy_arn: arn, version_id: default_version_id)
-      @policy = JSON.parse(URI.decode_www_form_component(gpv_response.document))
+      @policy = JSON.parse(URI.decode_www_form_component(gpv_response.policy_version.document))
     end
     @policy
   end
@@ -256,6 +256,10 @@ class AwsIamPolicy < Inspec.resource(1)
     class AwsClientApi < AwsBackendBase
       BackendFactory.set_default_backend(self)
       self.aws_client_class = Aws::IAM::Client
+
+      def get_policy_version(criteria)
+        aws_service_client.get_policy_version(criteria)
+      end
 
       def list_policies(criteria)
         aws_service_client.list_policies(criteria)

--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -94,8 +94,8 @@ class AwsIamPolicy < Inspec.resource(1)
     statements.any? do |statement|
       true && \
         has_statement__effect(statement, criteria) && \
-        has_statement__array_criterion(:action, statement, criteria)
-      #   has_statement__resource(statement, criteria)
+        has_statement__array_criterion(:action, statement, criteria) && \
+        has_statement__array_criterion(:resource, statement, criteria)
       #   has_statement__principal(statement, criteria)
     end
   end

--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -1,3 +1,6 @@
+require 'json'
+require 'uri'
+
 class AwsIamPolicy < Inspec.resource(1)
   name 'aws_iam_policy'
   desc 'Verifies settings for individual AWS IAM Policy'
@@ -48,6 +51,18 @@ class AwsIamPolicy < Inspec.resource(1)
 
   def attached_to_role?(role_name)
     attached_roles.include?(role_name)
+  end
+
+  def policy
+    return nil unless exists?
+    return @policy if defined?(@policy)
+
+    catch_aws_errors do
+      backend = BackendFactory.create(inspec_runner)
+      gpv_response = backend.get_policy_version(policy_arn: arn, version_id: default_version_id)
+      @policy = JSON.parse(URI.decode_www_form_component(gpv_response.document))
+    end
+    @policy
   end
 
   private

--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -19,7 +19,6 @@ class AwsIamPolicy < Inspec.resource(1)
   EXPECTED_CRITERIA = %w{
     Action
     Effect
-    Principal
     Resource
     Sid
   }.freeze
@@ -29,6 +28,7 @@ class AwsIamPolicy < Inspec.resource(1)
     NotAction
     NotPrincipal
     NotResource
+    Principal
   }.freeze
 
   def to_s
@@ -96,7 +96,6 @@ class AwsIamPolicy < Inspec.resource(1)
         has_statement__effect(statement, criteria) && \
         has_statement__array_criterion(:action, statement, criteria) && \
         has_statement__array_criterion(:resource, statement, criteria)
-      #   has_statement__principal(statement, criteria)
     end
   end
 
@@ -144,7 +143,7 @@ class AwsIamPolicy < Inspec.resource(1)
   def has_statement__normalize_statements
     policy['Statement'].map do |statement|
       # Coerce some values into arrays
-      %w{Action Principal Resource}.each do |field|
+      %w{Action Resource}.each do |field|
         if statement.key?(field)
           statement[field] = Array(statement[field])
         end

--- a/test/integration/aws/default/build/iam.tf
+++ b/test/integration/aws/default/build/iam.tf
@@ -117,6 +117,100 @@ output "iam_group_administrators" {
 }
 
 #======================================================#
+#                  IAM Policies
+#======================================================#
+
+# Test fixtures:
+# Note: Principal is not allowed on an IAM Policy. (May be allowed on a role?  certainly on s3 bucket?)
+#  alpha
+#    has 2 statements
+#    one is a wildcard on ec2
+#    both have IDs
+#    one is a resource full wildcard
+#    one is Allow, one is Deny
+#    scalar values throughout
+#  beta
+#    one statement
+#    list values for Resource and Action
+#  gamma
+#    allow all
+
+resource "aws_iam_policy" "alpha" {
+  name = "${terraform.env}-alpha"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "alpha01",
+      "Action": "ec2:Describe*",
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Sid": "alpha02",
+      "Action": "s3:GetObject",
+      "Effect": "Deny",
+      "Resource": "arn:aws:s3:::bobs-stuff"
+    }
+  ]
+}
+EOF
+}
+
+output "aws_iam_policy_alpha_name" {
+  value = "${aws_iam_policy.alpha.name}"
+}
+
+resource "aws_iam_policy" "beta" {
+  name = "${terraform.env}-beta"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "beta01",
+      "Action": [
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:ec2:::*",
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+output "aws_iam_policy_beta_name" {
+  value = "${aws_iam_policy.beta.name}"
+}
+
+resource "aws_iam_policy" "gamma" {
+  name = "${terraform.env}-gamma"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "gamma01",
+      "Action": "*",
+      "Effect": "Allow",
+      "Resource": "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+output "aws_iam_policy_gamma_name" {
+  value = "${aws_iam_policy.gamma.name}"
+}
+#======================================================#
 #                    IAM Group Memberships
 #======================================================#
 

--- a/test/integration/aws/default/build/iam.tf
+++ b/test/integration/aws/default/build/iam.tf
@@ -200,7 +200,6 @@ resource "aws_iam_policy" "gamma" {
       "Action": "*",
       "Effect": "Allow",
       "Resource": "*"
-      ]
     }
   ]
 }

--- a/test/integration/aws/default/verify/controls/aws_iam_policy.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_policy.rb
@@ -48,37 +48,37 @@ control "aws_iam_policy matchers" do
   end
 
   describe aws_iam_policy(fixtures['aws_iam_policy_alpha_name']) do
-    it { should have_statement(Resource: '*')}
-    it { should have_statement(Resource: '*', Sid: 'alpha01')}
-    it { should have_statement(Resource: 'arn:aws:s3:::bobs-stuff', Sid: 'alpha02')}
+    it { should have_statement('Resource' => '*')}
+    it { should have_statement('Resource' => '*', 'Sid' => 'alpha01')}
+    it { should have_statement('Resource' => 'arn:aws:s3:::bobs-stuff', 'Sid' => 'alpha02')}
 
-    it { should have_statement(Effect: 'Allow', Sid: 'alpha01')}
-    it { should have_statement(Effect: 'Deny', Sid: 'alpha02')}
+    it { should have_statement('Effect' => 'Allow', 'Sid' => 'alpha01')}
+    it { should have_statement('Effect' => 'Deny', 'Sid' => 'alpha02')}
 
-    it { should have_statement(Action: 'ec2:Describe*', Sid: 'alpha01')}
-    it { should_not have_statement(Action: 'ec2:Describe')}
-    it { should have_statement(Action: /^ec2:Describe\*$/, Sid: 'alpha01')}
-    it { should have_statement(Action: /^ec2:.+$/, Sid: 'alpha01')}
+    it { should have_statement('Action' => 'ec2:Describe*', 'Sid' => 'alpha01')}
+    it { should_not have_statement('Action' => 'ec2:Describe')}
+    it { should have_statement('Action' => /^ec2:Describe\*$/, 'Sid' => 'alpha01')}
+    it { should have_statement('Action' => /^ec2:.+$/, 'Sid' => 'alpha01')}
 
-    it { should have_statement(Action: 'ec2:Describe*', Resource: '*', Effect: 'Allow') }
-    it { should_not have_statement(Action: 'ec2:Describe*', Resource: 'arn:aws:s3:::bobs-stuff') }
+    it { should have_statement('Action' => 'ec2:Describe*', 'Resource' => '*', 'Effect' => 'Allow') }
+    it { should_not have_statement('Action' => 'ec2:Describe*', 'Resource' => 'arn:aws:s3:::bobs-stuff') }
 
     it { should_not grant_full_admin }
   end
 
   describe aws_iam_policy(fixtures['aws_iam_policy_beta_name']) do
-    it { should have_statement(Action: 'ec2:DescribeSubnets')}
-    it { should have_statement(Action: 'ec2:DescribeSecurityGroups')}
+    it { should have_statement('Action' => 'ec2:DescribeSubnets')}
+    it { should have_statement('Action' => 'ec2:DescribeSecurityGroups')}
     # Array indicates all must match
-    it { should_not have_statement(Action: ['ec2:DescribeSecurityGroups'])}
-    it { should have_statement(Action: ['ec2:DescribeSubnets', 'ec2:DescribeSecurityGroups'])}
-    it { should have_statement(Action: ['ec2:DescribeSecurityGroups', 'ec2:DescribeSubnets'])}
+    it { should_not have_statement('Action' => ['ec2:DescribeSecurityGroups'])}
+    it { should have_statement('Action' => ['ec2:DescribeSubnets', 'ec2:DescribeSecurityGroups'])}
+    it { should have_statement('Action' => ['ec2:DescribeSecurityGroups', 'ec2:DescribeSubnets'])}
     
-    it { should have_statement(Resource: 'arn:aws:ec2:::*')}
-    it { should have_statement(Resource: '*')}
-    it { should_not have_statement(Resource: ['*'])}    
-    it { should have_statement(Resource: ['arn:aws:ec2:::*', '*'])}
-    it { should have_statement(Resource: ['*', 'arn:aws:ec2:::*'])}
+    it { should have_statement('Resource' => 'arn:aws:ec2:::*')}
+    it { should have_statement('Resource' => '*')}
+    it { should_not have_statement('Resource' => ['*'])}    
+    it { should have_statement('Resource' => ['arn:aws:ec2:::*', '*'])}
+    it { should have_statement('Resource' => ['*', 'arn:aws:ec2:::*'])}
   end
 
   describe aws_iam_policy(fixtures['aws_iam_policy_gamma_name']) do

--- a/test/integration/aws/default/verify/controls/aws_iam_policy.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_policy.rb
@@ -1,9 +1,24 @@
+fixtures = {}
+[
+  'aws_iam_policy_alpha_name',
+].each do |fixture_name|
+  fixtures[fixture_name] = attribute(
+    fixture_name,
+    default: "default.#{fixture_name}",
+    description: 'See ../build/iam.tf',
+  )
+end
+
 control "aws_iam_policy recall" do
   describe aws_iam_policy("AWSSupportAccess") do
     it { should exist }
   end
 
   describe aws_iam_policy(policy_name: "AWSSupportAccess") do
+    it { should exist }
+  end
+
+  describe aws_iam_policy(fixtures['aws_iam_policy_alpha_name']) do
     it { should exist }
   end
 end
@@ -17,6 +32,11 @@ control "aws_iam_policy properties" do
     its('attached_groups') { should be_empty }
     its('attached_roles') { should be_empty }
   end
+
+  describe aws_iam_policy(fixtures['aws_iam_policy_alpha_name']) do
+    its('statement_count') { should cmp 2 }
+    its('policy') { should be_kind_of(Hash) }
+  end
 end
 
 control "aws_iam_policy matchers" do
@@ -26,4 +46,43 @@ control "aws_iam_policy matchers" do
   describe aws_iam_policy("AdministratorAccess") do
     it { should be_attached_to_user("test-fixture-maker") }
   end
+
+  describe aws_iam_policy(fixtures['aws_iam_policy_alpha_name']) do
+    it { should have_statement(Resource: '*')}
+    it { should have_statement(Resource: '*', Sid: 'alpha01')}
+    it { should have_statement(Resource: 'arn:aws:s3:::bobs-stuff', Sid: 'alpha02')}
+
+    it { should have_statement(Effect: 'Allow', Sid: 'alpha01')}
+    it { should have_statement(Effect: 'Deny', Sid: 'alpha02')}
+
+    it { should have_statement(Action: 'ec2:Describe*', Sid: 'alpha01')}
+    it { should_not have_statement(Action: 'ec2:Describe')}
+    it { should have_statement(Action: /^ec2:Describe\*$/, Sid: 'alpha01')}
+    it { should have_statement(Action: /^ec2:.+$/, Sid: 'alpha01')}
+
+    it { should have_statement(Action: 'ec2:Describe*', Resource: '*', Effect: 'Allow') }
+    it { should_not have_statement(Action: 'ec2:Describe*', Resource: 'arn:aws:s3:::bobs-stuff') }
+
+    it { should_not grant_full_admin }
+  end
+
+  describe aws_iam_policy(fixtures['aws_iam_policy_beta_name']) do
+    it { should have_statement(Action: 'ec2:DescribeSubnets')}
+    it { should have_statement(Action: 'ec2:DescribeSecurityGroups')}
+    # Array indicates all must match
+    it { should_not have_statement(Action: ['ec2:DescribeSecurityGroups'])}
+    it { should have_statement(Action: ['ec2:DescribeSubnets', 'ec2:DescribeSecurityGroups'])}
+    it { should have_statement(Action: ['ec2:DescribeSecurityGroups', 'ec2:DescribeSubnets'])}
+    
+    it { should have_statement(Resource: 'arn:aws:ec2:::*')}
+    it { should have_statement(Resource: '*')}
+    it { should_not have_statement(Resource: ['*'])}    
+    it { should have_statement(Resource: ['arn:aws:ec2:::*', '*'])}
+    it { should have_statement(Resource: ['*', 'arn:aws:ec2:::*'])}
+  end
+
+  describe aws_iam_policy(fixtures['aws_iam_policy_gamma_name']) do
+    it { should grant_full_admin }    
+  end
+  
 end

--- a/test/integration/aws/default/verify/controls/aws_iam_policy.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_policy.rb
@@ -1,6 +1,7 @@
 fixtures = {}
 [
   'aws_iam_policy_alpha_name',
+  'aws_iam_policy_beta_name',
 ].each do |fixture_name|
   fixtures[fixture_name] = attribute(
     fixture_name,
@@ -62,8 +63,6 @@ control "aws_iam_policy matchers" do
 
     it { should have_statement('Action' => 'ec2:Describe*', 'Resource' => '*', 'Effect' => 'Allow') }
     it { should_not have_statement('Action' => 'ec2:Describe*', 'Resource' => 'arn:aws:s3:::bobs-stuff') }
-
-    it { should_not grant_full_admin }
   end
 
   describe aws_iam_policy(fixtures['aws_iam_policy_beta_name']) do
@@ -79,10 +78,5 @@ control "aws_iam_policy matchers" do
     it { should_not have_statement('Resource' => ['*'])}    
     it { should have_statement('Resource' => ['arn:aws:ec2:::*', '*'])}
     it { should have_statement('Resource' => ['*', 'arn:aws:ec2:::*'])}
-  end
-
-  describe aws_iam_policy(fixtures['aws_iam_policy_gamma_name']) do
-    it { should grant_full_admin }    
-  end
-  
+  end  
 end

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -90,6 +90,12 @@ class AwsIamPolicyPropertiesTest < Minitest::Test
     assert_equal(['test-role'], AwsIamPolicy.new('test-policy-1').attached_roles)
     assert_nil(AwsIamPolicy.new(policy_name: 'non-existant').attached_roles)
   end
+
+  def test_property_policy
+    policy = AwsIamPolicy.new('test-policy-1').policy
+    assert_kind_of(Hash, policy)
+    assert_nil(AwsIamPolicy.new(policy_name: 'non-existant').policy)    
+  end
 end
 
 
@@ -196,6 +202,19 @@ module MAIPSB
         policy_roles: [],
       }
       OpenStruct.new( policy[query[:policy_arn]] )
+    end
+
+    def get_policy_version(query)
+      fixtures = {
+        'arn:aws:iam::aws:policy/test-policy-1' => {
+          'v1' => OpenStruct.new(
+            document: '%7B%0A%20%20%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Sid%22%3A%20%22CloudWatchEventsFullAccess%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Action%22%3A%20%22events%3A%2A%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Sid%22%3A%20%22IAMPassRoleForCloudWatchEvents%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Action%22%3A%20%22iam%3APassRole%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22arn%3Aaws%3Aiam%3A%3A%2A%3Arole%2FAWS_Events_Invoke_Targets%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%5D%0A%7D'
+          )
+        }
+      }
+      pv = fixtures.dig(query[:policy_arn], query[:version_id])
+      return pv if pv
+      raise Aws::IAM::Errors::NoSuchEntity.new(nil, nil)
     end
   end
 end

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -208,6 +208,29 @@ class AwsIamPolicyMatchersTest < Minitest::Test
     refute(AwsIamPolicy.new('test-policy-1').has_statement?('Effect' => 'Allow'))
     assert(AwsIamPolicy.new('test-policy-2').has_statement?('Effect' => 'Allow'))
   end
+
+  def test_have_statement_when_action_is_provided
+    # Able to match a simple string action when multiple statements present
+    assert(AwsIamPolicy.new('test-policy-2').has_statement?('Action' => 'iam:PassRole'))
+    # Able to match a wildcard string action
+    assert(AwsIamPolicy.new('test-policy-2').has_statement?('Action' => 'events:*'))
+    # Do not match a wildcard when using strings
+    refute(AwsIamPolicy.new('test-policy-2').has_statement?('Action' => 'events:EnableRule'))
+    # Do match when using a regex
+    assert(AwsIamPolicy.new('test-policy-2').has_statement?('Action' => /^events\:/))
+    # Able to match one action when the statement has an array of actions
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Action' => 'ec2:DescribeSubnets'))
+    # Do not match if only one action specified as an array when the statement has an array of actions
+    refute(AwsIamPolicy.new('test-policy-1').has_statement?('Action' => ['ec2:DescribeSubnets']))
+    # Do match if two actions specified when the statement has an array of actions
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Action' => ['ec2:DescribeSubnets', 'ec2:DescribeSecurityGroups']))
+    # Do match setwise if two actions specified when the statement has an array of actions
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Action' => ['ec2:DescribeSecurityGroups', 'ec2:DescribeSubnets']))
+    # Do match if only one regex action specified when the statement has an array of actions
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Action' => /^ec2\:Describe/))
+    # Do match if one regex action specified in an array when the statement has an array of actions
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Action' => [/^ec2\:Describe/]))
+  end
 end
 
 #=============================================================================#

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -184,6 +184,18 @@ class AwsIamPolicyMatchersTest < Minitest::Test
     ex = assert_raises(ArgumentError) {AwsIamPolicy.new('test-policy-1').has_statement?('foo' => 'dummy')}
     assert_match(/Unrecognized/, ex.message)
   end
+
+  def test_have_statement_when_sid_is_provided
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Sid' => 'beta01'))
+    assert(AwsIamPolicy.new('test-policy-2').has_statement?('Sid' => 'CloudWatchEventsFullAccess'))
+    assert(AwsIamPolicy.new('test-policy-2').has_statement?('Sid' => 'IAMPassRoleForCloudWatchEvents'))
+    refute(AwsIamPolicy.new('test-policy-2').has_statement?('Sid' => 'beta01'))
+
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Sid' => /eta/))
+    assert(AwsIamPolicy.new('test-policy-2').has_statement?('Sid' => /CloudWatch/))
+    refute(AwsIamPolicy.new('test-policy-2').has_statement?('Sid' => /eta/))
+
+  end
 end
 
 #=============================================================================#
@@ -254,12 +266,40 @@ module MAIPSB
         'arn:aws:iam::aws:policy/test-policy-1' => {
           'v1' => OpenStruct.new(
             # This is the integration test fixture "beta"
+            # {
+            #   "Version"=>"2012-10-17",
+            #   "Statement"=> [
+            #     {
+            #       "Sid"=>"beta01",
+            #       "Action"=>["ec2:DescribeSubnets", "ec2:DescribeSecurityGroups"],
+            #       "Effect"=>"Deny",
+            #       "Resource"=>["arn:aws:ec2:::*", "*"]
+            #     }
+            #   ]
+            # }
             document: '%7B%0A%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22Sid%22%3A%20%22beta01%22%2C%0A%20%20%20%20%20%20%22Action%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%22ec2%3ADescribeSubnets%22%2C%0A%20%20%20%20%20%20%20%20%22ec2%3ADescribeSecurityGroups%22%0A%20%20%20%20%20%20%5D%2C%0A%20%20%20%20%20%20%22Effect%22%3A%20%22Deny%22%2C%0A%20%20%20%20%20%20%22Resource%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%22arn%3Aaws%3Aec2%3A%3A%3A%2A%22%2C%0A%20%20%20%20%20%20%20%20%22%2A%22%0A%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%20%20%5D%0A%7D%0A'
           )
         },
         'arn:aws:iam::aws:policy/test-policy-2' => {
           'v1' => OpenStruct.new(
             # This is AWS-managed CloudWatchEventsFullAccess
+            # {
+            #   "Version"=>"2012-10-17",
+            #   "Statement"=> [
+            #     {
+            #       "Sid"=>"CloudWatchEventsFullAccess",
+            #       "Effect"=>"Allow",
+            #       "Action"=>"events:*",
+            #       "Resource"=>"*"
+            #     },
+            #     {
+            #       "Sid"=>"IAMPassRoleForCloudWatchEvents",
+            #       "Effect"=>"Allow",
+            #       "Action"=>"iam:PassRole",
+            #       "Resource"=>"arn:aws:iam::*:role/AWS_Events_Invoke_Targets"
+            #     }
+            #   ]
+            # }
             document: '%7B%0A%20%20%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Sid%22%3A%20%22CloudWatchEventsFullAccess%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Action%22%3A%20%22events%3A%2A%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Sid%22%3A%20%22IAMPassRoleForCloudWatchEvents%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Action%22%3A%20%22iam%3APassRole%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22arn%3Aaws%3Aiam%3A%3A%2A%3Arole%2FAWS_Events_Invoke_Targets%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%5D%0A%7D'
           )
         }

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -94,7 +94,15 @@ class AwsIamPolicyPropertiesTest < Minitest::Test
   def test_property_policy
     policy = AwsIamPolicy.new('test-policy-1').policy
     assert_kind_of(Hash, policy)
-    assert_nil(AwsIamPolicy.new(policy_name: 'non-existant').policy)    
+    assert(policy.key?('Statement'), "test-policy-1 should have a Statement key when unpacked")
+    assert_equal(1, policy['Statement'].count, "test-policy-1 should have 1 statements when unpacked")
+    assert_nil(AwsIamPolicy.new('non-existant').policy)    
+  end
+
+  def test_property_statement_count
+    assert_nil(AwsIamPolicy.new('non-existant').statement_count)
+    assert_equal(1, AwsIamPolicy.new('test-policy-1').statement_count)
+    assert_equal(2, AwsIamPolicy.new('test-policy-2').statement_count)
   end
 end
 
@@ -164,7 +172,7 @@ module MAIPSB
         OpenStruct.new({
           policy_name: 'test-policy-2',
           arn: 'arn:aws:iam::aws:policy/test-policy-2',
-          default_version_id: 'v2',
+          default_version_id: 'v1',
           attachment_count: 0,
           is_attachable: false,
         }),
@@ -208,6 +216,13 @@ module MAIPSB
       fixtures = {
         'arn:aws:iam::aws:policy/test-policy-1' => {
           'v1' => OpenStruct.new(
+            # This is the integration test fixture "beta"
+            document: '%7B%0A%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22Sid%22%3A%20%22beta01%22%2C%0A%20%20%20%20%20%20%22Action%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%22ec2%3ADescribeSubnets%22%2C%0A%20%20%20%20%20%20%20%20%22ec2%3ADescribeSecurityGroups%22%0A%20%20%20%20%20%20%5D%2C%0A%20%20%20%20%20%20%22Effect%22%3A%20%22Deny%22%2C%0A%20%20%20%20%20%20%22Resource%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%22arn%3Aaws%3Aec2%3A%3A%3A%2A%22%2C%0A%20%20%20%20%20%20%20%20%22%2A%22%0A%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%20%20%5D%0A%7D%0A'
+          )
+        },
+        'arn:aws:iam::aws:policy/test-policy-2' => {
+          'v1' => OpenStruct.new(
+            # This is AWS-managed CloudWatchEventsFullAccess
             document: '%7B%0A%20%20%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Sid%22%3A%20%22CloudWatchEventsFullAccess%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Action%22%3A%20%22events%3A%2A%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Sid%22%3A%20%22IAMPassRoleForCloudWatchEvents%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Action%22%3A%20%22iam%3APassRole%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22arn%3Aaws%3Aiam%3A%3A%2A%3Arole%2FAWS_Events_Invoke_Targets%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%5D%0A%7D'
           )
         }

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -147,6 +147,43 @@ class AwsIamPolicyMatchersTest < Minitest::Test
   def test_matcher_attached_to_role_negative
     refute AwsIamPolicy.new('test-policy-2').attached_to_role?('test-role')
   end
+
+  def test_have_statement_when_policy_does_not_exist
+    assert_nil AwsIamPolicy.new('nonesuch').has_statement?('Effect' => 'foo')
+  end
+
+  def test_have_statement_when_provided_no_criteria
+    AwsIamPolicy.new('test-policy-1').has_statement?
+  end
+
+  def test_have_statement_when_provided_acceptable_criteria
+    [
+      'Action',
+      'Effect',
+      'Principal',
+      'Resource',
+      'Sid',
+    ].each do |criterion|
+      AwsIamPolicy.new('test-policy-1').has_statement?(criterion => 'dummy')
+    end
+  end
+
+  def test_have_statement_when_provided_unimplemented_criteria
+    [
+      'Conditional',
+      'NotAction',
+      'NotPrincipal',
+      'NotResource',
+    ].each do |criterion|
+      ex = assert_raises(ArgumentError) {AwsIamPolicy.new('test-policy-1').has_statement?(criterion => 'dummy')}
+      assert_match(/not supported/, ex.message)
+    end
+  end
+
+  def test_have_statement_when_provided_unrecognized_criteria
+    ex = assert_raises(ArgumentError) {AwsIamPolicy.new('test-policy-1').has_statement?('foo' => 'dummy')}
+    assert_match(/Unrecognized/, ex.message)
+  end
 end
 
 #=============================================================================#

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -160,7 +160,6 @@ class AwsIamPolicyMatchersTest < Minitest::Test
     {
       'Action' => 'dummy',
       'Effect' => 'Deny',  # This has restictions on the value provided
-      'Principal' => 'dummy',
       'Resource' => 'dummy',
       'Sid' => 'dummy',
     }.each do |criterion, test_value|
@@ -174,6 +173,7 @@ class AwsIamPolicyMatchersTest < Minitest::Test
       'NotAction',
       'NotPrincipal',
       'NotResource',
+      'Principal'
     ].each do |criterion|
       ex = assert_raises(ArgumentError) {AwsIamPolicy.new('test-policy-1').has_statement?(criterion => 'dummy')}
       assert_match(/not supported/, ex.message)

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -231,6 +231,29 @@ class AwsIamPolicyMatchersTest < Minitest::Test
     # Do match if one regex action specified in an array when the statement has an array of actions
     assert(AwsIamPolicy.new('test-policy-1').has_statement?('Action' => [/^ec2\:Describe/]))
   end
+
+  def test_have_statement_when_resource_is_provided
+    # Able to match a simple string resource when multiple statements present
+    assert(AwsIamPolicy.new('test-policy-2').has_statement?('Resource' => 'arn:aws:iam::*:role/AWS_Events_Invoke_Targets'))
+    # Able to match a wildcard string resource
+    assert(AwsIamPolicy.new('test-policy-2').has_statement?('Resource' => '*'))
+    # Do not match a wildcard when using strings
+    refute(AwsIamPolicy.new('test-policy-2').has_statement?('Resource' => 'arn:aws:events:us-east-1:123456789012:rule/my-rule'))
+    # Do match when using a regex
+    assert(AwsIamPolicy.new('test-policy-2').has_statement?('Resource' => /AWS_Events_Invoke_Targets$/))
+    # Able to match one resource when the statement has an array of resources
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Resource' => 'arn:aws:ec2:::*'))
+    # Do not match if only one resource specified as an array when the statement has an array of resources
+    refute(AwsIamPolicy.new('test-policy-1').has_statement?('Resource' => ['arn:aws:ec2:::*']))
+    # Do match if two resources specified when the statement has an array of resources
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Resource' => ['arn:aws:ec2:::*', '*']))
+    # Do match setwise if two resources specified when the statement has an array of resources
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Resource' => ['*', 'arn:aws:ec2:::*']))
+    # Do match if only one regex resource specified when the statement has an array of resources
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Resource' => /^arn\:aws\:ec2/))
+    # Do match if one regex resource specified in an array when the statement has an array of resources
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Resource' => [/\*/]))
+  end
 end
 
 #=============================================================================#

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -363,7 +363,7 @@ module MAIPSB
         }
       }
       pv = fixtures.dig(query[:policy_arn], query[:version_id])
-      return pv if pv
+      return OpenStruct.new(policy_version: pv) if pv
       raise Aws::IAM::Errors::NoSuchEntity.new(nil, nil)
     end
   end

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -157,14 +157,14 @@ class AwsIamPolicyMatchersTest < Minitest::Test
   end
 
   def test_have_statement_when_provided_acceptable_criteria
-    [
-      'Action',
-      'Effect',
-      'Principal',
-      'Resource',
-      'Sid',
-    ].each do |criterion|
-      AwsIamPolicy.new('test-policy-1').has_statement?(criterion => 'dummy')
+    {
+      'Action' => 'dummy',
+      'Effect' => 'Deny',  # This has restictions on the value provided
+      'Principal' => 'dummy',
+      'Resource' => 'dummy',
+      'Sid' => 'dummy',
+    }.each do |criterion, test_value|
+      AwsIamPolicy.new('test-policy-1').has_statement?(criterion => test_value)
     end
   end
 
@@ -194,7 +194,19 @@ class AwsIamPolicyMatchersTest < Minitest::Test
     assert(AwsIamPolicy.new('test-policy-1').has_statement?('Sid' => /eta/))
     assert(AwsIamPolicy.new('test-policy-2').has_statement?('Sid' => /CloudWatch/))
     refute(AwsIamPolicy.new('test-policy-2').has_statement?('Sid' => /eta/))
+  end
 
+  def test_have_statement_when_provided_invalid_effect
+    assert_raises(ArgumentError) { AwsIamPolicy.new('test-policy-1').has_statement?('Effect' => 'Disallow') }
+    assert_raises(ArgumentError) { AwsIamPolicy.new('test-policy-1').has_statement?('Effect' => 'allow') }
+    assert_raises(ArgumentError) { AwsIamPolicy.new('test-policy-1').has_statement?('Effect' => :Allow) }
+    assert_raises(ArgumentError) { AwsIamPolicy.new('test-policy-1').has_statement?('Effect' => :allow) }
+  end
+
+  def test_have_statement_when_effect_is_provided
+    assert(AwsIamPolicy.new('test-policy-1').has_statement?('Effect' => 'Deny'))
+    refute(AwsIamPolicy.new('test-policy-1').has_statement?('Effect' => 'Allow'))
+    assert(AwsIamPolicy.new('test-policy-2').has_statement?('Effect' => 'Allow'))
   end
 end
 


### PR DESCRIPTION
This PR adds one low-level and two mid-level features for auditing the statements embedded in an IAM Policy.

While the features are currently only available on `aws_iam_policy`, it was designed to be easily refactored to become a mixin, allowing us to enable this feature on other policy-bearing objects, such as users, groups, roles, S3 buckets, Lambdas, etc.

Low-level: 
* `policy` is a property returning a struct as returned by the AWS API, after decoding and inflation to Ruby data structures.  It is intended to appeal to those who wish to perform in-depth traversal of the data structures in Ruby code.

Mid-level :
* `statement_count` is a property returning a numeric count of statements.  This can be used to detect if an unexpected statement was added or removed.
* `have_statement` is a matcher which provides a sophisticated search facility into the statement list.  This can be used to detect the presence (or absence) of particular statements.

Fixes #2749 

Unit and integration test run:
![screen shot 2018-04-05 at 14 15 57](https://user-images.githubusercontent.com/156460/38384339-e0f44176-38dc-11e8-8ac5-a74f0f47634f.png)
 