### PR TITLE
Refactor 'inspec init profile' into a reusable component.

### DIFF
--- a/lib/bundles/inspec-init.rb
+++ b/lib/bundles/inspec-init.rb
@@ -5,4 +5,8 @@
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
+module Init
+  autoload :Profile, 'inspec-init/profile'
+end
+
 require 'inspec-init/cli'

--- a/lib/bundles/inspec-init/cli.rb
+++ b/lib/bundles/inspec-init/cli.rb
@@ -15,7 +15,7 @@ module Init
       namespace
     end
 
-    # read template directoy
+    # read template directory
     template_dir = File.join(File.dirname(__FILE__), 'templates')
     Dir.glob(File.join(template_dir, '*')) do |template|
       relative = Pathname.new(template).relative_path_from(Pathname.new(template_dir))
@@ -23,76 +23,10 @@ module Init
       # register command for the template
       desc "#{relative} NAME", "Create a new #{relative}"
       option :overwrite, type: :boolean, default: false,
-         desc: 'Overwrites existing directory'
+        desc: 'Overwrites existing directory'
       define_method relative.to_s.to_sym do |name|
-        generator(relative.to_s, { name: name }, options)
+        Init::Profile.generator(relative.to_s, { name: name }, options)
       end
-    end
-
-    private
-
-    # 1. iterate over all files
-    # 2. read content in erb
-    # 3. write to target
-    def generator(type, attributes = {}, options = {}) # rubocop:disable Metrics/AbcSize
-      # path of this script
-      dir = File.dirname(__FILE__)
-      # look for template directory
-      base_dir = File.join(dir, 'templates', type)
-      # prepare glob for all subdirectories and files
-      template = File.join(base_dir, '**', '{*,.*}')
-      # Use the name attribute to define the path to the profile.
-      profile_path = attributes[:name]
-      # Use slashes (\, /) to split up the name into an Array then use the last entry
-      # to reset the name of the profile.
-      attributes[:name] = attributes[:name].split(%r{\\|\/}).last
-      # Generate the full target path on disk
-      target = Pathname.new(Dir.pwd).join(profile_path)
-      puts "Create new #{type} at #{mark_text(target)}"
-
-      # check that the directory does not exist
-      if File.exist?(target) && !options['overwrite']
-        error "#{mark_text(target)} exists already, use --overwrite"
-        exit 1
-      end
-
-      # ensure that target directory is available
-      FileUtils.mkdir_p(target)
-
-      # iterate over files and write to target path
-      Dir.glob(template) do |file|
-        relative = Pathname.new(file).relative_path_from(Pathname.new(base_dir))
-        destination = Pathname.new(target).join(relative)
-        if File.directory?(file)
-          li "Create directory #{mark_text(relative)}"
-          FileUtils.mkdir_p(destination)
-        elsif File.file?(file)
-          li "Create file #{mark_text(relative)}"
-          # read & render content
-          content = render(File.read(file), attributes)
-          # write file content
-          File.write(destination, content)
-        else
-          puts "Ignore #{file}, because its not an file or directoy"
-        end
-      end
-    end
-
-    # This is a render helper to bind hash values to a ERB template
-    def render(content, hash)
-      # create a new binding class
-      cls = Class.new do
-        hash.each do |key, value|
-          define_method key.to_sym do
-            value
-          end
-        end
-        # expose binding
-        define_method :bind do
-          binding
-        end
-      end
-      ERB.new(content).result(cls.new.bind)
     end
   end
 

--- a/lib/bundles/inspec-init/cli.rb
+++ b/lib/bundles/inspec-init/cli.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'pathname'
+require_relative 'renderer'
 
 module Init
   class CLI < Inspec::BaseCLI
@@ -15,17 +16,18 @@ module Init
       namespace
     end
 
-    # read template directory
+    # Look in the 'template' directory, and register a subcommand
+    # for each template directory found there.
     template_dir = File.join(File.dirname(__FILE__), 'templates')
     Dir.glob(File.join(template_dir, '*')) do |template|
