### PR TITLE
Set parent_profile field on child profiles (json report)

### DIFF
--- a/lib/inspec/dependencies/dependency_set.rb
+++ b/lib/inspec/dependencies/dependency_set.rb
@@ -14,9 +14,9 @@ module Inspec
     # @param cwd [String] Current working directory for relative path includes
     # @param vendor_path [String] Path to the vendor directory
     #
-    def self.from_lockfile(lockfile, cwd, cache, backend, opts = {})
+    def self.from_lockfile(lockfile, cwd, cache, backend, opts = {}, parent_profile = nil)
       dep_tree = lockfile.deps.map do |dep|
-        Inspec::Requirement.from_lock_entry(dep, cwd, cache, backend, opts)
+        Inspec::Requirement.from_lock_entry(dep, cwd, cache, backend, opts, parent_profile)
       end
 
       dep_list = flatten_dep_tree(dep_tree)

--- a/lib/inspec/dependencies/dependency_set.rb
+++ b/lib/inspec/dependencies/dependency_set.rb
@@ -14,9 +14,11 @@ module Inspec
     # @param cwd [String] Current working directory for relative path includes
     # @param vendor_path [String] Path to the vendor directory
     #
-    def self.from_lockfile(lockfile, cwd, cache, backend, opts = {}, parent_profile = nil)
+    # Disabled rubocoop check for now, this is up for a refactor for 3.0
+    # rubocop:disable Metrics/ParameterLists
+    def self.from_lockfile(lockfile, cwd, cache, backend, parent_profile, opts = {})
       dep_tree = lockfile.deps.map do |dep|
-        Inspec::Requirement.from_lock_entry(dep, cwd, cache, backend, opts, parent_profile)
+        Inspec::Requirement.from_lock_entry(dep, cwd, cache, backend, parent_profile, opts)
       end
 
       dep_list = flatten_dep_tree(dep_tree)

--- a/lib/inspec/dependencies/dependency_set.rb
+++ b/lib/inspec/dependencies/dependency_set.rb
@@ -14,15 +14,13 @@ module Inspec
     # @param cwd [String] Current working directory for relative path includes
     # @param vendor_path [String] Path to the vendor directory
     #
-    # Disabled rubocoop check for now, this is up for a refactor for 3.0
-    # rubocop:disable Metrics/ParameterLists
-    def self.from_lockfile(lockfile, cwd, cache, backend, parent_profile, opts = {})
+    def self.from_lockfile(lockfile, config, opts = {})
       dep_tree = lockfile.deps.map do |dep|
-        Inspec::Requirement.from_lock_entry(dep, cwd, cache, backend, parent_profile, opts)
+        Inspec::Requirement.from_lock_entry(dep, config, opts)
       end
 
       dep_list = flatten_dep_tree(dep_tree)
-      new(cwd, cache, dep_list, backend)
+      new(config[:cwd], config[:cache], dep_list, config[:backend])
     end
 
     def self.from_array(dependencies, cwd, cache, backend)

--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -36,8 +36,9 @@ module Inspec
 
       locked_deps = []
       Array(entry[:dependencies]).each do |dep_entry|
-        config[:praent_profile] = req.profile.name
-        locked_deps << Inspec::Requirement.from_lock_entry(dep_entry, config, opts)
+        dep_config = config.dup
+        dep_config[:parent_profile] = entry[:name]
+        locked_deps << Inspec::Requirement.from_lock_entry(dep_entry, dep_config, opts)
       end
       req.lock_deps(locked_deps)
       req

--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -25,29 +25,31 @@ module Inspec
           opts.merge(dep))
     end
 
-    def self.from_lock_entry(entry, cwd, cache, backend, opts = {})
+    def self.from_lock_entry(entry, cwd, cache, backend, opts = {}, parent_profile = nil)
       req = new(entry[:name],
                 entry[:version_constraints],
                 cache,
                 cwd,
-                entry[:resolved_source].merge(backend: backend).merge(opts))
+                entry[:resolved_source].merge(backend: backend).merge(opts),
+                parent_profile)
 
       locked_deps = []
       Array(entry[:dependencies]).each do |dep_entry|
