### PR TITLE
handle nil properties in iis_site

### DIFF
--- a/lib/resources/iis_site.rb
+++ b/lib/resources/iis_site.rb
@@ -40,19 +40,19 @@ module Inspec::Resources
     end
 
     def app_pool
-      iis_site[:app_pool]
+      iis_site.nil? ? nil : iis_site[:app_pool]
     end
 
     def bindings
-      iis_site[:bindings]
+      iis_site.nil? ? nil : iis_site[:bindings]
     end
 
     def state
-      iis_site[:state]
+      iis_site.nil? ? nil : iis_site[:state]
     end
 
     def path
-      iis_site[:path]
+      iis_site.nil? ? nil : iis_site[:path]
     end
 
     def exists?

--- a/test/integration/default/controls/iis_site_spec.rb
+++ b/test/integration/default/controls/iis_site_spec.rb
@@ -33,7 +33,7 @@ describe iis_website('Default Web Site') do
 end
 
 describe iis_app('/TestApp', 'Default Web Site') do
-  it { sould exist }
+  it { should exist }
   it { should have_application_pool('DefaultAppPool') }
   it { should have_protocols('http') }
   it { should have_site_name('Default Web Site') }

--- a/test/integration/default/controls/iis_site_spec.rb
+++ b/test/integration/default/controls/iis_site_spec.rb
@@ -40,3 +40,12 @@ describe iis_app('/TestApp', 'Default Web Site') do
   it { should have_physical_path('C:\\inetpub\\wwwroot\\Test') }
   it { should have_path('\\TestApp') }
 end
+
+# test testing a non existing website
+describe iis_site('DeletedSite') do
+  it { should_not exist }
+  its('app_pool') { should eq nil }
+  its('bindings') { should eq nil }
+  its('state') { should eq nil }
+  its('path') { should eq nil }
+end


### PR DESCRIPTION
As it stands we get a ``undefined method `[]' for nil:NilClass`` error if the following test is run after deleting Default Web Site:

```
describe iis_site("Default Web Site") do
  its('bindings') { should eq nil }
end
```

This change returns `nil` instead of trying to index into `nil`.

It also fixes a typo in iis_site_spec.