### PR TITLE
Update core resources with filtertable API changes

### DIFF
--- a/lib/resources/aide_conf.rb
+++ b/lib/resources/aide_conf.rb
@@ -44,12 +44,10 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:selection_lines, field: 'selection_line')
-          .add(:rules,           field: 'rules')
+    filter.register_column(:selection_lines, field: 'selection_line')
+          .register_column(:rules,           field: 'rules')
 
-    filter.connect(self, :params)
+    filter.install_filter_methods_on_resource(self, :params)
 
     private
 

--- a/lib/resources/auditd.rb
+++ b/lib/resources/auditd.rb
@@ -55,21 +55,19 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:file,         field: 'file')
-          .add(:list,         field: 'list')
-          .add(:action,       field: 'action')
-          .add(:fields,       field: 'fields')
-          .add(:fields_nokey, field: 'fields_nokey')
-          .add(:syscall,      field: 'syscall')
-          .add(:key,          field: 'key')
-          .add(:arch,         field: 'arch')
-          .add(:path,         field: 'path')
-          .add(:permissions,  field: 'permissions')
-          .add(:exit,         field: 'exit')
+    filter.register_column(:file,         field: 'file')
+          .register_column(:list,         field: 'list')
+          .register_column(:action,       field: 'action')
+          .register_column(:fields,       field: 'fields')
+          .register_column(:fields_nokey, field: 'fields_nokey')
+          .register_column(:syscall,      field: 'syscall')
+          .register_column(:key,          field: 'key')
+          .register_column(:arch,         field: 'arch')
+          .register_column(:path,         field: 'path')
+          .register_column(:permissions,  field: 'permissions')
+          .register_column(:exit,         field: 'exit')
 
-    filter.connect(self, :params)
+    filter.install_filter_methods_on_resource(self, :params)
 
     def status(name = nil)
       @status_content ||= inspec.command('/sbin/auditctl -s').stdout.chomp

--- a/lib/resources/aws/aws_cloudtrail_trails.rb
+++ b/lib/resources/aws/aws_cloudtrail_trails.rb
@@ -19,11 +19,10 @@ class AwsCloudTrailTrails < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add_accessor(:entries)
-        .add(:exists?) { |x| !x.entries.empty? }
-        .add(:names, field: :name)
-        .add(:trail_arns, field: :trail_arn)
-  filter.connect(self, :table)
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+        .register_column(:names, field: :name)
+        .register_column(:trail_arns, field: :trail_arn)
+  filter.install_filter_methods_on_resource(self, :table)
 
   def to_s
     'CloudTrail Trails'

--- a/lib/resources/aws/aws_cloudtrail_trails.rb
+++ b/lib/resources/aws/aws_cloudtrail_trails.rb
@@ -19,6 +19,7 @@ class AwsCloudTrailTrails < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:trail_arns, field: :trail_arn)
   filter.install_filter_methods_on_resource(self, :table)
 

--- a/lib/resources/aws/aws_cloudtrail_trails.rb
+++ b/lib/resources/aws/aws_cloudtrail_trails.rb
@@ -19,9 +19,7 @@ class AwsCloudTrailTrails < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-        .register_column(:names, field: :name)
-        .register_column(:trail_arns, field: :trail_arn)
+  filter.register_column(:trail_arns, field: :trail_arn)
   filter.install_filter_methods_on_resource(self, :table)
 
   def to_s

--- a/lib/resources/aws/aws_cloudtrail_trails.rb
+++ b/lib/resources/aws/aws_cloudtrail_trails.rb
@@ -21,6 +21,7 @@ class AwsCloudTrailTrails < Inspec.resource(1)
   filter = FilterTable.create
   filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:trail_arns, field: :trail_arn)
+  filter.register_column(:names, field: :name)
   filter.install_filter_methods_on_resource(self, :table)
 
   def to_s

--- a/lib/resources/aws/aws_ec2_instances.rb
+++ b/lib/resources/aws/aws_ec2_instances.rb
@@ -18,10 +18,9 @@ class AwsEc2Instances < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add_accessor(:entries)
-        .add(:exists?) { |x| !x.entries.empty? }
-        .add(:instance_ids, field: :instance_id)
-  filter.connect(self, :table)
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+        .register_column(:instance_ids, field: :instance_id)
+  filter.install_filter_methods_on_resource(self, :table)
 
   def to_s
     'EC2 Instances'

--- a/lib/resources/aws/aws_ec2_instances.rb
+++ b/lib/resources/aws/aws_ec2_instances.rb
@@ -18,8 +18,7 @@ class AwsEc2Instances < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-        .register_column(:instance_ids, field: :instance_id)
+  filter.register_column(:instance_ids, field: :instance_id)
   filter.install_filter_methods_on_resource(self, :table)
 
   def to_s

--- a/lib/resources/aws/aws_ec2_instances.rb
+++ b/lib/resources/aws/aws_ec2_instances.rb
@@ -18,6 +18,7 @@ class AwsEc2Instances < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:instance_ids, field: :instance_id)
   filter.install_filter_methods_on_resource(self, :table)
 

--- a/lib/resources/aws/aws_iam_access_keys.rb
+++ b/lib/resources/aws/aws_iam_access_keys.rb
@@ -38,8 +38,7 @@ class AwsIamAccessKeys < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-        .register_column(:access_key_ids, field: :access_key_id)
+  filter.register_column(:access_key_ids, field: :access_key_id)
         .register_column(:created_date, field: :create_date)
         .register_column(:created_days_ago, field: :created_days_ago)
         .register_column(:created_with_user, field: :created_with_user)

--- a/lib/resources/aws/aws_iam_access_keys.rb
+++ b/lib/resources/aws/aws_iam_access_keys.rb
@@ -38,24 +38,22 @@ class AwsIamAccessKeys < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add_accessor(:where)
-        .add_accessor(:entries)
-        .add(:exists?) { |x| !x.entries.empty? }
-        .add(:access_key_ids, field: :access_key_id)
-        .add(:created_date, field: :create_date)
-        .add(:created_days_ago, field: :created_days_ago)
-        .add(:created_with_user, field: :created_with_user)
-        .add(:created_hours_ago, field: :created_hours_ago)
-        .add(:usernames, field: :username)
-        .add(:active, field: :active)
-        .add(:inactive, field: :inactive)
-        .add(:last_used_date, field: :last_used_date)
-        .add(:last_used_hours_ago, field: :last_used_hours_ago)
-        .add(:last_used_days_ago,  field: :last_used_days_ago)
-        .add(:ever_used,           field: :ever_used)
-        .add(:never_used,          field: :never_used)
-        .add(:user_created_date,   field: :user_created_date)
-  filter.connect(self, :table)
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+        .register_column(:access_key_ids, field: :access_key_id)
+        .register_column(:created_date, field: :create_date)
+        .register_column(:created_days_ago, field: :created_days_ago)
+        .register_column(:created_with_user, field: :created_with_user)
+        .register_column(:created_hours_ago, field: :created_hours_ago)
+        .register_column(:usernames, field: :username)
+        .register_column(:active, field: :active)
+        .register_column(:inactive, field: :inactive)
+        .register_column(:last_used_date, field: :last_used_date)
+        .register_column(:last_used_hours_ago, field: :last_used_hours_ago)
+        .register_column(:last_used_days_ago,  field: :last_used_days_ago)
+        .register_column(:ever_used,           field: :ever_used)
+        .register_column(:never_used,          field: :never_used)
+        .register_column(:user_created_date,   field: :user_created_date)
+  filter.install_filter_methods_on_resource(self, :table)
 
   def to_s
     'IAM Access Keys'

