### PR TITLE
[ON HOLD] Provide they / their aliases for it / its

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -44,56 +44,58 @@ end
   * `should_not`  is the _negative condition_
   * `be_ridiculous`  is the _matcher_
 
-## Advanced Syntax
+## Plural Syntax
 
 ```
-describe foos('/path/to/foo.txt', ssl_verify: true).where { names == 'blah' } do
+describe foos('/path/to/foo.txt', ssl_verify: true).where { name == 'blah' } do
     its('jared') { should cmp >= 123 }
     its('jared.sort.first.monkey') { should be `loud` }
     its(['jared', 'monkey.with.dots']) { should be `loud` }
 end
 ```
 
-## Advanced Elements:
+## Elements of Plural Resources
 
 ### describe **foos**, where
 
-  * `foos` is a _plural resource_
+  * `foos` is a _plural resource_.  That means that it specializes in fetching and searching for audit objects in bulk.  The tests it performs will always be in reference to the group of selected audit objects.
 
 ### describe foos **('/path/to/foo.txt', ssl_verify: true)**, where
 
-  * `'/path/to/foo.txt'` and `ssl_verify: true` are the _resource parameters_. Resources take one or more parameters.
+  * `'/path/to/foo.txt'` and `ssl_verify: true` are the _resource parameters_. Resources take zero or more parameters.  Most plural resources do not take any resource  parameters.
 
 ## Filters:
 
-### describe foos ('/path/to/foo.txt', ssl_verify: true)**.where { names == 'blah' }** 
+### describe foos.**where(name: 'bob')** 
 
-  * `.where  { names == 'blah' }` is an example of a **filter**. 
-  * `{ names == 'blah' }` is an example of a _filter clause_ 
-  * Some resources support one or more filters.
-  * Filters are used on plural resources. 
+  * `.where(name: 'bob')` is an example of a **filter**. 
+  * `(name: 'blah')` is an example of a _filter clause_ using _method syntax_.
+  * All plural resources support the `where` filter, in both method and block syntax.
   * Some resources, such as `etc_hosts` are explicitly plural, while others, such as `passwd` are implicitly plural. 
 
-### **{ names == 'my-name' && spots == true }** are filter criteria
+### **{ name =~ /blah/ && has_spots? }** are filter criteria in a filter block
 
-  * `names` compares output to `blah`
-  * `has spots` evaluates to `true` or `false`
+  * `name` =~ `/blah/` selects just those `foo` resources whose name matches `/blah/`.
+  * `has_spots?` evaluates to `true` or `false`, and select those `foo` resources where that is true.
+  * filter criteria are nearly always named in the singular inflection
 
 ## Properties:
 
-### **its('jared') { should cmp >= 123 }**
+Properties on a plural resource are almost always named in the plural inflection, and usually return lists.  Usually their is one entry in the list per selected resource, but some properties de-duplicate the list.
 
-  * `jared` is the _property_
-  
-### **{ should cmp >= 123 }** is a conditional statement that uses a matcher with an operator and expected value.
+### **their('names') { should include 'jared' }**
 
-  * `cmp`  is the _matcher_
-  * `>=` is the operator (some matchers accept operators)
-  * `123` is the expected value
+  * `their` is an alias for  `its`.  You may use them interchangeably, but `they / their` reads better on plural resources.
+  * `names` is the _property_. It is an array of strings.
+
+### **{ should include 'jared' }** is a conditional statement that uses a matcher with an expected value.
+
+  * `include`  is the _matcher_
+  * `jared` is the expected value
 
 ## Properties with advanced usage:
 
 ### Some properties may have advanced usage:
-#### **its `('jared.sort.first.monkey') { should be `loud` }`**
+#### **`their ('raw_data.first.keys') { should include 'shoe_size' }`**
 
-  * `jared.sort.first.monkey` is an example of the `jared` property with an advanced usage
+  * `raw_data.first.keys` is an example of advanced property usage.  Each dot is evaluated as a method call.  For details, see the documentation of the `rspec-its` gem.

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -5,6 +5,8 @@
 require 'rspec/core'
 require 'rspec/its'
 require 'inspec/formatters'
