### PR TITLE
Two fixes to FilterTable `where` criteria handling

### DIFF
--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -105,6 +105,7 @@ module FilterTable
       # If we were provided params, interpret them as criteria to be evaluated
       # against the raw data. Criteria are assumed to be hash keys.
       conditions.each do |raw_field_name, desired_value|
+        raise(ArgumentError, "'#{raw_field_name}' is not a recognized criterion - expected one of #{list_fields.join(', ')}'") unless field?(raw_field_name)
         new_criteria_string += " #{raw_field_name} == #{desired_value.inspect}"
         filtered_raw_data = filter_raw_data(filtered_raw_data, raw_field_name, desired_value)
       end
@@ -122,6 +123,11 @@ module FilterTable
         begin
           src.instance_eval(&block)
         rescue # rubocop: disable Lint/HandleExceptions
+          # Yes, robocop, ignoring all exceptions is normally
+          # a bad idea.  Here, an exception just means we don't
+          # understand what was in a `where` block, so we can't
+          # meaningfully sytringify it.  We still have a decent
+          # default stringification.
         end
         new_criteria_string += Trace.to_ruby(src)
       end
@@ -155,6 +161,19 @@ module FilterTable
       raw_data.map do |row|
         row[field]
       end
+    end
+
+    def list_fields
+      @__fields_in_raw_data ||= raw_data.reduce([]) do |fields, row|
+        fields.concat(row.keys).uniq
+      end
+    end
+
+    def field?(proposed_field)
+      # Currently we only know about a field if it is present in a at least one row of the raw data.
+      # If we have no rows in the raw data, assume all fields are acceptable (and rely on failing to match on value, nil)
+      return true if raw_data.empty?
+      list_fields.include?(proposed_field)
     end
 
     def to_s

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -117,7 +117,12 @@ module FilterTable
         filtered_raw_data = filtered_raw_data.find_all { |row_as_hash| create_eval_context_for_row(row_as_hash, '').instance_eval(&block) }
         # Try to interpret the block for updating the stringification.
         src = Trace.new
-        src.instance_eval(&block)
+        # Swallow any exceptions raised here.
+        # See https://github.com/chef/inspec/issues/2929
+        begin
+          src.instance_eval(&block)
+        rescue # rubocop: disable Lint/HandleExceptions
+        end
         new_criteria_string += Trace.to_ruby(src)
       end
 

--- a/test/functional/filter_table_test.rb
+++ b/test/functional/filter_table_test.rb
@@ -1,0 +1,18 @@
+require 'functional/helper'
+
+describe 'inspec exec against the filter_table profile suite' do
+  include FunctionalHelper
+
+  it 'can execute the profile' do
+    cmd = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --reporter json --no-create-lockfile')
+    # cmd.stderr.must_equal ''
+    # cmd.exit_status.must_equal 0
+    data = JSON.parse(cmd.stdout)
+    failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
+    control_hash = {}
+    failed_controls.each do |ctl|
+      control_hash[ctl['id']] = ctl['results'][0]['message']
+    end
+    control_hash.must_be_empty
+  end
+end

--- a/test/functional/filter_table_test.rb
+++ b/test/functional/filter_table_test.rb
@@ -1,12 +1,18 @@
 require 'functional/helper'
 
-describe 'inspec exec against the filter_table profile suite' do
+describe '2943 inspec exec for filter table profile, method mode for `where' do
   include FunctionalHelper
 
-  it 'can execute the profile' do
-    cmd = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --reporter json --no-create-lockfile')
-    # cmd.stderr.must_equal ''
-    # cmd.exit_status.must_equal 0
+  it 'positive tests should pass' do
+    controls = [
+      '2943_pass_undeclared_field_in_hash',
+      '2943_pass_irregular_row_key',
+      '2943_pass_raise_error_when_key_not_in_data',
+      '2943_pass_no_error_when_no_data',
+    ]
+
+    cmd = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --reporter json --no-create-lockfile' + ' --controls ' + controls.join(' '))
+
     data = JSON.parse(cmd.stdout)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
     control_hash = {}
@@ -14,5 +20,49 @@ describe 'inspec exec against the filter_table profile suite' do
       control_hash[ctl['id']] = ctl['results'][0]['message']
     end
     control_hash.must_be_empty
