### PR TITLE
Plugins: Example CLI Plugin, a Resource Lister

### DIFF
--- a/examples/plugin/LICENSE
+++ b/examples/plugin/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 2018 Chef Software Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/plugin/README.md
+++ b/examples/plugin/README.md
@@ -1,0 +1,38 @@
+# InSpec Plugin Example - Resource Lister
+
+This plugin provides an example of building a plugin for use with [InSpec](https://inspec.io). Its functionality is simple, but useful: list resources included with InSpec.
+
+## To Install this as a User
+
+You will need InSpec v2.3 or later.
+
+If you just want to use this (not learn how to write a plugin), you can so by simply running:
+
+```
+you@machine $ inspec plugin install inspec-resource-lister
+```
+
+You can then run:
+
+```
+you@machine $ inspec plugin help resource-lister
+# ... Usage info
+
+you@machine $ inspec plugin resource-lister ../some-profile
+
+Resources found:
+  13 aws_security_group
+   2 json
+
+15 controls total.
+```
+
+## Development of a Plugin
+
+[Plugin Development]() is documented on the InSpec website.  Additionally, this example plugin has extensive comments explaining what is happening, and why.
+
+### A Tour of the Plugin
+
+One nice circuit of the plugin might be:
+ * look at the gemspec, to see what the plugin thinks it does
+ * look at the functional tests, to see the plugin proving it does what it says

--- a/examples/plugin/inspec-resource-lister.gemspec
+++ b/examples/plugin/inspec-resource-lister.gemspec
@@ -1,0 +1,45 @@
+# coding: utf-8
+
+# As plugins are usually packaged and distributed as a RubyGem,
+# we have to provide a .gemspec file, which controls the gembuild
+# and publish process.  This is a fairly generic gemspec.
+
+# It is traditional in a gemspec to dynamically load the current version
+# from a file in the source tree.  The next three lines make that happen.
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "inspec-resource-lister/version"
+
+Gem::Specification.new do |spec|
+  # Importantly, all InSpec plugins must be prefixed with `inspec-` (most
+  # plugins) or `train-` (plugins which add new connectivity features).
+  spec.name          = "inspec-resource-lister"
+
+  # It is polite to namespace your plugin under InspecPlugins::YourPluginInCamelCase
+  spec.version       = InspecPlugins::ResourceLister::VERSION
+  spec.authors       = ["Clinton Wolfe"]
+  spec.email         = ["cwolfe@chef.io"]
+  spec.summary       = "InSpec Plugin example, lists available resources"
+  spec.description   = "Example for implementing an InSpec plugin.  This simply lists available resources."
+  spec.homepage      = "https://github.com/inspec/inspec/tree/master/examples/plugin"
+  spec.license       = "Apache-2.0"
+
+  # Though complicated-looking, this is pretty standard for a gemspec.
+  # It just filters what will actually be packaged in the gem (leaving
+  # out tests, etc)
+  spec.files = %w{
+    README.md inspec-resource-lister.gemspec Gemfile
+  } + Dir.glob(
+    "lib/**/*", File::FNM_DOTMATCH
+  ).reject { |f| File.directory?(f) }
+  spec.require_paths = ["lib"]
+
+  # If you rely on any other gems, list them here with any constraints.
+  # This is how `inspec plugin install` is able to manage your dependencies.
+  # For example, perhaps you are writing a thing that talks to AWS, and you
+  # want to ensure you have `aws-sdk` in a certain version.
+
+  # All plugins should mention inspec, > 2.2.78
+  # 2.2.78 included the v2 Plugin API
+  spec.add_dependency "inspec", ">=2.2.78", "<4.0.0"
+end

--- a/examples/plugin/lib/inspec-resource-lister.rb
+++ b/examples/plugin/lib/inspec-resource-lister.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+
+# This file is known as the "entry point."
+# This is the file InSpec will try to load if it
+# thinks your plugin is installed.
+
+# The *only* thing this file should do is setup the
+# load path, then load the plugin definition file.
+
+# Next two lines simply add the path of the gem to the load path.
+# This is not needed when being loaded as a gem; but when doing
+# plugin development, you may need it.  Either way, it's harmless.
+libdir = File.dirname(__FILE__)
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+
+require "inspec-resource-lister/plugin"

--- a/examples/plugin/lib/inspec-resource-lister/cli_command.rb
+++ b/examples/plugin/lib/inspec-resource-lister/cli_command.rb
@@ -1,0 +1,73 @@
+# encoding: utf-8
+
+module InspecPlugins::ResourceLister
+
+  # This class will provide the actual CLI implementation.
+  # Its superclass is provided by another call to Inspec.plugin,
+  # this time with two args.  The first arg specifies we are requesting
+  # version 2 of the Plugins API.  The second says we are making a CLI
+  # Command plugin component, so please make available any DSL needed
+  # for that.
+  #  In fact, aside from a some housekeeping DSL methods, most of the
+  # DSL provided is that of Thor. Inspec.plugin(2, :cli_command)
+  # promises to return a class that is a subclass of Thor.  So, to add
+  # commands, usage information, and options, use the Thor documentation.
+  class CliCommand < Inspec.plugin(2, :cli_command)
+
+    # This isn't provided by Thor, but is needed by InSpec so that it can
+    # register the subcommand.  Args are a usage message, and a short decription.
+    # These will appear when someone has installed the plugin, and then they
+    # run `inspec help`.
+    subcommand_desc 'list-resources [COMMAND]', 'List resources that InSpec finds.'
+
+
+    # The usual rhythm for a Thor CLI file is description, options, command method.
+    # Thor just has you call DSL methods in sequence prior to each command.
+    # Let's make a command, 'core', that lists all of the resources included with InSpec.
+
+    # First, provide a usage / description. This will appear in `inspec help list-resources`.
+    desc 'core [OPTIONS]', 'List resources that are included with InSpec.'
+
+    # Let's include an option, -s, to summarize the list.
+    # Refer to the Thors docs; there is a lot you can do here.
+    option :summary, desc: 'Include a total at the bottom', \
+                     type: :boolean, default: true, aliases: [:s]
+
+    # OK, now the actual method itself.  If you provide params, you're telling Thor that
+    # you accept CLI arguments after all options have been consumed. Let's accept a
+    # pattern, assumed to be a wildcard substring. If we provide a default, the CLI arg becomes optional.
+    def core(pattern = /.+/)
+      # The code here will *only* be executed if someone actually runs
+      # `inspec list-resources core`.  So, we can lazily wait to load
+      # expensive things here. However, InSpec has in fact already
+      # loaded the Resources, so we don't have anything to load.
+
+      # If we were passed a CLI arg, wrap the arg in Regexp matchers so
+      # we will match anywhere in the name.
+      unless pattern == /.+/
+        pattern = Regexp.new('.*' + pattern + '.*')
+      end
+
+      # This gets a bit into InSpec innards; but this is simply a Hash.
+      registry = Inspec::Resource.default_registry
+      resource_names = registry.keys.grep(pattern).sort
+
+      # One day we'll have nice UI support.
+      resource_names.each { |name| puts name }
+
+      if options[:summary]
+        puts '-' * 30
+        puts "#{resource_names.count} resources total"
+      end
+    end
+
+    # A neat idea for future work would be to add another command, perhaps
+    # 'resource-pack', which examines a possibly remote resource pack and
+    # enumerates the resources it defines.
+
+    # Another idea might be to fetch a profile, and list the resources actually
+    # used in the controls of the profile, along with counts.
+
+  end
+end
+

--- a/examples/plugin/lib/inspec-resource-lister/plugin.rb
+++ b/examples/plugin/lib/inspec-resource-lister/plugin.rb
@@ -1,0 +1,55 @@
+# encoding: UTF-8
+
+# Plugin Definition file
+# The purpose of this file is to declare to InSpec what plugin_types (capabilities)
+# are included in this plugin, and provide hooks that will load them as needed.
+
+# It is important that this file load successfully and *quickly*.
+# Your plugin's functionality may never be used on this InSpec run; so we keep things
+# fast and light by only loading heavy things when they are needed.
+
+# Presumably this is light
+require 'inspec-resource-lister/version'
+
+# The InspecPlugins namespace is where all plugins should declare themselves.
+# The 'Inspec' capitalization is used throughout the InSpec source code; yes, it's
+# strange.
+module InspecPlugins
+
+  # Pick a reasonable namespace here for your plugin.  A reasonable choice
+  # would be the CamelCase version of your plugin gem name.
+  # inspec-resource-lister => ResourceLister
+  module ResourceLister
+
+    # This simple class handles the plugin definition, so calling it simply Plugin is OK.
+    #   Inspec.plugin returns various Classes, intended to be superclasses for various
+    # plugin components. Here, the one-arg form gives you the Plugin Definition superclass,
+    # which mainly gives you access to the hook / plugin_type DSL.
+    #   The number '2' says you are asking for version 2 of the plugin API. If there are
+    # future versions, InSpec promises plugin API v2 will work for at least two more InSpec
+    # major versions.
+    class Plugin < Inspec.plugin(2)
+
+      # Internal machine name of the plugin. InSpec will use this in errors, etc.
+      plugin_name :'inspec-resource-lister'
+
+      # Define a new CLI subcommand.
+      # The argument here will be used to match against the command line args,
+      # and if the user said `inspec list-resources`, this hook will get called.
+      # Notice that you can define multiple hooks with different names, and they
+      # don't have to match the plugin name.
+
+      # BUG in loader: Thor and Loader disagree about hyphen handling.  Must omit to get it to work :(
+      cli_command :listresources do
+        # Calling this hook doesn't mean list-resources is being executed - just
+        # that we should be ready to do so. So, load the file that defines the
+        # functionality.
+        require 'inspec-resource-lister/cli_command'
+
+        # Having loaded our functionality, return a class that will let the
+        # CLI engine tap into it.
+        InspecPlugins::ResourceLister::CliCommand
+      end
+    end
+  end
+end

--- a/examples/plugin/lib/inspec-resource-lister/version.rb
+++ b/examples/plugin/lib/inspec-resource-lister/version.rb
@@ -1,0 +1,10 @@
+# encoding: UTF-8
+
+# This file simply makes it easier for CI engines to update
+# the version stamp, and provide a clean way for the gemspec
+# to learn the current version.
+module InspecPlugins
+  module ResourceLister
+    VERSION = "0.1.0".freeze
+  end
+end


### PR DESCRIPTION
Included in this PR is an example of Plugins v2 CliCommand plugin. It is very simple - it simply lists the names of the resources that InSpec knows about.

The plugin is exhaustively commented for pedagogic purposes.

If we wish to include information on how to test a plugin using core facilities, we can do that after #3384 is merged, which provides such facilities.

If we wish to publish this to rubygems, I see no harm in that.
