### PR TITLE
cmp should recognise a string being a negative int (#3007)

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -269,7 +269,7 @@ end
 RSpec::Matchers.define :cmp do |first_expected| # rubocop:disable Metrics/BlockLength
 
   def integer?(value)
-    !(value =~ /\A0+\Z|\A[1-9]\d*\Z/).nil?
+    !(value =~ /\A-?0+\Z|\A-?[1-9]\d*\Z/).nil?
   end
 
   def float?(value)

--- a/test/integration/default/controls/cmp_matcher_spec.rb
+++ b/test/integration/default/controls/cmp_matcher_spec.rb
@@ -71,6 +71,19 @@ if os.linux?
     it { should_not cmp >= 13 }
   end
 
+  describe '-12' do
+    it { should cmp -12 }
+    it { should cmp < -11 }
+    it { should cmp > -13 }
+    it { should_not cmp < -12 }
+    it { should_not cmp > -12 }
+    it { should cmp <= -12 }
+    it { should cmp >= -12 }
+    it { should cmp >= -666 }
+    it { should_not cmp <= -13 }
+    it { should_not cmp >= -11 }
+  end
+
   # versions
   describe '2.4.12' do
     it { should cmp == '2.4.12' }


### PR DESCRIPTION
backports the fix for #3005 to inspec 1.x

Signed-off-by: James Stocks <jstocks@chef.io>