### PR TITLE
Fix the A2 compliance ssl flag

### DIFF
--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -157,6 +157,12 @@ module Fetchers
       opts = http_opts
       opts[:use_ssl] = uri.scheme == 'https'
 
+      if @insecure
+        opts[:verify_mode] = OpenSSL::SSL::VERIFY_NONE
+      else
+        opts[:verify_mode] = OpenSSL::SSL::VERIFY_PEER
+      end
+
       req = Net::HTTP::Post.new(uri)
       opts.each do |key, value|
         req.add_field(key, value)


### PR DESCRIPTION
The current code uses the old A1 headers which uses `ssl_verify_mode`. The new post request requires `verify_mode`.

Signed-off-by: Jared Quick <jquick@chef.io>