--- a/lib/resources/aws/aws_iam_access_keys.rb
+++ b/lib/resources/aws/aws_iam_access_keys.rb
@@ -38,6 +38,7 @@ class AwsIamAccessKeys < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:access_key_ids, field: :access_key_id)
         .register_column(:created_date, field: :create_date)
         .register_column(:created_days_ago, field: :created_days_ago)

--- a/lib/resources/aws/aws_iam_groups.rb
+++ b/lib/resources/aws/aws_iam_groups.rb
@@ -19,8 +19,8 @@ class AwsIamGroups < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add(:group_names, field: :group_name)
-  filter.connect(self, :table)
+  filter.register_column(:group_names, field: :group_name)
+  filter.install_filter_methods_on_resource(self, :table)
 
   def to_s
     'IAM Groups'

--- a/lib/resources/aws/aws_iam_policies.rb
+++ b/lib/resources/aws/aws_iam_policies.rb
@@ -18,6 +18,7 @@ class AwsIamPolicies < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:policy_names, field: :policy_name)
         .register_column(:arns, field: :arn)
   filter.install_filter_methods_on_resource(self, :table)

--- a/lib/resources/aws/aws_iam_policies.rb
+++ b/lib/resources/aws/aws_iam_policies.rb
@@ -18,8 +18,7 @@ class AwsIamPolicies < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-        .register_column(:policy_names, field: :policy_name)
+  filter.register_column(:policy_names, field: :policy_name)
         .register_column(:arns, field: :arn)
   filter.install_filter_methods_on_resource(self, :table)
 

--- a/lib/resources/aws/aws_iam_policies.rb
+++ b/lib/resources/aws/aws_iam_policies.rb
@@ -18,11 +18,10 @@ class AwsIamPolicies < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add_accessor(:entries)
-        .add(:exists?) { |x| !x.entries.empty? }
-        .add(:policy_names, field: :policy_name)
-        .add(:arns, field: :arn)
-  filter.connect(self, :table)
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+        .register_column(:policy_names, field: :policy_name)
+        .register_column(:arns, field: :arn)
+  filter.install_filter_methods_on_resource(self, :table)
 
   def to_s
     'IAM Policies'

--- a/lib/resources/aws/aws_iam_users.rb
+++ b/lib/resources/aws/aws_iam_users.rb
@@ -62,35 +62,30 @@ class AwsIamUsers < Inspec.resource(1)
   end
 
   filter = FilterTable.create
-  filter.add_accessor(:where)
-        .add_accessor(:entries)
-  # Summary methods
-  filter.add(:exists?) { |table| !table.params.empty? }
-        .add(:count) { |table| table.params.count }
 
   # These are included on the initial fetch
-  filter.add(:usernames, field: :user_name)
-        .add(:username) { |res| res.entries.map { |row| row[:user_name] } } # We should deprecate this; plural resources get plural properties
-        .add(:password_ever_used?, field: :password_ever_used?)
-        .add(:password_never_used?, field: :password_never_used?)
-        .add(:password_last_used_days_ago, field: :password_last_used_days_ago)
+  filter.register_column(:usernames, field: :user_name)
+        .register_column(:username) { |res| res.entries.map { |row| row[:user_name] } } # We should deprecate this; plural resources get plural properties
+        .register_column(:password_ever_used?, field: :password_ever_used?)
+        .register_column(:password_never_used?, field: :password_never_used?)
+        .register_column(:password_last_used_days_ago, field: :password_last_used_days_ago)
 
   # Remaining properties / criteria are handled lazily, grouped by fetcher
-  filter.add(:has_console_password?, field: :has_console_password?, lazy: method(:lazy_get_login_profile))
-        .add(:has_console_password, field: :has_console_password, lazy: method(:lazy_get_login_profile))
+  filter.register_column(:has_console_password?, field: :has_console_password?, lazy: method(:lazy_get_login_profile))
+        .register_column(:has_console_password, field: :has_console_password, lazy: method(:lazy_get_login_profile))
 
-  filter.add(:has_mfa_enabled?, field: :has_mfa_enabled?, lazy: method(:lazy_list_mfa_devices))
-        .add(:has_mfa_enabled, field: :has_mfa_enabled, lazy: method(:lazy_list_mfa_devices))
+  filter.register_column(:has_mfa_enabled?, field: :has_mfa_enabled?, lazy: method(:lazy_list_mfa_devices))
+        .register_column(:has_mfa_enabled, field: :has_mfa_enabled, lazy: method(:lazy_list_mfa_devices))
 
-  filter.add(:has_inline_policies?, field: :has_inline_policies?, lazy: method(:lazy_list_user_policies))
-        .add(:has_inline_policies, field: :has_inline_policies, lazy: method(:lazy_list_user_policies))
-        .add(:inline_policy_names, field: :inline_policy_names, style: :simple, lazy: method(:lazy_list_user_policies))
+  filter.register_column(:has_inline_policies?, field: :has_inline_policies?, lazy: method(:lazy_list_user_policies))
+        .register_column(:has_inline_policies, field: :has_inline_policies, lazy: method(:lazy_list_user_policies))
+        .register_column(:inline_policy_names, field: :inline_policy_names, style: :simple, lazy: method(:lazy_list_user_policies))
 
-  filter.add(:has_attached_policies?, field: :has_attached_policies?, lazy: method(:lazy_list_attached_policies))
-        .add(:has_attached_policies, field: :has_attached_policies, lazy: method(:lazy_list_attached_policies))
-        .add(:attached_policy_names, field: :attached_policy_names, style: :simple, lazy: method(:lazy_list_attached_policies))
-        .add(:attached_policy_arns, field: :attached_policy_arns, style: :simple, lazy: method(:lazy_list_attached_policies))
-  filter.connect(self, :table)
+  filter.register_column(:has_attached_policies?, field: :has_attached_policies?, lazy: method(:lazy_list_attached_policies))
+        .register_column(:has_attached_policies, field: :has_attached_policies, lazy: method(:lazy_list_attached_policies))
+        .register_column(:attached_policy_names, field: :attached_policy_names, style: :simple, lazy: method(:lazy_list_attached_policies))
+        .register_column(:attached_policy_arns, field: :attached_policy_arns, style: :simple, lazy: method(:lazy_list_attached_policies))
+  filter.install_filter_methods_on_resource(self, :table)
 
   def validate_params(raw_params)
     # No params yet

--- a/lib/resources/aws/aws_kms_keys.rb
+++ b/lib/resources/aws/aws_kms_keys.rb
@@ -18,8 +18,7 @@ class AwsKmsKeys < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-        .register_column(:key_arns, field: :key_arn)
+  filter.register_column(:key_arns, field: :key_arn)
         .register_column(:key_ids, field: :key_id)
   filter.install_filter_methods_on_resource(self, :table)
 

