### PR TITLE
Upgrade Terraform version pins for integration testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ profile-1.0.0.tar.gz
 terraform.tfstate*
 terraform.tfstate.backup
 inspec-azure.plan
+inspec-aws-*.plan

--- a/Rakefile
+++ b/Rakefile
@@ -105,7 +105,7 @@ namespace :test do
         abort("You must set the environment variable AWS_REGION") unless ENV['AWS_REGION']
         puts "----> Checking for required AWS profile..."
         sh("aws configure get aws_access_key_id --profile inspec-aws-test-#{account} > /dev/null")
-        sh("cd #{integration_dir}/build/ && terraform init")
+        sh("cd #{integration_dir}/build/ && terraform init -upgrade")
         sh("cd #{integration_dir}/build/ && terraform workspace new #{tf_workspace}")
         sh("cd #{integration_dir}/build/ && AWS_PROFILE=inspec-aws-test-#{account} terraform plan")
         sh("cd #{integration_dir}/build/ && AWS_PROFILE=inspec-aws-test-#{account} terraform apply")

--- a/Rakefile
+++ b/Rakefile
@@ -108,7 +108,7 @@ namespace :test do
         sh("cd #{integration_dir}/build/ && terraform init -upgrade")
         sh("cd #{integration_dir}/build/ && terraform workspace new #{tf_workspace}")
         sh("cd #{integration_dir}/build/ && AWS_PROFILE=inspec-aws-test-#{account} terraform plan")
-        sh("cd #{integration_dir}/build/ && AWS_PROFILE=inspec-aws-test-#{account} terraform apply")
+        sh("cd #{integration_dir}/build/ && AWS_PROFILE=inspec-aws-test-#{account} terraform apply -auto-approve")
         Rake::Task["test:aws:dump_attrs:#{account}"].execute
       end
 

--- a/Rakefile
+++ b/Rakefile
@@ -107,8 +107,8 @@ namespace :test do
         sh("aws configure get aws_access_key_id --profile inspec-aws-test-#{account} > /dev/null")
         sh("cd #{integration_dir}/build/ && terraform init -upgrade")
         sh("cd #{integration_dir}/build/ && terraform workspace new #{tf_workspace}")
-        sh("cd #{integration_dir}/build/ && AWS_PROFILE=inspec-aws-test-#{account} terraform plan")
-        sh("cd #{integration_dir}/build/ && AWS_PROFILE=inspec-aws-test-#{account} terraform apply -auto-approve")
+        sh("cd #{integration_dir}/build/ && AWS_PROFILE=inspec-aws-test-#{account} terraform plan -out inspec-aws-#{account}.plan")
+        sh("cd #{integration_dir}/build/ && AWS_PROFILE=inspec-aws-test-#{account} terraform apply -auto-approve inspec-aws-#{account}.plan")
         Rake::Task["test:aws:dump_attrs:#{account}"].execute
       end
 

--- a/Rakefile
+++ b/Rakefile
@@ -158,7 +158,7 @@ namespace :test do
       tf_workspace = args[:tf_workspace] || ENV['INSPEC_TERRAFORM_ENV']
       abort("You must either call the top-level test:azure task, or set the INSPEC_TERRAFORM_ENV variable.") unless tf_workspace
       puts '----> Setup'
-      sh("cd #{integration_dir}/build/ && terraform init")
+      sh("cd #{integration_dir}/build/ && terraform init -upgrade")
       sh("cd #{integration_dir}/build/ && terraform workspace new #{tf_workspace}")
 
       # Generate Azure crendentials

--- a/test/integration/aws/default/build/aws.tf
+++ b/test/integration/aws/default/build/aws.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.1"
+  version = "= 1.13.0"
 }
 
 data "aws_caller_identity" "creds" {}
@@ -12,10 +12,8 @@ output "aws_account_id" {
   value = "${data.aws_caller_identity.creds.account_id}"
 }
 
-data "aws_region" "region" {
-  current = true
-}
+data "aws_region" "current" {}
 
 output "aws_region" {
-  value = "${data.aws_region.region.name}"
+  value = "${data.aws_region.current.name}"
 }

--- a/test/integration/aws/default/build/aws.tf
+++ b/test/integration/aws/default/build/aws.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 0.10.0"
+  required_version = "~> 0.11.0"
 }
 
 provider "aws" {
-  version = "= 1.1"
+  version = "~> 1.1"
 }
 
 data "aws_caller_identity" "creds" {}

