### PR TITLE
Add list properties back to shadow

### DIFF
--- a/docs/resources/shadow.md.erb
+++ b/docs/resources/shadow.md.erb
@@ -27,7 +27,7 @@ These entries are defined as a colon-delimited row in the file, one row per user
 A `shadow` resource block declares user properties to be tested:
 
     describe shadow do
-      its('user') { should_not include 'forbidden_user' }
+      its('users') { should_not include 'forbidden_user' }
     end
 
 Properties can be used as a single query:
@@ -39,7 +39,7 @@ Properties can be used as a single query:
 Use the `.where` method to find properties that match a value:
 
     describe shadow.where { min_days == '0' } do
-      its ('user') { should include 'nfs' }
+      its ('users') { should include 'nfs' }
     end
 
     describe shadow.where { password =~ /[x|!|*]/ } do
@@ -48,14 +48,14 @@ Use the `.where` method to find properties that match a value:
 
 The following properties are available:
 
-* `user`
-* `password`
-* `last_change`
+* `users`
+* `passwords`
+* `last_changes`
 * `min_days`
 * `max_days`
 * `warn_days`
 * `inactive_days`
-* `expiry_date`
+* `expiry_dates`
 * `reserved`
 
 <br>
@@ -67,13 +67,13 @@ The following examples show how to use this InSpec audit resource.
 ### Test for a forbidden user
 
     describe shadow do
-      its('user') { should_not include 'forbidden_user' }
+      its('users') { should_not include 'forbidden_user' }
     end
 
 ### Test that a user appears one time
 
-    describe shadow.user('bin') do
-      its('password') { should cmp 'x' }
+    describe shadow.users('bin') do
+      its('passwords') { should cmp 'x' }
       its('count') { should eq 1 }
     end
 
@@ -81,25 +81,25 @@ The following examples show how to use this InSpec audit resource.
 
 ## Properties
 
-### user
+### users
 
-The `user` property tests if the username exists `/etc/shadow`:
+The `users` property tests if the username exists `/etc/shadow`:
 
-    its('user') { should eq 'root' }
+    its('users') { should include 'root' }
 
 ### password
 
-The `password` property returns the encrypted password string from the shadow file. The returned string may not be an encrypted password, but rather a `*` or similar which indicates that direct logins are not allowed.
+The `passwords` property returns the encrypted password string from the shadow file. The returned string may not be an encrypted password, but rather a `*` or similar which indicates that direct logins are not allowed.
 
 For example:
 
-    its('password') { should cmp '*' }
+    its('passwords') { should cmp '*' }
 
-### last_change
+### last_changes
 
-The `last_change` property tests the last time a password was changed:
+The `last_changes` property tests the last time a password was changed:
 
-    its('last_change') { should be_empty }
+    its('last_changes') { should be_empty }
 
 ### min_days
 
@@ -125,11 +125,11 @@ The `inactive_days` property tests the number of days a user must be inactive be
 
     its('inactive_days') { should be_empty }
 
-### expiry_date
+### expiry_dates
 
-The `expiry_date` property tests the number of days a user account has been disabled:
+The `expiry_dates` property tests the number of days a user account has been disabled:
 
-    its('expiry_date') { should be_empty }
+    its('expiry_dates') { should be_empty }
 
 ### count
 

--- a/docs/resources/shadow.md.erb
+++ b/docs/resources/shadow.md.erb
@@ -87,7 +87,7 @@ The `users` property tests if the username exists `/etc/shadow`:
 
     its('users') { should include 'root' }
 
-### password
+### passwords
 
 The `passwords` property returns the encrypted password string from the shadow file. The returned string may not be an encrypted password, but rather a `*` or similar which indicates that direct logins are not allowed.
 
@@ -95,37 +95,37 @@ For example:
 
     its('passwords') { should cmp '*' }
 
-### last_changes
+### last\_changes
 
 The `last_changes` property tests the last time a password was changed:
 
     its('last_changes') { should be_empty }
 
