### PR TITLE
cli: Downcase supermarket tool name to match URL

### DIFF
--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -48,7 +48,9 @@ module Supermarket
     # compares a profile with the supermarket tool info
     def self.same?(profile, supermarket_tool, supermarket_url = SUPERMARKET_URL)
       tool_owner, tool_name = profile_name(profile)
-      tool = "#{supermarket_url}/api/v1/tools/#{tool_name}"
+
+      # Tool name in Supermarket URL is downcased so we need to downcase
+      tool = "#{supermarket_url}/api/v1/tools/#{tool_name.downcase}"
       supermarket_tool['tool_owner'] == tool_owner && supermarket_tool['tool'] == tool
     end
 

--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -50,6 +50,8 @@ module Supermarket
     def self.same?(profile, supermarket_tool, supermarket_url = SUPERMARKET_URL)
       tool_owner, tool_name = profile_name(profile)
 
+      raise "Could not parse tool name from #{profile}" if tool_name.nil?
+
       # Tool name in Supermarket URL is downcased so we need to downcase
       tool = "#{supermarket_url}/api/v1/tools/#{tool_name.downcase}"
       supermarket_tool['tool_owner'] == tool_owner && supermarket_tool['tool'] == tool

--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -38,7 +38,8 @@ module Supermarket
     def self.info(profile, supermarket_url = SUPERMARKET_URL)
       _tool_owner, tool_name = profile_name("supermarket://#{profile}")
       return if tool_name.nil? || tool_name.empty?
-      url = "#{supermarket_url}/api/v1/tools/#{tool_name}"
+      # Tool name in Supermarket URL is downcased so we need to downcase
+      url = "#{supermarket_url}/api/v1/tools/#{tool_name.downcase}"
       _success, data = get(url, {})
       JSON.parse(data) if !data.nil?
     rescue JSON::ParserError

--- a/test/unit/bundles/inspec-supermarket/api_test.rb
+++ b/test/unit/bundles/inspec-supermarket/api_test.rb
@@ -139,6 +139,15 @@ describe Supermarket::API do
 
           profile.must_equal(profile_search_response_body['items'].first.merge({'slug' => 'test_name'}))
         end
+
+        it 'raises an error if tool name is not present' do
+          profile_name = 'supermarket://owner_only'
+          stub_request(:get, "#{supermarket_url}/api/v1/tools-search?items=100&type=compliance_profile").
+              to_return(:status => 200, :body => profile_search_response_body.to_json)
+
+          e = proc { subject.find(profile_name, supermarket_url) }.must_raise
+          e.message.must_equal("Could not parse tool name from #{profile_name}")
+        end
       end
     end
   end

--- a/test/unit/bundles/inspec-supermarket/api_test.rb
+++ b/test/unit/bundles/inspec-supermarket/api_test.rb
@@ -125,6 +125,20 @@ describe Supermarket::API do
 
           profile.must_equal(profile_search_response_body['items'].first.merge({'slug' => 'test_name'}))
         end
+
+        it 'downcases profile name for Supermarket API URL' do
+          profile_name = 'supermarket://test_owner/Test_Name'
+          stub_request(:get, "#{supermarket_url}/api/v1/tools-search?items=100&type=compliance_profile").
+              to_return(:status => 200, :body => profile_search_response_body.to_json)
+
+          profile = if default_url?(supermarket_url)
+                      subject.find(profile_name)
+                    else
+                      subject.find(profile_name, supermarket_url)
+                    end
+
+          profile.must_equal(profile_search_response_body['items'].first.merge({'slug' => 'test_name'}))
+        end
       end
     end
   end


### PR DESCRIPTION
This downcases the user provided tool name. Without this fetching the profile will fail because the Supermarket API downcases in the URL.