--- a/test/integration/aws/default/build/cloudtrail.tf
+++ b/test/integration/aws/default/build/cloudtrail.tf
@@ -71,7 +71,7 @@ resource "aws_iam_role_policy" "cloud_watch_logs_role_policy" {
                 "logs:CreateLogStream"
             ],
             "Resource": [
-                "arn:aws:logs:${data.aws_region.region.name}:${data.aws_caller_identity.creds.account_id}:log-group:${aws_cloudwatch_log_group.trail_1_log_group.name}:log-stream:${data.aws_caller_identity.creds.account_id}_CloudTrail_${data.aws_region.region.name}*"
+                "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.creds.account_id}:log-group:${aws_cloudwatch_log_group.trail_1_log_group.name}:log-stream:${data.aws_caller_identity.creds.account_id}_CloudTrail_${data.aws_region.current.name}*"
             ]
         },
         {
@@ -81,7 +81,7 @@ resource "aws_iam_role_policy" "cloud_watch_logs_role_policy" {
                 "logs:PutLogEvents"
             ],
             "Resource": [
-                "arn:aws:logs:${data.aws_region.region.name}:${data.aws_caller_identity.creds.account_id}:log-group:${aws_cloudwatch_log_group.trail_1_log_group.name}:log-stream:${data.aws_caller_identity.creds.account_id}_CloudTrail_${data.aws_region.region.name}*"
+                "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.creds.account_id}:log-group:${aws_cloudwatch_log_group.trail_1_log_group.name}:log-stream:${data.aws_caller_identity.creds.account_id}_CloudTrail_${data.aws_region.current.name}*"
             ]
         }
     ]