--- a/lib/resources/aws/aws_kms_keys.rb
+++ b/lib/resources/aws/aws_kms_keys.rb
@@ -18,11 +18,10 @@ class AwsKmsKeys < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add_accessor(:entries)
-        .add(:exists?) { |x| !x.entries.empty? }
-        .add(:key_arns, field: :key_arn)
-        .add(:key_ids, field: :key_id)
-  filter.connect(self, :table)
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+        .register_column(:key_arns, field: :key_arn)
+        .register_column(:key_ids, field: :key_id)
+  filter.install_filter_methods_on_resource(self, :table)
 
   def to_s
     'KMS Keys'

--- a/lib/resources/aws/aws_kms_keys.rb
+++ b/lib/resources/aws/aws_kms_keys.rb
@@ -18,6 +18,7 @@ class AwsKmsKeys < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:key_arns, field: :key_arn)
         .register_column(:key_ids, field: :key_id)
   filter.install_filter_methods_on_resource(self, :table)

--- a/lib/resources/aws/aws_route_tables.rb
+++ b/lib/resources/aws/aws_route_tables.rb
@@ -11,11 +11,10 @@ class AwsRouteTables < Inspec.resource(1)
   include AwsPluralResourceMixin
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add_accessor(:entries)
-        .add(:exists?) { |x| !x.entries.empty? }
-        .add(:vpc_ids, field: :vpc_id)
-        .add(:route_table_ids, field: :route_table_id)
-  filter.connect(self, :routes_data)
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+        .register_column(:vpc_ids, field: :vpc_id)
+        .register_column(:route_table_ids, field: :route_table_id)
+  filter.install_filter_methods_on_resource(self, :routes_data)
 
   def routes_data
     @table

--- a/lib/resources/aws/aws_route_tables.rb
+++ b/lib/resources/aws/aws_route_tables.rb
@@ -11,8 +11,7 @@ class AwsRouteTables < Inspec.resource(1)
   include AwsPluralResourceMixin
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-        .register_column(:vpc_ids, field: :vpc_id)
+  filter.register_column(:vpc_ids, field: :vpc_id)
         .register_column(:route_table_ids, field: :route_table_id)
   filter.install_filter_methods_on_resource(self, :routes_data)
 

--- a/lib/resources/aws/aws_route_tables.rb
+++ b/lib/resources/aws/aws_route_tables.rb
@@ -11,6 +11,7 @@ class AwsRouteTables < Inspec.resource(1)
   include AwsPluralResourceMixin
   # Underlying FilterTable implementation.
   filter = FilterTable.create
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:vpc_ids, field: :vpc_id)
         .register_column(:route_table_ids, field: :route_table_id)
   filter.install_filter_methods_on_resource(self, :routes_data)

--- a/lib/resources/aws/aws_s3_buckets.rb
+++ b/lib/resources/aws/aws_s3_buckets.rb
@@ -14,8 +14,7 @@ class AwsS3Buckets < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-        .register_column(:bucket_names, field: :name)
+  filter.register_column(:bucket_names, field: :name)
   filter.install_filter_methods_on_resource(self, :table)
 
   def to_s

--- a/lib/resources/aws/aws_s3_buckets.rb
+++ b/lib/resources/aws/aws_s3_buckets.rb
@@ -14,11 +14,9 @@ class AwsS3Buckets < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add_accessor(:where)
-        .add_accessor(:entries)
-        .add(:exists?) { |x| !x.entries.empty? }
-        .add(:bucket_names, field: :name)
-  filter.connect(self, :table)
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+        .register_column(:bucket_names, field: :name)
+  filter.install_filter_methods_on_resource(self, :table)
 
   def to_s
     'S3 Buckets'

--- a/lib/resources/aws/aws_s3_buckets.rb
+++ b/lib/resources/aws/aws_s3_buckets.rb
@@ -14,6 +14,7 @@ class AwsS3Buckets < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:bucket_names, field: :name)
   filter.install_filter_methods_on_resource(self, :table)
 

--- a/lib/resources/aws/aws_security_groups.rb
+++ b/lib/resources/aws/aws_security_groups.rb
@@ -18,6 +18,7 @@ EOX
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:group_ids, field: :group_id)
   filter.install_filter_methods_on_resource(self, :table)
 

--- a/lib/resources/aws/aws_security_groups.rb
+++ b/lib/resources/aws/aws_security_groups.rb
@@ -18,11 +18,9 @@ EOX
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add_accessor(:where)
-        .add_accessor(:entries)
-        .add(:exists?) { |x| !x.entries.empty? }
-        .add(:group_ids, field: :group_id)
-  filter.connect(self, :table)
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+        .register_column(:group_ids, field: :group_id)
+  filter.install_filter_methods_on_resource(self, :table)
 
   def to_s
     'EC2 Security Groups'

--- a/lib/resources/aws/aws_security_groups.rb
+++ b/lib/resources/aws/aws_security_groups.rb
@@ -18,8 +18,7 @@ EOX
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-        .register_column(:group_ids, field: :group_id)
+  filter.register_column(:group_ids, field: :group_id)
   filter.install_filter_methods_on_resource(self, :table)
 
   def to_s

--- a/lib/resources/aws/aws_sns_topics.rb
+++ b/lib/resources/aws/aws_sns_topics.rb
@@ -33,6 +33,7 @@ class AwsSnsTopics < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:topic_arns, field: :topic_arn)
   filter.install_filter_methods_on_resource(self, :table)
 

--- a/lib/resources/aws/aws_sns_topics.rb
+++ b/lib/resources/aws/aws_sns_topics.rb
@@ -33,11 +33,9 @@ class AwsSnsTopics < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add_accessor(:where)
-        .add_accessor(:entries)
-        .add(:exists?) { |x| !x.entries.empty? }
-        .add(:topic_arns, field: :topic_arn)
-  filter.connect(self, :table)
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+        .register_column(:topic_arns, field: :topic_arn)
+  filter.install_filter_methods_on_resource(self, :table)
 
   def to_s
     'EC2 SNS Topics'

--- a/lib/resources/aws/aws_sns_topics.rb
+++ b/lib/resources/aws/aws_sns_topics.rb
@@ -33,8 +33,7 @@ class AwsSnsTopics < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-        .register_column(:topic_arns, field: :topic_arn)
+  filter.register_column(:topic_arns, field: :topic_arn)
   filter.install_filter_methods_on_resource(self, :table)
 
   def to_s

--- a/lib/resources/aws/aws_subnets.rb
+++ b/lib/resources/aws/aws_subnets.rb
@@ -27,6 +27,7 @@ class AwsSubnets < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:vpc_ids, field: :vpc_id)
         .register_column(:subnet_ids, field: :subnet_id)
         .register_column(:cidr_blocks, field: :cidr_block)

--- a/lib/resources/aws/aws_subnets.rb
+++ b/lib/resources/aws/aws_subnets.rb
@@ -27,14 +27,12 @@ class AwsSubnets < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add_accessor(:where)
-        .add_accessor(:entries)
-        .add(:exists?) { |x| !x.entries.empty? }
-        .add(:vpc_ids, field: :vpc_id)
-        .add(:subnet_ids, field: :subnet_id)
-        .add(:cidr_blocks, field: :cidr_block)
-        .add(:states, field: :state)
-  filter.connect(self, :table)
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+        .register_column(:vpc_ids, field: :vpc_id)
+        .register_column(:subnet_ids, field: :subnet_id)
+        .register_column(:cidr_blocks, field: :cidr_block)
+        .register_column(:states, field: :state)
+  filter.install_filter_methods_on_resource(self, :table)
 
   def to_s
     'EC2 VPC Subnets'