-      relative = Pathname.new(template).relative_path_from(Pathname.new(template_dir))
+      template_name = Pathname.new(template).relative_path_from(Pathname.new(template_dir)).to_s
 
       # register command for the template
-      desc "#{relative} NAME", "Create a new #{relative}"
+      desc "#{template_name} NAME", "Create a new #{template_name}"
       option :overwrite, type: :boolean, default: false,
         desc: 'Overwrites existing directory'
-      define_method relative.to_s.to_sym do |name|
-        Init::Profile.generator(relative.to_s, { name: name }, options)
+      define_method template_name.to_sym do |name_for_new_structure|
+        renderer = Init::Renderer.new(template_name, self, { name: name_for_new_structure }, options)
       end
     end
   end

--- a/lib/bundles/inspec-init/cli.rb
+++ b/lib/bundles/inspec-init/cli.rb
@@ -27,7 +27,8 @@ module Init
       option :overwrite, type: :boolean, default: false,
         desc: 'Overwrites existing directory'
       define_method template_name.to_sym do |name_for_new_structure|
-        renderer = Init::Renderer.new(template_name, self, { name: name_for_new_structure }, options)
+        renderer = Init::Renderer.new(self, options)
+        renderer.render_with_values(template_name, name: name_for_new_structure)
       end
     end
   end

--- a/lib/bundles/inspec-init/profile.rb
+++ b/lib/bundles/inspec-init/profile.rb
@@ -1,0 +1,69 @@
+module Init
+  class Profile
+
+    # 1. iterate over all files
+    # 2. read content in erb
+    # 3. write to target
+    def self.generator(type, attributes = {}, options = {}) # rubocop:disable Metrics/AbcSize
+      # path of this script
+      dir = File.dirname(__FILE__)
+      # look for template directory
+      base_dir = File.join(dir, 'templates', type)
+      # prepare glob for all subdirectories and files
+      template = File.join(base_dir, '**', '{*,.*}')
+      # Use the name attribute to define the path to the profile.
+      profile_path = attributes[:name]
+      # Use slashes (\, /) to split up the name into an Array then use the last entry
+      # to reset the name of the profile.
+      attributes[:name] = attributes[:name].split(%r{\\|\/}).last
+      # Generate the full target path on disk
+      target = Pathname.new(Dir.pwd).join(profile_path)
+      puts "Create new #{type} at #{Inspec::BaseCLI.mark_text(target)}"
+
+      # check that the directory does not exist
+      if File.exist?(target) && !options['overwrite']
+        puts "#{Inspec::BaseCLI.mark_text(target)} exists already, use --overwrite"
+        exit 1
+      end
+
+      # ensure that target directory is available
+      FileUtils.mkdir_p(target)
+
+      # iterate over files and write to target path
+      Dir.glob(template) do |file|
+        relative = Pathname.new(file).relative_path_from(Pathname.new(base_dir))
+        destination = Pathname.new(target).join(relative)
+        if File.directory?(file)
+          Inspec::BaseCLI.li "Create directory #{Inspec::BaseCLI.mark_text(relative)}"
+          FileUtils.mkdir_p(destination)
+        elsif File.file?(file)
+          Inspec::BaseCLI.li "Create file #{Inspec::BaseCLI.mark_text(relative)}"
+          # read & render content
+          content = render(File.read(file), attributes)
+          # write file content
+          File.write(destination, content)
+        else
+          puts "Ignore #{file}, because its not an file or directoy"
+        end
+      end
+    end
+
+    # This is a render helper to bind hash values to a ERB template
+    def self.render(content, hash)
+      # create a new binding class
+      cls = Class.new do
+        hash.each do |key, value|
+          define_method key.to_sym do
+            value
+          end
+        end
+        # expose binding
+        define_method :bind do
+          binding
+        end
+      end
+      ERB.new(content).result(cls.new.bind)
+    end
+
+  end
+end

--- a/lib/bundles/inspec-init/renderer.rb
+++ b/lib/bundles/inspec-init/renderer.rb
@@ -6,52 +6,60 @@ module Init
     # Creates a renderer able to render the given template type
     # 1. iterate over all files
     # 2. read content in erb
