### PR TITLE
Create separate hab package for use under Automate

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -12,7 +12,11 @@ docker_images:
         - GEM_SOURCE: http://artifactory.chef.co/omnibus-gems-local
 
 habitat_packages:
-  - inspec
+  - inspec:
+    source: habitat/inspec
+  - automate-inspec:
+    source: habitat/automate-inspec
+
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:

--- a/habitat/automate-inspec/README.md
+++ b/habitat/automate-inspec/README.md
@@ -2,7 +2,12 @@
 
 ## Purpose
 
-This Habitat package is used in Automate 2 and requires the use of additional non open source plugins such as `inspec-scap`.
+This Habitat package is used in Automate 2.  Its installation is mutually exclusive with `chef/inspec`.  It is a package of `inspec`, with the following modifications:
+
+1. The package is released under the Chef Master License and Services Agreement; this permits the use of proprietary (non-free) features.
+1. The binstub for inspec is modified to detect whether the license has been accepted.
+1. The inspec-scap plugin is installed.
+1. To harmonize with Automate, the postgresql library is version-pinned to match that needed by chef/automate-postgresql.
 
 ## Testing
 
@@ -11,5 +16,5 @@ From the root of the InSpec source code run the following:
 ```
 hab studio enter
 GITHUB_TOKEN='YOUR_USERNAME:YOUR_PERSONAL_ACCESS_TOKEN' build habitat/automate-inspec
-MLSA_ACCEPTED='true' hab pkg exec your_origin/automate-inspec inspec scap
+MLSA_ACCEPTED='true' hab pkg exec chef/automate-inspec inspec scap
 ```

--- a/habitat/automate-inspec/README.md
+++ b/habitat/automate-inspec/README.md
@@ -5,7 +5,7 @@
 This Habitat package is used in Automate 2.  Its installation is mutually exclusive with `chef/inspec`.  It is a package of `inspec`, with the following modifications:
 
 1. The package is released under the Chef Master License and Services Agreement; this permits the use of proprietary (non-free) features.
-1. The binstub for inspec is modified to detect whether the license has been accepted.
+1. The binstub for inspec is modified to detect whether the license has been accepted. If it has not been accepted, `inspec` will exit with exit code 19.  It will not block on input.
 1. The inspec-scap plugin is installed.
 1. To harmonize with Automate, the postgresql library is version-pinned to match that needed by chef/automate-postgresql.
 

--- a/habitat/automate-inspec/README.md
+++ b/habitat/automate-inspec/README.md
@@ -1,0 +1,15 @@
+# Automate InSpec Habitat Package
+
+## Purpose
+
+This Habitat package is used in Automate 2 and requires the use of additional non open source plugins such as `inspec-scap`.
+
+## Testing
+
+From the root of the InSpec source code run the following:
+
+```
+hab studio enter
+GITHUB_TOKEN='YOUR_USERNAME:YOUR_PERSONAL_ACCESS_TOKEN' build habitat/automate-inspec
+MLSA_ACCEPTED='true' hab pkg exec your_origin/automate-inspec inspec scap
+```

