### PR TITLE
adding `versions` to the `gem` resource

### DIFF
--- a/docs/resources/gem.md.erb
+++ b/docs/resources/gem.md.erb
@@ -46,6 +46,15 @@ The following examples show how to use this InSpec audit resource.
       its('version') { should eq '0.33.0' }
     end
 
+### Verify that a particular version is installed when there are multiple versions installed
+
+    describe gem('rubocop') do
+      it { should be_installed }
+      its('versions') { should include /0.51.0/ }
+      its('versions.count') { should_not be > 3 }
+    end
+
+
 ### Verify that a gem package is not installed
 
     describe gem('rubocop') do
@@ -72,6 +81,21 @@ The following examples show how to use this InSpec audit resource.
 
 <br>
 
+## Properties
+
+### version (String)
+
+The `version` property returns a string of the default version on the system:
+
+    its('version') { should eq '0.33.0' }
+
+### versions
+
+The `versions` property returns an array of strings of all the versions of the gem installed on the system:
+
+    its('versions') { should include /0.33/ }
+
+
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
@@ -82,8 +106,3 @@ The `be_installed` matcher tests if the named Gem package is installed:
 
     it { should be_installed }
 
-### version
-
-The `version` matcher tests if the named package version is on the system:
-
-    its('version') { should eq '0.33.0' }

--- a/lib/resources/gem.rb
+++ b/lib/resources/gem.rb
@@ -49,9 +49,10 @@ module Inspec::Resources
       }
       return @info unless @info[:installed]
 
-      versions = params[2].split(',')
+      versions = params[2].split(',').map(&:strip)
       @info[:name] = params[1]
       @info[:version] = versions[0]
+      @info[:versions] = versions
       @info
     end
 
@@ -61,6 +62,11 @@ module Inspec::Resources
 
     def version
       info[:version]
+    end
+
+    # this returns an array of strings
+    def versions
+      info[:versions]
     end
 
     def to_s

--- a/test/unit/resources/gem_test.rb
+++ b/test/unit/resources/gem_test.rb
@@ -51,6 +51,20 @@ describe 'Inspec::Resources::Gem' do
     _(resource.gem_binary).must_equal '/opt/chef/embedded/bin/gem'
   end
 
+  it 'verifies gem in :chef when multiple versions are installed' do
+    resource = load_resource('gem', 'chef-sugar', :chef)
+    pkg = {
+      name: 'chef-sugar',
+      versions: ['3.3.0', '3.4.0'],
+      type: 'gem',
+      installed: true,
+    }
+    _(resource.installed?).must_equal true
+    _(resource.info.versions).must_include /3\.4/
+    _(resource.info.versions).wont_include /2\.4/
+    _(resource.gem_binary).must_equal '/opt/chef/embedded/bin/gem'
+  end
+
   it 'verify gem in :chef on windows' do
     resource = MockLoader.new(:windows).load_resource('gem', 'json', :chef)
     pkg = {


### PR DESCRIPTION
This is useful when you have multiple versions of the same gem installed. It can be leveraged like so:
```
describe gem('rest-client') do
  its('versions') { should include /1.8\.\d+/ }
  its('versions') { should include /2.0\.\d+/ }
  its('versions.count') { should_be eq 2 }
end
```

Signed-off-by: Ben Abrams <me@benabrams.it>