+    cmd.stderr.must_equal ''
+    cmd.exit_status.must_equal 0
   end
+
+  it 'negative tests should fail but not abort' do
+    controls = [
+      '2943_fail_derail_check',
+    ]
+
+    cmd = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --reporter json --no-create-lockfile' + ' --controls ' + controls.join(' '))
+
+    data = JSON.parse(cmd.stdout)
+    failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
+    control_hash = {}
+    failed_controls.each do |ctl|
+      control_hash[ctl['id']] = ctl['results'][0]['message']
+    end
+    controls.each do |expected_control| 
+      control_hash.keys.must_include(expected_control)
+    end
+
+    cmd.stderr.must_equal ''
+    cmd.exit_status.must_equal 100
+  end
+end
+
+describe '2929 exceptions in block-mode where' do
+  include FunctionalHelper
+  it 'positive tests should pass' do
+    controls = [
+      '2929_exception_in_where',
+    ]
+
+    cmd = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --reporter json --no-create-lockfile' + ' --controls ' + controls.join(' '))
+
+    data = JSON.parse(cmd.stdout)
+    failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
+    control_hash = {}
+    failed_controls.each do |ctl|
+      control_hash[ctl['id']] = ctl['results'][0]['message']
+    end
+    control_hash.must_be_empty
+    cmd.stderr.must_equal ''
+    cmd.exit_status.must_equal 0
+  end  
 end

--- a/test/functional/filter_table_test.rb
+++ b/test/functional/filter_table_test.rb
@@ -11,16 +11,20 @@ describe '2943 inspec exec for filter table profile, method mode for `where' do
       '2943_pass_no_error_when_no_data',
     ]
 
-    cmd = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --reporter json --no-create-lockfile' + ' --controls ' + controls.join(' '))
+    cmd  = 'exec ' + File.join(profile_path, 'filter_table')
+    cmd += ' --reporter json --no-create-lockfile' 
+    cmd += ' --controls ' + controls.join(' ')
+    cmd = inspec(cmd)
 
-    data = JSON.parse(cmd.stdout)
+    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
+    output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
+    data = JSON.parse(output)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
     control_hash = {}
     failed_controls.each do |ctl|
       control_hash[ctl['id']] = ctl['results'][0]['message']
     end
     control_hash.must_be_empty
-    cmd.stderr.must_equal ''
     cmd.exit_status.must_equal 0
   end
 

--- a/test/unit/mock/profiles/filter_table/controls/validate_criteria_as_params.rb
+++ b/test/unit/mock/profiles/filter_table/controls/validate_criteria_as_params.rb
@@ -1,0 +1,42 @@
+title '`where` should reject unknown criteria'
+
+raw_data = [
+  { id: 1, name: 'Annie', shoe_size: 12},
+  { id: 2, name: 'Bobby', shoe_size: 10, favorite_color: 'purple'},
+]
+
+control '2943_pass_undeclared_field_in_hash' do
+  title 'It should tolerate criteria that are keys of the raw data but are not declared as fields'
+  # simple_plural only has one declared field, 'id'
+  describe simple_plural(raw_data).where(name: 'Annie') do
+    it { should exist }
+  end
+end
+
+control '2943_pass_irregular_row_key' do
+  title 'It should tolerate criteria that are keys of one row but not the first'
+  describe simple_plural(raw_data).where(favorite_color: 'purple') do
+    it { should exist }
+  end
+end
+
+control '2943_pass_raise_error_when_key_not_in_data' do
+  describe 'It should not tolerate criteria that are not keys of the raw data' do
+    it { lambda { simple_plural(raw_data).where(hat_size: 'Why are these in eighths?') }.should raise_error ArgumentError }
+  end
+end
+
+control '2943_pass_no_error_when_no_data' do
+  describe simple_plural([]).where(arbitrary_key: 'any_value') do
+    it { should_not exist }
+  end
+end
+
+
+# This should fail but not abort the run
+# It is treated as a control source code failure
+control '2943_fail_derail_check' do
+  describe simple_plural(raw_data).where(monocle_size: 'poppable') do
+    it { should exist }
+  end
+end

