### PR TITLE
Suppress logs for json-automate reporter

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -240,7 +240,7 @@ module Inspec
 
     def suppress_log_output?(opts)
       return false if opts['reporter'].nil?
-      match = %w{json json-min json-rspec junit html yaml documentation progress} & opts['reporter'].keys
+      match = %w{json json-min json-rspec json-automate junit html yaml documentation progress} & opts['reporter'].keys
       unless match.empty?
         match.each do |m|
           # check to see if we are outputting to stdout

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -176,6 +176,11 @@ EOF
       cli.send(:suppress_log_output?, opts).must_equal true
     end
 
+    it 'suppresses json-automate' do
+      opts = { 'reporter' => { 'json-automate' => { 'stdout' => true }}}
+      cli.send(:suppress_log_output?, opts).must_equal true
+    end
+
     it 'suppresses junit' do
       opts = { 'reporter' => { 'junit' => { 'stdout' => true }}}
       cli.send(:suppress_log_output?, opts).must_equal true


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This change adds the `json-automate` reporter to the suppression list so logs get sent over to STDERR.

Fixes https://github.com/inspec/inspec/issues/3312