### PR TITLE
Fix unit tests for ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
   include:
   - rvm: 2.3.6
   - rvm: 2.4.3
-  - rvm: 2.5.0
+  - rvm: 2.5.1
   - rvm: 2.4.3
     script: bundle exec rake $SUITE
     env: SUITE="test:functional"
@@ -66,7 +66,6 @@ matrix:
     script: ./support/ci/deploy_website_to_acceptance.sh
 
   allow_failures:
-  - rvm: 2.5.0
   - env:
      - AFFECTED_DIRS="www"
      - secure: "jdzXUhP1o7RkfSikZLKgUcCIaKqLjqWa35dnxWnz7qAQ2draRKa7I7cXmUv76BZkW8HBUUH11dOi8YOVxPYPOzaqvcTCfqNqGVxsT9epgWa7rA8aXMXkECp548ry1rYJQpti9zpwsoe2GQyNPr9vNiWMiyj51CaABmZ6JzmFEEqlZc8vqpqWeqJvIqaibQGk7ByLKmi4R44fVwFKIG39RuxV+alc/G4nnQ2zmNTFuy8uFGs5EghQvRytzWY+s2AKtDiZ0YXYOII1Nl1unXNnNoQt9oI209ztlSm1+XOuTPelW6bEIx5i7OZFaSRPgJzWnkGN85C9nBE08L2az9Jz18/rYJF4fdVRttdGskueyYI21lh1FwlAg51ZG0RfLTYk2Pq+k4c+NO1cfmGcaXBwihfD5BWqrILU5HHkYszXCSmgl4hscC7/BS4Kgcq2z32JJwV8B+x4XngM0G4uzIn1Soia3lZXEKdnfVsxFDdMQ7FK60F3uQlq/44LRkZujRhqfAKOiz+0tsLexWzj7wK+DJY9Y00CUfh7xcxRxDxFNpOv1FWYFB9lUlaOt3HDHgUoksqbURiUzhOZZzTE/1MAtF2K6mbpME5CbN08J88L5JBlb+CX79XCzj30lNMeS0I/dCRQEmkygr2eJYxvRO2qsBNuphs4SWk8NZyS/llVZFI="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,10 +15,6 @@ branches:
     - master
     - release-2.0
 
-matrix:
-  allow_failures:
-    - ruby_version: "25"
-
 cache:
   - vendor/bundle -> appveyor.yml
 

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -261,7 +261,7 @@ describe Inspec::ProfileContext do
     describe 'adds a check via describe' do
       let(:check) {
         profile.load(format(context_format,
-          "describe os[:family] { it { must_equal 'debian' } }"
+          "describe(os[:family]) { it { must_equal 'debian' } }"
           ))
         get_checks[0]
       }


### PR DESCRIPTION
This fixes the conflicting tests for ruby 2.5 and changes travis/appvoyer to require 2.5 passing.

Signed-off-by: Jared Quick <jquick@chef.io>