### PR TITLE
Plugins: Filter Plugins During Search and Install

### DIFF
--- a/etc/plugin_filters.json
+++ b/etc/plugin_filters.json
@@ -1,0 +1,25 @@
+{
+  "file_version": "1.0.0",
+  "exclude": [
+    {
+      "plugin_name": "inspec-core",
+      "rationale": "This gem is a stripped-down alternate packaging of InSpec. It is not a plugin."
+    },
+    {
+      "plugin_name": "inspec-multi-server",
+      "rationale": "This gem is a script that attempts to drive a parallel execution of InSpec by wrapping and forking. It is not a plugin."
+    },
+    {
+      "plugin_name": "train-tax-calculator",
+      "rationale": "This gem is a tax calculation tool for the Philippines. It has nothing to do the Chef Train remote execution framework, or the InSpec project."
+    },
+    {
+      "plugin_name": "inspec-plugin-example",
+      "rationale": "This gem is an early self-taught example of a v1 plugin. Please use inspec-resource-lister as an example for PluginV2 development."
+    },
+    {
+      "plugin_name": "train-core",
+      "rationale": "This gem is a stripped-down alternate packaging of Train. It is not a plugin."
+    }
+  ]
+}

--- a/lib/inspec/plugin/v2.rb
+++ b/lib/inspec/plugin/v2.rb
@@ -11,6 +11,9 @@ module Inspec
         attr_accessor :version
       end
       class InstallError < Inspec::Plugin::V2::GemActionError; end
+      class PluginExcludedError < Inspec::Plugin::V2::InstallError
+        attr_accessor :details
+      end
       class UpdateError < Inspec::Plugin::V2::GemActionError
         attr_accessor :from_version, :to_version
       end

--- a/lib/inspec/plugin/v2/filter.rb
+++ b/lib/inspec/plugin/v2/filter.rb
@@ -1,0 +1,62 @@
+require 'singleton'
+require 'json'
+require 'inspec/globals'
+
+module Inspec::Plugin::V2
+  Exclusion = Struct.new(:plugin_name, :rationale)
+
+  class PluginFilter
+    include Singleton
+    def initialize
+      read_filter_data
+    end
+
+    def self.exclude?(plugin_name)
+      instance.exclude?(plugin_name)
+    end
+
+    def exclude?(plugin_name)
+      # Currently, logic is very simple: is there an exact match?
+      # In the future, we might add regexes on names, or exclude version ranges
+      return false unless @filter_data[:exclude].detect { |e| e.plugin_name == plugin_name }
+
+      # OK, return entire data structure.
+      @filter_data[:exclude].detect { |e| e.plugin_name == plugin_name }
+    end
+
+    private
+
+    def read_filter_data
+      path = File.join(Inspec.src_root, 'etc', 'plugin_filters.json')
+      @filter_data = JSON.parse(File.read(path))
+
+      unless @filter_data['file_version'] == '1.0.0'
+        raise Inspec::Plugin::V2::ConfigError, "Unknown plugin fillter file format at #{path}"
+      end
+
+      validate_plugin_filter_file('1.0.0')
+
+      @filter_data[:exclude] = @filter_data['exclude'].map do |entry|
+        Exclusion.new(entry['plugin_name'], entry['rationale'])
+      end
+      @filter_data.delete('exclude')
+    end
+
+    def validate_plugin_filter_file(_file_version)
+      unless @filter_data.key?('exclude') && @filter_data['exclude'].is_a?(Array)
+        raise Inspec::Plugin::V2::ConfigError, 'Unknown plugin fillter file format: expected "exclude" to be an array'
+      end
+      @filter_data['exclude'].each_with_index do |entry, idx|
+        unless entry.is_a? Hash
+          raise Inspec::Plugin::V2::ConfigError, "Unknown plugin fillter file format: expected entry #{idx} to be a Hash / JS Object"
+        end
+        unless entry.key?('plugin_name')
+          raise Inspec::Plugin::V2::ConfigError, "Unknown plugin fillter file format: expected entry #{idx} to have a \"plugin_name\" field"
+        end
+        unless entry.key?('rationale')
+          raise Inspec::Plugin::V2::ConfigError, "Unknown plugin fillter file format: expected entry #{idx} to have a \"rationale\" field"
+        end
+      end
+    end
+  end
+end

