### PR TITLE
Allow the depends key to be exposed in json profiles report 1.x

### DIFF
--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -127,6 +127,7 @@ module Inspec::Reporters
           copyright_email: p[:copyright_email],
           supports: p[:supports],
           attributes: p[:attributes],
+          depends: p[:depends],
           groups: profile_groups(p),
           controls: profile_controls(p),
         }

--- a/test/functional/inspec_compliance_test.rb
+++ b/test/functional/inspec_compliance_test.rb
@@ -27,7 +27,7 @@ describe 'inspec compliance' do
     # This will be fixed in the 1.0 release of Thor
     # See: https://github.com/erikhuda/thor/issues/244
     out.exit_status.must_equal 0
-    out.stderr.must_include 'ERROR: "inspec login" was called with no arguments'
+    out.stderr.must_include 'ERROR: "inspec compliance login" was called with no arguments'
   end
 
   it 'inspec compliance profiles without authentication' do
@@ -38,7 +38,7 @@ describe 'inspec compliance' do
 
   it 'try to upload a profile without directory' do
     out = inspec('compliance upload')
-    out.stderr.must_include 'ERROR: "inspec upload" was called with no arguments'
+    out.stderr.must_include 'ERROR: "inspec compliance upload" was called with no arguments'
     out.exit_status.must_equal 0
   end
 

--- a/test/unit/reporters/json_test.rb
+++ b/test/unit/reporters/json_test.rb
@@ -34,6 +34,22 @@ describe Inspec::Reporters::Json do
     end
   end
 
+  describe 'report output includes depends' do
+    it 'sets the depends key' do
+      depends = {
+        depends: {
+          'path' => '../child',
+          'name' => 'child',
+        }
+      }
+      data = JSON.parse(File.read(path + '/../mock/reporters/run_data.json'), symbolize_names: true)
+      data[:profiles].first[:depends] = depends
+      json_report = Inspec::Reporters::Json.new({ run_data: data })
+
+      json_report.report[:profiles].first[:depends].must_equal depends
+    end
+  end
+
   describe '#controls' do
     it 'confirm control output' do
       hash = {


### PR DESCRIPTION
This is the 1.x bug release for:
https://github.com/chef/inspec/pull/3033


This change allows the depends key to show up under the profiles if you have dependencies. This change allows A2 to accurately parse and digest dependent profiles. @alexpop has already confirmed the changes on this branch are working as expected for him.

Signed-off-by: Jared Quick <jquick@chef.io>