### PR TITLE
Update Resource documentation for Users Resource

### DIFF
--- a/docs/resources/users.md.erb
+++ b/docs/resources/users.md.erb
@@ -108,7 +108,7 @@ where `0` represents the maximum number of days.
 
 The `shell` matcher tests the path to the default shell for the user:
 
-    its('shell') { should eq '/bin/bash' }
+    its('shells') { should eq ['/bin/bash'] }
 
 ### uid
 


### PR DESCRIPTION
The `shell` matcher have to be `shells` and expects an array.
Wrong:
`its('shell') { should eq "/sbin/nologin" }`

Got error:
```
     ×  Users with username =~ /stockservice-.*/ shell
     undefined method 'shell' for Users with username =~ /stockservice-.*/:#<Class:0x000055c2471fa900>
     Did you mean?  shells
```

Correct:
its('shells') { should eq ["/sbin/nologin"] }

-----------------------------------------
$ inspec --version
2.1.43