--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -40,12 +40,11 @@ module InspecPlugins
       long_desc <<~EOLD
         Searches rubygems.org for InSpec plugins. Exits 0 on a search hit, 1 on user error,
         2 on a search miss. PATTERN is a simple string; a wildcard will be added as
-        a suffix, unles -e is used.
+        a suffix, unless -e is used.
       EOLD
       option :all, desc: 'List all available versions, not just the latest one.', type: :boolean, aliases: [:a]
       option :exact, desc: 'Assume PATTERN is exact; do not add a wildcard to the end', type: :boolean, aliases: [:e]
-      # Wish we could hide this
-      option :'include-test-fixture', type: :boolean, desc: 'Internal use'
+      option :'include-test-fixture', type: :boolean, desc: 'Internal use', hide: true
       # Justification for disabling ABC: currently at 33.51/33
       def search(search_term) # rubocop: disable Metrics/AbcSize
         search_results = installer.search(search_term, exact: options[:exact])

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
@@ -174,7 +174,7 @@ class PluginManagerCliSearch < MiniTest::Test
     assert_includes result.stdout, 'inspec-test-fixture', 'Search result should contain the gem name'
     assert_includes result.stdout, '1 plugin(s) found', 'Search result should find 1 plugin'
 
-    result = run_inspec_process('plugin search -e inspec-test-fixture')
+    result = run_inspec_process('plugin search -e --include-test-fixture inspec-test-fixture')
     assert_equal 0, result.exit_status, 'Search should exit 0 on a hit'
   end
 
@@ -183,7 +183,7 @@ class PluginManagerCliSearch < MiniTest::Test
     assert_equal 2, result.exit_status, 'Search should exit 2 on a miss'
     assert_includes result.stdout, '0 plugin(s) found', 'Search result should find 0 plugins'
 
-    result = run_inspec_process('plugin search -e inspec-test-')
+    result = run_inspec_process('plugin search -e --include-test-fixture inspec-test-')
     assert_equal 2, result.exit_status, 'Search should exit 2 on a miss'
   end
 
@@ -196,7 +196,7 @@ class PluginManagerCliSearch < MiniTest::Test
     line = result.stdout.split("\n").grep(/inspec-test-fixture/).first
     assert_match(/\s*inspec-test-fixture\s+\((\d+\.\d+\.\d+(,\s)?){2,}\)/,line,'Plugin line should include name and at least two versions')
 
-    result = run_inspec_process('plugin search -a inspec-test-fixture')
+    result = run_inspec_process('plugin search -a --include-test-fixture inspec-test-fixture')
     assert_equal 0, result.exit_status, 'Search should exit 0 on a hit'
   end
 

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
@@ -544,10 +544,10 @@ class PluginManagerCliInstall < MiniTest::Test
 
   def test_refuse_install_when_plugin_on_exclusion_list
 
-    # Here, 'inspec-core', 'inspec-multiserver', and 'train-tax-collector'
-    # are the names of real rubygems.  They are not InSpec/ Train plugins, though,
+    # Here, 'inspec-core', 'inspec-multi-server', and 'train-tax-collector'
+    # are the names of real rubygems.  They are not InSpec/Train plugins, though,
     # and installing them would be a jam-up.
