### PR TITLE
handle errors from automate report and display them to the user

### DIFF
--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -53,8 +53,13 @@ module Inspec::Reporters
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
 
-        http.request(req)
-        return true
+        res = http.request(req)
+        if res.is_a?(Net::HTTPSuccess)
+          return true
+        else
+          Inspec::Log.error "send_report: POST to #{uri.path} returned: #{res.body}"
+          return false
+        end
       rescue => e
         Inspec::Log.error "send_report: POST to #{uri.path} returned: #{e.message}"
         return false


### PR DESCRIPTION
I misconfigured the automate reporting url and it took me 30 min to figure out why it was not reported to Automate. I added a check that verifies that the report post was successful.