### PR TITLE
Fix `attribute` with empty hash regression

### DIFF
--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -142,8 +142,8 @@ module Inspec
         end
 
         # method for attributes; import attribute handling
-        define_method :attribute do |name, options = {}|
-          if options.empty?
+        define_method :attribute do |name, options = nil|
+          if options.nil?
             Inspec::AttributeRegistry.find_attribute(name, profile_id).value
           else
             profile_context_owner.register_attribute(name, options)

--- a/test/functional/attributes_test.rb
+++ b/test/functional/attributes_test.rb
@@ -29,7 +29,7 @@ describe 'attributes' do
       cmd += ' --attrs ' + File.join(profile_path, 'global_attributes', 'files', "attr.yml")
       out = inspec(cmd)
       out.stderr.must_equal ''
-      out.stdout.must_include '20 successful'
+      out.stdout.must_include '21 successful'
       out.exit_status.must_equal 0
     end
 

--- a/test/unit/mock/profiles/global_attributes/controls/attribute_from_yml.rb
+++ b/test/unit/mock/profiles/global_attributes/controls/attribute_from_yml.rb
@@ -39,3 +39,9 @@ describe 'test attribute with no defualt but has type' do
   subject { attribute('val_no_default_with_type').respond_to?(:fake_method) }
   it { should cmp true }
 end
+
+empty_hash_attribute = attribute('val_with_empty_hash_default', {})
+describe 'test attribute with default as empty hash' do
+  subject { empty_hash_attribute }
+  it { should cmp 'success' }
+end

--- a/test/unit/mock/profiles/global_attributes/files/attr.yml
+++ b/test/unit/mock/profiles/global_attributes/files/attr.yml
@@ -1,2 +1,3 @@
 val_user_override: bob
 val_numeric_override: 9999
+val_with_empty_hash_default: 'success'


### PR DESCRIPTION
This will allows for using the below in controls again:

```ruby
attribute('some_attribute', {})
```

This closes https://github.com/inspec/inspec/issues/3442