### PR TITLE
Translate `auditd -s` RHEL output to match CentOS

### DIFF
--- a/lib/resources/auditd.rb
+++ b/lib/resources/auditd.rb
@@ -58,6 +58,14 @@ module Inspec::Resources
 
     def status(name = nil)
       @status_content ||= inspec.command('/sbin/auditctl -s').stdout.chomp
+
+      # See: https://github.com/inspec/inspec/issues/3113
+      if @status_content =~ /^AUDIT_STATUS/
+        @status_content = @status_content.gsub('AUDIT_STATUS: ', '')
+                                         .tr(' ', "\n")
+                                         .tr('=', ' ')
+      end
+
       @status_params ||= Hash[@status_content.scan(/^([^ ]+) (.*)$/)]
 
       return @status_params[name] if name


### PR DESCRIPTION
This translates the output of `auditctl -s` on RHEL to match CentOS.

This is based on the details from issue #3113. I could not find a test box that would give me the output to match what was reported.

I would like to test this on a live system before merging.

This should fix #3113.