### PR TITLE
aws_iam_policy statement search fix for degenerate policies

### DIFF
--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -85,7 +85,7 @@ class AwsIamPolicy < Inspec.resource(1)
     return nil unless exists?
     # Typically it is an array of statements
     if policy['Statement'].is_a? Array
-      policy['Statement'].count    
+      policy['Statement'].count
     else
       # But if there is one statement, it is permissable to degenerate the array,
       # and place the statement as a hash directly under the 'Statement' key
@@ -138,7 +138,7 @@ class AwsIamPolicy < Inspec.resource(1)
     recognized_criteria
   end
 
-  def has_statement__normalize_criteria(criteria)    
+  def has_statement__normalize_criteria(criteria)
     # Transform keys into lowercase symbols
     criteria.keys.each do |provided_key|
       criteria[provided_key.downcase.to_sym] = criteria.delete(provided_key)
@@ -149,10 +149,10 @@ class AwsIamPolicy < Inspec.resource(1)
 
   def has_statement__normalize_statements
     # Some single-statement policies place their statement
-    # directly in policy['Statement'], rather than in an 
+    # directly in policy['Statement'], rather than in an
     # Array within it.  See arn:aws:iam::aws:policy/AWSCertificateManagerReadOnly
     # Thus, coerce to Array.
-    policy['Statement'] = [ policy['Statement'] ] if policy['Statement'].is_a? Hash
+    policy['Statement'] = [policy['Statement']] if policy['Statement'].is_a? Hash
     policy['Statement'].map do |statement|
       # Coerce some values into arrays
       %w{Action Resource}.each do |field|

--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -148,12 +148,13 @@ class AwsIamPolicy < Inspec.resource(1)
   end
 
   def has_statement__normalize_statements
+    # Some single-statement policies place their statement
+    # directly in policy['Statement'], rather than in an 
+    # Array within it.  See arn:aws:iam::aws:policy/AWSCertificateManagerReadOnly
+    # Thus, coerce to Array.
+    policy['Statement'] = [ policy['Statement'] ] if policy['Statement'].is_a? Hash
     policy['Statement'].map do |statement|
       # Coerce some values into arrays
-      # unless statement.kind_of? Hash
-      #   require 'byebug'; byebug 
-      #   puts policy_name
-      # end
       %w{Action Resource}.each do |field|
         if statement.key?(field)
           statement[field] = Array(statement[field])

--- a/test/integration/aws/default/verify/controls/aws_iam_policy.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_policy.rb
@@ -78,5 +78,25 @@ control "aws_iam_policy matchers" do
     it { should_not have_statement('Resource' => ['*'])}    
     it { should have_statement('Resource' => ['arn:aws:ec2:::*', '*'])}
     it { should have_statement('Resource' => ['*', 'arn:aws:ec2:::*'])}
-  end  
+  end
+
+  # AWSCertificateManagerReadOnly has an odd shape:
+  # its Statement list is not an array, but a hash - it's a degenerate form.
+  #   {
+  #     "Version": "2012-10-17",
+  #     "Statement": {
+  #         "Effect": "Allow",
+  #         "Action": [
+  #             "acm:DescribeCertificate",
+  #             "acm:ListCertificates",
+  #             "acm:GetCertificate",
+  #             "acm:ListTagsForCertificate"
+  #         ],
+  #         "Resource": "*"
+  #     }
+  # }
+  describe aws_iam_policy('AWSCertificateManagerReadOnly') do
+    its('statement_count') { should cmp 1 }
+    it { should have_statement 'Effect' => 'Allow', 'Action' => 'acm:GetCertificate' }
+  end
 end


### PR DESCRIPTION
I found an odd bug in `aws_iam_policy`; it assumed all JSON policy structures would have an Array at position policy['Statement'].  Apparently, if you have exactly one statement, you are permitted to skip the Array, and simply place your statement directly at policy['Statement'], like this:

```
# arn:aws:iam::aws:policy/AWSCertificateManagerReadOnly
{
    "Version": "2012-10-17",
    "Statement": {
        "Effect": "Allow",
        "Action": [
            "acm:DescribeCertificate",
            "acm:ListCertificates",
            "acm:GetCertificate",
            "acm:ListTagsForCertificate"
        ],
        "Resource": "*"
    }
}
```

As `statement_count` and `have_statement` assume that is an Array, hijinks and stacktraces ensue.

This PR includes test cases to replicate the bug, and then fixes it.

