### PR TITLE
Correct Windows Feature state detection

### DIFF
--- a/lib/resources/windows_feature.rb
+++ b/lib/resources/windows_feature.rb
@@ -40,6 +40,10 @@ module Inspec::Resources
       @feature = feature
       @cache = nil
 
+	  module_cmd = "if (!(get-module servermanager)){ import-module servermanager}"
+      cmd = inspec.command(module_cmd)
+	  cmd.stdout
+	  
       # verify that this resource is only supported on Windows
       return skip_resource 'The `windows_feature` resource is not supported on your OS.' if !inspec.os.windows?
     end

--- a/lib/resources/windows_feature.rb
+++ b/lib/resources/windows_feature.rb
@@ -40,10 +40,10 @@ module Inspec::Resources
       @feature = feature
       @cache = nil
 
-	  module_cmd = "if (!(get-module servermanager)){ import-module servermanager}"
+      module_cmd = 'if (!(get-module servermanager)){ import-module servermanager}'
       cmd = inspec.command(module_cmd)
-	  cmd.stdout
-	  
+      cmd.stdout
+
       # verify that this resource is only supported on Windows
       return skip_resource 'The `windows_feature` resource is not supported on your OS.' if !inspec.os.windows?
     end


### PR DESCRIPTION
When using inspec on Windows 2016 server found that the windows feature always marked feature as not installed.  Looked into it and found the command doesn't import server manager.  This changes loads server manager on init if required.  The Get-WindowsFeature then works and correctly identifies a WIndows Feature as installed Get-WindowsFeature

Edit (@clintoncwolfe): Move title to description