### PR TITLE
Refactors Terraform plan to break out steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ meta-profile-0.2.0.tar.gz
 profile-1.0.0.tar.gz
 .attribute.yml
 .terraform/
+terraform.tfvars
 terraform.tfstate*
 terraform.tfstate.backup
 inspec-azure.plan

--- a/README.md
+++ b/README.md
@@ -424,6 +424,12 @@ Use the rake task `bundle exec rake test:aws` to test the AWS resources against 
 
 Please see [TESTING_AGAINST_AWS.md](./test/integration/aws/TESTING_AGAINST_AWS.md) for details on how to setup the needed AWS accounts to perform testing.
 
+### Azure Tests
+
+Use the rake task `bundle exec rake test:azure` to test the Azure resources against an Azure account.
+
+Please see [TESTING_AGAINST_AZURE.md](./test/integration/aws/TESTING_AGAINST_AZURE.md) for details on how to setup the needed Azure accounts to perform testing.
+
 ## License
 
 |                |                                           |

--- a/Rakefile
+++ b/Rakefile
@@ -152,14 +152,29 @@ namespace :test do
   namespace :azure do
     # Specify the directory for the integration tests
     integration_dir = File.join(project_dir, 'test', 'integration', 'azure')
+    tf_vars_file = File.join(integration_dir, 'build', 'terraform.tfvars')
     attribute_file = File.join(integration_dir, '.attribute.yml')
 
     task :setup, :tf_workspace do |t, args|
       tf_workspace = args[:tf_workspace] || ENV['INSPEC_TERRAFORM_ENV']
       abort("You must either call the top-level test:azure task, or set the INSPEC_TERRAFORM_ENV variable.") unless tf_workspace
-      puts '----> Setup'
+
+      puts '----> Setup Terraform Workspace'
+
       sh("cd #{integration_dir}/build/ && terraform init -upgrade")
       sh("cd #{integration_dir}/build/ && terraform workspace new #{tf_workspace}")
+
+      Rake::Task["test:azure:vars"].execute
+      Rake::Task["test:azure:plan"].execute
+      Rake::Task["test:azure:apply"].execute
+    end
+
+    desc "Generate terraform.tfvars file"
+    task :vars do |t, args|
+
+      next if File.exist?(tf_vars_file)
+
+      puts '----> Generating Vars'
 
       # Generate Azure crendentials
       connection = Train.create('azure').connection
@@ -172,23 +187,43 @@ namespace :test do
       # Use the first 4 characters of the storage account to create a suffix
       suffix = sa_name[0..3]
 
-      # Create the plan that can be applied to Azure
-      cmd  = ""
-      cmd += "cd #{integration_dir}/build/ && terraform plan -out inspec-azure.plan"
-      cmd += " -var 'subscription_id=#{creds[:subscription_id]}' "
-      cmd += " -var 'client_id=#{creds[:client_id]}' "
-      cmd += " -var 'client_secret=#{creds[:client_secret]}' "
-      cmd += " -var 'tenant_id=#{creds[:tenant_id]}' "
-      cmd += " -var 'storage_account_name=#{sa_name}' "
-      cmd += " -var 'admin_password=#{admin_password}' "
-      cmd += " -var 'suffix=#{suffix}' "
-      sh(cmd)
+      content = <<~VARS
+        subscription_id = "#{creds[:subscription_id]}"
+        client_id = "#{creds[:client_id]}"
+        client_secret = "#{creds[:client_secret]}"
+        tenant_id = "#{creds[:tenant_id]}"
+        storage_account_name = "#{sa_name}"
+        admin_password = "#{admin_password}"
+        suffix = "#{suffix}"
+      VARS
 
-      # Apply the plan on Azure
-      cmd = "cd #{integration_dir}/build/ && terraform apply inspec-azure.plan"
-      sh(cmd)
+      content << "location = \"#{ENV['AZURE_LOCATION']}\"\n" if ENV['AZURE_LOCATION']
 
-      # Dump TF outputs to InSpec attributes file
+      File.write(tf_vars_file, content)
+    end
+
+    desc "generate plan from state using terraform.tfvars file"
+    task :plan, [:tf_workspace] => [:vars] do |t, args|
+      tf_workspace = args[:tf_workspace] || ENV['INSPEC_TERRAFORM_ENV']
+      abort("You must set the INSPEC_TERRAFORM_ENV variable.") unless tf_workspace
+
+      puts '----> Generating Plan'
+
+      result = sh("cd #{integration_dir}/build/ && terraform workspace select #{tf_workspace}")
+
+      sh("cd #{integration_dir}/build/ && terraform plan -out inspec-azure.plan")
+    end
+
+    desc "apply terraform plan"
+    task :apply, [:tf_workspace] => [:plan] do |t, args|
+      tf_workspace = args[:tf_workspace] || ENV['INSPEC_TERRAFORM_ENV']
+      abort("You must set the INSPEC_TERRAFORM_ENV variable.") unless tf_workspace
+      puts '----> Applying Plan'
+
+      sh("cd #{integration_dir}/build/ && terraform workspace select #{tf_workspace}")
+
+      sh("cd #{integration_dir}/build/ && terraform apply inspec-azure.plan")
+
       Rake::Task["test:azure:dump_attrs"].execute
     end
 
@@ -197,7 +232,7 @@ namespace :test do
         raw_output = File.read(attribute_file)
         yaml_output = raw_output.gsub(" = ", " : ")
         File.open(attribute_file, "w") {|file| file.puts yaml_output}
-      end
+    end
 
     task :run do
       puts '----> Run'
@@ -209,23 +244,11 @@ namespace :test do
       abort("You must either call the top-level test:azure task, or set the INSPEC_TERRAFORM_ENV variable.") unless tf_workspace
       puts '----> Cleanup'
 
