### PR TITLE
Enable inspec archive, check, and json to run as unpriveleged user

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -67,6 +67,8 @@ module Inspec
     def self.profile_options
       option :profiles_path, type: :string,
         desc: 'Folder which contains referenced profiles.'
+      option :vendor_cache, type: :string,
+        desc: 'Use the given path for caching dependencies. (default: ~/.inspec/cache)'
     end
 
     def self.exec_options
@@ -83,8 +85,6 @@ module Inspec
         desc: 'Use colors in output.'
       option :attrs, type: :array,
         desc: 'Load attributes file (experimental)'
-      option :vendor_cache, type: :string,
-        desc: 'Use the given path for caching dependencies. (default: ~/.inspec/cache)'
       option :create_lockfile, type: :boolean,
         desc: 'Write out a lockfile based on this execution (unless one already exists)'
       option :backend_cache, type: :boolean,

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -37,6 +37,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     o[:ignore_supports] = true
     o[:backend] = Inspec::Backend.create(target: 'mock://')
     o[:check_mode] = true
+    o[:vendor_cache] = Inspec::Cache.new(o[:vendor_cache])
 
     profile = Inspec::Profile.for_target(target, o)
     info = profile.info
@@ -70,6 +71,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     o[:ignore_supports] = true # we check for integrity only
     o[:backend] = Inspec::Backend.create(target: 'mock://')
     o[:check_mode] = true
+    o[:vendor_cache] = Inspec::Cache.new(o[:vendor_cache])
 
     # run check
     profile = Inspec::Profile.for_target(path, o)
@@ -140,6 +142,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     o[:logger] = Logger.new(STDOUT)
     o[:logger].level = get_log_level(o.log_level)
     o[:backend] = Inspec::Backend.create(target: 'mock://')
+    o[:vendor_cache] = Inspec::Cache.new(o[:vendor_cache])
 
     profile = Inspec::Profile.for_target(path, o)
     result = profile.check

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -34,7 +34,6 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   def json(target)
     o = opts.dup
     diagnose(o)
-    o[:ignore_supports] = true
     o[:backend] = Inspec::Backend.create(target: 'mock://')
     o[:check_mode] = true
     o[:vendor_cache] = Inspec::Cache.new(o[:vendor_cache])
@@ -68,7 +67,6 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   def check(path) # rubocop:disable Metrics/AbcSize
     o = opts.dup
     diagnose(o)
-    o[:ignore_supports] = true # we check for integrity only
     o[:backend] = Inspec::Backend.create(target: 'mock://')
     o[:check_mode] = true
     o[:vendor_cache] = Inspec::Cache.new(o[:vendor_cache])

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -39,7 +39,6 @@ module Inspec
       @target_profiles = []
       @controls = @conf[:controls] || []
       @depends = @conf[:depends] || []
-      @ignore_supports = @conf[:ignore_supports]
       @create_lockfile = @conf[:create_lockfile]
       @cache = Inspec::Cache.new(@conf[:vendor_cache])
 
@@ -196,8 +195,6 @@ module Inspec
     end
 
     def supports_profile?(profile)
-      return true if @ignore_supports
-
       if !profile.supports_runtime?
         raise 'This profile requires InSpec version '\
              "#{profile.metadata.inspec_requirement}. You are running "\

--- a/test/functional/inspec_check_test.rb
+++ b/test/functional/inspec_check_test.rb
@@ -4,6 +4,7 @@
 
 require 'functional/helper'
 require 'jsonschema'
+require 'tmpdir'
 
 describe 'inspec check' do
   include FunctionalHelper
@@ -48,6 +49,20 @@ describe 'inspec check' do
     it 'ignore train connection error' do
       out = inspec('check ' + File.join(examples_path, 'profile-azure'))
       out.exit_status.must_equal 0
+    end
+  end
+
+  describe 'inspec check with alternate cache dir' do
+    it 'writes to the alternate cache dir' do
+      Dir.mktmpdir do |tmpdir|
+        cache_dir = File.join(tmpdir, "inspec_check_test_cache")
+
+        File.exist?(cache_dir).must_equal false
+        out = inspec('check ' + integration_test_path + ' --vendor-cache ' + cache_dir)
+        out.exit_status.must_equal 0
+
+        File.exist?(cache_dir).must_equal true
+      end
     end
   end
 end


### PR DESCRIPTION
Hello,

I'm trying to run inspec archive, check, and json with an unprivileged user and it's failing because inspec expects to be able to write to a directory it doesn't have permission to. Here is an example of what I'm attempting and the error message I get:

```
vagrant@ubuntu-xenial:~/inspec$ sudo -u nobody ~/inspec/bin/inspec check ~/naughty_profile-0.1.0.tar.gz
/usr/lib/ruby/2.3.0/fileutils.rb:253:in `mkdir': Permission denied @ dir_s_mkdir - /home/vagrant/.inspec (Errno::EACCES)
        from /usr/lib/ruby/2.3.0/fileutils.rb:253:in `fu_mkdir'
        from /usr/lib/ruby/2.3.0/fileutils.rb:227:in `block (2 levels) in mkdir_p'
        from /usr/lib/ruby/2.3.0/fileutils.rb:225:in `reverse_each'
        from /usr/lib/ruby/2.3.0/fileutils.rb:225:in `block in mkdir_p'
        from /usr/lib/ruby/2.3.0/fileutils.rb:211:in `each'
        from /usr/lib/ruby/2.3.0/fileutils.rb:211:in `mkdir_p'
        from /home/vagrant/inspec/lib/inspec/dependencies/cache.rb:22:in `initialize'
        from /home/vagrant/inspec/lib/inspec/profile.rb:76:in `new'
        from /home/vagrant/inspec/lib/inspec/profile.rb:76:in `for_target'
        from /home/vagrant/inspec/lib/inspec/cli.rb:75:in `check'
        from /var/lib/gems/2.3.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
        from /var/lib/gems/2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
        from /var/lib/gems/2.3.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
        from /var/lib/gems/2.3.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
        from /home/vagrant/inspec/bin/inspec:12:in `<main>'
```

The exec command had an option, `--vendor-cache`, that allowed specifying where inspec should store things needed during processing, so I made that code work properly for the other commands.

On this branch the above example succeeds:

```
vagrant@ubuntu-xenial:~/inspec$ sudo -u nobody ./bin/inspec check ~/naughty_profile-0.1.0.tar.gz --vendor-cache=/tmp
Location:    /home/vagrant/naughty_profile-0.1.0.tar.gz
Profile:     naughty_profile
Controls:    0
Timestamp:   2018-07-31T01:38:20+00:00
Valid:       true

  !  No controls or tests were defined.

Summary:     0 errors, 1 warnings
```

I did not add any tests for the changed commands because I did not see any similar ones for the exec command, so I assumed these wouldn't be necessary.

I added the second commit because adding one line of code to the check method pushed it over the line length limit of the linter. I'd be happy to submit that code as a separate PR.