### PR TITLE
do not show success message since its confusing

### DIFF
--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -69,7 +69,8 @@ module Compliance
           li("#{profile['title']} v#{profile['version']} (#{mark_text(owner + '/' + profile['name'])})")
         }
       else
-        puts msg, 'Could not find any profiles'
+        puts msg if msg != 'success'
+        puts 'Could not find any profiles'
         exit 1
       end
     rescue Compliance::ServerConfigurationMissing


### PR DESCRIPTION
Turns the output from
<img width="382" alt="screen shot 2018-09-07 at 12 35 45 pm" src="https://user-images.githubusercontent.com/1178413/45214412-b1a6b380-b29a-11e8-93d5-0a5baea00670.png">
to
<img width="405" alt="screen shot 2018-09-07 at 12 35 57 pm" src="https://user-images.githubusercontent.com/1178413/45214404-ae132c80-b29a-11e8-94a2-794a55292bfa.png">
