### PR TITLE
Split inspec into a core gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # encoding: utf-8
 source 'https://rubygems.org'
-gemspec
+gemspec name: 'inspec'
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
   gem 'json', '~> 1.8'

--- a/Rakefile
+++ b/Rakefile
@@ -2,12 +2,14 @@
 # encoding: utf-8
 
 require 'bundler'
-require 'bundler/gem_tasks'
+require 'bundler/gem_helper'
 require 'rake/testtask'
 require 'passgen'
 require 'train'
 require_relative 'tasks/maintainers'
 require_relative 'tasks/spdx'
+
+Bundler::GemHelper.install_tasks name: 'inspec'
 
 def prompt(message)
   print(message)

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -8,8 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Dominik Richter']
   spec.email         = ['dominik.richter@gmail.com']
   spec.summary       = 'Just InSpec'
-  spec.description   = 'Core InSpec, local and SSH. See `inspec-aws`, ' \
-                       'and `inspec-azure` for AWS and Azure support.'
+  spec.description   = 'Core InSpec, local support only. See `inspec` for full support.'
   spec.homepage      = 'https://github.com/chef/inspec'
   spec.license       = 'Apache-2.0'
 

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
 
   spec.files = %w{README.md MAINTAINERS.toml MAINTAINERS.md LICENSE
-                  inspec.gemspec Gemfile CHANGELOG.md} +
+                  inspec-core.gemspec Gemfile CHANGELOG.md} +
                Dir.glob('{bin,docs,examples,lib}/**/*', File::FNM_DOTMATCH)
                   .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/ }
 

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -1,0 +1,44 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'inspec/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'inspec-core'
+  spec.version       = Inspec::VERSION
+  spec.authors       = ['Dominik Richter']
+  spec.email         = ['dominik.richter@gmail.com']
+  spec.summary       = 'Just InSpec'
+  spec.description   = 'Core InSpec, local and SSH. See `inspec-aws`, ' \
+                       'and `inspec-azure` for AWS and Azure support.'
+  spec.homepage      = 'https://github.com/chef/inspec'
+  spec.license       = 'Apache-2.0'
+
+  spec.files = %w{README.md MAINTAINERS.toml MAINTAINERS.md LICENSE
+                  inspec.gemspec Gemfile CHANGELOG.md} +
+               Dir.glob('{bin,docs,examples,lib}/**/*', File::FNM_DOTMATCH)
+                  .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/ }
+
+  spec.executables   = %w{inspec}
+  spec.require_paths = ['lib']
+
+  spec.required_ruby_version = '>= 2.3'
+
+  spec.add_dependency 'train-core', '~> 1.4'
+  spec.add_dependency 'thor', '~> 0.20'
+  spec.add_dependency 'json', '>= 1.8', '< 3.0'
+  spec.add_dependency 'method_source', '~> 0.8'
+  spec.add_dependency 'rubyzip', '~> 1.1'
+  spec.add_dependency 'rspec', '~> 3'
+  spec.add_dependency 'rspec-its', '~> 1.2'
+  spec.add_dependency 'hashie', '~> 3.4'
+  spec.add_dependency 'mixlib-log'
+  spec.add_dependency 'pry', '~> 0'
+  spec.add_dependency 'sslshake', '~> 1.2'
+  spec.add_dependency 'parallel', '~> 1.9'
+  spec.add_dependency 'faraday', '>=0.9.0'
+  spec.add_dependency 'tomlrb', '~> 1.2'
+  spec.add_dependency 'addressable', '~> 2.4'
+  spec.add_dependency 'parslet', '~> 1.5'
+  spec.add_dependency 'semverse'
+  spec.add_dependency 'htmlentities'
+end

--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -78,13 +78,16 @@ end
 require 'utils/filter'
 
 # AWS resources are included via their own file.
-require 'resource_support/aws'
+require 'resource_support/aws' if Gem.loaded_specs.has_key?('aws-sdk')
 
-require 'resources/azure/azure_backend.rb'
-require 'resources/azure/azure_generic_resource.rb'
-require 'resources/azure/azure_resource_group.rb'
-require 'resources/azure/azure_virtual_machine.rb'
-require 'resources/azure/azure_virtual_machine_data_disk.rb'
+if Gem.loaded_specs.has_key?('azure_mgmt_resources')
+  require 'resources/azure/azure_backend.rb'
+  require 'resources/azure/azure_generic_resource.rb'
+  require 'resources/azure/azure_resource_group.rb'
+  require 'resources/azure/azure_virtual_machine.rb'
+  require 'resources/azure/azure_virtual_machine_data_disk.rb'
+end
+
 require 'resources/aide_conf'
 require 'resources/apache'
 require 'resources/apache_conf'

--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -78,9 +78,9 @@ end
 require 'utils/filter'
 
 # AWS resources are included via their own file.
-require 'resource_support/aws' if Gem.loaded_specs.has_key?('aws-sdk')
+require 'resource_support/aws' if Gem.loaded_specs.key?('aws-sdk')
 
-if Gem.loaded_specs.has_key?('azure_mgmt_resources')
+if Gem.loaded_specs.key?('azure_mgmt_resources')
   require 'resources/azure/azure_backend.rb'
   require 'resources/azure/azure_generic_resource.rb'
   require 'resources/azure/azure_resource_group.rb'


### PR DESCRIPTION
This adds a `inspec-core.gemspec` to allow InSpec to be dependent on `train-core` which is distributed without support for additional cloud providers.