### PR TITLE
Detect inspec-core mode and do not attempt to load cloud resources

### DIFF
--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -85,8 +85,12 @@ end
 # Many resources use FilterTable.
 require 'utils/filter'
 
-# AWS resources are included via their own file.
-require 'resource_support/aws' if Gem.loaded_specs.key?('aws-sdk')
+# AWS resources are included via their own file,
+# but only consider loading them if we have the SDK available, and is v2.
+# https://github.com/inspec/inspec/issues/2571
+if Gem.loaded_specs.key?('aws-sdk') && Gem.loaded_specs['aws-sdk'].version < Gem::Version.new('3.0.0')
+  require 'resource_support/aws'
+end
 
 if Gem.loaded_specs.key?('azure_mgmt_resources')
   require 'resources/azure/azure_backend.rb'

--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -85,19 +85,27 @@ end
 # Many resources use FilterTable.
 require 'utils/filter'
 
-# AWS resources are included via their own file,
-# but only consider loading them if we have the SDK available, and is v2.
-# https://github.com/inspec/inspec/issues/2571
-if Gem.loaded_specs.key?('aws-sdk') && Gem.loaded_specs['aws-sdk'].version < Gem::Version.new('3.0.0')
-  require 'resource_support/aws'
-end
+# Detect if we are running the stripped-down inspec-core
+# This relies on AWS being stripped from the inspec-core gem
+inspec_core_only = !File.exist?(File.join(File.dirname(__FILE__), '..', 'resource_support', 'aws.rb'))
 
-if Gem.loaded_specs.key?('azure_mgmt_resources')
-  require 'resources/azure/azure_backend.rb'
-  require 'resources/azure/azure_generic_resource.rb'
-  require 'resources/azure/azure_resource_group.rb'
-  require 'resources/azure/azure_virtual_machine.rb'
-  require 'resources/azure/azure_virtual_machine_data_disk.rb'
+# Do not attempt to load cloud resources if we are in inspec-core mode
+unless inspec_core_only
+  # AWS resources are included via their own file,
+  # but only consider loading them if we have the SDK available, and is v2.
+  # https://github.com/inspec/inspec/issues/2571
+  if Gem.loaded_specs.key?('aws-sdk') && Gem.loaded_specs['aws-sdk'].version < Gem::Version.new('3.0.0')
+    require 'resource_support/aws'
+  end
+
+  # Azure resources
+  if Gem.loaded_specs.key?('azure_mgmt_resources')
+    require 'resources/azure/azure_backend.rb'
+    require 'resources/azure/azure_generic_resource.rb'
+    require 'resources/azure/azure_resource_group.rb'
+    require 'resources/azure/azure_virtual_machine.rb'
+    require 'resources/azure/azure_virtual_machine_data_disk.rb'
+  end
 end
 
 require 'resources/aide_conf'


### PR DESCRIPTION
Fixes #3161 
Affects #2571

On PR #3008, we created an additional gemspec for InSpec called `inspec-core`, which performs a normal gem build, then deletes all AWS and Azure files.  `inspec-core` also does not depend on the cloud SDK gems, which are quite large and less portable.  `inspec-core` is shipped with the chef client, so it may continue to have a small footprint and meet our portability commitments.

However, the code that detects whether to attempt to load the AWS and Azure resources relied on detecting whether the corresponding SDK was installed.  #3161 encountered a case in which the AWS 3 SDK was installed along with `inspec-core`, so the `inspec` code attempted to load the AWS resource files, which were absent; stacktrace ensued.

This PR makes three changes:
* Detect if we are running on `inspec-core`.  As there is no source code distinction other than the post-hoc exclusion of the AWS and Azure files, the conditional is based on checking for `lib/resource_support/aws.rb`. That could likely be improved.
* If we are under `inspec-core`, do not attempt to load AWS or Azure support.
* If we are under "full" `inspec`, check the AWS SDK version (v2 and v3 cannot cohabitate in a process, see #2571).  We currently rely on v2; if v3 is found, do not attempt to load.

This is challenging to test, but I did so manually.  `temp/` and `inspec-incident/` are sibling directories.

```
[cwolfe@lodi temp]$ cat Gemfile
source "https://rubygems.org"
gem 'inspec-core', :path => '../inspec-incident'
gem 'aws-sdk', "~> #{ENV['AWS_SDK_MAJOR_VERSION']}.0"

[cwolfe@lodi temp]$ # ----------------  Full InSpec, AWS SDK 3 ----------------- #
[cwolfe@lodi temp]$ export AWS_SDK_MAJOR_VERSION=3
[cwolfe@lodi temp]$ bundle update
...
[cwolfe@lodi temp]$ bundle exec inspec shell -c "Inspec::Resource.registry.key?('aws_iam_policy')"
false

[cwolfe@lodi temp]$ # ----------------  Full InSpec, AWS SDK 2 ----------------- #
[cwolfe@lodi temp]$ export AWS_SDK_MAJOR_VERSION=2
[cwolfe@lodi temp]$ bundle update
...
[cwolfe@lodi temp]$ bundle exec inspec shell -c "Inspec::Resource.registry.key?('aws_iam_policy')"
true

[cwolfe@lodi temp]$ # ----------------  inspec-core, AWS SDK 2 ----------------- #
[cwolfe@lodi temp]$ mv ../inspec-incident/lib/resource_support/aws.rb ../inspec-incident/lib/resource_support/aws.rb.disable
[cwolfe@lodi temp]$ bundle exec inspec shell -c "Inspec::Resource.registry.key?('aws_iam_policy')"
false

[cwolfe@lodi temp]$ # ----------------  inspec-core, AWS SDK 3 ----------------- #
[cwolfe@lodi temp]$ export AWS_SDK_MAJOR_VERSION=3
[cwolfe@lodi temp]$ bundle update
...
[cwolfe@lodi temp]$ bundle exec inspec shell -c "Inspec::Resource.registry.key?('aws_iam_policy')"
false
```

