### PR TITLE
Ensure resources fail that target something that isn't supported

### DIFF
--- a/lib/inspec/plugins/resource.rb
+++ b/lib/inspec/plugins/resource.rb
@@ -90,8 +90,8 @@ module Inspec
 
         def check_supports
           status = inspec.platform.supported?(@supports)
-          skip_msg = "Resource #{@__resource_name__.capitalize} is not supported on platform #{inspec.platform.name}/#{inspec.platform.release}."
-          skip_resource(skip_msg) unless status
+          fail_msg = "Resource #{@__resource_name__.capitalize} is not supported on platform #{inspec.platform.name}/#{inspec.platform.release}."
+          fail_resource(fail_msg) unless status
           status
         end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -146,8 +146,8 @@ Test Summary: 0 successful, 0 failures, 0 skipped
       stdout.must_include 'Resource Aws_iam_users is not supported on platform'
       stdout.must_include 'Resource Aws_iam_access_keys is not supported on platform'
       stdout.must_include 'Resource Aws_s3_bucket is not supported on platform'
-      stdout.must_include '3 skipped'
-      out.exit_status.must_equal 101
+      stdout.must_include '3 failures'
+      out.exit_status.must_equal 100
     end
   end
 

--- a/test/unit/resources/crontab_test.rb
+++ b/test/unit/resources/crontab_test.rb
@@ -155,9 +155,9 @@ describe 'Inspec::Resources::Crontab' do
   end
 
   describe 'it raises errors' do
-    it 'raises error on unsupported os' do
+    it 'fails and raises error on unsupported os' do
       resource = MockLoader.new(:windows).load_resource('crontab', { user: 'special' })
-      _(resource.resource_skipped?).must_equal true
+      _(resource.resource_failed?).must_equal true
       _(resource.resource_exception_message)
         .must_equal 'Resource Crontab is not supported on platform windows/6.2.9200.'
     end

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -147,9 +147,9 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   describe 'it raises errors' do
-    it 'raises error on unsupported os' do
+    it 'fails and raises error on unsupported os' do
       resource = MockLoader.new(:windows).load_resource('shadow')
-      _(resource.resource_skipped?).must_equal true
+      _(resource.resource_failed?).must_equal true
       _(resource.resource_exception_message)
         .must_equal 'Resource Shadow is not supported on platform windows/6.2.9200.'
     end

--- a/test/unit/resources/virtualization_test.rb
+++ b/test/unit/resources/virtualization_test.rb
@@ -6,9 +6,9 @@ require 'inspec/resource'
 describe 'Inspec::Resources::Virtualization' do
   let(:resource) { MockLoader.new(:ubuntu).load_resource('virtualization') }
 
-  it 'skips the resource if OS is not Linux' do
+  it 'fails the resource if OS is not Linux' do
     resource = MockLoader.new(:windows).load_resource('virtualization')
-    resource.resource_skipped?.must_equal true
+    resource.resource_failed?.must_equal true
   end
 
   it 'returns nil for all properties if no virutalization platform is found' do

--- a/test/unit/resources/wmi_test.rb
+++ b/test/unit/resources/wmi_test.rb
@@ -25,7 +25,7 @@ describe 'Inspec::Resources::WMI' do
   # ubuntu 14.04 with upstart
   it 'fail wmi on ubuntu' do
     resource = MockLoader.new(:ubuntu1404).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
-    _(resource.resource_skipped?).must_equal true
+    _(resource.resource_failed?).must_equal true
     _(resource.resource_exception_message)
       .must_equal 'Resource Wmi is not supported on platform ubuntu/14.04.'
   end


### PR DESCRIPTION
This PR Implements one task from our skip overhaul where we will now fail rather than skip on a unsupported platform. 

ref: https://github.com/inspec/inspec/issues/3158