### PR TITLE
Ability to render contrib resource pack docs on main website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ terraform.tfstate*
 terraform.tfstate.backup
 inspec-azure.plan
 inspec-aws-*.plan
+contrib/*

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :tools do
   gem 'pry', '~> 0.10'
   gem 'rb-readline'
   gem 'license_finder'
+  gem 'git', '~> 1.4'
 end
 
 # gems for Maintainers.md generation

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,6 @@ require 'passgen'
 require 'train'
 require_relative 'tasks/maintainers'
 require_relative 'tasks/spdx'
-require_relative 'tasks/contrib'
 
 Bundler::GemHelper.install_tasks name: 'inspec'
 
@@ -26,6 +25,13 @@ begin
   require_relative 'tasks/docs'
 rescue LoadError
   puts 'docs tasks are unavailable because the ruby-progressbar gem is not available.'
+end
+
+begin
+  require 'git'
+  require_relative 'tasks/contrib'
+rescue LoadError
+  puts 'contrib tasks are unavailable because the git gem is not available.'
 end
 
 # Rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ require 'passgen'
 require 'train'
 require_relative 'tasks/maintainers'
 require_relative 'tasks/spdx'
+require_relative 'tasks/contrib'
 
 Bundler::GemHelper.install_tasks name: 'inspec'
 

--- a/contrib/contrib.yaml
+++ b/contrib/contrib.yaml
@@ -1,4 +1,8 @@
 resource_packs:
+  # Example
+  # some-project:
+  #   git_repo: the-repo-URL
+  #   doc_sub_dir: some/oddball/path # Optional, default is docs/resources
   inspec-gcp:
     git_repo: https://github.com/inspec/inspec-gcp.git
   inspec-azure-v2:

--- a/contrib/contrib.yaml
+++ b/contrib/contrib.yaml
@@ -1,3 +1,5 @@
 resource_packs:
   inspec-gcp:
-    git: https://github.com/inspec/inspec-gcp.git
+    git_repo: https://github.com/inspec/inspec-gcp.git
+  inspec-azure-v2:
+    git_repo: git@github.com:chef/cis-azure-prototype.git

--- a/contrib/contrib.yaml
+++ b/contrib/contrib.yaml
@@ -3,7 +3,13 @@ resource_packs:
   # some-project:
   #   git_repo: the-repo-URL
   #   doc_sub_dir: some/oddball/path # Optional, default is docs/resources
+  #   doc_group_title: Group Title used on website
+  #   resource_file_regex: Regex used to identify files belonging to this group on the website
   inspec-gcp:
     git_repo: https://github.com/inspec/inspec-gcp.git
+    doc_group_title: GCP
+    resource_file_regex: ^google_
   inspec-azure-v2:
     git_repo: git@github.com:chef/cis-azure-prototype.git
+    doc_group_title: Azure
+    resource_file_regex: ^azure

--- a/contrib/contrib.yaml
+++ b/contrib/contrib.yaml
@@ -1,0 +1,3 @@
+resource_packs:
+  inspec-gcp:
+    git: https://github.com/inspec/inspec-gcp.git

--- a/contrib/contrib.yaml
+++ b/contrib/contrib.yaml
@@ -1,15 +1,19 @@
-resource_packs:
+resource_packs: {}
   # Example
   # some-project:
   #   git_repo: the-repo-URL
   #   doc_sub_dir: some/oddball/path # Optional, default is docs/resources
   #   doc_group_title: Group Title used on website
   #   resource_file_regex: Regex used to identify files belonging to this group on the website
-  inspec-gcp:
-    git_repo: https://github.com/inspec/inspec-gcp.git
-    doc_group_title: GCP
-    resource_file_regex: ^google_
-  inspec-azure-v2:
-    git_repo: git@github.com:chef/cis-azure-prototype.git
-    doc_group_title: Azure
-    resource_file_regex: ^azure
+
+  # This won't show up because the docs have the wrong file endings
+  # inspec-gcp:
+  #  git_repo: https://github.com/inspec/inspec-gcp.git
+  #  doc_group_title: GCP
+  #  resource_file_regex: ^google_
+  
+  # This is the future location of the REST-based azure resources
+  #inspec-azure-v2:
+  #  git_repo: git@github.com:inspec/inspec-azure
+  #  doc_group_title: Azure
+  #  resource_file_regex: ^azure

--- a/tasks/contrib.rb
+++ b/tasks/contrib.rb
@@ -54,4 +54,21 @@ namespace :contrib do
       end
     end
   end
+
+  desc 'Cleanup docs from resource packs in core'
+  task :cleanup_docs => [:read_config] do |t|
+    puts "Purging resource pack docs..."
+    config['resource_packs'].each do |name, info|
+      doc_sub_dir = info["doc_sub_dir"] || 'docs/resources'
+      doc_src_path = File.join(CONTRIB_DIR, name, doc_sub_dir)
+      dest_path = RESOURCE_DOC_DIR
+      puts "  #{name}"
+      Dir.chdir(doc_src_path) do
+        Dir.glob('*.md*').each do |file|
+          cruft = File.join(dest_path, file)
+          FileUtils.rm_f(cruft)
+        end
+      end
+    end
+  end
 end

--- a/tasks/contrib.rb
+++ b/tasks/contrib.rb
@@ -4,7 +4,7 @@
 
 require 'fileutils'
 require 'yaml'
-
+require 'git'
 
 CONTRIB_DIR=File.expand_path(File.join(__dir__, '..', 'contrib')).freeze
 
@@ -16,6 +16,24 @@ namespace :contrib do
   end
 
   task :fetch_resource_packs => [:read_config] do |t|
+    puts "Fetching contrib resource packs..."
+    config['resource_packs'].each do |name, info|
+      clone_path = File.join(CONTRIB_DIR, name)
+      git = nil
+      verb = nil
+      if File.exist?(clone_path)
+        git = Git.open(clone_path)
+        git.fetch
+        verb = 'fetched'
+      else
+        git = Git.clone(info['git_repo'], name, path: CONTRIB_DIR)
+        verb = 'cloned'
+      end
+
+      sha = git.log[0].sha[0..6]
+      branch = git.current_branch
+      puts "  #{name}: #{verb}, now at #{sha}" + (branch ? " (#{branch})" : '')
+    end
   end
 
   desc 'Moves docs from resource packs into the core for doc building'

--- a/tasks/contrib.rb
+++ b/tasks/contrib.rb
@@ -7,6 +7,7 @@ require 'yaml'
 require 'git'
 
 CONTRIB_DIR=File.expand_path(File.join(__dir__, '..', 'contrib')).freeze
+RESOURCE_DOC_DIR=File.expand_path(File.join(__dir__, '..', 'docs', 'resources')).freeze
 
 namespace :contrib do
   config = nil
@@ -36,7 +37,21 @@ namespace :contrib do
     end
   end
 
-  desc 'Moves docs from resource packs into the core for doc building'
-  task :merge_docs => [:fetch_resource_packs] do |t|
+  desc 'Copy docs from resource packs into the core for doc building'
+  task :copy_docs => [:fetch_resource_packs] do |t|
+    puts "Copying resource pack docs..."
+    config['resource_packs'].each do |name, info|
+      doc_sub_dir = info["doc_sub_dir"] || 'docs/resources'
+      doc_src_path = File.join(CONTRIB_DIR, name, doc_sub_dir)
+      dest_path = RESOURCE_DOC_DIR
+      puts "  #{name}:"
+      Dir.chdir(doc_src_path) do
+        Dir.glob('*.md*').each do |file|
+          # TODO: check file for Availability section in markdown?
+          FileUtils.cp(file, dest_path)
+          puts "    #{file}"
+        end
+      end
+    end
   end
 end

--- a/tasks/contrib.rb
+++ b/tasks/contrib.rb
@@ -1,0 +1,21 @@
+
+# Rake tasks to assist in coordinating operations with separately
+# maintained projects.
+
+require 'fileutils'
+
+CONTRIB_DIR=File.expand_path(File.join(__dir__, '..', 'contrib')).freeze
+
+namespace :contrib do
+  config = nil
+
+  task :read_config do |t|
+  end
+
+  task :fetch_resource_packs => [:read_config] do |t|
+  end
+
+  desc 'Moves docs from resource packs into the core for doc building'
+  task :merge_docs => [:fetch_resource_packs] do |t|
+  end
+end

--- a/tasks/contrib.rb
+++ b/tasks/contrib.rb
@@ -3,6 +3,8 @@
 # maintained projects.
 
 require 'fileutils'
+require 'yaml'
+
 
 CONTRIB_DIR=File.expand_path(File.join(__dir__, '..', 'contrib')).freeze
 
@@ -10,6 +12,7 @@ namespace :contrib do
   config = nil
 
   task :read_config do |t|
+    config = YAML.load(File.read(File.join(CONTRIB_DIR, 'contrib.yaml')))
   end
 
   task :fetch_resource_packs => [:read_config] do |t|

--- a/tasks/contrib.rb
+++ b/tasks/contrib.rb
@@ -9,15 +9,15 @@ require 'git'
 CONTRIB_DIR=File.expand_path(File.join(__dir__, '..', 'contrib')).freeze
 RESOURCE_DOC_DIR=File.expand_path(File.join(__dir__, '..', 'docs', 'resources')).freeze
 
-namespace :contrib do
+namespace :contrib do # rubocop: disable Metrics/BlockLength
   config = nil
 
-  task :read_config do |t|
+  task :read_config do
     config = YAML.load(File.read(File.join(CONTRIB_DIR, 'contrib.yaml')))
   end
 
-  task :fetch_resource_packs => [:read_config] do |t|
-    puts "Fetching contrib resource packs..."
+  task fetch_resource_packs: [:read_config] do
+    puts 'Fetching contrib resource packs...'
     config['resource_packs'].each do |name, info|
       clone_path = File.join(CONTRIB_DIR, name)
       git = nil
@@ -38,10 +38,10 @@ namespace :contrib do
   end
 
   desc 'Copy docs from resource packs into the core for doc building'
-  task :copy_docs => [:fetch_resource_packs] do |t|
-    puts "Copying resource pack docs..."
+  task copy_docs: [:fetch_resource_packs] do
+    puts 'Copying resource pack docs...'
     config['resource_packs'].each do |name, info|
-      doc_sub_dir = info["doc_sub_dir"] || 'docs/resources'
+      doc_sub_dir = info['doc_sub_dir'] || 'docs/resources'
       doc_src_path = File.join(CONTRIB_DIR, name, doc_sub_dir)
       dest_path = RESOURCE_DOC_DIR
       puts "  #{name}:"
@@ -56,10 +56,10 @@ namespace :contrib do
   end
 
   desc 'Cleanup docs from resource packs in core'
-  task :cleanup_docs => [:read_config] do |t|
-    puts "Purging resource pack docs..."
+  task cleanup_docs: [:read_config] do
+    puts 'Purging resource pack docs...'
     config['resource_packs'].each do |name, info|
-      doc_sub_dir = info["doc_sub_dir"] || 'docs/resources'
+      doc_sub_dir = info['doc_sub_dir'] || 'docs/resources'
       doc_src_path = File.join(CONTRIB_DIR, name, doc_sub_dir)
       dest_path = RESOURCE_DOC_DIR
       puts "  #{name}"
@@ -72,3 +72,4 @@ namespace :contrib do
     end
   end
 end
+# rubocop enable: Metrics/BlockLength

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -168,7 +168,7 @@ class ResourceDocs
     # doc_file looks like /resources/foo.md.erb - trim off directory and file extension
     trimmed_doc_files = resource_doc_files.dup.map { |file| File.basename(file).sub(/\.md(\.erb)?$/, '') }
     resources_by_group = Hash[group_regexes.map { |info| [info[:group_name], []] }] # Initialize each group to an empty array
-    resources_by_group['OS'] = []
+    resources_by_group['OS resources'] = []
     trimmed_doc_files.each do |doc_file|
       matched = false
       group_regexes.each do |group_info|
@@ -179,7 +179,7 @@ class ResourceDocs
         end
       end
       # Any resources that don't match a regex are assumed to be 'os' resources.
-      resources_by_group['OS'] << doc_file unless matched
+      resources_by_group['OS resources'] << doc_file unless matched
     end
 
     # Now transform the resource lists into HTML
@@ -196,10 +196,10 @@ class ResourceDocs
     # Generate the big buttons that jump to the section of the page for each group.
     markdown << '<div class="row columns align">'
     # "Sorted, except OS is always in first place"
-    ordered_group_names = ['OS'] + resources_by_group.keys.sort.reject { |group_name| group_name == 'OS' }
+    ordered_group_names = ['OS resources'] + resources_by_group.keys.sort.reject { |group_name| group_name == 'OS resources' }
     button_template = '<a class="resources-button button btn-lg btn-purple-o shadow margin-right-xs" href="%s">%s</a>'
     ordered_group_names.each do |group_name|
-      markdown << format(button_template, '#'+(group_name+'-resources').downcase, group_name + ' resources')
+      markdown << format(button_template, '#'+(group_name+'-resources').downcase, group_name)
       markdown << "\n"
     end
     markdown << '</div>'
@@ -211,7 +211,7 @@ class ResourceDocs
 </div>
 '
     ordered_group_names.each do |group_name|
-      markdown << format(group_section_header_template, (group_name + '-resources').downcase, group_name + ' resources')
+      markdown << format(group_section_header_template, (group_name + '-resources').downcase, group_name)
       markdown << renderer.ul(markdown_resource_links_by_group[group_name])
     end
 

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -19,6 +19,7 @@ require 'erb'
 require 'ruby-progressbar'
 require 'fileutils'
 require_relative './shared'
+require_relative './contrib'
 
 WWW_DIR     = File.expand_path(File.join(__dir__, '..', 'www')).freeze
 DOCS_DIR    = File.expand_path(File.join(__dir__, '..', 'docs')).freeze
@@ -256,7 +257,7 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
   end
 
   desc 'Create resources docs'
-  task :resources, [:clean] do
+  task resources: [:clean, :'contrib:copy_docs'] do
     src = DOCS_DIR
     dst = File.join(WWW_DIR, 'source', 'docs', 'reference', 'resources')
     FileUtils.mkdir_p(dst)

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -20,10 +20,16 @@ require 'ruby-progressbar'
 require 'fileutils'
 require 'yaml'
 require_relative './shared'
-require_relative './contrib'
 
 WWW_DIR     = File.expand_path(File.join(__dir__, '..', 'www')).freeze
 DOCS_DIR    = File.expand_path(File.join(__dir__, '..', 'docs')).freeze
+
+begin
+  require 'git'
+  require_relative './contrib'
+rescue LoadError
+  puts 'contrib tasks are unavailable because the git gem is not available.'
+end
 
 class Markdown
   class << self

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -161,13 +161,13 @@ class ResourceDocs
     ]
     # Also pick up regexes and group names from contrib resource packs.
     contrib_config['resource_packs'].values.each do |project_info|
-      group_regexes << {group_name: project_info['doc_group_title'], regex: Regexp.new(project_info['resource_file_regex'])}
+      group_regexes << { group_name: project_info['doc_group_title'], regex: Regexp.new(project_info['resource_file_regex']) }
     end
 
     # OK, apply the regexes we have to the resource doc file list we were passed.
     # doc_file looks like /resources/foo.md.erb - trim off directory and file extension
     trimmed_doc_files = resource_doc_files.dup.map { |file| File.basename(file).sub(/\.md(\.erb)?$/, '') }
-    resources_by_group = Hash[group_regexes.map{|info| [info[:group_name], []]}] # Initialize each group to an empty array
+    resources_by_group = Hash[group_regexes.map { |info| [info[:group_name], []] }] # Initialize each group to an empty array
     resources_by_group['OS'] = []
     trimmed_doc_files.each do |doc_file|
       matched = false
@@ -191,7 +191,7 @@ class ResourceDocs
     end
 
     # Remove any groups that have no resource docs.
-    resources_by_group.reject! { |group_name, resource_list| resource_list.empty? }
+    resources_by_group.reject! { |_, resource_list| resource_list.empty? }
 
     # Generate the big buttons that jump to the section of the page for each group.
     markdown << '<div class="row columns align">'

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -295,7 +295,7 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
     FileUtils.mkdir_p(dst)
 
     docs = ResourceDocs.new(src)
-    resources = Dir[File.join(src, 'resources/*.md.erb')]
+    resources = Dir.glob([File.join(src, 'resources/*.md.erb'), File.join(src, 'resources/*.md')])
                 .map { |x| x.sub(/^#{src}/, '') }
                 .sort
     puts "Found #{resources.length} resource docs"

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -296,8 +296,8 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
 
     docs = ResourceDocs.new(src)
     resources = Dir.glob([File.join(src, 'resources/*.md.erb'), File.join(src, 'resources/*.md')])
-                .map { |x| x.sub(/^#{src}/, '') }
-                .sort
+                   .map { |x| x.sub(/^#{src}/, '') }
+                   .sort
     puts "Found #{resources.length} resource docs"
     puts "Rendering docs to #{dst}/"
 

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -305,7 +305,7 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
     progressbar = ProgressBar.create(total: resources.length, title: 'Rendering')
     resources.each do |file|
       progressbar.log('          '+file)
-      dst_name = File.basename(file).sub(/\.md\.erb$/, '.html.md')
+      dst_name = File.basename(file).sub(/\.md(\.erb)?$/, '.html.md')
       res = docs.render(file)
       File.write(File.join(dst, dst_name), res)
       progressbar.increment

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -279,7 +279,11 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
   end
 
   desc 'Create resources docs'
-  task resources: [:clean, :'contrib:copy_docs'] do
+  # This task injects the contrib:cleanup_docs as a followup
+  # to the actual doc building.
+  task resources: [:resources_actual, :'contrib:cleanup_docs']
+
+  task resources_actual: [:clean, :'contrib:copy_docs'] do
     src = DOCS_DIR
     dst = File.join(WWW_DIR, 'source', 'docs', 'reference', 'resources')
     FileUtils.mkdir_p(dst)

--- a/www/Gemfile
+++ b/www/Gemfile
@@ -25,6 +25,9 @@ gem 'redcarpet'
 gem 'docker-api'
 gem 'github-markup'
 
+# Needed to fetch contrib resource packs, etc.
+gem 'git', '~> 1.4'
+
 # Build process requirements
 gem 'inquirer'
 gem 'inspec', path: '..'


### PR DESCRIPTION
We've having a lot of discussions about how to best handle resource packs lately.  We want innovation to happen, but to keep the core of inspec stable; one solution to this is encourage the use of [resource packs](https://www.inspec.io/docs/reference/glossary/#resource-pack) as first-class citizens.

One major pain point around that is publicity.  If we at Chef place innovative functionality in a resource pack, how can people find it?

A long term solution might involve a public service like Supermarket.  A short term solution might be to render the docs of the resource packs (selectively) on the main inspec.io website.

This PR:

* Introduces a YAML config file at `contrib/contrib.yaml` which lists git locations of resource packs to fetch during doc build time
* Adds Rake tasks, which can fetch the resource packs, and copy out the docs to core.  _This functionality may also be useful in future work easing the testing cycle for resource packs._
* Overhauls the Rake code that generates the [Resource Overview docs page](https://www.inspec.io/docs/reference/resources/), to allow it to list resources in a more generic way.

Refs #3128 
Attn: @dmccown @davymcaleer @chris-rock 


Here are a few screenshots, with the REST-based Azure resource pack added as a contrib.  Note that the existing Azure resources and the the ones in the resource pack are co-habitating nicely.

Presumably we'd have PRS on the contrib resource pack to add a note to the docs indicating installation instructions (that is, a profile dependency).

![screen shot 2018-06-28 at 19 52 23](https://user-images.githubusercontent.com/156460/42066390-36306282-7b0e-11e8-9c48-ebc9bf6d3ed6.png)
![screen shot 2018-06-28 at 19 52 43](https://user-images.githubusercontent.com/156460/42066395-3a639392-7b0e-11e8-9eed-78c57bf0c428.png)
![screen shot 2018-06-28 at 20 01 40](https://user-images.githubusercontent.com/156460/42066397-3cf68bb4-7b0e-11e8-8766-597c938ed3d4.png)