-        locked_deps << Inspec::Requirement.from_lock_entry(dep_entry, cwd, cache, backend, opts)
+        locked_deps << Inspec::Requirement.from_lock_entry(dep_entry, cwd, cache, backend, opts, req.profile.name)
       end
       req.lock_deps(locked_deps)
       req
     end
 
     attr_reader :cwd, :opts, :version_constraints
-    def initialize(name, version_constraints, cache, cwd, opts)
+    def initialize(name, version_constraints, cache, cwd, opts, parent_profile = nil)
       @name = name
       @version_constraints = Array(version_constraints)
       @cache = cache
       @backend = opts[:backend]
       @opts = opts
       @cwd = cwd
+      @parent_profile = parent_profile
     end
 
     #
@@ -114,10 +116,12 @@ module Inspec
       return @profile unless @profile.nil?
       opts = @opts.dup
       opts[:backend] = @backend
-      if !@dependencies.nil?
+      if !@dependencies.nil? && !@dependencies.empty?
         opts[:dependencies] = Inspec::DependencySet.from_array(@dependencies, @cwd, @cache, @backend)
       end
       @profile = Inspec::Profile.for_fetcher(fetcher, opts)
+      @profile.parent_profile = @parent_profile
+      @profile
     end
   end
 end

--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -25,24 +25,26 @@ module Inspec
           opts.merge(dep))
     end
 
-    def self.from_lock_entry(entry, cwd, cache, backend, opts = {}, parent_profile = nil)
+    # Disabled rubocop check for now, this is up for a refactor for 3.0
+    # rubocop:disable Metrics/ParameterLists
+    def self.from_lock_entry(entry, cwd, cache, backend, parent_profile, opts = {})
       req = new(entry[:name],
                 entry[:version_constraints],
                 cache,
                 cwd,
-                entry[:resolved_source].merge(backend: backend).merge(opts),
-                parent_profile)
+                parent_profile,
+                entry[:resolved_source].merge(backend: backend).merge(opts))
 
       locked_deps = []
       Array(entry[:dependencies]).each do |dep_entry|
-        locked_deps << Inspec::Requirement.from_lock_entry(dep_entry, cwd, cache, backend, opts, req.profile.name)
+        locked_deps << Inspec::Requirement.from_lock_entry(dep_entry, cwd, cache, backend, req.profile.name, opts)
       end
       req.lock_deps(locked_deps)
       req
     end
 
     attr_reader :cwd, :opts, :version_constraints
-    def initialize(name, version_constraints, cache, cwd, opts, parent_profile = nil)
+    def initialize(name, version_constraints, cache, cwd, parent_profile, opts)
       @name = name
       @version_constraints = Array(version_constraints)
       @cache = cache

--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -17,11 +17,14 @@ module Inspec
       if dep[:path]
         req_path = File.expand_path(dep[:path], req_path)
       end
+      config = {
+        cache: cache,
+        cwd: req_path,
+      }
 
       new(dep[:name],
           dep[:version],
-          cache,
-          req_path,
+          config,
           opts.merge(dep))
     end
 

--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -25,33 +25,30 @@ module Inspec
           opts.merge(dep))
     end
 
-    # Disabled rubocop check for now, this is up for a refactor for 3.0
-    # rubocop:disable Metrics/ParameterLists
-    def self.from_lock_entry(entry, cwd, cache, backend, parent_profile, opts = {})
+    def self.from_lock_entry(entry, config, opts = {})
       req = new(entry[:name],
                 entry[:version_constraints],
-                cache,
-                cwd,
-                parent_profile,
-                entry[:resolved_source].merge(backend: backend).merge(opts))
+                config,
+                entry[:resolved_source].merge(backend: config[:backend]).merge(opts))
 
       locked_deps = []
       Array(entry[:dependencies]).each do |dep_entry|
-        locked_deps << Inspec::Requirement.from_lock_entry(dep_entry, cwd, cache, backend, req.profile.name, opts)
+        config[:praent_profile] = req.profile.name
+        locked_deps << Inspec::Requirement.from_lock_entry(dep_entry, config, opts)
       end
       req.lock_deps(locked_deps)
       req
     end
 
     attr_reader :cwd, :opts, :version_constraints
-    def initialize(name, version_constraints, cache, cwd, parent_profile, opts)
+    def initialize(name, version_constraints, config, opts)
       @name = name
       @version_constraints = Array(version_constraints)
-      @cache = cache
+      @cache = config[:cache]
       @backend = opts[:backend]
       @opts = opts