-      connection = Train.create('azure').connection
-      creds = connection.options
-
-      cmd  = ""
-      cmd += "cd #{integration_dir}/build/ && terraform destroy -force "
-      cmd += " -var 'subscription_id=#{creds[:subscription_id]}' "
-      cmd += " -var 'client_id=#{creds[:client_id]}' "
-      cmd += " -var 'client_secret=#{creds[:client_secret]}' "
-      cmd += " -var 'tenant_id=#{creds[:tenant_id]}' "
-      cmd += " -var 'storage_account_name=dummy' "
-      cmd += " -var 'admin_password=dummy' "
-      cmd += " -var 'suffix=dummy' "
-
-      sh(cmd)
+      sh("cd #{integration_dir}/build/ && terraform destroy -force ")
 
       sh("cd #{integration_dir}/build/ && terraform workspace select default")
       sh("cd #{integration_dir}/build && terraform workspace delete #{tf_workspace}")
+      File.delete(tf_vars_file)
     end
   end
 

--- a/test/integration/aws/TESTING_AGAINST_AWS.md
+++ b/test/integration/aws/TESTING_AGAINST_AWS.md
@@ -13,7 +13,7 @@ We use the AWS CLI credentials system to manage credentials.
 
 ### Installing Terraform
 
-Download [Terraform](https://www.terraform.io/downloads.html).  We require at least v0.10 . To install and choose from multiple Terraform versions, consider using [tfenv](https://github.com/kamatama41/tfenv).
+Download [Terraform](https://www.terraform.io/downloads.html).  We require at least v0.10. To install and choose from multiple Terraform versions, consider using [tfenv](https://github.com/kamatama41/tfenv).
 
 ### Installing AWS CLI
 
@@ -95,7 +95,7 @@ To run the tests against one account only:
  ```
  bundle exec rake test:aws:minimal
  ```
- 
+
 Each account has separate tasks for setup, running the tests, and cleanup.  You may run them separately:
 
 ```

--- a/test/integration/azure/TESTING_AGAINST_AZURE.md
+++ b/test/integration/azure/TESTING_AGAINST_AZURE.md
@@ -1,0 +1,71 @@
+# Testing Against Azure - Integration Testing
+
+## Problem Statement
+
+We want to test Azure-related InSpec resource against Azure itself. This requires a test fixture in Azure to examine using InSpec.
+
+## General Approach
+
+We have a Terraform plan to set up and destroy test fixtures in Azure. When the environment is running we have a set of integration tests that may run against it.
+
+Credentials are handled via a `~/.azure/credentials` file. Create a directory in your home directory called `.azure`. Then create a file called `credentials`. An example file is below:
+
+```
+[subscription_id]
+client_id=
+client_secret=
+tenant_id=
+```
+
+Substitute `subscription_id` for your Azure subscription ID. Client ID and client secret can be obtained when you create your application account (instructions below).
+
+Tenant ID can be obtained by logging into the Azure portal. Browse to the `Azure Active Directory` and click on `properties`. The `Directory ID` is your Tenant ID.
+
+### Installing Terraform
+
+Download [Terraform](https://www.terraform.io/downloads.html).  We require at least v0.10. To install and choose from multiple Terraform versions, consider using [tfenv](https://github.com/kamatama41/tfenv).
+
+## Current Solution
+
+We have registered an application to use for authentication. We use Terraform to create the needed resources that we run our tests against.
+
+### Creating the Application account
+
+1. Login to the Azure portal.
+2. Click on `Azure Active Directory`.
+3. Click on `APP registrations`.
+4. Click on `New application registration`.
+5. Fill in a name and a Sign-on URL. Select `Web app / API` from the `Application Type` drop down. Save your application.
+6. Note your Application ID. This is your `client_id` above.
+6. Click on `Settings`
+7. Click on `Keys`
+8. Create a new password. This value is your `client_secret` above.
+9. Go to your subscription (click on `All Services` then subscriptions). Choose your subscription from that list.
+11. Note your Subscription ID can be found here.
+10. Click `Access Control (IAM)`
+11. Click Add
+13. Select the `contributor` role.
+12. Select the application you just created and save.
+
+## Running the integration tests
+`INSPEC_TERRAFORM_ENVIRONMENT` should be set to a unique value for you to work against. See [Terraform Workspaces](https://www.terraform.io/docs/state/workspaces.html)
+
+`AZURE_LOCATION` may be set to the region you'd prefer to test in. The default setting is "West Europe".
+
+To run all Azure integration tests, run:
+
+`INSPEC_TERRAFORM_ENVIRONMENT=$YOUR_WORKSPACE bundle exec rake test:azure`
+
+If you are doing something which requires changing the Azure environment, e.g. developing a new Azure module you may want to have your environment running while you make changes.
+
+`INSPEC_TERRAFORM_ENVIRONMENT=$YOUR_WORKSPACE bundle exec rake test:azure:setup`
+
+After making any changes to Terraform. Apply your changes.
+
+`INSPEC_TERRAFORM_ENVIRONMENT=$YOUR_WORKSPACE bundle exec rake test:azure:apply`
+
+This will automatically regenerate your plan file and apply the changes.
+
+When you are done, and wish to destroy your environment:
+
+`INSPEC_TERRAFORM_ENVIRONMENT=$YOUR_WORKSPACE bundle exec rake test:azure:cleanup`


### PR DESCRIPTION
This change should make it easier to work with a running environment.
You may now apply changes without doing a full teardown/rebuild any time
you make a change to the terraform plan.

Adds some documenation on how to use the Terraform tooling.

Signed-off-by: David McCown <dmccown@chef.io>