### PR TITLE
Overhaul Glossary

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -144,7 +144,7 @@ A [resource](#resource) that is _not_ included with InSpec. It may be a resource
 ### describe
 ### describe block
 
-The _`describe`_ keyword is used with a _`describe block`_ to refer to an InSpec resource.  You use the `describe` keyword along with the name of a resource to enclose related [tests](#test) that apply to the resource. Multiple describe blocks are usually grouped together in a [control](#control), but you can also use them outside of a control.
+The _`describe`_ keyword is used with a _`describe block`_ to refer to an InSpec resource.  You use the `describe` keyword along with the name of a [resource](#resource) to enclose related [tests](#test) that apply to the resource. Multiple describe blocks are usually grouped together in a [control](#control), but you can also use them outside of a control.
 
 ```
 control 'Rule 1.1 - Color restrictions' do
@@ -209,7 +209,7 @@ Here, `{ engine_cylinders >= 6 }` is a block-syntax filter statement referring t
 ```
 # Vroom!
 describe cars.where { engine_cylinders >= 6 } do
-  its('city_mpg') { should be < 25 }
+  its('city_mpg_ratings') { should_not include '4-star' }
 end
 ```
 
@@ -248,7 +248,21 @@ end
 
 ### matcher
 
-### operator
+A _`matcher`_ performs the actual assertions against [resources](#resource) or the [properties](#property) of resources.  Matchers always return a true/false value. Matchers fall into two camps:
+ * [resource-specific matchers](#resource_specific_matchers), which operate directly on the resource, are used with [it](#it), and tend to be highly customized to the auditing needs of the resource
+ * [universal matchers](#universal_matchers), which operate on the properties of the resource, are used with [its](#its), and tend to be very generic, operating on text, numbers, and lists
+
+Some matchers accept parameters, called [expected results](#expected_results).
+
+For information on how RSpec matchers are related o InSpec matchers, see [InSpec and RSpec](https://www.inspec.io/docs/reference/inspec_and_friends/#rspec).
+
+Here, `be_classy` is a resource-specific matcher operating directly on the `car`, while `cmp` is a universal matcher operating on the `manufacturer` property.
+```
+describe car(owner: 'Tony Clifton') do
+  it { should be_classy }
+  its('manufacturer') { should cmp 'Cadillac' }
+end
+```
 
 ### plugin
 
@@ -264,18 +278,57 @@ end
 
 ### resource pack
 
-A _resource pack_ is a type of [profile](#profile) that is used to distribute [custom resources](#custom_resource). This specialized type of profile contains no [controls](#control), but it does contain a `libraries` directory which where Ruby files define custom resources.
+A _resource pack_ is a type of [profile](#profile) that is used to distribute [custom resources](#custom_resource). This specialized type of profile contains no [controls](#control), but it does contain a `libraries` directory within which Ruby files define custom resources.
 
 ### resource parameter
 
+_`resource parameters`_ are information passed to the resource when they are declared. Typically, resource parameters provide identifying information or connectivity information.  Resource parameters are not the same as a [filter statement](#filter_statement).
+
+Resource parameters vary from resource to resource; refer to the [resource documentation](https://www.inspec.io/docs/reference/resources/) for details.
+
+Here, `owner: 'Tony Clifton'` is a resource parameter.
+```
+describe car(owner: 'Tony Clifton') do
+  it { should be_classy }
+end
+```
+
 ### resource-specific matcher
+
+A [matcher](#matcher) that operates directly on the [resource](#resource), as opposed to operating on a property as a [universal matcher](#universal matcher) does.
+
+Resource-specific matchers often provide highly customized behavior. Check the [resource documentation](#https://www.inspec.io/docs/reference/resources/) to discover which resource-specific matchers are available for your resource.
+
+For example, the hypothetical `car` resource defines a `classy?` method, which is exposed as the `be_classy` matcher in InSpec tests.
+
+```
+describe car(owner: 'Tony Clifton') do
+  it { should be_classy }
+end
+```
 
 ### singular resource
 
+A [resource](#resource) intended to uniquely identify a single object on the [target](#target). Singular resources specialize in providing richer auditing capabilities via resource-specific matchers. Compare to [plural resources](#plural_resource).
+
 ### target
+
+The _`target`_ is the OS or API on which InSpec is performing audits. In InSpec 1.x, this was always an operating system target (a bare metal machine, VM, or container). In InSpec 2.x and later, this can be an OS target, or an API target, including cloud providers such as AWS. InSpec is agentless, meaning that the InSpec code and profiles remain on your workstation, and the target is remotely interrogated without installing anything.
 
 ### test
 
+A _`test`_ is an individual assertion about the state of the [resource](#resource) or one of its [properties](#property). All tests begin with the keyword [it](#it) or [its](#its). Tests are grouped within a [describe block](#describe_block).
+
 ### universal matcher
 
-A _universal matcher_ is a [matcher](#matcher) that can be used on any type of [resource](#resource). For example, you can use the `cmp` matcher to check the value of properties without having to worry about Ruby type-casting.  Universal matchers are documented on the [Universal Matchers](https://www.inspec.io/docs/reference/matchers/) page.
+A _universal matcher_ is a [matcher](#matcher) that can be used on the [properties](#property) of any type of [resource](#resource). For example, you can use the `cmp` matcher to check the value of properties without having to worry about Ruby type-casting.  Universal matchers are almost always used with the [its](#its) keyword.
+
+Universal matchers are documented on the [Universal Matchers](https://www.inspec.io/docs/reference/matchers/) page.
+
+Here, we access the 'color' property, then use the `cmp` universal matcher to compare the property to the 'black' [expected result](#expected_result).
+
+```
+describe car(owner: 'Bruce Wayne') do
+  its('color') { should cmp 'black' }
+end
+```

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -32,7 +32,7 @@ end
 
 _car_ is a [resource](#resource).  Since we are only talking about one car, it is a [singular resource](#singular_resource).
 
-#### describe foo(_owner: 'Tony Clifton'_)
+#### describe car(_owner: 'Tony Clifton'_)
 
 _owner_ is a [resource parameter](#resource_parameter) along with _'Tony Clifton'_, a resource parameter value.
 
@@ -235,7 +235,6 @@ Within a [describe block](#describe), _`its`_ declares an individual [test](#tes
 
 The property to access is passed as a single string argument to `its`. As an advanced usage, if the property has methods you are interested in, you can call them using '`.`' within the string; even more advanced calling patterns are possible - see [the rspec-its documentation](https://github.com/rspec/rspec-its#usage).
 
-
 Here, `its('fuzzy_dice') { should ... }` declares a test, testing against the `fuzzy_dice` property of Tony Clifton's car. Let's assume - Tony being Tony - that `fuzzy_dice` will return an Array.
 
 ```
@@ -264,17 +263,68 @@ describe car(owner: 'Tony Clifton') do
 end
 ```
 
-### plugin
-
 ### plural resource
+
+A _`plural resource`_ is a [resource](#resource) that specializes in performing searches and represents multiple occurrences of the resource on the [target](#target) platform. Plural resources are used to audit counts, inspect group properties, and have the unique ability to enforce negative tests ("nothing like this should exist") often required by compliance standards. Plural resources are not intended to perform in-depth auditing of an individual; use [singular resources](#singular_resource) for that.
+
+Plural resources nearly always have a name that ends in 's': `processes`, `aws_security_groups`, `cars`. Plural resources generally do not have [resource-specific matchers](#resource_specific_matcher). If they have properties, they are almost always list properties, meaning that they return a list of values, which may or may not be de-duplicated.
+
+Plural resources support [filter statements](#filter_statement). See the [resource documentation](https://www.inspec.io/docs/reference/resources/) for details regarding which [filter criteria](#filter_criteria) are supported on each resource.
+
+Here, `cars` is a plural resource.
+```
+describe cars.where(color: 'blue') do
+  its('count') { should eq 20 }
+  its('license_plates') { should include 'AUTOAZUL' }
+
+  # License plates are unique, should have 20
+  its('license_plates.count') { should cmp 20 }
+
+  # Manufacturers are de-duplicated
+  its('manufacturers') { should include 'Subaru' }
+  its('manufacturers.count') { should be < 10 }
+end
+```
 
 ### profile
 
+A _`profile`_ is a set of related [controls](#control) in a distributable form.  You might have a locally-developed profile that your organization uses to define baseline security on all machines, or you might use a pre-defined profile that implements the requirements of a specific compliance standard.  For full details about the capabilities of a profile, see the [profile documentation](https://www.inspec.io/docs/reference/profiles/).
+
+Profiles may be distributed locally as a directory tree, as a tarball or zipfile at a URL, as a git repo, and several other ways. Profiles contain metadata, including versioning, and can setup dependency relationships with other profiles.
+
+Aside from controls, profiles can also contain [custom resources](#custom_resource).  If the profile contains only custom resources and no controls, we call it a [resource pack](#resource_pack).
+
 ### property
+
+A fact about a [resource](#resource). Typically, you use the [its](#its) keyword to access the property and write a [test](#test) within a [describe block](#describe_block), and then use a [universal matcher](#universal_matcher) to make assertions about the value of the property.
+
+Each resource has different properties. See the [resource documentation](https://www.inspec.io/docs/reference/resources/) for details.
+
+Here, `manufacturer` is a property of the `car` resource.
+```
+describe car(owner: 'Tony Clifton') do
+  its('manufacturer') { should cmp 'Cadillac' }
+end
+```
 
 ### reporter
 
+An output format for the `inspec exec` command line. Several reporters are available, including JSON and JUnit; see the [inspec exec documentation](https://www.inspec.io/docs/reference/cli/#exec).
+
 ### resource
+
+A _`resource`_ represents a category of things on the [target](#target) you wish to examine. For example, to check for the existence and permissions of a file, you would use the [`file`](https://www.inspec.io/docs/reference/resources/file/) resource. InSpec offers dozens of different resources, from the highly specialized (such as `aws_security_group`, which examines firewall rules in AWS) to the very general (such as `command`, which runs a command and lets you examine its output).
+
+Resources are generally categorized as either [singular](#singular_resource) or [plural](#plural_resource), though there are some irregular resources that cannot be cleanly considered one or the other.
+
+Resources are used within a [describe block](#describe_block) to perform [tests](#test).
+
+Here, `car` is a resource.
+```
+describe car(owner: 'Tony Clifton') do
+  it { should be_classy }
+end
+```
 
 ### resource pack
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -104,20 +104,6 @@ _'Cadillac'_ is an [expected result](#expected_result).  Some matchers take an e
 
 _be >=_ is an [operator matcher](#operator matcher). It allows you to perform numeric comparisions. All plural resources have a `count` property.
 
-### Advanced Syntax
-
-#### Block-Filter Syntax
-```
-```
-
-#### Method Access on Properties
-```
-```
-
-#### Using Resources without Describe Blocks
-```
-```
-
 ## Text Glossary
 
 ### attribute

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,6 +1,16 @@
 # InSpec Glossary
 
-## Basic Syntax
+This document should help you become familiar with some of the terminology used by the InSpec project.
+
+There are two ways to use it:
+
+* A [text glossary](#text_glossary).  Learn the meaning of a word you have encountered.
+* A [visual glossary](#visual_glossary).  Look at examples and see how the parts are labelled.
+
+## Visual Glossary
+
+### Basic Syntax
+
 ```
 describe foo('/path/to/foo.txt') do
     its('blah') { should cmp '123' }
@@ -9,19 +19,19 @@ describe foo('/path/to/foo.txt') do
     it { should_not be_ridiculous }
 end
 ```
-## Basic Elements:
+### Basic Elements:
 
-### describe **foo**, where
+#### describe **foo**, where
 
   * `foo` is the _resource_
 
-### describe foo **('/path/to/foo.txt')**, where
+#### describe foo **('/path/to/foo.txt')**, where
 
   * `'/path/to/foo.txt'` is the _resource parameter_
 
-## Tests:
+### Tests:
 
-### **its('blah') { should cmp '123' }** is an _individual test_, where
+#### **its('blah') { should cmp '123' }** is an _individual test_, where
 
   * `blah` is a _property_
   * { should cmp '123' } is a _condition statement_
@@ -29,22 +39,22 @@ end
   * `cmp`  is the _matcher_
   * `'123'`  is the _expected result_
 
-### **{ should exist }** is a _condition statement_, where
+#### **{ should exist }** is a _condition statement_, where
 
   * `should`  is the _condition_
   * `exist`  is the _matcher_
 
-### **{ should be\_reasonable }** is a _condition statement_, where
-    
+#### **{ should be\_reasonable }** is a _condition statement_, where
+
   * `should`  is the _condition_
   * `be_reasonable`  is the _matcher_
 
-### **{ should\_not be\_ridiculous }** is a _negative condition statement_, where
+#### **{ should\_not be\_ridiculous }** is a _negative condition statement_, where
 
   * `should_not`  is the _negative condition_
   * `be_ridiculous`  is the _matcher_
 
-## Advanced Syntax
+### Advanced Syntax
 
 ```
 describe foos('/path/to/foo.txt', ssl_verify: true).where { names == 'blah' } do
@@ -54,19 +64,19 @@ describe foos('/path/to/foo.txt', ssl_verify: true).where { names == 'blah' } do
 end
 ```
 
-## Advanced Elements:
+### Advanced Elements:
 
-### describe **foos**, where
+#### describe **foos**, where
 
   * `foos` is a _plural resource_
 
-### describe foos **('/path/to/foo.txt', ssl_verify: true)**, where
+#### describe foos **('/path/to/foo.txt', ssl_verify: true)**, where
 
   * `'/path/to/foo.txt'` and `ssl_verify: true` are the _resource parameters_. Resources take one or more parameters.
 
-## Filters:
+### Filters:
 
-### describe foos ('/path/to/foo.txt', ssl_verify: true)**.where { names == 'blah' }** 
+#### describe foos ('/path/to/foo.txt', ssl_verify: true)**.where { names == 'blah' }** 
 
   * `.where  { names == 'blah' }` is an example of a **filter**. 
   * `{ names == 'blah' }` is an example of a _filter clause_ 
@@ -74,26 +84,64 @@ end
   * Filters are used on plural resources. 
   * Some resources, such as `etc_hosts` are explicitly plural, while others, such as `passwd` are implicitly plural. 
 
-### **{ names == 'my-name' && spots == true }** are filter criteria
+#### **{ names == 'my-name' && spots == true }** are filter criteria
 
   * `names` compares output to `blah`
   * `has spots` evaluates to `true` or `false`
 
-## Properties:
+### Properties:
 
-### **its('jared') { should cmp >= 123 }**
+#### **its('jared') { should cmp >= 123 }**
 
   * `jared` is the _property_
-  
-### **{ should cmp >= 123 }** is a conditional statement that uses a matcher with an operator and expected value.
+
+#### **{ should cmp >= 123 }** is a conditional statement that uses a matcher with an operator and expected value.
 
   * `cmp`  is the _matcher_
   * `>=` is the operator (some matchers accept operators)
   * `123` is the expected value
 
-## Properties with advanced usage:
+### Properties with advanced usage:
 
-### Some properties may have advanced usage:
+Some properties may have advanced usage:
+
 #### **its `('jared.sort.first.monkey') { should be `loud` }`**
 
   * `jared.sort.first.monkey` is an example of the `jared` property with an advanced usage
+
+## Text Glossary
+
+### attribute
+
+An _attribute_ is a parameter that InSpec can read from a YAML file provided on the command line.  You can use this feature to make a [profile's](#profile) behavior vary by passing different attribute files, or to store secrets that should not be directly present in a profile.  InSpec attributes are unrelated to Chef attributes.
+
+The CLI syntax for attributes is documented under the [`inspec exec`](https://www.inspec.io/docs/reference/cli/#exec) command.
+
+The syntax for accessing attributes within a profile is documented in the [profiles documentation](https://www.inspec.io/docs/reference/profiles/#profile-attributes).
+
+### condition statement
+
+### control
+### core resource
+### custom resource
+### DSL
+### expected result
+### filter criteria
+### matcher
+### operator
+### plural resource
+### profile
+### property
+### reporter
+### resource
+### resource pack
+
+A _resource pack_ is a type of [profile](#profile) that is used to distribute [custom resources](#custom_resource). This specialized type of profile contains no [controls](#control), but it does contain a `libraries` directory which where Ruby files define custom resources.
+
+### resource parameter
+### resource-specific matcher
+### singular resource
+### target
+### universal matcher
+
+A _universal matcher_ is a [matcher](#matcher) that can be used on any type of [resource](#resource). For example, you can use the `cmp` matcher to check the value of properties without having to worry about Ruby type-casting.  Universal matchers are documented on the [Universal Matchers](https://www.inspec.io/docs/reference/matchers/) page.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -128,33 +128,154 @@ The CLI syntax for attributes is documented under the [`inspec exec`](https://ww
 
 The syntax for accessing attributes within a profile is documented in the [profiles documentation](https://www.inspec.io/docs/reference/profiles/#profile-attributes).
 
-### condition statement
-
 ### control
+### control block
+
+The _`control`_ keyword is used to declare a _`control block`_. Here, the word 'control' means a 'regulatory control, recommendation, or requirement' - not a software engineering construct.  A `control block` has a name (which usually refers to the assigned ID of the regulatory recommendation it implements), metadata such as descriptions, references, and tags, and finally groups together related [describe blocks](#decribe_block) to implement the checks.
+
 ### core resource
+
+A [resource](#resource) that is included with InSpec; you are not required to install additional [plugins](#plugin) or depend on a [resource pack](#resource pack) to use the resource.
+
 ### custom resource
+
+A [resource](#resource) that is _not_ included with InSpec. It may be a resource of your own creation, or one you obtain by depending on a [resource pack](#resource pack).
+
+### describe
+### describe block
+
+The _`describe`_ keyword is used with a _`describe block`_ to refer to an InSpec resource.  You use the `describe` keyword along with the name of a resource to enclose related [tests](#test) that apply to the resource. Multiple describe blocks are usually grouped together in a [control](#control), but you can also use them outside of a control.
+
+```
+control 'Rule 1.1 - Color restrictions' do
+  # Count only blue cars
+  describe cars.where(color: 'blue') do
+    its('count') { should eq 20 }
+  end
+end
+```
+
 ### DSL
+
+_DSL_ is an acronym for _Domain Specific Language_. It refers to the language extensions InSpec provides to make authoring resources and controls easier.  While InSpec control files are use Ruby, the _Control DSL_ makes it easy to write controls without knowledge of Ruby by providing DSL keywords such as [describe](#describe), [control](#control), [it](#it) and [its](#its). See the [InSpec DSL page](https://www.inspec.io/docs/reference/dsl_inspec/) for details about keywords available to control authors.
+
+For [custom resource](#custom_resource) authors, an additional DSL is available - see the [Resource DSL page](https://www.inspec.io/docs/reference/dsl_resource/).
+
 ### expected result
+
+When using a [matcher](#matcher), the _`expected result`_ is the value the matcher will compare against the [property](#property) being accessed.
+
+In this example, the [`cmp`](https://www.inspec.io/docs/reference/matchers/#cmp) matcher is being used to compare the `color` property to the expected result 'black'.
+
+```
+describe car(owner: 'Bruce Wayne') do
+  its('color') { should cmp 'black' }
+end
+```
+
 ### filter statement
+
+When using a [plural resource](#plural_resource), a _`filter statement`_ is used to select individual test subjects using [filter criteria](#filter_criteria). A filter statement almost always is indicated by the keyword `where`, and may be repeated using method chaining.
+
+A filter statement may use method call syntax (which allows basic criteria operations, such as equality, regex matching, and ruby `===` comparison) or block syntax (which allows arbitrary code).
+
+In this example, `where(...)` is the filter statement.
+```
+# Count only blue cars
+describe cars.where(color: 'blue') do
+  its('count') { should eq 20 }
+end
+```
+
+### filter criterion
 ### filter criteria
+
+When using a [plural resource](#plural_resource), a _`filter criterion`_ is used to select individual test subjects within a [filter statement](#filter_statement). You may use multiple _`filter criteria`_ in a single filter statement.
+
+When method-call syntax is used with the filter statement, you provide filter criteria as a Hash, with filter criteria names as keys, and conditions as the Hash values. You may provide test, true/false, or numbers, in which case the comparison is equality; or you may provide a regular expression, in which case a match is performed.
+
+Here, `(color: blue)` is a single filter criterion being used with a filter statement in method-call syntax.
+
+```
+# Count only blue cars
+describe cars.where(color: 'blue') do
+  its('count') { should eq 20 }
+end
+```
+
+When block-method syntax is used with the filter statement, you provide a block. The block may contain arbitrary code, and each filter criteria will be available as an accessor. The block will be evaluated once per row, and each block that evaluates to a truthy value will pass the filter.
+
+Here, `{ engine_cylinders >= 6 }` is a block-syntax filter statement referring to one filter criterion.
+```
+# Vroom!
+describe cars.where { engine_cylinders >= 6 } do
+  its('city_mpg') { should be < 25 }
+end
+```
+
 ### it
+
+Within a [describe block](#describe), _`it`_ declares an individual [test](#test) directly against the [resource](#resource) (as opposed to testing against one of the resource's [properties](#property), as [its](#its) does). Though it is possible to use [universal matchers](#universal_matcher) with `it`, it is much more typical to use [resource-specific matchers](#resource_specific_matchers).
+
+`it` may be used with `should`, or negated using `should_not`.
+
+Here, `it { should ... }` declares a test, calling the `classy?` matcher on Tony Clifton's car.
+
+```
+describe car(owner: 'Tony Clifton') do
+  it { should be_classy }
+end
+```
+
 ### its
+
+Within a [describe block](#describe), _`its`_ declares an individual [test](#test) against a property of the [resource](#resource) (as opposed to testing directly against the resource itself, as [it](#it) does). You must use [universal matchers](#universal_matcher) with `its`; you cannot use [resource-specific matchers](#resource_specific_matchers).
+
+`its` may be used with `should`, or negated using `should_not`.
+
+The property to access is passed as a single string argument to `its`. As an advanced usage, if the property has methods you are interested in, you can call them using '`.`' within the string; even more advanced calling patterns are possible - see [the rspec-its documentation](https://github.com/rspec/rspec-its#usage).
+
+
+Here, `its('fuzzy_dice') { should ... }` declares a test, testing against the `fuzzy_dice` property of Tony Clifton's car. Let's assume - Tony being Tony - that `fuzzy_dice` will return an Array.
+
+```
+describe car(owner: 'Tony Clifton') do
+  its('fuzzy_dice') { should_not be_empty }
+  its('fuzzy_dice.count') { should be >= 2 }
+  its('fuzzy_dice.first.fuzziness') { should cmp 'outlandishly so' }
+end
+```
+
 ### matcher
+
 ### operator
+
+### plugin
+
 ### plural resource
+
 ### profile
+
 ### property
+
 ### reporter
+
 ### resource
+
 ### resource pack
 
 A _resource pack_ is a type of [profile](#profile) that is used to distribute [custom resources](#custom_resource). This specialized type of profile contains no [controls](#control), but it does contain a `libraries` directory which where Ruby files define custom resources.
 
 ### resource parameter
+
 ### resource-specific matcher
+
 ### singular resource
+
 ### target
+
 ### test
+
 ### universal matcher
 
 A _universal matcher_ is a [matcher](#matcher) that can be used on any type of [resource](#resource). For example, you can use the `cmp` matcher to check the value of properties without having to worry about Ruby type-casting.  Universal matchers are documented on the [Universal Matchers](https://www.inspec.io/docs/reference/matchers/) page.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -5,54 +5,61 @@ This document should help you become familiar with some of the terminology used 
 There are two ways to use it:
 
 * A [text glossary](#text_glossary).  Learn the meaning of a word you have encountered.
-* A [visual glossary](#visual_glossary).  Look at examples and see how the parts are labelled.
+* A [visual glossary](#visual_glossary).  Look at examples and see how the parts are labelled.  You can then use the text glossary to read details of each concept.
 
 ## Visual Glossary
 
+### Motivating Example
+
+Suppose we are interested in auditing cars.
+
 ### Basic Syntax
 
+Let's look at some simple examples.
+
+### Singular Resource Example
+
 ```
-describe foo('/path/to/foo.txt') do
-    its('blah') { should cmp '123' }
+describe car(owner: 'Tony Clifton') do
     it { should exist }
-    it { should be_reasonable }
-    it { should_not be_ridiculous }
+    its('license_plate') { should cmp 'MOONMAN' }
+    it { should be_classy }
+    it { should_not have_check_engine_light_on }
 end
 ```
-### Basic Elements:
 
-#### describe **foo**, where
+#### describe _car_(owner: 'Tony Clifton') do
 
-  * `foo` is the _resource_
+_car_ is a [resource](#resource).  Since we are only talking about one car, it is a [singular resource](#singular_resource).
 
-#### describe foo **('/path/to/foo.txt')**, where
+#### describe foo(_owner: 'Tony Clifton'_)
 
-  * `'/path/to/foo.txt'` is the _resource parameter_
+_owner_ is a [resource parameter](#resource_parameter) along with _'Tony Clifton'_, a resource parameter value.
 
-### Tests:
+#### _it { should exist }_
 
-#### **its('blah') { should cmp '123' }** is an _individual test_, where
+Each line within the resource block that begins with `it` or `its` is a [test](#test).  Use [it](#it) to access [resource-specific matchers](#resource_specific_matcher), and use [its](#its) to access [properties](#property) of the [resource](#resource), which are then used with [universal matchers](#universal_matcher).
 
-  * `blah` is a _property_
-  * { should cmp '123' } is a _condition statement_
-  * `should`  is the _condition_
-  * `cmp`  is the _matcher_
-  * `'123'`  is the _expected result_
+#### its('_license_plate_') { should cmp 'MOONMAN' }
 
-#### **{ should exist }** is a _condition statement_, where
+_license_plate_ is a [property](#property) of the [resource](#resource).  Properties expose information about the resource for you to test. Some properties are numbers, some (like this one) are text, some are lists, and some are more complex objects.  Properties are always used with [universal matchers](#universal_matcher).
 
-  * `should`  is the _condition_
-  * `exist`  is the _matcher_
+#### its('license_plate') { should _cmp_ 'MOONMAN' }
 
-#### **{ should be\_reasonable }** is a _condition statement_, where
+_cmp_ is a [universal matcher](#universal_matcher).  `cmp` is a very flexible, loosely typed equality operator; here it is checking to see if the license plate text is the same as the text 'MOONMAN'.  Notice it is operating on the license plate text (the property value); it does not operate on the resource.  You can find the full list of supported universal matchers on the [Universal Matcher page](https://www.inspec.io/docs/reference/matchers/).
 
-  * `should`  is the _condition_
-  * `be_reasonable`  is the _matcher_
+#### its('license_plate') { should cmp _'MOONMAN'_ }
 
-#### **{ should\_not be\_ridiculous }** is a _negative condition statement_, where
+_'MOONMAN'_ is an expected value.  Some matchers take an expected value; others do not.
 
-  * `should_not`  is the _negative condition_
-  * `be_ridiculous`  is the _matcher_
+#### it { should _be\_classy_ }
+
+_be\_classy_ is a [resource-specific matcher](#resource_specific_matcher). It will return a yes-or-no value, based on whether Tony's car is classy or not.  (It is.  Tony is a classy guy.)
+
+#### it { _should\_not_ have\_check\_engine\_light\_on }
+
+_should\_not_ indicates this is a negated test. So, this test will pass if the matcher says "no".
+
 
 ### Advanced Syntax
 
@@ -66,11 +73,11 @@ end
 
 ### Advanced Elements:
 
-#### describe **foos**, where
+#### describe **foos**
 
   * `foos` is a _plural resource_
 
-#### describe foos **('/path/to/foo.txt', ssl_verify: true)**, where
+#### describe foos **('/path/to/foo.txt', ssl_verify: true)**
 
   * `'/path/to/foo.txt'` and `ssl_verify: true` are the _resource parameters_. Resources take one or more parameters.
 
@@ -127,6 +134,8 @@ The syntax for accessing attributes within a profile is documented in the [profi
 ### DSL
 ### expected result
 ### filter criteria
+### it
+### its
 ### matcher
 ### operator
 ### plural resource
@@ -142,6 +151,7 @@ A _resource pack_ is a type of [profile](#profile) that is used to distribute [c
 ### resource-specific matcher
 ### singular resource
 ### target
+### test
 ### universal matcher
 
 A _universal matcher_ is a [matcher](#matcher) that can be used on any type of [resource](#resource). For example, you can use the `cmp` matcher to check the value of properties without having to worry about Ruby type-casting.  Universal matchers are documented on the [Universal Matchers](https://www.inspec.io/docs/reference/matchers/) page.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -11,7 +11,7 @@ There are two ways to use it:
 
 ### Motivating Example
 
-Suppose we are interested in auditing cars.
+Suppose we are interested in auditing cars.  Let's suppose we have two InSpec resources for  auditing: `cars`, which can search for and filter groups of cars, and `car`, which can perform detailed auditing of a single car.
 
 ### Basic Syntax
 
@@ -50,7 +50,7 @@ _cmp_ is a [universal matcher](#universal_matcher).  `cmp` is a very flexible, l
 
 #### its('license_plate') { should cmp _'MOONMAN'_ }
 
-_'MOONMAN'_ is an expected value.  Some matchers take an expected value; others do not.
+_'MOONMAN'_ is an [expected result](#expected_result).  Some matchers take an expected result; others do not.
 
 #### it { should _be\_classy_ }
 
@@ -60,61 +60,63 @@ _be\_classy_ is a [resource-specific matcher](#resource_specific_matcher). It wi
 
 _should\_not_ indicates this is a negated test. So, this test will pass if the matcher says "no".
 
+### Plural Resource Example
+
+```
+  describe cars.where(color: /^b/) do
+    it { should exist }
+    its('manufacturers') { should include 'Cadillac' }
+    its('count') { should be >= 10 }
+  end
+```
+
+#### describe _cars_.where(color: /^b/) do
+
+_cars_ is a [resource](#resource).  Since we are potentially talking about many cars, it is a [plural resource](#plural_resource).
+
+#### describe cars._where(color: /^b/)_ do
+
+_where(color: /^b/)_ is a [filter statement](#filter_statement).  Without a filter statement, `cars` would simply select all the cars in the world.
+
+#### describe cars.where(_color: /^b/_) do
+
+_color_ is a [filter criterion](#filter_criteria) along with its filter value, _/^b/_.  Here, the criterion is expressing that we want to select all cars whose colors begin with the letter 'b' - blue, brown, burgundy, etc.
+
+#### _it { should exist }_
+
+Each line within the resource block that begins with `it` or `its` is a [test](#test).  Use [it](#it) to access [resource-specific matchers](#resource_specific_matcher), and use [its](#its) to access [properties](#property) of the [resource](#resource), which are then used with [universal matchers](#universal_matcher).
+
+With plural resources, `exist` has a special meaning: did the filter match anything?
+
+#### its('_manufacturers_') { should include 'Cadillac' }
+
+_manufacturers_ is a [property](#property) of the [resource](#resource).  Properties expose information about the resource for you to test. On plural resources, properties are almost always names in the plural, and almost always return a list of values.  Here, it would be a list of the names of the manufacturers of the cars. Some list properties are de-duplicated; for example, you might have 10 cars, but if they are all Subarus and Cadillacs, you will only have two entries in the `manufacturers` property. Be sure to check the documentation for your resource.
+
+#### its('manufacturers') { should _include_ 'Cadillac' }
+
+_include_ is a [universal matcher](#universal_matcher).  `include` works with lists, and checks to see if an expecteddd result is present. Here, it is checking to see if the list of manufacturers contains an entry with the text 'Cadillac'. Notice it is operating on the manufacturers list (the property value); it does not operate on the resource.  You can find the full list of supported universal matchers on the [Universal Matcher page](https://www.inspec.io/docs/reference/matchers/).
+
+#### its('manufacturers') { should include '_Cadillac_' }
+
+_'Cadillac'_ is an [expected result](#expected_result).  Some matchers take an expected result; others do not.
+
+#### its('count') { should _be >=_ 10 }
+
+_be >=_ is an [operator matcher](#operator matcher). It allows you to perform numeric comparisions. All plural resources have a `count` property.
 
 ### Advanced Syntax
 
+#### Block-Filter Syntax
 ```
-describe foos('/path/to/foo.txt', ssl_verify: true).where { names == 'blah' } do
-    its('jared') { should cmp >= 123 }
-    its('jared.sort.first.monkey') { should be `loud` }
-    its(['jared', 'monkey.with.dots']) { should be `loud` }
-end
 ```
 
-### Advanced Elements:
+#### Method Access on Properties
+```
+```
 
-#### describe **foos**
-
-  * `foos` is a _plural resource_
-
-#### describe foos **('/path/to/foo.txt', ssl_verify: true)**
-
-  * `'/path/to/foo.txt'` and `ssl_verify: true` are the _resource parameters_. Resources take one or more parameters.
-
-### Filters:
-
-#### describe foos ('/path/to/foo.txt', ssl_verify: true)**.where { names == 'blah' }** 
-
-  * `.where  { names == 'blah' }` is an example of a **filter**. 
-  * `{ names == 'blah' }` is an example of a _filter clause_ 
-  * Some resources support one or more filters.
-  * Filters are used on plural resources. 
-  * Some resources, such as `etc_hosts` are explicitly plural, while others, such as `passwd` are implicitly plural. 
-
-#### **{ names == 'my-name' && spots == true }** are filter criteria
-
-  * `names` compares output to `blah`
-  * `has spots` evaluates to `true` or `false`
-
-### Properties:
-
-#### **its('jared') { should cmp >= 123 }**
-
-  * `jared` is the _property_
-
-#### **{ should cmp >= 123 }** is a conditional statement that uses a matcher with an operator and expected value.
-
-  * `cmp`  is the _matcher_
-  * `>=` is the operator (some matchers accept operators)
-  * `123` is the expected value
-
-### Properties with advanced usage:
-
-Some properties may have advanced usage:
-
-#### **its `('jared.sort.first.monkey') { should be `loud` }`**
-
-  * `jared.sort.first.monkey` is an example of the `jared` property with an advanced usage
+#### Using Resources without Describe Blocks
+```
+```
 
 ## Text Glossary
 
@@ -133,6 +135,7 @@ The syntax for accessing attributes within a profile is documented in the [profi
 ### custom resource
 ### DSL
 ### expected result
+### filter statement
 ### filter criteria
 ### it
 ### its

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -4,14 +4,14 @@ This document should help you become familiar with some of the terminology used 
 
 There are two ways to use it:
 
-* A [text glossary](#text_glossary).  Learn the meaning of a word you have encountered.
-* A [visual glossary](#visual_glossary).  Look at examples and see how the parts are labelled.  You can then use the text glossary to read details of each concept.
+* A [text glossary](#text_glossary). Learn the meaning of a word you have encountered.
+* A [visual glossary](#visual_glossary). Look at examples and see how the parts are labelled. You can then use the text glossary to read details of each concept.
 
 ## Visual Glossary
 
 ### Motivating Example
 
-Suppose we are interested in auditing cars.  Let's suppose we have two InSpec resources for  auditing: `cars`, which can search for and filter groups of cars, and `car`, which can perform detailed auditing of a single car.
+Suppose we are interested in auditing cars. Let's suppose we have two InSpec resources for auditing: `cars`, which searchs for and filters groups of cars, and `car`, which performs detailed auditing of a single car.
 
 ### Basic Syntax
 
@@ -19,7 +19,7 @@ Let's look at some simple examples.
 
 ### Singular Resource Example
 
-```
+```inspec
 describe car(owner: 'Tony Clifton') do
     it { should exist }
     its('license_plate') { should cmp 'MOONMAN' }
@@ -28,41 +28,41 @@ describe car(owner: 'Tony Clifton') do
 end
 ```
 
-#### describe _car_(owner: 'Tony Clifton') do
+#### describe car(owner: 'Tony Clifton') do
 
-_car_ is a [resource](#resource).  Since we are only talking about one car, it is a [singular resource](#singular_resource).
+_car_ is a [resource](#resource). Since we are talking about only one car, it is a [singular resource](#singular_resource).
 
 #### describe car(_owner: 'Tony Clifton'_)
 
-_owner_ is a [resource parameter](#resource_parameter) along with _'Tony Clifton'_, a resource parameter value.
+_owner_ is a [resource parameter](#resource_parameter) and _'Tony Clifton'_ is a resource parameter value.
 
 #### _it { should exist }_
 
-Each line within the resource block that begins with `it` or `its` is a [test](#test).  Use [it](#it) to access [resource-specific matchers](#resource_specific_matcher), and use [its](#its) to access [properties](#property) of the [resource](#resource), which are then used with [universal matchers](#universal_matcher).
+Each line within the resource block beginning with `it` or `its` is a [test](#test). Use [it](#it) to access [resource-specific matchers](#resource_specific_matcher), and use [its](#its) to access [properties](#property) of the [resource](#resource), which are in turn used with [universal matchers](#universal_matcher).
 
-#### its('_license_plate_') { should cmp 'MOONMAN' }
+#### its('_license\_plate_') { should cmp 'MOONMAN' }
 
-_license_plate_ is a [property](#property) of the [resource](#resource).  Properties expose information about the resource for you to test. Some properties are numbers, some (like this one) are text, some are lists, and some are more complex objects.  Properties are always used with [universal matchers](#universal_matcher).
+_license\_plate_ is a [property](#property) belonging to the [resource](#resource). Properties expose testable information about the resource. Some properties are numbers, some (like this one) are text, some are lists, and some are more complex objects. Properties are always used with [universal matchers](#universal_matcher).
 
-#### its('license_plate') { should _cmp_ 'MOONMAN' }
+#### its('license\_plate') { should _cmp_ 'MOONMAN' }
 
-_cmp_ is a [universal matcher](#universal_matcher).  `cmp` is a very flexible, loosely typed equality operator; here it is checking to see if the license plate text is the same as the text 'MOONMAN'.  Notice it is operating on the license plate text (the property value); it does not operate on the resource.  You can find the full list of supported universal matchers on the [Universal Matcher page](https://www.inspec.io/docs/reference/matchers/).
+_cmp_ is a [universal matcher](#universal_matcher). `cmp` is a very flexible, loosely typed equality operator; here it checks to see if the license plate text is the same as the text 'MOONMAN'. Notice that the test operates on the license plate text (the property value) and not on the resource. You can find the full list of supported universal matchers on the [Universal Matcher page](https://www.inspec.io/docs/reference/matchers/).
 
-#### its('license_plate') { should cmp _'MOONMAN'_ }
+#### its('license\_plate') { should cmp _'MOONMAN'_ }
 
-_'MOONMAN'_ is an [expected result](#expected_result).  Some matchers take an expected result; others do not.
+_'MOONMAN'_ is an [expected result](#expected_result). Some matchers take an expected result; others do not.
 
 #### it { should _be\_classy_ }
 
-_be\_classy_ is a [resource-specific matcher](#resource_specific_matcher). It will return a yes-or-no value, based on whether Tony's car is classy or not.  (It is.  Tony is a classy guy.)
+_be\_classy_ is a [resource-specific matcher](#resource_specific_matcher). It returns a yes-or-no value, based on whether Tony's car is classy or not. (It is. Tony is a classy guy.)
 
 #### it { _should\_not_ have\_check\_engine\_light\_on }
 
-_should\_not_ indicates this is a negated test. So, this test will pass if the matcher says "no".
+_should\_not_ indicates this is a negated test. So, this test passes if the matcher says "no".
 
 ### Plural Resource Example
 
-```
+```inspec
   describe cars.where(color: /^b/) do
     it { should exist }
     its('manufacturers') { should include 'Cadillac' }
@@ -72,52 +72,53 @@ _should\_not_ indicates this is a negated test. So, this test will pass if the m
 
 #### describe _cars_.where(color: /^b/) do
 
-_cars_ is a [resource](#resource).  Since we are potentially talking about many cars, it is a [plural resource](#plural_resource).
+_cars_ is a [resource](#resource). Since we are potentially talking about many cars, it is a [plural resource](#plural_resource).
 
 #### describe cars._where(color: /^b/)_ do
 
-_where(color: /^b/)_ is a [filter statement](#filter_statement).  Without a filter statement, `cars` would simply select all the cars in the world.
+_where(color: /^b/)_ is a [filter statement](#filter_statement). Without a filter statement, `cars` simply selects all the cars in the world.
 
 #### describe cars.where(_color: /^b/_) do
 
-_color_ is a [filter criterion](#filter_criteria) along with its filter value, _/^b/_.  Here, the criterion is expressing that we want to select all cars whose colors begin with the letter 'b' - blue, brown, burgundy, etc.
+_color_ is a [filter criterion](#filter_criteria) along with its filter value, _/^b/_. Here, the criterion expresses that we want to select all cars whose colors begin with the letter 'b' - blue, brown, burgundy, etc.
 
 #### _it { should exist }_
 
-Each line within the resource block that begins with `it` or `its` is a [test](#test).  Use [it](#it) to access [resource-specific matchers](#resource_specific_matcher), and use [its](#its) to access [properties](#property) of the [resource](#resource), which are then used with [universal matchers](#universal_matcher).
+Each line within the resource block beginning with `it` or `its` is a [test](#test). Use [it](#it) to access [resource-specific matchers](#resource_specific_matcher), and use [its](#its) to access [properties](#property) of the [resource](#resource), which are in turn used with [universal matchers](#universal_matcher).
 
 With plural resources, `exist` has a special meaning: did the filter match anything?
 
 #### its('_manufacturers_') { should include 'Cadillac' }
 
-_manufacturers_ is a [property](#property) of the [resource](#resource).  Properties expose information about the resource for you to test. On plural resources, properties are almost always names in the plural, and almost always return a list of values.  Here, it would be a list of the names of the manufacturers of the cars. Some list properties are de-duplicated; for example, you might have 10 cars, but if they are all Subarus and Cadillacs, you will only have two entries in the `manufacturers` property. Be sure to check the documentation for your resource.
+_manufacturers_ is a [property](#property) of the [resource](#resource). Properties expose testable information about the resource. On plural resources, properties are almost always names in the plural, and almost always return a list of values. Here, the test returns a list of the car manufacturer names. Some list properties are de-duplicated; for example, you might have 10 cars, but if they are all Subarus and Cadillacs, it returns only two entries in the `manufacturers` property. Be sure to check the documentation for your resource.
 
 #### its('manufacturers') { should _include_ 'Cadillac' }
 
-_include_ is a [universal matcher](#universal_matcher).  `include` works with lists, and checks to see if an expecteddd result is present. Here, it is checking to see if the list of manufacturers contains an entry with the text 'Cadillac'. Notice it is operating on the manufacturers list (the property value); it does not operate on the resource.  You can find the full list of supported universal matchers on the [Universal Matcher page](https://www.inspec.io/docs/reference/matchers/).
+_include_ is a [universal matcher](#universal_matcher). `include` works with lists, and checks to see if an expected result is present. Here, it checks to see if the list of manufacturers contains an entry with the text 'Cadillac'. Notice it operates on the manufacturers list (the property value) and not on the resource. You can find the full list of supported universal matchers on the [Universal Matcher page](https://www.inspec.io/docs/reference/matchers/).
 
 #### its('manufacturers') { should include '_Cadillac_' }
 
-_'Cadillac'_ is an [expected result](#expected_result).  Some matchers take an expected result; others do not.
+_'Cadillac'_ is an [expected result](#expected_result). Some matchers take an expected result; others do not.
 
 #### its('count') { should _be >=_ 10 }
 
-_be >=_ is an [operator matcher](#operator matcher). It allows you to perform numeric comparisions. All plural resources have a `count` property.
+_be >=_ is an [operator matcher](#operator matcher). It allows you to perform numeric comparisons. All plural resources have a `count` property.
 
 ## Text Glossary
 
 ### attribute
 
-An _attribute_ is a parameter that InSpec can read from a YAML file provided on the command line.  You can use this feature to make a [profile's](#profile) behavior vary by passing different attribute files, or to store secrets that should not be directly present in a profile.  InSpec attributes are unrelated to Chef attributes.
+An _attribute_ is a parameter that InSpec reads from a YAML file provided on the command line. You can use this feature either to change a [profile's](#profile) behavior by passing different attribute files or to store secrets that should not be directly present in a profile. InSpec attributes are unrelated to Chef attributes.
 
 The CLI syntax for attributes is documented under the [`inspec exec`](https://www.inspec.io/docs/reference/cli/#exec) command.
 
 The syntax for accessing attributes within a profile is documented in the [profiles documentation](https://www.inspec.io/docs/reference/profiles/#profile-attributes).
 
 ### control
+
 ### control block
 
-The _`control`_ keyword is used to declare a _`control block`_. Here, the word 'control' means a 'regulatory control, recommendation, or requirement' - not a software engineering construct.  A `control block` has a name (which usually refers to the assigned ID of the regulatory recommendation it implements), metadata such as descriptions, references, and tags, and finally groups together related [describe blocks](#decribe_block) to implement the checks.
+The _`control`_ keyword is used to declare a _`control block`_. Here, the word 'control' means a 'regulatory control, recommendation, or requirement' - not a software engineering construct. A `control block` has a name (which usually refers to the assigned ID of the regulatory recommendation it implements), metadata such as descriptions, references, and tags, and finally groups together related [describe blocks](#describe_block) to implement the checks.
 
 ### core resource
 
@@ -128,9 +129,10 @@ A [resource](#resource) that is included with InSpec; you are not required to in
 A [resource](#resource) that is _not_ included with InSpec. It may be a resource of your own creation, or one you obtain by depending on a [resource pack](#resource pack).
 
 ### describe
+
 ### describe block
 
-The _`describe`_ keyword is used with a _`describe block`_ to refer to an InSpec resource.  You use the `describe` keyword along with the name of a [resource](#resource) to enclose related [tests](#test) that apply to the resource. Multiple describe blocks are usually grouped together in a [control](#control), but you can also use them outside of a control.
+The _`describe`_ keyword is used with a _`describe block`_ to refer to an InSpec resource. You use the `describe` keyword along with the name of a [resource](#resource) to enclose related [tests](#test) that apply to the resource. Multiple describe blocks are usually grouped together in a [control](#control), but you can also use them outside of a control.
 
 ```
 control 'Rule 1.1 - Color restrictions' do
@@ -143,7 +145,7 @@ end
 
 ### DSL
 
-_DSL_ is an acronym for _Domain Specific Language_. It refers to the language extensions InSpec provides to make authoring resources and controls easier.  While InSpec control files are use Ruby, the _Control DSL_ makes it easy to write controls without knowledge of Ruby by providing DSL keywords such as [describe](#describe), [control](#control), [it](#it) and [its](#its). See the [InSpec DSL page](https://www.inspec.io/docs/reference/dsl_inspec/) for details about keywords available to control authors.
+_DSL_ is an acronym for _Domain Specific Language_. It refers to the language extensions InSpec provides to make authoring resources and controls easier. While InSpec control files are use Ruby, the _Control DSL_ makes it easy to write controls without knowledge of Ruby by providing DSL keywords such as [describe](#describe), [control](#control), [it](#it) and [its](#its). See the [InSpec DSL page](https://www.inspec.io/docs/reference/dsl_inspec/) for details about keywords available to control authors.
 
 For [custom resource](#custom_resource) authors, an additional DSL is available - see the [Resource DSL page](https://www.inspec.io/docs/reference/dsl_resource/).
 
@@ -166,6 +168,7 @@ When using a [plural resource](#plural_resource), a _`filter statement`_ is used
 A filter statement may use method call syntax (which allows basic criteria operations, such as equality, regex matching, and ruby `===` comparison) or block syntax (which allows arbitrary code).
 
 In this example, `where(...)` is the filter statement.
+
 ```
 # Count only blue cars
 describe cars.where(color: 'blue') do
@@ -174,6 +177,7 @@ end
 ```
 
 ### filter criterion
+
 ### filter criteria
 
 When using a [plural resource](#plural_resource), a _`filter criterion`_ is used to select individual test subjects within a [filter statement](#filter_statement). You may use multiple _`filter criteria`_ in a single filter statement.
@@ -192,6 +196,7 @@ end
 When block-method syntax is used with the filter statement, you provide a block. The block may contain arbitrary code, and each filter criteria will be available as an accessor. The block will be evaluated once per row, and each block that evaluates to a truthy value will pass the filter.
 
 Here, `{ engine_cylinders >= 6 }` is a block-syntax filter statement referring to one filter criterion.
+
 ```
 # Vroom!
 describe cars.where { engine_cylinders >= 6 } do
@@ -233,15 +238,17 @@ end
 
 ### matcher
 
-A _`matcher`_ performs the actual assertions against [resources](#resource) or the [properties](#property) of resources.  Matchers always return a true/false value. Matchers fall into two camps:
- * [resource-specific matchers](#resource_specific_matchers), which operate directly on the resource, are used with [it](#it), and tend to be highly customized to the auditing needs of the resource
- * [universal matchers](#universal_matchers), which operate on the properties of the resource, are used with [its](#its), and tend to be very generic, operating on text, numbers, and lists
+A _`matcher`_ performs the actual assertions against [resources](#resource) or the [properties](#property) of resources. Matchers always return a true/false value. Matchers fall into two camps:
+
+* [resource-specific matchers](#resource_specific_matchers), which operate directly on the resource, are used with [it](#it), and tend to be highly customized to the auditing needs of the resource
+* [universal matchers](#universal_matchers), which operate on the properties of the resource, are used with [its](#its), and tend to be very generic, operating on text, numbers, and lists
 
 Some matchers accept parameters, called [expected results](#expected_results).
 
 For information on how RSpec matchers are related o InSpec matchers, see [InSpec and RSpec](https://www.inspec.io/docs/reference/inspec_and_friends/#rspec).
 
 Here, `be_classy` is a resource-specific matcher operating directly on the `car`, while `cmp` is a universal matcher operating on the `manufacturer` property.
+
 ```
 describe car(owner: 'Tony Clifton') do
   it { should be_classy }
@@ -258,6 +265,7 @@ Plural resources nearly always have a name that ends in 's': `processes`, `aws_s
 Plural resources support [filter statements](#filter_statement). See the [resource documentation](https://www.inspec.io/docs/reference/resources/) for details regarding which [filter criteria](#filter_criteria) are supported on each resource.
 
 Here, `cars` is a plural resource.
+
 ```
 describe cars.where(color: 'blue') do
   its('count') { should eq 20 }
@@ -274,11 +282,11 @@ end
 
 ### profile
 
-A _`profile`_ is a set of related [controls](#control) in a distributable form.  You might have a locally-developed profile that your organization uses to define baseline security on all machines, or you might use a pre-defined profile that implements the requirements of a specific compliance standard.  For full details about the capabilities of a profile, see the [profile documentation](https://www.inspec.io/docs/reference/profiles/).
+A _`profile`_ is a set of related [controls](#control) in a distributable form. You might have a locally-developed profile that your organization uses to define baseline security on all machines, or you might use a pre-defined profile that implements the requirements of a specific compliance standard. For full details about the capabilities of a profile, see the [profile documentation](https://www.inspec.io/docs/reference/profiles/).
 
 Profiles may be distributed locally as a directory tree, as a tarball or zipfile at a URL, as a git repo, and several other ways. Profiles contain metadata, including versioning, and can setup dependency relationships with other profiles.
 
-Aside from controls, profiles can also contain [custom resources](#custom_resource).  If the profile contains only custom resources and no controls, we call it a [resource pack](#resource_pack).
+Aside from controls, profiles can also contain [custom resources](#custom_resource). If the profile contains only custom resources and no controls, we call it a [resource pack](#resource_pack).
 
 ### property
 
@@ -287,6 +295,7 @@ A fact about a [resource](#resource). Typically, you use the [its](#its) keyword
 Each resource has different properties. See the [resource documentation](https://www.inspec.io/docs/reference/resources/) for details.
 
 Here, `manufacturer` is a property of the `car` resource.
+
 ```
 describe car(owner: 'Tony Clifton') do
   its('manufacturer') { should cmp 'Cadillac' }
@@ -306,6 +315,7 @@ Resources are generally categorized as either [singular](#singular_resource) or 
 Resources are used within a [describe block](#describe_block) to perform [tests](#test).
 
 Here, `car` is a resource.
+
 ```
 describe car(owner: 'Tony Clifton') do
   it { should be_classy }
@@ -318,11 +328,12 @@ A _resource pack_ is a type of [profile](#profile) that is used to distribute [c
 
 ### resource parameter
 
-_`resource parameters`_ are information passed to the resource when they are declared. Typically, resource parameters provide identifying information or connectivity information.  Resource parameters are not the same as a [filter statement](#filter_statement).
+_`resource parameters`_ are information passed to the resource when they are declared. Typically, resource parameters provide identifying information or connectivity information. Resource parameters are not the same as a [filter statement](#filter_statement).
 
 Resource parameters vary from resource to resource; refer to the [resource documentation](https://www.inspec.io/docs/reference/resources/) for details.
 
 Here, `owner: 'Tony Clifton'` is a resource parameter.
+
 ```
 describe car(owner: 'Tony Clifton') do
   it { should be_classy }
@@ -357,7 +368,7 @@ A _`test`_ is an individual assertion about the state of the [resource](#resourc
 
 ### universal matcher
 
-A _universal matcher_ is a [matcher](#matcher) that can be used on the [properties](#property) of any type of [resource](#resource). For example, you can use the `cmp` matcher to check the value of properties without having to worry about Ruby type-casting.  Universal matchers are almost always used with the [its](#its) keyword.
+A _universal matcher_ is a [matcher](#matcher) that can be used on the [properties](#property) of any type of [resource](#resource). For example, you can use the `cmp` matcher to check the value of properties without having to worry about Ruby type-casting. Universal matchers are almost always used with the [its](#its) keyword.
 
 Universal matchers are documented on the [Universal Matchers](https://www.inspec.io/docs/reference/matchers/) page.
 


### PR DESCRIPTION
This PR makes three major changes to the glossary on the docs site:
1. Re-works the visual glossary example to be a concrete example (car/cars) instead of the 'foo' resource with 'jared' property.
2. Re-names the "Advanced usage" section of the visual glossary to just be the plural example section.  We might add an advanced usage section later.
3. Largest change by linecount was adding a full text glossary with extensive terms, prose, examples, and cross-linking.  

A big side-effect of this PR is that now we'll be able to link to individual glossary terms.