### PR TITLE
windows_feature resource: Add DISM support

### DIFF
--- a/docs/resources/windows_feature.md.erb
+++ b/docs/resources/windows_feature.md.erb
@@ -28,9 +28,21 @@ where
 
 The following examples show how to use this InSpec audit resource.
 
-### Test the DHCP Server feature
+### Test the DHCP feature (Attempts PowerShell then DISM)
 
-    describe windows_feature('DHCP Server') do
+    describe windows_feature('DHCP') do
+      it{ should be_installed }
+    end
+
+### Test the IIS-WebServer feature using DISM
+
+    describe windows_feature('IIS-WebServer', DISM) do
+      it{ should be_installed }
+    end
+
+### Test the NetFx3 feature using DISM
+
+    describe windows_feature('NetFx3', :dism) do
       it{ should be_installed }
     end
 

--- a/lib/resources/windows_feature.rb
+++ b/lib/resources/windows_feature.rb
@@ -29,9 +29,6 @@ module Inspec::Resources
       @feature = feature
       @method = method
       @cache = nil
-
-      # verify that this resource is only supported on Windows
-      return skip_resource 'The `windows_feature` resource is not supported on your OS.' if !inspec.os.windows?
     end
 
     # returns true if the package is installed

--- a/lib/resources/windows_feature.rb
+++ b/lib/resources/windows_feature.rb
@@ -100,7 +100,7 @@ module Inspec::Resources
       # non-server OS. This attempts to use the `dism` command to get the info.
       if cmd.stderr =~ /The term 'Get-WindowsFeature' is not recognized/
         feature_info[:name] = feature
-        feature_info[:error] = cmd.stderr
+        feature_info[:error] = 'Could not find `Get-WindowsFeature`'
       else
         # We cannot rely on `cmd.exit_status != 0` because by default the
         # command will exit 1 even on success. So, if we cannot parse the JSON

--- a/lib/resources/windows_feature.rb
+++ b/lib/resources/windows_feature.rb
@@ -47,6 +47,9 @@ module Inspec::Resources
       when :powershell
         @cache = info_via_powershell(@feature)
         if @cache[:error]
+          # TODO: Allow handling `Inspec::Exception` outside of initialize
+          # See: https://github.com/inspec/inspec/issues/3237
+          # The below will fail the resource regardless of what is raised
           raise Inspec::Exceptions::ResourceFailed, @cache[:error]
         end
       when :dism

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -272,7 +272,9 @@ class MockLoader
       '(choco list --local-only --exact --include-programs --limit-output \'git\') -Replace "\|", "=" | ConvertFrom-StringData | ConvertTo-JSON' => empty.call,
       "New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Service -Value (Get-Service -Name 'dhcp'| Select-Object -Property Name, DisplayName, Status) -PassThru | Add-Member -MemberType NoteProperty -Name WMI -Value (Get-WmiObject -Class Win32_Service | Where-Object {$_.Name -eq 'dhcp' -or $_.DisplayName -eq 'dhcp'} | Select-Object -Property StartMode) -PassThru | ConvertTo-Json" => cmd.call('get-service-dhcp'),
       "New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name Pip -Value (Invoke-Command -ScriptBlock {where.exe pip}) -PassThru | Add-Member -MemberType NoteProperty -Name Python -Value (Invoke-Command -ScriptBlock {where.exe python}) -PassThru | ConvertTo-Json" => cmd.call('get-windows-pip-package'),
-      "Get-WindowsFeature | Where-Object {$_.Name -eq 'dhcp' -or $_.DisplayName -eq 'dhcp'} | Select-Object -Property Name,DisplayName,Description,Installed,InstallState | ConvertTo-Json" => cmd.call('get-windows-feature'),
+      "Get-WindowsFeature | Where-Object {$_.Name -eq 'DHCP' -or $_.DisplayName -eq 'DHCP'} | Select-Object -Property Name,DisplayName,Description,Installed,InstallState | ConvertTo-Json" => cmd.call('get-windows-feature'),
+      "Get-WindowsFeature | Where-Object {$_.Name -eq 'IIS-WebServer' -or $_.DisplayName -eq 'IIS-WebServer'} | Select-Object -Property Name,DisplayName,Description,Installed,InstallState | ConvertTo-Json" => cmd_exit_1.call('get-windows-feature-iis-webserver'),
+      "dism /online /get-featureinfo /featurename:IIS-WebServer" => cmd.call('dism-iis-webserver'),
       'lsmod' => cmd.call('lsmod'),
       '/sbin/sysctl -q -n net.ipv4.conf.all.forwarding' => cmd.call('sbin_sysctl'),
       # ports on windows

