### PR TITLE
Hard code ruby path in binstub to avoid cross-ruby contamination

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -15,6 +15,7 @@ pkg_deps=(
   core/libxslt
   core/net-tools
   core/ruby
+  core/bundler
 )
 pkg_build_deps=(
   core/bundler
@@ -87,7 +88,7 @@ GEMFILE
   # Delete everything that's not inspec in bin
   find "$pkg_prefix/bin" -type f -not -name 'inspec' -delete
 
-  fix_interpreter "$pkg_prefix/bin/inspec" core/coreutils bin/env
+  fix_interpreter "$pkg_prefix/bin/inspec" core/ruby ruby
 
   # Insert the SSL cert path into the inspec executable
   sed -i "2iENV['SSL_CERT_FILE'] = '$(pkg_path_for cacerts)/ssl/cert.pem'" \


### PR DESCRIPTION
In order to avoid other rubies (and since we control the inspec ruby path), we want to hardcode our ruby here so we don't use env and end up with an unexpected ruby

Signed-off-by: Scott Hain <shain@chef.io>