### PR TITLE
Add A2 support for profile compliance depends

### DIFF
--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -62,7 +62,8 @@ module Compliance
       config['token'] = Compliance::API.get_token(config)
 
       # Needed for automate2 post request
-      config['profile'] = Compliance::API.profile_split(profile)
+      profile_stub = profile || target[:compliance]
+      config['profile'] = Compliance::API.profile_split(profile_stub)
 
       new(profile_fetch_url, config)
     rescue URI::Error => _e

--- a/test/unit/bundles/inspec-compliance/target_test.rb
+++ b/test/unit/bundles/inspec-compliance/target_test.rb
@@ -50,4 +50,29 @@ describe Compliance::Fetcher do
       proc { fetcher.send(:compliance_profile_name) }.must_raise RuntimeError
     end
   end
+
+  describe 'when the server calls a automate profile' do
+    before do
+      Compliance::Configuration.expects(:new).returns({ 'token' => "123abc" })
+    end
+
+    it 'returns the correct profile name when parsing url' do
+      Compliance::API.stubs(:exist?).returns(true)
+      fetcher = Compliance::Fetcher.resolve('compliance://admin/ssh-baseline')
+      assert = ["admin", "ssh-baseline", nil]
+      fetcher.instance_variable_get(:"@config")['profile'].must_equal assert
+    end
+
+    it 'returns the correct profile name when parsing compliance hash' do
+      Compliance::API.stubs(:exist?).returns(true)
+      hash = {
+        target: "https://a2.instance.com/api/v0/compliance/tar",
+        compliance: "admin/ssh-baseline",
+        sha256: "132j1kjdasfasdoaefaewo12312",
+      }
+      fetcher = Compliance::Fetcher.resolve(hash)
+      assert = ["admin", "ssh-baseline", nil]
+      fetcher.instance_variable_get(:"@config")['profile'].must_equal assert
+    end
+  end
 end


### PR DESCRIPTION
This change allows A2 compliance services to properly function when defined as a profile dependency.

This allows you to run:
```
depends:
  - name: ssh-baseline
    compliance: admin/ssh-baseline
```
in a profile wrapper and work correctly with A2

Signed-off-by: Jared Quick <jquick@chef.io>