-    # 3. write to target
-    def initialize(type, cli_ui, attributes = {}, options = {})
-      dir = File.dirname(__FILE__)
+    # 3. write to full_destination_root_path
+
+    attr_reader :overwrite_mode, :ui
+    def initialize(cli_ui, cli_options = {})
+      @ui = cli_ui
+      @overwrite_mode = cli_options['overwrite']
+    end
+
+    # rubocop: disable Metrics/AbcSize
+    def render_with_values(template_type, template_values = {})
       # look for template directory
-      base_dir = File.join(dir, 'templates', type)
+      base_dir = File.join(File.dirname(__FILE__), 'templates', template_type)
       # prepare glob for all subdirectories and files
-      template = File.join(base_dir, '**', '{*,.*}')
+      template_glob = File.join(base_dir, '**', '{*,.*}')
       # Use the name attribute to define the path to the profile.
-      profile_path = attributes[:name]
+      profile_path = template_values[:name]
       # Use slashes (\, /) to split up the name into an Array then use the last entry
       # to reset the name of the profile.
-      attributes[:name] = attributes[:name].split(%r{\\|\/}).last
-      # Generate the full target path on disk
-      target = Pathname.new(Dir.pwd).join(profile_path)
-      puts "Create new #{type} at #{cli_ui.mark_text(target)}"
+      template_values[:name] = template_values[:name].split(%r{\\|\/}).last
+      # Generate the full full_destination_root_path path on disk
+      full_destination_root_path = Pathname.new(Dir.pwd).join(profile_path)
+      puts "Create new #{template_type} at #{ui.mark_text(full_destination_root_path)}"
 
       # check that the directory does not exist
-      if File.exist?(target) && !options['overwrite']
-        puts "#{cli_ui.mark_text(target)} exists already, use --overwrite"
+      if File.exist?(full_destination_root_path) && !overwrite_mode
+        puts "#{ui.mark_text(full_destination_root_path)} exists already, use --overwrite"
         exit 1
       end
 
-      # ensure that target directory is available
-      FileUtils.mkdir_p(target)
+      # ensure that full_destination_root_path directory is available
+      FileUtils.mkdir_p(full_destination_root_path)
 
-      # iterate over files and write to target path
-      Dir.glob(template) do |file|
-        relative = Pathname.new(file).relative_path_from(Pathname.new(base_dir))
-        destination = Pathname.new(target).join(relative)
+      # iterate over files and write to full_destination_root_path
+      Dir.glob(template_glob) do |file|
+        relative_destination_item_path = Pathname.new(file).relative_path_from(Pathname.new(base_dir))
+        full_destination_item_path = Pathname.new(full_destination_root_path).join(relative_destination_item_path)
         if File.directory?(file)
-          cli_ui.li "Create directory #{cli_ui.mark_text(relative)}"
-          FileUtils.mkdir_p(destination)
+          ui.li "Create directory #{ui.mark_text(relative_destination_item_path)}"
+          FileUtils.mkdir_p(full_destination_item_path)
         elsif File.file?(file)
-          cli_ui.li "Create file #{cli_ui.mark_text(relative)}"
+          ui.li "Create file #{ui.mark_text(relative_destination_item_path)}"
           # read & render content
-          content = render(File.read(file), attributes)
+          content = render(File.read(file), template_values)
           # write file content
-          File.write(destination, content)
+          File.write(full_destination_item_path, content)
         else
           puts "Ignore #{file}, because its not an file or directoy"
         end
       end
     end
+    # rubocop: enable Metrics/AbcSize
 
     # This is a render helper to bind hash values to a ERB template
-    def render(content, hash)
+    def render(template_content, hash)
       # create a new binding class
       cls = Class.new do
         hash.each do |key, value|
@@ -64,7 +72,7 @@ module Init
           binding
         end
       end
-      ERB.new(content).result(cls.new.bind)
+      ERB.new(template_content).result(cls.new.bind)
     end
   end
 end

