### PR TITLE
updated skip message to reflect accurate version of audit support

### DIFF
--- a/lib/resources/auditd.rb
+++ b/lib/resources/auditd.rb
@@ -34,7 +34,7 @@ module Inspec::Resources
       @params = []
 
       if @content =~ /^LIST_RULES:/
-        return skip_resource 'The version of audit is outdated. The `auditd` resource supports versions of audit >= 2.3.'
+        return skip_resource 'The version of audit is outdated. The `auditd` resource supports versions of audit >= 2.3.5'
       end
       parse_content
     end


### PR DESCRIPTION
This change updates the `skip_resource` message of the `auditd` resource reflecting a more precise version. Version `2.3.5` of the [audit-userspace](https://github.com/linux-audit/audit-userspace) introduced the change that removed the `LIST_RULES: ` prefix when viewing the rules and changed the output format to match the rules in the rules files.

From the 2.3.5 changelog:
```
- Change formatting of rules listing in auditctl to look like audit.rules
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>