### PR TITLE
Prevent logs from showing up when running inspec json

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -35,6 +35,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   def json(target)
     o = opts.dup
     diagnose(o)
+    o['log_location'] = STDERR
+    configure_logger(o)
+
     o[:backend] = Inspec::Backend.create(target: 'mock://')
     o[:check_mode] = true
     o[:vendor_cache] = Inspec::Cache.new(o[:vendor_cache])

--- a/test/functional/inspec_json_profile_test.rb
+++ b/test/functional/inspec_json_profile_test.rb
@@ -135,7 +135,6 @@ describe 'inspec json' do
 
     it 'can execute a profile inheritance' do
       out = inspec('json ' + profile)
-      out.stderr.must_equal ''
       out.exit_status.must_equal 0
       JSON.load(out.stdout).must_be_kind_of Hash
     end
@@ -150,7 +149,7 @@ describe 'inspec json' do
   end
 
   describe 'inspec json does not write logs to STDOUT' do
-    it 'execute a profile with warn calls and parses as valid json' do
+    it 'can execute a profile with warn calls and parse STDOUT as valid JSON' do
       out = inspec('json ' + File.join(profile_path, 'warn_logs'))
       out.exit_status.must_equal 0
       JSON.load(out.stdout)

--- a/test/functional/inspec_json_profile_test.rb
+++ b/test/functional/inspec_json_profile_test.rb
@@ -149,6 +149,14 @@ describe 'inspec json' do
     end
   end
 
+  describe 'inspec json does not write logs to STDOUT' do
+    it 'execute a profile with warn calls and parses as valid json' do
+      out = inspec('json ' + File.join(profile_path, 'warn_logs'))
+      out.exit_status.must_equal 0
+      JSON.load(out.stdout)
+    end
+  end
+
   describe 'inspec json with a profile containing only_if' do
     it 'ignores the `only_if`' do
       out = inspec('json ' + File.join(profile_path, 'only-if-os-nope'))

--- a/test/unit/mock/profiles/warn_logs/controls/control_with_logs.rb
+++ b/test/unit/mock/profiles/warn_logs/controls/control_with_logs.rb
@@ -1,0 +1,11 @@
+Inspec::Log.warn 'This is a warn call!'
+Inspec::Log.warn 'This is another warn call!'
+
+control 'tmp-1.0' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/warn_logs/inspec.yml
+++ b/test/unit/mock/profiles/warn_logs/inspec.yml
@@ -1,0 +1,8 @@
+name: warn_logs
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

Currently our functional tests are broken for `inspec json` depending on the order of the tests. This fix pushes `Inspec::Log` to STDERR when running `inspec json`