### PR TITLE
Add A2 support to the inspec-compliance toolset

### DIFF
--- a/lib/bundles/inspec-compliance/README.md
+++ b/lib/bundles/inspec-compliance/README.md
@@ -37,6 +37,14 @@ Commands:
   inspec compliance version           # displays the version of the Chef Compliance server
 ```
 
+### Login with Chef Automate2
+
+You will need an API token for authentication. You can retrieve one via the admin section of your A2 web gui.
+
+```
+$ inspec compliance login https://automate2.compliance.test --insecure --user 'admin' --token 'zuop..._KzE'
+```
+
 ### Login with Chef Automate
 
 You will need an access token for authentication. You can retrieve one via [UI](https://docs.chef.io/api_delivery.html) or [CLI](https://docs.chef.io/ctl_delivery.html#delivery-token).

--- a/lib/bundles/inspec-compliance/api/login.rb
+++ b/lib/bundles/inspec-compliance/api/login.rb
@@ -17,16 +17,14 @@ module Compliance
 
         case options['server_type']
         when :automate2
-          config = Login::Automate2Server.login(options)
+          Login::Automate2Server.login(options)
         when :automate
-          config = Login::AutomateServer.login(options)
+          Login::AutomateServer.login(options)
         when :compliance
-          config = Login::ComplianceServer.login(options)
+          Login::ComplianceServer.login(options)
         else
           raise CannotDetermineServerType, "Unable to determine if #{options['server']} is a Chef Automate or Chef Compliance server"
         end
-
-        puts "Stored configuration for Chef #{config['server_type'].capitalize}: #{config['server']}' with user: '#{config['user']}'"
       end
 
       module Automate2Server
@@ -40,7 +38,6 @@ module Compliance
 
         def self.store_access_token(options, token)
           config = Compliance::Configuration.new
-
           config.clean
 
           config['automate'] = {}

--- a/lib/bundles/inspec-compliance/api/login.rb
+++ b/lib/bundles/inspec-compliance/api/login.rb
@@ -16,6 +16,8 @@ module Compliance
         options['server_type'] = Compliance::API.determine_server_type(options['server'], options['insecure'])
 
         case options['server_type']
+        when :automate2
+          config = Login::Automate2Server.login(options)
         when :automate
           config = Login::AutomateServer.login(options)
         when :compliance
@@ -25,6 +27,48 @@ module Compliance
         end
 
         puts "Stored configuration for Chef #{config['server_type'].capitalize}: #{config['server']}' with user: '#{config['user']}'"
+      end
+
+      module Automate2Server
+        def self.login(options)
+          verify_thor_options(options)
+
+          options['url'] = options['server'] + '/api/v0'
+          token = options['dctoken'] || options['token']
+          store_access_token(options, token)
+        end
+
+        def self.store_access_token(options, token)
+          config = Compliance::Configuration.new
+
+          config.clean
+
+          config['automate'] = {}
+          config['automate']['ent'] = 'automate'
+          config['automate']['token_type'] = 'dctoken'
+          config['server'] = options['url']
+          config['user'] = options['user']
+          config['owner'] = options['user']
+          config['insecure'] = options['insecure'] || false
+          config['server_type'] = options['server_type'].to_s
+          config['token'] = token
+          config['version'] = '0'
+
+          config.store
+          config
+        end
+
+        def self.verify_thor_options(o)
+          error_msg = []
+
+          error_msg.push('Please specify a user using `--user=\'USER\'`') if o['user'].nil?
+
+          if o['token'].nil? && o['dctoken'].nil?
+            error_msg.push('Please specify a token using `--token=\'APITOKEN\'`')
+          end
+
+          raise ArgumentError, error_msg.join("\n") unless error_msg.empty?
+        end
       end
 
       module AutomateServer

--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -44,6 +44,8 @@ module Compliance
     def login(server)
       options['server'] = server
       Compliance::API.login(options)
+      config = Compliance::Configuration.new
+      puts "Stored configuration for Chef #{config['server_type'].capitalize}: #{config['server']}' with user: '#{config['user']}'"
     end
 
     desc 'profiles', 'list all available profiles in Chef Compliance'

--- a/lib/bundles/inspec-compliance/http.rb
+++ b/lib/bundles/inspec-compliance/http.rb
@@ -33,6 +33,16 @@ module Compliance
       send_request(uri, req, insecure)
     end
 
+    def self.post_with_headers(url, headers, body, insecure)
+      uri = _parse_url(url)
+      req = Net::HTTP::Post.new(uri.path)
+      req.body = body unless body.nil?
+      headers&.each do |key, value|
+        req.add_field(key, value)
+      end
+      send_request(uri, req, insecure)
+    end
+
     # post a file
     def self.post_file(url, headers, file_path, insecure)
       uri = _parse_url(url)
@@ -54,6 +64,35 @@ module Compliance
 
       boundary = 'INSPEC-PROFILE-UPLOAD'
       req.add_field('session', boundary)
+      res=http.request(req)
+      res
+    end
+
+    def self.post_multipart_file(url, headers, file_path, insecure)
+      uri = _parse_url(url)
+      raise "Unable to parse URL: #{url}" if uri.nil? || uri.host.nil?
+      http = Net::HTTP.new(uri.host, uri.port)
+
+      # set connection flags
+      http.use_ssl = (uri.scheme == 'https')
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE if insecure
+
+      req = Net::HTTP::Post.new(uri)
+      headers.each do |key, value|
+        req.add_field(key, value)
+      end
+
+      boundry = 'AaB03x'
+      req.add_field('Content-Type', "multipart/form-data; boundary=#{boundry}")
+
+      post_body = []
+      post_body << "--#{boundry}\r\n"
+      post_body << "Content-Disposition: form-data; name=\"file\"; filename=\"#{File.basename(file_path)}\"\r\n"
+      post_body << "Content-Type: application/x-gtar\r\n\r\n"
+      post_body << File.read(file_path)
+      post_body << "\r\n\r\n--#{boundry}--\r\n"
+      req.body = post_body.join
+
       res=http.request(req)
       res
     end

