### PR TITLE
apache_conf resource: Strip quotes from values

### DIFF
--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -87,8 +87,10 @@ module Inspec::Resources
         ).params
 
         # Capture any characters between quotes that are not escaped in values
-        params.values.map! do |x|
-          x.map! { |y| y[/(?<=["|'])(?:\\.|[^"'\\])*(?=["|'])/] || y }
+        params.values.map! do |value|
+          value.map! do |sub_value|
+            sub_value[/(?<=["|'])(?:\\.|[^"'\\])*(?=["|'])/] || sub_value
+          end
         end
 
         @params.merge!(params)

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -86,9 +86,9 @@ module Inspec::Resources
           multiple_values: true,
         ).params
 
-        # Capture and use any non-whitespace between quotes in values
-        params.values.each.map do |x|
-          x.map! { |y| y.gsub(/['"](\S+)['"]/, '\1') }
+        # Capture any characters between quotes that are not escaped in values
+        params.values.map! do |x|
+          x.map! { |y| y[/(?<=["|'])(?:\\.|[^"'\\])*(?=["|'])/] || y }
         end
 
         @params.merge!(params)

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -85,6 +85,12 @@ module Inspec::Resources
           assignment_regex: /^\s*(\S+)\s+((?=.*\s+$).*?|.*)\s*$/,
           multiple_values: true,
         ).params
+
+        # Capture and use any non-whitespace between quotes in values
+        params.values.each.map do |x|
+          x.map! { |y| y.gsub(/['"](\S+)['"]/, '\1') }
+        end
+
         @params.merge!(params)
 
         to_read = to_read.drop(1)

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -11,7 +11,7 @@ describe 'Inspec::Resources::ApacheConf' do
     resource = MockLoader.new(:ubuntu1404).load_resource('apache_conf')
     _(resource.params).must_be_kind_of Hash
     _(resource.content).must_be_kind_of String
-    _(resource.params('ServerRoot')).must_equal ['"/etc/apache2"']
+    _(resource.params('ServerRoot')).must_equal ['/etc/apache2']
     _(resource.params('ServerAlias')).must_equal ['inspec.test www.inspec.test io.inspec.test']
     _(resource.params('Listen').sort).must_equal ['443', '80']
     # sourced using a linked file in conf-enabled/
@@ -27,7 +27,7 @@ describe 'Inspec::Resources::ApacheConf' do
     resource = MockLoader.new(:centos6).load_resource('apache_conf')
     _(resource.params).must_be_kind_of Hash
     _(resource.content).must_be_kind_of String
-    _(resource.params('ServerRoot')).must_equal ['"/etc/httpd"']
+    _(resource.params('ServerRoot')).must_equal ['/etc/httpd']
     _(resource.params('Listen').sort).must_equal ['443', '80']
 
     # sourced using an absolute path in httpd.conf


### PR DESCRIPTION
This removes quotes from values captured by SimpleConfig.

Example:

`['\"/etc/apache2\"']`

becomes

`['/etc/apache2']`

This solves the bug portion of #3123 