### PR TITLE
Add train GCP transport

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,11 @@
 source 'https://supermarket.chef.io'
 
 cookbook 'apt'
+cookbook 'yum'
+cookbook 'postgresql'
+cookbook 'docker'
+cookbook 'yum-epel'
+cookbook 'packagecloud'
 cookbook 'os_prepare', path: './test/cookbooks/os_prepare'
 cookbook 'runit', github: 'hw-cookbooks/runit'
 cookbook 'ssh-hardening', git: 'https://github.com/dev-sec/chef-ssh-hardening.git'

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :test do
 end
 
 group :integration do
-  gem 'berkshelf', '~> 4.3'
+  gem 'berkshelf', '~> 5.2'
   gem 'test-kitchen', '~> 1.6'
   gem 'kitchen-vagrant'
   # we need winrm v2 support >= 0.15.1

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'train', '~> 1.4'
+  spec.add_dependency 'train', '~> 1.4.9'
   spec.add_dependency 'thor', '~> 0.20'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'method_source', '~> 0.8'

--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -42,6 +42,10 @@ override 'ruby', version: '2.4.3'
 # This issue is not evident in 2.6.x, hence the pin.
 override 'rubygems', version: '2.6.14'
 
+# grab the current train release from rubygems.org
+train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
+override 'train', version: "v#{train_stable}"
+
 dependency 'preparation'
 
 dependency 'inspec'

--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -25,6 +25,7 @@ dependency 'bundler'
 dependency 'rb-readline'
 dependency 'appbundler'
 dependency 'unf_ext'
+dependency 'train'
 
 license :project_license
 


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This change includes the Train pin for the new GCP features as well as a berkshelf update which is needed to support it.

This is manually testing of Train master for now. Will be updated once the Train gem is released.