--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -13,7 +13,7 @@ module Compliance
   class Fetcher < Fetchers::Url
     name 'compliance'
     priority 500
-    def self.resolve(target) # rubocop:disable PerceivedComplexity, Metrics/CyclomaticComplexity
+    def self.resolve(target) # rubocop:disable PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize
       uri = if target.is_a?(String) && URI(target).scheme == 'compliance'
               URI(target)
             elsif target.respond_to?(:key?) && target.key?(:compliance)
@@ -33,6 +33,9 @@ module Compliance
           if config['server_type'] == 'automate'
             server = 'automate'
             msg = 'inspec compliance login https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --token USERTOKEN'
+          elsif config['server_type'] == 'automate2'
+            server = 'automate2'
+            msg = 'inspec compliance login https://your_automate2_server --user USER --token APITOKEN'
           else
             server = 'compliance'
             msg = "inspec compliance login https://your_compliance_server --user admin --insecure --token 'PASTE TOKEN HERE' "
@@ -57,6 +60,10 @@ module Compliance
       end
       # We need to pass the token to the fetcher
       config['token'] = Compliance::API.get_token(config)
+
+      # Needed for automate2 post request
+      config['profile'] = Compliance::API.profile_split(profile)
+
       new(profile_fetch_url, config)
     rescue URI::Error => _e
       nil

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -240,6 +240,9 @@ module Inspec
         raise ArgumentError, "Please provide a value for --#{v}. For example: --#{v}=hello."
       end
 
+      # check for compliance settings
+      Compliance::API.login(o['compliance']) if o['compliance']
+
       o
     end
 

--- a/test/unit/bundles/inspec-compliance/api/login_test.rb
+++ b/test/unit/bundles/inspec-compliance/api/login_test.rb
@@ -47,6 +47,44 @@ describe Compliance::API do
   end
 
   describe '.login' do
+    describe 'when target is a Chef Automate2 server' do
+      before do
+        Compliance::API.expects(:determine_server_type).returns(:automate2)
+      end
+
+      it 'raises an error if `--user` is missing' do
+        options = automate_options
+        options.delete('user')
+        err = proc { Compliance::API.login(options) }.must_raise(ArgumentError)
+        err.message.must_match(/Please specify a user.*/)
+        err.message.lines.length.must_equal(1)
+      end
+
+      it 'raises an error if `--token` and `--dctoken` are missing' do
+        options = automate_options
+        options.delete('token')
+        options.delete('dctoken')
+        err = proc { Compliance::API.login(options) }.must_raise(ArgumentError)
+        err.message.must_match(/Please specify a token.*/)
+        err.message.lines.length.must_equal(1)
+      end
+
+      it 'stores an access token' do
+        stub_request(:get, automate_options['server'] + '/compliance/version')
+          .to_return(status: 200, body: '', headers: {})
+        options = automate_options
+        Compliance::Configuration.expects(:new).returns(fake_config)
+
+        proc { Compliance::API.login(options) }.must_output(/Stored configuration.*Automate/)
+        fake_config['automate']['ent'].must_equal('automate')
+        fake_config['automate']['token_type'].must_equal('dctoken')
+        fake_config['user'].must_equal('someone')
+        fake_config['server'].must_equal('https://automate.example.com/api/v0')
+        fake_config['server_type'].must_equal('automate2')
+        fake_config['token'].must_equal('token')
+      end
+    end
+
     describe 'when target is a Chef Automate server' do
       before do
         Compliance::API.expects(:determine_server_type).returns(:automate)

--- a/test/unit/bundles/inspec-compliance/api/login_test.rb
+++ b/test/unit/bundles/inspec-compliance/api/login_test.rb
@@ -75,7 +75,7 @@ describe Compliance::API do
         options = automate_options
         Compliance::Configuration.expects(:new).returns(fake_config)
 
-        proc { Compliance::API.login(options) }.must_output(/Stored configuration.*Automate/)
+        Compliance::API.login(options)
         fake_config['automate']['ent'].must_equal('automate')
         fake_config['automate']['token_type'].must_equal('dctoken')
         fake_config['user'].must_equal('someone')
@@ -121,7 +121,7 @@ describe Compliance::API do
         options = automate_options
         Compliance::Configuration.expects(:new).returns(fake_config)
 
-        proc { Compliance::API.login(options) }.must_output(/Stored configuration.*Automate/)
+        Compliance::API.login(options)
         fake_config['automate']['ent'].must_equal('automate')
         fake_config['automate']['token_type'].must_equal('usertoken')
         fake_config['user'].must_equal('someone')
@@ -161,7 +161,7 @@ describe Compliance::API do
         options = compliance_options
         Compliance::Configuration.expects(:new).returns(fake_config)
 
-        proc { Compliance::API.login(options) }.must_output(/Stored configuration.*Compliance/)
+        Compliance::API.login(options)
         fake_config['user'].must_equal('someone')
         fake_config['server'].must_equal('https://compliance.example.com/api')
         fake_config['server_type'].must_equal('compliance')


### PR DESCRIPTION
This is the initial support for Automate 2 with the compliance tools. This supports login/upload/download/exec/logout calls accordingly.

Signed-off-by: Jared Quick <jquick@chef.io>