-      @cwd = cwd
-      @parent_profile = parent_profile
+      @cwd = config[:cwd]
+      @parent_profile = config[:parent_profile]
     end
 
     #

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -416,7 +416,13 @@ module Inspec
     end
 
     def load_dependencies
-      Inspec::DependencySet.from_lockfile(lockfile, cwd, @cache, @backend, name, { attributes: @attr_values })
+      config = {
+        cwd: cwd,
+        cache: @cache,
+        backend: @backend,
+        parent_profile: name,
+      }
+      Inspec::DependencySet.from_lockfile(lockfile, config, { attributes: @attr_values })
     end
 
     # Calculate this profile's SHA256 checksum. Includes metadata, dependencies,

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -416,7 +416,7 @@ module Inspec
     end
 
     def load_dependencies
-      Inspec::DependencySet.from_lockfile(lockfile, cwd, @cache, @backend, { attributes: @attr_values }, name)
+      Inspec::DependencySet.from_lockfile(lockfile, cwd, @cache, @backend, name, { attributes: @attr_values })
     end
 
     # Calculate this profile's SHA256 checksum. Includes metadata, dependencies,

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -79,6 +79,7 @@ module Inspec
     end
 
     attr_reader :source_reader, :backend, :runner_context, :check_mode
+    attr_accessor :parent_profile
     def_delegator :@source_reader, :tests
     def_delegator :@source_reader, :libraries
     def_delegator :@source_reader, :metadata
@@ -230,6 +231,7 @@ module Inspec
       # add information about the required attributes
       res[:attributes] = res[:attributes].map(&:to_hash) unless res[:attributes].nil? || res[:attributes].empty?
       res[:sha256] = sha256
+      res[:parent_profile] = parent_profile unless parent_profile.nil?
       res
     end
 
@@ -414,7 +416,7 @@ module Inspec
     end
 
     def load_dependencies
-      Inspec::DependencySet.from_lockfile(lockfile, cwd, @cache, @backend, { attributes: @attr_values })
+      Inspec::DependencySet.from_lockfile(lockfile, cwd, @cache, @backend, { attributes: @attr_values }, name)
     end
 
     # Calculate this profile's SHA256 checksum. Includes metadata, dependencies,

--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -105,6 +105,7 @@ module Inspec::Reporters
           copyright_email: p[:copyright_email],
           supports: p[:supports],
           attributes: p[:attributes],
+          parent_profile: p[:parent_profile],
           depends: p[:depends],
           groups: profile_groups(p),
           controls: profile_controls(p),

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -333,6 +333,7 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
     let(:out) { inspec('exec ' + File.join(profile_path, 'wrapper-override') + ' --no-create-lockfile --vendor-cache ' +  File.join(profile_path, 'wrapper-override', 'vendor') + ' --reporter json') }
     let(:json) { JSON.load(out.stdout) }
     let(:controls) { json['profiles'][0]['controls'] }
+    let(:child_profile) { json['profiles'].select { |p| p['name'] == 'myprofile1' }.first }
     let(:override) { controls.select { |c| c['title'] == 'Profile 1 - Control 2-updated' }.first }
 
     it 'completes the run with failed controls but no exception' do
@@ -347,6 +348,7 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
       override['title'].must_equal "Profile 1 - Control 2-updated"
       tags_assert = {"password"=>nil, "password-updated"=>nil}
       override['tags'].must_equal tags_assert
+      child_profile['parent_profile'].must_equal 'wrapper-override'
     end
   end
 

--- a/test/unit/dependencies/requirement_test.rb
+++ b/test/unit/dependencies/requirement_test.rb
@@ -2,7 +2,8 @@ require 'helper'
 require 'inspec/dependencies/requirement'
 
 describe Inspec::Requirement do
-  let(:req) { Inspec::Requirement.new('foo', constraints, nil, nil, {}) }
+  let(:config) { { cwd: nil, backend: nil } }
+  let(:req) { Inspec::Requirement.new('foo', constraints, config, {}) }
 
   describe '#source_satisfies_spec?' do
 


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This change adds a optional `parent_profile` filed to the profile info section. This is used when a profile depends on others and they are loaded. This addition will make it possible to link child profiles to parent profiles when digesting the json report.

Fixes https://github.com/inspec/inspec/issues/3135