### PR TITLE
Fix vendor functional test to not validate a repo hash that can change.

### DIFF
--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -49,7 +49,10 @@ describe 'example inheritance profile' do
 
       File.exist?(File.join(tmpdir, 'vendor')).must_equal true
       File.exist?(File.join(tmpdir, 'inspec.lock')).must_equal true
-      File.exist?(File.join(tmpdir, 'vendor', 'accb84911787830f5b973f3e49de78bbff931946', 'README.md')).must_equal true
+      # Check that our vendor directory exists
+      Dir.glob(File.join(tmpdir, 'vendor', '*')).length.must_equal 1
+      # Check that our vendor directory has contents
+      Dir.glob(File.join(tmpdir, 'vendor', '*', '*')).length.must_be :>=, 8
     end
   end
 


### PR DESCRIPTION
This functional test was validating that a randomly named directory 
created by mktemp existed. We are now checking that _a_ directory exists
where it should but not validating the name. We are also now checking
that the created directory has around the right number of files.

Signed-off-by: Miah Johnson <miah@chia-pet.org>