### PR TITLE
Fix the compliance target error checks

### DIFF
--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -17,12 +17,12 @@ module Compliance
 
     def initialize(target, opts)
       super(target, opts)
+      @upstream_sha256 = ''
       if target.is_a?(Hash) && target.key?(:url)
         @target = target[:url]
         @upstream_sha256 = target[:sha256]
       elsif target.is_a?(String)
         @target = target
-        @upstream_sha256 = ''
       end
     end
 
@@ -30,7 +30,7 @@ module Compliance
       upstream_sha256.empty? ? super : upstream_sha256
     end
 
-    def self.check_compliance_token(config)
+    def self.check_compliance_token(uri, config)
       if config['token'].nil? && config['refresh_token'].nil?
         if config['server_type'] == 'automate'
           server = 'automate'
@@ -73,7 +73,7 @@ module Compliance
       if target.respond_to?(:key?) && target.key?(:sha256)
         profile_checksum = target[:sha256]
       else
-        check_compliance_token(config)
+        check_compliance_token(uri, config)
         # verifies that the target e.g base/ssh exists
         # Call profiles directly instead of exist? to capture the results
         # so we can access the upstream sha256 from the results.

--- a/test/unit/bundles/inspec-compliance/target_test.rb
+++ b/test/unit/bundles/inspec-compliance/target_test.rb
@@ -3,6 +3,20 @@ require 'helper'
 describe Compliance::Fetcher do
   let(:config) { { 'server' => 'myserver' } }
 
+  describe 'the check_compliance_token method' do
+    let(:fetcher) { fetcher = Compliance::Fetcher.new('a/bad/url', config) }
+
+    it 'returns without error if token is set' do
+      config['token'] = 'my-token'
+      fetcher.class.check_compliance_token('http://test.com', config)
+    end
+
+    it 'returns an error when token is not set' do
+      ex = assert_raises(Inspec::FetcherFailure) { fetcher.class.check_compliance_token('http://test.com', config) }
+      ex.message.must_include "Cannot fetch http://test.com because your compliance token has not been\nconfigured."
+    end
+  end
+
   describe 'when the server is an automate2 server' do
     before { Compliance::API.expects(:is_automate2_server?).with(config).returns(true) }
 


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This makes sure `@upstream_sha256` is always set along with making the `check_compliance_token` error have a `uri` to specify in the error message.

Confirmed this fixes the upstream Audit issues.