### PR TITLE
Convert legacy supports to their platform counterparts

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -229,7 +229,7 @@ module Inspec
       info(load_params.dup)
     end
 
-    def info(res = params.dup)
+    def info(res = params.dup) # rubocop:disable Metrics/CyclomaticComplexity
       # add information about the controls
       res[:controls] = res[:controls].map do |id, rule|
         next if id.to_s.empty?

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -252,6 +252,15 @@ module Inspec
       res[:attributes] = res[:attributes].map(&:to_hash) unless res[:attributes].nil? || res[:attributes].empty?
       res[:sha256] = sha256
       res[:parent_profile] = parent_profile unless parent_profile.nil?
+
+      # convert legacy os-* supports to their platform counterpart
+      if res[:supports] && !res[:supports].empty?
+        res[:supports].each do |support|
+          support[:"platform-family"] = support.delete(:"os-family") if support.key?(:"os-family")
+          support[:"platform-name"] = support.delete(:"os-name") if support.key?(:"os-name")
+        end
+      end
+
       res
     end
 

--- a/lib/inspec/schema.rb
+++ b/lib/inspec/schema.rb
@@ -102,7 +102,12 @@ module Inspec
       'type' => 'object',
       'additionalProperties' => false,
       'properties' => {
+        'platform-family' => { 'type' => 'string', 'optional' => true },
+        'platform-name' => { 'type' => 'string', 'optional' => true },
+        'platform' => { 'type' => 'string', 'optional' => true },
+        # os-* supports are being deprecated
         'os-family' => { 'type' => 'string', 'optional' => true },
+        'os-name' => { 'type' => 'string', 'optional' => true },
       },
     }.freeze
 

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -59,7 +59,7 @@ describe 'inspec exec with json formatter' do
         "summary" => "Demonstrates the use of InSpec Compliance Profile",
         "version" => "1.0.0",
         "sha256" => "57709d3a3d5cd06f4179be7e6fbe254c09e3af25ce274e474d52623e34487cc4",
-        "supports" => [{"os-family" => "unix"}],
+        "supports" => [{"platform-family" => "unix"}],
         "attributes" => []
       })
 

--- a/test/unit/mock/profiles/skippy-profile-os/inspec.yml
+++ b/test/unit/mock/profiles/skippy-profile-os/inspec.yml
@@ -3,3 +3,4 @@ title: skip-like functionality
 version: 1.0.0
 supports:
 - os-family: definitely_not_supported
+- os-name: definitely_also_not_supported

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -99,6 +99,17 @@ describe Inspec::Profile do
     end
   end
 
+  describe 'code info with supports override' do
+    let(:profile_id) { 'skippy-profile-os' }
+
+    it 'overrides os-name and os-family' do
+      path = MockLoader.profile_zip(profile_id)
+      info = MockLoader.load_profile(path).info
+      info[:supports][0][:"platform-family"].must_equal "definitely_not_supported"
+      info[:supports][1][:"platform-name"].must_equal "definitely_also_not_supported"
+    end
+  end
+
   describe 'when checking' do
     describe 'an empty profile' do
       let(:profile_id) { 'empty-metadata' }


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This change will update `os-name` and `os-family` when outputting to reports or json profile extract.

Fixes https://github.com/inspec/inspec/issues/3144