### PR TITLE
Fixed Docs asking for metric instead of metric_name

### DIFF
--- a/docs/resources/aws_cloudwatch_alarm.md.erb
+++ b/docs/resources/aws_cloudwatch_alarm.md.erb
@@ -17,7 +17,7 @@ An `aws_cloudwatch_alarm` resource block searches for a Cloudwatch Alarm, specif
 
     # Look for a specific alarm
     aws_cloudwatch_alarm(
-      metric: 'my-metric-name',
+      metric_name: 'my-metric-name',
       metric_namespace: 'my-metric-namespace',
     ) do
       it { should exist }

--- a/lib/resources/aws/aws_cloudwatch_alarm.rb
+++ b/lib/resources/aws/aws_cloudwatch_alarm.rb
@@ -3,7 +3,7 @@ class AwsCloudwatchAlarm < Inspec.resource(1)
   desc <<-EOD
   # Look for a specific alarm
   aws_cloudwatch_alarm(
-    metric: 'my-metric-name',
+    metric_name: 'my-metric-name',
     metric_namespace: 'my-metric-namespace',
   ) do
     it { should exist }


### PR DESCRIPTION
Just a little bug I noticed with a colleague when getting our Alarms and Metrics set up in Terraform! Thanks :) 