### PR TITLE
Fix shell quoting in docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For Linux:
 
 ```
 docker pull chef/inspec
-function inspec { docker run -it --rm -v $(pwd):/share chef/inspec $@; }
+function inspec { docker run -it --rm -v $(pwd):/share chef/inspec "$@"; }
 ```
 
 For Windows (PowerShell):


### PR DESCRIPTION
This changes the use of `$@` to have double quotes, which avoids double
shell expansion of arguments to the function.

Example:
```
$ function tx { ls $@; }
$ tx a b
ls: cannot access 'a': No such file or directory
ls: cannot access 'b': No such file or directory
$ tx 'a b'
ls: cannot access 'a': No such file or directory
ls: cannot access 'b': No such file or directory
$ function tx { ls "$@"; }
$ tx a b
ls: cannot access 'a': No such file or directory
ls: cannot access 'b': No such file or directory
$ tx 'a b'
ls: cannot access 'a b': No such file or directory
$
```

Observe how in the corrected version the `'a b'` test case (a single
argument with a space inside) is handled correctly, while with the
original version the space is exposed to the shell, and the string
is broken up.

Signed-off-by: David Schmitt <david.schmitt@puppet.com>