### PR TITLE
Fix the A2 vendoring with depends on the A2 server

### DIFF
--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -96,6 +96,12 @@ module Compliance
             %r{^#{@config['server']}/owners/(?<owner>[^/]+)/compliance/(?<id>[^/]+)/tar$}
           end.match(@target)
 
+      if Compliance::API.is_automate2_server?(@config)
+        m = {}
+        m[:owner] = @config['profile'][0]
+        m[:id] = @config['profile'][1]
+      end
+
       raise 'Unable to determine compliance profile name. This can be caused by ' \
         'an incorrect server in your configuration. Try to login to compliance ' \
         'via the `inspec compliance login` command.' if m.nil?

--- a/test/unit/bundles/inspec-compliance/target_test.rb
+++ b/test/unit/bundles/inspec-compliance/target_test.rb
@@ -3,6 +3,16 @@ require 'helper'
 describe Compliance::Fetcher do
   let(:config) { { 'server' => 'myserver' } }
 
+  describe 'when the server is an automate2 server' do
+    before { Compliance::API.expects(:is_automate2_server?).with(config).returns(true) }
+
+    it 'returns the correct owner and profile name' do
+      config['profile'] = ['admin', 'ssh-baseline', nil]
+      fetcher = Compliance::Fetcher.new('myserver/profile', config)
+      fetcher.send(:compliance_profile_name).must_equal 'admin/ssh-baseline'
+    end
+  end
+
   describe 'when the server is an automate server pre-0.8.0' do
     before { Compliance::API.expects(:is_automate_server_pre_080?).with(config).returns(true) }
 


### PR DESCRIPTION
There is a issue pulling the profile info when vendoring on the A2 server. This fixes the issue by pulling the profile owner and id from the profile tag instead of the url.

Signed-off-by: Jared Quick <jquick@chef.io>