### PR TITLE
Plugins V2 API: CLI Command Plugin Type

### DIFF
--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -179,7 +179,7 @@ If things go wrong, have a look at `status.load_exception`.
 
 Depending on the plugin type, activation may be triggered by a number of different events. For example, CliCommand plugin types are activated when their activation name is mentioned in the command line arguments.
 
-After activation, code for that aspect of the plugin is loaded and ready to execute. Executioon may be triggered by a number of different events. For example, the CliCommand plugin types are implicitly executed by Thor when `Inspec::CLI` calls `start()`.
+After activation, code for that aspect of the plugin is loaded and ready to execute. Execution may be triggered by a number of different events. For example, the CliCommand plugin types are implicitly executed by Thor when `Inspec::CLI` calls `start()`.
 
 Refer to the sections below for details about activation and execution timing.
 
@@ -202,16 +202,13 @@ Commands:
   inspec archive PATH      # archive a profile to tar.gz (default) or zip
   inspec sweeten ...       # Add spoonfuls til the medicine goes down
 # Detailed help
-[cwolfe@lodi inspec-plugins]$ be inspec help sweeten
+[cwolfe@lodi inspec-plugins]$ inspec help sweeten
 Commands:
   inspec sweeten add [opts]       # Adds sweetener to your beverage
   inspec sweeten count            # Reports on teaspoons in your beverage, always bad news
 ```
 
-Currently, it cannot do a direct (non-namespaced) command
-```bash
-
-
+Currently, it cannot create a direct (non-namespaced) command, such as `inspec mycommand` with no subcommands.
 
 ### Declare your plugin activators
 
@@ -245,7 +242,7 @@ Execution occurs implicitly via `Thor.start()`, which is handled by `bin/inspec`
 
 ### Implementation class for CLI Commands
 
