### PR TITLE
Add db_name flag

### DIFF
--- a/docs/resources/mssql_session.md.erb
+++ b/docs/resources/mssql_session.md.erb
@@ -63,6 +63,14 @@ The following examples show how to use this InSpec audit resource.
       its("value") { should cmp > '12.00.4457' }
     end
 
+### Test a specific database
+
+    sql = mssql_session(user: 'my_user', password: 'password', db_name: 'test')
+
+    describe sql.query("SELECT Name AS result FROM Product WHERE ProductID == 1").row(0).column('result') do
+      its("value") { should eq 'foo' }
+    end
+
 <br>
 
 ## Matchers

--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -29,7 +29,7 @@ module Inspec::Resources
       end
     "
 
-    attr_reader :user, :password, :host, :port, :instance, :local_mode
+    attr_reader :user, :password, :host, :port, :instance, :local_mode, :db_name
     def initialize(opts = {})
       @user = opts[:user]
       @password = opts[:password] || opts[:pass]
@@ -46,6 +46,7 @@ module Inspec::Resources
         end
       end
       @instance = opts[:instance]
+      @db_name = opts[:db_name]
 
       # check if sqlcmd is available
       raise Inspec::Exceptions::ResourceSkipped, 'sqlcmd is missing' unless inspec.command('sqlcmd').exist?
@@ -69,6 +70,9 @@ module Inspec::Resources
         else
           cmd_string += "\\#{@instance}'"
         end
+      end
+      unless @db_name.nil? 
+        cmd_string += " -d '#{@db_name}'"
       end
       cmd = inspec.command(cmd_string)
       out = cmd.stdout + "\n" + cmd.stderr


### PR DESCRIPTION
Currently the mssql_session resource fires the query against the login's default database.  Adding the `-d` flag to the SQLCMD query allows for a user to query any database they have access to on the provided host & instance (if any).  I have added an attribute (db_name) for users to call out a database they want to run the query against, and an example of the attribute to let users know it's available for use.