### PR TITLE
Fix json automate tests and render call

### DIFF
--- a/lib/inspec/reporters/json_automate.rb
+++ b/lib/inspec/reporters/json_automate.rb
@@ -10,7 +10,7 @@ module Inspec::Reporters
     end
 
     def render
-      output(report_merged.to_json, false)
+      output(report.to_json, false)
     end
 
     def report

--- a/test/unit/reporters/json_automate_test.rb
+++ b/test/unit/reporters/json_automate_test.rb
@@ -8,7 +8,7 @@ describe Inspec::Reporters::JsonAutomate do
     data = JSON.parse(File.read(path + '/../mock/reporters/run_data_wrapper.json'), symbolize_names: true)
     Inspec::Reporters::JsonAutomate.new({ run_data: data })
   end
-  let(:profiles) { report.report[:profiles] }
+  let(:profiles) { report.send(:profiles) }
 
   describe '#render' do
     it 'confirms render output' do
@@ -22,7 +22,7 @@ describe Inspec::Reporters::JsonAutomate do
     it 'outputs the correct report_merged' do
       output = File.read(path + '/../mock/reporters/json_merged_output')
       output = JSON.parse(output, symbolize_names: true)
-      report.report_merged.must_equal output
+      report.report.must_equal output
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

The `json-automate` reporter's test were not firing because the test did not end with `_test`. This let some bugs out in the last audit fix. This PR fixes the tests along with the current render issue. 