### PR TITLE
Refactor 'inspec init profile' into a reusable component.

### DIFF
--- a/lib/bundles/inspec-init.rb
+++ b/lib/bundles/inspec-init.rb
@@ -5,4 +5,8 @@
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
+module Init
+  autoload :Profile, 'inspec-init/profile'
+end
+
 require 'inspec-init/cli'

--- a/lib/bundles/inspec-init/cli.rb
+++ b/lib/bundles/inspec-init/cli.rb
@@ -15,7 +15,7 @@ module Init
       namespace
     end
 
-    # read template directoy
+    # read template directory
     template_dir = File.join(File.dirname(__FILE__), 'templates')
     Dir.glob(File.join(template_dir, '*')) do |template|
       relative = Pathname.new(template).relative_path_from(Pathname.new(template_dir))
@@ -23,76 +23,10 @@ module Init
       # register command for the template
       desc "#{relative} NAME", "Create a new #{relative}"
       option :overwrite, type: :boolean, default: false,
-         desc: 'Overwrites existing directory'
+        desc: 'Overwrites existing directory'
       define_method relative.to_s.to_sym do |name|
-        generator(relative.to_s, { name: name }, options)
+        Init::Profile.generator(relative.to_s, { name: name }, options)
       end
-    end
-
-    private
-
-    # 1. iterate over all files
-    # 2. read content in erb
-    # 3. write to target
-    def generator(type, attributes = {}, options = {}) # rubocop:disable Metrics/AbcSize
-      # path of this script
-      dir = File.dirname(__FILE__)
-      # look for template directory
-      base_dir = File.join(dir, 'templates', type)
-      # prepare glob for all subdirectories and files
-      template = File.join(base_dir, '**', '{*,.*}')
-      # Use the name attribute to define the path to the profile.
-      profile_path = attributes[:name]
-      # Use slashes (\, /) to split up the name into an Array then use the last entry
-      # to reset the name of the profile.
-      attributes[:name] = attributes[:name].split(%r{\\|\/}).last
-      # Generate the full target path on disk
-      target = Pathname.new(Dir.pwd).join(profile_path)
-      puts "Create new #{type} at #{mark_text(target)}"
-
-      # check that the directory does not exist
-      if File.exist?(target) && !options['overwrite']
-        error "#{mark_text(target)} exists already, use --overwrite"
-        exit 1
-      end
-
-      # ensure that target directory is available
-      FileUtils.mkdir_p(target)
-
-      # iterate over files and write to target path
-      Dir.glob(template) do |file|
-        relative = Pathname.new(file).relative_path_from(Pathname.new(base_dir))
-        destination = Pathname.new(target).join(relative)
-        if File.directory?(file)
-          li "Create directory #{mark_text(relative)}"
-          FileUtils.mkdir_p(destination)
-        elsif File.file?(file)
-          li "Create file #{mark_text(relative)}"
-          # read & render content
-          content = render(File.read(file), attributes)
-          # write file content
-          File.write(destination, content)
-        else
-          puts "Ignore #{file}, because its not an file or directoy"
-        end
-      end
-    end
-
-    # This is a render helper to bind hash values to a ERB template
-    def render(content, hash)
-      # create a new binding class
-      cls = Class.new do
-        hash.each do |key, value|
-          define_method key.to_sym do
-            value
-          end
-        end
-        # expose binding
-        define_method :bind do
-          binding
-        end
-      end
-      ERB.new(content).result(cls.new.bind)
     end
   end
 

--- a/lib/bundles/inspec-init/profile.rb
+++ b/lib/bundles/inspec-init/profile.rb
@@ -1,0 +1,69 @@
+module Init
+  class Profile
+
+    # 1. iterate over all files
+    # 2. read content in erb
+    # 3. write to target
+    def self.generator(type, attributes = {}, options = {}) # rubocop:disable Metrics/AbcSize
+      # path of this script
+      dir = File.dirname(__FILE__)
+      # look for template directory
+      base_dir = File.join(dir, 'templates', type)
+      # prepare glob for all subdirectories and files
+      template = File.join(base_dir, '**', '{*,.*}')
+      # Use the name attribute to define the path to the profile.
+      profile_path = attributes[:name]
+      # Use slashes (\, /) to split up the name into an Array then use the last entry
+      # to reset the name of the profile.
+      attributes[:name] = attributes[:name].split(%r{\\|\/}).last
+      # Generate the full target path on disk
+      target = Pathname.new(Dir.pwd).join(profile_path)
+      puts "Create new #{type} at #{Inspec::BaseCLI.mark_text(target)}"
+
+      # check that the directory does not exist
+      if File.exist?(target) && !options['overwrite']
+        puts "#{Inspec::BaseCLI.mark_text(target)} exists already, use --overwrite"
+        exit 1
+      end
+
+      # ensure that target directory is available
+      FileUtils.mkdir_p(target)
+
+      # iterate over files and write to target path
+      Dir.glob(template) do |file|
+        relative = Pathname.new(file).relative_path_from(Pathname.new(base_dir))
+        destination = Pathname.new(target).join(relative)
+        if File.directory?(file)
+          Inspec::BaseCLI.li "Create directory #{Inspec::BaseCLI.mark_text(relative)}"
+          FileUtils.mkdir_p(destination)
+        elsif File.file?(file)
+          Inspec::BaseCLI.li "Create file #{Inspec::BaseCLI.mark_text(relative)}"
+          # read & render content
+          content = render(File.read(file), attributes)
+          # write file content
+          File.write(destination, content)
+        else
+          puts "Ignore #{file}, because its not an file or directoy"
+        end
+      end
+    end
+
+    # This is a render helper to bind hash values to a ERB template
+    def self.render(content, hash)
+      # create a new binding class
+      cls = Class.new do
+        hash.each do |key, value|
+          define_method key.to_sym do
+            value
+          end
+        end
+        # expose binding
+        define_method :bind do
+          binding
+        end
+      end
+      ERB.new(content).result(cls.new.bind)
+    end
+
+  end
+end

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -364,7 +364,7 @@ module Inspec
       o[:logger].level = get_log_level(o.log_level)
     end
 
-    def mark_text(text)
+    def self.mark_text(text)
       "\e[0;36m#{text}\e[0m"
     end
 
@@ -372,7 +372,7 @@ module Inspec
       puts "\n== #{title}\n\n"
     end
 
-    def li(entry)
+    def self.li(entry)
       puts " #{mark_text('*')} #{entry}"
     end
   end


### PR DESCRIPTION
base_cli.rb had several methods used internally, these are exposed so
lib/bundles/inspec-init/profile.rb can act as a library for anything
that needs to create new Inspec profiles programatically (ie. inspec-iggy)

Additional PRs will add CLI options similar to "chef generate cookbook"

Signed-off-by: Matt Ray <matthewhray@gmail.com>