### PR TITLE
Mechanically inject Availability sections into the core docs

### DIFF
--- a/docs/resources/aide_conf.md.erb
+++ b/docs/resources/aide_conf.md.erb
@@ -9,6 +9,16 @@ Use the `aide_conf` InSpec audit resource to test the rules established for the 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.37.6 of InSpec.
+
 ## Syntax
 
 An `aide_conf` resource block can be used to determine if the selection lines contain one (or more) directories whose files should be added to the aide database:

--- a/docs/resources/apache.md.erb
+++ b/docs/resources/apache.md.erb
@@ -11,6 +11,16 @@ Use the `apache` InSpec audit resource to test the state of the Apache server on
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.51.15 of InSpec.
+
 ## Syntax
 
 An `apache` InSpec audit resource block declares settings that should be tested:

--- a/docs/resources/apache_conf.md.erb
+++ b/docs/resources/apache_conf.md.erb
@@ -9,6 +9,16 @@ Use the `apache_conf` InSpec audit resource to test the configuration settings f
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `apache_conf` InSpec audit resource block declares configuration settings that should be tested:

--- a/docs/resources/apt.md.erb
+++ b/docs/resources/apt.md.erb
@@ -9,6 +9,16 @@ Use the `apt` InSpec audit resource to verify Apt repositories on the Debian and
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `apt` resource block tests the contents of Apt and PPA repositories:

--- a/docs/resources/audit_policy.md.erb
+++ b/docs/resources/audit_policy.md.erb
@@ -9,6 +9,16 @@ Use the `audit_policy` InSpec audit resource to test auditing policies on the Wi
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `audit_policy` resource block declares a parameter that belongs to an audit policy category or subcategory:

--- a/docs/resources/auditd.md.erb
+++ b/docs/resources/auditd.md.erb
@@ -9,6 +9,16 @@ Use the `auditd` InSpec audit resource to test the rules for logging that exist 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.38.8 of InSpec.
+
 ## Syntax
 
 An `auditd` resource block declares one (or more) rules to be tested, and then what that rule should do:

--- a/docs/resources/auditd_conf.md.erb
+++ b/docs/resources/auditd_conf.md.erb
@@ -9,6 +9,16 @@ Use the `auditd_conf` InSpec audit resource to test the configuration settings f
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `auditd_conf` resource block declares configuration settings that should be tested:

--- a/docs/resources/aws_cloudtrail_trail.md.erb
+++ b/docs/resources/aws_cloudtrail_trail.md.erb
@@ -13,6 +13,16 @@ Each AWS Cloudtrail Trail is uniquely identified by its `trail_name` or `trail_a
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_cloudtrail_trail` resource block identifies a trail by `trail_name`.

--- a/docs/resources/aws_cloudtrail_trails.md.erb
+++ b/docs/resources/aws_cloudtrail_trails.md.erb
@@ -13,6 +13,16 @@ Each AWS CloudTrail Trails is uniquely identified by its trail name or trail arn
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_cloudtrail_trails` resource block collects a group of CloudTrail Trails and then tests that group.

--- a/docs/resources/aws_cloudwatch_alarm.md.erb
+++ b/docs/resources/aws_cloudwatch_alarm.md.erb
@@ -11,6 +11,16 @@ Cloudwatch Alarms are currently identified using the metric name and metric name
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_cloudwatch_alarm` resource block searches for a Cloudwatch Alarm, specified by several search options. If more than one Alarm matches, an error occurs.

--- a/docs/resources/aws_cloudwatch_log_metric_filter.md.erb
+++ b/docs/resources/aws_cloudwatch_log_metric_filter.md.erb
@@ -11,6 +11,16 @@ A Log Metric Filter (LMF) is an AWS resource that observes log traffic, looks fo
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_cloudwatch_log_metric_filter` resource block searches for an LMF, specified by several search options.  If more than one log metric filter matches, an error occurs.

--- a/docs/resources/aws_config_delivery_channel.md.erb
+++ b/docs/resources/aws_config_delivery_channel.md.erb
@@ -13,6 +13,16 @@ As of April 2018, each AWS region may have only one Delivery Channel.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.1.21 of InSpec.
+
 ## Resource Parameters
 
 An `aws_config_delivery_channel` resource block declares the tests for a single AWS Config Delivery Channel.

--- a/docs/resources/aws_config_recorder.md.erb
+++ b/docs/resources/aws_config_recorder.md.erb
@@ -12,6 +12,16 @@ As of April 2018, you are only permitted one configuration recorder per region.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.32 of InSpec.
+
 ## Resource Parameters
 
 An `aws_config_recorder` resource block declares the tests for a single AWS configuration recorder.

--- a/docs/resources/aws_ec2_instance.md.erb
+++ b/docs/resources/aws_ec2_instance.md.erb
@@ -9,6 +9,16 @@ Use the `aws_ec2_instance` InSpec audit resource to test properties of a single 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_ec2_instance` resource block declares the tests for a single AWS EC2 instance by either name or id.

--- a/docs/resources/aws_ec2_instances.md.erb
+++ b/docs/resources/aws_ec2_instances.md.erb
@@ -13,6 +13,16 @@ Each EC2 instance is uniquely identified by its ID.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.1.72 of InSpec.
+
 ## Syntax
 
 An `aws_ec2_instances` resource block collects a group of EC2 Instances and then tests that group.

--- a/docs/resources/aws_elb.md.erb
+++ b/docs/resources/aws_elb.md.erb
@@ -11,6 +11,16 @@ To audit ELBs in bulk or to search, use `aws_elbs` (plural).
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.2.10 of InSpec.
+
 ## Resource Parameters
 
 An `aws_elb` resource block declares the tests for a single AWS ELB by ELB name.

