### PR TITLE
Populate code for inspec json inheritance

### DIFF
--- a/lib/inspec/dependencies/dependency_set.rb
+++ b/lib/inspec/dependencies/dependency_set.rb
@@ -47,7 +47,7 @@ module Inspec
     end
 
     attr_reader :vendor_path
-    attr_writer :dep_list
+    attr_accessor :dep_list
     # initialize
     #
     # @param cwd [String] current working directory for relative path includes

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -229,7 +229,7 @@ module Inspec
       info(load_params.dup)
     end
 
-    def info(res = params.dup) # rubocop:disable Metrics/CyclomaticComplexity
+    def info(res = params.dup) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       # add information about the controls
       res[:controls] = res[:controls].map do |id, rule|
         next if id.to_s.empty?
@@ -242,9 +242,9 @@ module Inspec
 
         # if the code field is empty try and pull info from dependencies
         if data[:code].empty?
-          locked_dependencies.dep_list.each do |name, dep|
+          locked_dependencies.dep_list.each do |_name, dep|
             profile = dep.profile
-            if profile.runner_context&.current_load.values.first == data[:source_location][:ref]
+            if profile.runner_context&.current_load&.values&.first == data[:source_location][:ref]
               data[:code] = Inspec::MethodSource.code_at(data[:source_location], profile.source_reader)
             end
           end
@@ -273,6 +273,7 @@ module Inspec
 
       res
     end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     # Check if the profile is internally well-structured. The logger will be
     # used to print information on errors and warnings which are found.

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -246,6 +246,7 @@ module Inspec
             profile = dep.profile
             code = Inspec::MethodSource.code_at(data[:source_location], profile.source_reader)
             data[:code] = code unless code.nil? || code.empty?
+            break if !data[:code].empty?
           end
         end
         data
@@ -272,7 +273,6 @@ module Inspec
 
       res
     end
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     # Check if the profile is internally well-structured. The logger will be
     # used to print information on errors and warnings which are found.

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -241,12 +241,11 @@ module Inspec
         data[:id] = id
 
         # if the code field is empty try and pull info from dependencies
-        if data[:code].empty?
+        if data[:code].empty? && parent_profile.nil?
           locked_dependencies.dep_list.each do |_name, dep|
             profile = dep.profile
-            if profile.runner_context&.current_load&.values&.first == data[:source_location][:ref]
-              data[:code] = Inspec::MethodSource.code_at(data[:source_location], profile.source_reader)
-            end
+            code = Inspec::MethodSource.code_at(data[:source_location], profile.source_reader)
+            data[:code] = code unless code.nil? || code.empty?
           end
         end
         data

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -239,6 +239,16 @@ module Inspec
         data[:impact] = 1.0 if data[:impact] > 1.0
         data[:impact] = 0.0 if data[:impact] < 0.0
         data[:id] = id
+
+        # if the code field is empty try and pull info from dependencies
+        if data[:code].empty?
+          locked_dependencies.dep_list.each do |name, dep|
+            profile = dep.profile
+            if profile.runner_context&.current_load.values.first == data[:source_location][:ref]
+              data[:code] = Inspec::MethodSource.code_at(data[:source_location], profile.source_reader)
+            end
+          end
+        end
         data
       end.compact
 

--- a/test/functional/inspec_json_profile_test.rb
+++ b/test/functional/inspec_json_profile_test.rb
@@ -131,7 +131,8 @@ describe 'inspec json' do
   end
 
   describe 'inspec json with a inheritance profile' do
-    let(:profile) { File.join(profile_path, 'dependencies', 'inheritance') }
+    let(:profile) { File.join(examples_path, 'meta-profile') }
+
     it 'can execute a profile inheritance' do
       out = inspec('json ' + profile)
       out.stderr.must_equal ''
@@ -144,9 +145,6 @@ describe 'inspec json' do
       json = JSON.load(out.stdout)
       json['controls'].each do |control|
         control['code'].empty?.must_equal false
-        if control['id'] == "profilea-2"
-          control['code'].must_equal "control 'profilea-2' do\n  describe gordon_config do\n    its('version') { should eq('1.0') }\n  end\nend\n"
-        end
       end
     end
   end

--- a/test/functional/inspec_json_profile_test.rb
+++ b/test/functional/inspec_json_profile_test.rb
@@ -130,6 +130,27 @@ describe 'inspec json' do
     end
   end
 
+  describe 'inspec json with a inheritance profile' do
+    let(:profile) { File.join(profile_path, 'dependencies', 'inheritance') }
+    it 'can execute a profile inheritance' do
+      out = inspec('json ' + profile)
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+      JSON.load(out.stdout).must_be_kind_of Hash
+    end
+
+    it 'populates code from child profiles' do
+      out = inspec('json ' + profile)
+      json = JSON.load(out.stdout)
+      json['controls'].each do |control|
+        control['code'].empty?.must_equal false
+        if control['id'] == "profilea-2"
+          control['code'].must_equal "control 'profilea-2' do\n  describe gordon_config do\n    its('version') { should eq('1.0') }\n  end\nend\n"
+        end
+      end
+    end
+  end
+
   describe 'inspec json with a profile containing only_if' do
     it 'ignores the `only_if`' do
       out = inspec('json ' + File.join(profile_path, 'only-if-os-nope'))


### PR DESCRIPTION
Fixes https://github.com/chef/a2/issues/3622

This fix allows the `inspec json` command to pull code info from child profiles when needed.