### PR TITLE
Add a passthrough for report_uuid

### DIFF
--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -23,7 +23,7 @@ module Inspec::Reporters
       final_report[:node_uuid] = @config['node_uuid'] || @run_data[:platform][:uuid]
       raise Inspec::ReporterError, 'Cannot find a UUID for your node. Please specify one via json-config.' if final_report[:node_uuid].nil?
 
-      final_report[:report_uuid] = uuid_from_string(final_report[:end_time] + final_report[:node_uuid])
+      final_report[:report_uuid] = @config['report_uuid'] || uuid_from_string(final_report[:end_time] + final_report[:node_uuid])
 
       # optional json-config passthrough options
       %w{node_name environment roles recipies}.each do |option|

--- a/test/unit/reporters/automate_test.rb
+++ b/test/unit/reporters/automate_test.rb
@@ -11,6 +11,7 @@ describe Inspec::Reporters::Automate do
       'node_uuid' => "22ad2f99-f84f-5456-95a0-7e91b4b66690",
       'node_name' => "test_node",
       'environment' => "prod",
+      'report_uuid' => "22ad2f99-f84f-5456-95a0-7e91b4b12345",
     }
   end
   let(:report) do 
@@ -24,6 +25,7 @@ describe Inspec::Reporters::Automate do
       report.enriched_report[:node_uuid].must_equal "22ad2f99-f84f-5456-95a0-7e91b4b66690"
       report.enriched_report[:node_name].must_equal "test_node"
       report.enriched_report[:environment].must_equal "prod"
+      report.enriched_report[:report_uuid].must_equal "22ad2f99-f84f-5456-95a0-7e91b4b12345"
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

Adds a passthrough config option for automate report_uuid

This is needed for https://github.com/chef/a2/pull/2508