-### min_days
+### min\_days
 
 The `min_days` property tests the minimum number of days a password must exist, before it may be changed:
 
     its('min_days') { should eq 0 }
 
-### max_days
+### max\_days
 
 The `max_days` property tests the maximum number of days after which a password must be changed:
 
     its('max_days') { should eq 90 }
 
-### warn_days
+### warn\_days
 
 The `warn_days` property tests the number of days a user is warned about an expiring password:
 
     its('warn_days') { should eq 7 }
 
-### inactive_days
+### inactive\_days
 
 The `inactive_days` property tests the number of days a user must be inactive before the user account is disabled:
 
     its('inactive_days') { should be_empty }
 
-### expiry_dates
+### expiry\_dates
 
 The `expiry_dates` property tests the number of days a user account has been disabled:
 

--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -46,15 +46,21 @@ module Inspec::Resources
     filtertable
       .add_accessor(:where)
       .add_accessor(:entries)
-      .add(:user, field: 'user')
-      .add(:password, field: 'password')
-      .add(:last_change, field: 'last_change')
+      .add(:users, field: 'user')
+      .add(:passwords, field: 'password')
+      .add(:last_changes, field: 'last_change')
       .add(:min_days, field: 'min_days')
       .add(:max_days, field: 'max_days')
       .add(:warn_days, field: 'warn_days')
       .add(:inactive_days, field: 'inactive_days')
-      .add(:expiry_date, field: 'expiry_date')
+      .add(:expiry_dates, field: 'expiry_date')
       .add(:reserved, field: 'reserved')
