### PR TITLE
Split InSpec into multiple gems for 'core', 'aws', and 'azure'.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # encoding: utf-8
 source 'https://rubygems.org'
-gemspec
+gemspec name: 'inspec'
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
   gem 'json', '~> 1.8'

--- a/Rakefile
+++ b/Rakefile
@@ -2,12 +2,14 @@
 # encoding: utf-8
 
 require 'bundler'
-require 'bundler/gem_tasks'
+require 'bundler/gem_helper'
 require 'rake/testtask'
 require 'passgen'
 require 'train'
 require_relative 'tasks/maintainers'
 require_relative 'tasks/spdx'
+
+Bundler::GemHelper.install_tasks name: 'inspec'
 
 def prompt(message)
   print(message)

--- a/inspec-aws.gemspec
+++ b/inspec-aws.gemspec
@@ -1,0 +1,24 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'inspec/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'inspec-aws'
+  spec.version       = Inspec::VERSION
+  spec.authors       = ['Dominik Richter']
+  spec.email         = ['dominik.richter@gmail.com']
+  spec.summary       = 'Provides AWS support for InSpec'
+  spec.description   = 'Allows InSpec to verify the state of your AWS cloud infrastructure.'
+  spec.homepage      = 'https://github.com/chef/inspec'
+  spec.license       = 'Apache-2.0'
+
+  spec.files = %w[LICENSE inspec-aws.gemspec] +
+    Dir.glob('lib/{resource_support/aws,resources/aws}/**/*',
+               File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
+
+  spec.require_paths = ['lib']
+
+  spec.required_ruby_version = '>= 2.3'
+
+  spec.add_dependency 'inspec-core'
+end

--- a/inspec-aws.gemspec
+++ b/inspec-aws.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/chef/inspec'
   spec.license       = 'Apache-2.0'
 
-  spec.files = %w[LICENSE inspec-aws.gemspec] +
-    Dir.glob('lib/{resource_support/aws,resources/aws}/**/*',
-               File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
+  spec.files = %w{LICENSE inspec-aws.gemspec} +
+               Dir.glob('lib/{resource_support/aws,resources/aws}/**/*',
+                        File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
 
   spec.require_paths = ['lib']
 

--- a/inspec-aws.gemspec
+++ b/inspec-aws.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'inspec-core'
+  spec.add_dependency 'train-aws'
+
 end

--- a/inspec-azure.gemspec
+++ b/inspec-azure.gemspec
@@ -1,0 +1,24 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'inspec/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'inspec-azure'
+  spec.version       = Inspec::VERSION
+  spec.authors       = ['Dominik Richter']
+  spec.email         = ['dominik.richter@gmail.com']
+  spec.summary       = 'Provides Azure support for InSpec'
+  spec.description   = 'Allows InSpec to verify the state of your Azure cloud infrastructure.'
+  spec.homepage      = 'https://github.com/chef/inspec'
+  spec.license       = 'Apache-2.0'
+
+  spec.files = %w[LICENSE inspec-azure.gemspec] +
+    Dir.glob('lib/resources/azure/**/*', File::FNM_DOTMATCH)
+    .reject { |f| File.directory?(f) }
+
+  spec.require_paths = ['lib']
+
+  spec.required_ruby_version = '>= 2.3'
+
+  spec.add_dependency 'inspec-core'
+end

--- a/inspec-azure.gemspec
+++ b/inspec-azure.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'inspec-core'
+  spec.add_dependency 'train-azure'
 end

--- a/inspec-azure.gemspec
+++ b/inspec-azure.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/chef/inspec'
   spec.license       = 'Apache-2.0'
 
-  spec.files = %w[LICENSE inspec-azure.gemspec] +
-    Dir.glob('lib/resources/azure/**/*', File::FNM_DOTMATCH)
-    .reject { |f| File.directory?(f) }
+  spec.files = %w{LICENSE inspec-azure.gemspec} +
+               Dir.glob('lib/resources/azure/**/*', File::FNM_DOTMATCH)
+                  .reject { |f| File.directory?(f) }
 
   spec.require_paths = ['lib']
 

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -1,0 +1,45 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'inspec/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'inspec-core'
+  spec.version       = Inspec::VERSION
+  spec.authors       = ['Dominik Richter']
+  spec.email         = ['dominik.richter@gmail.com']
+  spec.summary       = 'Just InSpec'
+  spec.description   = 'Core InSpec, local and SSH. See `inspec-aws`, ' \
+                       'and `inspec-azure` for AWS and Azure support.'
+  spec.homepage      = 'https://github.com/chef/inspec'
+  spec.license       = 'Apache-2.0'
+
+  spec.files = %w[
+    README.md MAINTAINERS.toml MAINTAINERS.md LICENSE inspec.gemspec
+    Gemfile CHANGELOG.md
+  ] + Dir.glob('{bin,docs,examples,lib}/**/*', File::FNM_DOTMATCH)
+    .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/}
+
+  spec.executables   = %w{inspec}
+  spec.require_paths = ['lib']
+
+  spec.required_ruby_version = '>= 2.3'
+
+  spec.add_dependency 'train-core', '~> 1.4'
+  spec.add_dependency 'thor', '~> 0.20'
+  spec.add_dependency 'json', '>= 1.8', '< 3.0'
+  spec.add_dependency 'method_source', '~> 0.8'
+  spec.add_dependency 'rubyzip', '~> 1.1'
+  spec.add_dependency 'rspec', '~> 3'
+  spec.add_dependency 'rspec-its', '~> 1.2'
+  spec.add_dependency 'hashie', '~> 3.4'
+  spec.add_dependency 'mixlib-log'
+  spec.add_dependency 'pry', '~> 0'
+  spec.add_dependency 'sslshake', '~> 1.2'
+  spec.add_dependency 'parallel', '~> 1.9'
+  spec.add_dependency 'faraday', '>=0.9.0'
+  spec.add_dependency 'tomlrb', '~> 1.2'
+  spec.add_dependency 'addressable', '~> 2.4'
+  spec.add_dependency 'parslet', '~> 1.5'
+  spec.add_dependency 'semverse'
+  spec.add_dependency 'htmlentities'
+end

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -13,11 +13,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/chef/inspec'
   spec.license       = 'Apache-2.0'
 
-  spec.files = %w[
-    README.md MAINTAINERS.toml MAINTAINERS.md LICENSE inspec.gemspec
-    Gemfile CHANGELOG.md
-  ] + Dir.glob('{bin,docs,examples,lib}/**/*', File::FNM_DOTMATCH)
-    .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/}
+  spec.files = %w{README.md MAINTAINERS.toml MAINTAINERS.md LICENSE
+                  inspec.gemspec Gemfile CHANGELOG.md} +
+               Dir.glob('{bin,docs,examples,lib}/**/*', File::FNM_DOTMATCH)
+                  .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/ }
 
   spec.executables   = %w{inspec}
   spec.require_paths = ['lib']


### PR DESCRIPTION
This adds a few gem specs to allow InSpec to be distributed without support for additional cloud providers. I've left the `inspec.gemspec` alone so InSpec can still be distributed as is. In the future after these supplemental gem specs have proven themselves `inspec.gemspec` would be modified to depend on them.

We now have:

 - `inspec-core` which is just InSpec, with local, ssh, and Windows.
 - `inspec-aws` which provides AWS support.
 - `inspec-azure` which provides Azure support.

The aws, and azure, gems all depend on `core`.  So if you want to install InSpec with support for AWS you can install `inspec-aws` and you'll be fine.

The `description` and `summary` of our gem specs could probably be improved here (HELP)

These supplemental gem specs do not include distribution of `tests` (spec.test_files) as that was [deprecated](https://github.com/rubygems/guides/issues/90) 