+# They / Their can only be used with RSpec runner
+require 'inspec/they_their'
 
 # There be dragons!! Or borgs, or something...
 # This file and all its contents cannot be unit-tested. both test-suits

--- a/lib/inspec/they_their.rb
+++ b/lib/inspec/they_their.rb
@@ -1,5 +1,16 @@
 module RSpec
   module Its
+    # This is from the gem rspec-its.  We can just alias.
     alias their its
+  end
+end
+
+module RSpec
+  module Core
+    class ExampleGroup
+      # Can't just alias here, the methods are all handled by special macros.
+      # See https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/example_group.rb#L158
+      define_example_method :they
+    end
   end
 end

--- a/lib/inspec/they_their.rb
+++ b/lib/inspec/they_their.rb
@@ -1,0 +1,5 @@
+module RSpec
+  module Its
+    alias their its
+  end
+end

--- a/test/functional/filter_table_test.rb
+++ b/test/functional/filter_table_test.rb
@@ -1,5 +1,30 @@
 require 'functional/helper'
 
+describe '3109 they / their support' do
+  include FunctionalHelper
+  it 'positive tests should pass' do
+    controls = [
+      '3109_their',
+    ]
+
+    cmd  = 'exec ' + File.join(profile_path, 'filter_table')
+    cmd += ' --reporter json --no-create-lockfile' 
+    cmd += ' --controls ' + controls.join(' ')
+    cmd = inspec(cmd)
+
+    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
+    output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
+    data = JSON.parse(output)
+    failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
+    control_hash = {}
+    failed_controls.each do |ctl|
+      control_hash[ctl['id']] = ctl['results'][0]['message']
+    end
+    control_hash.must_be_empty
+    cmd.exit_status.must_equal 0
+  end
+end
+
 describe '2943 inspec exec for filter table profile, method mode for `where' do
   include FunctionalHelper
 

--- a/test/functional/filter_table_test.rb
+++ b/test/functional/filter_table_test.rb
@@ -5,6 +5,7 @@ describe '3109 they / their support' do
   it 'positive tests should pass' do
     controls = [
       '3109_their',
+      '3109_they',
     ]
 
     cmd  = 'exec ' + File.join(profile_path, 'filter_table')

--- a/test/unit/mock/profiles/filter_table/controls/they_their.rb
+++ b/test/unit/mock/profiles/filter_table/controls/they_their.rb
@@ -1,0 +1,19 @@
+title 'Verify they / their support works correctly - Issue 3109'
+
+fresh_data = ->() do
+  [
+    { id: 0, color: :red }.dup,
+    { id: 1, color: :blue, }.dup,
+    { id: 2, color: :green }.dup,
+  ]
+end
+
+control '3109_their' do
+  desc 'their should work as an alias for its'
+  describe simple_plural(fresh_data.call) do
+    its('count') { should eq 3 }
+    their('count') { should eq 3 }
+    its('ids.count') { should eq 3 }
+    their('ids.count') { should eq 3 }
+  end
+end

--- a/test/unit/mock/profiles/filter_table/controls/they_their.rb
+++ b/test/unit/mock/profiles/filter_table/controls/they_their.rb
@@ -17,3 +17,15 @@ control '3109_their' do
     their('ids.count') { should eq 3 }
   end
 end
+
+control '3109_they' do
+  desc 'they should work as an alias for it'
+  describe simple_plural(fresh_data.call) do
+    it { should exist }
+    they { should exist }
+  end
+  describe simple_plural(fresh_data.call).raw_data.first do
+    it { should_not be_a_kind_of(Struct) }
+    they { should_not be_a_kind_of(Struct) }
+  end
+end


### PR DESCRIPTION
Fixes #3109 

Simply aliases `they` to `it` and `their` to `its`, allowing us to say:

```ruby
describe things do
  they { should exist }
  their('stuff') { should include 'bananas' }
end
```

This isn't directly impacting FilterTable, but it is useful for all plural resources.