--- a/lib/resources/aws/aws_subnets.rb
+++ b/lib/resources/aws/aws_subnets.rb
@@ -27,8 +27,7 @@ class AwsSubnets < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-        .register_column(:vpc_ids, field: :vpc_id)
+  filter.register_column(:vpc_ids, field: :vpc_id)
         .register_column(:subnet_ids, field: :subnet_id)
         .register_column(:cidr_blocks, field: :cidr_block)
         .register_column(:states, field: :state)

--- a/lib/resources/aws/aws_vpcs.rb
+++ b/lib/resources/aws/aws_vpcs.rb
@@ -12,6 +12,7 @@ class AwsVpcs < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:cidr_blocks, field: :cidr_block)
         .register_column(:vpc_ids, field: :vpc_id)
   # We need a dummy here, so FilterTable will define and populate the dhcp_options_id field

--- a/lib/resources/aws/aws_vpcs.rb
+++ b/lib/resources/aws/aws_vpcs.rb
@@ -12,8 +12,7 @@ class AwsVpcs < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-        .register_column(:cidr_blocks, field: :cidr_block)
+  filter.register_column(:cidr_blocks, field: :cidr_block)
         .register_column(:vpc_ids, field: :vpc_id)
   # We need a dummy here, so FilterTable will define and populate the dhcp_options_id field
   filter.register_column(:dummy, field: :dhcp_options_id)

--- a/lib/resources/aws/aws_vpcs.rb
+++ b/lib/resources/aws/aws_vpcs.rb
@@ -12,15 +12,13 @@ class AwsVpcs < Inspec.resource(1)
 
   # Underlying FilterTable implementation.
   filter = FilterTable.create
-  filter.add_accessor(:entries)
-        .add_accessor(:where)
-        .add(:exists?) { |x| !x.entries.empty? }
-        .add(:cidr_blocks, field: :cidr_block)
-        .add(:vpc_ids, field: :vpc_id)
+  filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+        .register_column(:cidr_blocks, field: :cidr_block)
+        .register_column(:vpc_ids, field: :vpc_id)
   # We need a dummy here, so FilterTable will define and populate the dhcp_options_id field
-  filter.add(:dummy, field: :dhcp_options_id)
-        .add(:dhcp_options_ids) { |obj| obj.entries.map(&:dhcp_options_id).uniq }
-  filter.connect(self, :table)
+  filter.register_column(:dummy, field: :dhcp_options_id)
+        .register_column(:dhcp_options_ids) { |obj| obj.entries.map(&:dhcp_options_id).uniq }
+  filter.install_filter_methods_on_resource(self, :table)
 
   def validate_params(raw_params)
     # No params yet

--- a/lib/resources/azure/azure_generic_resource.rb
+++ b/lib/resources/azure/azure_generic_resource.rb
@@ -33,17 +33,13 @@ module Inspec::Resources
 
     # Define the filter table so that it can be interrogated
     @filter = FilterTable.create
-    @filter.add_accessor(:count)
-           .add_accessor(:entries)
-           .add_accessor(:where)
-           .add_accessor(:contains)
-           .add(:exist?, field: 'exist?')
-           .add(:type, field: 'type')
-           .add(:name, field: 'name')
-           .add(:location, field: 'location')
-           .add(:properties, field: 'properties')
+    @filter.register_filter_method(:contains)
+           .register_column(:type, field: 'type')
+           .register_column(:name, field: 'name')
+           .register_column(:location, field: 'location')
+           .register_column(:properties, field: 'properties')
 
-    @filter.connect(self, :probes)
+    @filter.install_filter_methods_on_resource(self, :probes)
 
     def parse_resource(resource)
       # return a hash of information

--- a/lib/resources/azure/azure_virtual_machine_data_disk.rb
+++ b/lib/resources/azure/azure_virtual_machine_data_disk.rb
@@ -15,23 +15,21 @@ module Inspec::Resources
 
     # Create a filter table so that tests on the disk can be performed
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:exists?) { |x| !x.entries.empty? }
-          .add(:disk, field: :disk)
-          .add(:number, field: :number)
-          .add(:name, field: :name)
-          .add(:size, field: :size)
-          .add(:vhd_uri, field: :vhd_uri)
-          .add(:storage_account_name, field: :storage_account_name)
-          .add(:lun, field: :lun)
-          .add(:caching, field: :caching)
-          .add(:create_option, field: :create_option)
-          .add(:is_managed_disk?, field: :is_managed_disk?)
-          .add(:storage_account_type, field: :storage_account_type)
-          .add(:subscription_id, field: :subscription_id)
-          .add(:resource_group, field: :resource_group)
-    filter.connect(self, :datadisk_details)
+    filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+          .register_column(:disk, field: :disk)
+          .register_column(:number, field: :number)
+          .register_column(:name, field: :name)
+          .register_column(:size, field: :size)
+          .register_column(:vhd_uri, field: :vhd_uri)
+          .register_column(:storage_account_name, field: :storage_account_name)
+          .register_column(:lun, field: :lun)
+          .register_column(:caching, field: :caching)
+          .register_column(:create_option, field: :create_option)
+          .register_column(:is_managed_disk?, field: :is_managed_disk?)
+          .register_column(:storage_account_type, field: :storage_account_type)
+          .register_column(:subscription_id, field: :subscription_id)
+          .register_column(:resource_group, field: :resource_group)
+    filter.install_filter_methods_on_resource(self, :datadisk_details)
 
     # Constructor for the resource. This calls the parent constructor to
     # get the generic resource for the specified machine. This will provide

--- a/lib/resources/azure/azure_virtual_machine_data_disk.rb
+++ b/lib/resources/azure/azure_virtual_machine_data_disk.rb
@@ -15,6 +15,7 @@ module Inspec::Resources
 
     # Create a filter table so that tests on the disk can be performed
     filter = FilterTable.create
+    filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
     filter.register_column(:disk, field: :disk)
           .register_column(:number, field: :number)
           .register_column(:name, field: :name)

--- a/lib/resources/azure/azure_virtual_machine_data_disk.rb
+++ b/lib/resources/azure/azure_virtual_machine_data_disk.rb
@@ -15,8 +15,7 @@ module Inspec::Resources
 
     # Create a filter table so that tests on the disk can be performed
     filter = FilterTable.create
-    filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-          .register_column(:disk, field: :disk)
+    filter.register_column(:disk, field: :disk)
           .register_column(:number, field: :number)
           .register_column(:name, field: :name)
           .register_column(:size, field: :size)

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -65,24 +65,22 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:minutes,  field: 'minute')
-          .add(:hours,    field: 'hour')
-          .add(:days,     field: 'day')
-          .add(:months,   field: 'month')
-          .add(:weekdays, field: 'weekday')
-          .add(:user,     field: 'user')
-          .add(:commands, field: 'command')
+    filter.register_column(:minutes,  field: 'minute')
+          .register_column(:hours,    field: 'hour')
+          .register_column(:days,     field: 'day')
+          .register_column(:months,   field: 'month')
+          .register_column(:weekdays, field: 'weekday')
+          .register_column(:user,     field: 'user')
+          .register_column(:commands, field: 'command')
 
     # rebuild the crontab line from raw content
