### PR TITLE
Update shadow#to_s to return @path instead of hardcoded `/etc/shadow`

### DIFF
--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -120,7 +120,7 @@ module Inspec::Resources
 
     def to_s
       f = @filters.empty? ? '' : ' with'+@filters
-      "/etc/shadow#{f}"
+      "#{@path}#{f}"
     end
 
     private

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -110,6 +110,10 @@ describe 'Inspec::Resources::Shadow' do
         expect(shadow.users(user).inactive_days).must_equal([])
       end
     end
+
+    it 'returns the unreadable_shadow path' do
+      expect(unreadable_shadow.to_s).must_equal '/fakepath/fakefile'
+    end
   end
 
   describe 'filter via name =~ /^www/' do


### PR DESCRIPTION
The #to_s method should return the @path rather than a hardcoded `/etc/shadow`.

previously:
```
inspec> s = shadow('/Users/miah/projects/github/tmp/inspec/test/unit/mock/files/shadow')
=> /etc/shadow
```

now:
```
inspec> a = shadow('/Users/miah/projects/github/tmp/inspec/test/unit/mock/files/shadow')
=> /Users/miah/projects/github/tmp/inspec/test/unit/mock/files/shadow
```


Signed-off-by: Miah Johnson <miah@chia-pet.org>

Fixes https://github.com/chef/inspec/issues/2977