### PR TITLE
Policy statement search: don't stacktrace on missing field

### DIFF
--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -189,10 +189,10 @@ class AwsIamPolicy < Inspec.resource(1)
   def has_statement__array_criterion(crit_name, statement, criteria)
     return true unless criteria.key?(crit_name)
     check = criteria[crit_name]
-     # This is an array due to normalize_statements
-     # If it is nil, the statement does not have an entry for that dimension;
-     # but since we were asked to match on it (on nothing), we
-     # decide to never match
+    # This is an array due to normalize_statements
+    # If it is nil, the statement does not have an entry for that dimension;
+    # but since we were asked to match on it (on nothing), we
+    # decide to never match
     values = statement[crit_name]
     return false if values.nil?
 

--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -189,7 +189,12 @@ class AwsIamPolicy < Inspec.resource(1)
   def has_statement__array_criterion(crit_name, statement, criteria)
     return true unless criteria.key?(crit_name)
     check = criteria[crit_name]
-    values = statement[crit_name] # This is an array due to normalize_statements
+     # This is an array due to normalize_statements
+     # If it is nil, the statement does not have an entry for that dimension;
+     # but since we were asked to match on it (on nothing), we
+     # decide to never match
+    values = statement[crit_name]
+    return false if values.nil?
 
     if check.is_a?(String)
       # If check is a string, it only has to match one of the values

--- a/test/integration/aws/default/verify/controls/aws_iam_policy.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_policy.rb
@@ -98,5 +98,13 @@ control "aws_iam_policy matchers" do
   describe aws_iam_policy('AWSCertificateManagerReadOnly') do
     its('statement_count') { should cmp 1 }
     it { should have_statement 'Effect' => 'Allow', 'Action' => 'acm:GetCertificate' }
+  end  
+  
+  # This policy has a statment with a NotAction, and no Action
+  # We don't yet support NotAction
+  # But if you ask for action, it should not match, and also not explode
+  # arn:aws:iam::aws:policy/PowerUserAccess
+  describe aws_iam_policy('PowerUserAccess') do
+    it { should_not have_statement 'Action' => 'iam:*' }
   end
 end

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -233,6 +233,8 @@ class AwsIamPolicyMatchersTest < Minitest::Test
     assert(AwsIamPolicy.new('test-policy-1').has_statement?('Action' => [/^ec2\:Describe/]))
     # Able to match a degenerate policy doc in which there is exactly one statement as a hash.
     assert(AwsIamPolicy.new('test-policy-3').has_statement?('Action' => 'acm:GetCertificate'))
+    # Don't explode, and also don't match, if a policy has a statement without an Action
+    refute(AwsIamPolicy.new('test-policy-4').has_statement?('Action' => 'iam:*'))
   end
 
   def test_have_statement_when_resource_is_provided
@@ -289,11 +291,19 @@ module MAIPSB
           is_attachable: false,
         }),
         OpenStruct.new({
+<<<<<<< HEAD
           policy_name: 'test-policy-3',
           arn: 'arn:aws:iam::aws:policy/test-policy-3',
           default_version_id: 'v1',
           attachment_count: 0,
           is_attachable: true,
+=======
+          policy_name: 'test-policy-4',
+          arn: 'arn:aws:iam::aws:policy/test-policy-4',
+          default_version_id: 'v1',
+          attachment_count: 0,
+          is_attachable: false,
+>>>>>>> Add unit and integration tests for replicating policy with no action
         }),
       ]
       OpenStruct.new({ policies: fixtures })
@@ -373,6 +383,7 @@ module MAIPSB
             document: '%7B%0A%20%20%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Sid%22%3A%20%22CloudWatchEventsFullAccess%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Action%22%3A%20%22events%3A%2A%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Sid%22%3A%20%22IAMPassRoleForCloudWatchEvents%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Action%22%3A%20%22iam%3APassRole%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22arn%3Aaws%3Aiam%3A%3A%2A%3Arole%2FAWS_Events_Invoke_Targets%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%5D%0A%7D'
           )
         },