-    filter.add(:content) { |t, _|
+    filter.register_custom_property(:content) { |t, _|
       t.entries.map do |e|
         [e.minute, e.hour, e.day, e.month, e.weekday, e.user, e.command].compact.join(' ')
       end.join("\n")
     }
 
-    filter.connect(self, :params)
+    filter.install_filter_methods_on_resource(self, :params)
 
     def to_s
       if is_system_crontab?

--- a/lib/resources/docker.rb
+++ b/lib/resources/docker.rb
@@ -22,8 +22,7 @@ module Inspec::Resources
           .register_column(:running_for,    field: 'runningfor')
           .register_column(:sizes,          field: 'size')
           .register_column(:status,         field: 'status')
-          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
-          .register_column(:running?) { |x|
+          .register_custom_matcher(:running?) { |x|
             x.where { status.downcase.start_with?('up') }
           }
     filter.install_filter_methods_on_resource(self, :containers)
@@ -43,7 +42,6 @@ module Inspec::Resources
           .register_column(:digests,          field: 'digest')
           .register_column(:created,          field: 'createdat')
           .register_column(:created_since,    field: 'createdsize')
-          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
     filter.install_filter_methods_on_resource(self, :images)
 
     attr_reader :images
@@ -60,7 +58,6 @@ module Inspec::Resources
           .register_column(:replicas,         field: 'replicas')
           .register_column(:images,           field: 'image')
           .register_column(:ports,            field: 'ports')
-          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
     filter.install_filter_methods_on_resource(self, :services)
 
     attr_reader :services

--- a/lib/resources/docker.rb
+++ b/lib/resources/docker.rb
@@ -10,25 +10,23 @@ module Inspec::Resources
   class DockerContainerFilter
     # use filtertable for containers
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:commands,       field: 'command')
-          .add(:ids,            field: 'id')
-          .add(:images,         field: 'image')
-          .add(:labels,         field: 'labels')
-          .add(:local_volumes,  field: 'localvolumes')
-          .add(:mounts,         field: 'mounts')
-          .add(:names,          field: 'names')
-          .add(:networks,       field: 'networks')
-          .add(:ports,          field: 'ports')
-          .add(:running_for,    field: 'runningfor')
-          .add(:sizes,          field: 'size')
-          .add(:status,         field: 'status')
-          .add(:exists?) { |x| !x.entries.empty? }
-          .add(:running?) { |x|
+    filter.register_column(:commands,       field: 'command')
+          .register_column(:ids,            field: 'id')
+          .register_column(:images,         field: 'image')
+          .register_column(:labels,         field: 'labels')
+          .register_column(:local_volumes,  field: 'localvolumes')
+          .register_column(:mounts,         field: 'mounts')
+          .register_column(:names,          field: 'names')
+          .register_column(:networks,       field: 'networks')
+          .register_column(:ports,          field: 'ports')
+          .register_column(:running_for,    field: 'runningfor')
+          .register_column(:sizes,          field: 'size')
+          .register_column(:status,         field: 'status')
+          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+          .register_column(:running?) { |x|
             x.where { status.downcase.start_with?('up') }
           }
-    filter.connect(self, :containers)
+    filter.install_filter_methods_on_resource(self, :containers)
 
     attr_reader :containers
     def initialize(containers)
@@ -38,17 +36,15 @@ module Inspec::Resources
 
   class DockerImageFilter
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:ids,              field: 'id')
-          .add(:repositories,     field: 'repository')
-          .add(:tags,             field: 'tag')
-          .add(:sizes,            field: 'size')
-          .add(:digests,          field: 'digest')
-          .add(:created,          field: 'createdat')
-          .add(:created_since,    field: 'createdsize')
-          .add(:exists?) { |x| !x.entries.empty? }
-    filter.connect(self, :images)
+    filter.register_column(:ids,              field: 'id')
+          .register_column(:repositories,     field: 'repository')
+          .register_column(:tags,             field: 'tag')
+          .register_column(:sizes,            field: 'size')
+          .register_column(:digests,          field: 'digest')
+          .register_column(:created,          field: 'createdat')
+          .register_column(:created_since,    field: 'createdsize')
+          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+    filter.install_filter_methods_on_resource(self, :images)
 
     attr_reader :images
     def initialize(images)
@@ -58,16 +54,14 @@ module Inspec::Resources
 
   class DockerServiceFilter
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:ids,              field: 'id')
-          .add(:names,            field: 'name')
-          .add(:modes,            field: 'mode')
-          .add(:replicas,         field: 'replicas')
-          .add(:images,           field: 'image')
-          .add(:ports,            field: 'ports')
-          .add(:exists?) { |x| !x.entries.empty? }
-    filter.connect(self, :services)
+    filter.register_column(:ids,              field: 'id')
+          .register_column(:names,            field: 'name')
+          .register_column(:modes,            field: 'mode')
+          .register_column(:replicas,         field: 'replicas')
+          .register_column(:images,           field: 'image')
+          .register_column(:ports,            field: 'ports')
+          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+    filter.install_filter_methods_on_resource(self, :services)
 
     attr_reader :services
     def initialize(services)

--- a/lib/resources/docker.rb
+++ b/lib/resources/docker.rb
@@ -10,6 +10,7 @@ module Inspec::Resources
   class DockerContainerFilter
     # use filtertable for containers
     filter = FilterTable.create
+    filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
     filter.register_column(:commands,       field: 'command')
           .register_column(:ids,            field: 'id')
           .register_column(:images,         field: 'image')
@@ -35,6 +36,7 @@ module Inspec::Resources
 
   class DockerImageFilter
     filter = FilterTable.create
+    filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
     filter.register_column(:ids,              field: 'id')
           .register_column(:repositories,     field: 'repository')
           .register_column(:tags,             field: 'tag')
@@ -52,6 +54,7 @@ module Inspec::Resources
 
   class DockerServiceFilter
     filter = FilterTable.create
+    filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
     filter.register_column(:ids,              field: 'id')
           .register_column(:names,            field: 'name')
           .register_column(:modes,            field: 'mode')

--- a/lib/resources/elasticsearch.rb
+++ b/lib/resources/elasticsearch.rb
@@ -45,7 +45,6 @@ module Inspec::Resources
           .register_column(:module_list,           field: 'module_list')
           .register_column(:node_id,               field: 'node_id')
           .register_column(:ingest,                field: 'ingest')
-          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
           .register_custom_property(:node_count) { |t, _|
             t.entries.length
           }

--- a/lib/resources/elasticsearch.rb
+++ b/lib/resources/elasticsearch.rb
@@ -24,6 +24,7 @@ module Inspec::Resources
     "
 
     filter = FilterTable.create
+    filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
     filter.register_column(:cluster_name,          field: 'cluster_name')
           .register_column(:node_name,             field: 'name')
           .register_column(:transport_address,     field: 'transport_address')

