### PR TITLE
Allow target-id passthrough

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -62,8 +62,8 @@ module Inspec
         desc: 'Specifies the bastion port if applicable'
       option :insecure, type: :boolean, default: false,
         desc: 'Disable SSL verification on select targets'
-      option :uuid, type: :string,
-        desc: 'Provide a UUID which will be included on reports.'
+      option :target_id, type: :string,
+        desc: 'Provide a id which will be included on reports.'
     end
 
     def self.profile_options
@@ -144,7 +144,7 @@ module Inspec
               'file' => target,
               'stdout' => false,
             }
-            reports[reporter_name]['uuid'] = opts['uuid'] if opts['uuid']
+            reports[reporter_name]['target_id'] = opts['target_id'] if opts['target_id']
           end
         end
         opts['reporter'] = reports
@@ -155,7 +155,7 @@ module Inspec
         opts['reporter'].each do |reporter_name, config|
           opts['reporter'][reporter_name] = {} if config.nil?
           opts['reporter'][reporter_name]['stdout'] = true if opts['reporter'][reporter_name].empty?
-          opts['reporter'][reporter_name]['uuid'] = opts['uuid'] if opts['uuid']
+          opts['reporter'][reporter_name]['target_id'] = opts['target_id'] if opts['target_id']
         end
       end
 

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -62,6 +62,8 @@ module Inspec
         desc: 'Specifies the bastion port if applicable'
       option :insecure, type: :boolean, default: false,
         desc: 'Disable SSL verification on select targets'
+      option :uuid, type: :string,
+        desc: 'Provide a UUID which will be included on reports.'
     end
 
     def self.profile_options
@@ -142,6 +144,7 @@ module Inspec
               'file' => target,
               'stdout' => false,
             }
+            reports[reporter_name]['uuid'] = opts['uuid'] if opts['uuid']
           end
         end
         opts['reporter'] = reports
@@ -152,6 +155,7 @@ module Inspec
         opts['reporter'].each do |reporter_name, config|
           opts['reporter'][reporter_name] = {} if config.nil?
           opts['reporter'][reporter_name]['stdout'] = true if opts['reporter'][reporter_name].empty?
+          opts['reporter'][reporter_name]['uuid'] = opts['uuid'] if opts['uuid']
         end
       end
 

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -63,7 +63,7 @@ module Inspec
       option :insecure, type: :boolean, default: false,
         desc: 'Disable SSL verification on select targets'
       option :target_id, type: :string,
-        desc: 'Provide a id which will be included on reports.'
+        desc: 'Provide a ID which will be included on reports'
     end
 
     def self.profile_options

--- a/lib/inspec/formatters/base.rb
+++ b/lib/inspec/formatters/base.rb
@@ -69,7 +69,6 @@ module Inspec::Formatters
         name: platform(:name),
         release: platform(:release),
         target: backend_target,
-        uuid: platform(:uuid),
       }
     end
 

--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -23,7 +23,7 @@ module Inspec::Reporters
       final_report[:type] = 'inspec_report'
 
       final_report[:end_time] = Time.now.utc.strftime('%FT%TZ')
-      final_report[:node_uuid] = @config['node_uuid'] || @config['uuid']
+      final_report[:node_uuid] = @config['node_uuid'] || @config['target_id']
       raise Inspec::ReporterError, 'Cannot find a UUID for your node. Please specify one via json-config.' if final_report[:node_uuid].nil?
 
       final_report[:report_uuid] = @config['report_uuid'] || uuid_from_string(final_report[:end_time] + final_report[:node_uuid])

--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -23,7 +23,7 @@ module Inspec::Reporters
       final_report[:type] = 'inspec_report'
 
       final_report[:end_time] = Time.now.utc.strftime('%FT%TZ')
