### PR TITLE
Modify `cmp` matcher output to use `.inspect`

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -294,13 +294,13 @@ RSpec::Matchers.define :cmp do |first_expected| # rubocop:disable Metrics/BlockL
   end
 
   failure_message do |actual|
-    actual = ('0' + actual.to_s(8)).inspect if octal?(@expected)
-    "\n" + format_expectation(false) + "\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
+    actual = ('0' + actual.to_s(8)) if octal?(@expected)
+    "\n" + format_expectation(false) + "\n     got: #{actual.inspect}\n\n(compared using `cmp` matcher)\n"
   end
 
   failure_message_when_negated do |actual|
     actual = ('0' + actual.to_s(8)).inspect if octal?(@expected)
-    "\n" + format_expectation(true) + "\n     got: #{actual}\n\n(compared using `cmp` matcher)\n"
+    "\n" + format_expectation(true) + "\n     got: #{actual.inspect}\n\n(compared using `cmp` matcher)\n"
   end
 
   description do


### PR DESCRIPTION
This modifies the output of failed test when using the `cmp` matcher by calling `.inspect` on the actual value passed.

This makes it easier to diagnose failed matches due to characters such as `\n` not being visible.

Current behavior:
```
inspec> describe command('echo demo') do
inspec>   its('stdout') { should cmp 'demo' }
inspec> end

Profile: inspec-shell
Version: (not specified)

  Command: `echo demo`
     ×  stdout should cmp == "demo"

     expected: "demo"
          got: demo

     (compared using `cmp` matcher)

Test Summary: 0 successful, 1 failure, 0 skipped
```

New behavior:
```
inspec> describe command('echo demo') do
inspec>   its('stdout') { should cmp 'demo' }
inspec> end

Profile: inspec-shell
Version: (not specified)

  Command: `echo demo`
     ×  stdout should cmp == "demo"

     expected: "demo"
          got: "demo\n"

     (compared using `cmp` matcher)

Test Summary: 0 successful, 1 failure, 0 skipped
```

Many thanks to @jazaval for discovering this!