### PR TITLE
Add missing `git` to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VERSION=2.1.43
 ARG GEM_SOURCE=https://rubygems.org
 
 RUN mkdir -p /share
-RUN apk add --update build-base libxml2-dev libffi-dev && \
+RUN apk add --update build-base libxml2-dev libffi-dev git && \
     gem install --no-document --source ${GEM_SOURCE} --version ${VERSION} inspec && \
     apk del build-base
 ENTRYPOINT ["inspec"]


### PR DESCRIPTION

When git is missing from a container, and a profile or resource that uses git the following error will appear:

```
[2018-04-17T19:03:58+00:00] ERROR: Report handler Chef::Handler::AuditReport raised #<RuntimeError: Unable to resolve master to a specific git commit for https://github.com/dev-sec/tests-ssh-hardening.git>
```

There is a issue about this at: https://github.com/chef/inspec/issues/1270 and it was noted that the error message needs to be updated, and that `git` was missing from our Dockerfile. This PR resolves the missing `git` in our Dockerfile =)