### PR TITLE
Update PowerShell requirement and add an asterisk

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Remote Targets
 | Oracle Enterprise Linux      | 5, 6, 7                                          | i386, x86_64  |
 | Red Hat Enterprise Linux     | 5, 6, 7                                          | i386, x86_64  |
 | Solaris                      | 10, 11                                           | sparc, x86    |
-| Windows                      | 7, 8, 8.1, 10, 2008, 2008R2 , 2012, 2012R2, 2016 | x86, x86_64   |
+| Windows\*                    | 7, 8, 8.1, 10, 2008, 2008R2 , 2012, 2012R2, 2016 | x86, x86_64   |
 | Ubuntu Linux                 |                                                  | x86, x86_64   |
 | SUSE Linux Enterprise Server | 11, 12                                           | x86_64        |
 | Scientific Linux             | 5.x, 6.x and 7.x                                 | i386, x86_64  |
@@ -304,7 +304,7 @@ Remote Targets
 | Arch Linux                   |                                                  | x86_64        |
 | HP-UX                        | 11.31                                            | ia64          |
 
-*For Windows, PowerShell 3.0 or above is required.*
+\**For Windows, PowerShell 5.0 or above is required.*
 
 In addition, runtime support is provided for:
 


### PR DESCRIPTION
We require a minimum of PowerShell 5.0 to use Windows as a remote target.