### PR TITLE
Fix the git fetcher to vendor correctly

### DIFF
--- a/lib/fetchers/git.rb
+++ b/lib/fetchers/git.rb
@@ -50,7 +50,7 @@ module Fetchers
         Dir.mktmpdir do |tmpdir|
           checkout(tmpdir)
           Inspec::Log.debug("Checkout of #{resolved_ref} successful. Moving checkout to #{dir}")
-          FileUtils.cp_r(tmpdir, @repo_directory)
+          FileUtils.cp_r(tmpdir + '/.', @repo_directory)
         end
       end
       @repo_directory

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -34,6 +34,25 @@ describe 'example inheritance profile' do
     end
   end
 
+  it 'can vendor profile dependencies from git' do
+    git_depends_path = File.join(profile_path, 'git-depends')
+
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.cp_r(git_depends_path + '/.', tmpdir)
+      File.exist?(File.join(tmpdir, 'vendor')).must_equal false
+
+      out = inspec('vendor ' + tmpdir + ' --overwrite')
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+
+      out.stdout.must_include "Dependencies for profile #{tmpdir} successfully vendored to #{tmpdir}/vendor"
+
+      File.exist?(File.join(tmpdir, 'vendor')).must_equal true
+      File.exist?(File.join(tmpdir, 'inspec.lock')).must_equal true
+      File.exist?(File.join(tmpdir, 'vendor', 'accb84911787830f5b973f3e49de78bbff931946', 'README.md')).must_equal true
+    end
+  end
+
   it 'ensure nothing is loaded from external source if vendored profile is used' do
     prepare_examples('meta-profile') do |dir|
       out = inspec('vendor ' + dir + ' --overwrite')

--- a/test/unit/fetchers/git_test.rb
+++ b/test/unit/fetchers/git_test.rb
@@ -70,7 +70,7 @@ a7729ce65636d6d8b80159dd5dd7a40fdb6f2501\trefs/tags/anothertag^{}\n")
     end
 
     def expect_mv_into_place
-      FileUtils.expects(:cp_r).with('test-tmp-dir', 'fetchpath')
+      FileUtils.expects(:cp_r).with('test-tmp-dir/.', 'fetchpath')
     end
 
     it "resolves to the revision of master by default" do

--- a/test/unit/mock/profiles/git-depends/inspec.yml
+++ b/test/unit/mock/profiles/git-depends/inspec.yml
@@ -1,0 +1,10 @@
+name: git depends
+title: InSpec example simple inheritance
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
+copyright_email: support@chef.io
+license: Apache 2 license
+version: 1.0.0
+depends:
+  - name: ssh
+    git: https://github.com/dev-sec/ssh-baseline.git


### PR DESCRIPTION
The current git fetcher copies the folder that was checked out instead of the checkout internals. This breaks the dependency reader as it does not expect a imbedded folder. 

Fixes https://github.com/inspec/inspec/issues/3067


Signed-off-by: Jared Quick <jquick@chef.io>