### PR TITLE
Allow apache_conf include files to be empty

### DIFF
--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -125,7 +125,7 @@ module Inspec::Resources
     end
 
     def read_file(path)
-      @files_contents[path] ||= read_file_content(path)
+      @files_contents[path] ||= read_file_content(path, true)
     end
 
     def conf_dir


### PR DESCRIPTION
Fixes #3232 

In the `read_file` method we can call `read_file_content` with the second
argument `true` to avoid skipping on an empty file.

We will still skip the control if the main configuration file is empty
as there is still an explicit call to `read_file_content` without this
argument in the `read_content` method.