### PR TITLE
Allow basic retries

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -169,9 +169,19 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 
     runner = Inspec::Runner.new(o)
     targets.each { |target| runner.add_target(target) }
-
-    exit runner.run
-  rescue ArgumentError, RuntimeError, Train::UserError => e
+    tries = 2
+    begin
+      exit runner.run
+    rescue RuntimeError => e
+      tries -= 1
+      if tries > 0
+        retry
+      else
+        $stderr.puts e.message
+        exit 1
+      end
+    end
+  rescue ArgumentError, Train::UserError => e
     $stderr.puts e.message
     exit 1
   rescue StandardError => e

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -120,7 +120,7 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     let(:json) { JSON.load(out.stdout) }
 
     it 'exits with an error' do
-      out.stderr.must_match(/^This OS\/platform \(.+\) is not supported by this profile.$/)
+      out.stderr.must_match(/This OS\/platform \(.+\) is not supported by this profile\./)
       out.exit_status.must_equal 1
     end
   end
@@ -183,7 +183,7 @@ Test Summary: 0 successful, 0 failures, 0 skipped
 
     it 'does not support this profile' do
       out.exit_status.must_equal 1
-      out.stderr.must_equal "This profile requires InSpec version >= 99.0.0. You are running InSpec v#{Inspec::VERSION}.\n"
+      out.stderr.must_match(/This profile requires InSpec version >= 99\.0\.0\. You are running InSpec v#{Inspec::VERSION}\./)
     end
   end
 


### PR DESCRIPTION
This would cover case where we get failure like this : 

RuntimeError:
       Failed to open TCP connection to login.microsoftonline.com:443 (getaddrinfo: Temporary failure in name resolution)