-      final_report[:node_uuid] = @config['node_uuid'] || @run_data[:platform][:uuid]
+      final_report[:node_uuid] = @config['node_uuid'] || @config['uuid']
       raise Inspec::ReporterError, 'Cannot find a UUID for your node. Please specify one via json-config.' if final_report[:node_uuid].nil?
 
       final_report[:report_uuid] = @config['report_uuid'] || uuid_from_string(final_report[:end_time] + final_report[:node_uuid])

--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -66,6 +66,7 @@ module Inspec::Reporters
       output("Profile: #{format_profile_name(profile)}")
       output("Version: #{profile[:version] || '(not specified)'}")
       output("Target:  #{run_data[:platform][:target]}") unless run_data[:platform][:target].nil?
+      output("UUID:    #{@config['uuid']}") unless @config['uuid'].nil?
       output('')
     end
 

--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -66,7 +66,7 @@ module Inspec::Reporters
       output("Profile: #{format_profile_name(profile)}")
       output("Version: #{profile[:version] || '(not specified)'}")
       output("Target:  #{run_data[:platform][:target]}") unless run_data[:platform][:target].nil?
-      output("UUID:    #{@config['uuid']}") unless @config['uuid'].nil?
+      output("ID:      #{@config['target_id']}") unless @config['target_id'].nil?
       output('')
     end
 

--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -63,11 +63,17 @@ module Inspec::Reporters
     private
 
     def print_profile_header(profile)
-      output("Profile: #{format_profile_name(profile)}")
-      output("Version: #{profile[:version] || '(not specified)'}")
-      output("Target:  #{run_data[:platform][:target]}") unless run_data[:platform][:target].nil?
-      output("ID:      #{@config['target_id']}") unless @config['target_id'].nil?
-      output('')
+      header = {
+        'Profile' => format_profile_name(profile),
+        'Version' => profile[:version] || '(not specified)',
+      }
+      header['Target'] = run_data[:platform][:target] unless run_data[:platform][:target].nil?
+      header['Target ID'] = @config['target_id'] unless @config['target_id'].nil?
+
+      pad = header.keys.max_by(&:length).length + 1
+      header.each do |title, value|
+        output(format("%-#{pad}s %s", title + ':', value))
+      end
     end
 
     def print_standard_control_results(profile)

--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -74,6 +74,7 @@ module Inspec::Reporters
       header.each do |title, value|
         output(format("%-#{pad}s %s", title + ':', value))
       end
+      output('')
     end
 
     def print_standard_control_results(profile)

--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -26,7 +26,7 @@ module Inspec::Reporters
         name: run_data[:platform][:name],
         release: run_data[:platform][:release],
       }
-      platform[:uuid] = @config['uuid'] if @config['uuid']
+      platform[:target_id] = @config['target_id'] if @config['target_id']
       platform
     end
 

--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -22,10 +22,12 @@ module Inspec::Reporters
     private
 
     def platform
-      {
+      platform = {
         name: run_data[:platform][:name],
         release: run_data[:platform][:release],
       }
+      platform[:uuid] = @config['uuid'] if @config['uuid']
+      platform
     end
 
     def profile_results(control)

--- a/lib/inspec/schema.rb
+++ b/lib/inspec/schema.rb
@@ -42,6 +42,7 @@ module Inspec
       'properties' => {
         'name' => { 'type' => 'string' },
         'release' => { 'type' => 'string' },
+        'uuid' => { 'type' => 'string', 'optional' => true },
       },
     }.freeze
 

--- a/lib/inspec/schema.rb
+++ b/lib/inspec/schema.rb
@@ -42,7 +42,7 @@ module Inspec
       'properties' => {
         'name' => { 'type' => 'string' },
         'release' => { 'type' => 'string' },
-        'uuid' => { 'type' => 'string', 'optional' => true },
+        'target_id' => { 'type' => 'string', 'optional' => true },
       },
     }.freeze
 

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -28,6 +28,17 @@ describe 'inspec exec with json formatter' do
     JSON::Schema.validate(data, schema)
   end
 
