### PR TITLE
Amazon linux service mgmt detection

### DIFF
--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -162,7 +162,7 @@ module Inspec::Resources
       elsif %w{aix}.include?(platform)
         SrcMstr.new(inspec)
       elsif %w{amazon}.include?(platform)
-        if os[:release].start_with?('20\d\d')
+        if os[:release] =~ /^20\d\d/
           Upstart.new(inspec, service_ctl)
         else
           Systemd.new(inspec, service_ctl)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -68,6 +68,8 @@ class MockLoader
     solaris10:  { name: "solaris", family: 'solaris', release: '10', arch: 'i386'},
     hpux:       { name: 'hpux', family: 'hpux', release: 'B.11.31', arch: 'ia64'},
     aix:        { name: 'aix', family: 'aix', release: '7.2', arch: 'powerpc' },
+    amazon:     { name: 'amazon', family: 'redhat', release: '2015.03', arch: 'x86_64' },
+    amazon2:    { name: 'amazon', family: 'redhat', release: '2', arch: 'x86_64' },
     undefined:  { name: nil, family: nil, release: nil, arch: nil },
   }
 

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -127,6 +127,33 @@ describe 'Inspec::Resources::Service' do
     _(resource.params).must_equal params
   end
 
+  # Amazon Linux
+  it 'verify amazon linux service parsing' do
+    resource = MockLoader.new(:amazon).load_resource('service', 'ssh')
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal 'upstart'
+    _(resource.name).must_equal 'ssh'
+    _(resource.description).must_be_nil
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+    _(resource.params.UnitFileState).must_be_nil
+  end
+
+  # Amazon Linux 2
+  it 'verify amazon linux 2 service parsing' do
+    resource = MockLoader.new(:amazon2).load_resource('service', 'sshd')
+    params = Hashie::Mash.new({ 'ActiveState' => 'active', 'Description' => 'OpenSSH server daemon', 'Id' => 'sshd.service', 'LoadState' => 'loaded', 'Names' => 'sshd.service', 'SubState' => 'running', 'UnitFileState' => 'enabled' })
+    _(resource.type).must_equal 'systemd'
+    _(resource.name).must_equal 'sshd.service'
+    _(resource.description).must_equal 'OpenSSH server daemon'
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+  end
+
   # centos 6 with sysv
   it 'verify centos 6 service parsing' do
     resource = MockLoader.new(:centos6).load_resource('service', 'sshd')


### PR DESCRIPTION
Looks like when support for Amazon Linux 2 was added, detection for Amazon 1 had this bug introduced:

```ruby
# Current behavior
> '2015.03'.start_with?('20\d\d')
=> false

# Proposed behavior
> '2015.03 =~ /^20\d\d/
=> 0
```

This change also adds a test for both Amazon linux 1 and 2 service detection. I haven't touched the tests for inspec before, please let me know If I should improve my change.