### PR TITLE
Add warning when returning DEFAULT_ATTRIBUTE

### DIFF
--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -6,7 +6,17 @@ module Inspec
     attr_writer :value
 
     DEFAULT_ATTRIBUTE = Class.new do
+      def initialize(name)
+        @name = name
+      end
+
       def method_missing(*_)
+        Inspec::Log.warn(
+          "Returning DEFAULT_ATTRIBUTE for '#{@name}'. "\
+          "Use --attrs to provide a value for '#{@name}' or specify a default  "\
+          "value with `attribute('#{@name}', default: 'somedefault', ...)`.",
+        )
+
         self
       end
 
@@ -27,7 +37,7 @@ module Inspec
     end
 
     def default
-      @opts.key?(:default) ? @opts[:default] : DEFAULT_ATTRIBUTE.new
+      @opts.key?(:default) ? @opts[:default] : DEFAULT_ATTRIBUTE.new(@name)
     end
 
     def title


### PR DESCRIPTION
When the anonymous DEFAULT_ATTRIBUTE class is used, log a warning.

We now pass in the attribute name to that class so it can be used in the log message.

Fixes #2865 
Complement of #2891 

![image](https://user-images.githubusercontent.com/92880/38526341-beff9ff8-3c0a-11e8-802a-224871aa3b3f.png)
