### PR TITLE
load inspec plugin help if no argument is given

### DIFF
--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -90,7 +90,7 @@ module Inspec::Plugin::V2
         next if act.activated
         # If there is anything in the CLI args with the same name, activate it
         # If the word 'help' appears in the first position, load all CLI plugins
-        if cli_args.include?(act.activator_name.to_s) || cli_args[0] == 'help'
+        if cli_args.include?(act.activator_name.to_s) || cli_args[0] == 'help' || cli_args.size == 0
           activate(:cli_command, act.activator_name)
           act.implementation_class.register_with_thor
         end


### PR DESCRIPTION
Before this PR, everything was working for `inspec help` but not pure `inspec`. `inspec` also shows the help message.

depends on #3384 and need to be rebased, once its merged

