### PR TITLE
Fix etc_fstab mount_options split

### DIFF
--- a/lib/resources/etc_fstab.rb
+++ b/lib/resources/etc_fstab.rb
@@ -79,7 +79,7 @@ module Inspec::Resources
         'device_name'         => attributes[0],
         'mount_point'         => attributes[1],
         'file_system_type'    => attributes[2],
-        'mount_options'       => attributes[3].split(','),
+        'mount_options'       => attributes[3] =~ /,/ ? attributes[3].split(',') : attributes[3],
         'dump_options'        => attributes[4].to_i,
         'file_system_options' => attributes[5].to_i,
       }


### PR DESCRIPTION
Most often the _mounts_options_ part in _/etc/fstab_ will be simple _defaults_