### PR TITLE
Change its to it in aws root user docs

### DIFF
--- a/docs/resources/aws_iam_root_user.md.erb
+++ b/docs/resources/aws_iam_root_user.md.erb
@@ -15,10 +15,10 @@ To test properties of a specific AWS user use the `aws_iam_user` resource.
 
 ## Syntax
 
-An `aws_iam_root_user` resource block requires no parameters but has several matchers
+An `aws_iam_root_user` resource block requires no parameters but has several matchers.
 
     describe aws_iam_root_user do
-      its { should have_mfa_enabled }
+      it { should have_mfa_enabled }
     end
 
 <br>


### PR DESCRIPTION
The example code had an `its` instead of `it`, which lead to a confusing message for a user.  See #2920 