### PR TITLE
Ensure @params in shadow resource always has a valid value.

### DIFF
--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -34,7 +34,6 @@ module Inspec::Resources
 
     include FileReader
 
-    attr_reader :params
     attr_reader :lines
 
     def initialize(path = '/etc/shadow', opts = nil)
@@ -43,7 +42,7 @@ module Inspec::Resources
       @filters = opts[:filters] || ''
       @raw_content = opts[:content] || read_file_content(@path, allow_empty: true)
       @lines = @raw_content.to_s.split("\n")
-      @params = @lines.map { |l| parse_shadow_line(l) }
+      params
     end
 
     filtertable = FilterTable.create
@@ -74,7 +73,7 @@ module Inspec::Resources
 
     def filter(query = {})
       return self if query.nil? || query.empty?
-      res = @params
+      res = params
       filters = ''
       query.each do |attr, condition|
         condition = condition.to_s if condition.is_a? Integer
@@ -121,10 +120,14 @@ module Inspec::Resources
       "/etc/shadow#{f}"
     end
 
+    def params
+      @params = @lines.nil? ? [] : @lines.map { |l| parse_shadow_line(l) }
+    end
+
     private
 
     def map_data(id)
-      @params.map { |x| x[id] }
+      params.map { |x| x[id] }
     end
 
     # Parse a line of /etc/shadow

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -49,10 +49,11 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   it 'access all params of the file' do
-    _(shadow.params[0]).must_equal({
-      'user' => 'root', 'password' => 'x', 'last_change' => '1',
-      'min_days' => '2', 'max_days' => '3', 'warn_days' => nil,
-      'inactive_days' => nil, 'expiry_date' => nil, 'reserved' => nil,
+    _(shadow.entries[0].to_h).must_equal({
+      user: 'root', password: 'x', last_change: '1',
+      min_days: '2', max_days: '3', warn_days: nil,
+      inactive_days: nil, expiry_date: nil, reserved: nil,
+      content: nil, count: nil
     })
   end
 
@@ -91,7 +92,7 @@ describe 'Inspec::Resources::Shadow' do
     let(:unreadable_shadow) { load_resource('shadow', '/fakepath/fakefile') }
 
     it 'can read /etc/shadow and #filter matches user with no password and inactive_days' do
-      users = shadow.filter(password: /[^x]/).params.map { |x| x['user'] }
+      users = shadow.filter(password: /[^x]/).entries.map { |x| x['user'] }
       users.each do |user|
         proc { expect(shadow.users(user).user).must_equal(['www-data']) }.must_output nil,
           '[DEPRECATION] The shadow `users` property is deprecated and will' \
@@ -103,7 +104,7 @@ describe 'Inspec::Resources::Shadow' do
     end
 
     it 'cant read /etc/unreadable_shadow and #filter matches nothing' do
-      users = unreadable_shadow.filter(password: /[^x]/).params.map { |x| x['user'] }
+      users = unreadable_shadow.filter(password: /[^x]/).entries.map { |x| x['user'] }
       users.each do |user|
         expect(shadow.users(user).user).must_equal([])
         expect(shadow.users(user).inactive_days).must_equal([])

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -44,7 +44,8 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   it 'access all lines of the file' do
-    _(shadow.lines[0]).must_equal 'root:x:1:2:3::::'
+    proc { _(shadow.lines[0]).must_equal 'root:x:1:2:3::::' }.must_output nil,
+      "[DEPRECATION] The shadow `lines` property is deprecated and will be removed in InSpec 3.0.\n"
   end
 
   it 'access all params of the file' do
@@ -87,14 +88,20 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   describe 'when method chained' do
-    let(:unreadable_shadow) { load_resource('shadow', '/etc/unreadable_shadow') }
+    let(:unreadable_shadow) { load_resource('shadow', '/fakepath/fakefile') }
+
     it 'can read /etc/shadow and #filter matches user with no password and inactive_days' do
       users = shadow.filter(password: /[^x]/).params.map { |x| x['user'] }
       users.each do |user|
-        expect(shadow.users(user).user).must_equal(['www-data'])
-        expect(shadow.users(user).inactive_days).must_equal(['50'])
+        proc { expect(shadow.users(user).user).must_equal(['www-data']) }.must_output nil,
+          '[DEPRECATION] The shadow `users` property is deprecated and will' \
+          " be removed in InSpec 3.0.  Please use `user` instead.\n"
+        proc { expect(shadow.users(user).inactive_days).must_equal(['50']) }.must_output nil,
+          '[DEPRECATION] The shadow `users` property is deprecated and will' \
+          " be removed in InSpec 3.0.  Please use `user` instead.\n"
       end
     end
+
     it 'cant read /etc/unreadable_shadow and #filter matches nothing' do
       users = unreadable_shadow.filter(password: /[^x]/).params.map { |x| x['user'] }
       users.each do |user|

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -86,6 +86,24 @@ describe 'Inspec::Resources::Shadow' do
     end
   end
 
+  describe 'when method chained' do
+    let(:unreadable_shadow) { load_resource('shadow', '/etc/unreadable_shadow') }
+    it 'can read /etc/shadow and #filter matches user with no password and inactive_days' do
+      users = shadow.filter(password: /[^x]/).params.map { |x| x['user'] }
+      users.each do |user|
+        expect(shadow.users(user).user).must_equal(['www-data'])
+        expect(shadow.users(user).inactive_days).must_equal(['50'])
+      end
+    end
+    it 'cant read /etc/unreadable_shadow and #filter matches nothing' do
+      users = unreadable_shadow.filter(password: /[^x]/).params.map { |x| x['user'] }
+      users.each do |user|
+        expect(shadow.users(user).user).must_equal([])
+        expect(shadow.users(user).inactive_days).must_equal([])
+      end
+    end
+  end
+
   describe 'filter via name =~ /^www/' do
     let(:child) { shadow.user(/^www/) }
 


### PR DESCRIPTION
Add tests for method chained shadow resource with readable and unreadable shadow files.

Ensure @params always has a safe value, otherwise we may stacktrace when
unable to read /etc/shadow and invoked with method chaining.

My only complaint with this is that when the `/etc/shadow` file is unreadable, you won't see the error when chaining; you'll need to test the file or a specific user.

<img width="1450" alt="image" src="https://user-images.githubusercontent.com/49856/38575182-aa1617ca-3caf-11e8-85f2-466d93832890.png">

Signed-off-by: Miah Johnson <miah@chia-pet.org>

Fixes #2913 