### PR TITLE
Update `only_if` to allow user specified messages.

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -174,8 +174,9 @@ module Inspec
       rule.instance_variable_get(:@__skip_rule)
     end
 
-    def self.set_skip_rule(rule, value)
-      rule.instance_variable_set(:@__skip_rule, { result: value })
+    def self.set_skip_rule(rule, value, message = nil)
+      rule.instance_variable_set(:@__skip_rule,
+                                 { result: value, message: message })
     end
 
     def self.merge_count(rule)

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -117,7 +117,7 @@ module Inspec
     #
     # @param [Type] &block returns true if tests are added, false otherwise
     # @return [nil]
-    def only_if(message=nil)
+    def only_if(message = nil)
       return unless block_given?
       return if @__skip_only_if_eval == true
 
@@ -175,7 +175,7 @@ module Inspec
     end
 
     def self.set_skip_rule(rule, value)
-      rule.instance_variable_set(:@__skip_rule, value)
+      rule.instance_variable_set(:@__skip_rule, { result: value })
     end
 
     def self.merge_count(rule)
@@ -184,8 +184,8 @@ module Inspec
 
     def self.prepare_checks(rule)
       msg = skip_status(rule)
-      return checks(rule) unless msg.eql?(true) || msg[:result]
-      if msg.eql?(true) || msg[:message].nil?
+      return checks(rule) unless msg[:result].eql?(true)
+      if msg[:result].eql?(true) && msg[:message].nil?
         msg = 'Skipped control due to only_if condition.'
       else
         msg = "Skipped control due to only_if condition: #{msg[:message]}"

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -187,15 +187,15 @@ module Inspec
       skip_check = skip_status(rule)
       return checks(rule) unless skip_check[:result].eql?(true)
       if skip_check[:message]
-        skip_check = "Skipped control due to only_if condition: #{skip_check[:message]}"
+        msg = "Skipped control due to only_if condition: #{skip_check[:message]}"
       else
-        skip_check = 'Skipped control due to only_if condition.'
+        msg = 'Skipped control due to only_if condition.'
       end
 
       # TODO: we use os as the carrier here, but should consider
       # a separate resource to do skipping
       resource = rule.os
-      resource.skip_resource(skip_check)
+      resource.skip_resource(msg)
       [['describe', [resource], nil]]
     end
 

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -184,18 +184,18 @@ module Inspec
     end
 
     def self.prepare_checks(rule)
-      msg = skip_status(rule)
-      return checks(rule) unless msg[:result].eql?(true)
-      if msg[:result].eql?(true) && msg[:message].nil?
-        msg = 'Skipped control due to only_if condition.'
+      skip_check = skip_status(rule)
+      return checks(rule) unless skip_check[:result].eql?(true)
+      if skip_check[:message]
+        skip_check = "Skipped control due to only_if condition: #{skip_check[:message]}"
       else
-        msg = "Skipped control due to only_if condition: #{msg[:message]}"
+        skip_check = 'Skipped control due to only_if condition.'
       end
 
       # TODO: we use os as the carrier here, but should consider
       # a separate resource to do skipping
       resource = rule.os
-      resource.skip_resource(msg)
+      resource.skip_resource(skip_check)
       [['describe', [resource], nil]]
     end
 

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -117,6 +117,7 @@ describe Inspec::ProfileContext do
     describe 'global only_if' do
       let(:if_true) { "only_if { true }\n" }
       let(:if_false) { "only_if { false }\n" }
+      let(:if_false_message) { "only_if('if_false_message skipped') { false }\n" }
       let(:describe) { "describe nil do its(:to_i) { should eq rand } end\n" }
       let(:control) { "control 1 do\n#{describe}\nend\n" }
       let(:control_2) { "control 2 do\n#{describe}\nend\n" }
@@ -177,6 +178,14 @@ describe Inspec::ProfileContext do
         get_checks.length.must_equal 1
         get_checks[0][1][0].resource_skipped?.must_equal true
         get_checks[0][1][0].resource_exception_message.must_equal 'Skipped control due to only_if condition.'
+        get_checks[0][1][0].resource_failed?.must_equal false
+      end
+
+      it 'allows specifying a message with true only_if' do
+        profile.load(if_false_message + control)
+        get_checks.length.must_equal 1
+        get_checks[0][1][0].resource_skipped?.must_equal true
+        get_checks[0][1][0].resource_exception_message.must_equal 'Skipped control due to only_if condition: if_false_message skipped'
         get_checks[0][1][0].resource_failed?.must_equal false
       end
 

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -117,7 +117,6 @@ describe Inspec::ProfileContext do
     describe 'global only_if' do
       let(:if_true) { "only_if { true }\n" }
       let(:if_false) { "only_if { false }\n" }
-      let(:if_false_message) { "only_if('if_false_message skipped') { false }\n" }
       let(:describe) { "describe nil do its(:to_i) { should eq rand } end\n" }
       let(:control) { "control 1 do\n#{describe}\nend\n" }
       let(:control_2) { "control 2 do\n#{describe}\nend\n" }
@@ -182,10 +181,11 @@ describe Inspec::ProfileContext do
       end
 
       it 'allows specifying a message with true only_if' do
-        profile.load(if_false_message + control)
+        profile.load("only_if('this is a only_if skipped message') { false }\n" + control)
         get_checks.length.must_equal 1
         get_checks[0][1][0].resource_skipped?.must_equal true
-        get_checks[0][1][0].resource_exception_message.must_equal 'Skipped control due to only_if condition: if_false_message skipped'
+        get_checks[0][1][0].resource_exception_message.must_equal 'Skipped' \
+         ' control due to only_if condition: this is a only_if skipped message'
         get_checks[0][1][0].resource_failed?.must_equal false
       end
 


### PR DESCRIPTION
Updates only_if to allow a user to specify a message to say why it was skipped. If the user does not supply a message the default
message is used.

```
control 'nutcracker-connect-redis-001' do
  impact 1.0
  title 'Check if nutcracker can pass commands to redis'
  desc 'execute redis-cli set key command, to check connectivity of the service'

  only_if('redis is not installed.') do
    command('redis-cli').exist?
  end

  describe command('redis-cli SET test_inspec "HELLO"') do
    its(:stdout) { should match(/OK/) }
  end
end
```

```
  ↺  nutcracker-connect-redis-001: Check if nutcracker can pass commands to redis
     ↺  Skipped control due to only_if condition: redis is not installed.
```

Ref: https://github.com/inspec/inspec/issues/3158
Signed-off-by: Miah Johnson <miah@chia-pet.org>

Fixes: https://github.com/inspec/inspec/issues/1900