### PR TITLE
Remove load locks for cloud resources

### DIFF
--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -91,21 +91,12 @@ inspec_core_only = !File.exist?(File.join(File.dirname(__FILE__), '..', 'resourc
 
 # Do not attempt to load cloud resources if we are in inspec-core mode
 unless inspec_core_only
-  # AWS resources are included via their own file,
-  # but only consider loading them if we have the SDK available, and is v2.
-  # https://github.com/inspec/inspec/issues/2571
-  if Gem.loaded_specs.key?('aws-sdk') && Gem.loaded_specs['aws-sdk'].version < Gem::Version.new('3.0.0')
-    require 'resource_support/aws'
-  end
-
-  # Azure resources
-  if Gem.loaded_specs.key?('azure_mgmt_resources')
-    require 'resources/azure/azure_backend.rb'
-    require 'resources/azure/azure_generic_resource.rb'
-    require 'resources/azure/azure_resource_group.rb'
-    require 'resources/azure/azure_virtual_machine.rb'
-    require 'resources/azure/azure_virtual_machine_data_disk.rb'
-  end
+  require 'resource_support/aws'
+  require 'resources/azure/azure_backend.rb'
+  require 'resources/azure/azure_generic_resource.rb'
+  require 'resources/azure/azure_resource_group.rb'
+  require 'resources/azure/azure_virtual_machine.rb'
+  require 'resources/azure/azure_virtual_machine_data_disk.rb'
 end
 
 require 'resources/aide_conf'


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

If you install InSpec via a gem (without bundle) you will not load aws/azure at the time of resource load (the transport init happens after this). Thus all resources will fail like:
```
×  aws-1: Checks the machine is running
     ×  Control Source Code Error myaws/controls/example.rb:6
     undefined method `aws_ec2_instance' for #<#<Class:0x00007fa1f8cf7b40>:0x00007fa1f8cf5ea8>
```

Using a bundle, omni, or hab(A2) will get around this issue as it will auto load all the gems in your bundle during a bundle exec.

Removing the load locks fixes the issue.