### PR TITLE
Generate describe code for an array of strings

### DIFF
--- a/lib/inspec/objects/describe.rb
+++ b/lib/inspec/objects/describe.rb
@@ -11,7 +11,14 @@ module Inspec
       end
 
       def to_ruby
-        itsy = its.nil? ? 'it' : 'its(' + its.to_s.inspect + ')'
+        itsy = 'it'
+        unless its.nil?
+          if its.is_a? Array
+            itsy = 'its(' + its.inspect + ')'
+          else
+            itsy = 'its(' + its.to_s.inspect + ')'
+          end
+        end
         naughty = negated ? '_not' : ''
         xpect = if expectation.nil?
                   ''

--- a/test/unit/dsl/describe_test.rb
+++ b/test/unit/dsl/describe_test.rb
@@ -119,5 +119,15 @@ describe "unknown object" do
 end
 '.strip
     end
+
+    it 'constructs a test with an array of strings' do
+      obj.qualifier = [['resource']]
+      obj.add_test(['explorer', 'exe'], 'cmp', 1)
+      obj.to_ruby.must_equal '
+describe resource do
+  its(["explorer", "exe"]) { should cmp 1 }
+end
+'.strip
+    end
   end
 end


### PR DESCRIPTION
Context:
When testing a Windows registry key with a period character in it e.g. `explorer.exe` it is not possible to use `its("explorer.exe")` because the period would be interpreted as method chaining.
In this case, you must instead use `its(["explorer", "exe"])`
See https://github.com/inspec/inspec/issues/1281

This commit fixes `to_ruby`in `Inspec::Describe` so that it produces an array in the generated Inspec code instead of a string.

Signed-off-by: James Stocks <jstocks@chef.io>