### PR TITLE
Update hab package to use psql client

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -24,7 +24,7 @@ pkg_deps=(
   core/less
   core/mysql-client
   core/netcat
-  core/postgresql
+  core/postgresql-client
 )
 pkg_build_deps=(
   core/gcc


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This change updates the hab plan to use the postgresql-client. This should limit the version difference upstream.

https://bldr.habitat.sh/#/pkgs/core/postgresql-client/latest