### PR TITLE
Remove skip from inherited profiles from showing up in reporting (breaking change)

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -548,10 +548,12 @@ module Inspec
       params[:controls] = controls = {}
       params[:groups] = groups = {}
       prefix = @source_reader.target.prefix || ''
-      tests.each do |rule|
-        next if rule.nil?
-        f = load_rule_filepath(prefix, rule)
-        load_rule(rule, f, controls, groups)
+      unless tests.nil?
+        tests.each do |rule|
+          next if rule.nil?
+          f = load_rule_filepath(prefix, rule)
+          load_rule(rule, f, controls, groups)
+        end
       end
       params[:attributes] = @runner_context.attributes
       params

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -183,10 +183,10 @@ module Inspec
 
     def collect_tests(include_list = @controls)
       unless @tests_collected
+        return unless supports_platform?
         locked_dependencies.each(&:collect_tests)
 
         tests.each do |path, content|
-          next unless supports_platform?
           next if content.nil? || content.empty?
           abs_path = source_reader.target.abs_path(path)
           @runner_context.load_control_file(content, abs_path, nil)

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -548,12 +548,10 @@ module Inspec
       params[:controls] = controls = {}
       params[:groups] = groups = {}
       prefix = @source_reader.target.prefix || ''
-      unless tests.nil?
-        tests.each do |rule|
-          next if rule.nil?
-          f = load_rule_filepath(prefix, rule)
-          load_rule(rule, f, controls, groups)
-        end
+      tests&.each do |rule|
+        next if rule.nil?
+        f = load_rule_filepath(prefix, rule)
+        load_rule(rule, f, controls, groups)
       end
       params[:attributes] = @runner_context.attributes
       params

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -85,6 +85,11 @@ module Inspec
         profile_context = profile.load_libraries
 
         profile_context.dependencies.list.values.each do |requirement|
+          unless requirement.profile.supports_platform?
+            Inspec::Log.warn "Skipping profile: '#{requirement.profile.name}'" \
+             " on unsupported platform: '#{@backend.platform.name}'."
+            next
+          end
           @test_collector.add_profile(requirement.profile)
         end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -354,7 +354,7 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
   describe 'when a dependency does not support our backend platform' do
     it 'skips the controls from that profile' do
       out = inspec("exec #{File.join(profile_path, 'profile-support-skip')} --no-create-lockfile")
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "WARN: Skipping profile: 'windows-only' on unsupported platform"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "WARN: Skipping profile"
       out.stdout.force_encoding(Encoding::UTF_8).must_include "0 successful, 0 failures, 0 skipped\n"
     end
   end
@@ -421,10 +421,10 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
     let(:controls) { json['profiles'][0]['controls'] }
 
     it 'skips loaded inherited profiles on unsupported platforms' do
-      json['profiles'][0]['depends'][0]['name'].must_equal 'windows-only'
+      json['profiles'][0]['depends'][0]['name'].must_equal 'unsupported_inspec'
       controls.must_be_empty
       stderr = out.stderr.force_encoding(Encoding::UTF_8)
-      stderr.must_include "WARN: Skipping profile: 'windows-only'"
+      stderr.must_include "WARN: Skipping profile"
     end
   end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -354,7 +354,8 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
   describe 'when a dependency does not support our backend platform' do
     it 'skips the controls from that profile' do
       out = inspec("exec #{File.join(profile_path, 'profile-support-skip')} --no-create-lockfile")
