### PR TITLE
Update the node platform issues to warn severity

### DIFF
--- a/lib/inspec/formatters/base.rb
+++ b/lib/inspec/formatters/base.rb
@@ -189,7 +189,7 @@ module Inspec::Formatters
       begin
         @backend.platform[field]
       rescue Train::Error => e
-        Inspec::Log.error(e.message)
+        Inspec::Log.warn(e.message)
         nil
       end
     end


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

These issues will not block a run currently so its confusing to the user to show `ERROR` in the output. Updating these to `WARN` calls instead.