### PR TITLE
Bump omnibus ruby to 2.5.1

### DIFF
--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -37,7 +37,7 @@ end
 build_version Inspec::VERSION
 build_iteration 1
 
-override 'ruby', version: '2.4.3'
+override 'ruby', version: '2.5.1'
 # RubyGems 2.7.0 caused issues in the Jenkins pipelines, trouble installing bundler.
 # This issue is not evident in 2.6.x, hence the pin.
 override 'rubygems', version: '2.6.14'


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This updates the standalone omnibus inspec build to use Ruby 2.5.1. I have created artifacts here and tested them:
http://manhattan.cd.chef.co/job/inspec-trigger-ad_hoc/36/downstreambuildview/

http://artifactory.chef.co/webapp/#/builds/inspec/2.2.92+20180913131150/1536846065608/published%20/com.getchef:inspec:2.2.92+20180913131150

Looks to be working as expected.