### PR TITLE
Add job_uuid passthrough for automate report

### DIFF
--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -26,7 +26,7 @@ module Inspec::Reporters
       final_report[:report_uuid] = @config['report_uuid'] || uuid_from_string(final_report[:end_time] + final_report[:node_uuid])
 
       # optional json-config passthrough options
-      %w{node_name environment roles recipies}.each do |option|
+      %w{node_name environment roles recipies job_uuid}.each do |option|
         final_report[option.to_sym] = @config[option] unless @config[option].nil?
       end
       final_report

--- a/test/unit/reporters/automate_test.rb
+++ b/test/unit/reporters/automate_test.rb
@@ -12,6 +12,7 @@ describe Inspec::Reporters::Automate do
       'node_name' => "test_node",
       'environment' => "prod",
       'report_uuid' => "22ad2f99-f84f-5456-95a0-7e91b4b12345",
+      'job_uuid' => "22ad2f99-f84f-5456-95a0-jobuuid12345",
     }
   end
   let(:report) do 
@@ -26,6 +27,7 @@ describe Inspec::Reporters::Automate do
       report.enriched_report[:node_name].must_equal "test_node"
       report.enriched_report[:environment].must_equal "prod"
       report.enriched_report[:report_uuid].must_equal "22ad2f99-f84f-5456-95a0-7e91b4b12345"
+      report.enriched_report[:job_uuid].must_equal "22ad2f99-f84f-5456-95a0-jobuuid12345"
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This is needed for A2 filtering. This allows to to passthrough `job_uuid` as an optional field in the json config.