### PR TITLE
Add link to cookie policy

### DIFF
--- a/www/source/layouts/_footer.slim
+++ b/www/source/layouts/_footer.slim
@@ -18,7 +18,7 @@ footer#main-footer.dark-bg
           a.footer--logo.inspec href="/"
             img src="/images/inspec-by-chef-logo.png" alt="logo for InSpec"
         li
-          a.footer--logo.chef href="http://www.chef.io"
+          a.footer--logo.chef href="https://www.chef.io"
               img src="/images/chef-logo.png" alt="logo for Chef Software"
 
     .columns.large-8.medium-8
@@ -31,6 +31,8 @@ footer#main-footer.dark-bg
           a.link.footer--link href="/legal/trademark-policy" Trademark Policy
         li
           a.link.footer--link href="/legal/privacy-policy" Privacy Policy
+        li
+          a.link.footer--link href="https://www.chef.io/cookie-policy/" Cookie Policy
 
 
       //logos for mobile


### PR DESCRIPTION
This change adds a link to the Chef cookie policy, and updates a Chef URL to use https.

Signed-off-by: Christian Nunciato <chris@nunciato.org>