### PR TITLE
Accept regexes for --controls option to inspec exec

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -65,7 +65,7 @@ module Inspec
       target_options
       profile_options
       option :controls, type: :array,
-        desc: 'A list of controls to run. Ignore all other tests.'
+        desc: 'A list of control names to run, or a list of /regexes/ to match against control names. Ignore all other tests.'
       option :format, type: :string,
         desc: '[DEPRECATED] Please use --reporter - this will be removed in InSpec 3.0'
       option :reporter, type: :array,

--- a/test/functional/filter_table_test.rb
+++ b/test/functional/filter_table_test.rb
@@ -117,7 +117,7 @@ describe '2370 lazy_load for filter table' do
 
   it 'negative tests should fail but not abort' do
     controls = [
-      '2370_proc_handle_exception',
+      '2370_fail_proc_handle_exception',
     ]
 
     cmd = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --reporter json --no-create-lockfile' + ' --controls ' + controls.join(' '))

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -82,12 +82,30 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     out.stdout.force_encoding(Encoding::UTF_8).must_include "Test Summary: \e[38;5;41m1 successful\e[0m, \e[38;5;9m1 failure\e[0m, \e[38;5;247m1 skipped\e[0m\n"
   end
 
-  it 'executes only specified controls' do
-    out = inspec('exec ' + example_profile + ' --no-create-lockfile --controls tmp-1.0')
-    out.stderr.must_equal ''
+  it 'executes only specified controls when selecting passing controls by literal names' do
+    out = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --no-create-lockfile --controls 2943_pass_undeclared_field_in_hash 2943_pass_irregular_row_key')
     out.exit_status.must_equal 0
-    out.stdout.must_include "\nProfile Summary: \e[38;5;41m1 successful control\e[0m, 0 control failures, 0 controls skipped\n"
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "\nProfile Summary: \e[38;5;41m2 successful controls\e[0m, 0 control failures, 0 controls skipped\n"
   end
+
+  it 'executes only specified controls when selecting failing controls by literal names' do
+    out = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --no-create-lockfile --controls 2943_fail_derail_check')
+    out.exit_status.must_equal 100
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "\nProfile Summary: 0 successful controls, \e[38;5;9m1 control failure\e[0m, 0 controls skipped"
+  end
+
+  it 'executes only specified controls when selecting passing controls by regex' do
+    out = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --no-create-lockfile --controls \'/^2943_pass/\'')
+    out.exit_status.must_equal 0
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: \e[38;5;41m4 successful controls\e[0m, 0 control failures, 0 controls skipped"
+  end
+
+  it 'executes only specified controls when selecting failing controls by regex' do
+    out = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --no-create-lockfile --controls \'/^(2943|2370)_fail/\'')
+    out.exit_status.must_equal 100
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: 0 successful controls, \e[38;5;9m2 control failures\e[0m, 0 controls skipped"
+  end
+
 
   it 'can execute a simple file with the default formatter' do
     out = inspec('exec ' + example_control  + ' --no-create-lockfile')

--- a/test/unit/mock/profiles/filter_table/controls/lazy_loading_columns.rb
+++ b/test/unit/mock/profiles/filter_table/controls/lazy_loading_columns.rb
@@ -117,7 +117,7 @@ control '2370_no_rows' do
   end
 end
 
-control '2370_proc_handle_exception' do
+control '2370_fail_proc_handle_exception' do
   desc 'An exception in a Proc should not derail the run'
   # TODO read exception
   describe lazy_loader(fresh_data.call).lazy_4s do


### PR DESCRIPTION
Fixes #3082 

This PR alters the behavior of the Profile `filter_controls` method to look for Regular Expression patterns in the filter list.  I require that the user enclose regexes on the command line in `/`, so that they can be differentiated from strings with funny characters.

Multiple regexes may be provided, space separated.  A mix of plain strings and regexes also works.

A functional test is provided.

The user experience looks like:

```
[cwolfe@lodi inspec-cli]$ bundle exec inspec exec test/unit/mock/profiles/filter_table/ --controls '/^2943_pass/'

Profile: InSpec Profile (filter_table)
Version: 0.1.0
Target:  local://

  ✔  2943_pass_undeclared_field_in_hash: It should tolerate criteria that are keys of the raw data but are not declared as fields
     ✔  simple_plural with name == "Annie" should exist
  ✔  2943_pass_irregular_row_key: It should tolerate criteria that are keys of one row but not the first
     ✔  simple_plural with favorite_color == "purple" should exist
  ✔  2943_pass_raise_error_when_key_not_in_data: It should not tolerate criteria that are not keys of the raw data
     ✔  It should not tolerate criteria that are not keys of the raw data should raise ArgumentError
  ✔  2943_pass_no_error_when_no_data: simple_plural with arbitrary_key == "any_value"
     ✔  simple_plural with arbitrary_key == "any_value" should not exist

Profile Summary: 4 successful controls, 0 control failures, 0 controls skipped
Test Summary: 4 successful, 0 failures, 0 skipped
```

(the example profile contains numerous other controls)