### PR TITLE
Add json-automate to the report method

### DIFF
--- a/lib/inspec/reporters.rb
+++ b/lib/inspec/reporters.rb
@@ -59,6 +59,8 @@ module Inspec::Reporters
       reporter = Inspec::Reporters::Json.new(config)
     when 'json-min'
       reporter = Inspec::Reporters::JsonMin.new(config)
+    when 'json-automate'
+      reporter = Inspec::Reporters::JsonAutomate.new(config)
     when 'yaml'
       reporter = Inspec::Reporters::Yaml.new(config)
     else

--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -17,7 +17,7 @@ module Inspec::Reporters
 
     def enriched_report
       # grab the report from the parent class
-      final_report = report_merged
+      final_report = report
 
       # Label this content as an inspec_report
       final_report[:type] = 'inspec_report'

--- a/lib/inspec/reporters/json_automate.rb
+++ b/lib/inspec/reporters/json_automate.rb
@@ -13,9 +13,9 @@ module Inspec::Reporters
       output(report_merged.to_json, false)
     end
 
-    def report_merged
+    def report
       # grab profiles from the json parent class
-      @profiles = report[:profiles]
+      @profiles = profiles
 
       {
         platform: platform,


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This allows the `json-automate` report be access via ad-hoc runners calling report. This is mainly for the Audit cookbook.