### PR TITLE
Populate report code for merged controls

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -531,6 +531,17 @@ module Inspec
         source_location: location,
       }
 
+      # try and grab code text from merge locations
+      if controls[id][:code].empty? && Inspec::Rule.merge_count(rule) > 0
+        Inspec::Rule.merge_changes(rule).each do |location|
+          code = Inspec::MethodSource.code_at(location, source_reader)
+          if !code.empty?
+            controls[id][:code] = code
+            break
+          end
+        end
+      end
+
       groups[file] ||= {
         title: rule.instance_variable_get(:@__group_title),
         controls: [],

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -533,8 +533,8 @@ module Inspec
 
       # try and grab code text from merge locations
       if controls[id][:code].empty? && Inspec::Rule.merge_count(rule) > 0
-        Inspec::Rule.merge_changes(rule).each do |location|
-          code = Inspec::MethodSource.code_at(location, source_reader)
+        Inspec::Rule.merge_changes(rule).each do |merge_location|
+          code = Inspec::MethodSource.code_at(merge_location, source_reader)
           if !code.empty?
             controls[id][:code] = code
             break

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -44,6 +44,7 @@ module Inspec
       @__checks = []
       @__skip_rule = nil
       @__merge_count = 0
+      @__merge_changes = []
       @__skip_only_if_eval = opts[:skip_only_if_eval]
 
       # evaluate the given definition
@@ -181,6 +182,10 @@ module Inspec
       rule.instance_variable_get(:@__merge_count)
     end
 
+    def self.merge_changes(rule)
+      rule.instance_variable_get(:@__merge_changes)
+    end
+
     def self.prepare_checks(rule)
       msg = skip_status(rule)
       return checks(rule) unless msg
@@ -211,12 +216,6 @@ module Inspec
       dst.tag(src.tag)       unless src.tag.nil?
       dst.ref(src.ref)       unless src.ref.nil?
 
-      # use the most recent source location
-      dst.instance_variable_set(
-        :@__source_location,
-        src.instance_variable_get(:@__source_location),
-      )
-
       # merge indirect fields
       # checks defined in the source will completely eliminate
       # all checks that were defined in the destination
@@ -224,8 +223,13 @@ module Inspec
       dst.instance_variable_set(:@__checks, sc) unless sc.empty?
       sr = skip_status(src)
       set_skip_rule(dst, sr) unless sr.nil?
-      # increment merge count
+
+      # Save merge history
       dst.instance_variable_set(:@__merge_count, merge_count(dst) + 1)
+      dst.instance_variable_set(
+        :@__merge_changes,
+        merge_changes(dst) << src.instance_variable_get(:@__source_location)
+      )
     end
 
     private

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -228,7 +228,7 @@ module Inspec
       dst.instance_variable_set(:@__merge_count, merge_count(dst) + 1)
       dst.instance_variable_set(
         :@__merge_changes,
-        merge_changes(dst) << src.instance_variable_get(:@__source_location)
+        merge_changes(dst) << src.instance_variable_get(:@__source_location),
       )
     end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -380,6 +380,7 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
     let(:json) { JSON.load(out.stdout) }
     let(:controls) { json['profiles'][0]['controls'] }
     let(:child_profile) { json['profiles'].select { |p| p['name'] == 'myprofile1' }.first }
+    let(:child_control) { child_profile['controls'].select { |c| c['title'] == 'Profile 1 - Control 2-updated' }.first }
     let(:override) { controls.select { |c| c['title'] == 'Profile 1 - Control 2-updated' }.first }
 
     it 'completes the run with failed controls but no exception' do
@@ -395,6 +396,10 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
       tags_assert = {"password"=>nil, "password-updated"=>nil}
       override['tags'].must_equal tags_assert
       child_profile['parent_profile'].must_equal 'wrapper-override'
+
+      # check for original code on child profile
+      assert = "control 'pro1-con2' do\n  impact 0.9\n  title 'Profile 1 - Control 2'\n  desc 'Profile 1 - Control 2 description'\n  tag 'password'\n  describe file('/etc/passwdddddddddd') do\n    it { should exist }\n  end\nend\n"
+      child_control['code'].must_equal assert
     end
   end
 


### PR DESCRIPTION
This PR populates the code fields found in the various json reports when a control merge happens. This change allows us to see the various code definitions of a control during its merge state.

Fixes https://github.com/inspec/inspec/issues/3250