--- a/docs/resources/aws_elbs.md.erb
+++ b/docs/resources/aws_elbs.md.erb
@@ -11,6 +11,16 @@ To audit a specific ELB in detail when its name is known, use `aws_elb` (singula
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.2.10 of InSpec.
+
 ## Syntax
 
 An `aws_elb` resource block uses an optional filter to select a group of ELBs and then tests that group.

--- a/docs/resources/aws_flow_log.md.erb
+++ b/docs/resources/aws_flow_log.md.erb
@@ -7,6 +7,16 @@ platform: aws
 
 Use the `aws_flow_log` InSpec audit resource to test properties of a single Flow Log.
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.2.10 of InSpec.
+
 ## Syntax
 
     describe aws_flow_log('fl-9c718cf5') do

--- a/docs/resources/aws_iam_access_key.md.erb
+++ b/docs/resources/aws_iam_access_key.md.erb
@@ -9,6 +9,16 @@ Use the `aws_iam_access_key` InSpec audit resource to test properties of a singl
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_iam_access_key` resource block declares the tests for a single AWS IAM access key. An access key is uniquely identified by its access key id.

--- a/docs/resources/aws_iam_access_keys.md.erb
+++ b/docs/resources/aws_iam_access_keys.md.erb
@@ -14,6 +14,16 @@ Access Keys are closely related to AWS User resources. Use this resource to perf
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_iam_access_keys` resource block uses an optional filter to select a group of access keys and then tests that group.

--- a/docs/resources/aws_iam_group.md.erb
+++ b/docs/resources/aws_iam_group.md.erb
@@ -11,6 +11,16 @@ To test properties of multiple or all groups, use the `aws_iam_groups` resource.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_iam_group` resource block identifies a group by group name.

--- a/docs/resources/aws_iam_groups.md.erb
+++ b/docs/resources/aws_iam_groups.md.erb
@@ -11,6 +11,16 @@ To test properties of a single group, use the `aws_iam_group` resource.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_iam_groups` resource block uses an optional filter to select a collection of IAM groups and then tests that collection.

--- a/docs/resources/aws_iam_password_policy.md.erb
+++ b/docs/resources/aws_iam_password_policy.md.erb
@@ -9,6 +9,16 @@ Use the `aws_iam_password_policy` InSpec audit resource to test properties of th
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_iam_password_policy` resource block takes no parameters. Several properties and matchers are available.

--- a/docs/resources/aws_iam_policies.md.erb
+++ b/docs/resources/aws_iam_policies.md.erb
@@ -13,6 +13,16 @@ Each IAM Policy is uniquely identified by either its `policy_name` or `arn`.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_iam_policies` resource block collects a group of IAM Policies and then tests that group.

--- a/docs/resources/aws_iam_policy.md.erb
+++ b/docs/resources/aws_iam_policy.md.erb
@@ -13,6 +13,16 @@ Each IAM Policy is uniquely identified by either its policy\_name or arn.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_iam_policy` resource block identifies a policy by policy name.

--- a/docs/resources/aws_iam_role.md.erb
+++ b/docs/resources/aws_iam_role.md.erb
@@ -9,6 +9,16 @@ Use the `aws_iam_role` InSpec audit resource to test properties of a single IAM 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
     # Ensure that a certain role exists by name

--- a/docs/resources/aws_iam_root_user.md.erb
+++ b/docs/resources/aws_iam_root_user.md.erb
@@ -13,6 +13,16 @@ To test properties of a specific AWS user use the `aws_iam_user` resource.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_iam_root_user` resource block requires no parameters but has several matchers.

--- a/docs/resources/aws_iam_user.md.erb
+++ b/docs/resources/aws_iam_user.md.erb
@@ -13,6 +13,16 @@ To test properties of the special AWS root user (which owns the account), use th
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Resource Parameters
 
 An `aws_iam_user` resource block declares a user by name, and then lists tests to be performed.

--- a/docs/resources/aws_iam_users.md.erb
+++ b/docs/resources/aws_iam_users.md.erb
@@ -13,6 +13,16 @@ To test properties of the special AWS root user (which owns the account), use th
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_iam_users` resource block uses a filter to select a group of users and then tests that group. With no filter, it returns all AWS IAM users.

--- a/docs/resources/aws_kms_key.md.erb
+++ b/docs/resources/aws_kms_key.md.erb
@@ -14,6 +14,16 @@ Each AWS KMS Key is uniquely identified by its key_id or arn.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.1.21 of InSpec.
+
 ## Syntax
 
 An aws_kms_key resource block identifies a key by key_arn or the key id.

--- a/docs/resources/aws_kms_keys.md.erb
+++ b/docs/resources/aws_kms_keys.md.erb
@@ -15,6 +15,16 @@ Each AWS KMS Key is uniquely identified by its key-id or key-arn.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_kms_keys` resource block uses an optional filter to select a group of KMS Keys and then tests that group.

--- a/docs/resources/aws_rds_instance.md.erb
+++ b/docs/resources/aws_rds_instance.md.erb
@@ -10,6 +10,16 @@ RDS gives you access to the capabilities of a MySQL, MariaDB, PostgreSQL, Micros
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.1.21 of InSpec.
+
 ## Syntax
 
 An `aws_rds_instance` resource block uses resource parameters to search for an RDS instance, and then tests that RDS instance.  If no RDS instances match, no error is raised, but the `exists` matcher will return `false` and all properties will be `nil`.  If more than one RDS instance matches (due to vague search parameters), an error is raised.

--- a/docs/resources/aws_route_table.md.erb
+++ b/docs/resources/aws_route_table.md.erb
@@ -9,6 +9,16 @@ Use the `aws_route_table` InSpec audit resource to test properties of a single R
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
     # Ensure that a certain route table exists by name

--- a/docs/resources/aws_route_tables.md.erb
+++ b/docs/resources/aws_route_tables.md.erb
@@ -8,6 +8,16 @@ Use the `aws_route_tables` InSpec audit resource to test properties of all or a 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.1.30 of InSpec.
+
 ## Syntax
 
   # Ensure that there is at least one route table

--- a/docs/resources/aws_s3_bucket.md.erb
+++ b/docs/resources/aws_s3_bucket.md.erb
@@ -21,6 +21,16 @@ In particular, users of the `be_public` matcher should carefully examine the con
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_s3_bucket` resource block declares a bucket by name, and then lists tests to be performed.

--- a/docs/resources/aws_s3_bucket_object.md.erb
+++ b/docs/resources/aws_s3_bucket_object.md.erb
@@ -17,6 +17,16 @@ S3 object security is a complex matter.  For details on how AWS evaluates reques
 
 As of January 2018, this resource supports evaluating S3 Object ACLs. In particular, users of the `be_public` matcher should carefully examine the conditions under which the matcher will detect an insecure bucket.  See the `be_public` section under the Matchers section below.
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.1.10 of InSpec.
+
 ## Syntax
 
 An `aws_s3_bucket_object` resource block declares a bucket and an object key by name, and then lists tests to be performed.

--- a/docs/resources/aws_s3_buckets.md.erb
+++ b/docs/resources/aws_s3_buckets.md.erb
@@ -10,6 +10,16 @@ Use the `aws_s3_bucket` InSpec audit resource to perform in-depth auditing of a 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.1.30 of InSpec.
+
 ## Syntax
 
 An `aws_s3_buckets` resource block takes no arguments

--- a/docs/resources/aws_security_group.md.erb
+++ b/docs/resources/aws_security_group.md.erb
@@ -18,6 +18,16 @@ While this resource provides facilities for searching inbound and outbound rules
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 Resource parameters: group_id, group_name, id, vpc_id

--- a/docs/resources/aws_security_groups.md.erb
+++ b/docs/resources/aws_security_groups.md.erb
@@ -11,6 +11,16 @@ Security groups are a networking construct that contain ingress and egress rules
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_security_groups` resource block uses an optional filter to select a group of security groups and then tests that group.

--- a/docs/resources/aws_sns_subscription.md.erb
+++ b/docs/resources/aws_sns_subscription.md.erb
@@ -8,6 +8,16 @@ Use the `aws_sns_subscription` InSpec audit resource to test detailed properties
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.1.10 of InSpec.
+
 ## Syntax
 
 An `aws_sns_subscription` resource block uses resource parameters to search for a SNS Subscription, and then tests that subscriptions properties.  If no Subscriptions match, no error is raised, but the `exists` matcher will return `false` and all properties will be `nil`.

--- a/docs/resources/aws_sns_topic.md.erb
+++ b/docs/resources/aws_sns_topic.md.erb
@@ -8,6 +8,16 @@ Use the `aws_sns_topic` InSpec audit resource to test properties of a single AWS
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
     # Ensure that a topic exists and has at least one subscription

--- a/docs/resources/aws_sns_topics.md.erb
+++ b/docs/resources/aws_sns_topics.md.erb
@@ -9,6 +9,16 @@ User the 'aws_sns_topic' InSpec audit resource to test a single SNS Topic in an 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.1.10 of InSpec.
+
 ## Syntax
 
 An `aws_sns_topics` resource block takes no filter conditions.

--- a/docs/resources/aws_subnet.md.erb
+++ b/docs/resources/aws_subnet.md.erb
@@ -13,6 +13,16 @@ To test properties of all or a group of VPC subnets, use the `aws_subnets` resou
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_subnet` resource block uses the parameter to select a VPC and a subnet in the VPC.

--- a/docs/resources/aws_subnets.md.erb
+++ b/docs/resources/aws_subnets.md.erb
@@ -13,6 +13,16 @@ Separating IP addresses allows for protection if there is a failure in one avail
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_subnets` resource block uses an optional filter to select a group of subnets and then tests that group.

--- a/docs/resources/aws_vpc.md.erb
+++ b/docs/resources/aws_vpc.md.erb
@@ -17,6 +17,16 @@ Every AWS account has at least one VPC, the "default" VPC, in every region.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_vpc` resource block identifies a VPC by id. If no VPC ID is provided, the default VPC is used.

--- a/docs/resources/aws_vpcs.md.erb
+++ b/docs/resources/aws_vpcs.md.erb
@@ -15,6 +15,16 @@ Every AWS account has at least one VPC, the "default" VPC, in every region.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 An `aws_vpcs` resource block uses an optional filter to select a group of VPCs and then tests that group.

--- a/docs/resources/azure_generic_resource.md.erb
+++ b/docs/resources/azure_generic_resource.md.erb
@@ -8,6 +8,16 @@ title: About the azure_generic_resource Resource
 
 Use the `azure_generic_resource` InSpec audit resource to test any valid Azure Resource. This is very useful if you need to test something that we do not yet have a specific Inspec resource for.
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
     describe azure_generic_resource(group_name: 'MyResourceGroup', name: 'MyResource') do

--- a/docs/resources/azure_resource_group.md.erb
+++ b/docs/resources/azure_resource_group.md.erb
@@ -7,6 +7,16 @@ platform: azure
 
 Use the `azure_resource_group_resource_counts` InSpec audit resource to check the number of Azure resources in a resource group.
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 The name of the resource group is specified as a parameter on the resource:

--- a/docs/resources/azure_virtual_machine.md.erb
+++ b/docs/resources/azure_virtual_machine.md.erb
@@ -7,6 +7,16 @@ platform: azure
 
 Use the `azure_virtual_machine` InSpec audit resource to ensure that a Virtual Machine has been provisioned correctly.
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 The name of the machine and the resource group are required as properties to the resource.

--- a/docs/resources/azure_virtual_machine_data_disk.md.erb
+++ b/docs/resources/azure_virtual_machine_data_disk.md.erb
@@ -7,6 +7,16 @@ platform: azure
 
 Use this resource to ensure that a specific data disk attached to a machine has been created properly.
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.0.16 of InSpec.
+
 ## Syntax
 
 The name of the resource group and machine are required to use this resource.

--- a/docs/resources/bash.md.erb
+++ b/docs/resources/bash.md.erb
@@ -9,6 +9,16 @@ Use the `bash` InSpec audit resource to test an arbitrary command that is run on
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `command` resource block declares a command to be run, one (or more) expected outputs, and the location to which that output is sent:

--- a/docs/resources/bond.md.erb
+++ b/docs/resources/bond.md.erb
@@ -9,6 +9,16 @@ Use the `bond` InSpec audit resource to test a logical, bonded network interface
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `bond` resource block declares a bonded network interface, and then specifies the properties of that bonded network interface to be tested:

--- a/docs/resources/bridge.md.erb
+++ b/docs/resources/bridge.md.erb
@@ -9,6 +9,16 @@ Use the `bridge` InSpec audit resource to test basic network bridge properties, 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `bridge` resource block declares the bridge to be tested and what interface it should be associated with:

--- a/docs/resources/bsd_service.md.erb
+++ b/docs/resources/bsd_service.md.erb
@@ -9,6 +9,16 @@ Use the `bsd_service` InSpec audit resource to test a service using a Berkeley O
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `bsd_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:

--- a/docs/resources/chocolatey_package.md.erb
+++ b/docs/resources/chocolatey_package.md.erb
@@ -9,6 +9,16 @@ Use the `chocolatey_package` InSpec audit resource to test if the named [Chocola
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v2.1.30 of InSpec.
+
 ## Syntax
 
 A `chocolatey_package` resource block declares the name of a Chocolatey package to be tested:

--- a/docs/resources/command.md.erb
+++ b/docs/resources/command.md.erb
@@ -9,6 +9,16 @@ Use the `command` InSpec audit resource to test an arbitrary command that is run
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `command` resource block declares a command to be run, one (or more) expected values, and the location to which that output is sent:

--- a/docs/resources/cpan.md.erb
+++ b/docs/resources/cpan.md.erb
@@ -9,6 +9,16 @@ Use the `cpan` InSpec audit resource to test Perl modules that are installed by 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.43.5 of InSpec.
+
 ## Syntax
 
 A `cpan` resource block declares a package and (optionally) a package version:

--- a/docs/resources/cran.md.erb
+++ b/docs/resources/cran.md.erb
@@ -9,6 +9,16 @@ Use the `cran` InSpec audit resource to test R modules that are installed from C
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.43.5 of InSpec.
+
 ## Syntax
 
 A `cran` resource block declares a package and (optionally) a package version:

--- a/docs/resources/crontab.md.erb
+++ b/docs/resources/crontab.md.erb
@@ -9,6 +9,16 @@ Use the `crontab` InSpec audit resource to test the crontab entries for a partic
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.15.0 of InSpec.
+
 ## Syntax
 
 A `crontab` resource block declares a user (which defaults to the current user, if not specified), and then the details to be tested, such as the schedule elements for each crontab entry or the commands itself:

--- a/docs/resources/csv.md.erb
+++ b/docs/resources/csv.md.erb
@@ -9,6 +9,16 @@ Use the `csv` InSpec audit resource to test configuration data in a CSV file.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `csv` resource block declares the configuration data to be tested:

--- a/docs/resources/dh_params.md.erb
+++ b/docs/resources/dh_params.md.erb
@@ -9,6 +9,16 @@ Use the `dh_params` InSpec audit resource to test Diffie-Hellman (DH) parameters
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.19.0 of InSpec.
+
 ## Syntax
 
 A `dh_params` resource block declares a parameter file to be tested.

--- a/docs/resources/directory.md.erb
+++ b/docs/resources/directory.md.erb
@@ -9,6 +9,16 @@ Use the `directory` InSpec audit resource to test if the file type is a director
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `directory` resource block declares the location of the directory to be tested, and then one (or more) matchers.

--- a/docs/resources/docker.md.erb
+++ b/docs/resources/docker.md.erb
@@ -9,6 +9,16 @@ Use the `docker` InSpec audit resource to test configuration data for the Docker
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.21.0 of InSpec.
+
 ## Syntax
 
 A `docker` resource block declares allows you to write test for many containers:

--- a/docs/resources/docker_container.md.erb
+++ b/docs/resources/docker_container.md.erb
@@ -9,6 +9,16 @@ Use the `docker_container` InSpec audit resource to test a Docker container.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.21.0 of InSpec.
+
 ## Syntax
 
 A `docker_container` resource block declares the configuration data to be tested:

--- a/docs/resources/docker_image.md.erb
+++ b/docs/resources/docker_image.md.erb
@@ -9,6 +9,16 @@ Use the `docker_image` InSpec audit resource to verify a Docker image.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.21.0 of InSpec.
+
 ## Syntax
 
 A `docker_image` resource block declares the image:

--- a/docs/resources/docker_service.md.erb
+++ b/docs/resources/docker_service.md.erb
@@ -9,6 +9,16 @@ Use the `docker_service` InSpec audit resource to verify a docker swarm service.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.51.0 of InSpec.
+
 ## Syntax
 
 A `docker_service` resource block declares the service by name:

--- a/docs/resources/elasticsearch.md.erb
+++ b/docs/resources/elasticsearch.md.erb
@@ -12,6 +12,16 @@ a variety of settings and statuses.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.43.5 of InSpec.
+
 ## Syntax
 
     describe elasticsearch do

--- a/docs/resources/etc_fstab.md.erb
+++ b/docs/resources/etc_fstab.md.erb
@@ -9,6 +9,16 @@ Use the `etc_fstab` InSpec audit resource to test information about all partitio
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.37.6 of InSpec.
+
 ## Syntax
 
 An etc_fstab rule specifies a device name, its mount point, its mount type, the options its mounted with,

--- a/docs/resources/etc_group.md.erb
+++ b/docs/resources/etc_group.md.erb
@@ -9,6 +9,16 @@ Use the `etc_group` InSpec audit resource to test groups that are defined on Lin
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `etc_group` resource block declares a collection of properties to be tested:

--- a/docs/resources/etc_hosts.md.erb
+++ b/docs/resources/etc_hosts.md.erb
@@ -9,6 +9,16 @@ Use the `etc_hosts` InSpec audit resource to test rules set to match IP addresse
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.37.6 of InSpec.
+
 ## Syntax
 
 An etc/hosts rule specifies an IP address and what its hostname is along with optional aliases it can have.

--- a/docs/resources/etc_hosts_allow.md.erb
+++ b/docs/resources/etc_hosts_allow.md.erb
@@ -9,6 +9,16 @@ Use the `etc_hosts_allow` InSpec audit resource to test rules defined for accept
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.39.1 of InSpec.
+
 ## Syntax
 
 An etc/hosts.allow rule specifies one or more daemons mapped to one or more clients, with zero or more options to for accepting traffic when found.

--- a/docs/resources/etc_hosts_deny.md.erb
+++ b/docs/resources/etc_hosts_deny.md.erb
@@ -9,6 +9,16 @@ Use the `etc_hosts_deny` InSpec audit resource to test rules for rejecting daemo
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.39.1 of InSpec.
+
 ## Syntax
 
 An etc/hosts.deny rule specifies one or more daemons mapped to one or more clients, with zero or more options for rejecting traffic when found.

--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -9,6 +9,16 @@ Use the `file` InSpec audit resource to test all system file types, including fi
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `file` resource block declares the location of the file type to be tested, the expected file type  (if required), and one (or more) resource properties.

--- a/docs/resources/filesystem.md.erb
+++ b/docs/resources/filesystem.md.erb
@@ -9,6 +9,16 @@ Use the `filesystem` InSpec resource to audit filesystem disk space usage.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.51.0 of InSpec.
+
 ## Syntax
 
 A `filesystem` resource block declares tests for disk space in a partition:

--- a/docs/resources/firewalld.md.erb
+++ b/docs/resources/firewalld.md.erb
@@ -11,6 +11,16 @@ A firewalld has a number of zones that can be configured to allow and deny acces
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.40.0 of InSpec.
+
 ## Syntax
 
     describe firewalld do

--- a/docs/resources/gem.md.erb
+++ b/docs/resources/gem.md.erb
@@ -9,6 +9,16 @@ Use the `gem` InSpec audit resource to test if a global Gem package is installed
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `gem` resource block declares a package and (optionally) a package version:

--- a/docs/resources/group.md.erb
+++ b/docs/resources/group.md.erb
@@ -9,6 +9,16 @@ Use the `group` InSpec audit resource to test groups on the system.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `group` resource block declares a group, and then the details to be tested, such as if the group is a local group, the group identifier, or if the group exists:

--- a/docs/resources/grub_conf.md.erb
+++ b/docs/resources/grub_conf.md.erb
@@ -9,6 +9,16 @@ Grub is a boot loader on the Linux platform used to load and then transfer contr
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `grub_conf` resource block declares a list of settings in a `grub.conf` file:

--- a/docs/resources/host.md.erb
+++ b/docs/resources/host.md.erb
@@ -9,6 +9,16 @@ Use the `host` InSpec audit resource to test the name used to refer to a specifi
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `host` resource block declares a host name, and then (depending on what is to be tested) a port and/or a protocol:

--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -9,6 +9,16 @@ Use the `http` InSpec audit resource to test an http endpoint.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.10.0 of InSpec.
+
 ## Syntax
 
 An `http` resource block declares the configuration settings to be tested:

--- a/docs/resources/iis_app.md.erb
+++ b/docs/resources/iis_app.md.erb
@@ -9,6 +9,16 @@ Use the `iis_app` InSpec audit resource to test the state of IIS on Windows Serv
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.28.0 of InSpec.
+
 ## Syntax
 
 An `iis_app` resource block declares details about the named site:

--- a/docs/resources/iis_site.md.erb
+++ b/docs/resources/iis_site.md.erb
@@ -9,6 +9,16 @@ Use the `iis_site` InSpec audit resource to test the state of IIS on Windows Ser
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `iis_site` resource block declares details about the named site:

--- a/docs/resources/inetd_conf.md.erb
+++ b/docs/resources/inetd_conf.md.erb
@@ -9,6 +9,16 @@ Use the `inetd_conf` InSpec audit resource to test if a service is listed in the
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `inetd_conf` resource block declares the list of services that are enabled in the `inetd.conf` file:

--- a/docs/resources/ini.md.erb
+++ b/docs/resources/ini.md.erb
@@ -9,6 +9,16 @@ Use the `ini` InSpec audit resource to test settings in an INI file.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `ini` resource block declares the configuration settings to be tested:

--- a/docs/resources/interface.md.erb
+++ b/docs/resources/interface.md.erb
@@ -12,6 +12,16 @@ Use the `interface` InSpec audit resource to test basic network adapter properti
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `interface` resource block declares network interface properties to be tested:

--- a/docs/resources/iptables.md.erb
+++ b/docs/resources/iptables.md.erb
@@ -9,6 +9,16 @@ Use the `iptables` InSpec audit resource to test rules that are defined in `ipta
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `iptables` resource block declares tests for rules in IP tables:

--- a/docs/resources/json.md.erb
+++ b/docs/resources/json.md.erb
@@ -9,6 +9,16 @@ Use the `json` InSpec audit resource to test data in a JSON file.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `json` resource block declares the data to be tested. Assume the following JSON file:

--- a/docs/resources/kernel_module.md.erb
+++ b/docs/resources/kernel_module.md.erb
@@ -15,6 +15,16 @@ method.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `kernel_module` resource block declares a module name, and then tests if that

--- a/docs/resources/kernel_parameter.md.erb
+++ b/docs/resources/kernel_parameter.md.erb
@@ -9,6 +9,16 @@ Use the `kernel_parameter` InSpec audit resource to test kernel parameters on Li
  These parameters are located under `/proc/cmdline`.
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `kernel_parameter` resource block declares a parameter and then a value to be tested:

--- a/docs/resources/key_rsa.md.erb
+++ b/docs/resources/key_rsa.md.erb
@@ -11,6 +11,16 @@ This resource is mainly useful when used in conjunction with the x509_certificat
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.18.0 of InSpec.
+
 ## Syntax
 
 An `key_rsa` resource block declares a `key file` to be tested.

--- a/docs/resources/launchd_service.md.erb
+++ b/docs/resources/launchd_service.md.erb
@@ -9,6 +9,16 @@ Use the ``launchd_service`` InSpec audit resource to test a service using Launch
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A ``launchd_service`` resource block declares the name of a service and then one (or more) matchers to test the state of the service:

--- a/docs/resources/limits_conf.md.erb
+++ b/docs/resources/limits_conf.md.erb
@@ -20,6 +20,16 @@ Entries in the `limits.conf` file are similar to:
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `limits_conf` resource block declares a domain to be tested, along with associated type, item, and value:

--- a/docs/resources/login_defs.md.erb
+++ b/docs/resources/login_defs.md.erb
@@ -9,6 +9,16 @@ Use the `login_defs` InSpec audit resource to test configuration settings in the
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `login_defs` resource block declares the `login.defs` configuration data to be tested:

--- a/docs/resources/mount.md.erb
+++ b/docs/resources/mount.md.erb
@@ -9,6 +9,16 @@ Use the `mount` InSpec audit resource to test the mount points on FreeBSD and Li
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `mount` resource block declares the synchronization settings that should be tested:

--- a/docs/resources/mssql_session.md.erb
+++ b/docs/resources/mssql_session.md.erb
@@ -9,6 +9,16 @@ Use the `mssql_session` InSpec audit resource to test SQL commands run against a
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.24.0 of InSpec.
+
 ## Syntax
 
 A `mssql_session` resource block declares the username and password to use for the session, and then the command to be run:

--- a/docs/resources/mysql_conf.md.erb
+++ b/docs/resources/mysql_conf.md.erb
@@ -9,6 +9,16 @@ Use the `mysql_conf` InSpec audit resource to test the contents of the configura
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `mysql_conf` resource block declares one (or more) settings in the `my.cnf` file, and then compares the setting in the configuration file to the value stated in the test:

--- a/docs/resources/mysql_session.md.erb
+++ b/docs/resources/mysql_session.md.erb
@@ -9,6 +9,16 @@ Use the `mysql_session` InSpec audit resource to test SQL commands run against a
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `mysql_session` resource block declares the username and password to use for the session, and then the command to be run:

--- a/docs/resources/nginx.md.erb
+++ b/docs/resources/nginx.md.erb
@@ -11,6 +11,16 @@ Nginx resource extracts and exposes data reported by the command 'nginx -V'
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.37.6 of InSpec.
+
 ## Syntax
 
 An `nginx` InSpec audit resource block extracts configuration settings that should be tested:

--- a/docs/resources/nginx_conf.md.erb
+++ b/docs/resources/nginx_conf.md.erb
@@ -11,6 +11,16 @@ Use the `nginx_conf` InSpec resource to test configuration data for the NGINX se
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.37.6 of InSpec.
+
 ## Syntax
 
 An `nginx_conf` resource block declares the client NGINX configuration data to be tested:

--- a/docs/resources/npm.md.erb
+++ b/docs/resources/npm.md.erb
@@ -9,6 +9,16 @@ Use the `npm` InSpec audit resource to test if a global NPM package is installed
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `npm` resource block declares a package and (optionally) a package version:

--- a/docs/resources/ntp_conf.md.erb
+++ b/docs/resources/ntp_conf.md.erb
@@ -9,6 +9,16 @@ Use the `ntp_conf` InSpec audit resource to test the synchronization settings de
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `ntp_conf` resource block declares the synchronization settings that should be tested:

--- a/docs/resources/oneget.md.erb
+++ b/docs/resources/oneget.md.erb
@@ -9,6 +9,16 @@ Use the `oneget` InSpec audit resource to test if the named package and/or packa
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `oneget` resource block declares a package and (optionally) a package version:

--- a/docs/resources/oracledb_session.md.erb
+++ b/docs/resources/oracledb_session.md.erb
@@ -9,6 +9,16 @@ Use the `oracledb_session` InSpec audit resource to test SQL commands run agains
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `oracledb_session` resource block declares the username and password to use for the session with an optional service to connect to, and then the command to be run:

--- a/docs/resources/os.md.erb
+++ b/docs/resources/os.md.erb
@@ -9,6 +9,16 @@ Use the `os` InSpec audit resource to test the platform on which the system is r
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `os` resource block declares the platform to be tested. The platform may specified via matcher or control block name. For example, using a matcher:

--- a/docs/resources/os_env.md.erb
+++ b/docs/resources/os_env.md.erb
@@ -9,6 +9,16 @@ Use the `os_env` InSpec audit resource to test the environment variables for the
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `os_env` resource block declares an environment variable, and then declares its value:

--- a/docs/resources/package.md.erb
+++ b/docs/resources/package.md.erb
@@ -9,6 +9,16 @@ Use the `package` InSpec audit resource to test if the named package and/or pack
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `package` resource block declares a package and (optionally) a package version:

--- a/docs/resources/packages.md.erb
+++ b/docs/resources/packages.md.erb
@@ -9,6 +9,16 @@ Use the `packages` InSpec audit resource to test the properties of multiple pack
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.51.15 of InSpec.
+
 ## Syntax
 
 A `packages` resource block declares a regular expression search to select packages

--- a/docs/resources/parse_config.md.erb
+++ b/docs/resources/parse_config.md.erb
@@ -9,6 +9,16 @@ Use the `parse_config` InSpec audit resource to test arbitrary configuration fil
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `parse_config` resource block declares the location of the configuration setting to be tested, and then what value is to be tested. Because this resource relies on arbitrary configuration files, the test itself is often arbitrary and relies on custom Ruby code:

--- a/docs/resources/parse_config_file.md.erb
+++ b/docs/resources/parse_config_file.md.erb
@@ -9,6 +9,16 @@ Use the `parse_config_file` InSpec audit resource to test arbitrary configuratio
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `parse_config_file` InSpec audit resource block declares the location of the configuration file to be tested, and then which settings in that file are to be tested.

--- a/docs/resources/passwd.md.erb
+++ b/docs/resources/passwd.md.erb
@@ -21,6 +21,16 @@ These entries are defined as a colon-delimited row in the file, one row per user
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `passwd` resource block declares one (or more) users and associated user information to be tested:

--- a/docs/resources/pip.md.erb
+++ b/docs/resources/pip.md.erb
@@ -9,6 +9,16 @@ Use the `pip` InSpec audit resource to test packages that are installed using th
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `pip` resource block declares a package and (optionally) a package version:

--- a/docs/resources/port.md.erb
+++ b/docs/resources/port.md.erb
@@ -9,6 +9,16 @@ Use the `port` InSpec audit resource to test basic port properties, such as port
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `port` resource block declares a port, and then depending on what needs to be tested, a process, protocol, process identifier, and its state (is it listening?):

--- a/docs/resources/postgres_conf.md.erb
+++ b/docs/resources/postgres_conf.md.erb
@@ -9,6 +9,16 @@ Use the `postgres_conf` InSpec audit resource to test the contents of the config
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `postgres_conf` resource block declares one (or more) settings in the `postgresql.conf` file, and then compares the setting in the configuration file to the value stated in the test:

--- a/docs/resources/postgres_hba_conf.md.erb
+++ b/docs/resources/postgres_hba_conf.md.erb
@@ -9,6 +9,16 @@ Use the `postgres_hba_conf` InSpec audit resource to test the client authenticat
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.31.0 of InSpec.
+
 ## Syntax
 
 An `postgres_hba_conf` InSpec audit resource block declares client authentication data that should be tested:

--- a/docs/resources/postgres_ident_conf.md.erb
+++ b/docs/resources/postgres_ident_conf.md.erb
@@ -9,6 +9,16 @@ Use the `postgres_ident_conf` InSpec audit resource to test the client authentic
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.31.0 of InSpec.
+
 ## Syntax
 
 An `postgres_ident_conf` InSpec audit resource block declares client authentication data that should be tested:

--- a/docs/resources/postgres_session.md.erb
+++ b/docs/resources/postgres_session.md.erb
@@ -9,6 +9,16 @@ Use the `postgres_session` InSpec audit resource to test SQL commands run agains
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `postgres_session` resource block declares the username and password to use for the session, and then the command to be run:

--- a/docs/resources/powershell.md.erb
+++ b/docs/resources/powershell.md.erb
@@ -9,6 +9,16 @@ Use the `powershell` InSpec audit resource to test a Powershell script on the Wi
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `powershell` resource block declares a Powershell script to be tested, and then compares the output of that command to the matcher in the test:

--- a/docs/resources/processes.md.erb
+++ b/docs/resources/processes.md.erb
@@ -9,6 +9,16 @@ Use the `processes` InSpec audit resource to test properties for programs that a
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `processes` resource block declares the name of the process to be tested, and then declares one (or more) property/value pairs:

--- a/docs/resources/rabbitmq_config.md.erb
+++ b/docs/resources/rabbitmq_config.md.erb
@@ -9,6 +9,16 @@ Use the `rabbitmq_config` InSpec audit resource to test configuration data for t
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.20.0 of InSpec.
+
 ## Syntax
 
 A `rabbitmq_config` resource block declares the RabbitMQ configuration data to be tested:

--- a/docs/resources/registry_key.md.erb
+++ b/docs/resources/registry_key.md.erb
@@ -9,6 +9,16 @@ Use the `registry_key` InSpec audit resource to test key values in the Windows r
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `registry_key` resource block declares the item in the Windows registry, the path to a setting under that item, and then one (or more) name/value pairs to be tested.

--- a/docs/resources/runit_service.md.erb
+++ b/docs/resources/runit_service.md.erb
@@ -9,6 +9,16 @@ Use the `runit_service` InSpec audit resource to test a service using runit.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `runit_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:

--- a/docs/resources/security_policy.md.erb
+++ b/docs/resources/security_policy.md.erb
@@ -9,6 +9,16 @@ Use the `security_policy` InSpec audit resource to test security policies on the
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `security_policy` resource block declares the name of a security policy and the value to be tested:

--- a/docs/resources/service.md.erb
+++ b/docs/resources/service.md.erb
@@ -11,6 +11,16 @@ Under some circumstances, it may be necessary to specify the service manager by 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:

--- a/docs/resources/shadow.md.erb
+++ b/docs/resources/shadow.md.erb
@@ -26,6 +26,16 @@ The `shadow` resource understands this format, allows you to search on the field
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Resource Parameters
 
 The `shadow` resource takes one optional parameter: the path to the shadow file. If omitted, `/etc/shadow` is assumed.

--- a/docs/resources/ssh_config.md.erb
+++ b/docs/resources/ssh_config.md.erb
@@ -9,6 +9,16 @@ Use the `ssh_config` InSpec audit resource to test OpenSSH client configuration 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `ssh_config` resource block declares the client OpenSSH configuration data to be tested:

--- a/docs/resources/sshd_config.md.erb
+++ b/docs/resources/sshd_config.md.erb
@@ -9,6 +9,16 @@ Use the `sshd_config` InSpec audit resource to test configuration data for the O
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `sshd_config` resource block declares the client OpenSSH configuration data to be tested:

--- a/docs/resources/ssl.md.erb
+++ b/docs/resources/ssl.md.erb
@@ -9,6 +9,16 @@ Use the `ssl` InSpec audit resource to test SSL settings for the named port.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `ssl` resource block declares an SSL port, and then other properties of the test like cipher and/or protocol:

--- a/docs/resources/sys_info.md.erb
+++ b/docs/resources/sys_info.md.erb
@@ -9,6 +9,16 @@ Use the `sys_info` InSpec audit resource to test for operating system properties
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `sys_info` resource block declares the hostname to be tested:

--- a/docs/resources/systemd_service.md.erb
+++ b/docs/resources/systemd_service.md.erb
@@ -9,6 +9,16 @@ Use the `systemd_service` InSpec audit resource to test a service using SystemD.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `systemd_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:

--- a/docs/resources/sysv_service.md.erb
+++ b/docs/resources/sysv_service.md.erb
@@ -9,6 +9,16 @@ Use the `sysv_service` InSpec audit resource to test a service using SystemV.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `sysv_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:

--- a/docs/resources/upstart_service.md.erb
+++ b/docs/resources/upstart_service.md.erb
@@ -9,6 +9,16 @@ Use the `upstart_service` InSpec audit resource to test a service using Upstart.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `upstart_service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:

--- a/docs/resources/user.md.erb
+++ b/docs/resources/user.md.erb
@@ -9,6 +9,16 @@ Use the `user` InSpec audit resource to test user profiles for a single, known/e
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `user` resource block declares a user name, and then one (or more) matchers:

--- a/docs/resources/users.md.erb
+++ b/docs/resources/users.md.erb
@@ -9,6 +9,16 @@ Use the `users` InSpec audit resource to look up all local users available on th
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `users` resource block declares a user name, and then one (or more) matchers:

--- a/docs/resources/vbscript.md.erb
+++ b/docs/resources/vbscript.md.erb
@@ -9,6 +9,16 @@ Use the `vbscript` InSpec audit resource to test a VBScript on the Windows platf
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `vbscript` resource block tests the output of a VBScript on the Windows platform:

--- a/docs/resources/virtualization.md.erb
+++ b/docs/resources/virtualization.md.erb
@@ -9,6 +9,16 @@ Use the `virtualization` InSpec audit resource to test the virtualization platfo
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.28.0 of InSpec.
+
 ## Syntax
 
 An `virtualization` resource block declares the virtualization platform that should be tested:

--- a/docs/resources/windows_feature.md.erb
+++ b/docs/resources/windows_feature.md.erb
@@ -9,6 +9,16 @@ Use the `windows_feature` InSpec audit resource to test features on Windows via 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `windows_feature` resource block declares the name of the Windows feature, tests if that feature is installed, and then returns information about that feature:

--- a/docs/resources/windows_hotfix.md.erb
+++ b/docs/resources/windows_hotfix.md.erb
@@ -9,6 +9,16 @@ Use the `windows_hotfix` InSpec audit resource to test if the hotfix has been in
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.39.1 of InSpec.
+
 ## Syntax
 
 A `windows_hotfix` resource block declares a hotfix to validate:

--- a/docs/resources/windows_task.md.erb
+++ b/docs/resources/windows_task.md.erb
@@ -10,6 +10,16 @@ Microsoft and application vendors use scheduled tasks to perform a variety of sy
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.10.0 of InSpec.
+
 ## Syntax
 
 A `windows_task` resource block declares the name of the task (as its full path) and tests its configuration:

--- a/docs/resources/wmi.md.erb
+++ b/docs/resources/wmi.md.erb
@@ -9,6 +9,16 @@ Use the `wmi` InSpec audit resource to test WMI settings on the Windows platform
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `wmi` resource block tests WMI settings on the Windows platform:

--- a/docs/resources/x509_certificate.md.erb
+++ b/docs/resources/x509_certificate.md.erb
@@ -15,6 +15,16 @@ certificates.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.18.0 of InSpec.
+
 ## Syntax
 
 An `x509_certificate` resource block declares a certificate `key file` to be tested.

--- a/docs/resources/xinetd_conf.md.erb
+++ b/docs/resources/xinetd_conf.md.erb
@@ -9,6 +9,16 @@ Use the `xinetd_conf` InSpec audit resource to test services under `/etc/xinet.d
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 An `xinetd_conf` resource block declares settings found in a `xinetd.conf` file for the named service:

--- a/docs/resources/xml.md.erb
+++ b/docs/resources/xml.md.erb
@@ -9,6 +9,16 @@ Use the `xml` InSpec audit resource to test data in an XML file.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.37.6 of InSpec.
+
 ## Syntax
 
 An `xml` resource block declares the data to be tested. Assume the following XML file:

--- a/docs/resources/yaml.md.erb
+++ b/docs/resources/yaml.md.erb
@@ -9,6 +9,16 @@ Use the `yaml` InSpec audit resource to test configuration data in a Yaml file.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `yaml` resource block declares the configuration data to be tested. Assume the following Yaml file:

--- a/docs/resources/yum.md.erb
+++ b/docs/resources/yum.md.erb
@@ -9,6 +9,16 @@ Use the `yum` InSpec audit resource to test packages in the Yum repository.
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
 ## Syntax
 
 A `yum` resource block declares a package repo, tests if the package repository is present, and if it that package repository is a valid package source (i.e. "is enabled"):

--- a/docs/resources/zfs_dataset.md.erb
+++ b/docs/resources/zfs_dataset.md.erb
@@ -9,6 +9,16 @@ Use the `zfs_dataset` InSpec audit resource to test the ZFS datasets on FreeBSD 
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.16.0 of InSpec.
+
 ## Syntax
 
 A `zfs_dataset` resource block declares the ZFS dataset properties that should be tested:

--- a/docs/resources/zfs_pool.md.erb
+++ b/docs/resources/zfs_pool.md.erb
@@ -9,6 +9,16 @@ Use the `zfs_pool` InSpec audit resource to test the ZFS pools on FreeBSD system
 
 <br>
 
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.16.0 of InSpec.
+
 ## Syntax
 
 A `zfs_pool` resource block declares the ZFS pool properties that should be tested:


### PR DESCRIPTION
Like the title says, this PR is the result of using a [horrid little script](https://github.com/inspec/inspec/blob/cw/doc-analysis/tasks/lib/doc_analyzer/horrid-little-script.rb) to inject an Availability section into the core docs.  This aims to do three things:

* Make it clearer which resources are currently core resources (See #3184 )
* Clarify when each resource was introduced (a common source of support questions).
* Drive @jerryaldrichiii completely bats, because the parser-renderer happily mangles whitespace and wraps lines.  So, this about a ~5,000 line delta. Effort could be spent reducing that; it might be worthwhile, as we can use the same libraries to enforce consistency and extract metadata from some resources.


 UPDATE: I found how to disable line wrapping.  That reduced the change to a "manageable" 3400 LOC change.  Woot?

UPDATE 2: After discussion, I reworked the injector to just a line-splicing approach, instead of a full re-render.  That makes a nice clean PR - only things here should be the availability section itself.