### PR TITLE
Add support in aws_route_table to allow 17 hexadecimal characters

### DIFF
--- a/lib/resources/aws/aws_route_table.rb
+++ b/lib/resources/aws/aws_route_table.rb
@@ -3,7 +3,7 @@ class AwsRouteTable < Inspec.resource(1)
   desc 'Verifies settings for an AWS Route Table'
   example "
     describe aws_route_table do
-      its('route_table_id') { should cmp 'rtb-2c60ec44' }
+      its('route_table_id') { should cmp 'rtb-05462d2278326a79c' }
     end
   "
   supports platform: 'aws'
@@ -27,10 +27,10 @@ class AwsRouteTable < Inspec.resource(1)
     )
 
     if validated_params.key?(:route_table_id) &&
-       validated_params[:route_table_id] !~ /^rtb\-[0-9a-f]{8}$/
+       validated_params[:route_table_id] !~ /^rtb\-([0-9a-f]{17})|(^rtb\-[0-9a-f]{8})$/
       raise ArgumentError,
             'aws_route_table Route Table ID must be in the' \
-            ' format "rtb-" followed by 8 hexadecimal characters.'
+            ' format "rtb-" followed by 8 or 17 hexadecimal characters.'
     end
 
     validated_params

--- a/test/unit/resources/aws_route_table_test.rb
+++ b/test/unit/resources/aws_route_table_test.rb
@@ -20,7 +20,7 @@ class BasicAwsRouteTableTest2 < Minitest::Test
   end
 
   def test_search_hit
-    assert AwsRouteTable.new('rtb-2c60ec44').exists?
+    assert AwsRouteTable.new('rtb-05462d2278326a79c').exists?
     assert AwsRouteTable.new('rtb-58508630').exists?
 
     # not hexadecimal
@@ -48,7 +48,7 @@ module AwsMRtbB
       fixtures = [
         OpenStruct.new({associations: [],
                           propagating_vgws: [],
-                          route_table_id: 'rtb-2c60ec44',
+                          route_table_id: 'rtb-05462d2278326a79c',
                           routes: [
                             {destination_cidr_block: '172.32.1.0/24', gateway_id: 'igw-4fb9e626', origin: 'CreateRoute', state: 'active'},
                             {destination_cidr_block: '172.31.0.0/16', gateway_id: 'local', origin: 'CreateRouteTable', state: 'active'}

--- a/test/unit/resources/aws_route_tables_test.rb
+++ b/test/unit/resources/aws_route_tables_test.rb
@@ -38,7 +38,7 @@ class BasicAwsRouteTablesTest2 < Minitest::Test
   def test_property_route_table_ids
     basic = AwsRouteTables.new
     assert_kind_of(Array, basic.route_table_ids)
-    assert(basic.route_table_ids.include?('rtb-2c60ec44'))
+    assert(basic.route_table_ids.include?('rtb-05462d2278326a79c'))
     assert(basic.route_table_ids.include?('rtb-58508630'))
     refute(basic.route_table_ids.include?(nil))
   end
@@ -56,7 +56,7 @@ module AwsMRtbB
     def describe_route_tables(query)
       fixtures = [
         OpenStruct.new({
-                          route_table_id: 'rtb-2c60ec44',
+                          route_table_id: 'rtb-05462d2278326a79c',
                           vpc_id: 'vpc-169f777e'
         }),
         OpenStruct.new({


### PR DESCRIPTION
Signed-off-by: Ksenia Chistova <kchistova@gmail.com>

Fixes #3269 