### PR TITLE
Add cloudlinux under redhat family

### DIFF
--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -134,9 +134,9 @@ module Inspec::Resources
         else
           SysV.new(inspec, service_ctl || '/usr/sbin/service')
         end
-      elsif %w{redhat fedora centos oracle}.include?(platform)
+      elsif %w{redhat fedora centos oracle cloudlinux}.include?(platform)
         version = os[:release].to_i
-        if (%w{redhat centos oracle}.include?(platform) && version >= 7) || (platform == 'fedora' && version >= 15)
+        if (%w{redhat centos oracle cloudlinux}.include?(platform) && version >= 7) || (platform == 'fedora' && version >= 15)
           Systemd.new(inspec, service_ctl)
         else
           SysV.new(inspec, service_ctl || '/sbin/service')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -49,6 +49,7 @@ class MockLoader
     centos5:    { name: 'centos', family: 'redhat', release: '5.11', arch: 'x86_64' },
     centos6:    { name: 'centos', family: 'redhat', release: '6.6', arch: 'x86_64' },
     centos7:    { name: 'centos', family: 'redhat', release: '7.1.1503', arch: 'x86_64' },
+    cloudlinux: { name: 'cloudlinux', family: 'redhat', release: '7.4', arch: 'x86_64' },
     coreos:     { name: 'coreos', family: 'coreos', release: '1437.0.0', arch: 'x86_64' },
     debian6:    { name: 'debian', family: 'debian', release: '6', arch: 'x86_64' },
     debian7:    { name: 'debian', family: 'debian', release: '7', arch: 'x86_64' },

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -191,6 +191,44 @@ describe 'Inspec::Resources::Service' do
     _(resource.params.UnitFileState).must_equal 'static'
   end
 
+  # cloudlinux 7 with systemd
+  it 'verify cloudlinux 7 service parsing' do
+    resource = MockLoader.new(:cloudlinux).load_resource('service', 'sshd')
+    params = Hashie::Mash.new({ 'ActiveState' => 'active', 'Description' => 'OpenSSH server daemon', 'Id' => 'sshd.service', 'LoadState' => 'loaded', 'Names' => 'sshd.service', 'SubState' => 'running', 'UnitFileState' => 'enabled' })
+    _(resource.type).must_equal 'systemd'
+    _(resource.name).must_equal 'sshd.service'
+    _(resource.description).must_equal 'OpenSSH server daemon'
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+  end
+
+  it 'verify cloudlinux 7 service parsing with systemd_service and service_ctl override' do
+    resource = MockLoader.new(:cloudlinux).load_resource('systemd_service', 'sshd', '/path/to/systemctl')
+    params = Hashie::Mash.new({ 'ActiveState' => 'active', 'Description' => 'OpenSSH server daemon', 'Id' => 'sshd.service', 'LoadState' => 'loaded', 'Names' => 'sshd.service', 'UnitFileState' => 'enabled', 'SubState' => 'running' })
+    _(resource.type).must_equal 'systemd'
+    _(resource.name).must_equal 'sshd.service'
+    _(resource.description).must_equal 'OpenSSH server daemon'
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+  end
+
+  it 'verify cloudlinux 7 service parsing with static loaded service' do
+    resource = MockLoader.new(:cloudlinux).load_resource('service', 'dbus')
+    params = Hashie::Mash.new({ 'Description' => 'D-Bus System Message Bus', 'Id' => 'dbus.service', 'LoadState' => 'loaded', 'Names' => 'messagebus.service dbus.service', 'SubState' => 'running', 'UnitFileState' => 'static' })
+    _(resource.type).must_equal 'systemd'
+    _(resource.name).must_equal 'dbus.service'
+    _(resource.description).must_equal 'D-Bus System Message Bus'
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+    _(resource.params.UnitFileState).must_equal 'static'
+  end
+
   # freebsd
   it 'verify freebsd10 service parsing' do
     resource = MockLoader.new(:freebsd10).load_resource('service', 'sendmail')


### PR DESCRIPTION
Train is already able to add cloudlinux under os and platforms.
```
You are currently running on:

    Name:      cloudlinux
    Families:  redhat, linux, unix, os
    Release:   7.4
    Arch:      x86_64
```

Adding cloudlinux to the `select_service_mgmt` method so the correct init system can be returned for it.  Adding tests for the OS and adding it to the helper.

fixes #2932  