### PR TITLE
Add functional tests for nested attributes

### DIFF
--- a/test/functional/attributes.rb
+++ b/test/functional/attributes.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+
+require 'functional/helper'
+
+describe 'attributes' do
+  include FunctionalHelper
+
+  [
+    'flat',
+    # 'nested',
+  ].each do |attr_file|
+    it "runs OK on #{attr_file} attributes" do
+      cmd = 'exec '
+      cmd += File.join(profile_path, 'attributes')
+      cmd += ' --no-create-lockfile'
+      cmd += ' --attrs ' + File.join(profile_path, 'attributes', 'attributes', "#{attr_file}.yaml")
+      cmd += ' --controls ' + attr_file
+      out = inspec(cmd)
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+    end
+  end
+end

--- a/test/functional/attributes.rb
+++ b/test/functional/attributes.rb
@@ -7,7 +7,7 @@ describe 'attributes' do
 
   [
     'flat',
-    # 'nested',
+    'nested',
   ].each do |attr_file|
     it "runs OK on #{attr_file} attributes" do
       cmd = 'exec '

--- a/test/unit/mock/profiles/attributes/attributes/flat.yaml
+++ b/test/unit/mock/profiles/attributes/attributes/flat.yaml
@@ -1,0 +1,6 @@
+an_integer: 1
+a_quoted_string: "Should not have quotes"
+an_unquoted_string: Should not have quotes
+lowercase_true: true
+titlecase_true: True
+titlecase_false: False

--- a/test/unit/mock/profiles/attributes/attributes/nested.yaml
+++ b/test/unit/mock/profiles/attributes/attributes/nested.yaml
@@ -1,0 +1,32 @@
+one_level_array:
+  - thing1
+  - thing2
+two_level_array:
+  -
+    - row1col1
+    - row1col2
+  -
+    - row2col1
+    - row2col2
+one_level_hash:
+  key1: value1
+  key2: value2
+two_level_hash:
+  key1:
+    key11: value11
+    key12: value12
+  key2:
+    key21: value21
+    key22: value22
+hash_of_arrays:
+  key1:
+    - thing11
+    - thing12
+  key2:
+    - thing21
+    - thing22
+array_of_hashes:
+  - key11: value11
+    key12: value12
+  - key21: value21
+    key22: value22

--- a/test/unit/mock/profiles/attributes/controls/flat.rb
+++ b/test/unit/mock/profiles/attributes/controls/flat.rb
@@ -1,0 +1,29 @@
+expecteds = {
+  an_integer: 1,
+  a_quoted_string: 'Should not have quotes',
+  an_unquoted_string: 'Should not have quotes',
+  lowercase_true: true,
+  titlecase_true: true,
+  titlecase_false: false,
+}
+tests = expecteds.keys.map do |test_name|
+  {
+    name: test_name,
+    expected: expecteds[test_name],
+    attr_via_string: attribute(test_name.to_s, default: "#{test_name}_default"),
+    attr_via_symbol: attribute(test_name, default: "#{test_name}_default"),
+  }
+end
+
+control 'flat' do
+  tests.each do |info|
+    describe "#{info[:name]} using string key" do
+      subject { info[:attr_via_string] }
+      it { should eq info[:expected] }
+    end
+    # describe "#{info[:name]} using symbol key" do
+    #   subject { info[:attr_via_symbol] }
+    #   it { should eq info[:expected] }
+    # end
+  end
+end

--- a/test/unit/mock/profiles/attributes/controls/flat.rb
+++ b/test/unit/mock/profiles/attributes/controls/flat.rb
@@ -21,9 +21,5 @@ control 'flat' do
       subject { info[:attr_via_string] }
       it { should eq info[:expected] }
     end
-    # describe "#{info[:name]} using symbol key" do
-    #   subject { info[:attr_via_symbol] }
-    #   it { should eq info[:expected] }
-    # end
   end
 end

