### PR TITLE
make `inspec` fail file resources when they are not found.

### DIFF
--- a/lib/utils/file_reader.rb
+++ b/lib/utils/file_reader.rb
@@ -8,16 +8,16 @@ module FileReader
     # ResourceFailed during a major version bump.
     file = inspec.file(path)
     if !file.file?
-      raise Inspec::Exceptions::ResourceSkipped, "Can't find file: #{path}"
+      raise Inspec::Exceptions::ResourceFailed, "Can't find file: #{path}"
     end
 
     raw_content = file.content
     if raw_content.nil?
-      raise Inspec::Exceptions::ResourceSkipped, "Can't read file: #{path}"
+      raise Inspec::Exceptions::ResourceFailed, "Can't read file: #{path}"
     end
 
     if !allow_empty && raw_content.empty?
-      raise Inspec::Exceptions::ResourceSkipped, "File is empty: #{path}"
+      raise Inspec::Exceptions::ResourceFailed, "File is empty: #{path}"
     end
 
     raw_content

--- a/test/unit/resources/json_test.rb
+++ b/test/unit/resources/json_test.rb
@@ -67,19 +67,19 @@ describe 'Inspec::Resources::JSON' do
 
     it 'raises an exception when the file does not exist' do
       file.expects(:file?).returns(false)
-      proc { resource.send(:load_raw_from_file, path) }.must_raise Inspec::Exceptions::ResourceSkipped
+      proc { resource.send(:load_raw_from_file, path) }.must_raise Inspec::Exceptions::ResourceFailed
     end
 
     it 'raises an exception if the file content is nil' do
       file.expects(:file?).returns(true)
       file.expects(:content).returns(nil)
-      proc { resource.send(:load_raw_from_file, path) }.must_raise Inspec::Exceptions::ResourceSkipped
+      proc { resource.send(:load_raw_from_file, path) }.must_raise Inspec::Exceptions::ResourceFailed
     end
 
     it 'raises an exception if the file content is empty' do
       file.expects(:file?).returns(true)
       file.expects(:content).at_least_once.returns('')
-      proc { resource.send(:load_raw_from_file, path) }.must_raise Inspec::Exceptions::ResourceSkipped
+      proc { resource.send(:load_raw_from_file, path) }.must_raise Inspec::Exceptions::ResourceFailed
     end
 
     it 'returns the file content' do


### PR DESCRIPTION
This is a breaking change and should make it into the next major release.

fixes #3412 by making tests fail when they rightfully should.

Signed-off-by: Ben Abrams <me@benabrams.it>