### PR TITLE
Since /proc/xen is an empty dir in Amazon Linux, inspec falsely detects docker instances as platform='xen'

### DIFF
--- a/lib/resources/virtualization.rb
+++ b/lib/resources/virtualization.rb
@@ -67,15 +67,15 @@ module Inspec::Resources
     # - Additional edge cases likely should not change the above assumptions
     #   but rather be additive - btm
     def detect_xen
-      return false unless inspec.file('/proc/xen').exist?
-      @virtualization_data[:system] = 'xen'
-      @virtualization_data[:role] = 'guest'
-
       # This file should exist on most Xen systems, normally empty for guests
-      if inspec.file('/proc/xen/capabilities').exist? &&
-          inspec.file('/proc/xen/capabilities').content =~ /control_d/i # rubocop:disable Layout/MultilineOperationIndentation
+      return false unless inspec.file('/proc/xen/capabilities').exist?
+      @virtualization_data[:system] = 'xen'
+      if inspec.file('/proc/xen/capabilities').content =~ /control_d/i # rubocop:disable Layout/MultilineOperationIndentation
         @virtualization_data[:role] = 'host'
+      else
+        @virtualization_data[:role] = 'guest'
       end
+
       true
     end
 

--- a/lib/resources/virtualization.rb
+++ b/lib/resources/virtualization.rb
@@ -70,7 +70,7 @@ module Inspec::Resources
       # This file should exist on most Xen systems, normally empty for guests
       return false unless inspec.file('/proc/xen/capabilities').exist?
       @virtualization_data[:system] = 'xen'
-      if inspec.file('/proc/xen/capabilities').content =~ /control_d/i # rubocop:disable Layout/MultilineOperationIndentation
+      if inspec.file('/proc/xen/capabilities').content =~ /control_d/i
         @virtualization_data[:role] = 'host'
       else
         @virtualization_data[:role] = 'guest'


### PR DESCRIPTION
This was already noted in the comments, albeit for EL6. Since the code already checks `/proc/xen/capabilities` to determine if it's a Xen host vs Xen guest, use that more specific test to `set virtualization_data[:system] = 'xen'`