### PR TITLE
Prevent Slashes in profile names

### DIFF
--- a/lib/bundles/inspec-init/cli.rb
+++ b/lib/bundles/inspec-init/cli.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-# author: Christoph Hartmann
 
 require 'pathname'
 
@@ -42,8 +41,13 @@ module Init
       base_dir = File.join(dir, 'templates', type)
       # prepare glob for all subdirectories and files
       template = File.join(base_dir, '**', '{*,.*}')
-      # generate target path
-      target = Pathname.new(Dir.pwd).join(attributes[:name])
+      # Use the name attribute to define the path to the profile.
+      profile_path = attributes[:name]
+      # Use slashes (\, /) to split up the name into an Array then use the last entry
+      # to reset the name of the profile.
+      attributes[:name] = attributes[:name].split(%r{\\|\/}).last
+      # Generate the full target path on disk
+      target = Pathname.new(Dir.pwd).join(profile_path)
       puts "Create new #{type} at #{mark_text(target)}"
 
       # check that the directory does not exist

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 # Copyright 2015 Dominik Richter
-# author: Dominik Richter
-# author: Christoph Hartmann
 
 require 'logger'
 require 'rubygems/version'
@@ -78,10 +76,9 @@ module Inspec
         errors.push("Missing profile #{field} in #{ref}")
       end
 
-      if params[:name] =~ %r{[\/\\]}
-        warnings.push("Your profile name (#{params[:name]}) contains a slash " \
-          'which will not be permitted in InSpec 2.0. Please change your profile ' \
-          'name in the `inspec.yml` file.')
+      if %r{[\/\\]} =~ params[:name]
+        errors.push("The profile name (#{params[:name]}) contains a slash" \
+                      ' which is not permitted. Please remove all slashes from `inspec.yml`.')
       end
 
       # if version is set, ensure it is correct
@@ -190,7 +187,7 @@ module Inspec
       # unit tests that look for warning sequences
       return if original_target.to_s.empty?
       metadata.params[:title] = "tests from #{original_target}"
-      metadata.params[:name] = metadata.params[:title].gsub(%r{[\\\/]}, '.')
+      metadata.params[:name] = metadata.params[:title].gsub(%r{[\/\\]}, '.')
     end
 
     def self.finalize(metadata, profile_id, options, logger = nil)

--- a/test/functional/inspec_init_test.rb
+++ b/test/functional/inspec_init_test.rb
@@ -1,0 +1,23 @@
+require 'functional/helper'
+require 'fileutils'
+require 'tmpdir'
+require 'yaml'
+
+describe 'inspec init' do
+  include FunctionalHelper
+
+  tmpdir = Dir.tmpdir
+
+  describe 'inspec init profile with/slash' do
+    it 'names profile with string after last slash' do
+      slash_profile = "#{tmpdir}/inspecwith/slash"
+      out = inspec("init profile #{slash_profile}")
+      out.exit_status.must_equal 0
+      File.exist?(slash_profile).must_equal true
+      profile = YAML.load_file("#{slash_profile}/inspec.yml")
+      profile['name'].must_equal 'slash'
+    end
+  end
+
+  Dir.glob("#{tmpdir}/inspecwith*").each {|i| FileUtils.remove_entry_secure(i) }
+end

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -1,6 +1,4 @@
 # encoding: utf-8
-# author: Christoph Hartmann
-# author: Dominik Richter
 
 require 'helper'
 require 'inspec/profile_context'
@@ -127,7 +125,7 @@ describe Inspec::Profile do
         result[:warnings].length.must_equal 5
       end
     end
-    
+
     describe 'an empty profile (legacy mode)' do
       let(:profile_id) { 'legacy-empty-metadata' }
 
@@ -337,19 +335,20 @@ describe Inspec::Profile do
     describe 'a profile with a slash in the name' do
       let(:profile_path) { 'slash-in-name/not-allowed' } # Slashes allowed here
       let(:profile_name) { 'slash-in-name/not-allowed' }   # But not here
-      it 'issues a deprecation warning' do
+      it 'issues an error' do
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_path}"]
-        logger.expect :warn, nil, ["Your profile name (#{profile_name}) contains a slash which " \
-          "will not be permitted in InSpec 2.0. Please change your profile name in the `inspec.yml` file."]
-        logger.expect :info, nil, ['Metadata OK.']
+        logger.expect :error, nil, ["The profile name (#{profile_name}) contains a slash which " \
+          'is not permitted. Please remove all slashes from `inspec.yml`.']
         logger.expect :info, nil, ['Found 1 controls.']
+        logger.expect :info, nil, ['Control definitions OK.']
 
         result = MockLoader.load_profile(profile_path, {logger: logger}).check
         logger.verify
-        result[:warnings].length.must_equal 1
+        result[:warnings].length.must_equal 0
+        result[:errors].length.must_equal 1
       end
     end
-    
+
     describe 'shows warning if license is invalid' do
       let(:profile_id) { 'license-invalid' }
       let(:profile_path) { MockLoader.profile_zip(profile_id) }


### PR DESCRIPTION
When a profile is created with init, the last item after a / is the
profile name. eg "with/slash" would result in a profile created in the
"with" directory named "slash"

Add test for inspec init, and updated other for new output.

Clean up profiles created during testing and place them in temporary
directories.

Signed-off-by: Miah Johnson <miah@chia-pet.org>

Fixes chef#1783