### PR TITLE
A number of bug fixes and new features for oracledb_session resource

### DIFF
--- a/docs/resources/oracledb_session.md.erb
+++ b/docs/resources/oracledb_session.md.erb
@@ -25,6 +25,11 @@ where
 
 <br>
 
+## Resource Properties
+* rows the query result as array of hashes
+* row(id)  selected row from query result
+* column(name) array with values from selected column
+ 
 ## Examples
 
 The following examples show how to use this InSpec audit resource.
@@ -43,6 +48,14 @@ The following examples show how to use this InSpec audit resource.
 
     describe sql.query('SELECT NAME FROM v$database;').row(0).column('name') do
       its('value') { should cmp 'ORCL' }
+    end
+
+### Test for table contains a specified value in any row for the given column name
+
+    sql = oracledb_session(user: 'my_user', pass: 'password')
+
+    describe sql.query('SELECT * FROM my_table;').column('my_column') do
+      it { should include 'my_value' }
     end
 
 <br>

--- a/docs/resources/oracledb_session.md.erb
+++ b/docs/resources/oracledb_session.md.erb
@@ -28,7 +28,7 @@ where
 
 ## Resource Properties
 * rows the query result as array of hashes
-* row(id)  selected row from query result
+* row(number)  selected row from query result, where number is just a row number in the query result
 * column(name) array with values from selected column
  
 ## Examples

