### PR TITLE
Update AWS Security Group to work with IPV6 rules.

### DIFF
--- a/docs/resources/aws_security_group.md.erb
+++ b/docs/resources/aws_security_group.md.erb
@@ -12,7 +12,6 @@ SGs are a networking construct which contain ingress and egress rules for networ
 
 While this resource provides facilities for searching inbound and outbound rules on a variety of criteria, there is currently no support for performing matches based on:
 
- * IPv6 ranges
  * References to other Security Groups
  * References to VPC peers or other AWS services (that is, no support for searches based on 'prefix lists').
 
@@ -143,7 +142,7 @@ A string identifying the VPC that contains the Security Group. Since VPCs common
 <br>
 ## Properties
 
-* [`description`](#description), [`group_id`](#group_id), [`group_name`](#group_name), [`inbound_rules`](#inbound_rules), [`outbound_rules`](#outbound_rules), [`vpc_id`](#vpc_id)
+* [`description`](#description), [`group_id`](#group_id), [`group_name`](#group_name), [`inbound_rules`](#inbound_rules), [`inbound_rules_count`](#inbound_rules_count), [`outbound_rules`](#outbound_rules), [`outbound_rules_count`](#outbound_rules_count), [`vpc_id`](#vpc_id)
 
 <br>
 
@@ -191,6 +190,14 @@ If the Security Group could not be found (that is, `exists` is false), `inbound_
       its('inbound_rules.first') { should include(from_port: '22', ip_ranges: ['10.2.17.0/24']) }
     end
 
+### inbound\_rules\_count
+
+A Number totalling the number of individual rules defined - It is a sum of the combinations of port, protocol, ipv4 rules, ipv6 rules and security group rules.
+
+    describe aws_security_group(group_name: linux_servers) do
+      its('inbound_rules_count'){ should eq 10 }
+    end
+
 ### outbound\_rules
 
 A list of the rules that the Security Group applies to outgoing network traffic initiated by the AWS resource in the Security Group. This is a low-level property that is used by the [`allow_out`](#allow_out) matcher; see it for detailed examples. `outbound_rules` is provided here for those wishing to use Ruby code to inspect the rules directly, instead of using higher-level matchers.
@@ -201,6 +208,14 @@ If the Security Group could not be found (that is, `exists` is false), `outbound
 
     describe aws_security_group(group_name: isolated_servers) do
       its('outbound_rules.last') { should_not include(ip_ranges:['0.0.0.0/0']) }
+    end
+
+### outbound\_rules\_count
+
+A Number totalling the number of individual rules defined - It is a sum of the combinations of port, protocol, ipv4 rules, ipv6 rules and security group rules.
+
+    describe aws_security_group(group_name: linux_servers) do
+      its('outbound_rules_count'){ should eq 2 }
     end
 
 ### vpc\_id
@@ -240,6 +255,7 @@ The matchers accept a key-value list of search criteria.  For a rule to match, i
 
   * from_port - Determines if a rule exists whose port range begins at the specified number. The word 'from_' does *not* relate to inbound/outbound directionality; it relates to the port range ("counting _from_"). `from_port` is an exact criterion; so if the rule allows 1000-2000 and you specify a `from_port` of 1001, it does not match.
   * ipv4_range - Specifies an IPv4 address or subnet as a CIDR, or a list of them, to be checked as a permissible origin (for `allow_in`) or destination (for `allow_out`) for traffic.  Each AWS Security Group rule may have multiple allowed source IP ranges.
+  * ipv6_range - Specifies an IPv6 address or subnet as a CIDR, or a list of them, to be checked as a permissible origin (for `allow_in`) or destination (for `allow_out`) for traffic.  Each AWS Security Group rule may have multiple allowed source IP ranges.
   * port - Determines if a particular TCP/IP port is reachable. allow_in and allow_out examine whether the specified port is included in the port range of a rule, while allow_in. You may specify the port as a string (`'22'`) or as a number.
   * position - A one-based index into the list of rules. If provided, this restricts the evaluation to the rule at that position. You may also use the special values `:first` and `:last`. `position` may also be used to enable `allow_in_only` and `allow_out_only` to work with multi-rule Security Groups.
   * protocol - Specifies the IP protocol. 'tcp', 'udp', and 'icmp' are some typical values. The string "-1" or 'any' is used to indicate any protocol.
@@ -248,6 +264,7 @@ The matchers accept a key-value list of search criteria.  For a rule to match, i
     describe aws_security_group(group_name: 'mixed-functionality-group') do
       # Allow RDP from defined range
       it { should allow_in(port: 3389, ipv4_range: '10.5.0.0/16') }
+      it { should allow_in(port: 3389, ipv6_range: '2001:db8::/122') }
 
       # Allow SSH from two ranges
       it { should allow_in(port: 22, ipv4_range: ['10.5.0.0/16', '10.2.3.0/24']) }

--- a/test/integration/aws/default/build/ec2.tf
+++ b/test/integration/aws/default/build/ec2.tf
@@ -251,6 +251,7 @@ resource "aws_security_group_rule" "alpha_x11" {
   to_port           = "6007"
   protocol          = "tcp"
   cidr_blocks       = ["10.1.2.0/24", "10.3.2.0/24"]
+  ipv6_cidr_blocks = ["2001:db8::/122"]
   security_group_id = "${aws_security_group.alpha.id}"
 }
 
@@ -260,6 +261,15 @@ resource "aws_security_group_rule" "alpha_all_ports" {
   to_port           = "65535"
   protocol          = "tcp"
   cidr_blocks       = ["10.1.2.0/24"]
+  security_group_id = "${aws_security_group.alpha.id}"
+}
+
+resource "aws_security_group_rule" "alpha_piv6_all_ports" {
+  type              = "ingress"
+  from_port         = "0"
+  to_port           = "65535"
+  protocol          = "tcp"
+  ipv6_cidr_blocks = ["2001:db8::/122"]
   security_group_id = "${aws_security_group.alpha.id}"
 }
 

--- a/test/integration/aws/default/verify/controls/aws_security_group.rb
+++ b/test/integration/aws/default/verify/controls/aws_security_group.rb
@@ -40,9 +40,11 @@ control "aws_security_group properties" do
     its('inbound_rules') { should be_a_kind_of(Array)}
     its('inbound_rules.first') { should be_a_kind_of(Hash)}
     its('inbound_rules.count') { should cmp 3 } # 3 explicit, one implicit
+    its('inbound_rules_count') { should cmp 4 }
     its('outbound_rules') { should be_a_kind_of(Array)}
     its('outbound_rules.first') { should be_a_kind_of(Hash)}
     its('outbound_rules.count') { should cmp 1 } # 1 explicit
+    its('outbound_rules_count') { should cmp 3 } # 3 CIDR blocks specified
   end  
 end
 
@@ -54,6 +56,7 @@ control "aws_security_group matchers" do
     it { should_not allow_in(ipv4_range: "0.0.0.0/0", port: 22)}
     it { should allow_in(ipv4_range: "10.1.2.0/24", port: 22)}
     it { should allow_in(ipv4_range: ["10.1.2.0/24"], port: 22)}
+    it { should allow_in(ipv6_range: ["2001:db8::/122"], port: 22)}
 
     it { should allow_in({ipv4_range: "10.1.2.32/32", position: 2}) }    
     it { should_not allow_in_only({ipv4_range: "10.1.2.32/32", position: 2}) }
@@ -68,5 +71,7 @@ control "aws_security_group matchers" do
     it { should allow_out(ipv4_range: ["10.1.2.0/24", "10.3.2.0/24"], from_port: 6000, to_port: 6007)}
     it { should allow_out(ipv4_range: ["10.1.2.0/24", "10.3.2.0/24"], from_port: 6000, to_port: 6007, position: 1)}
 
+    it { should allow_out(ipv6_range: ["2001:db8::/122"])}
+    it { should allow_out(ipv6_range: ["2001:db8::/122"], from_port: 6000, to_port: 6007)}
   end
 end


### PR DESCRIPTION
Also added inbound_rules_count and outbound_rules_count for total variants

Signed-off-by: Martin Logan <martinloganzz@gmail.com>

I'm relatively new to ruby so please feel free to give me any feedback and I'll endeavor to address it