--- a/lib/resources/elasticsearch.rb
+++ b/lib/resources/elasticsearch.rb
@@ -24,35 +24,33 @@ module Inspec::Resources
     "
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:cluster_name,          field: 'cluster_name')
-          .add(:node_name,             field: 'name')
-          .add(:transport_address,     field: 'transport_address')
-          .add(:host,                  field: 'host')
-          .add(:ip,                    field: 'ip')
-          .add(:version,               field: 'version')
-          .add(:build_hash,            field: 'build_hash')
-          .add(:total_indexing_buffer, field: 'total_indexing_buffer')
-          .add(:roles,                 field: 'roles')
-          .add(:settings,              field: 'settings')
-          .add(:os,                    field: 'os')
-          .add(:process,               field: 'process')
-          .add(:jvm,                   field: 'jvm')
-          .add(:transport,             field: 'transport')
-          .add(:http,                  field: 'http')
-          .add(:plugins,               field: 'plugins')
-          .add(:plugin_list,           field: 'plugin_list')
-          .add(:modules,               field: 'modules')
-          .add(:module_list,           field: 'module_list')
-          .add(:node_id,               field: 'node_id')
-          .add(:ingest,                field: 'ingest')
-          .add(:exists?) { |x| !x.entries.empty? }
-          .add(:node_count) { |t, _|
+    filter.register_column(:cluster_name,          field: 'cluster_name')
+          .register_column(:node_name,             field: 'name')
+          .register_column(:transport_address,     field: 'transport_address')
+          .register_column(:host,                  field: 'host')
+          .register_column(:ip,                    field: 'ip')
+          .register_column(:version,               field: 'version')
+          .register_column(:build_hash,            field: 'build_hash')
+          .register_column(:total_indexing_buffer, field: 'total_indexing_buffer')
+          .register_column(:roles,                 field: 'roles')
+          .register_column(:settings,              field: 'settings')
+          .register_column(:os,                    field: 'os')
+          .register_column(:process,               field: 'process')
+          .register_column(:jvm,                   field: 'jvm')
+          .register_column(:transport,             field: 'transport')
+          .register_column(:http,                  field: 'http')
+          .register_column(:plugins,               field: 'plugins')
+          .register_column(:plugin_list,           field: 'plugin_list')
+          .register_column(:modules,               field: 'modules')
+          .register_column(:module_list,           field: 'module_list')
+          .register_column(:node_id,               field: 'node_id')
+          .register_column(:ingest,                field: 'ingest')
+          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+          .register_custom_property(:node_count) { |t, _|
             t.entries.length
           }
 
-    filter.connect(self, :nodes)
+    filter.install_filter_methods_on_resource(self, :nodes)
 
     attr_reader :nodes, :url
 

--- a/lib/resources/etc_fstab.rb
+++ b/lib/resources/etc_fstab.rb
@@ -38,17 +38,15 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:device_name,           field: 'device_name')
-          .add(:mount_point,           field: 'mount_point')
-          .add(:file_system_type,      field: 'file_system_type')
-          .add(:mount_options,         field: 'mount_options')
-          .add(:dump_options,          field: 'dump_options')
-          .add(:file_system_options,   field: 'file_system_options')
-          .add(:configured?) { |x| x.entries.any? }
+    filter.register_column(:device_name,           field: 'device_name')
+          .register_column(:mount_point,           field: 'mount_point')
+          .register_column(:file_system_type,      field: 'file_system_type')
+          .register_column(:mount_options,         field: 'mount_options')
+          .register_column(:dump_options,          field: 'dump_options')
+          .register_column(:file_system_options,   field: 'file_system_options')
+          .register_custom_matcher(:configured?) { |x| x.entries.any? }
 
-    filter.connect(self, :params)
+    filter.install_filter_methods_on_resource(self, :params)
 
     def nfs_file_systems
       where { file_system_type.match(/nfs/) }

--- a/lib/resources/etc_hosts.rb
+++ b/lib/resources/etc_hosts.rb
@@ -33,12 +33,10 @@ class EtcHosts < Inspec.resource(1)
   end
 
   FilterTable.create
-             .add_accessor(:where)
-             .add_accessor(:entries)
-             .add(:ip_address,     field: 'ip_address')
-             .add(:primary_name,   field: 'primary_name')
-             .add(:all_host_names, field: 'all_host_names')
-             .connect(self, :params)
+             .register_column(:ip_address,     field: 'ip_address')
+             .register_column(:primary_name,   field: 'primary_name')
+             .register_column(:all_host_names, field: 'all_host_names')
+             .install_filter_methods_on_resource(self, :params)
 
   private
 

--- a/lib/resources/etc_hosts_allow_deny.rb
+++ b/lib/resources/etc_hosts_allow_deny.rb
@@ -29,13 +29,11 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:daemon,      field: 'daemon')
-          .add(:client_list, field: 'client_list')
-          .add(:options,     field: 'options')
+    filter.register_column(:daemon,      field: 'daemon')
+          .register_column(:client_list, field: 'client_list')
+          .register_column(:options,     field: 'options')
 
-    filter.connect(self, :params)
+    filter.install_filter_methods_on_resource(self, :params)
 
     private
 

--- a/lib/resources/firewalld.rb
+++ b/lib/resources/firewalld.rb
@@ -28,14 +28,12 @@ module Inspec::Resources
     attr_reader :params
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:zone,       field: 'zone')
-          .add(:interfaces, field: 'interfaces')
-          .add(:sources,    field: 'sources')
-          .add(:services,   field: 'services')
+    filter.register_column(:zone,       field: 'zone')
+          .register_column(:interfaces, field: 'interfaces')
+          .register_column(:sources,    field: 'sources')
+          .register_column(:services,   field: 'services')
 
-    filter.connect(self, :params)
+    filter.install_filter_methods_on_resource(self, :params)
 
     def initialize
       @params = parse_active_zones(active_zones)

--- a/lib/resources/groups.rb
+++ b/lib/resources/groups.rb
@@ -51,7 +51,6 @@ module Inspec::Resources
           .register_column(:gids,      field: 'gid')
           .register_column(:domains,   field: 'domain')
           .register_column(:members,   field: 'members')
-          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
     filter.install_filter_methods_on_resource(self, :collect_group_details)
 
     def to_s

--- a/lib/resources/groups.rb
+++ b/lib/resources/groups.rb
@@ -47,14 +47,12 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:names,     field: 'name')
-          .add(:gids,      field: 'gid')
-          .add(:domains,   field: 'domain')
-          .add(:members,   field: 'members')
-          .add(:exists?) { |x| !x.entries.empty? }
-    filter.connect(self, :collect_group_details)
+    filter.register_column(:names,     field: 'name')
+          .register_column(:gids,      field: 'gid')
+          .register_column(:domains,   field: 'domain')
+          .register_column(:members,   field: 'members')
+          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+    filter.install_filter_methods_on_resource(self, :collect_group_details)
 
     def to_s
       'Groups'

--- a/lib/resources/groups.rb
+++ b/lib/resources/groups.rb
@@ -47,6 +47,7 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
+    filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
     filter.register_column(:names,     field: 'name')
           .register_column(:gids,      field: 'gid')
           .register_column(:domains,   field: 'domain')

