### PR TITLE
Update Junit.rb to add failures attribute

### DIFF
--- a/lib/inspec/reporters/junit.rb
+++ b/lib/inspec/reporters/junit.rb
@@ -27,6 +27,7 @@ module Inspec::Reporters
       profile_xml.add_attribute('name', profile[:name])
       profile_xml.add_attribute('tests', count_profile_tests(profile))
       profile_xml.add_attribute('failed', count_profile_failed_tests(profile))
+      profile_xml.add_attribute('failures', count_profile_failed_tests(profile))
 
       profile[:controls].each do |control|
         next if control[:results].nil?

--- a/test/unit/mock/reporters/junit_output
+++ b/test/unit/mock/reporters/junit_output
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <testsuites>
-  <testsuite name='long_commands' tests='4' failed='1'>
+  <testsuite name='long_commands' tests='4' failed='1' failures='1'>
     <testcase name='File /tmp should be directory' classname='long_commands.Anonymous' target='local://' time='0.002058'/>
     <testcase name='File /tmp should be directory' classname='long_commands.tmp-1.0' target='local://' time='0.000102'/>
     <testcase name='gem package rubocop should be installed' classname='long_commands.Anonymous' target='local://' time='0.000168'>


### PR DESCRIPTION
I was trying to run inspec in a CI and I could not find any test failures in builds, even though the inspec run failed
This PR address 1 point  of this issue #3006 
I think the junit formater should be reviewed to make sure it matches the junit schema 

I found this example as reference https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd