### PR TITLE
Fix gem tests from recent merge

### DIFF
--- a/test/unit/resources/gem_test.rb
+++ b/test/unit/resources/gem_test.rb
@@ -19,6 +19,7 @@ describe 'Inspec::Resources::Gem' do
       version: '0.33.0',
       type: 'gem',
       installed: true,
+      versions: ["0.33.0", "0.32.1", "0.28.0"],
     }
     _(resource.installed?).must_equal true
     _(resource.info).must_equal pkg
@@ -32,6 +33,7 @@ describe 'Inspec::Resources::Gem' do
       version: '0.10.4',
       type: 'gem',
       installed: true,
+      versions: ["0.10.4"],
     }
     _(resource.installed?).must_equal true
     _(resource.info).must_equal pkg
@@ -45,6 +47,7 @@ describe 'Inspec::Resources::Gem' do
       version: '3.4.0',
       type: 'gem',
       installed: true,
+      versions: ["3.4.0"],
     }
     _(resource.installed?).must_equal true
     _(resource.info).must_equal pkg
@@ -60,8 +63,8 @@ describe 'Inspec::Resources::Gem' do
       installed: true,
     }
     _(resource.installed?).must_equal true
-    _(resource.info.versions).must_include /3\.4/
-    _(resource.info.versions).wont_include /2\.4/
+    _(resource.versions[0]).must_match /3\.4/
+    _(resource.versions).wont_include /2\.4/
     _(resource.gem_binary).must_equal '/opt/chef/embedded/bin/gem'
   end
 
@@ -72,6 +75,7 @@ describe 'Inspec::Resources::Gem' do
       version: '1.8.3',
       type: 'gem',
       installed: true,
+      versions: ["1.8.3"],
     }
     _(resource.installed?).must_equal true
     _(resource.info).must_equal pkg
@@ -85,6 +89,7 @@ describe 'Inspec::Resources::Gem' do
       version: '0.0.12',
       type: 'gem',
       installed: true,
+      versions: ["0.0.12"],
     }
     _(resource.installed?).must_equal true
     _(resource.info).must_equal pkg


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

Somehow the gem_tests were broken on merging https://github.com/inspec/inspec/pull/3398

 This fixes them. Still digging into why tests passed.