### PR TITLE
1.x - Adjust version test to allow for inspec 2.x being available

### DIFF
--- a/test/functional/inspec_test.rb
+++ b/test/functional/inspec_test.rb
@@ -39,7 +39,7 @@ describe 'command tests' do
       out = inspec('version')
       out.stderr.must_equal ''
       out.exit_status.must_equal 0
-      out.stdout.must_equal Inspec::VERSION+"\n"
+      out.stdout.must_match /^#{Inspec::VERSION}\n\nYour version of InSpec is out of date! The latest version is [0-9\.]*\n$/
     end
 
     it 'prints the version as JSON when the format is specified as JSON' do


### PR DESCRIPTION
The test for `inspec version` fails on the 1.x branch because it does not allow for the extra "new version available" text that correctly appears now that inspec 2.x is released.
This commit adjusts the test to expect a newer version notification.

Signed-off-by: James Stocks <jstocks@chef.io>