--- a/lib/resources/nginx_conf.rb
+++ b/lib/resources/nginx_conf.rb
@@ -156,9 +156,8 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add(:servers, field: 'server')
-          .connect(self, :server_table)
+    filter.register_column(:servers, field: 'server')
+          .install_filter_methods_on_resource(self, :server_table)
 
     def locations
       servers.map(&:locations).flatten
@@ -184,9 +183,8 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add(:locations, field: 'location')
-          .connect(self, :location_table)
+    filter.register_column(:locations, field: 'location')
+          .install_filter_methods_on_resource(self, :location_table)
 
     def to_s
       server = ''

--- a/lib/resources/packages.rb
+++ b/lib/resources/packages.rb
@@ -42,13 +42,11 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:statuses,  field: 'status', style: :simple)
-          .add(:names,     field: 'name')
-          .add(:versions,  field: 'version')
-          .add(:architectures, field: 'architecture')
-          .connect(self, :filtered_packages)
+    filter.register_column(:statuses,  field: 'status', style: :simple)
+          .register_column(:names,     field: 'name')
+          .register_column(:versions,  field: 'version')
+          .register_column(:architectures, field: 'architecture')
+          .install_filter_methods_on_resource(self, :filtered_packages)
 
     private
 

--- a/lib/resources/passwd.rb
+++ b/lib/resources/passwd.rb
@@ -50,24 +50,22 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:users,     field: 'user')
-          .add(:passwords, field: 'password')
-          .add(:uids,      field: 'uid')
-          .add(:gids,      field: 'gid')
-          .add(:descs,     field: 'desc')
-          .add(:homes,     field: 'home')
-          .add(:shells,    field: 'shell')
+    filter.register_column(:users,     field: 'user')
+          .register_column(:passwords, field: 'password')
+          .register_column(:uids,      field: 'uid')
+          .register_column(:gids,      field: 'gid')
+          .register_column(:descs,     field: 'desc')
+          .register_column(:homes,     field: 'home')
+          .register_column(:shells,    field: 'shell')
 
     # rebuild the passwd line from raw content
-    filter.add(:content) { |t, _|
+    filter.register_custom_property(:content) { |t, _|
       t.entries.map do |e|
         [e.user, e.password, e.uid, e.gid, e.desc, e.home, e.shell].join(':')
       end.join("\n")
     }
 
-    filter.connect(self, :params)
+    filter.install_filter_methods_on_resource(self, :params)
 
     def to_s
       '/etc/passwd'

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -39,15 +39,13 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:ports,     field: 'port', style: :simple)
-          .add(:addresses, field: 'address', style: :simple)
-          .add(:protocols, field: 'protocol', style: :simple)
-          .add(:processes, field: 'process', style: :simple)
-          .add(:pids,      field: 'pid', style: :simple)
-          .add(:listening?) { |x| !x.entries.empty? }
-    filter.connect(self, :info)
+    filter.register_column(:ports,     field: 'port', style: :simple)
+          .register_column(:addresses, field: 'address', style: :simple)
+          .register_column(:protocols, field: 'protocol', style: :simple)
+          .register_column(:processes, field: 'process', style: :simple)
+          .register_column(:pids,      field: 'pid', style: :simple)
+          .register_custom_matcher(:listening?) { |x| !x.entries.empty? }
+    filter.install_filter_methods_on_resource(self, :info)
 
     def to_s
       "Port #{@port}"

--- a/lib/resources/postgres_hba_conf.rb
+++ b/lib/resources/postgres_hba_conf.rb
@@ -28,16 +28,14 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:type,     field: 'type')
-          .add(:database, field: 'database')
-          .add(:user,     field: 'user')
-          .add(:address,  field: 'address')
-          .add(:auth_method, field: 'auth_method')
-          .add(:auth_params, field: 'auth_params')
+    filter.register_column(:type,     field: 'type')
+          .register_column(:database, field: 'database')
+          .register_column(:user,     field: 'user')
+          .register_column(:address,  field: 'address')
+          .register_column(:auth_method, field: 'auth_method')
+          .register_column(:auth_params, field: 'auth_params')
 
-    filter.connect(self, :params)
+    filter.install_filter_methods_on_resource(self, :params)
 
     def to_s
       "Postgres Hba Config #{@conf_file}"

--- a/lib/resources/postgres_ident_conf.rb
+++ b/lib/resources/postgres_ident_conf.rb
@@ -27,13 +27,11 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:map_name,        field: 'map_name')
-          .add(:system_username, field: 'system_username')
-          .add(:pg_username,     field: 'pg_username')
+    filter.register_column(:map_name,        field: 'map_name')
+          .register_column(:system_username, field: 'system_username')
+          .register_column(:pg_username,     field: 'pg_username')
 
-    filter.connect(self, :params)
+    filter.install_filter_methods_on_resource(self, :params)
 
     def to_s
       "PostgreSQL Ident Config #{@conf_file}"

--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -61,21 +61,19 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:labels,   field: 'label')
-          .add(:pids,     field: 'pid')
-          .add(:cpus,     field: 'cpu')
-          .add(:mem,      field: 'mem')
-          .add(:vsz,      field: 'vsz')
-          .add(:rss,      field: 'rss')
-          .add(:tty,      field: 'tty')
-          .add(:states,   field: 'stat')
-          .add(:start,    field: 'start')
-          .add(:time,     field: 'time')
-          .add(:users,    field: 'user')
-          .add(:commands, field: 'command')
-          .connect(self, :filtered_processes)
+    filter.register_column(:labels,   field: 'label')
+          .register_column(:pids,     field: 'pid')
+          .register_column(:cpus,     field: 'cpu')
+          .register_column(:mem,      field: 'mem')
+          .register_column(:vsz,      field: 'vsz')
+          .register_column(:rss,      field: 'rss')
+          .register_column(:tty,      field: 'tty')
+          .register_column(:states,   field: 'stat')
+          .register_column(:start,    field: 'start')
+          .register_column(:time,     field: 'time')
+          .register_column(:users,    field: 'user')
+          .register_column(:commands, field: 'command')
+          .install_filter_methods_on_resource(self, :filtered_processes)
 
     private
 

--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -44,20 +44,13 @@ module Inspec::Resources
 
     filtertable = FilterTable.create
     filtertable
-<<<<<<< HEAD
       .register_column(:users, field: 'user')
       .register_column(:passwords, field: 'password')
       .register_column(:last_changes, field: 'last_change')
-=======
-      .register_column(:user, field: 'user')
-      .register_column(:password, field: 'password')
-      .register_column(:last_change, field: 'last_change')
->>>>>>> Search and replace filtertable methods to use new names, and rely on automatic methods
       .register_column(:min_days, field: 'min_days')
       .register_column(:max_days, field: 'max_days')
       .register_column(:warn_days, field: 'warn_days')
       .register_column(:inactive_days, field: 'inactive_days')
-<<<<<<< HEAD
       .register_column(:expiry_dates, field: 'expiry_date')
       .register_column(:reserved, field: 'reserved')
     # These are deprecated, but we need to "alias" them
