### PR TITLE
Allow the jsonAutomate report to be executed from cli

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -168,7 +168,7 @@ module Inspec
         'documentation',
         'html',
         'json',
-        'json-merged',
+        'json-automate',
         'json-min',
         'json-rspec',
         'junit',

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -168,6 +168,7 @@ module Inspec
         'documentation',
         'html',
         'json',
+        'json-merged',
         'json-min',
         'json-rspec',
         'junit',

--- a/lib/inspec/reporters.rb
+++ b/lib/inspec/reporters.rb
@@ -17,6 +17,8 @@ module Inspec::Reporters
       reporter = Inspec::Reporters::CLI.new(config)
     when 'json'
       reporter = Inspec::Reporters::Json.new(config)
+    when 'json-merged'
+      reporter = Inspec::Reporters::JsonMerged.new(config)
     when 'json-min'
       reporter = Inspec::Reporters::JsonMin.new(config)
     when 'junit'

--- a/lib/inspec/reporters.rb
+++ b/lib/inspec/reporters.rb
@@ -1,7 +1,7 @@
 require 'inspec/reporters/base'
 require 'inspec/reporters/cli'
 require 'inspec/reporters/json'
-require 'inspec/reporters/json_merged'
+require 'inspec/reporters/json_automate'
 require 'inspec/reporters/json_min'
 require 'inspec/reporters/junit'
 require 'inspec/reporters/automate'
@@ -17,8 +17,10 @@ module Inspec::Reporters
       reporter = Inspec::Reporters::CLI.new(config)
     when 'json'
       reporter = Inspec::Reporters::Json.new(config)
-    when 'json-merged'
-      reporter = Inspec::Reporters::JsonMerged.new(config)
+    # This reporter is only used for Chef internal. We reserve the
+    # right to introduce breaking changes to this reporter at any time.
+    when 'json-automate'
+      reporter = Inspec::Reporters::JsonAutomate.new(config)
     when 'json-min'
       reporter = Inspec::Reporters::JsonMin.new(config)
     when 'junit'

--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -4,7 +4,7 @@ require 'json'
 require 'net/http'
 
 module Inspec::Reporters
-  class Automate < JsonMerged
+  class Automate < JsonAutomate
     def initialize(config)
       super(config)
 

--- a/lib/inspec/reporters/json_automate.rb
+++ b/lib/inspec/reporters/json_automate.rb
@@ -3,7 +3,7 @@
 require 'json'
 
 module Inspec::Reporters
-  class JsonMerged < Json
+  class JsonAutomate < Json
     def initialize(config)
       super(config)
       @profiles = []

--- a/test/unit/reporters/json_automate.rb
+++ b/test/unit/reporters/json_automate.rb
@@ -2,11 +2,11 @@
 
 require 'helper'
 
-describe Inspec::Reporters::JsonMin do
+describe Inspec::Reporters::JsonAutomate do
   let(:path) { File.expand_path(File.dirname(__FILE__)) }
   let(:report) do
     data = JSON.parse(File.read(path + '/../mock/reporters/run_data_wrapper.json'), symbolize_names: true)
-    Inspec::Reporters::JsonMerged.new({ run_data: data })
+    Inspec::Reporters::JsonAutomate.new({ run_data: data })
   end
   let(:profiles) { report.report[:profiles] }
 


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This change allows the A2 team or other reports to test the JsonMerged report used in A2. This change also allows us to easily replace the report type in the Audit cookbook.

Please not the JsonMerged already has a full test suite and this change is just allowing it to be accessed via the reporter cli flag.

Note this is intentionally undocumented for now.