--- a/test/unit/mock/cmd/dism-iis-webserver
+++ b/test/unit/mock/cmd/dism-iis-webserver
@@ -1,0 +1,20 @@
+
+Deployment Image Servicing and Management tool
+Version: 10.0.16299.15
+
+Image Version: 10.0.16299.15
+
+Feature Information:
+
+Feature Name : IIS-WebServer
+Display Name : World Wide Web Services
+Description : Installs the IIS 10.0 World Wide Web Services. Provides support for HTML web sites and optional support for ASP.NET, Classic ASP, and web server extensions.
+Restart Required : Possible
+State : Disabled
+
+Custom Properties:
+
+(No custom properties found)
+
+The operation completed successfully.
+

--- a/test/unit/mock/cmd/get-windows-feature-iis-webserver
+++ b/test/unit/mock/cmd/get-windows-feature-iis-webserver
@@ -1,0 +1,7 @@
+The term 'Get-WindowsFeature' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
+At line:1 char:1
++ Get-WindowsFeature | Where-Object {$_.Name -eq 'IIS-Webserver' -or $_ ...
++ ~~~~~~~~~~~~~~~~~~
++ CategoryInfo          : ObjectNotFound: (Get-WindowsFeature:String) [], CommandNotFoundException
++ FullyQualifiedErrorId : CommandNotFoundException
+

--- a/test/unit/resources/windows_feature_test.rb
+++ b/test/unit/resources/windows_feature_test.rb
@@ -5,13 +5,29 @@
 require 'helper'
 require 'inspec/resource'
 
-describe 'Inspec::Resources::Feature' do
-  describe 'feature' do
-    it 'verify windows feature parsing' do
-      resource = MockLoader.new(:windows).load_resource('windows_feature', 'dhcp')
-      pkg = { name: 'DHCP', description: 'Dynamic Host Configuration Protocol (DHCP) Server enables you to centrally configure, manage, and provide temporary IP addresses and related information for client computers.', installed: false, type: 'windows-feature' }
-      _(resource.info).must_equal pkg
-      _(resource.installed?).must_equal false
-    end
+describe 'Inspec::Resources::WindowsFeature' do
+  it 'can retrieve feature info using Get-WindowsFeature' do
+    resource = MockLoader.new(:windows).load_resource('windows_feature', 'DHCP')
+    params = {
+      name: 'DHCP',
+      description: 'Dynamic Host Configuration Protocol (DHCP) Server enables you to centrally configure, manage, and provide temporary IP addresses and related information for client computers.',
+      installed: false,
+      type: 'windows-feature'
+    }
+    _(resource.info).must_equal params
+    _(resource.installed?).must_equal false
+  end
+
+  it 'uses DISM when Get-WindowsFeature does not exist' do
+    resource = MockLoader.new(:windows)
+                         .load_resource('windows_feature', 'IIS-WebServer')
+    params = {
+      name: 'IIS-WebServer',
+      description: 'Installs the IIS 10.0 World Wide Web Services. Provides support for HTML web sites and optional support for ASP.NET, Classic ASP, and web server extensions.',
+      installed: true,
+      type: 'dism'
+    }
+    _(resource.info).must_equal params
+    _(resource.installed?).must_equal true
   end
 end

--- a/test/unit/resources/windows_feature_test.rb
+++ b/test/unit/resources/windows_feature_test.rb
@@ -51,7 +51,7 @@ describe 'Inspec::Resources::WindowsFeature' do
     _(resource.installed?).must_equal true
   end
 
-  it 'fails the resource if PowerShell method is specified but command fails' do
+  it 'fails the resource if PowerShell method is used but command not found' do
     resource = MockLoader.new(:windows).load_resource(
       'windows_feature',
       'IIS-WebServer',
@@ -62,6 +62,6 @@ describe 'Inspec::Resources::WindowsFeature' do
       resource.info
     }.must_raise(Inspec::Exceptions::ResourceFailed)
 
-    e.message.must_match(/The term 'Get-WindowsFeature' is not recognized/)
+    e.message.must_match(/Could not find `Get-WindowsFeature`/)
   end
 end


### PR DESCRIPTION
This modifies the `windows_feature` resource to fallback to DISM when the `Get-WindowsFeature` command is not available.

This closes #3141 