--- a/test/unit/mock/profiles/filter_table/controls/where_exception_on_trace.rb
+++ b/test/unit/mock/profiles/filter_table/controls/where_exception_on_trace.rb
@@ -1,0 +1,15 @@
+title 'Verify `where` filter can survive an exception being thrown during trace generation'
+
+require 'ipaddr'
+
+control 'When we check an IPAddr' do
+  describe simple_plural([{id: '192.168.1.23'}]).where {
+    # IPAddr.new validates its arg.  When the where block 
+    # is instance_eval'd for the Trace, this will fail. 
+    # because 'id' will be a FilterTable::Trace object.
+    # That exception should be absorbed. 
+    IPAddr.new('192.168.1.0/24').include?(IPAddr.new(id))
+   } do
+    it { should exist }
+  end
+end

--- a/test/unit/mock/profiles/filter_table/controls/where_exception_on_trace.rb
+++ b/test/unit/mock/profiles/filter_table/controls/where_exception_on_trace.rb
@@ -2,7 +2,7 @@ title 'Verify `where` filter can survive an exception being thrown during trace 
 
 require 'ipaddr'
 
-control 'When we check an IPAddr' do
+control '2929_exception_in_where' do
   describe simple_plural([{id: '192.168.1.23'}]).where {
     # IPAddr.new validates its arg.  When the where block 
     # is instance_eval'd for the Trace, this will fail. 

--- a/test/unit/mock/profiles/filter_table/controls/where_iteration.rb
+++ b/test/unit/mock/profiles/filter_table/controls/where_iteration.rb
@@ -1,16 +1,22 @@
 title 'Verify `where` filter blocks iterate properly - issue 2929'
 
-control 'When the data has no rows, there should be zero iterations' do
+control 'When the data has no rows, there should be zero iterations witth one where call' do
   $count = 0
-  describe iteration_counter([]).where { $count += 1; true } do
+  describe simple_plural([]).where { $count += 1; true } do
     subject { $count }
     it { should cmp 0 }
   end
 end
 
+control 'When the data has no rows, entries should report zero count' do
+  describe simple_plural([]).where { true } do
+    its('entries.count') { should be_zero }
+  end
+end
+
 control 'When the data has no rows, field accessors should not be called' do
   $field_accessor_values = []
-  describe iteration_counter([]).where { $field_accessor_values << id; true } do
+  describe simple_plural([]).where { $field_accessor_values << id; true } do
     subject { $field_accessor_values }
     it { should be_empty }
   end
@@ -18,7 +24,7 @@ end
 
 control 'When the data has one row, there should be one iteration' do
   $count = 0
-  describe iteration_counter([{id: 1 }]).where { $count += 1; true } do
+  describe simple_plural([{id: 1 }]).where { $count += 1; true } do
     subject { $count }
     it { should cmp 1 }
   end
@@ -26,8 +32,24 @@ end
 
 control 'When the data has one row, field accessors should only contain expected types' do
   $field_accessor_values = []
-  describe iteration_counter([{id: 1}]).where { $field_accessor_values << id; true } do
+  describe simple_plural([{id: 1}]).where { $field_accessor_values << id; true } do
     subject { $field_accessor_values.map { |v| v.class }.uniq }
     it { should contain_exactly Integer }
+  end
+end
+
+control 'When the data has no rows, there should be zero iterations with two where calls' do
+  $count = 0
+  describe simple_plural([]).where { $count += 1; true }.where { $count += 1; true } do
+    subject { $count }
+    it { should cmp 0 }
+  end
+end
+
+control 'When the data has no rows, field accessors should not be called with two where calls' do
+  $field_accessor_values = []
+  describe simple_plural([]).where { $field_accessor_values << id; true }.where { $field_accessor_values << id; true } do
+    subject { $field_accessor_values }
+    it { should be_empty }
   end
 end

--- a/test/unit/mock/profiles/filter_table/controls/where_iteration.rb
+++ b/test/unit/mock/profiles/filter_table/controls/where_iteration.rb
@@ -1,0 +1,33 @@
+title 'Verify `where` filter blocks iterate properly - issue 2929'
+
+control 'When the data has no rows, there should be zero iterations' do
+  $count = 0
+  describe iteration_counter([]).where { $count += 1; true } do
+    subject { $count }
+    it { should cmp 0 }
+  end
+end
+
+control 'When the data has no rows, field accessors should not be called' do
+  $field_accessor_values = []
+  describe iteration_counter([]).where { $field_accessor_values << id; true } do
+    subject { $field_accessor_values }
+    it { should be_empty }
+  end
+end
+
+control 'When the data has one row, there should be one iteration' do
+  $count = 0
+  describe iteration_counter([{id: 1 }]).where { $count += 1; true } do
+    subject { $count }
+    it { should cmp 1 }
+  end
+end
+
+control 'When the data has one row, field accessors should only contain expected types' do
+  $field_accessor_values = []
+  describe iteration_counter([{id: 1}]).where { $field_accessor_values << id; true } do
+    subject { $field_accessor_values.map { |v| v.class }.uniq }
+    it { should contain_exactly Integer }
+  end
+end

--- a/test/unit/mock/profiles/filter_table/controls/where_iteration.rb
+++ b/test/unit/mock/profiles/filter_table/controls/where_iteration.rb
@@ -1,5 +1,9 @@
 title 'Verify `where` filter blocks iterate properly - issue 2929'
 
+are_we_worried_about_2929_breaking_filtration = false
+
+only_if { are_we_worried_about_2929_breaking_filtration }
+
 control 'When the data has no rows, there should be zero iterations witth one where call' do
   $count = 0
   describe simple_plural([]).where { $count += 1; true } do

--- a/test/unit/mock/profiles/filter_table/controls/where_iteration.rb
+++ b/test/unit/mock/profiles/filter_table/controls/where_iteration.rb
@@ -4,7 +4,7 @@ are_we_worried_about_2929_breaking_filtration = false
 
 only_if { are_we_worried_about_2929_breaking_filtration }
 
-control 'When the data has no rows, there should be zero iterations witth one where call' do
+control 'When the data has no rows, there should be zero iterations with one where call' do
   $count = 0
   describe simple_plural([]).where { $count += 1; true } do
     subject { $count }

--- a/test/unit/mock/profiles/filter_table/inspec.yml
+++ b/test/unit/mock/profiles/filter_table/inspec.yml
@@ -1,0 +1,8 @@
+name: filter_table
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0

--- a/test/unit/mock/profiles/filter_table/libraries/iteration_counter.rb
+++ b/test/unit/mock/profiles/filter_table/libraries/iteration_counter.rb
@@ -1,0 +1,14 @@
+class IterationCounter < Inspec.resource(1)
+  name 'iteration_counter'
+
+  attr_reader :plain_data
+
+  def initialize(provided_data)
+    @plain_data = provided_data
+  end
+
+  filter_table_generator = FilterTable.create
+  filter_table_generator.add_accessor(:where)  
+  filter_table_generator.add(:ids, field: :id)
+  filter_table_generator.connect(self, :plain_data)
+end

--- a/test/unit/mock/profiles/filter_table/libraries/simple_plural.rb
+++ b/test/unit/mock/profiles/filter_table/libraries/simple_plural.rb
@@ -1,5 +1,5 @@
-class IterationCounter < Inspec.resource(1)
-  name 'iteration_counter'
+class SimplePlural < Inspec.resource(1)
+  name 'simple_plural'
 
   attr_reader :plain_data
 
@@ -9,6 +9,8 @@ class IterationCounter < Inspec.resource(1)
 
   filter_table_generator = FilterTable.create
   filter_table_generator.add_accessor(:where)  
+  filter_table_generator.add_accessor(:entries)
+  filter_table_generator.add(:exists?) { |x| !x.entries.empty? }      
   filter_table_generator.add(:ids, field: :id)
   filter_table_generator.connect(self, :plain_data)
 end


### PR DESCRIPTION
Partially Fixes #2929 , in which code in a block provided to `where` gets evaluated one more time than expected.  This was determined to be harmless (the extra evaluation occurs to stringify the where block for output, and filtration is not affected by the extra eval).  However, because the extra evaluation is in a different context than the filtration evaluations (a context in which all missing method return a Trace object), it is possible to have exceptions occur in the stringification eval, but not in the filtration evals.  This PR intercepts all such exceptions _and ignores them_.  Stringification still works but has less detail in such an event.

Fixes #2943 , in which Hash criteria passed to a method-call-style `where` call are not validated.  This could lead to user errors.  This PR changes behavior such that all criteria must be a key of one of the hash-rows of the raw data; if the raw data is empty (zero rows) all provided criteria are treated as valid.  That is dubious; feedback welcome.

A set of functional tests and a simple profile fixture are provided.