### PR TITLE
Fix matcher output when the args to the matcher are a hash for two resources

### DIFF
--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -93,8 +93,9 @@ class AwsIamPolicy < Inspec.resource(1)
     end
   end
 
-  def has_statement?(raw_criteria = {})
+  def has_statement?(provided_criteria = {})
     return nil unless exists?
+    raw_criteria = provided_criteria.dup # provided_criteria is used for output formatting - can't delete from it.
     criteria = has_statement__normalize_criteria(has_statement__validate_criteria(raw_criteria))
     @normalized_statements ||= has_statement__normalize_statements
     statements = has_statement__focus_on_sid(@normalized_statements, criteria)

--- a/lib/resources/aws/aws_security_group.rb
+++ b/lib/resources/aws/aws_security_group.rb
@@ -19,22 +19,22 @@ class AwsSecurityGroup < Inspec.resource(1)
   end
 
   def allow_in?(criteria = {})
-    allow(inbound_rules, criteria)
+    allow(inbound_rules, criteria.dup)
   end
   RSpec::Matchers.alias_matcher :allow_in, :be_allow_in
 
   def allow_out?(criteria = {})
-    allow(outbound_rules, criteria)
+    allow(outbound_rules, criteria.dup)
   end
   RSpec::Matchers.alias_matcher :allow_out, :be_allow_out
 
   def allow_in_only?(criteria = {})
-    allow_only(inbound_rules, criteria)
+    allow_only(inbound_rules, criteria.dup)
   end
   RSpec::Matchers.alias_matcher :allow_in_only, :be_allow_in_only
 
   def allow_out_only?(criteria = {})
-    allow_only(outbound_rules, criteria)
+    allow_only(outbound_rules, criteria.dup)
   end
   RSpec::Matchers.alias_matcher :allow_out_only, :be_allow_out_only
 


### PR DESCRIPTION
Fixes #2925 

2925 indicated that reporters would output an empty hash when a matcher that accepted hash arguments was used.  It turned out that works fine - it's just that two resources, `aws_iam_security_group` and `aws_iam_policy` were both using Hash#delete to whitelist criteria in matchers, without `dup`ing the Hash.  So, if all went well, the input hash would be emptied; and the reporter would faithfully include an empty hash in the test description.

This fix simply adds `dup` calls to the matcher hash arguments.  To test, run the AWS integration tests and observe test output for the two affected resources.