+  it 'can execute a profile and validate the json schema with uuid' do
+    out = inspec('exec ' + example_profile + ' --reporter json --no-create-lockfile --uuid 1d3e399f-4d71-4863-ac54-84d437fbc444')
+    out.stderr.must_equal ''
+    out.exit_status.must_equal 101
+    data = JSON.parse(out.stdout)
+    data['platform']['uuid'].must_equal '1d3e399f-4d71-4863-ac54-84d437fbc444'
+    sout = inspec('schema exec-json')
+    schema = JSON.parse(sout.stdout)
+    JSON::Schema.validate(data, schema)
+  end
+
   describe 'execute a profile with json formatting' do
     let(:json) { JSON.load(inspec('exec ' + example_profile + ' --reporter json --no-create-lockfile').stdout) }
     let(:profile) { json['profiles'][0] }

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -28,12 +28,12 @@ describe 'inspec exec with json formatter' do
     JSON::Schema.validate(data, schema)
   end
 
-  it 'can execute a profile and validate the json schema with uuid' do
-    out = inspec('exec ' + example_profile + ' --reporter json --no-create-lockfile --uuid 1d3e399f-4d71-4863-ac54-84d437fbc444')
+  it 'can execute a profile and validate the json schema with target_id' do
+    out = inspec('exec ' + example_profile + ' --reporter json --no-create-lockfile --target-id 1d3e399f-4d71-4863-ac54-84d437fbc444')
     out.stderr.must_equal ''
     out.exit_status.must_equal 101
     data = JSON.parse(out.stdout)
-    data['platform']['uuid'].must_equal '1d3e399f-4d71-4863-ac54-84d437fbc444'
+    data['platform']['target_id'].must_equal '1d3e399f-4d71-4863-ac54-84d437fbc444'
     sout = inspec('schema exec-json')
     schema = JSON.parse(sout.stdout)
     JSON::Schema.validate(data, schema)

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -46,6 +46,15 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     File.stat("#{outpath}/foo/bar/test.json").size.must_be :>, 0
   end
 
+  it 'can execute the profile with a uuid passthrough' do
+    outpath = Dir.tmpdir
+    out = inspec("exec #{example_profile} --no-create-lockfile --uuid 1d3e399f-4d71-4863-ac54-84d437fbc444")
+    out.stderr.must_equal ''
+    out.exit_status.must_equal 101
+    stdout = out.stdout.force_encoding(Encoding::UTF_8)
+    stdout.must_include "UUID:    1d3e399f-4d71-4863-ac54-84d437fbc444"
+  end
+
   it 'executes a metadata-only profile' do
     out = inspec('exec ' + File.join(profile_path, 'complete-metadata') + ' --no-create-lockfile')
     out.stderr.must_equal ''

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -52,7 +52,7 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     out.stderr.must_equal ''
     out.exit_status.must_equal 101
     stdout = out.stdout.force_encoding(Encoding::UTF_8)
-    stdout.must_include "ID:      1d3e399f-4d71-4863-ac54-84d437fbc444"
+    stdout.must_include "Target ID: 1d3e399f-4d71-4863-ac54-84d437fbc444"
   end
 
   it 'executes a metadata-only profile' do

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -46,13 +46,13 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     File.stat("#{outpath}/foo/bar/test.json").size.must_be :>, 0
   end
 
-  it 'can execute the profile with a uuid passthrough' do
+  it 'can execute the profile with a target_id passthrough' do
     outpath = Dir.tmpdir
-    out = inspec("exec #{example_profile} --no-create-lockfile --uuid 1d3e399f-4d71-4863-ac54-84d437fbc444")
+    out = inspec("exec #{example_profile} --no-create-lockfile --target-id 1d3e399f-4d71-4863-ac54-84d437fbc444")
     out.stderr.must_equal ''
     out.exit_status.must_equal 101
     stdout = out.stdout.force_encoding(Encoding::UTF_8)
