### PR TITLE
Update hab plan for hab 0.56+

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -43,7 +43,7 @@ do_prepare() {
 
 do_unpack() {
   mkdir -pv "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  cp -R "$PLAN_CONTEXT"/../ "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  cp -RT "$PLAN_CONTEXT"/.. "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
 }
 
 do_build() {


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This fixes the CP issue with new versions of habitat. You can find more info here:
https://forums.habitat.sh/t/cannot-find-gemspec-file-after-upgrade/717