### PR TITLE
Add tags property to aws_s3_bucket

### DIFF
--- a/docs/resources/aws_s3_bucket.md.erb
+++ b/docs/resources/aws_s3_bucket.md.erb
@@ -58,12 +58,6 @@ The following examples show how to use this InSpec audit resource.
     describe aws_s3_bucket('test_bucket') do
       it { should_not be_public }
     end
-
-### Check if a bucket tag exists
-
-    describe aws_ec2_instance('i-090c29e4f4c165b74') do
-      its('tags') { should include(key: 'Name', value: /^*$/) }
-    end
 <br>
 
 ## Properties
@@ -80,6 +74,13 @@ The `region` property identifies the AWS Region in which the S3 bucket is locate
 ### tags
 
 The `tags` property is a hash of tags associated with the bucket.
+
+    describe aws_s3_bucket('test_bucket') do
+      #Check for a specific key and value
+      its('tags') { should include(key: 'Delete-After', value: '20180613'}
+      #Check the given tag exists
+      its('tags') { should include(key: 'Name', value: /^*$/)}
+    end
 
 ## Unsupported Properties
 

--- a/docs/resources/aws_s3_bucket.md.erb
+++ b/docs/resources/aws_s3_bucket.md.erb
@@ -58,6 +58,12 @@ The following examples show how to use this InSpec audit resource.
     describe aws_s3_bucket('test_bucket') do
       it { should_not be_public }
     end
+
+### Check if a bucket tag exists
+
+    describe aws_ec2_instance('i-090c29e4f4c165b74') do
+      its('tags') { should include(key: 'Name', value: /^*$/) }
+    end
 <br>
 
 ## Properties
@@ -70,6 +76,10 @@ The `region` property identifies the AWS Region in which the S3 bucket is locate
       # Check if the correct region is set
       its('region') { should eq 'us-east-1' }
     end
+
+### tags
+
+The `tags` property is a hash of tags associated with the bucket.
 
 ## Unsupported Properties
 

--- a/lib/resources/aws/aws_s3_bucket.rb
+++ b/lib/resources/aws/aws_s3_bucket.rb
@@ -12,6 +12,7 @@ class AwsS3Bucket < Inspec.resource(1)
   include AwsSingularResourceMixin
   attr_reader :bucket_name, :has_default_encryption_enabled, :has_access_logging_enabled, :region
 
+
   def to_s
     "S3 Bucket #{@bucket_name}"
   end
@@ -19,6 +20,12 @@ class AwsS3Bucket < Inspec.resource(1)
   def bucket_acl
     catch_aws_errors do
       @bucket_acl ||= BackendFactory.create(inspec_runner).get_bucket_acl(bucket: bucket_name).grants
+    end
+  end
+
+  def tags
+    catch_aws_errors do
+      @tags ||= BackendFactory.create(inspec_runner).get_bucket_tagging(bucket: bucket_name).tag_set.map { |tag| { key: tag.key, value: tag.value } }
     end
   end
 
@@ -131,6 +138,10 @@ class AwsS3Bucket < Inspec.resource(1)
 
       def get_bucket_encryption(query)
         aws_service_client.get_bucket_encryption(query)
+      end
+
+      def get_bucket_tagging(query)
+        aws_service_client.get_bucket_tagging(query)
       end
     end
   end

--- a/lib/resources/aws/aws_s3_bucket.rb
+++ b/lib/resources/aws/aws_s3_bucket.rb
@@ -12,7 +12,6 @@ class AwsS3Bucket < Inspec.resource(1)
   include AwsSingularResourceMixin
   attr_reader :bucket_name, :has_default_encryption_enabled, :has_access_logging_enabled, :region
 
-
   def to_s
     "S3 Bucket #{@bucket_name}"
   end


### PR DESCRIPTION
### 🎛 Description

🙋 feature request:

As an inspec user, I would like the AWS S3 Bucket resource to support the reading and testing of tags.

### 🌍 InSpec and Platform Version

Inspec version: 2.2.12
Platform: AWS, running inspec from OSX 10.13.5

### 💁 Possible Solutions

Using the aws get_bucket_tagging call, I added a `tags` property definition to the aws_s3_bucket resource, following the pattern from the aws_ec2_instance resource.  Behavior is expected to match that of `aws_ec2_instance`'s tags property.