### PR TITLE
Rename Plugin::name to Plugin::register

### DIFF
--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -11,7 +11,7 @@ require 'inspec/errors'
 # similar to `inspec exec http://localhost:2134/owners/%base%/compliance/%ssh%/tar --user %token%`
 module Compliance
   class Fetcher < Fetchers::Url
-    name 'compliance'
+    register 'compliance'
     priority 500
     def self.resolve(target) # rubocop:disable PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize
       uri = if target.is_a?(String) && URI(target).scheme == 'compliance'

--- a/lib/bundles/inspec-supermarket/target.rb
+++ b/lib/bundles/inspec-supermarket/target.rb
@@ -9,7 +9,7 @@ require 'fetchers/url'
 # InSpec Target Helper for Supermarket
 module Supermarket
   class Fetcher < Inspec.fetcher(1)
-    name 'supermarket'
+    register 'supermarket'
     priority 500
 
     def self.resolve(target, opts = {})

--- a/lib/fetchers/git.rb
+++ b/lib/fetchers/git.rb
@@ -25,7 +25,7 @@ module Fetchers
   # omnibus source for hints.
   #
   class Git < Inspec.fetcher(1)
-    name 'git'
+    register 'git'
     priority 200
 
     def self.resolve(target, opts = {})

--- a/lib/fetchers/local.rb
+++ b/lib/fetchers/local.rb
@@ -6,7 +6,7 @@ require 'openssl'
 
 module Fetchers
   class Local < Inspec.fetcher(1)
-    name 'local'
+    register 'local'
     priority 0
 
     def self.resolve(target)

--- a/lib/fetchers/mock.rb
+++ b/lib/fetchers/mock.rb
@@ -4,7 +4,7 @@
 
 module Fetchers
   class Mock < Inspec.fetcher(1)
-    name 'mock'
+    register 'mock'
     priority 0
 
     def self.resolve(target)

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -16,7 +16,7 @@ module Fetchers
       'application/gzip' => '.tar.gz',
     }.freeze
 
-    name 'url'
+    register 'url'
     priority 200
 
     def self.resolve(target, opts = {})

--- a/lib/inspec/secrets/yaml.rb
+++ b/lib/inspec/secrets/yaml.rb
@@ -4,7 +4,7 @@ require 'yaml'
 
 module Secrets
   class YAML < Inspec.secrets(1)
-    name 'yaml'
+    register 'yaml'
 
     attr_reader :attributes
 

--- a/lib/source_readers/flat.rb
+++ b/lib/source_readers/flat.rb
@@ -7,7 +7,7 @@ require 'inspec/metadata'
 
 module SourceReaders
   class Flat < Inspec.source_reader(1)
-    name 'flat'
+    register 'flat'
     priority 5
 
     def self.resolve(target)

--- a/lib/source_readers/inspec.rb
+++ b/lib/source_readers/inspec.rb
@@ -7,7 +7,7 @@ require 'inspec/metadata'
 
 module SourceReaders
   class InspecReader < Inspec.source_reader(1)
-    name 'inspec'
+    register 'inspec'
     priority 10
 
     def self.resolve(target)

--- a/lib/utils/plugin_registry.rb
+++ b/lib/utils/plugin_registry.rb
@@ -46,7 +46,7 @@ class PluginRegistry
     #
     # @param [String] the unique name of this plugin
     # @return [nil] disregard
-    def self.name(name)
+    def self.register(name)
       raise "Trying to register #{self} with name == nil" if name.nil?
       @name = name
       plugin_registry.registry[name] = self


### PR DESCRIPTION
fixes #3055

The current method name `name` crashes pry (https://github.com/pry/pry/issues/1535)
Although that should be addressed in pry; `register` is a better self-describing name for the method anyway.

Signed-off-by: James Stocks <jstocks@chef.io>