+    # These are deprecated, but we need to "alias" them
+    filtertable
+      .add(:user) { |table, value| table.resource.user(value) }
+      .add(:password) { |table, value| table.resource.password(value) }
+      .add(:last_change) { |table, value| table.resource.last_change(value) }
+      .add(:expiry_date) { |table, value| table.resource.expiry_date(value) }
 
     filtertable.add(:content) { |t, _|
       t.entries.map do |e|
@@ -88,28 +94,30 @@ module Inspec::Resources
       Shadow.new(@path, content: content, filters: @filters + filters)
     end
 
-    def users(query = nil)
-      warn '[DEPRECATION] The shadow `users` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `user` instead.'
-      query.nil? ? user : user(query)
+    # Next 4 are deprecated methods.  We define them here so we can emit a deprecation message.
+    # Ther are also defined on the Table, above.
+    def user(query = nil)
+      warn '[DEPRECATION] The shadow `user` property is deprecated and will be removed' \
+       ' in InSpec 3.0.  Please use `users` instead.'
+      query.nil? ? where.users : where('user' => query)
     end
 
-    def passwords(query = nil)
-      warn '[DEPRECATION] The shadow `passwords` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `password` instead.'
-      query.nil? ? password : password(query)
+    def password(query = nil)
+      warn '[DEPRECATION] The shadow `password` property is deprecated and will be removed' \
+       ' in InSpec 3.0.  Please use `passwords` instead.'
+      query.nil? ? where.passwords : where('password' => query)
     end
 
-    def last_changes(query = nil)
-      warn '[DEPRECATION] The shadow `last_changes` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `last_change` instead.'
-      query.nil? ? last_change : last_change(query)
+    def last_change(query = nil)
+      warn '[DEPRECATION] The shadow `last_change` property is deprecated and will be removed' \
+       ' in InSpec 3.0.  Please use `last_changes` instead.'
+      query.nil? ? where.last_changes : where('last_change' => query)
     end
 
-    def expiry_dates(query = nil)
-      warn '[DEPRECATION] The shadow `expiry_dates` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `expiry_date` instead.'
-      query.nil? ? expiry_date : expiry_date(query)
+    def expiry_date(query = nil)
+      warn '[DEPRECATION] The shadow `expiry_date` property is deprecated and will be removed' \
+       ' in InSpec 3.0.  Please use `expiry_dates` instead.'
+      query.nil? ? where.expiry_dates : where('expiry_date' => query)
     end
 
     def lines

--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -89,7 +89,7 @@ module Inspec::Resources
     end
 
     # Next 4 are deprecated methods.  We define them here so we can emit a deprecation message.
-    # Ther are also defined on the Table, above.
+    # They are also defined on the Table, above.
     def user(query = nil)
       warn '[DEPRECATION] The shadow `user` property is deprecated and will be removed' \
        ' in InSpec 3.0.  Please use `users` instead.'

--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -44,35 +44,29 @@ module Inspec::Resources
 
     filtertable = FilterTable.create
     filtertable
-      .add_accessor(:where)
-      .add_accessor(:entries)
-      .add(:users, field: 'user')
-      .add(:passwords, field: 'password')
-      .add(:last_changes, field: 'last_change')
-      .add(:min_days, field: 'min_days')
-      .add(:max_days, field: 'max_days')
-      .add(:warn_days, field: 'warn_days')
-      .add(:inactive_days, field: 'inactive_days')
-      .add(:expiry_dates, field: 'expiry_date')
-      .add(:reserved, field: 'reserved')
+      .register_column(:users, field: 'user')
+      .register_column(:passwords, field: 'password')
+      .register_column(:last_changes, field: 'last_change')
+      .register_column(:min_days, field: 'min_days')
+      .register_column(:max_days, field: 'max_days')
+      .register_column(:warn_days, field: 'warn_days')
+      .register_column(:inactive_days, field: 'inactive_days')
+      .register_column(:expiry_dates, field: 'expiry_date')
+      .register_column(:reserved, field: 'reserved')
     # These are deprecated, but we need to "alias" them
     filtertable
-      .add(:user) { |table, value| table.resource.user(value) }
-      .add(:password) { |table, value| table.resource.password(value) }
-      .add(:last_change) { |table, value| table.resource.last_change(value) }
-      .add(:expiry_date) { |table, value| table.resource.expiry_date(value) }
+      .register_custom_property(:user) { |table, value| table.resource.user(value) }
+      .register_custom_property(:password) { |table, value| table.resource.password(value) }
+      .register_custom_property(:last_change) { |table, value| table.resource.last_change(value) }
+      .register_custom_property(:expiry_date) { |table, value| table.resource.expiry_date(value) }
 
-    filtertable.add(:content) { |t, _|
+    filtertable.register_custom_property(:content) { |t, _|
       t.entries.map do |e|
         [e.user, e.password, e.last_change, e.min_days, e.max_days, e.warn_days, e.inactive_days, e.expiry_date].compact.join(':')
       end.join("\n")
     }
 
-    filtertable.add(:count) { |i, _|
-      i.entries.length
-    }
-
-    filtertable.connect(self, :set_params)
+    filtertable.install_filter_methods_on_resource(self, :set_params)
 
     def filter(query = {})
       return self if query.nil? || query.empty?

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -57,27 +57,27 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   it 'returns deprecation notice on user property' do
-    proc { _(shadow.users).must_equal %w{root www-data} }.must_output nil,
-      '[DEPRECATION] The shadow `users` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `user` instead.\n"
+    proc { _(shadow.user).must_equal %w{root www-data} }.must_output nil,
+      '[DEPRECATION] The shadow `user` property is deprecated and will' \
+      " be removed in InSpec 3.0.  Please use `users` instead.\n"
   end
 
   it 'returns deprecatation notice on password property' do
-    proc { _(shadow.passwords).must_equal %w{x !!} }.must_output nil,
-      '[DEPRECATION] The shadow `passwords` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `password` instead.\n"
+    proc { _(shadow.password).must_equal %w{x !!} }.must_output nil,
+      '[DEPRECATION] The shadow `password` property is deprecated and will' \
+      " be removed in InSpec 3.0.  Please use `passwords` instead.\n"
   end
 
   it 'returns deprecation notice on last_change property' do
-    proc { _(shadow.last_changes).must_equal %w{1 10} }.must_output nil,
-      '[DEPRECATION] The shadow `last_changes` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `last_change` instead.\n"
+    proc { _(shadow.last_change).must_equal %w{1 10} }.must_output nil,
+      '[DEPRECATION] The shadow `last_change` property is deprecated and will' \
+      " be removed in InSpec 3.0.  Please use `last_changes` instead.\n"
   end
 
-  it 'returns deprecation notice on expiry_dates property' do
-    proc { _(shadow.expiry_dates).must_equal [nil, "60"] }.must_output nil,
-      '[DEPRECATION] The shadow `expiry_dates` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `expiry_date` instead.\n"
+  it 'returns deprecation notice on expiry_date property' do
+    proc { _(shadow.expiry_date).must_equal [nil, "60"] }.must_output nil,
+      '[DEPRECATION] The shadow `expiry_date` property is deprecated and will' \
+      " be removed in InSpec 3.0.  Please use `expiry_dates` instead.\n"
   end
 
   describe 'multiple filters' do
@@ -92,13 +92,13 @@ describe 'Inspec::Resources::Shadow' do
 
     it 'can read /etc/shadow and #filter matches user with no password and inactive_days' do
       users = shadow.filter(password: /[^x]/).entries.map { |x| x['user'] }
-      users.each do |user|
-        proc { expect(shadow.users(user).user).must_equal(['www-data']) }.must_output nil,
-          '[DEPRECATION] The shadow `users` property is deprecated and will' \
-          " be removed in InSpec 3.0.  Please use `user` instead.\n"
-        proc { expect(shadow.users(user).inactive_days).must_equal(['50']) }.must_output nil,
-          '[DEPRECATION] The shadow `users` property is deprecated and will' \
-          " be removed in InSpec 3.0.  Please use `user` instead.\n"
+      users.each do |expected_user|
+        proc { expect(shadow.user(expected_user).users).must_equal(['www-data']) }.must_output nil,
+          '[DEPRECATION] The shadow `user` property is deprecated and will' \
+          " be removed in InSpec 3.0.  Please use `users` instead.\n"
+        proc { expect(shadow.user(expected_user).inactive_days).must_equal(['50']) }.must_output nil,
+          '[DEPRECATION] The shadow `user` property is deprecated and will' \
+          " be removed in InSpec 3.0.  Please use `users` instead.\n"
       end
     end
 
@@ -116,10 +116,10 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   describe 'filter via name =~ /^www/' do
-    let(:child) { shadow.user(/^www/) }
+    let(:child) { shadow.users(/^www/) }
 
     it 'filters by user via name (regex)' do
-      _(child.user).must_equal ['www-data']
+      _(child.users).must_equal ['www-data']
       _(child.count).must_equal 1
     end
 
@@ -129,10 +129,10 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   describe 'filter via name = root' do
-    let(:child) { shadow.user('root') }
+    let(:child) { shadow.users('root') }
 
     it 'filters by user name' do
-      _(child.user).must_equal %w{root}
+      _(child.users).must_equal %w{root}
       _(child.count).must_equal 1
     end
   end
@@ -141,7 +141,7 @@ describe 'Inspec::Resources::Shadow' do
     let(:child) { shadow.min_days('20') }
 
     it 'filters by property' do
-      _(child.user).must_equal %w{www-data}
+      _(child.users).must_equal %w{www-data}
       _(child.count).must_equal 1
     end
   end


### PR DESCRIPTION
The `shadow` resource has a troubled past.  It is plural, but at one point its plural-named properties (passwords, users, etc) were deprecated.  That made some people sad, and went against the usual practice for plural resources, whose UX is a bit better understood now.

This PR un-deprecates the plural form of the properties, and deprecates the singular form, which should make a different group of people sad.

Fixes #2992 
Fixes  #3136

Refs #2801
Refs #2642