--- a/habitat/automate-inspec/plan.sh
+++ b/habitat/automate-inspec/plan.sh
@@ -1,0 +1,81 @@
+pkg_name=automate-inspec
+pkg_origin=chef
+pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
+pkg_description="InSpec packaged for use in Chef Automate"
+pkg_upstream_url=https://www.inspec.io/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Chef-MLSA")
+pkg_deps=(
+  core/busybox-static
+  core/cacerts
+  core/coreutils
+  core/libxml2
+  core/libxslt
+  core/net-tools
+  core/ruby
+
+  # Needed for some InSpec resources
+  core/bind
+  core/curl
+  core/docker
+  core/git
+  core/less
+  core/mysql-client
+  core/netcat
+)
+pkg_build_deps=(
+  core/gcc
+  core/git
+  core/make
+)
+pkg_bin_dirs=(bin)
+
+do_prepare() {
+  export GEM_HOME="$pkg_prefix/lib"
+  build_line "Setting GEM_HOME=$GEM_HOME"
+  export GEM_PATH="$GEM_HOME"
+  build_line "Setting GEM_PATH=$GEM_PATH"
+}
+
+do_unpack() {
+  export INSPEC_SCAP_SRC_CACHE="$HAB_CACHE_SRC_PATH/$pkg_dirname/inspec-scap"
+
+  build_line "Cloning InSpec SCAP source to $INSPEC_SCAP_SRC_CACHE"
+  mkdir -pv "$INSPEC_SCAP_SRC_CACHE"
+  git clone --depth=1 https://$GITHUB_TOKEN@github.com/chef/inspec-scap.git $INSPEC_SCAP_SRC_CACHE
+}
+
+do_build() {
+  pushd "$INSPEC_SCAP_SRC_CACHE"
+    gem build inspec-scap.gemspec
+  popd
+}
+
+do_install() {
+  pushd "$INSPEC_SCAP_SRC_CACHE"
+    gem install inspec-scap-*.gem
+  popd
+
+  wrap_inspec_bin
+}
+
+# Need to wrap the InSpec binary to ensure GEM_HOME/GEM_PATH is correct
+wrap_inspec_bin() {
+  local bin="$pkg_prefix/bin/inspec"
+  local real_bin="$GEM_HOME/gems/inspec-${pkg_version}/bin/inspec"
+  build_line "Adding wrapper $bin to $real_bin"
+  cat <<EOF > "$bin"
+#!$(pkg_path_for busybox-static)/bin/sh
+export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
+set -e
+export GEM_HOME="$GEM_HOME"
+export GEM_PATH="$GEM_PATH"
+
+exec $(pkg_path_for core/ruby)/bin/ruby $real_bin \$@
+EOF
+  chmod -v 755 "$bin"
+}
+
+do_strip() {
+  return 0
+}

