### PR TITLE
Document exit codes for 'inspec exec' and add --no-distinct-exit option

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -83,6 +83,8 @@ module Inspec
         desc: 'Allow caching for backend command output. (default: true)'
       option :show_progress, type: :boolean,
         desc: 'Show progress while executing tests.'
+      option :distinct_exit, type: :boolean, default: true,
+        desc: 'Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.'
     end
 
     def self.default_options

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -157,7 +157,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 
   desc 'exec PATHS', 'run all test files at the specified PATH.'
   long_desc <<~EOT
-    Loads the given profile(s) and fetches their dependencies if needed.  Then connects to the target and executes any controls contained in the profiles.  One or more reporters are used to generate output.  If all tests passed (no fails, no skips) exit code 0 is returned.  If some tests skipped but none failed, exit code 100 is returned. If at least one test failed, exit code 101 is returned.  If inspec failed for any other reason, exit code 1 is returned.
+    Loads the given profile(s) and fetches their dependencies if needed.  Then connects to the target and executes any controls contained in the profiles.  One or more reporters are used to generate output.  If all tests passed (no fails, no skips) exit code 0 is returned.  If some tests skipped but none failed, exit code 101 is returned. If at least one test failed, exit code 100 is returned.  If inspec failed for any other reason, exit code 1 is returned.
   EOT
   exec_options
   def exec(*targets)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -207,6 +207,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: 'Enable one or more output reporters: cli, documentation, html, progress, json, json-min, json-rspec, junit'
   option :depends, type: :array, default: [],
     desc: 'A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell'
+  option :distinct_exit, type: :boolean, default: true,
+    desc: 'Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.'
   def shell_func
     o = opts(:shell).dup
     diagnose(o)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -156,6 +156,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   end
 
   desc 'exec PATHS', 'run all test files at the specified PATH.'
+  long_desc <<~EOT
+    Loads the given profile(s) and fetches their dependencies if needed.  Then connects to the target and executes any controls contained in the profiles.  One or more reporters are used to generate output.  If all tests passed (no fails, no skips) exit code 0 is returned.  If some tests skipped but none failed, exit code 100 is returned. If at least one test failed, exit code 101 is returned.  If inspec failed for any other reason, exit code 1 is returned.
+  EOT
   exec_options
   def exec(*targets)
     o = opts(:exec).dup

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -87,9 +87,9 @@ module Inspec
       if stats[:failed][:total] == 0 && stats[:skipped][:total] == 0
         0
       elsif stats[:failed][:total] > 0
-        100
+        @conf['distinct_exit'] ? 100 : 1
       elsif stats[:skipped][:total] > 0
-        101
+        @conf['distinct_exit'] ? 101 : 0
       else
         @rspec_exit_code
       end

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -224,6 +224,9 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
 
       res << f.h2(cmd.usage.split.first)
       res << f.p(cmd.description.capitalize)
+      if cmd.long_description
+        res << f.p(cmd.long_description)
+      end
 
       res << f.h3('Syntax')
       res << f.p('This subcommand has the following syntax:')

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -119,6 +119,26 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     end
   end
 
+  describe 'with a profile that contains skipped controls and the --no-distinct-exit flag' do
+    let(:out) { inspec('exec ' + File.join(profile_path, 'skippy-controls') + ' --no-distinct-exit --no-create-lockfile') }
+
+    it 'exits with code 0 and skipped tests in output' do
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: 0 successful controls, 0 control failures, \e[38;5;247m2 controls skipped\e[0m\nTest Summary: 0 successful, 0 failures, \e[38;5;247m2 skipped\e[0m\n"
+    end
+  end
+
+  describe 'with a profile that contains failing controls and the --no-distinct-exit flag' do
+    let(:out) { inspec('exec ' + File.join(profile_path, 'failures') + ' --no-distinct-exit --no-create-lockfile') }
+
+    it 'exits with code 1' do
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 1
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: 0 successful controls, \e[38;5;9m2 control failures\e[0m, 0 controls skipped"
+    end
+  end
+
   describe 'with a profile that contains skipped resources' do
     let(:out) { inspec('exec ' + File.join(profile_path, 'aws-profile')) }
     let(:stdout) { out.stdout.force_encoding(Encoding::UTF_8) }


### PR DESCRIPTION
Fixes #2896 
Fixes #3167 
Refs #1825 

* Adds a 'long description' to the Thor configuration for the `inspec exec` command, which includes the exit code behavior.  This makes the CLI usage info include it.  
* Alters the website CLI doc generator to use the long description if present.
* Adds a `--distinct-exit` CLI option to `exec`, enabled by default.  If disabled, changes behavior to exit code 1 on test or any other failure, exit 0 on normal or skip-only runs.


To test the website generator, `cd www && bundle update && bundle rake docs:cli`
Excerpt from generated website docs:

---

## exec

Run all test files at the specified path.

Loads the given profile(s) and fetches their dependencies if needed.  Then connects to the target and executes any controls contained in the profiles.  One or more reporters are used to generate output.  If all tests passed (no fails, no skips) exit code 0 is returned.  If some tests skipped but none failed, exit code 101 is returned. If at least one test failed, exit code 100 is returned.  If inspec failed for any other reason, exit code 1 is returned.


### Syntax

This subcommand has the following syntax:

---


Excerpt from the CLI usage, from `inspec help exec`:

---
...
  l, [--log-level=LOG_LEVEL]                       # Set the log level: info (default), debug, warn, error
      [--log-location=LOG_LOCATION]                # Location to send diagnostic log messages to. (default: STDOUT or STDERR)
      [--diagnose], [--no-diagnose]                # Show diagnostics (versions, configurations)

Description:
  Loads the given profile(s) and fetches their dependencies if needed. Then connects to the target and executes
  any controls contained in the profiles. One or more reporters are used to generate output. If all tests
  passed (no fails, no skips) exit code 0 is returned. If some tests skipped but none failed, exit code 101 is
  returned. If at least one test failed, exit code 100 is returned. If inspec failed for any other reason, exit
  code 1 is returned.

---
