### PR TITLE
Add git dependency to habitat plan.

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -20,6 +20,7 @@ pkg_deps=(
   core/bind
   core/curl
   core/docker
+  core/git
   core/less
   core/mysql-client
   core/netcat


### PR DESCRIPTION
I ran into the same error as https://github.com/chef/inspec/issues/1270 today while using the inspec hab package. Since there are already dependencies on things like mysql and postgres to support various inspec features, git seemed like something that should be there.