### PR TITLE
command resource: Allow redacting `#to_s`

### DIFF
--- a/docs/resources/command.md.erb
+++ b/docs/resources/command.md.erb
@@ -124,19 +124,25 @@ Wix includes several tools -- such as `candle` (preprocesses and compiles source
       end
     end
 
-<br>
-
 ### Redacting Sensitive Commands
 
-By default the command that is ran is shown in the InSpec output. This can be problematic if the command contains sensitive arguments such as a password.
+By default the command that is ran is shown in the InSpec output. This can be problematic if the command contains sensitive arguments such as a password. These sensitive parts can be redacted by passing in `redact_regex` and a regular expression to redact. Optionally, you can use 2 capture groups to fine tune what is redacted.
 
-These sensitive parts can be redacted by passing in `redact_command` and a regular expression to redact. Optionally, you can use 2 capture groups to fine tune what is redacted.
+The following examples show how to use `redact_regex`:
 
-The following examples show how to use `redact_command` with the command resource:
+    # Example without capture groups
+    describe command('myapp -p secretpassword -d no_redact', redact_regex: /-p .* -d/) do
+      its('exit_status') { should cmp 0 }
+    end
 
-    # With capture groups
-    options = { redact_command: /(-p ).*( -d)/ }
-    describe command('myapp -p secretpassword -d no_redact', options) do
+    # Result (no capture groups used)
+    Command: `myapp REDACTED no_redact`
+       ✔  exit_status should cmp == 0
+
+    # Example with capture groups
+    # Each set of parenthesis is a capture group.
+    # Anything in the two capture groups will not be 'REDACTED'
+    describe command('myapp -p secretpassword -d no_redact', redact_regex: /(-p ).*( -d)/) do
       its('exit_status') { should cmp 0 }
     end
 
@@ -144,15 +150,9 @@ The following examples show how to use `redact_command` with the command resourc
     Command: `myapp -p REDACTED -d no_redact`
        ✔  exit_status should cmp == 0
 
-    # Without capture groups
-    options = { redact_command: /-p .* -d/ }
-    describe command('myapp -p secretpassword -d no_redact', options) do
-      its('exit_status') { should cmp 0 }
-    end
+> For more info/help on regular expressions, we recommend [RegExr](https://regexr.com/)
 
-    # Result (no capture groups used)
-    Command: `myapp REDACTED no_redact`
-       ✔  exit_status should cmp == 0
+<br>
 
 ## Matchers
 

--- a/docs/resources/command.md.erb
+++ b/docs/resources/command.md.erb
@@ -126,6 +126,34 @@ Wix includes several tools -- such as `candle` (preprocesses and compiles source
 
 <br>
 
+### Redacting Sensitive Commands
+
+By default the command that is ran is shown in the InSpec output. This can be problematic if the command contains sensitive arguments such as a password.
+
+These sensitive parts can be redacted by passing in `redact_command` and a regular expression to redact. Optionally, you can use 2 capture groups to fine tune what is redacted.
+
+The following examples show how to use `redact_command` with the command resource:
+
+    # With capture groups
+    options = { redact_command: /(-p ).*( -d)/ }
+    describe command('myapp -p secretpassword -d no_redact', options) do
+      its('exit_status') { should cmp 0 }
+    end
+
+    # Result (capture groups used)
+    Command: `myapp -p REDACTED -d no_redact`
+       ✔  exit_status should cmp == 0
+
+    # Without capture groups
+    options = { redact_command: /-p .* -d/ }
+    describe command('myapp -p secretpassword -d no_redact', options) do
+      its('exit_status') { should cmp 0 }
+    end
+
+    # Result (no capture groups used)
+    Command: `myapp REDACTED no_redact`
+       ✔  exit_status should cmp == 0
+
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -22,11 +22,22 @@ module Inspec::Resources
 
     attr_reader :command
 
-    def initialize(cmd)
+    def initialize(cmd, options = {})
       if cmd.nil?
         raise 'InSpec `command` was called with `nil` as the argument. This is not supported. Please provide a valid command instead.'
       end
+
       @command = cmd
+
+      if options[:redact_command]
+        unless options[:redact_command].is_a?(Regexp)
+          # Make sure command is replaced so sensitive output isn't shown
+          @command = 'ERROR'
+          raise Inspec::Exceptions::ResourceFailed,
+                'The `redact_command` option must be a regular expression'
+        end
+        @redact_regex = options[:redact_command]
+      end
     end
 
     def result
@@ -67,7 +78,11 @@ module Inspec::Resources
     end
 
     def to_s
-      "Command #{@command}"
+      output = "Command: `#{@command}`"
+      # Redact output if the `redact_command` option is passed
+      # If no capture groups are passed then `\1` and `\2` are ignored
+      output.gsub!(@redact_regex, '\1REDACTED\2') unless @redact_regex.nil?
+      output
     end
   end
 end

--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -29,14 +29,14 @@ module Inspec::Resources
 
       @command = cmd
 
-      if options[:redact_command]
-        unless options[:redact_command].is_a?(Regexp)
+      if options[:redact_regex]
+        unless options[:redact_regex].is_a?(Regexp)
           # Make sure command is replaced so sensitive output isn't shown
           @command = 'ERROR'
           raise Inspec::Exceptions::ResourceFailed,
-                'The `redact_command` option must be a regular expression'
+                'The `redact_regex` option must be a regular expression'
         end
-        @redact_regex = options[:redact_command]
+        @redact_regex = options[:redact_regex]
       end
     end
 
@@ -79,7 +79,7 @@ module Inspec::Resources
 
     def to_s
       output = "Command: `#{@command}`"
-      # Redact output if the `redact_command` option is passed
+      # Redact output if the `redact_regex` option is passed
       # If no capture groups are passed then `\1` and `\2` are ignored
       output.gsub!(@redact_regex, '\1REDACTED\2') unless @redact_regex.nil?
       output

--- a/test/unit/resources/command_test.rb
+++ b/test/unit/resources/command_test.rb
@@ -36,21 +36,21 @@ describe Inspec::Resources::Cmd do
     proc { resource(nil).result }.must_raise StandardError
   end
 
-  it 'fails the resource if `redact_command` is not a regular expression' do
-    result = resource('env', redact_command: 'string')
+  it 'fails the resource if `redact_regex` is not a regular expression' do
+    result = resource('env', redact_regex: 'string')
     result.resource_failed?.must_equal true
     result.resource_exception_message.must_match /must be a regular expression/
   end
 
-  it 'redacts output if `redact_command` is passed with caputure groups' do
+  it 'redacts output if `redact_regex` is passed with caputure groups' do
     cmd = 'command_with_password -p supersecret -d no_redact'
     expected_to_s = 'Command: `command_with_password -p REDACTED -d no_redact`'
-    resource(cmd, redact_command: /(-p ).*( -d)/).to_s.must_equal(expected_to_s)
+    resource(cmd, redact_regex: /(-p ).*( -d)/).to_s.must_equal(expected_to_s)
   end
 
-  it 'redacts output if `redact_command` is passed without a caputure group' do
+  it 'redacts output if `redact_regex` is passed without a caputure group' do
     cmd = 'command_with_password -p supersecret -d no_redact'
     expected_to_s = 'Command: `command_with_password REDACTED no_redact`'
-    resource(cmd, redact_command: /-p .* -d/).to_s.must_equal(expected_to_s)
+    resource(cmd, redact_regex: /-p .* -d/).to_s.must_equal(expected_to_s)
   end
 end

--- a/test/unit/resources/command_test.rb
+++ b/test/unit/resources/command_test.rb
@@ -7,12 +7,12 @@ require 'inspec/resource'
 
 describe Inspec::Resources::Cmd do
   let(:x) { rand.to_s }
-  def resource(y)
-    load_resource('command', y)
+  def resource(command, options = {} )
+    load_resource('command', command, options)
   end
 
   it 'prints as a bash command' do
-    resource(x).to_s.must_equal 'Command '+x
+    resource(x).to_s.must_equal "Command: `#{x}`"
   end
 
   it 'runs a valid mocked command' do
@@ -34,5 +34,23 @@ describe Inspec::Resources::Cmd do
 
   it 'raises when called with nil as a command' do
     proc { resource(nil).result }.must_raise StandardError
+  end
+
+  it 'fails the resource if `redact_command` is not a regular expression' do
+    result = resource('env', redact_command: 'string')
+    result.resource_failed?.must_equal true
+    result.resource_exception_message.must_match /must be a regular expression/
+  end
+
+  it 'redacts output if `redact_command` is passed with caputure groups' do
+    cmd = 'command_with_password -p supersecret -d no_redact'
+    expected_to_s = 'Command: `command_with_password -p REDACTED -d no_redact`'
+    resource(cmd, redact_command: /(-p ).*( -d)/).to_s.must_equal(expected_to_s)
+  end
+
+  it 'redacts output if `redact_command` is passed without a caputure group' do
+    cmd = 'command_with_password -p supersecret -d no_redact'
+    expected_to_s = 'Command: `command_with_password REDACTED no_redact`'
+    resource(cmd, redact_command: /-p .* -d/).to_s.must_equal(expected_to_s)
   end
 end


### PR DESCRIPTION
This allows the user to redact command arguments when using the `command` resource.

This also changes how the `#to_s` is rendered (adds a `:` and some backticks) let me know if that is too drastic of a change.

Examples:

```
# With capture groups
options = { redact_command: /(-p ).*( -d)/ }
describe command('myapp -p secretpassword -d no_redact', options) do
  its('exit_status') { should cmp 0 }
end

# Result (capture groups used)
Command: `myapp -p REDACTED -d no_redact`
          ✔  exit_status should cmp == 0

# Without capture groups
options = { redact_command: /-p .* -d/ }
describe command('myapp -p secretpassword -d no_redact', options) do
  its('exit_status') { should cmp 0 }
end

# Result (no capture groups used)
Command: `myapp REDACTED no_redact`
          ✔  exit_status should cmp == 0
```

This fixes https://github.com/inspec/inspec/issues/3185