### PR TITLE
Infer `--sudo` when `--sudo-password` is used

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -277,6 +277,12 @@ module Inspec
         raise ArgumentError, "Please provide a value for --#{v}. For example: --#{v}=hello."
       end
 
+      # Infer `--sudo` if using `--sudo-password` without `--sudo`
+      if o[:sudo_password] && !o[:sudo]
+        o[:sudo] = true
+        warn 'WARN: `--sudo-password` used without `--sudo`. Adding `--sudo`.'
+      end
+
       # check for compliance settings
       Compliance::API.login(o['compliance']) if o['compliance']
 


### PR DESCRIPTION
This does the following:
  - Adds `--sudo` if using `--sudo-password`
  - Warns the user if using `--sudo-password` without `--sudo`
  - Adds unit tests for `Inspec::BaseCLI#opts`

This closes #3313