-In your `cli.rb`, you should begin by requesting the superclass from Inspec:
+In your `cli.rb`, you should begin by requesting the superclass from `Inspec.plugin`:
 
 ```ruby
 module InspecPlugins::Sweeten

--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -159,3 +159,51 @@ TODO
 Depending on the plugin type, execution may be triggered by a number of different events.
 
 TODO
+
+## Implementing a CLI Command Plugin
+
+### Declare your plugin activators
+
+In your `plugin.rb`, include one or more `cli_command` activation blocks.  The activation block name will be matched against the command line arguments; if the name is present, your activator will fire (in which case it should load any needed libraries) and should return your implementation class.
+
+#### CliCommand Activator Example
+
+```ruby
+
+# In plugin.rb
+module InspecPlugins::Sweeten
+  class Plugin < Inspec.plugin(2)
+    # ... other plugin stuff
+
+    cli_command :sweeten do
+      require_relative 'cli.rb'
+      InspecPlugins::Sweeten::CliCommand
+    end
+  end
+end
+```
+
+Like any activator, the block above will only be executed if needed. For CliCommand plugins, the plugin system naively scans through ARGV, looking for the activation name as a whole element.  Multiple CLI activations may occur.
+
+```bash
+you@machine $ inspec sweeten ... # Your CliCommand implementation is activated and executed
+you@machine $ inspec exec ... # Your CliCommand implementation is not activated
+```
+
+### Implementation class for CLI Commands
+
+In your `cli.rb`, you should begin by requesting the superclass from Inspec:
+
+```ruby
+module InspecPlugins::Sweeten
+  class CliCommand < Inspec.plugin(2, :cli_command)
+    # ...
+  end
+end
+```
+
+The Inspec plugin v2 system promises the following:
+
+* The superclass will be an (indirect) subclass of Thor
+* The plugin system will handle registering the subcommand with Thor for you
+

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -288,6 +288,7 @@ begin
   v2_loader = Inspec::Plugin::V2::Loader.new
   v2_loader.load_all
   v2_loader.exit_on_load_error
+  v2_loader.activate_mentioned_cli_plugins
 
   # Load v1 plugins on startup
   ctl = Inspec::PluginCtl.new

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -74,6 +74,19 @@ module Inspec::Plugin::V2
       # rubocop: enable Lint/RescueException
     end
 
+    def activate_mentioned_cli_plugins(cli_args = ARGV)
+      # Get a list of CLI plugin activation hooks
+      registry.find_activators(plugin_type: :cli_command).each do |act|
+        next if act.activated
+        # If there is anything in the CLI args with the same name, activate it
+        # If the word 'help' appears in the first position, load all CLI plugins
+        if cli_args.include?(act.activator_name.to_s) || cli_args[0] == 'help'
+          activate(:cli_command, act.activator_name)
+          act.implementation_class.register_with_thor
+        end
+      end
+    end
+
     private
 
     def annotate_status_after_loading(plugin_name)

--- a/lib/inspec/plugin/v2/plugin_base.rb
+++ b/lib/inspec/plugin/v2/plugin_base.rb
@@ -22,12 +22,12 @@ module Inspec::Plugin::V2
     #    type base class
     #  * defines the DSL method with the same name as the plugin type.
     #
-    # @ param [Symbol] plugin_type_name
-    def self.register_plugin_type(plugin_type_name)
+    # @param [Symbol] plugin_type_name
+    # @param [Class] the plugin type class, defaults to assuming inheritance
+    def self.register_plugin_type(plugin_type_name, new_plugin_type_base_class = self)
       new_dsl_method_name = plugin_type_name
-      new_plugin_type_base_class = self
 
-      # This lets the Inspec.plugin(2,:your_plugin) work
+      # This lets the Inspec.plugin(2,:your_plugin_type) work
       @@plugin_type_classes[plugin_type_name] = new_plugin_type_base_class
 
       # This part defines the DSL command to register a concrete plugin's implementation of a plugin type

--- a/lib/inspec/plugin/v2/plugin_types/cli.rb
+++ b/lib/inspec/plugin/v2/plugin_types/cli.rb
@@ -1,7 +1,13 @@
+require 'inspec/base_cli'
+
 module Inspec::Plugin::V2::PluginType
   # CLI subcommand type
-  class CliCommand < Inspec::Plugin::V2::PluginBase
-    register_plugin_type(:cli_command)
+
+  # TODO: consider adding an adapter superclass or something
+  class CliCommand < Inspec::BaseCLI
+    # This class MUST inherit from Thor, which makes it a bit awkward to register
+    # Since we can't inherit from PluginBase, we use the two-arg form of register_plugin_type
+    Inspec::Plugin::V2::PluginBase.register_plugin_type(:cli_command, self)
     # TODO: API
 
     # Invokes the subcommand defined by the plugin.

--- a/lib/inspec/plugin/v2/plugin_types/cli.rb
+++ b/lib/inspec/plugin/v2/plugin_types/cli.rb
@@ -1,0 +1,7 @@
+module Inspec::Plugin::V2::PluginType
+  # CLI subcommand type
+  class CliCommand < Inspec::Plugin::V2::PluginBase
+    register_plugin_type(:cli_command)
+    # TODO: API
+  end
+end

--- a/lib/inspec/plugin/v2/plugin_types/cli.rb
+++ b/lib/inspec/plugin/v2/plugin_types/cli.rb
@@ -3,5 +3,11 @@ module Inspec::Plugin::V2::PluginType
   class CliCommand < Inspec::Plugin::V2::PluginBase
     register_plugin_type(:cli_command)
     # TODO: API
+
+    # Invokes the subcommand defined by the plugin.
+    # @param [Hash] cli_args
+    def invoke(*)
+      raise NotImplementedError, 'The plugin author must implement invoke(...) in their CliCommand subclass'
+    end
   end
 end

--- a/lib/inspec/plugin/v2/plugin_types/cli.rb
+++ b/lib/inspec/plugin/v2/plugin_types/cli.rb
@@ -15,7 +15,7 @@ module Inspec::Plugin::V2::PluginType
       @desc_msg = desc_msg
     end
 
-    # Register the command group with Thor.  This must be called on the implementaion class AFTER
+    # Register the command group with Thor.  This must be called on the implementation class AFTER
     # the the cli_command activator has been called
     def self.register_with_thor
       # Figure out my activator name (= subcommand group name)

--- a/lib/inspec/plugin/v2/plugin_types/cli.rb
+++ b/lib/inspec/plugin/v2/plugin_types/cli.rb
@@ -5,15 +5,41 @@ module Inspec::Plugin::V2::PluginType
 
   # TODO: consider adding an adapter superclass or something
   class CliCommand < Inspec::BaseCLI
-    # This class MUST inherit from Thor, which makes it a bit awkward to register
+    # This class MUST inherit from Thor, which makes it a bit awkward to register the plugin subtype
     # Since we can't inherit from PluginBase, we use the two-arg form of register_plugin_type
     Inspec::Plugin::V2::PluginBase.register_plugin_type(:cli_command, self)
-    # TODO: API
 
-    # Invokes the subcommand defined by the plugin.
-    # @param [Hash] cli_args
-    def invoke(*)
-      raise NotImplementedError, 'The plugin author must implement invoke(...) in their CliCommand subclass'
+    # Provide a description for the command group.
+    def self.subcommand_desc(usage_msg, desc_msg)
+      @usage_msg = usage_msg
+      @desc_msg = desc_msg
     end
+
+    # Register the command group with Thor.  This must be called on the implementaion class AFTER
+    # the the cli_command activator has been called
+    def self.register_with_thor
+      # Figure out my activator name (= subcommand group name)
+      subcommand_name = Inspec::Plugin::V2::Registry.instance \
+        .find_activators(plugin_type: :cli_command, implementation_class: self) \
+        .first.activator_name.to_s
+
+      # # Inform Thor of our group name - not needed?
+      # namespace subcommand_name
+
+      # # TODO: find another solution, once https://github.com/erikhuda/thor/issues/261 is fixed
+      # define_method :banner do |command, _namespace = nil, _subcommand = false|
+      #   "#{basename} #{subcommand_prefix} #{command.usage}"
+      # end
+
+      # # Required for Thor banner workaround
+      # def self.subcommand_prefix
+      #   namespace
+      # end
+
+      # Register with Thor
+      Inspec::InspecCLI.register(self, subcommand_name, @usage_msg, @desc_msg, {})
+    end
+
+
   end
 end

--- a/lib/inspec/plugin/v2/plugin_types/cli.rb
+++ b/lib/inspec/plugin/v2/plugin_types/cli.rb
@@ -1,9 +1,6 @@
 require 'inspec/base_cli'
 
 module Inspec::Plugin::V2::PluginType
-  # CLI subcommand type
-
-  # TODO: consider adding an adapter superclass or something
   class CliCommand < Inspec::BaseCLI
     # This class MUST inherit from Thor, which makes it a bit awkward to register the plugin subtype
     # Since we can't inherit from PluginBase, we use the two-arg form of register_plugin_type
@@ -20,26 +17,11 @@ module Inspec::Plugin::V2::PluginType
     def self.register_with_thor
       # Figure out my activator name (= subcommand group name)
       subcommand_name = Inspec::Plugin::V2::Registry.instance \
-        .find_activators(plugin_type: :cli_command, implementation_class: self) \
-        .first.activator_name.to_s
-
-      # # Inform Thor of our group name - not needed?
-      # namespace subcommand_name
-
-      # # TODO: find another solution, once https://github.com/erikhuda/thor/issues/261 is fixed
-      # define_method :banner do |command, _namespace = nil, _subcommand = false|
-      #   "#{basename} #{subcommand_prefix} #{command.usage}"
-      # end
-
-      # # Required for Thor banner workaround
-      # def self.subcommand_prefix
-      #   namespace
-      # end
+                                                    .find_activators(plugin_type: :cli_command, implementation_class: self) \
+                                                    .first.activator_name.to_s
 
       # Register with Thor
       Inspec::InspecCLI.register(self, subcommand_name, @usage_msg, @desc_msg, {})
     end
-
-
   end
 end

--- a/lib/inspec/plugin/v2/registry.rb
+++ b/lib/inspec/plugin/v2/registry.rb
@@ -48,10 +48,11 @@ module Inspec::Plugin::V2
     # @param [Symbol] plugin_name Restricts the search to the given plugin
     # @param [Symbol] plugin_type Restricts the search to the given plugin type
     # @param [Symbol] activator_name Name of the activator
+    # @param [Class] implementation_class Implementation class returned by an already-actived plugin type
     # @returns [Array] Possibly empty array of Activators
     def find_activators(filters = {})
       plugin_statuses.map(&:activators).flatten.select do |act|
-        [:plugin_name, :plugin_type, :activator_name].all? do |criteria|
+        [:plugin_name, :plugin_type, :activator_name, :implementation_class].all? do |criteria|
           !filters.key?(criteria) || act[criteria] == filters[criteria]
         end
       end

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -1,6 +1,5 @@
 # Functional tests related to plugin facility
 require 'functional/helper'
-require 'byebug'
 
 #=========================================================================================#
 #                                Loader Errors

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -76,8 +76,8 @@ describe 'cli command plugins' do
   include FunctionalHelper
 
   it 'is able to respond to a plugin-based cli subcommand' do
-    outcome = inspec_with_env('meaning-of-life-the-universe-and-everything',  INSPEC_CONFIG_DIR: File.join(config_dir_path, 'meaning_by_path'))
-    outcome.stderr.wont_include 'Could not find command "meaning-of-life-the-universe-and-everything"'
+    outcome = inspec_with_env('meaningoflife answer',  INSPEC_CONFIG_DIR: File.join(config_dir_path, 'meaning_by_path'))
+    outcome.stderr.wont_include 'Could not find command "meaningoflife"'
     outcome.exit_status.must_equal 42
   end
 end

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -1,5 +1,6 @@
 # Functional tests related to plugin facility
 require 'functional/helper'
+require 'byebug'
 
 #=========================================================================================#
 #                                Loader Errors
@@ -71,6 +72,12 @@ end
 #=========================================================================================#
 #                           CliCommand plugin type
 #=========================================================================================#
+describe 'cli command plugins' do
+  include FunctionalHelper
 
-# should be able to use a CLI subcommand provided by a plugin
-# should be able to use a CLI subcommand provided by a plugin when the userdir is in a custom location
+  it 'is able to respond to a plugin-based cli subcommand' do
+    outcome = inspec_with_env('meaning-of-life-the-universe-and-everything',  INSPEC_CONFIG_DIR: File.join(config_dir_path, 'meaning_by_path'))
+    outcome.stderr.wont_include 'Could not find command "meaning-of-life-the-universe-and-everything"'
+    outcome.exit_status.must_equal 42
+  end
+end

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -78,6 +78,23 @@ describe 'cli command plugins' do
   it 'is able to respond to a plugin-based cli subcommand' do
     outcome = inspec_with_env('meaningoflife answer',  INSPEC_CONFIG_DIR: File.join(config_dir_path, 'meaning_by_path'))
     outcome.stderr.wont_include 'Could not find command "meaningoflife"'
+    outcome.stderr.must_equal ''
+    outcome.stdout.must_equal ''
     outcome.exit_status.must_equal 42
+  end
+
+  it 'is able to respond to [help subcommand] invocations' do
+    outcome = inspec_with_env('help meaningoflife',  INSPEC_CONFIG_DIR: File.join(config_dir_path, 'meaning_by_path'))
+    outcome.exit_status.must_equal 0
+    outcome.stderr.must_equal ''
+    outcome.stdout.must_include 'inspec meaningoflife answer'
+    outcome.stdout.must_include 'Exits immediately with an exit code reflecting the answer to life the universe, and everything.'
+  end
+
+  # This is an important test; usually CLI plugins are only activated when their name is present in ARGV
+  it 'includes plugin-based cli commands in top-level help' do
+    outcome = inspec_with_env('help',  INSPEC_CONFIG_DIR: File.join(config_dir_path, 'meaning_by_path'))
+    outcome.exit_status.must_equal 0
+    outcome.stdout.must_include 'inspec meaningoflife'
   end
 end

--- a/test/unit/mock/plugins/meaning_of_life_path_mode/inspec-meaning-of-life/cli_command.rb
+++ b/test/unit/mock/plugins/meaning_of_life_path_mode/inspec-meaning-of-life/cli_command.rb
@@ -1,0 +1,13 @@
+module InspecPlugins
+  module MeaningOfLife
+    class CliCommand < Inspec.plugin(2, :cli_command)
+
+      # CLI test example
+      def invoke(cli_opts = {})
+        # exit immediately with code 42
+        exit 42
+      end
+    end
+
+  end
+end

--- a/test/unit/mock/plugins/meaning_of_life_path_mode/inspec-meaning-of-life/cli_command.rb
+++ b/test/unit/mock/plugins/meaning_of_life_path_mode/inspec-meaning-of-life/cli_command.rb
@@ -1,13 +1,16 @@
 module InspecPlugins
   module MeaningOfLife
     class CliCommand < Inspec.plugin(2, :cli_command)
+      # Need to tell my superclass about my group description
+      subcommand_desc 'meaningoflife answer', 'Get answers once and for all.'
 
       # CLI test example
-      def invoke(cli_opts = {})
+      desc 'answer', "Exits immediately with an exit code reflecting the answer to life the universe, and everything."
+      def answer
         # exit immediately with code 42
         exit 42
       end
-    end
 
+    end
   end
 end

--- a/test/unit/mock/plugins/meaning_of_life_path_mode/inspec-meaning-of-life/plugin.rb
+++ b/test/unit/mock/plugins/meaning_of_life_path_mode/inspec-meaning-of-life/plugin.rb
@@ -10,9 +10,10 @@ module InspecPlugins
         InspecPlugins::MeaningOfLife::MockPlugin
       end
 
-      cli_command 'meaning-of-life-the-universe-and-everything' do
-        require_relative './cli_command'
-        InspecPlugins::MeaningOfLife::MockPLugin
+      cli_command 'meaningoflife' do
+        # NOTE: we can't use require, because these test files are repeatedly reloaded
+        load 'test/unit/mock/plugins/meaning_of_life_path_mode/inspec-meaning-of-life/cli_command.rb'
+        InspecPlugins::MeaningOfLife::CliCommand
       end
     end
 

--- a/test/unit/mock/plugins/meaning_of_life_path_mode/inspec-meaning-of-life/plugin.rb
+++ b/test/unit/mock/plugins/meaning_of_life_path_mode/inspec-meaning-of-life/plugin.rb
@@ -9,6 +9,11 @@ module InspecPlugins
         load 'test/unit/mock/plugins/meaning_of_life_path_mode/inspec-meaning-of-life/mock_plugin.rb'
         InspecPlugins::MeaningOfLife::MockPlugin
       end
+
+      cli_command 'meaning-of-life-the-universe-and-everything' do
+        require_relative './cli_command'
+        InspecPlugins::MeaningOfLife::MockPLugin
+      end
     end
 
   end

--- a/test/unit/plugin/v2/api_cli_test.rb
+++ b/test/unit/plugin/v2/api_cli_test.rb
@@ -24,5 +24,29 @@ class PluginV2VersionedApiCLITests < MiniTest::Test
   end
 end
 
+class CliCommandPluginV2API < MiniTest::Test
+  def test_cli_command_api_methods_present
+    # instance methods
+    [
+      :invoke,
+    ].each do |method_name|
+      klass = Inspec::Plugin::V2::PluginType::CliCommand
+      assert klass.method_defined?(method_name), "CliCommand api instance method: #{method_name}"
+    end
+  end
+
+  def test_cli_command_api_methods_abstract_throws_not_implemented
+    [
+      :invoke,
+    ].each do |method_name|
+      cmd = Inspec::Plugin::V2::PluginType::CliCommand.new
+      assert_raises(NotImplementedError, "CliCommand api abstract class method: #{method_name}") do
+        cmd.send(method_name)
+      end
+    end
+  end
+
+end
+
 # cli base class responds to a list of methods
 # cli base class throws NotImplemented on abstract methods

--- a/test/unit/plugin/v2/api_cli_test.rb
+++ b/test/unit/plugin/v2/api_cli_test.rb
@@ -1,4 +1,28 @@
-# you can call Inspec.plugin(2, :cli) and get the CLI plugin base class
+require 'minitest/autorun'
+require 'minitest/test'
+require 'byebug'
+
+require_relative '../../../../lib/inspec/plugin/v2'
+
+class PluginV2VersionedApiCLITests < MiniTest::Test
+  # you can call Inspec.plugin(2, :cli_command) and get the plugin base class
+  def test_calling_Inspec_dot_plugin_with_cli_returns_the_cli_base_class
+    klass = Inspec.plugin(2, :cli_command)
+    assert_kind_of Class, klass
+    assert_equal 'Inspec::Plugin::V2::PluginType::CliCommand', klass.name
+  end
+
+  def test_plugin_type_base_classes_can_be_accessed_by_name
+    klass = Inspec::Plugin::V2::PluginBase.base_class_for_type(:cli_command)
+    assert_kind_of Class, klass
+    assert_equal 'Inspec::Plugin::V2::PluginType::CliCommand', klass.name
+  end
+
+  def test_plugin_type_registers_an_activation_dsl_method
+    klass = Inspec::Plugin::V2::PluginBase
+    assert_respond_to klass, :cli_command, 'Activation method for cli_method'
+  end
+end
+
 # cli base class responds to a list of methods
 # cli base class throws NotImplemented on abstract methods
-# cli base class returns :cli for plugin_type

--- a/test/unit/plugin/v2/api_cli_test.rb
+++ b/test/unit/plugin/v2/api_cli_test.rb
@@ -4,7 +4,7 @@ require 'byebug'
 
 require_relative '../../../../lib/inspec/plugin/v2'
 
-class PluginV2VersionedApiCLITests < MiniTest::Test
+class CliCommandSuperclassTests < MiniTest::Test
   # you can call Inspec.plugin(2, :cli_command) and get the plugin base class
   def test_calling_Inspec_dot_plugin_with_cli_returns_the_cli_base_class
     klass = Inspec.plugin(2, :cli_command)
@@ -20,7 +20,12 @@ class PluginV2VersionedApiCLITests < MiniTest::Test
 
   def test_plugin_type_registers_an_activation_dsl_method
     klass = Inspec::Plugin::V2::PluginBase
-    assert_respond_to klass, :cli_command, 'Activation method for cli_method'
+    assert_respond_to klass, :cli_command, 'Activation method for cli_command'
+  end
+
+  def test_cli_plugin_type_inherits_from_thor
+    klass = Inspec.plugin(2, :cli_command)
+    assert_includes klass.ancestors, ::Thor, 'Cli Command plugin type should inherit from Thor'
   end
 end
 


### PR DESCRIPTION
This PR implements the command-line subcommand API for InSpec plugins V2, as specified on #3089 .

Like v1 plugins and the existing CLI system, V2 CLI plugins are Thor-based, and this is explicitly exposed to them.

This PR includes updates to the `docs/dev/plugins.md` file to cover CLI command types.  

This PR includes unit testing on the CLI API, and functional testing of a simple cli subcommand.

This is a subtopic branch off of #3278 . Once that PR is merged, this PR will be re-targeted to master.

I consider this PR ready for full review - thanks for any and all feedback!