### PR TITLE
updating kitchen-puppet example for the `puppet_apply` provisioner

### DIFF
--- a/examples/kitchen-puppet/.kitchen.yml
+++ b/examples/kitchen-puppet/.kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
   # Not installing chef since inspec is used for testing
   require_chef_for_busser: false
   manifests_path: manifests
+  modules_path: modules
 
 verifier:
   name: inspec


### PR DESCRIPTION
The `puppet_apply` provisioner complains when a `modules_path` is not defined:

```
-----> Converging <default-ubuntu-1604>...
       Preparing files for transfer
       Preparing modules
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #converge action: [No modules_path detected. Please specify one in .kitchen.yml] on default-ubuntu-1604
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

Adding an empty modules path fixes things

Signed-off-by: Shaun Mouton <smouton@chef.io>