### PR TITLE
Support the Busybox variant of netstat in the port resource

### DIFF
--- a/test/unit/mock/cmd/netstat-tulpen-busybox
+++ b/test/unit/mock/cmd/netstat-tulpen-busybox
@@ -1,0 +1,9 @@
+Active Internet connections (only servers)
+Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
+tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      1/sshd
+tcp6       0      48 2601:1:ad80:1445::54776 2620:0:861:52:208::6667 LISTEN     2043/pidgin
+tcp6       0      0 :::22                   :::*                    LISTEN      1/sshd
+udp        0      0 0.0.0.0:111             0.0.0.0:*                           545/rpcbind
+tcp6       0      0 192.168.1.123:8005      :::*                    LISTEN      1234/java
+udp6       0      0 fe80::42:acff:fe11::123 :::*                                3335/ntpd
+tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      579/nginx: worker p

--- a/test/unit/resources/port_test.rb
+++ b/test/unit/resources/port_test.rb
@@ -71,6 +71,15 @@ describe 'Inspec::Resources::Port' do
     _(resource.addresses).must_equal ['10.0.2.15', 'fe80::a00:27ff:fe32:ed09']
   end
 
+  it 'verify port on Alpine Linux without iproute2 installed' do
+    resource = MockLoader.new(:alpine).load_resource('port', 22)
+    _(resource.listening?).must_equal true
+    _(resource.protocols).must_equal %w{ tcp tcp6 }
+    _(resource.pids).must_equal [1]
+    _(resource.processes).must_equal ['sshd']
+    _(resource.addresses).must_equal ["0.0.0.0", "::"]
+  end
+
   it 'verify port on MacOs x' do
     resource = MockLoader.new(:osx104).load_resource('port', 2022)
     _(resource.listening?).must_equal true


### PR DESCRIPTION
This would fix #2890.

The Busybox variant of netstat doesn't have a User or Inode column in the
output, resulting in issues with the port resource in Habitat or Alpine Linux
when the iproute2 package isn't installed and the ss command isn't there.

Signed-off-by: Jonathan Hartman <j@hartman.io>