--- a/docs/resources/oracledb_session.md.erb
+++ b/docs/resources/oracledb_session.md.erb
@@ -20,7 +20,7 @@ A `oracledb_session` resource block declares the username and password to use fo
 where
 
 * `oracledb_session` declares a username and password with permission to run the query (required), and an optional parameters for host (default: `localhost`), SID (default: `nil`, which uses the default SID, and path to the sqlplus binary (default: `sqlplus`).
-* it is possible to run queries as sysdba/sysoper by setting password to value 'as sysdba', see examples
+* it is possible to run queries as sysdba/sysoper by using `as_db_role option`, see examples
 * `query('QUERY')` contains the query to be run
 * `its('value') { should eq('') }` compares the results of the query against the expected result in the test
 
@@ -53,7 +53,7 @@ The following examples show how to use this InSpec audit resource.
 
 ### Test for table contains a specified value in any row for the given column name
 
-    sql = oracledb_session(user: 'my_user', pass: 'password')
+    sql = oracledb_session(user: 'my_user', pass: 'password', service: 'MYSID')
 
     describe sql.query('SELECT * FROM my_table;').column('my_column') do
       it { should include 'my_value' }
@@ -62,11 +62,12 @@ The following examples show how to use this InSpec audit resource.
 ### Test tablespace exists as sysdba
     The check will change user (with su) to specified user and run 'sqlplus / as sysdba' (sysoper, sysasm) 
 
-    sql = oracledb_session(user: 'oracle', pass: 'as sysdba', service: 'MYSID')
+    sql = oracledb_session(as_os_user: 'oracle', as_db_role: 'sysdba', service: 'MYSID')
 
     describe sql.query('SELECT tablespace_name AS name FROM dba_tablespaces;').column('name') do
       it { should include 'MYTABLESPACE' }
     end
+    NOTE: option `as_os_user` available only on unix-like systems and not supported on Windows. Also this option requires that you are running inspec as `root` or with `--sudo`
 
 ### Test number of rows in the query result
 

--- a/docs/resources/oracledb_session.md.erb
+++ b/docs/resources/oracledb_session.md.erb
@@ -20,6 +20,7 @@ A `oracledb_session` resource block declares the username and password to use fo
 where
 
 * `oracledb_session` declares a username and password with permission to run the query (required), and an optional parameters for host (default: `localhost`), SID (default: `nil`, which uses the default SID, and path to the sqlplus binary (default: `sqlplus`).
+* it is possible to run queries as sydba/sysoper by set password to value 'as sysdba', see examples
 * `query('QUERY')` contains the query to be run
 * `its('value') { should eq('') }` compares the results of the query against the expected result in the test
 
@@ -56,6 +57,15 @@ The following examples show how to use this InSpec audit resource.
 
     describe sql.query('SELECT * FROM my_table;').column('my_column') do
       it { should include 'my_value' }
+    end
+
+### Test tablespace exists as sysdba
+    The check will change user (with su) to specified user and run 'sqlplus / as sysdba' (sysoper, sysasm) 
+
+    sql = oracledb_session(user: 'oracle', pass: 'as sysdba', service: 'MYSID')
+
+    describe sql.query('SELECT tablespace_name AS name FROM dba_tablespaces;').column('name') do
+      it { should include 'MYTABLESPACE' }
     end
 
 <br>

--- a/docs/resources/oracledb_session.md.erb
+++ b/docs/resources/oracledb_session.md.erb
@@ -26,7 +26,7 @@ where
 
 <br>
 
-## Resource Properties
+## oracledb_session(...).query method Properties
 * rows the query result as array of hashes
 * row(number)  selected row from query result, where number is just a row number in the query result
 * column(name) array with values from selected column
@@ -68,6 +68,23 @@ The following examples show how to use this InSpec audit resource.
       it { should include 'MYTABLESPACE' }
     end
 
+### Test number of rows in the query result
+
+    sql = oracledb_session(user: 'my_user', pass: 'password')
+
+    describe sql.query('SELECT * FROM my_table;').rows do
+      its('count') { should eq 20 }
+    end
+
+### Use data out of (remote) DB query to build other tests
+
+    sql = oracledb_session(user: 'my_user', pass: 'password', host: 'my.remote.db', service: 'MYSID')
+
+    sql.query('SELECT * FROM files;').rows.each do |file_row|
+      describe file(file_row['path']) do
+	its('owner') { should eq file_row['owner']}
+      end
+    end
 <br>
 
 ## Matchers

--- a/docs/resources/oracledb_session.md.erb
+++ b/docs/resources/oracledb_session.md.erb
@@ -20,7 +20,7 @@ A `oracledb_session` resource block declares the username and password to use fo
 where
 
 * `oracledb_session` declares a username and password with permission to run the query (required), and an optional parameters for host (default: `localhost`), SID (default: `nil`, which uses the default SID, and path to the sqlplus binary (default: `sqlplus`).
-* it is possible to run queries as sydba/sysoper by set password to value 'as sysdba', see examples
+* it is possible to run queries as sysdba/sysoper by setting password to value 'as sysdba', see examples
 * `query('QUERY')` contains the query to be run
 * `its('value') { should eq('') }` compares the results of the query against the expected result in the test
 

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -55,7 +55,7 @@ module Inspec::Resources
         p = :parse_csv_result
       else
         bin = @sqlplus_bin
-        opts = "SET MARKUP HTML ON\nSET FEEDBACK OFF"
+        opts = "SET MARKUP HTML ON\nSET PAGESIZE 32000\nSET FEEDBACK OFF"
         p = :parse_html_result
       end
 

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -35,7 +35,7 @@ module Inspec::Resources
       @service = opts[:service]
 
       # we prefer sqlci although it is way slower than sqlplus, but it understands csv properly
-      @sqlcl_bin = 'sql'
+      @sqlcl_bin = 'sql' unless opts.has_key?(:sqlplus_bin) # don't use it if user specified sqlplus_bin option
       @sqlplus_bin = opts[:sqlplus_bin] || 'sqlplus'
 
       return skip_resource "Can't run Oracle checks without authentication" if @user.nil? || @password.nil?
@@ -49,7 +49,7 @@ module Inspec::Resources
 
       p = nil
       # use sqlplus if sqlcl is not available
-      if inspec.command(@sqlcl_bin).exist?
+      if @sqlcl_bin and inspec.command(@sqlcl_bin).exist?
         bin = @sqlcl_bin
         opts = "set sqlformat csv\nSET FEEDBACK OFF"
         p = :parse_csv_result

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -35,7 +35,7 @@ module Inspec::Resources
       @service = opts[:service]
 
       # we prefer sqlci although it is way slower than sqlplus, but it understands csv properly
-      @sqlcl_bin = 'sql' unless opts.has_key?(:sqlplus_bin) # don't use it if user specified sqlplus_bin option
+      @sqlcl_bin = 'sql' unless opts.key?(:sqlplus_bin) # don't use it if user specified sqlplus_bin option
       @sqlplus_bin = opts[:sqlplus_bin] || 'sqlplus'
 
       return skip_resource "Can't run Oracle checks without authentication" if @user.nil? || @password.nil?
@@ -61,7 +61,7 @@ module Inspec::Resources
 
       query = verify_query(escaped_query)
       query += ';' unless query.end_with?(';')
-      if /as (sysdba|sysoper|sysasm)/i === @password
+      if @password =~ /as (sysdba|sysoper|sysasm)/i
         command = %{su - #{user} -c "env ORACLE_SID=#{@service} #{bin} / #{@password} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC"}
       else
         command = %{#{bin} "#{@user}"/"#{@password}"@#{@host}:#{@port}/#{@service} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC}

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -44,8 +44,8 @@ module Inspec::Resources
       @sqlcl_bin = 'sql' unless opts.key?(:sqlplus_bin) # don't use it if user specified sqlplus_bin option
       @sqlplus_bin = opts[:sqlplus_bin] || 'sqlplus'
 
-      return skip_resource "Can't run Oracle checks without authentication" if @su_user.nil? && (@user.nil? || @password.nil?)
-      return skip_resource 'You must provide a service name for the session' if @service.nil?
+      return fail_resource "Can't run Oracle checks without authentication" if @su_user.nil? && (@user.nil? || @password.nil?)
+      return fail_resource 'You must provide a service name for the session' if @service.nil?
     end
 
     def query(q)

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -61,7 +61,11 @@ module Inspec::Resources
 
       query = verify_query(escaped_query)
       query += ';' unless query.end_with?(';')
-      command = %{#{bin} "#{@user}"/"#{@password}"@#{@host}:#{@port}/#{@service} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC}
+      if /as (sysdba|sysoper|sysasm)/i === @password
+        command = %{su - #{user} -c "env ORACLE_SID=#{@service} #{bin} / #{@password} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC"}
+      else
+        command = %{#{bin} "#{@user}"/"#{@password}"@#{@host}:#{@port}/#{@service} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC}
+      end
       cmd = inspec.command(command)
 
       out = cmd.stdout + "\n" + cmd.stderr

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -61,7 +61,7 @@ module Inspec::Resources
 
       query = verify_query(escaped_query)
       query += ';' unless query.end_with?(';')
-      command = %{echo "#{opts}\n#{query}\nEXIT" | #{bin} "#{@user}"/"#{@password}"@#{@host}:#{@port}/#{@service}}
+      command = %{#{bin} "#{@user}"/"#{@password}"@#{@host}:#{@port}/#{@service} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC}
       cmd = inspec.command(command)
 
       out = cmd.stdout + "\n" + cmd.stderr

--- a/lib/utils/database_helpers.rb
+++ b/lib/utils/database_helpers.rb
@@ -59,7 +59,7 @@ module DatabaseHelper
     def column(column)
       result = []
       @results.each do |row|
-        result << row[column] if row.has_key?(column)
+        result << row[column] if row.key?(column)
       end
       result
     end

--- a/lib/utils/database_helpers.rb
+++ b/lib/utils/database_helpers.rb
@@ -48,8 +48,20 @@ module DatabaseHelper
       @cmd.exit_status == 0 && @error.nil?
     end
 
+    def rows
+      @results
+    end
+
     def row(id)
       SQLRow.new(self, @results[id])
+    end
+
+    def column(column)
+      result = []
+      @results.each do |row|
+        result << row[column] if row.has_key?(column)
+      end
+      result
     end
 
     def size

--- a/lib/utils/database_helpers.rb
+++ b/lib/utils/database_helpers.rb
@@ -59,7 +59,7 @@ module DatabaseHelper
     def column(column)
       result = []
       @results.each do |row|
-        result << row[column] if row.key?(column)
+        result << row[column]
       end
       result
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -461,7 +461,7 @@ class MockLoader
       "7d1a7a0f2bd1e7da9a6904e1f28981146ec01a0323623e12a8579d30a3960a79" => cmd.call('mssql-result'),
       # oracle
       "bash -c 'type \"sqlplus\"'" => cmd.call('oracle-cmd'),
-      "527f243fe9b01fc7b7d78eb1ef5200e272b011aa07c9f59836d950107d6d2a5c" => cmd.call('oracle-result'),
+      "1998da5bc0f09bd5258fad51f45447556572b747f631661831d6fcb49269a448" => cmd.call('oracle-result'),
       # nginx mock cmd
       %{nginx -V 2>&1} => cmd.call('nginx-v'),
       %{/usr/sbin/nginx -V 2>&1} => cmd.call('nginx-v'),


### PR DESCRIPTION
Started with fixing the issue #3169 and finished with extended resource, which covers my real life needs in checking Oracle query results.
The bug fixes includes:
* If user specify sqlplus_bin always use it, even if sql exists 
* reformat command for execution to make sudo working. So I can specify:
sqlplus_bin: 'su - oracle sqlplus'.
The new features include:
* methods 'rows' and 'column' which allows easier processing of multi-rows results
* make possible to execute queries as sysdba/sysoper/sysasm

All fixes and features are in separate commits to make possible partial merge.