### PR TITLE
Allow the depends key to be exposed in json profiles report

### DIFF
--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -105,6 +105,7 @@ module Inspec::Reporters
           copyright_email: p[:copyright_email],
           supports: p[:supports],
           attributes: p[:attributes],
+          depends: p[:depends],
           groups: profile_groups(p),
           controls: profile_controls(p),
         }

--- a/test/unit/reporters/json_test.rb
+++ b/test/unit/reporters/json_test.rb
@@ -34,6 +34,22 @@ describe Inspec::Reporters::Json do
     end
   end
 
+  describe 'report output includes depends' do
+    it 'sets the depends key' do
+      depends = {
+        depends: {
+          'path' => '../child',
+          'name' => 'child',
+        }
+      }
+      data = JSON.parse(File.read(path + '/../mock/reporters/run_data.json'), symbolize_names: true)
+      data[:profiles].first[:depends] = depends
+      json_report = Inspec::Reporters::Json.new({ run_data: data })
+
+      json_report.report[:profiles].first[:depends].must_equal depends
+    end
+  end
+
   describe '#profile_results' do
     it 'confirm profile_results output' do
       hash = {


### PR DESCRIPTION
This change allows the depends key to show up under the profiles if you have dependencies. This change allows A2 to accurately parse and digest dependent profiles. @alexpop has already confirmed the changes on this branch are working as expected for him.