### PR TITLE
Added db_name flag

### DIFF
--- a/docs/resources/mssql_session.md.erb
+++ b/docs/resources/mssql_session.md.erb
@@ -62,6 +62,14 @@ The following examples show how to use this InSpec audit resource.
     describe sql.query("SELECT SERVERPROPERTY('ProductVersion') as result").row(0).column('result') do
       its("value") { should cmp > '12.00.4457' }
     end
+  
+### Test a specific database
+
+    sql = mssql_session(user: 'my_user', password: 'password', db_name: 'test')
+
+    describe sql.query("SELECT Name AS result FROM Product WHERE ProductID == 1").row(0).column('result') do
+      its("value") { should eq 'foo' }
+    end
 
 <br>
 

--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -54,7 +54,7 @@ module Inspec::Resources
       raise Inspec::Exceptions::ResourceSkipped, "Can't connect to the MS SQL Server." unless test_connection
     end
 
-    def query(q)
+    def query(q) # rubocop:disable Metrics/PerceivedComplexity
       escaped_query = q.gsub(/\\/, '\\\\').gsub(/"/, '\\"').gsub(/\$/, '\\$')
       # surpress 'x rows affected' in SQLCMD with 'set nocount on;'
       cmd_string = "sqlcmd -Q \"set nocount on; #{escaped_query}\" -W -w 1024 -s ','"

--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -59,6 +59,7 @@ module Inspec::Resources
       # surpress 'x rows affected' in SQLCMD with 'set nocount on;'
       cmd_string = "sqlcmd -Q \"set nocount on; #{escaped_query}\" -W -w 1024 -s ','"
       cmd_string += " -U '#{@user}' -P '#{@password}'" unless @user.nil? || @password.nil?
+      cmd_string += " -d '#{@db_name}'" unless @db_name.nil?
       unless local_mode?
         if @port.nil?
           cmd_string += " -S '#{@host}"
@@ -70,9 +71,6 @@ module Inspec::Resources
         else
           cmd_string += "\\#{@instance}'"
         end
-      end
-      unless @db_name.nil? 
-        cmd_string += " -d '#{@db_name}'"
       end
       cmd = inspec.command(cmd_string)
       out = cmd.stdout + "\n" + cmd.stderr

--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -29,7 +29,7 @@ module Inspec::Resources
       end
     "
 
-    attr_reader :user, :password, :host, :port, :instance, :local_mode
+    attr_reader :user, :password, :host, :port, :instance, :local_mode, :db_name
     def initialize(opts = {})
       @user = opts[:user]
       @password = opts[:password] || opts[:pass]
@@ -46,6 +46,7 @@ module Inspec::Resources
         end
       end
       @instance = opts[:instance]
+      @db_name = opts[:db_name]
 
       # check if sqlcmd is available
       raise Inspec::Exceptions::ResourceSkipped, 'sqlcmd is missing' unless inspec.command('sqlcmd').exist?
@@ -69,6 +70,9 @@ module Inspec::Resources
         else
           cmd_string += "\\#{@instance}'"
         end
+      end
+      unless @db_name.nil? 
+        cmd_string += " -d '#{@db_name}'"
       end
       cmd = inspec.command(cmd_string)
       out = cmd.stdout + "\n" + cmd.stderr


### PR DESCRIPTION
Signed-off-by: Kayleigh <kayleigh.doores@gmail.com>

By default SQLCMD queries against the default dabase that is assigned to that users login.  Adding the `-d` flag allows for specifying a database outside of the default scope, that a user has access to.  I added `db_name` as a flag for the resource, and an example so that users know that it's there.