-      out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: 0 successful controls, 0 control failures, \e[38;5;247m2 controls skipped\e[0m\n"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "WARN: Skipping profile: 'windows-only' on unsupported platform"
+      out.stdout.force_encoding(Encoding::UTF_8).must_include "0 successful, 0 failures, 0 skipped\n"
     end
   end
 
@@ -411,6 +412,19 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
       stdout.must_include '×  should eq "secret"'
       stdout.must_include '*** sensitive output suppressed ***'
       stdout.must_include "\nTest Summary: \e[38;5;41m2 successful\e[0m, \e[38;5;9m2 failures\e[0m, 0 skipped\n"
+    end
+  end
+
+  describe 'with a profile that loads dependencies' do
+    let(:out) { inspec('exec ' + File.join(profile_path, 'profile-support-skip') + ' --no-create-lockfile --reporter json') }
+    let(:json) { JSON.load(out.stdout) }
+    let(:controls) { json['profiles'][0]['controls'] }
+
+    it 'skips loaded inherited profiles on unsupported platforms' do
+      json['profiles'][0]['depends'][0]['name'].must_equal 'windows-only'
+      controls.must_be_empty
+      stderr = out.stderr.force_encoding(Encoding::UTF_8)
+      stderr.must_include "WARN: Skipping profile: 'windows-only'"
     end
   end
 

--- a/test/unit/file_provider_test.rb
+++ b/test/unit/file_provider_test.rb
@@ -85,7 +85,7 @@ describe Inspec::ZipProvider do
 
     it 'must contain all files' do
       subject.files.sort.must_equal %w{inspec.yml libraries libraries/testlib.rb
-        controls controls/filesystem_spec.rb files files/a_sub_dir
+        controls controls/host_spec.rb files files/a_sub_dir
         files/a_sub_dir/sub_items.conf files/items.conf}.sort
     end
 
@@ -130,7 +130,7 @@ describe Inspec::ZipProvider do
 
     it 'must contain all files' do
       subject.files.sort.must_equal %w{inspec.yml libraries libraries/testlib.rb
-        controls controls/filesystem_spec.rb files files/a_sub_dir
+        controls controls/host_spec.rb files files/a_sub_dir
         files/a_sub_dir/sub_items.conf files/items.conf}.sort
     end
 
@@ -152,7 +152,7 @@ describe Inspec::TarProvider do
 
     it 'must contain all files' do
       subject.files.sort.must_equal %w{inspec.yml libraries/testlib.rb
-        controls/filesystem_spec.rb files/a_sub_dir/sub_items.conf
+        controls/host_spec.rb files/a_sub_dir/sub_items.conf
         files/items.conf}.sort
     end
 

--- a/test/unit/mock/profiles/complete-profile/controls/host_spec.rb
+++ b/test/unit/mock/profiles/complete-profile/controls/host_spec.rb
@@ -1,15 +1,15 @@
 # encoding: utf-8
 # copyright: 2015, Chef Software, Inc
 
-title 'Proc Filesystem Configuration'
+title 'Host example.com lookup'
 
 control 'test01' do
   impact 0.5
   title 'Catchy title'
   desc '
-    There should always be a /proc
+    example.com should always exist.
   '
-  describe file('/proc') do
-    it { should be_mounted }
+  describe host('example.com') do
+    it { should be_resolvable }
   end
 end

--- a/test/unit/mock/profiles/complete-profile/inspec.yml
+++ b/test/unit/mock/profiles/complete-profile/inspec.yml
@@ -9,3 +9,5 @@ version: 1.0.0
 license: Apache-2.0
 supports:
 - os-family: linux
+- os-family: bsd
+- os-family: windows

--- a/test/unit/mock/profiles/unsupported_inspec/inspec.yml
+++ b/test/unit/mock/profiles/unsupported_inspec/inspec.yml
@@ -1,1 +1,3 @@
 inspec_version: '>= 99.0.0'
+supports:
+  - os-family: unsupported_inspec

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -110,6 +110,15 @@ describe Inspec::Profile do
     end
   end
 
+  describe 'skips loading on unsupported platform' do
+    let(:profile_id) { 'windows-only' }
+
+    it 'loads our profile but skips loading controls' do
+      info = MockLoader.load_profile(profile_id).info
+      info[:controls].must_be_empty
+    end
+  end
+
   describe 'when checking' do
     describe 'an empty profile' do
       let(:profile_id) { 'empty-metadata' }

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -68,14 +68,14 @@ describe Inspec::Profile do
     end
 
     it 'works on a complete profile' do
-      MockLoader.load_profile('complete-profile').sha256.must_equal '5a129bd0a06f3d27589871a8dc8c65361d3730e802b926755191b610b7f99d3a'
+      MockLoader.load_profile('complete-profile').sha256.must_equal '25cf05093c695d807e488b04e3551f19de900c1d2b0cbfadb476a5786efa7323'
     end
   end
 
   describe 'code info' do
     let(:profile_id) { 'complete-profile' }
-    let(:code) { "control 'test01' do\n  impact 0.5\n  title 'Catchy title'\n  desc '\n    There should always be a /proc\n  '\n  describe file('/proc') do\n    it { should be_mounted }\n  end\nend\n" }
-    let(:loc) { {:ref=>"controls/filesystem_spec.rb", :line=>6} }
+    let(:code) { "control 'test01' do\n  impact 0.5\n  title 'Catchy title'\n  desc '\n    example.com should always exist.\n  '\n  describe host('example.com') do\n    it { should be_resolvable }\n  end\nend\n" }
+    let(:loc) { {:ref=>"controls/host_spec.rb", :line=>6} }
 
     it 'gets code from an uncompressed profile' do
       info = MockLoader.load_profile(profile_id).info


### PR DESCRIPTION
I've made a few changes to allow inherited profiles to be skipped when they are loaded on unsupported platforms. We will now also output a WARN to STDERR detailing which profile was skipped:

```
[2018-08-28T14:36:37-07:00] WARN: Skipping profile: 'windows-only' on unsupported platform: 'mac_os_x'.
```

Please let me know how this implementation looks and if I missed anything.

ref: https://github.com/inspec/inspec/issues/3158