### PR TITLE
Fix the brew command to install inspec

### DIFF
--- a/www/source/downloads.html.slim
+++ b/www/source/downloads.html.slim
@@ -31,7 +31,7 @@ header.bg-gradient.margin-top-offset.short-bg.relative
     .large-6.medium-6.mobile-12.columns.margin-under-xs
       .box-white.shadow.strict-center.fit-height.relative.slide-up.z-20
         .align-vertical-50
-          small.t-gray For OSX users
+          small.t-gray For macOS users
           hr.center.margin-under-xs
           h3.pad-top-xs Homebrew package
           p.pad-under-xs
@@ -41,7 +41,7 @@ header.bg-gradient.margin-top-offset.short-bg.relative
           .pad-under-xs
             .box-code.box-code-overwrite.shadow.margin-top-xs
              i#copy.fa.fa-copy.copy.t-purple.mobile-hide onclick="copyToClipboard('#install')"
-             code#install brew cask install inspec
+             code#install brew cask install chef/chef/inspec
         .triangle-right
   #particles-third
     canvas.particles-js-canvas-el /


### PR DESCRIPTION
InSpec was pulled from the casks a while ago. We have our own setup now,
but the command to pull from there is a bit different. Also OSX should
be macOS.

Signed-off-by: Tim Smith <tsmith@chef.io>