### PR TITLE
powershell resource: Add support line for Unix

### DIFF
--- a/lib/resources/powershell.rb
+++ b/lib/resources/powershell.rb
@@ -5,6 +5,7 @@ module Inspec::Resources
   class PowershellScript < Cmd
     name 'powershell'
     supports platform: 'windows'
+    supports platform: 'unix'
     desc 'Use the powershell InSpec audit resource to test a Windows PowerShell script on the Microsoft Windows platform.'
     example "
       script = <<-EOH


### PR DESCRIPTION
This allows the `powershell` resource to work on Linux/Unix/OSX