### PR TITLE
Add extra fault checking to git fetcher

### DIFF
--- a/lib/fetchers/git.rb
+++ b/lib/fetchers/git.rb
@@ -83,7 +83,9 @@ module Fetchers
     end
 
     def resolve_ref(ref_name)
-      cmd = shellout("git ls-remote \"#{@remote_url}\" \"#{ref_name}*\"")
+      command_string = "git ls-remote \"#{@remote_url}\" \"#{ref_name}*\""
+      cmd = shellout(command_string)
+      raise "Error running '#{command_string}': #{cmd.stderr}" unless cmd.stderr == ''
       ref = parse_ls_remote(cmd.stdout, ref_name)
       if !ref
         raise "Unable to resolve #{ref_name} to a specific git commit for #{@remote_url}"


### PR DESCRIPTION
Raise with the stderr from `git ls-remote` if stderr is not empty.
This is useful when inspec runs in CI and you do not have direct control/troublshooting options.

Signed-off-by: James Stocks <jstocks@chef.io>