-    stdout.must_include "UUID:    1d3e399f-4d71-4863-ac54-84d437fbc444"
+    stdout.must_include "ID:      1d3e399f-4d71-4863-ac54-84d437fbc444"
   end
 
   it 'executes a metadata-only profile' do

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -123,10 +123,10 @@ EOF
       parsed.must_equal assert
     end
 
-    it 'parses cli report and attaches uuid' do
-      opts = { 'reporter' => ['cli'], 'uuid' => '1d3e399f-4d71-4863-ac54-84d437fbc444' }
+    it 'parses cli report and attaches target_id' do
+      opts = { 'reporter' => ['cli'], 'target_id' => '1d3e399f-4d71-4863-ac54-84d437fbc444' }
       parsed = Inspec::BaseCLI.parse_reporters(opts)
-      assert = {"reporter"=>{"cli"=>{"stdout"=>true, "uuid"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}}, "uuid"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}
+      assert = {"reporter"=>{"cli"=>{"stdout"=>true, "target_id"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}}, "target_id"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}
       parsed.must_equal assert
     end
 

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -123,6 +123,13 @@ EOF
       parsed.must_equal assert
     end
 
+    it 'parses cli report and attaches uuid' do
+      opts = { 'reporter' => ['cli'], 'uuid' => '1d3e399f-4d71-4863-ac54-84d437fbc444' }
+      parsed = Inspec::BaseCLI.parse_reporters(opts)
+      assert = {"reporter"=>{"cli"=>{"stdout"=>true, "uuid"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}}, "uuid"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}
+      parsed.must_equal assert
+    end
+
     it 'parse cli reporters with format' do
       opts = { 'format' => 'json' }
       parsed = Inspec::BaseCLI.parse_reporters(opts)

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -119,22 +119,22 @@ EOF
     it 'parse cli reporters' do
       opts = { 'reporter' => ['cli'] }
       parsed = Inspec::BaseCLI.parse_reporters(opts)
-      assert = { 'reporter' => { 'cli' => { 'stdout' => true }}}
-      parsed.must_equal assert
+      expected_value = { 'reporter' => { 'cli' => { 'stdout' => true }}}
+      parsed.must_equal expected_value
     end
 
     it 'parses cli report and attaches target_id' do
       opts = { 'reporter' => ['cli'], 'target_id' => '1d3e399f-4d71-4863-ac54-84d437fbc444' }
       parsed = Inspec::BaseCLI.parse_reporters(opts)
-      assert = {"reporter"=>{"cli"=>{"stdout"=>true, "target_id"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}}, "target_id"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}
-      parsed.must_equal assert
+      expected_value = {"reporter"=>{"cli"=>{"stdout"=>true, "target_id"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}}, "target_id"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}
+      parsed.must_equal expected_value
     end
 
     it 'parse cli reporters with format' do
       opts = { 'format' => 'json' }
       parsed = Inspec::BaseCLI.parse_reporters(opts)
-      assert = { 'reporter' => { 'json' => { 'stdout' => true }}}
-      parsed.must_equal assert
+      expected_value = { 'reporter' => { 'json' => { 'stdout' => true }}}
+      parsed.must_equal expected_value
     end
 
     it 'parse cli reporters with format and output' do
@@ -143,8 +143,8 @@ EOF
       proc {
         opts = { 'format' => 'json', 'output' => '/tmp/inspec_out.json' }
         parsed = Inspec::BaseCLI.parse_reporters(opts)
-        assert = { 'reporter' => { 'json' => { 'file' => '/tmp/inspec_out.json', 'stdout' => false }}}
-        parsed.must_equal assert
+        expected_value = { 'reporter' => { 'json' => { 'file' => '/tmp/inspec_out.json', 'stdout' => false }}}
+        parsed.must_equal expected_value
       }.must_output nil, error end
     end
 


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This adds a new CLI option to pass through a UUID. This will show up on the output reports accordingly. Both `--target-id` and `--json-config` are supported. 

Fixes https://github.com/inspec/inspec/issues/3319