### PR TITLE
ensure we use the mock backend when we upload profiles

### DIFF
--- a/lib/bundles/inspec-compliance/cli.rb
+++ b/lib/bundles/inspec-compliance/cli.rb
@@ -149,6 +149,12 @@ module Compliance
 
       o = options.dup
       configure_logger(o)
+
+      # only run against the mock backend, otherwise we run against the local system
+      o[:backend] = Inspec::Backend.create(target: 'mock://')
+      o[:check_mode] = true
+      o[:vendor_cache] = Inspec::Cache.new(o[:vendor_cache])
+
       # check the profile, we only allow to upload valid profiles
       profile = Inspec::Profile.for_target(path, o)
 
@@ -190,7 +196,9 @@ module Compliance
       end
 
       # if it is a directory, tar it to tmp directory
+      generated = false
       if File.directory?(path)
+        generated = true
         archive_path = Dir::Tmpname.create([profile_name, '.tar.gz']) {}
         puts "Generate temporary profile archive at #{archive_path}"
         profile.archive({ output: archive_path, ignore_errors: false, overwrite: true })
@@ -207,6 +215,9 @@ module Compliance
         puts 'Uploading to Chef Compliance'
       end
       success, msg = Compliance::API.upload(config, config['owner'], pname, archive_path)
+
+      # delete temp file if it was temporary generated
+      File.delete(archive_path) if generated && File.exist?(archive_path)
 
       if success
         puts 'Successfully uploaded profile'


### PR DESCRIPTION
The compliance upload has not used the mock backend. This is especially recognized due to long run-times on Windows if wmi resources have been used. We should never execute a profile against the local target for upload.

It also catches an issue where generated profiles are not deleted if they've been generated

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>