### PR TITLE
Inline and attached policies for aws_iam_user and aws_iam_users

### DIFF
--- a/docs/resources/aws_iam_user.md.erb
+++ b/docs/resources/aws_iam_user.md.erb
@@ -13,7 +13,7 @@ To test properties of the special AWS root user (which owns the account), use th
 
 <br>
 
-## Syntax
+## Resource Parameters
 
 An `aws_iam_user` resource block declares a user by name, and then lists tests to be performed.
 
@@ -47,9 +47,51 @@ The following examples show how to use this InSpec audit resource.
 
 <br>
 
+## Properties
+
+### attached\_policy\_arns
+
+Returns a list of IAM Managed Policy ARNs as strings that identify the policies that are attached to the user. If there are no attached policies, returns an empty list.
+
+    describe aws_iam_user('bob') do
+      # This is a customer-managed policy
+      its('attached_policy_arns') { should include 'arn:aws:iam::123456789012:policy/test-inline-policy-01' }
+      # This is an AWS-managed policy
+      its('attached_policy_arns') { should include 'arn:aws:iam::aws:policy/AlexaForBusinessGatewayExecution' }      
+    end
+
+### attached\_policy\_names
+
+Returns a list of IAM Managed Policy Names as strings that identify the policies that are attached to the user. If there are no attached policies, returns an empty list.
+
+    describe aws_iam_user('bob') do
+      # This is a customer-managed policy
+      its('attached_policy_names') { should include 'test-inline-policy-01' }
+      # This is an AWS-managed policy
+      its('attached_policy_names') { should include 'AlexaForBusinessGatewayExecution' }      
+    end
+
+### inline\_policy\_names
+
+Returns a list of IAM Inline Policy Names as strings that identify the inline policies that are directly embedded in the user. If there are no embedded policies, returns an empty list.
+
+    describe aws_iam_user('bob') do
+      its('inline_policy_names') { should include 'test-inline-policy-01' }
+      its('inline_policy_names.count') { should eq 1 }      
+    end
+
+
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [universal matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### have\_attached\_policies
+
+The `have\_attached\_policies` matcher tests if the user has at least one IAM managed policy attached to the user.
+
+    describe aws_iam_user('bob') do
+      it { should_not have_attached_policies }
+    end
 
 ### have\_console\_password
 
@@ -57,8 +99,17 @@ The `have_console_password` matcher tests if the user has a password that could 
 
     it { should have_console_password }
 
+### have\_inline\_policies
+
+The `have\_inline\_policies` matcher tests if the user has at least one IAM policy embedded directly in the user record.
+
+    describe aws_iam_user('bob') do
+      it { should_not have_inline_policies }
+    end
+
 ### have\_mfa\_enabled
 
 The `have_mfa_enabled` matcher tests if the user has Multi-Factor Authentication enabled, requiring them to enter a secondary code when they login to the web console.
 
     it { should have_mfa_enabled }
+ 

--- a/docs/resources/aws_iam_users.md.erb
+++ b/docs/resources/aws_iam_users.md.erb
@@ -15,19 +15,19 @@ To test properties of the special AWS root user (which owns the account), use th
 
 ## Syntax
 
-An `aws_iam_users` resource block users a filter to select a group of users and then tests that group
+An `aws_iam_users` resource block uses a filter to select a group of users and then tests that group.  With no filter, it returns all AWS IAM users.
 
+    # No filter
+    # We expect 42 users
+    describe aws_iam_users do
+      its('usernames.count') { should eq 42 }
+    end
+
+    # Using a filter
+    # All users should have MFA (no user without MFA should exist)
     describe aws_iam_users.where(has_mfa_enabled?: false) do
       it { should_not exist }
     end
-
-<br>
-
-## Filter Criteria
-
-* `has_mfa_enabled`, `has_console_password`, `password_ever_used?`, `password_never_used?`, `password_last_used_days_ago`, `username`
-
-<br>
 
 ## Examples
 
@@ -84,7 +84,190 @@ The following examples show how to use this InSpec audit resource.
 
 <br>
 
+## Filter Criteria
+
+You may pass filter criteria to `where` to narrow down the result set.
+
+### has\_attached\_policies
+
+True or false.  Filters the users to include only those that have at least one IAM managed policy attached to the user.
+
+    # Don't attach policies to users
+    describe aws_iam_users.where(has_attached_policies: true) do
+      it { should_not exist }
+    end
+
+### has\_console\_password
+
+True or false. Filters the users to include only those that have a console password (that is, they are able to login to the AWS web UI using a password). 
+
+    # No console passwords for anyone
+    describe aws_iam_users.where(has_console_password: true) do
+      it { should_not exist }
+    end
+
+### has\_inline\_policies
+
+True or false.  Filters the users to include only those that have at least one IAM policy directly embedded in the user record.
+
+    # Embedding policies is usually hard to manage
+    describe aws_iam_users.where(has_inline_policies: true) do
+      it { should_not exist }
+    end
+
+### has\_mfa\_enabled
+
+True or false. Filters the users to include only those that have some kind of Mult-Factor Authentication enabled (virtual or hardware).
+
+    # Require MFA for everyone
+    describe aws_iam_users.where(has_mfa_enabled: false) do
+      it { should_not exist }
+    end
+
+### password\_ever\_used
+
+True or false. Filters the users to include only those that have used their password at least once.
+
+    # Someone should have used their password
+    describe aws_iam_users.where(password_ever_used: true) do
+      it { should exist }
+    end
+
+### password\_last\_used_days\_ago
+
+Integer.  Filters the users to include only those who used their password a certain number of days ago.  '0' means today.
+
+    # Bob should login every day
+    describe aws_iam_users.where(password_ever_used: true, password_last_used_days_ago:0) do
+      its('usernames') { should include 'bob' }
+    end
+
+    # This filter is often more useful in block mode, using a greater-than
+    # Here, audit users who have not logged in in the last 30 days 
+    describe aws_iam_users.where do 
+      password_ever_used && password_last_used_days_ago > 30
+    end do
+      it { should_not exist' }
+    end
+
+### password\_never\_used
+
+True or false. Filters the users to include only those that have used _never_ their password.
+
+    # No zombie accounts!
+    describe aws_iam_users.where(password_never_used: true) do
+      it { should_not exist }
+    end
+
+### username
+
+String.  Filters the users to include only those whose username matches the value you provide.
+
+    # Block mode example (recommended)
+    # Service users should not have a password
+    describe aws_iam_users.where { username.start_with?('service') } do
+      it { should_not have_console_password }
+    end
+
+    # Method call example.  This is a poor use of aws_iam_users (plural); 
+    # if you want to audit an individual user whose username you know, use 
+    # aws_iam_user (singular)
+    # Verify Bob exists
+    describe aws_iam_users.where(username: 'bob') do
+      it { should exist }
+    end
+
+## Properties
+
+Properties are used with the `its` test to obtain information about the matched users.  Properties always return arrays, though they may be empty.
+
+### attached\_policy\_arns
+
+Array of strings.  Each entry is the ARN of an IAM managed policy that is attached to at least one matched user.  The list is de-duplicated, so if you have five users that are all attached to the same policy, `attached_policy_arns` will return only one ARN, not five.
+
+    # Service users should be attached to a custom service policy
+    describe aws_iam_users.where { username.start_with?('service') } do
+      its('attached_policy_arns') { should include  'arn:aws:iam::123456789012:policy/MyServicePolicy' }
+    end
+
+### attached\_policy\_names
+
+Array of strings.  Each entry is the friendly name of an IAM managed policy that is attached to at least one matched user.  The list is de-duplicated, so if you have five users that are all attached to the same policy, `attached_policy_names` will return only one name, not five.
+
+    # Service users should be attached to a custom service policy
+    # and not include Admin policy!
+    describe aws_iam_users.where { username.start_with?('service') } do
+      its('attached_policy_names') { should include  'MyServicePolicy' }
+      its('attached_policy_names') { should_not include  'AdministratorAccess' }
+    end
+
+### inline\_policy\_names
+
+Array of strings.  Each entry is the name of an embedded policy that is embedded in at least one matched user.  Keep in mind that each user has a copy of a policy (which can then be modified). This means that two users can have an embedded policy with the same name, but very different contents. The list is de-duplicated, so if you have five users that have an inline policy with the same name, `inline_policy_names` will return only one name, not five.
+
+    # Service users should have a bespoke policy
+    describe aws_iam_users.where { username.start_with?('service') } do
+      its('inline_policy_names') { should include  'some-bespoke-policy' }
+    end
+
+### usernames
+
+Array of strings.  Each entry is the name of a user that matched.  There will be exactly as many usernames here as there were users that matched, though it is possible to have non-unique usernames.
+
+    # 42 Users, including Bob, should have a password.
+    describe aws_iam_users.where(has_console_password: true) do
+      its('usernames') { should include  'bob' }
+      its('usernames.count') { should eq 42 }
+    end
+
 ## Matchers
 
-This InSpec audit resource has no specific matchers. 
-For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following resource-specific matchers. 
+For a full list of available matchers, please visit our [universal matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+As a plural resource, all matchers beginning with `have_` will return true if _any_ of the selected users match.
+
+### exist
+
+The test passes if the filtered user set is not empty.  This basic matcher is frequently used with `should_not` to detect undesired conditions.
+
+    # Require MFA for everyone
+    describe aws_iam_users.where(has_mfa_enabled: false) do
+      it { should_not exist }
+    end
+
+### have\_attached\_policies
+
+The test passes if at least one user in the filtered set has at least one attached IAM managed policy.
+
+    # Bachelors don't have attachments
+    describe aws_iam_users.where { username =~ /bachelor/ } do
+      it { should_not have_attached_policies }
+    end
+
+### have\_console\_password
+
+The test passes if at least one user in the filtered set has a console password.
+
+    describe aws_iam_users do
+      it { should_not have_console_password }
+    end
+
+### have\_inline\_policies
+
+The test passes if at least one user in the filtered set has at least one embedded policy.
+
+    # No one should have an inline policy
+    describe aws_iam_users do
+      it { should_not have_inline_policies }
+    end
+
+### have\_mfa\_enabled
+
+The test passes if at least one user in the filtered set has MFA enabled (virtual or hardware).
+
+    # At least one person should use MFA.
+    # This does not mean ALL users have MFA.
+    describe aws_iam_users do
+      it { should have_mfa_enabled }
+    end

--- a/docs/resources/aws_iam_users.md.erb
+++ b/docs/resources/aws_iam_users.md.erb
@@ -15,7 +15,7 @@ To test properties of the special AWS root user (which owns the account), use th
 
 ## Syntax
 
-An `aws_iam_users` resource block uses a filter to select a group of users and then tests that group.  With no filter, it returns all AWS IAM users.
+An `aws_iam_users` resource block uses a filter to select a group of users and then tests that group. With no filter, it returns all AWS IAM users.
 
     # No filter
     # We expect 42 users
@@ -90,7 +90,7 @@ You may pass filter criteria to `where` to narrow down the result set.
 
 ### has\_attached\_policies
 
-True or false.  Filters the users to include only those that have at least one IAM managed policy attached to the user.
+True or false. Filters the users to include only those that have at least one IAM managed policy attached to the user.
 
     # Don't attach policies to users
     describe aws_iam_users.where(has_attached_policies: true) do
@@ -108,7 +108,7 @@ True or false. Filters the users to include only those that have a console passw
 
 ### has\_inline\_policies
 
-True or false.  Filters the users to include only those that have at least one IAM policy directly embedded in the user record.
+True or false. Filters the users to include only those that have at least one IAM policy directly embedded in the user record.
 
     # Embedding policies is usually hard to manage
     describe aws_iam_users.where(has_inline_policies: true) do
@@ -135,7 +135,7 @@ True or false. Filters the users to include only those that have used their pass
 
 ### password\_last\_used_days\_ago
 
-Integer.  Filters the users to include only those who used their password a certain number of days ago.  '0' means today.
+Integer. Filters the users to include only those who used their password a certain number of days ago. '0' means today.
 
     # Bob should login every day
     describe aws_iam_users.where(password_ever_used: true, password_last_used_days_ago:0) do
@@ -161,7 +161,7 @@ True or false. Filters the users to include only those that have used _never_ th
 
 ### username
 
-String.  Filters the users to include only those whose username matches the value you provide.
+String. Filters the users to include only those whose username matches the value you provide.
 
     # Block mode example (recommended)
     # Service users should not have a password
@@ -169,7 +169,7 @@ String.  Filters the users to include only those whose username matches the valu
       it { should_not have_console_password }
     end
 
-    # Method call example.  This is a poor use of aws_iam_users (plural); 
+    # Method call example. This is a poor use of aws_iam_users (plural); 
     # if you want to audit an individual user whose username you know, use 
     # aws_iam_user (singular)
     # Verify Bob exists
@@ -179,11 +179,11 @@ String.  Filters the users to include only those whose username matches the valu
 
 ## Properties
 
-Properties are used with the `its` test to obtain information about the matched users.  Properties always return arrays, though they may be empty.
+Properties are used with the `its` test to obtain information about the matched users. Properties always return arrays, though they may be empty.
 
 ### attached\_policy\_arns
 
-Array of strings.  Each entry is the ARN of an IAM managed policy that is attached to at least one matched user.  The list is de-duplicated, so if you have five users that are all attached to the same policy, `attached_policy_arns` will return only one ARN, not five.
+Array of strings. Each entry is the ARN of an IAM managed policy that is attached to at least one matched user. The list is de-duplicated, so if you have five users that are all attached to the same policy, `attached_policy_arns` will return only one ARN, not five.
 
     # Service users should be attached to a custom service policy
     describe aws_iam_users.where { username.start_with?('service') } do
@@ -192,7 +192,7 @@ Array of strings.  Each entry is the ARN of an IAM managed policy that is attach
 
 ### attached\_policy\_names
 
-Array of strings.  Each entry is the friendly name of an IAM managed policy that is attached to at least one matched user.  The list is de-duplicated, so if you have five users that are all attached to the same policy, `attached_policy_names` will return only one name, not five.
+Array of strings. Each entry is the friendly name of an IAM managed policy that is attached to at least one matched user. The list is de-duplicated, so if you have five users that are all attached to the same policy, `attached_policy_names` will return only one name, not five.
 
     # Service users should be attached to a custom service policy
     # and not include Admin policy!
@@ -203,7 +203,7 @@ Array of strings.  Each entry is the friendly name of an IAM managed policy that
 
 ### inline\_policy\_names
 
-Array of strings.  Each entry is the name of an embedded policy that is embedded in at least one matched user.  Keep in mind that each user has a copy of a policy (which can then be modified). This means that two users can have an embedded policy with the same name, but very different contents. The list is de-duplicated, so if you have five users that have an inline policy with the same name, `inline_policy_names` will return only one name, not five.
+Array of strings. Each entry is the name of an embedded policy that is embedded in at least one matched user. Keep in mind that each user has a copy of a policy (which can then be modified). This means that two users can have an embedded policy with the same name, but very different contents. The list is de-duplicated, so if you have five users that have an inline policy with the same name, `inline_policy_names` will return only one name, not five.
 
     # Service users should have a bespoke policy
     describe aws_iam_users.where { username.start_with?('service') } do
@@ -212,7 +212,7 @@ Array of strings.  Each entry is the name of an embedded policy that is embedded
 
 ### usernames
 
-Array of strings.  Each entry is the name of a user that matched.  There will be exactly as many usernames here as there were users that matched, though it is possible to have non-unique usernames.
+Array of strings. Each entry is the name of a user that matched. There will be exactly as many usernames here as there were users that matched, though it is possible to have non-unique usernames.
 
     # 42 Users, including Bob, should have a password.
     describe aws_iam_users.where(has_console_password: true) do
@@ -229,7 +229,7 @@ As a plural resource, all matchers beginning with `have_` will return true if _a
 
 ### exist
 
-The test passes if the filtered user set is not empty.  This basic matcher is frequently used with `should_not` to detect undesired conditions.
+The test passes if the filtered user set is not empty. This basic matcher is frequently used with `should_not` to detect undesired conditions.
 
     # Require MFA for everyone
     describe aws_iam_users.where(has_mfa_enabled: false) do

--- a/lib/resources/aws/aws_iam_users.rb
+++ b/lib/resources/aws/aws_iam_users.rb
@@ -92,9 +92,11 @@ class AwsIamUsers < Inspec.resource(1)
 
       user[:inline_policy_names_source] = backend.list_user_policies(user_name: user[:user_name]).policy_names
       user[:has_inline_policies] = !user[:inline_policy_names_source].empty?
+      user[:has_inline_policies?] = user[:has_inline_policies]
 
       attached_policies = backend.list_attached_user_policies(user_name: user[:user_name]).attached_policies
       user[:has_attached_policies] = !attached_policies.empty?
+      user[:has_attached_policies?] = user[:has_attached_policies]
       user[:attached_policy_names_source] = attached_policies.map { |p| p[:policy_name] }
       user[:attached_policy_arns_source] = attached_policies.map { |p| p[:policy_arn] }
 

--- a/test/integration/aws/default/build/iam.tf
+++ b/test/integration/aws/default/build/iam.tf
@@ -2,6 +2,7 @@
 
 variable "login_profile_pgp_key" {
   type = "string"
+
   # You may override this using a tfvars file or other approaches.
   default = "mQINBFit+9sBEAC7Aj1/IqLBMupJ/ESurbFy/h5Nukxd2c5JmzyIXbEgjnjrZCpFDCZ9fHYsEchzO9e9u+RiqJE78/Rp3PJjQeJnA4fln/XxK8K7U/Vyi9p725blielNsqRr6ERQZlbBb8uPHHd5YKOOSt+fLQuG2n/Ss13W5WKREpMLkzd80Uyl6Yofsguj8YdKvExV5akvi2VrZcHBIhmbjU+R33kDOuNlHGx4fhVHhydegog0nQnB48hRJQgbMPoMlySM666JDW4DmePms56M7IUDHFCH+oMGCGTdcuzo4BQwv6TMS6mZM3QVtnyEI5rVmbfkhc70ChqYbFB8isvmsLTRvJXdhyrXHA+YjiN3yMOq1oE/N85ug3D5tp9+yT7O+hu+vmgZ1oqRamuwExPZsmfwWd4lcTbu8sRMQy6J9H7b3ZPaN/cr0uO8RE5e1u7EhewV2+07glW7nuXY5DqPCvyIHqOINHvIh7uMWbAdYIiy73GMaNP3W3b/HQOXwdFz8N0kxT3AgTw+vJ5kiCzpG6gwJeFZtke2zzd5WDqUSs0uaCwEyR5FkB9H3YwNawZ1n1lzuTFcxVpnjLc6TOsrWtQ5Ccy9MFHOp/mxtnsOc/Le6YmcAK3xJ4FvSrOzyWH1Jc01wHmG1kLWznDW8+xFj+Zki+g/h0XtezVErmlffvqYT8cT1npeuwARAQABtCJpbnNwZWMtYXdzIDxpbnNwZWMtYXdzQGluc3BlYy5jb20+iQI4BBMBAgAiBQJYrfvbAhsDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRCbG1xp7O1xwOK4D/4riU9Bs3ZF6e5lO2SzwBS6m+9aFBGkVZGndcMW+k05ksKmyOuYjbyukeHlRxVeVKpbOxJSIKoame+7LNmtlK/0y+kvKN1hkmLas0yZcTlS4V6mJRTR9DXKsIVjlbvQQ3iqHSqZSqg0UbVDjG3PaupWqlBW3pqb1lisDcTWKmltaOigCJsmpiOA23+SEYjTzXzV5wpBGPTFnyhPD+cjh0AZIC0+/u0zA1ycMUFP1d1p+DDQQuhqV5CHMbdExdyScpPnJU7tLoFytiwhVkbgUG11CoVHfFYac0Eome4jW5TFwfrg5leZob6xWUaJrQa+GKB8TVbW7ytQG0s1zQFUIhBdl975ftHAhyy7yerNXW2asgnQ6XiFbWK8RI/pPnktbc9upRb1roegye+Rp79ocmFe0nnzgsE74JFqlPoG4qglicuzcBMpCyRfixfdQIa1uyxOHHUvYhyzAKrEIsSeJfD4t3scypo4j0Kx3eG0ejRszpdVNVLJOHHAMXbgJBhHufQHX+4ZruI8+CqQ3rJsHezJOX3gH8GP0jkmTEj+ZiTE9tyoHSjwHTSIVKaadlLN+XUcvDnAK38UEo2+CxEnbsURe0mJsdvzN7SFw/DnQle4w3L4vqjvsGxM2xc/uqIpXIxmBd8yf8T4J8taZX2DNtN8Tgz2yiWFTjHCG9lzPZmwabkCDQRYrfvbARAAy24tShvJmUCMB+QfnZV9dTjB6ZY9chdvQaeejotQY4cnw8AU8J38niydEeU4QpUWyrNa0WM4mtY/naR1Q216KVvDQTgcWFRuxs7VzyAf4slVRa2H6VdNRUx9m3jCpzoWku3TtXlOV0P9gRb7LWESX6Xp62nO5A/6wYDLLWD1pGWSdetQrTsGKy9F0rHr4WGRGQlvPg4x523LLkIV6+7TmHCUuvi6SY4ZtX2pLZ/cooX/Dw8LHwG7a6d9WIdbBGsU5z4wltc1CjwAY9M4FfDjnL5vp/jhHrmzna/rh2PI4AP16te/YR8s1ybWHacHgjKGN4Wtq/GywcGUxVPIlXaUbCz9uDGt/b19JxptOONcdgjFv1AQkAcrGehNlEsiDkaSqSaqbjWZ2RCICu2HPvxBBBxowJtpu3gDG69tKvuSPbFn2fYxs98X8DQsXIFEb7A5ZJmPgpigRAiPGhBo/llZBw8aGrd1ZCUSreEasQkVkLiXoCOgby16IROFnxhqfD6z8qr08beHgifzBVqwPQ8cUpLEOvX/kqH7vcqSOMI6RanXzrVWiuy0HFVlMHPF5RV7JZBSEr/ZkElducC3LeY6t5X5yViVlIvP+6M4U9iIkuCPdBnt350quKGnZWqhkMoLLFDl7Q++83SSc1/u3iyqzFGzF3VFE2pA6OSpIYFJMFUAEQEAAYkCHwQYAQIACQUCWK372wIbDAAKCRCbG1xp7O1xwMOJD/4iEpEMzMINqTkB7UWJyZxvJ3q353SASPD78TTrh9Yp+dWwSPLgqygxDToPVOTgW1FEli3VY24ibHG6BSA6WTQFD/Gf2Z2AVEdNaIAWLjz5GNG0fSJfLy/W4umPN4RCjd7A4OYoFVLU4Wr042Cb3L6/wQojZF7qiDK9quvySmJgOQHW+/ToxV3BXtm+YSxSOVLNuMr7+FaIcmtrLLYgp38x3ST6jeJGiFQRHDjtc8VoKaIpQZkBqWCQZYk+medoOqAYEBKxNUWOiof04kOJUvNQ6jTimIOpuYVpllRi3CorSavwk68cCtqTS7GDwfky14rL6FYDzhh/POBv2u7WepZ7sFSAg9hhHq+8Gy/e5kNPpVg7vmNsXbcNX9VnGSsg8GEoEnKJ3vLV/hrpGlFkQ87ppOVQ7qQlVFvbodA85xs3OWCevvUQYYqyrmbV1PKdMoXaRZRexY6EHuUSBrtXuprwXuKEa1ELu5LbmzN008BJTKVLlf2jhbGvt9yH2QhPzeFHlLz5r0tc/3cxJx2S0Sz0varCsfN2knOazjxIW/l3RYkXfNF26vF2eaJuCeakeAqPVBnG3b1KPEcwVLSidu44TLfZ4x3DtHE4oZb+OfV4Q/1uUy7qu5QpUwI+JAsJUWbeWhXBOTmMgXfoI1M9ns+yR/IrZtC4+SVN9C0PBGeLMQ=="
 }
@@ -27,7 +28,7 @@ resource "aws_iam_account_password_policy" "fixture" {
 
 #----------------------- Recall -----------------------#
 resource "aws_iam_user" "recall_hit" {
-    name = "${terraform.env}.recall_hit"
+  name = "${terraform.env}.recall_hit"
 }
 
 output "iam_user_recall_hit" {
@@ -43,12 +44,12 @@ output "iam_user_recall_miss" {
 # TODO: test for no console password user
 
 resource "aws_iam_user" "has_console_password" {
-    name = "${terraform.env}.has_console_password"
-    force_destroy = true
+  name          = "${terraform.env}.has_console_password"
+  force_destroy = true
 }
 
 resource "aws_iam_user_login_profile" "login_profile_for_password_user" {
-  user = "${aws_iam_user.has_console_password.name}"
+  user    = "${aws_iam_user.has_console_password.name}"
   pgp_key = "${var.login_profile_pgp_key}"
 }
 
@@ -62,7 +63,7 @@ output "iam_user_has_console_password" {
 # TODO: tests and fixtures for hardware mfa
 
 resource "aws_iam_user" "no_mfa_enabled" {
-    name = "${terraform.env}.no_mfa_enabled"
+  name = "${terraform.env}.no_mfa_enabled"
 }
 
 output "iam_user_no_mfa_enabled" {
@@ -76,7 +77,7 @@ resource "aws_iam_user" "with_access_key" {
 }
 
 resource "aws_iam_access_key" "access_key_for_user" {
-  user = "${aws_iam_user.with_access_key.name}"
+  user    = "${aws_iam_user.with_access_key.name}"
   pgp_key = "${var.login_profile_pgp_key}"
 }
 
@@ -96,11 +97,11 @@ output "iam_user_without_access_key" {
 #                    IAM Access Keys
 #======================================================#
 
-output "iam_access_key_recall_hit" { 
+output "iam_access_key_recall_hit" {
   value = "${aws_iam_access_key.access_key_for_user.id}"
 }
 
-output "iam_access_key_recall_miss" { 
+output "iam_access_key_recall_miss" {
   value = "AKIAFAKEFAKEFAKEFAKE"
 }
 
@@ -221,4 +222,201 @@ resource "aws_iam_group_membership" "administrators_membership" {
   ]
 
   group = "${aws_iam_group.administrators.name}"
+}
+
+#======================================================#
+#           User Policies - Attached and Inline
+#======================================================#
+
+# Naming scheme: 1i_1a means one 
+# inline policy, one attached policy, etc
+
+#------------------------------------------#
+# A user with neither attached nor inline
+#------------------------------------------#
+output "iam_user_for_policies_0i_0a_name" {
+  value = "${aws_iam_user.recall_hit.name}"
+}
+
+#------------------------------------------#
+# A user with one inline and no attached
+#------------------------------------------#
+
+resource "aws_iam_user" "for_policies_1i_0a" {
+  name = "${terraform.env}_user_for_policies_1i_0a"
+}
+
+resource "aws_iam_user_policy" "test_1i_0a" {
+  name = "test_1i_0a_1"
+  user = "${aws_iam_user.for_policies_1i_0a.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [ 
+    { "Action": "ec2:Describe*", "Effect": "Allow", "Resource": "*" } 
+  ]
+}
+EOF
+}
+
+output "iam_user_for_policies_1i_0a_name" {
+  value = "${aws_iam_user.for_policies_1i_0a.name}"
+}
+
+#------------------------------------------#
+# A user with two inlines and no attached
+#------------------------------------------#
+
+resource "aws_iam_user" "for_policies_2i_0a" {
+  name = "${terraform.env}_user_for_policies_2i_0a"
+}
+
+resource "aws_iam_user_policy" "test_2i_0a_1" {
+  name = "test_2i_0a_1"
+  user = "${aws_iam_user.for_policies_2i_0a.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [ 
+    { "Action": "s3:List*", "Effect": "Allow", "Resource": "*" } 
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user_policy" "test_2i_0a_2" {
+  name = "test_2i_0a_2"
+  user = "${aws_iam_user.for_policies_2i_0a.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [ 
+    { "Action": "rds:Describe*", "Effect": "Allow", "Resource": "*" } 
+  ]
+}
+EOF
+}
+
+output "iam_user_for_policies_2i_0a_name" {
+  value = "${aws_iam_user.for_policies_2i_0a.name}"
+}
+
+#------------------------------------------#
+# A user with one inline and one attached
+#------------------------------------------#
+
+resource "aws_iam_user" "for_policies_1i_1a" {
+  name = "${terraform.env}_user_for_policies_1i_1a"
+}
+
+resource "aws_iam_user_policy" "test_1i_1a" {
+  name = "test_1i_1a_1"
+  user = "${aws_iam_user.for_policies_1i_1a.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [ 
+    { "Action": "sns:Describe*", "Effect": "Allow", "Resource": "*" } 
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "user_attached_1i_1a_1" {
+  name = "${terraform.env}_user_attached_1i_1a_1"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [ 
+    { "Action": "ec2:Describe*", "Effect": "Allow", "Resource": "*" } 
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user_policy_attachment" "attch_1i_1a_1" {
+  user       = "${aws_iam_user.for_policies_1i_1a.name}"
+  policy_arn = "${aws_iam_policy.user_attached_1i_1a_1.arn}"
+}
+
+output "iam_policy_user_attached_1i_1a_1_arn" {
+  value = "${aws_iam_policy.user_attached_1i_1a_1.arn}"
+}
+
+output "iam_policy_user_attached_1i_1a_1_name" {
+  value = "${aws_iam_policy.user_attached_1i_1a_1.name}"
+}
+
+output "iam_user_for_policies_1i_1a_name" {
+  value = "${aws_iam_user.for_policies_1i_1a.name}"
+}
+
+#------------------------------------------#
+# A user with no inline and two attached
+#------------------------------------------#
+
+resource "aws_iam_user" "for_policies_0i_2a" {
+  name = "${terraform.env}_user_for_policies_0i_2a"
+}
+
+# We'd like to test with an AWS-Managed policy, but 
+# the old AWS TF plugin we're using doesn't support the data lookup.
+# For now, hardcode until https://github.com/chef/inspec/issues/2884
+# data "aws_iam_policy" "user_attached_0i_2a_1" {
+#   arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+# }
+variable "aws_iam_policy_user_attached_0i_2a_1_arn" {
+  default = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+variable "aws_iam_policy_user_attached_0i_2a_1_name" {
+  default = "ReadOnlyAccess"
+}
+
+resource "aws_iam_policy" "user_attached_0i_2a_2" {
+  name = "${terraform.env}_user_attached_0i_2a_2"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [ 
+    { "Action": "ec2:Describe*", "Effect": "Allow", "Resource": "*" } 
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user_policy_attachment" "attch_0i_2a_1" {
+  user       = "${aws_iam_user.for_policies_0i_2a.name}"
+  policy_arn = "${var.aws_iam_policy_user_attached_0i_2a_1_arn}"
+}
+
+resource "aws_iam_user_policy_attachment" "attch_0i_2a_2" {
+  user       = "${aws_iam_user.for_policies_0i_2a.name}"
+  policy_arn = "${aws_iam_policy.user_attached_0i_2a_2.arn}"
+}
+
+output "iam_policy_user_attached_0i_2a_1_arn" {
+  value = "${var.aws_iam_policy_user_attached_0i_2a_1_arn}"
+}
+
+output "iam_policy_user_attached_0i_2a_1_name" {
+  value = "${var.aws_iam_policy_user_attached_0i_2a_1_name}"
+}
+
+output "iam_policy_user_attached_0i_2a_2_arn" {
+  value = "${aws_iam_policy.user_attached_0i_2a_2.arn}"
+}
+
+output "iam_policy_user_attached_0i_2a_2_name" {
+  value = "${aws_iam_policy.user_attached_0i_2a_2.name}"
+}
+
+output "iam_user_for_policies_0i_2a_name" {
+  value = "${aws_iam_user.for_policies_0i_2a.name}"
 }

--- a/test/integration/aws/default/verify/controls/aws_iam_user.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_user.rb
@@ -5,6 +5,20 @@ fixtures = {}
   'iam_user_no_mfa_enabled',
   'iam_user_has_console_password',
   'iam_user_with_access_key',
+
+  # Naming scheme: 1i_1a means one 
+  # inline policy, one attached policy, etc
+  'iam_user_for_policies_0i_0a_name',
+  'iam_user_for_policies_1i_0a_name',
+  'iam_user_for_policies_2i_0a_name',
+  'iam_user_for_policies_1i_1a_name',
+  'iam_user_for_policies_0i_2a_name',
+  'iam_policy_user_attached_1i_1a_1_arn',
+  'iam_policy_user_attached_1i_1a_1_name',
+  'iam_policy_user_attached_0i_2a_1_arn',
+  'iam_policy_user_attached_0i_2a_1_name',
+  'iam_policy_user_attached_0i_2a_2_arn',
+  'iam_policy_user_attached_0i_2a_2_name',
 ].each do |fixture_name|
   fixtures[fixture_name] = attribute(
     fixture_name,
@@ -48,4 +62,50 @@ control "aws_iam_user properties" do
      its('status') { should eq 'Active' }
     end
   }
+
+  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+  #       Inline and Attached Policies
+  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+  [
+    [0,0],
+    [1,0],
+    [2,0],
+    [1,1],
+    [0,2],
+  ].each do |combo_as_ints|
+    inline_count, attached_count = *combo_as_ints
+    combo_as_string = "#{inline_count}i_#{attached_count}a"
+    describe aws_iam_user(fixtures["iam_user_for_policies_#{combo_as_string}_name"]) do
+      # Check inline has flag
+      if inline_count > 0
+        it { should have_inline_policies }        
+      else
+        it { should_not have_inline_policies }
+      end
+
+      # Check inline count
+      its('inline_policy_names.count') { should eq inline_count }
+
+      # Check for expected inline name(s)
+      for 1..inline_count do |idx|
+        its('inline_policy_names') { should include "test_#{combo_as_string}_#{idx}"}
+      end
+
+      # Check attached has flag
+      if attached_count > 0
+        it { should have_attached_policies }        
+      else
+        it { should_not have_attached_policies }
+      end
+
+      # Check attached count
+      its('attached_policy_names.count') { should eq attached_count }
+
+      # Check for expected attached name(s) and arn(s)
+      for 1..attached_count do |idx|
+        its('attached_policy_arns') { should include fixtures["iam_policy_user_attached_#{combo_as_string}_#{idx}_arn"] }
+        its('attached_policy_names') { should include fixtures["iam_policy_user_attached_#{combo_as_string}_#{idx}_name"] }
+      end
+    end
+  end
 end

--- a/test/integration/aws/default/verify/controls/aws_iam_user.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_user.rb
@@ -87,7 +87,7 @@ control "aws_iam_user properties" do
       its('inline_policy_names.count') { should eq inline_count }
 
       # Check for expected inline name(s)
-      for 1..inline_count do |idx|
+      (1..inline_count).each do |idx|
         its('inline_policy_names') { should include "test_#{combo_as_string}_#{idx}"}
       end
 
@@ -102,7 +102,7 @@ control "aws_iam_user properties" do
       its('attached_policy_names.count') { should eq attached_count }
 
       # Check for expected attached name(s) and arn(s)
-      for 1..attached_count do |idx|
+      (1..attached_count).each do |idx|
         its('attached_policy_arns') { should include fixtures["iam_policy_user_attached_#{combo_as_string}_#{idx}_arn"] }
         its('attached_policy_names') { should include fixtures["iam_policy_user_attached_#{combo_as_string}_#{idx}_name"] }
       end

--- a/test/integration/aws/default/verify/controls/aws_iam_users.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_users.rb
@@ -1,7 +1,52 @@
+fixtures = {}
+[
+  # Naming scheme: 1i_1a means one 
+  # inline policy, one attached policy, etc
+  'iam_user_for_policies_0i_0a_name',
+  'iam_user_for_policies_1i_0a_name',
+  'iam_user_for_policies_2i_0a_name',
+  'iam_user_for_policies_1i_1a_name',
+  'iam_user_for_policies_0i_2a_name',
+  'iam_policy_user_attached_1i_1a_1_arn',
+  'iam_policy_user_attached_1i_1a_1_name',
+  'iam_policy_user_attached_0i_2a_1_arn',
+  'iam_policy_user_attached_0i_2a_1_name',
+  'iam_policy_user_attached_0i_2a_2_arn',
+  'iam_policy_user_attached_0i_2a_2_name',
+].each do |fixture_name|
+  fixtures[fixture_name] = attribute(
+    fixture_name,
+    default: "default.#{fixture_name}",
+    description: 'See ../build/iam.tf',
+  )
+end
 
 control "aws_iam_users filtering" do
   describe aws_iam_users.where(has_console_password?: true)
                         .where(has_mfa_enabled?: false) do
     it { should exist }
+  end
+
+  describe aws_iam_users.where(has_inline_policies?: true) do
+    its('entries.count') { should eq 3 }
+    its('usernames') { should include fixture['iam_user_for_policies_1i_0a_name'] }
+    its('usernames') { should include fixture['iam_user_for_policies_1i_1a_name'] }
+    its('usernames') { should_not include fixture['iam_user_for_policies_0i_2a_name'] }
+
+    its('inline_policy_names.count') { should eq 4 }
+    its('inline_policy_names') { should include 'test_1i_0a_1' }
+    its('attached_policy_names.count') { should eq 1 }
+  end
+
+  describe aws_iam_users.where(has_attached_policies?: true) do
+    its('entries.count') { should eq 2 }
+    its('usernames') { should include fixture['iam_user_for_policies_0i_2a_name'] }
+    its('usernames') { should include fixture['iam_user_for_policies_1i_1a_name'] }
+    its('usernames') { should_not include fixture['iam_user_for_policies_1i_0a_name'] }
+
+    its('attached_policy_names.count') { should eq 3 }
+    its('attached_policy_names') { should include 'iam_policy_user_attached_1i_1a_1_name' }
+    its('attached_policy_arns.count') { should eq 3 }    
+    its('attached_policy_arns') { should include 'iam_policy_user_attached_1i_1a_1_arn' }
   end
 end

--- a/test/integration/aws/default/verify/controls/aws_iam_users.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_users.rb
@@ -27,26 +27,29 @@ control "aws_iam_users filtering" do
     it { should exist }
   end
 
-  describe aws_iam_users.where(has_inline_policies?: true) do
+  describe aws_iam_users.where { user_name =~ /user_for_policies/ }
+                        .where(has_inline_policies: true) do
     its('entries.count') { should eq 3 }
-    its('usernames') { should include fixture['iam_user_for_policies_1i_0a_name'] }
-    its('usernames') { should include fixture['iam_user_for_policies_1i_1a_name'] }
-    its('usernames') { should_not include fixture['iam_user_for_policies_0i_2a_name'] }
+    its('usernames') { should include fixtures['iam_user_for_policies_1i_0a_name'] }
+    its('usernames') { should include fixtures['iam_user_for_policies_1i_1a_name'] }
+    its('usernames') { should_not include fixtures['iam_user_for_policies_0i_2a_name'] }
 
     its('inline_policy_names.count') { should eq 4 }
     its('inline_policy_names') { should include 'test_1i_0a_1' }
     its('attached_policy_names.count') { should eq 1 }
   end
 
-  describe aws_iam_users.where(has_attached_policies?: true) do
+  describe aws_iam_users.where { user_name =~ /user_for_policies/ }
+                        .where(has_attached_policies: true) do
+    # We have 2 users from our fixtures
     its('entries.count') { should eq 2 }
-    its('usernames') { should include fixture['iam_user_for_policies_0i_2a_name'] }
-    its('usernames') { should include fixture['iam_user_for_policies_1i_1a_name'] }
-    its('usernames') { should_not include fixture['iam_user_for_policies_1i_0a_name'] }
+    its('usernames') { should include fixtures['iam_user_for_policies_0i_2a_name'] }
+    its('usernames') { should include fixtures['iam_user_for_policies_1i_1a_name'] }
+    its('usernames') { should_not include fixtures['iam_user_for_policies_1i_0a_name'] }
 
     its('attached_policy_names.count') { should eq 3 }
-    its('attached_policy_names') { should include 'iam_policy_user_attached_1i_1a_1_name' }
+    its('attached_policy_names') { should include fixtures['iam_policy_user_attached_1i_1a_1_name'] }
     its('attached_policy_arns.count') { should eq 3 }    
-    its('attached_policy_arns') { should include 'iam_policy_user_attached_1i_1a_1_arn' }
+    its('attached_policy_arns') { should include fixtures['iam_policy_user_attached_1i_1a_1_arn'] }
   end
 end

--- a/test/unit/resources/aws_iam_users_test.rb
+++ b/test/unit/resources/aws_iam_users_test.rb
@@ -97,7 +97,7 @@ class AwsIamUsersTestFilterCriteria < Minitest::Test
   #------------------------------------------#
   def test_users_have_inline_policies
     AwsIamUsers::BackendFactory.select(Maiusb::Basic)
-    users = AwsIamUsers.new.where(has_inline_policies: true)
+    users = AwsIamUsers.new.where(has_inline_policies?: true)
     assert_equal(2, users.entries.count)
     assert_includes users.usernames, 'bob'
     assert_includes users.usernames, 'carol'


### PR DESCRIPTION
Adds matchers, properties, and filters for auditing policies attached to or embedded in AWS IAM users for both the singular and plural resources.

Also expands documentation on `aws_iam_users`, which had a lot missing.

Adds extensive integration tests around users and policies, in anticipation of #2749 being expanded to policies attached or embedded on users.

Among the properties are the ones needed to enable fetching individual policies for policy searching.  The policies themselves are not fetched.

This PR will introduce a further performance degradation on `aws_iam_user` and more severely on `aws_iam_users`.  Tracked on #2370 and #2942 .

Fixes #2719