@@ -66,10 +59,6 @@ module Inspec::Resources
       .register_custom_property(:password) { |table, value| table.resource.password(value) }
       .register_custom_property(:last_change) { |table, value| table.resource.last_change(value) }
       .register_custom_property(:expiry_date) { |table, value| table.resource.expiry_date(value) }
-=======
-      .register_column(:expiry_date, field: 'expiry_date')
-      .register_column(:reserved, field: 'reserved')
->>>>>>> Search and replace filtertable methods to use new names, and rely on automatic methods
 
     filtertable.register_custom_property(:content) { |t, _|
       t.entries.map do |e|
@@ -77,13 +66,6 @@ module Inspec::Resources
       end.join("\n")
     }
 
-<<<<<<< HEAD
-=======
-    filtertable.register_custom_property(:count) { |i, _|
-      i.entries.length
-    }
-
->>>>>>> Search and replace filtertable methods to use new names, and rely on automatic methods
     filtertable.install_filter_methods_on_resource(self, :set_params)
 
     def filter(query = {})

--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -44,13 +44,20 @@ module Inspec::Resources
 
     filtertable = FilterTable.create
     filtertable
+<<<<<<< HEAD
       .register_column(:users, field: 'user')
       .register_column(:passwords, field: 'password')
       .register_column(:last_changes, field: 'last_change')
+=======
+      .register_column(:user, field: 'user')
+      .register_column(:password, field: 'password')
+      .register_column(:last_change, field: 'last_change')
+>>>>>>> Search and replace filtertable methods to use new names, and rely on automatic methods
       .register_column(:min_days, field: 'min_days')
       .register_column(:max_days, field: 'max_days')
       .register_column(:warn_days, field: 'warn_days')
       .register_column(:inactive_days, field: 'inactive_days')
+<<<<<<< HEAD
       .register_column(:expiry_dates, field: 'expiry_date')
       .register_column(:reserved, field: 'reserved')
     # These are deprecated, but we need to "alias" them
@@ -59,6 +66,10 @@ module Inspec::Resources
       .register_custom_property(:password) { |table, value| table.resource.password(value) }
       .register_custom_property(:last_change) { |table, value| table.resource.last_change(value) }
       .register_custom_property(:expiry_date) { |table, value| table.resource.expiry_date(value) }
+=======
+      .register_column(:expiry_date, field: 'expiry_date')
+      .register_column(:reserved, field: 'reserved')
+>>>>>>> Search and replace filtertable methods to use new names, and rely on automatic methods
 
     filtertable.register_custom_property(:content) { |t, _|
       t.entries.map do |e|
@@ -66,6 +77,13 @@ module Inspec::Resources
       end.join("\n")
     }
 
+<<<<<<< HEAD
+=======
+    filtertable.register_custom_property(:count) { |i, _|
+      i.entries.length
+    }
+
+>>>>>>> Search and replace filtertable methods to use new names, and rely on automatic methods
     filtertable.install_filter_methods_on_resource(self, :set_params)
 
     def filter(query = {})

--- a/lib/resources/users.rb
+++ b/lib/resources/users.rb
@@ -70,23 +70,21 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:usernames, field: :username)
-          .add(:uids,      field: :uid)
-          .add(:gids,      field: :gid)
-          .add(:groupnames, field: :groupname)
-          .add(:groups,    field: :groups)
-          .add(:homes,     field: :home)
-          .add(:shells,    field: :shell)
-          .add(:mindays,   field: :mindays)
-          .add(:maxdays,   field: :maxdays)
-          .add(:warndays,  field: :warndays)
-          .add(:disabled,  field: :disabled)
-          .add(:exists?) { |x| !x.entries.empty? }
-          .add(:disabled?) { |x| x.where { disabled == false }.entries.empty? }
-          .add(:enabled?) { |x| x.where { disabled == true }.entries.empty? }
-    filter.connect(self, :collect_user_details)
+    filter.register_column(:usernames, field: :username)
+          .register_column(:uids,      field: :uid)
+          .register_column(:gids,      field: :gid)
+          .register_column(:groupnames, field: :groupname)
+          .register_column(:groups,    field: :groups)
+          .register_column(:homes,     field: :home)
+          .register_column(:shells,    field: :shell)
+          .register_column(:mindays,   field: :mindays)
+          .register_column(:maxdays,   field: :maxdays)
+          .register_column(:warndays,  field: :warndays)
+          .register_column(:disabled,  field: :disabled)
+          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
+          .register_custom_matcher(:disabled?) { |x| x.where { disabled == false }.entries.empty? }
+          .register_custom_matcher(:enabled?) { |x| x.where { disabled == true }.entries.empty? }
+    filter.install_filter_methods_on_resource(self, :collect_user_details)
 
     def to_s
       'Users'

--- a/lib/resources/users.rb
+++ b/lib/resources/users.rb
@@ -70,6 +70,7 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
+    filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
     filter.register_column(:usernames, field: :username)
           .register_column(:uids,      field: :uid)
           .register_column(:gids,      field: :gid)

--- a/lib/resources/users.rb
+++ b/lib/resources/users.rb
@@ -81,7 +81,6 @@ module Inspec::Resources
           .register_column(:maxdays,   field: :maxdays)
           .register_column(:warndays,  field: :warndays)
           .register_column(:disabled,  field: :disabled)
-          .register_custom_matcher(:exists?) { |x| !x.entries.empty? }
           .register_custom_matcher(:disabled?) { |x| x.where { disabled == false }.entries.empty? }
           .register_custom_matcher(:enabled?) { |x| x.where { disabled == true }.entries.empty? }
     filter.install_filter_methods_on_resource(self, :collect_user_details)

--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -37,17 +37,15 @@ module Inspec::Resources
     end
 
     filter = FilterTable.create
-    filter.add_accessor(:where)
-          .add_accessor(:entries)
-          .add(:services,     field: 'service')
-          .add(:ids,          field: 'id')
-          .add(:socket_types, field: 'socket_type')
-          .add(:types,        field: 'type')
-          .add(:protocols,    field: 'protocol')
-          .add(:wait,         field: 'wait')
-          .add(:disabled?) { |x| x.where('disable' => 'no').services.empty? }
-          .add(:enabled?) { |x| x.where('disable' => 'yes').services.empty? }
-          .connect(self, :service_lines)
+    filter.register_column(:services,     field: 'service')
+          .register_column(:ids,          field: 'id')
+          .register_column(:socket_types, field: 'socket_type')
+          .register_column(:types,        field: 'type')
+          .register_column(:protocols,    field: 'protocol')
+          .register_column(:wait,         field: 'wait')
+          .register_custom_matcher(:disabled?) { |x| x.where('disable' => 'no').services.empty? }
+          .register_custom_matcher(:enabled?) { |x| x.where('disable' => 'yes').services.empty? }
+          .install_filter_methods_on_resource(self, :service_lines)
 
     private
 


### PR DESCRIPTION
This updates all core resources to:
 * rename `add` to one of the three aliases, as appropriate (`register_column`, `register_custom_matcher`, `register_custom_property`)
 * remove all but one call to `add_accessor` (these are now provided automatically)
 * rename `connect` to `install_filter_methods_on_resource`

There are a lot of lines changed, but they are all simple.  Main motivation for this is so that future code browsers / copiers will get on the right foot.

