### PR TITLE
Add insecure option to the automate report json

### DIFF
--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -115,3 +115,47 @@ This reporter includes all information from the rspec runner. Unlike the json re
 ### html
 
 This renders html code to view your tests in a browser. It includes all the test and summary information.
+
+
+## Automate Reporter
+
+The automate reporter type is a special reporter used with the Automate 2 suite. To use this reporter you must pass in the correct configuration via a json config `--json-config`.
+
+Example config:
+```json
+"reporter": {
+    "automate" : {
+        "stdout" : false,
+        "url" : "https://YOUR_A2_URL/data-collector/v0/",
+        "token" : "YOUR_A2_ADMIN_TOKEN",
+        "insecure" : true,
+        "node_name" : "inspec_test_node",
+        "environment" : "prod"
+    }
+}
+```
+
+### Manditory fields:
+#### stdout
+This will either suppress or show the automate report in the CLI screen on completion
+
+#### url
+This is your Automate 2 url. Append `data-collector/v0/` at the end.
+
+#### token
+This is your Automate 2 token. You can generate this token by navigating to the admin tab of A2 and then api keys.
+
+### Optional fields
+#### insecure
+This will disable or enable the ssl check when accessing the Automate 2 instance.
+
+PLEASE NOTE: These fields are ONLY needed if you do not have chef-client attached to a chef server running on your node. The fields below will be automaticlly pulled from the chef server.
+
+#### node_name
+This will be the node name which shows up in Automate 2.
+
+#### node_uuid
+This overrides the node uuid sent up to Automate 2. On non-chef nodes we will try to generate a static node uuid for you from your hardware. This will almost never be needed unless your working with a unique virtual setup.
+
+#### environment
+This will set the enviroment metadata for Automate 2.

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -135,7 +135,7 @@ Example config:
 }
 ```
 
-### Manditory fields:
+### Mandatory fields:
 #### stdout
 This will either suppress or show the automate report in the CLI screen on completion
 

--- a/lib/bundles/inspec-compliance/README.md
+++ b/lib/bundles/inspec-compliance/README.md
@@ -37,12 +37,26 @@ Commands:
   inspec compliance version           # displays the version of the Chef Compliance server
 ```
 
-### Login with Chef Automate2
+### Login with Chef Automate 2
 
 You will need an API token for authentication. You can retrieve one via the admin section of your A2 web gui.
 
 ```
 $ inspec compliance login https://automate2.compliance.test --insecure --user 'admin' --token 'zuop..._KzE'
+```
+
+#### Login with Chef Automate 2 via json-config
+
+With automate 2 you can automatically login by passing a json config via `--json-config`
+
+Example:
+```json
+"compliance": {
+    "server" : "https://YOUR_A2_URL",
+    "token" : "YOUR_A2_ADMIN_TOKEN",
+    "user" : "YOUR_A2_USER",
+    "insecure" : true
+}
 ```
 
 ### Login with Chef Automate

--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -8,6 +8,9 @@ module Inspec::Reporters
     def initialize(config)
       super(config)
 
+      # allow the insecure flag
+      @config['verify_ssl'] = !@config['insecure'] if @config.key?('insecure')
+
       # default to not verifying ssl for sending reports
       @config['verify_ssl'] = @config['verify_ssl'] || false
     end

--- a/test/unit/reporters/automate_test.rb
+++ b/test/unit/reporters/automate_test.rb
@@ -53,4 +53,20 @@ describe Inspec::Reporters::Automate do
       report.send(:uuid_from_string, end_time + node_uuid).must_equal assert
     end
   end
+
+  describe 'config insecure override' do
+    it 'updates verify_ssl if insecure is set to false' do
+      options['insecure'] = false
+      reporter = Inspec::Reporters::Automate.new(options)
+      config = reporter.instance_variable_get(:@config)
+      config['verify_ssl'].must_equal true
+    end
+
+    it 'updates verify_ssl if insecure is set to true' do
+      options['insecure'] = true
+      reporter = Inspec::Reporters::Automate.new(options)
+      config = reporter.instance_variable_get(:@config)
+      config['verify_ssl'].must_equal false
+    end
+  end
 end


### PR DESCRIPTION
Currently the automate report json uses `verify_ssl` while the compliance json uses `insecure` this is confusing. Adding in the `insecure` as a option for automate and will use that in the documentation.

Signed-off-by: Jared Quick <jquick@chef.io>