+<<<<<<< HEAD
         'arn:aws:iam::aws:policy/test-policy-3' => {
           'v1' => OpenStruct.new(
             # This is AWS-managed AWSCertificateManagerReadOnly
@@ -390,6 +401,35 @@ module MAIPSB
             #     }
             # }
             document: '%7B%0A%20%20%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%20%20%22Statement%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%22Action%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22acm%3ADescribeCertificate%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22acm%3AListCertificates%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22acm%3AGetCertificate%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22acm%3AListTagsForCertificate%22%0A%20%20%20%20%20%20%20%20%5D%2C%0A%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%7D%0A%7D',
+=======
+        'arn:aws:iam::aws:policy/test-policy-4' => {
+          'v1' => OpenStruct.new(
+            # This is arn:aws:iam::aws:policy/PowerUserAccess
+            # {
+            #   "Version": "2012-10-17",
+            #   "Statement": [
+            #     {
+            #       "Effect": "Allow",
+            #       "NotAction": [
+            #         "iam:*",
+            #         "organizations:*"
+            #       ],
+            #       "Resource": "*"
+            #     },
+            #     {
+            #       "Effect": "Allow",
+            #       "Action": [
+            #           "iam:CreateServiceLinkedRole",
+            #           "iam:DeleteServiceLinkedRole",
+            #           "iam:ListRoles",
+            #           "organizations:DescribeOrganization"
+            #       ],
+            #       "Resource": "*"
+            #     }
+            #   ]
+            # }
+            document: '%7B%0A%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%22NotAction%22%3A%20%5B%22iam%3A%2A%22%2C%20%22organizations%3A%2A%22%5D%2C%0A%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%7D%2C%7B%0A%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%22Action%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%22iam%3ACreateServiceLinkedRole%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22iam%3ADeleteServiceLinkedRole%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22iam%3AListRoles%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22organizations%3ADescribeOrganization%22%0A%20%20%20%20%20%20%5D%2C%0A%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%7D%0A%20%20%5D%0A%7D',
+>>>>>>> Add unit and integration tests for replicating policy with no action
           )
         },
       }

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -291,19 +291,18 @@ module MAIPSB
           is_attachable: false,
         }),
         OpenStruct.new({
-<<<<<<< HEAD
           policy_name: 'test-policy-3',
           arn: 'arn:aws:iam::aws:policy/test-policy-3',
           default_version_id: 'v1',
           attachment_count: 0,
           is_attachable: true,
-=======
+        }),
+        OpenStruct.new({
           policy_name: 'test-policy-4',
           arn: 'arn:aws:iam::aws:policy/test-policy-4',
           default_version_id: 'v1',
           attachment_count: 0,
           is_attachable: false,
->>>>>>> Add unit and integration tests for replicating policy with no action
         }),
       ]
       OpenStruct.new({ policies: fixtures })
@@ -383,7 +382,6 @@ module MAIPSB
             document: '%7B%0A%20%20%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Sid%22%3A%20%22CloudWatchEventsFullAccess%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Action%22%3A%20%22events%3A%2A%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Sid%22%3A%20%22IAMPassRoleForCloudWatchEvents%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Action%22%3A%20%22iam%3APassRole%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22arn%3Aaws%3Aiam%3A%3A%2A%3Arole%2FAWS_Events_Invoke_Targets%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%5D%0A%7D'
           )
         },
-<<<<<<< HEAD
         'arn:aws:iam::aws:policy/test-policy-3' => {
           'v1' => OpenStruct.new(
             # This is AWS-managed AWSCertificateManagerReadOnly
@@ -401,7 +399,8 @@ module MAIPSB
             #     }
             # }
             document: '%7B%0A%20%20%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%20%20%22Statement%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%22Action%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22acm%3ADescribeCertificate%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22acm%3AListCertificates%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22acm%3AGetCertificate%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22acm%3AListTagsForCertificate%22%0A%20%20%20%20%20%20%20%20%5D%2C%0A%20%20%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%7D%0A%7D',
-=======
+          )
+        },
         'arn:aws:iam::aws:policy/test-policy-4' => {
           'v1' => OpenStruct.new(
             # This is arn:aws:iam::aws:policy/PowerUserAccess
@@ -429,7 +428,6 @@ module MAIPSB
             #   ]
             # }
             document: '%7B%0A%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%22NotAction%22%3A%20%5B%22iam%3A%2A%22%2C%20%22organizations%3A%2A%22%5D%2C%0A%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%7D%2C%7B%0A%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%22Action%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%22iam%3ACreateServiceLinkedRole%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22iam%3ADeleteServiceLinkedRole%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22iam%3AListRoles%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22organizations%3ADescribeOrganization%22%0A%20%20%20%20%20%20%5D%2C%0A%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%7D%0A%20%20%5D%0A%7D',
->>>>>>> Add unit and integration tests for replicating policy with no action
           )
         },
       }


### PR DESCRIPTION
If a criterion was provided to the `aws_iam_policy` `have_statement` system, but one or more statements was missing that key, a run abort and stacktrace would occur.

Because required fields vary with AWS service, and mutually exclusive fields exist (for example, Action and NotAction), this condition can arise.  It was discovered while looping over all AWS-managed profiles, and blowing up on a statement that had no Action component (because it had a NotAction component).

This change will cause the search to not-match if a criterion is presented for a statement that does not provide the field.