--- a/lib/bundles/inspec-init/renderer.rb
+++ b/lib/bundles/inspec-init/renderer.rb
@@ -59,6 +59,7 @@ module Init
     # rubocop: enable Metrics/AbcSize
 
     # This is a render helper to bind hash values to a ERB template
+    # ERB provides result_with_hash in ruby 2.5.0+, which does exactly this
     def render(template_content, hash)
       # create a new binding class
       cls = Class.new do

--- a/lib/bundles/inspec-init/renderer.rb
+++ b/lib/bundles/inspec-init/renderer.rb
@@ -27,12 +27,12 @@ module Init
       template_values[:name] = template_values[:name].split(%r{\\|\/}).last
       # Generate the full full_destination_root_path path on disk
       full_destination_root_path = Pathname.new(Dir.pwd).join(profile_path)
-      puts "Create new #{template_type} at #{ui.mark_text(full_destination_root_path)}"
+      ui.plain_text "Create new #{template_type} at #{ui.mark_text(full_destination_root_path)}"
 
       # check that the directory does not exist
       if File.exist?(full_destination_root_path) && !overwrite_mode
-        puts "#{ui.mark_text(full_destination_root_path)} exists already, use --overwrite"
-        exit 1
+        ui.plain_text "#{ui.mark_text(full_destination_root_path)} exists already, use --overwrite"
+        ui.exit(1)
       end
 
       # ensure that full_destination_root_path directory is available
@@ -52,7 +52,7 @@ module Init
           # write file content
           File.write(full_destination_item_path, content)
         else
-          puts "Ignore #{file}, because its not an file or directoy"
+          ui.plain_text "Ignore #{file}, because its not an file or directoy"
         end
       end
     end

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -364,7 +364,7 @@ module Inspec
       o[:logger].level = get_log_level(o.log_level)
     end
 
-    def mark_text(text)
+    def self.mark_text(text)
       "\e[0;36m#{text}\e[0m"
     end
 
@@ -372,7 +372,7 @@ module Inspec
       puts "\n== #{title}\n\n"
     end
 
-    def li(entry)
+    def self.li(entry)
       puts " #{mark_text('*')} #{entry}"
     end
   end

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -225,6 +225,14 @@ module Inspec
       def li(entry)
         puts " #{mark_text('*')} #{entry}"
       end
+
+      def exit(code)
+        Kernel.exit code
+      end
+
+      def plain_text(msg)
+        puts msg
+      end
     end
 
     private

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -210,6 +210,23 @@ module Inspec
       str
     end
 
+    # These need to be public methods on any BaseCLI instance,
+    # but Thor interprets all methods as subcommands.  The no_commands block
+    # treats them as regular methods.
+    no_commands do
+      def mark_text(text)
+        "\e[0;36m#{text}\e[0m"
+      end
+
+      def headline(title)
+        puts "\n== #{title}\n\n"
+      end
+
+      def li(entry)
+        puts " #{mark_text('*')} #{entry}"
+      end
+    end
+
     private
 
     def suppress_log_output?(opts)
@@ -362,18 +379,6 @@ module Inspec
         o[:logger].formatter = Logger::JSONFormatter.new
       end
       o[:logger].level = get_log_level(o.log_level)
-    end
-
-    def self.mark_text(text)
-      "\e[0;36m#{text}\e[0m"
-    end
-
-    def headline(title)
-      puts "\n== #{title}\n\n"
-    end
-
-    def self.li(entry)
-      puts " #{mark_text('*')} #{entry}"
     end
   end
 end


### PR DESCRIPTION
This PR is an adoption of #3202 from @mattray.

Refactors Init::Profile into a reusable class named Init::Renderer, and alters its interface from being class-based to instance-based.

Exposes several output formatting methods on BaseCLI for use by subclasses.

Variable name clarification pass on Init::Renderer.

---
base_cli.rb had several methods used internally, these are exposed so
lib/bundles/inspec-init/profile.rb can act as a library for anything
that needs to create new Inspec profiles programatically (ie. inspec-iggy)

Additional PRs will add CLI options similar to "chef generate cookbook"