### PR TITLE
Error cleanly if a reporter errors while rendering

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -107,7 +107,8 @@ module Inspec
       return if @conf['reporter'].nil?
 
       @conf['reporter'].each do |reporter|
-        Inspec::Reporters.render(reporter, run_data)
+        result = Inspec::Reporters.render(reporter, run_data)
+        raise Inspec::ReporterError, "Error generating reporter '#{reporter[0]}'" if result == false
       end
     end
 

--- a/test/functional/inspec_exec_automate.rb
+++ b/test/functional/inspec_exec_automate.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+
+require 'functional/helper'
+require 'tempfile'
+
+describe 'inspec exec automate' do
+  include FunctionalHelper
+
+  let(:json_file) do
+    file = Tempfile.new('json.conf')
+    json = <<~EOF
+    {
+    "reporter": {
+        "automate" : {
+            "stdout" : false,
+            "url" : "https://fake_url_a2.com/data-collector/v0/",
+            "token" : "faketoken123",
+            "insecure" : true
+            }
+        }
+    }
+    EOF
+
+    file.write(json)
+    file.close
+    file.path
+  end
+
+  it 'fails when trying to send a report to a fake url' do
+    out = inspec('exec ' + example_profile  + ' --no-create-lockfile --json-config ' + json_file)
+    out.stderr.must_equal "Error generating reporter 'automate'\n"
+    out.exit_status.must_equal 1
+    stdout = out.stdout.force_encoding(Encoding::UTF_8)
+    stdout.must_include "ERROR: send_report: POST to /data-collector/v0/"
+  end
+end

--- a/test/functional/inspec_exec_automate.rb
+++ b/test/functional/inspec_exec_automate.rb
@@ -1,6 +1,4 @@
 # encoding: utf-8
-# author: Dominik Richter
-# author: Christoph Hartmann
 
 require 'functional/helper'
 require 'tempfile'


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This change updates the reporter code to error if one of the reporters fails to render/send.

Before:
```
jquick@Jareds-MBP:~/Chef/inspec/_test
(master)> _inspec exec ssh-baseline-2.2.0/ --json-config config2.json
[2018-08-08T09:48:52-04:00] ERROR: send_report: POST to /data-collector/v0/ returned: Failed to open TCP connection to xa2-local-inplace-upgrade-dev.cd.chef.co:443 (getaddrinfo: nodename nor servname provided, or not known)

jquick@Jareds-MBP:~/Chef/inspec/_test
(master)> echo $?
100
```
After:
```
jquick@Jareds-MBP:~/Chef/inspec/_test
(master)> _inspec exec ssh-baseline-2.2.0/ --json-config config2.json
[2018-08-08T09:49:02-04:00] ERROR: send_report: POST to /data-collector/v0/ returned: Failed to open TCP connection to xa2-local-inplace-upgrade-dev.cd.chef.co:443 (getaddrinfo: nodename nor servname provided, or not known)
Error generating reporter 'automate'

jquick@Jareds-MBP:~/Chef/inspec/_test
(master)> echo $?
1
```

Fixes https://github.com/inspec/inspec/issues/3272