--- a/habitat/automate-inspec/plan.sh
+++ b/habitat/automate-inspec/plan.sh
@@ -22,7 +22,8 @@ pkg_deps=(
   core/less
   core/mysql-client
   core/netcat
-  core/postgresql
+  # See https://github.com/chef/inspec/issues/3002
+  core/postgresql/9.6.8
 )
 pkg_build_deps=(
   core/gcc

--- a/habitat/automate-inspec/plan.sh
+++ b/habitat/automate-inspec/plan.sh
@@ -102,7 +102,7 @@ https://www.chef.io/online-master-agreement
 =========================================================================
 EOL
   echo 'Set the environment variable MLSA_ACCEPTED to true to accept'
-  exit 1
+  exit 19  
 fi
 
 exec $(pkg_path_for core/ruby)/bin/ruby $real_bin \$@

--- a/habitat/automate-inspec/plan.sh
+++ b/habitat/automate-inspec/plan.sh
@@ -1,3 +1,7 @@
+# This is a repackaging of InSpec for Automate 2.
+# Changes:
+#  * After installing inspec as a gem, install inspec-scap as a gem
+#  * Force acceptance of a license to use inspec (TODO)
 pkg_name=automate-inspec
 pkg_origin=chef
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
@@ -22,6 +26,7 @@ pkg_deps=(
   core/less
   core/mysql-client
   core/netcat
+  # TODO: inspec has core/postgresql listed here; why doesn't this file?
 )
 pkg_build_deps=(
   core/gcc
@@ -30,6 +35,10 @@ pkg_build_deps=(
 )
 pkg_bin_dirs=(bin)
 
+# Implementaion notes:
+# * We assume we're being built from the inspec repo in the root directory
+# * So, we already have the inspec files; but we need to fetch the inspec-scap code
+
 do_prepare() {
   export GEM_HOME="$pkg_prefix/lib"
   build_line "Setting GEM_HOME=$GEM_HOME"
@@ -37,23 +46,53 @@ do_prepare() {
   build_line "Setting GEM_PATH=$GEM_PATH"
 }
 
-do_unpack() {
-  export INSPEC_SCAP_SRC_CACHE="$HAB_CACHE_SRC_PATH/$pkg_dirname/inspec-scap"
+do_download() {
+  # TODO: I can't get the token auth to work - it wants a username and then the token as password.  
+  # git clone --depth=1 https://$GITHUB_TOKEN@github.com/chef/inspec-scap.git $INSPEC_SCAP_SRC_CACHE
+  # https://github.com/chef/inspec-scap/archive/master.tar.gz
+  # https://github.com/chef/inspec-scap/archive/1.7.0.tar.gz
+  # Cheating by placing tarballs in mirror/
+  true
+}
 
+do_unpack() {
+  # Copy in the inspec source into the build area
+  export INSPEC_MAIN_SRC_CACHE="$HAB_CACHE_SRC_PATH/$pkg_dirname/inspec"
+  mkdir -pv "$INSPEC_MAIN_SRC_CACHE"
+  cp -R "$PLAN_CONTEXT"/../../ "$INSPEC_MAIN_SRC_CACHE"
+
+  # Now obtain inspec-scap
+  export INSPEC_SCAP_SRC_CACHE="$HAB_CACHE_SRC_PATH/$pkg_dirname/inspec-scap"
+  # TODO: this line is buried, should be moved to top
+  export INSPEC_SCAP_VERSION=1.7.0 
   build_line "Cloning InSpec SCAP source to $INSPEC_SCAP_SRC_CACHE"
   mkdir -pv "$INSPEC_SCAP_SRC_CACHE"
-  git clone --depth=1 https://$GITHUB_TOKEN@github.com/chef/inspec-scap.git $INSPEC_SCAP_SRC_CACHE
+  pushd $INSPEC_SCAP_SRC_CACHE
+    # TODO, clone, don't untar
+    tar xzf /src/mirror/inspec-scap-"$INSPEC_SCAP_VERSION".tar.gz
+  popd
 }
 
 do_build() {
-  pushd "$INSPEC_SCAP_SRC_CACHE"
+  # First build InSpec
+  pushd "$INSPEC_MAIN_SRC_CACHE"
+    gem build inspec.gemspec
+  popd
+  attach
+  # Now build inspec-scap
+  pushd "$INSPEC_SCAP_SRC_CACHE/inspec-scap-$INSPEC_SCAP_VERSION"
     gem build inspec-scap.gemspec
   popd
 }
 
 do_install() {
-  pushd "$INSPEC_SCAP_SRC_CACHE"
-    gem install inspec-scap-*.gem
+  # First install InSpec
+  pushd "$INSPEC_MAIN_SRC_CACHE"
+    gem install inspec-*.gem --no-document
+  popd
+  # Now install inspec-scap
+  pushd "$INSPEC_SCAP_SRC_CACHE/inspec-scap-$INSPEC_SCAP_VERSION"
+    gem install inspec-scap-*.gem --no-document
   popd
 
   wrap_inspec_bin

--- a/habitat/inspec/plan.sh
+++ b/habitat/inspec/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=inspec
 pkg_origin=chef
-pkg_version=$(cat "$PLAN_CONTEXT/../VERSION")
+pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_description="InSpec is an open-source testing framework for infrastructure
   with a human- and machine-readable language for specifying compliance,
   security and policy requirements."
@@ -43,7 +43,7 @@ do_prepare() {
 
 do_unpack() {
   mkdir -pv "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  cp -R "$PLAN_CONTEXT"/../ "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  cp -R "$PLAN_CONTEXT"/../../ "$HAB_CACHE_SRC_PATH/$pkg_dirname"
 }
 
 do_build() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=inspec
 pkg_origin=chef
-pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
+pkg_version=$(cat "$PLAN_CONTEXT/../VERSION")
 pkg_description="InSpec is an open-source testing framework for infrastructure
   with a human- and machine-readable language for specifying compliance,
   security and policy requirements."
@@ -43,7 +43,7 @@ do_prepare() {
 
 do_unpack() {
   mkdir -pv "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  cp -R "$PLAN_CONTEXT"/../../ "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  cp -R "$PLAN_CONTEXT"/../ "$HAB_CACHE_SRC_PATH/$pkg_dirname"
 }
 
 do_build() {


### PR DESCRIPTION
This PR make a separate Habitat package, for use when `inspec` is being installed on an Automate server.  The primary changes are that it changes the licensing, and also installs `inspec-scap`, a plugin for profile interpretation.

The Expeditor configuration is likely borken at this point, as we need to handle the git clone of the inspec-scap repo safely (we currently rely on an env var, which we're not setting).