### PR TITLE
Fix distinct_exit cli desc to reflect reality

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -221,7 +221,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :depends, type: :array, default: [],
     desc: 'A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell'
   option :distinct_exit, type: :boolean, default: true,
-    desc: 'Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.'
+    desc: 'Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures.'
   def shell_func
     o = opts(:shell).dup
     diagnose(o)


### PR DESCRIPTION
The description for `distinct_exit` had the exist codes backwards.

From the long desc
> If some tests skipped but none failed, exit code 101 is returned. If at least one test failed, exit code 100 is returned.