@@ -164,7 +164,7 @@ resource "aws_kms_key" "trail_1_key" {
       "Resource": "*",
       "Condition": {
         "StringEquals": {
-          "kms:ViaService": "ec2.${data.aws_region.region.name}.amazonaws.com",
+          "kms:ViaService": "ec2.${data.aws_region.current.name}.amazonaws.com",
           "kms:CallerAccount": "${data.aws_caller_identity.creds.account_id}"
         }
       }

--- a/test/integration/aws/default/build/cloudtrail.tf
+++ b/test/integration/aws/default/build/cloudtrail.tf
@@ -178,7 +178,7 @@ resource "aws_cloudtrail" "trail_1" {
   depends_on                    = ["aws_iam_role_policy.cloud_watch_logs_role_policy"]
   name                          = "${terraform.env}-trail-01"
   s3_bucket_name                = "${aws_s3_bucket.trail_1_bucket.id}"
-  include_global_service_events = false
+  include_global_service_events = true
   enable_logging                = true
   is_multi_region_trail         = true
   enable_log_file_validation    = true

--- a/test/integration/aws/default/build/route_table.tf
+++ b/test/integration/aws/default/build/route_table.tf
@@ -2,10 +2,9 @@
 #                                 Route Tables
 #===========================================================================#
 
-
 data "aws_internet_gateway" "default" {
   filter {
-    name = "attachment.vpc-id"
+    name   = "attachment.vpc-id"
     values = ["${data.aws_vpc.default.id}"]
   }
 }
@@ -36,16 +35,8 @@ output "route_table_2_id" {
   value = "${aws_route_table.rtb2.id}"
 }
 
-output "route_table_1_associations" {
-  value = "${aws_route_table.rtb.associations}"
-}
-
 output "route_table_1_propagating_vgws" {
   value = "${aws_route_table.rtb.propagating_vgws}"
-}
-
-output "route_table_1_routes" {
-  value = "${aws_route_table.rtb.routes}"
 }
 
 output "route_table_1_vpc_id" {

--- a/test/integration/aws/minimal/build/aws.tf
+++ b/test/integration/aws/minimal/build/aws.tf
@@ -1,12 +1,13 @@
 terraform {
-  required_version = "~> 0.10.0"
+  required_version = "~> 0.11.0"
 }
 
 provider "aws" {
-  version = "= 1.1"
+  version = "= 1.13.0"
 }
 
 data "aws_caller_identity" "creds" {}
+
 output "aws_account_id" {
   value = "${data.aws_caller_identity.creds.account_id}"
 }

--- a/test/integration/azure/build/azure.tf
+++ b/test/integration/azure/build/azure.tf
@@ -1,5 +1,6 @@
 # Configure variables
 variable "storage_account_name" {}
+
 variable "admin_password" {}
 
 variable "subscription_id" {}
@@ -15,17 +16,22 @@ variable "location" {
   default = "West Europe"
 }
 
-# Output the sub ID so the fixture system has something to chew on
-output "subscription_id" {
-  value = "${var.subscription_id}"
+terraform {
+  required_version = "~> 0.11.0"
 }
 
 # Configure the Azure RM provider
 provider "azurerm" {
+  version         = "~> 1.3"
   subscription_id = "${var.subscription_id}"
   client_id       = "${var.client_id}"
   client_secret   = "${var.client_secret}"
   tenant_id       = "${var.tenant_id}"
+}
+
+# Output the sub ID so the fixture system has something to chew on
+output "subscription_id" {
+  value = "${var.subscription_id}"
 }
 
 # Create a resource group for the machine to be created in
@@ -40,10 +46,10 @@ resource "azurerm_resource_group" "rg" {
 
 # Create the storage account to be used
 resource "azurerm_storage_account" "sa" {
-  name                = "${var.storage_account_name}"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  account_tier        = "Standard"
+  name                     = "${var.storage_account_name}"
+  location                 = "${var.location}"
+  resource_group_name      = "${azurerm_resource_group.rg.name}"
+  account_tier             = "Standard"
   account_replication_type = "LRS"
 }
 
@@ -66,20 +72,20 @@ resource "azurerm_public_ip" "public_ip_1" {
 
 # Create a network security group so it can be tested
 resource "azurerm_network_security_group" "nsg" {
-  name                  = "Inspec-NSG"
-  location              = "${var.location}"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
+  name                = "Inspec-NSG"
+  location            = "${var.location}"
+  resource_group_name = "${azurerm_resource_group.rg.name}"
 
   security_rule {
-    name                        = "SSH-22"
-    priority                    = 100
-    direction                   = "Inbound"
-    access                      = "Allow"
-    protocol                    = "Tcp"
-    source_port_range           = "*"
-    destination_port_range      = "22"
-    source_address_prefix       = "*"
-    destination_address_prefix  = "*"
+    name                       = "SSH-22"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
   }
 }
 
@@ -160,9 +166,9 @@ resource "azurerm_virtual_machine" "vm_linux_internal" {
 
   # Create the OS disk
   storage_os_disk {
-    name          = "Linux-Internal-OSDisk-MD"
-    caching       = "ReadWrite"
-    create_option = "FromImage"
+    name              = "Linux-Internal-OSDisk-MD"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
   }
 
@@ -180,7 +186,7 @@ resource "azurerm_virtual_machine" "vm_linux_internal" {
   # Add boot diagnostics to the machine. These will be added to the 
   # created storage acccount
   boot_diagnostics {
-    enabled = true
+    enabled     = true
     storage_uri = "${azurerm_storage_account.sa.primary_blob_endpoint}"
   }
 }
@@ -230,8 +236,9 @@ resource "azurerm_virtual_machine" "vm_linux_external" {
 
   os_profile_linux_config {
     disable_password_authentication = true
+
     ssh_keys {
-      path = "/home/azure/.ssh/authorized_keys"
+      path     = "/home/azure/.ssh/authorized_keys"
       key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDOxB7GqUxppqRBG5pB2fkkhlWkWUWmFjO3ZEc+VW70erOJWfUvhzBDDQziAOVKtNF2NsY0uyRJqwaP1idL0F7GDQtQl+HhkKW1gOCoTrNptJiYfIm05jTETRWObP0kGMPoAWlkWPBluUAI74B4nkvg7SKNpe36IZhuA8/kvVjxBfWy0r/b/dh+QEIb1eE8HfELAN8SrvrydT7My7g0YFT65V00A2HVa5X3oZaBXRKbmd5gZXBJXEbgHZqA9+NnIQkZXH0vkYYOQTANB8taVwjNVftpXzf2zEupONCYOOoIAep2tXuv2YmWuHr/Y5rCv2mK28ZVcM7W9UmwM0CMHZE7 azure@inspec.local"
     }
   }
@@ -254,19 +261,19 @@ resource "azurerm_virtual_machine" "vm_windows_internal" {
 
   # Create the OS disk
   storage_os_disk {
-    name          = "Windows-Internal-OSDisk-MD"
-    caching       = "ReadWrite"
-    create_option = "FromImage"
+    name              = "Windows-Internal-OSDisk-MD"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
   }
 
   # Create 1 data disk to be used for testing
   storage_data_disk {
-    name          = "Windows-Internal-DataDisk-1-MD"
-    create_option = "Empty"
+    name              = "Windows-Internal-DataDisk-1-MD"
+    create_option     = "Empty"
     managed_disk_type = "Standard_LRS"
-    lun           = 0
-    disk_size_gb  = "1024"
+    lun               = 0
+    disk_size_gb      = "1024"
   }
 
   # Specify the name of the machine and the access credentials
@@ -280,5 +287,3 @@ resource "azurerm_virtual_machine" "vm_windows_internal" {
     provision_vm_agent = true
   }
 }
-
-


### PR DESCRIPTION
Moves version pin for Terraform to be `~> 0.11.0`, azure provider to `1.3.3`, and aws to `1.13`.  I found the aws provider v`1.14` panicked; so I backed down to 1.13 without incident.

Also fixed a handful of TF errors which caused things to fail idempotency.

Fixes #2884 
Unblocks #2937 
