### PR TITLE
Plugins: Load all CLI commands on usage on empty invocation

### DIFF
--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -84,5 +84,23 @@ end
 #=========================================================================================#
 #                           inspec plugin command
 #=========================================================================================#
-
 # See lib/plugins/inspec-plugin-manager-cli/test
+
+#=========================================================================================#
+#                                CLI Usage Messaging
+#=========================================================================================#
+describe 'plugin cli usage message integration' do
+  include FunctionalHelper
+
+  [' help', ''].each do |invocation|
+    it "includes v2 plugins in `inspec#{invocation}` output" do
+      outcome = inspec(invocation)
+      outcome.stderr.must_equal ''
+
+      # These are some subcommands provided by core v2 plugins
+      ['habitat', 'artifact'].each do |subcommand|
+        outcome.stdout.must_include('inspec ' + subcommand)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When inspec is invoked with no args or options, we display a usage message.  This PR ensures all v2 plugins are loaded, so their messages are present.

Functional test included.

A refactor to clarify the activation logic is included.

Fixes #3427 