-    # This is configured in etc/plugin-filter.json .
+    # This is configured in 'etc/plugin-filter.json'.
     [
       'inspec-core',
       'inspec-multi-server',

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
@@ -143,8 +143,14 @@ class PluginManagerCliSearch < MiniTest::Test
   include CorePluginFunctionalHelper
   include PluginManagerHelpers
 
+  # TODO: Thor can't hide options, but we wish it could.
+  # def test_search_include_fixture_hidden_option
+  #   result = run_inspec_process_with_this_plugin('plugin help search')
+  #   refute_includes result.stdout, '--include-test-fixture'
+  # end
+
   def test_search_for_a_real_gem_with_full_name_no_options
-    result = run_inspec_process('plugin search inspec-test-fixture')
+    result = run_inspec_process('plugin search --include-test-fixture inspec-test-fixture')
     assert_equal 0, result.exit_status, 'Search should exit 0 on a hit'
     assert_includes result.stdout, 'inspec-test-fixture', 'Search result should contain the gem name'
     assert_includes result.stdout, '1 plugin(s) found', 'Search result should find 1 plugin'
@@ -153,7 +159,7 @@ class PluginManagerCliSearch < MiniTest::Test
   end
 
   def test_search_for_a_real_gem_with_stub_name_no_options
-    result = run_inspec_process('plugin search inspec-test-')
+    result = run_inspec_process('plugin search --include-test-fixture inspec-test-')
     assert_equal 0, result.exit_status, 'Search should exit 0 on a hit'
     assert_includes result.stdout, 'inspec-test-fixture', 'Search result should contain the gem name'
     assert_includes result.stdout, '1 plugin(s) found', 'Search result should find 1 plugin'
@@ -163,7 +169,7 @@ class PluginManagerCliSearch < MiniTest::Test
   end
 
   def test_search_for_a_real_gem_with_full_name_and_exact_option
-    result = run_inspec_process('plugin search --exact inspec-test-fixture')
+    result = run_inspec_process('plugin search --exact --include-test-fixture inspec-test-fixture')
     assert_equal 0, result.exit_status, 'Search should exit 0 on a hit'
     assert_includes result.stdout, 'inspec-test-fixture', 'Search result should contain the gem name'
     assert_includes result.stdout, '1 plugin(s) found', 'Search result should find 1 plugin'
@@ -173,7 +179,7 @@ class PluginManagerCliSearch < MiniTest::Test
   end
 
   def test_search_for_a_real_gem_with_stub_name_and_exact_option
-    result = run_inspec_process('plugin search --exact inspec-test-')
+    result = run_inspec_process('plugin search --exact --include-test-fixture inspec-test-')
     assert_equal 2, result.exit_status, 'Search should exit 2 on a miss'
     assert_includes result.stdout, '0 plugin(s) found', 'Search result should find 0 plugins'
 
@@ -182,7 +188,7 @@ class PluginManagerCliSearch < MiniTest::Test
   end
 
   def test_search_for_a_real_gem_with_full_name_and_all_option
-    result = run_inspec_process('plugin search --all inspec-test-fixture')
+    result = run_inspec_process('plugin search --all --include-test-fixture inspec-test-fixture')
     assert_equal 0, result.exit_status, 'Search should exit 0 on a hit'
     assert_includes result.stdout, 'inspec-test-fixture', 'Search result should contain the gem name'
     assert_includes result.stdout, '1 plugin(s) found', 'Search result should find 1 plugin'
@@ -195,19 +201,19 @@ class PluginManagerCliSearch < MiniTest::Test
   end
 
   def test_search_for_a_gem_with_missing_prefix
-    result = run_inspec_process('plugin search test-fixture')
+    result = run_inspec_process('plugin search --include-test-fixture test-fixture')
     assert_equal 1, result.exit_status, 'Search should exit 1 on user error'
     assert_includes result.stdout, "All inspec plugins must begin with either 'inspec-' or 'train-'"
   end
 
   def test_search_for_a_gem_that_does_not_exist
-    result = run_inspec_process('plugin search inspec-test-fixture-nonesuch')
+    result = run_inspec_process('plugin search --include-test-fixture inspec-test-fixture-nonesuch')
     assert_equal 2, result.exit_status, 'Search should exit 2 on a miss'
     assert_includes result.stdout, '0 plugin(s) found', 'Search result should find 0 plugins'
   end
 
   def test_search_for_a_real_gem_with_full_name_no_options_and_train_name
-    result = run_inspec_process('plugin search train-test-fixture')
+    result = run_inspec_process('plugin search --include-test-fixture train-test-fixture')
     assert_equal 0, result.exit_status, 'Search should exit 0 on a hit'
     assert_includes result.stdout, 'train-test-fixture', 'Search result should contain the gem name'
     assert_includes result.stdout, '1 plugin(s) found', 'Search result should find 1 plugin'
@@ -216,7 +222,7 @@ class PluginManagerCliSearch < MiniTest::Test
   end
 
   def test_search_omit_excluded_inspec_plugins
-    result = run_inspec_process('plugin search inspec-')
+    result = run_inspec_process('plugin search --include-test-fixture inspec-')
     assert_equal 0, result.exit_status, 'Search should exit 0'
     assert_includes result.stdout, 'inspec-test-fixture', 'Search result should contain the test gem'
     [
@@ -226,6 +232,17 @@ class PluginManagerCliSearch < MiniTest::Test
       refute_includes result.stdout, plugin_name, 'Search result should not contain excluded gems'
     end
   end
+  def test_search_for_a_real_gem_with_full_name_no_options_filter_fixtures
+    result = run_inspec_process('plugin search inspec-test-fixture')
+    refute_includes result.stdout, 'inspec-test-fixture', 'Search result should not contain the fixture gem name'
+  end
+
+  def test_search_for_a_real_gem_with_full_name_no_options_filter_fixtures_train
+    result = run_inspec_process('plugin search train-test-fixture')
+    refute_includes result.stdout, 'train-test-fixture', 'Search result should not contain the fixture gem name'
+  end
+
+
 end
 
 #-----------------------------------------------------------------------------------------#

--- a/lib/plugins/inspec-plugin-manager-cli/test/unit/cli_args_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/unit/cli_args_test.rb
@@ -26,7 +26,7 @@ class PluginManagerCliOptions < MiniTest::Test
 
   def test_search_args
     arg_config = cli_class.all_commands['search'].options
-    assert_equal 2, arg_config.count, 'The search command should have 2 options'
+    assert_equal 3, arg_config.count, 'The search command should have 2 options'
 
     assert_includes arg_config.keys, :all, 'The search command should have an --all option'
     assert_equal :boolean, arg_config[:all].type, 'The --all option should be boolean'
@@ -39,6 +39,10 @@ class PluginManagerCliOptions < MiniTest::Test
     assert_equal :e, arg_config[:exact].aliases.first, 'The --exact option should be aliased as -e'
     refute_nil arg_config[:exact].description, 'The --exact option should have a description'
     refute arg_config[:exact].required, 'The --exact option should not be required'
+
+    assert_includes arg_config.keys, :'include-test-fixture', 'The search command should have an --include-test-fixture option'
+    assert_equal :boolean, arg_config[:'include-test-fixture'].type, 'The --include-test-fixture option should be boolean'
+    refute arg_config[:'include-test-fixture'].required, 'The --include-test-fixture option should not be required'
 
     assert_equal 1, cli_class.instance_method(:search).arity, 'The search command should take one argument'
   end

--- a/lib/plugins/inspec-plugin-manager-cli/test/unit/cli_args_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/unit/cli_args_test.rb
@@ -26,7 +26,7 @@ class PluginManagerCliOptions < MiniTest::Test
 
   def test_search_args
     arg_config = cli_class.all_commands['search'].options
-    assert_equal 3, arg_config.count, 'The search command should have 2 options'
+    assert_equal 3, arg_config.count, 'The search command should have 3 options'
 
     assert_includes arg_config.keys, :all, 'The search command should have an --all option'
     assert_equal :boolean, arg_config[:all].type, 'The --all option should be boolean'

--- a/test/unit/plugin/v2/installer_test.rb
+++ b/test/unit/plugin/v2/installer_test.rb
@@ -218,6 +218,24 @@ class PluginInstallerInstallationTests < MiniTest::Test
     assert_includes entry.keys, 'installation_path', 'plugins.json should include installation_path key'
     assert_equal @plugin_fixture_src_path, entry['installation_path'], 'plugins.json should include correct value for installation path'
   end
+
+  def test_refuse_to_install_gem_whose_name_is_on_the_reject_list
+    ENV['INSPEC_CONFIG_DIR'] = File.join(@config_dir_path, 'empty')
+
+    # Here, 'inspec-core', 'inspec-multiserver', and 'train-tax-collector'
+    # are the names of real rubygems.  They are not InSPec/ Train plugins, though,
+    # and installing them would be a jam-up.
+    # This is configured in etc/plugin-filter.json .
+    [
+      'inspec-core',
+      'inspec-multi-server',
+      'train-tax-calculator',
+    ].each do |plugin_name|
+      ex = assert_raises(Inspec::Plugin::V2::InstallError) { @installer.install(plugin_name)}
+      assert_includes(ex.message, 'on the Plugin Exclusion List')
+      assert_includes(ex.message, 'Rationale:')
+    end
+  end
 end
 
 #-----------------------------------------------------------------------#
@@ -433,6 +451,37 @@ class PluginInstallerSearchTests < MiniTest::Test
     version_list = results['inspec-test-fixture']
     assert_includes version_list, '0.1.0', 'Version list should contain 0.1.0'
     assert_includes version_list, '0.2.0', 'Version list should contain 0.2.0'
+  end
+
+  def test_search_omits_inspec_gem_on_the_reject_list
+    results = @installer.search('inspec-')
+    assert results.key?('inspec-test-fixture')
+
+    # Here, 'inspec-core', 'inspec-multiserver'
+    # are the names of real rubygems.  They are not InSpec/ Train plugins, though,
+    # and installing them would be a jam-up.
+    # This is configured in etc/plugin_filters.json .
+    [
+      'inspec-core',
+      'inspec-multi-server',
+    ].each do |plugin_name|
+      refute results.key(plugin_name)
+    end
+  end
+
+  def test_search_omits_train_gem_on_the_reject_list
+    results = @installer.search('train-')
+    assert results.key?('train-test-fixture')
+
+    # Here, train-tax-calculator'
+    # is the name of a real rubygem.  They are not InSpec/ Train plugins, though,
+    # and installing them would be a jam-up.
+    # This is configured in etc/plugin_filters.json .
+    [
+      'train-tax-calculator'
+    ].each do |plugin_name|
+      refute results.key(plugin_name)
+    end
   end
 end
 

--- a/test/unit/plugin/v2/installer_test.rb
+++ b/test/unit/plugin/v2/installer_test.rb
@@ -222,10 +222,10 @@ class PluginInstallerInstallationTests < MiniTest::Test
   def test_refuse_to_install_gem_whose_name_is_on_the_reject_list
     ENV['INSPEC_CONFIG_DIR'] = File.join(@config_dir_path, 'empty')
 
-    # Here, 'inspec-core', 'inspec-multiserver', and 'train-tax-collector'
-    # are the names of real rubygems.  They are not InSPec/ Train plugins, though,
+    # Here, 'inspec-core', 'inspec-multi-server', and 'train-tax-collector'
+    # are the names of real rubygems.  They are not InSPec/Train plugins, though,
     # and installing them would be a jam-up.
-    # This is configured in etc/plugin-filter.json .
+    # This is configured in 'etc/plugin-filter.json'.
     [
       'inspec-core',
       'inspec-multi-server',
@@ -457,10 +457,10 @@ class PluginInstallerSearchTests < MiniTest::Test
     results = @installer.search('inspec-')
     assert results.key?('inspec-test-fixture')
 
-    # Here, 'inspec-core', 'inspec-multiserver'
-    # are the names of real rubygems.  They are not InSpec/ Train plugins, though,
+    # Here, 'inspec-core', 'inspec-multi-server'
+    # are the names of real rubygems.  They are not InSpec/Train plugins, though,
     # and installing them would be a jam-up.
-    # This is configured in etc/plugin_filters.json .
+    # This is configured in 'etc/plugin_filters.json'.
     [
       'inspec-core',
       'inspec-multi-server',
@@ -474,9 +474,9 @@ class PluginInstallerSearchTests < MiniTest::Test
     assert results.key?('train-test-fixture')
 
     # Here, train-tax-calculator'
-    # is the name of a real rubygem.  They are not InSpec/ Train plugins, though,
-    # and installing them would be a jam-up.
-    # This is configured in etc/plugin_filters.json .
+    # is the name of a real rubygem.  It is not a InSpec/Train plugin, though,
+    # and installing it would be a jam-up.
+    # This is configured in 'etc/plugin_filters.json'.
     [
       'train-tax-calculator'
     ].each do |plugin_name|


### PR DESCRIPTION
This PR:
 * Adds a JSON config file at etc/plugin_filters.json, which lists the names of Gems that we wish to exclude from plugin activity
 * Each exclusion must have a Rationale, which is used in error messages
 * `inspec plugin search` uses the exclusion list to filter results
 * `inspec plugin install` refuses to install gems on the exclusion list, and explains why in detail
 * `inspec plugin search` now hides `{inspec,train}-test-fixture` by default (using a different mechanism), but will reveal it when passed a special flag.