### PR TITLE
Fix filesystem docs typo

### DIFF
--- a/docs/resources/filesystem.md.erb
+++ b/docs/resources/filesystem.md.erb
@@ -28,7 +28,7 @@ where
 
 The following examples show how to use this InSpec audit resource.
 
-### Test if the root partition is greater thank 32000 MB
+### Test if the root partition is greater than 32000 MB
 
     describe filesystem('/') do
       its('size') { should be >= 32000 }


### PR DESCRIPTION
small typo i found at https://www.inspec.io/docs/reference/resources/filesystem/