### PR TITLE
Add in missing changes from Expeditor outage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 <!-- latest_release 2.1.84 -->
 ## [v2.1.84](https://github.com/inspec/inspec/tree/v2.1.84) (2018-05-31)
 
+#### New Features
+- Enhance groups resource with members property [#3029](https://github.com/inspec/inspec/pull/3029)
+- Adding YAML reporter [#3081](https://github.com/inspec/inspec/pull/3081)
+
+#### Enhancements
+- Remove unneeded "-a" from the RPM query for performance improvement [#3077](https://github.com/inspec/inspec/pull/3077)
+- mssql_session default port and local_mode [#3031](https://github.com/inspec/inspec/pull/3031)
+
+#### Bug Fixes
+- handle nil properties in iis_site [#3040](https://github.com/inspec/inspec/pull/3040)
+- Fixing wrong attribute reference for rspec output [#3080](https://github.com/inspec/inspec/pull/3080)
+- Fix the git fetcher to vendor correctly [#3097](https://github.com/inspec/inspec/pull/3097)
+
 #### Merged Pull Requests
 - Generate new org builds [#3087](https://github.com/inspec/inspec/pull/3087) ([jquick](https://github.com/jquick))
 <!-- latest_release -->


### PR DESCRIPTION
Since Expeditor was not linked correctly we are manually inputing the missing merges.

Signed-off-by: Jared Quick <jquick@chef.io>