--- a/test/unit/mock/profiles/attributes/controls/nested.rb
+++ b/test/unit/mock/profiles/attributes/controls/nested.rb
@@ -1,0 +1,77 @@
+attr_names = [
+  :one_level_array,
+  :two_level_array,
+  :one_level_hash,
+  :two_level_hash,
+  :hash_of_arrays,
+  :array_of_hashes,
+]
+attrs = {}
+attr_names.each do |attr_name|
+  # Store as a symbol-fetched attribute
+  attrs[attr_name] = attribute(attr_name, default: "#{attr_name}_sym_default")
+  # .. and store under a string name, as a string-fetched attribute!
+  attrs[attr_name.to_s] = attribute(attr_name.to_s, default: "#{attr_name}_str_default")
+end
+
+# For now, these all use string keys, as that is normal InSpec behavior
+# Also, for 'its' calls, see https://github.com/rspec/rspec-its#usage
+control 'nested' do
+
+  describe 'one_level_array' do
+    subject { attrs['one_level_array'] }
+    it { should be_a_kind_of(Array) }
+    it { should respond_to(:[])}
+    its([0]) { should eq 'thing1' }
+    its([1]) { should eq 'thing2' }
+    # Should this be nil? Or one_level_array_default?
+    its([2]) { should be nil }
+  end
+
+  describe 'two_level_array' do
+    # Access first row
+    subject { attrs['two_level_array'][0] }
+    it { should be_a_kind_of(Array) }
+    it { should respond_to(:[])}
+    its([0]) { should eq 'row1col1' }
+    its([1]) { should eq 'row1col2' }
+  end
+
+  describe 'one_level_hash' do
+    subject { attrs['one_level_hash'] }
+    it { should be_a_kind_of(Hash) }
+    it { should respond_to(:[])}
+    its(['key1']) { should eq 'value1' }
+    its(['key2']) { should eq 'value2' }
+    its('keys.count') { should eq 2 }
+  end
+
+  describe 'two_level_hash' do
+    subject { attrs['two_level_hash'] }
+    it { should be_a_kind_of(Hash) }
+    it { should respond_to(:[])}
+    its(['key1', 'key11']) { should eq 'value11' }
+    its(['key2', 'key22']) { should eq 'value22' }
+    its('keys.count') { should eq 2 }
+  end
+
+  describe 'hash_of_arrays' do
+    subject { attrs['hash_of_arrays'] }
+    it { should be_a_kind_of(Hash) }
+    it { should respond_to(:[])}
+    its(['key1', 0]) { should eq 'thing11' }
+    its(['key2', 1]) { should eq 'thing22' }
+    its('keys.count') { should eq 2 }
+  end
+
+  describe 'array_of_hashes' do
+    subject { attrs['array_of_hashes'] }
+    it { should be_a_kind_of(Array) }
+    it { should respond_to(:[])}
+
+    # These fail
+    # its([0, 'key11']) { should eq 'value11' }
+    # its([1, 'key22']) { should eq 'value22' }
+    its('count') { should eq 2 }
+  end
+end

--- a/test/unit/mock/profiles/attributes/inspec.yml
+++ b/test/unit/mock/profiles/attributes/inspec.yml
@@ -1,0 +1,9 @@
+name: attributes
+version: 1.0.0
+maintainer: inspec@chef.io
+title: Attributes
+license: Apache-2.0
+supports:
+  - linux
+  - darwin
+  - windows


### PR DESCRIPTION
On #2991 , we have a PR in which a contributor aimed to simplify access to hierarchical attributes (that is, arrays of arrays, hashes of arrays, etc, in YAML).  Discussion went towards adding `[]` to Attribute, so it would appear natural.  On #2991, unit tests were added.  However, no functional tests were on hand - so the YAML parser and Attribute were never tested directly.

It turns out that without #2991, Attribute already works for arrays of arrays, hashes of hashes, hashes of arrays, but not well for arrays of hashes (though that may be a flaw in rspec-its).

Additionally, `attribute(...)` was found to have two peculiar properties:
* it can only be used in profile context (not within a control, or a describe block)
* it must key all attribute lookups using a string, and silently misses of a Symbol is provided

Both of those could be improved.

This PR simply adds functional tests to exercise attributes.
