### PR TITLE
Fix for custom controls

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -228,7 +228,7 @@ module Inspec
       sc = checks(src)
       dst.instance_variable_set(:@__checks, sc) unless sc.empty?
       sr = skip_status(src)
-      set_skip_rule(dst, sr) unless sr.nil?
+      set_skip_rule(dst, sr[:result] || sr) unless sr.nil?
 
       # Save merge history
       dst.instance_variable_set(:@__merge_count, merge_count(dst) + 1)


### PR DESCRIPTION
We have a custom control named lets say `custom_control` which we used in our  inspec code. It is created by extending the `::Inspec::DSL` module. After https://github.com/inspec/inspec/pull/3267 was merged it broke our pipelines. I identified that https://github.com/inspec/inspec/commit/3a9ed68c729311c5b06c2ddbdb28f2d2cd41e0fa#diff-7116ea72e5d980e406887620c1facc6cR179 has changed and was returning a hash now instead of a boolean. So in our custom control it was returning something like `{:result=>{:result=>true, :message=>nil}, :message=>nil}` instead of `{:result=>true, :message=>nil}`. I have fixed this by reverting this to just the value. I tested with a standard control and our custom control and it seems to be working. @jerryaldrichiii @miah @jquick What do you think? 