### PR TITLE
Detect windows packages with trailing/leading spaces

### DIFF
--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -270,7 +270,7 @@ module Inspec::Resources
       # Find the package
       cmd = inspec.command <<-EOF.gsub(/^\s*/, '')
         Get-ItemProperty (@("#{search_paths.join('", "')}") | Where-Object { Test-Path $_ }) |
-        Where-Object { $_.DisplayName -like "#{package_name}" -or $_.PSChildName -like "#{package_name}" } |
+        Where-Object { $_.DisplayName -match "^\\s*#{package_name}\\s*$" -or $_.PSChildName -match "^\\s*#{package_name}\\s*$" } |
         Select-Object -Property DisplayName,DisplayVersion | ConvertTo-Json
       EOF
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -290,7 +290,7 @@ class MockLoader
       'rmsock f0000000000000001 tcpcb' => cmd.call('rmsock-f0001'),
       'rmsock f0000000000000002 tcpcb' => cmd.call('rmsock-f0002'),
       # packages on windows
-      '6785190b3df7291a7622b0b75b0217a9a78bd04690bc978df51ae17ec852a282' => cmd.call('get-item-property-package'),
+      '3ec839acbcd768cc827af6bbc970785b5b331d49855abc40c93a8c01f2ae9839' => cmd.call('get-item-property-package'),
       # service status upstart on ubuntu
       'initctl status ssh' => cmd.call('initctl-status-ssh'),
       # upstart version on ubuntu

--- a/test/unit/mock/cmd/get-item-property-package
+++ b/test/unit/mock/cmd/get-item-property-package
@@ -1,4 +1,4 @@
 {
-    "DisplayName":  "Chef Client v12.12.15",
+    "DisplayName":  "Chef Client v12.12.15 ",
     "DisplayVersion":  "12.12.15.1"
 }

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -103,7 +103,7 @@ describe 'Inspec::Resources::Package' do
   # windows
   it 'verify windows package parsing' do
     resource = MockLoader.new(:windows).load_resource('package', 'Chef Client v12.12.15')
-    pkg = { name: 'Chef Client v12.12.15', installed: true, version: '12.12.15.1', type: 'windows' }
+    pkg = { name: 'Chef Client v12.12.15 ', installed: true, version: '12.12.15.1', type: 'windows' }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal '12.12.15.1'
     _(resource.info).must_equal pkg


### PR DESCRIPTION
The current windows package matcher does a hard string comparison. This did not match when packages had a trailing space in the registry. This change updates the matcher to be a regex that allows leading/trailing spaces. I have confirmed that this `-match` flag is allowed in all powershell versions.

Fixes https://github.com/inspec/inspec/issues/3072

Signed-off-by: Jared Quick <jquick@chef.io>