### PR TITLE
Add missing tests for groups resource, document members property, and assorted fixes.

### DIFF
--- a/docs/resources/group.md.erb
+++ b/docs/resources/group.md.erb
@@ -5,7 +5,7 @@ platform: os
 
 # group
 
-Use the `group` InSpec audit resource to test groups on the system.
+Use the `group` InSpec audit resource to test a single group on the system.
 
 <br>
 
@@ -30,7 +30,7 @@ A `group` resource block declares a group, and then the details to be tested, su
 
 where
 
-* `'group_name'` must specify the name of a group on the system
+* `'group_name'` must specify the name of a group to be tested on the system
 * `exist` and `'gid'` are valid matchers for this resource
 
 <br>
@@ -48,6 +48,20 @@ The following examples show how to use this InSpec audit resource.
 
 <br>
 
+## Properties
+
+### gid
+
+The `gid` property tests the named group identifier:
+
+    its('gid') { should eq 1234 }
+
+### members
+
+The `members` property tests the members that belong to the group:
+
+    its('members') { should include 'root' }
+
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
@@ -60,12 +74,6 @@ The `be_local` matcher tests if the group is a local group:
 
 ### exist
 
-The `exist` matcher tests if the named user exists:
+The `exist` matcher tests if the named group exists:
 
     it { should exist }
-
-### gid
-
-The `gid` matcher tests the named group identifier:
-
-    its('gid') { should eq 1234 }

--- a/docs/resources/groups.md.erb
+++ b/docs/resources/groups.md.erb
@@ -1,0 +1,85 @@
+---
+title: About the groups Resource
+platform: os
+---
+
+# group
+
+Use the `groups` InSpec audit resource to test multiple groups on the system.
+
+<br>
+
+## Availability
+
+### Installation
+
+This resource is distributed along with InSpec itself. You can use it automatically.
+
+### Version
+
+This resource first became available in v1.0.0 of InSpec.
+
+## Syntax
+
+A `groups` resource block uses `where` to filter entries from the systems groups. If `where` is omitted, all entries are selected.
+
+    describe groups do
+      its('names') { should eq ['wheel', 'daemon', 'sys', 'adm'] }
+      its('names') { should include 'wheel' }
+    end
+
+    describe groups.where { members =~ /root/ } do
+      its('names') { should eq ['wheel', 'daemon', 'sys', 'adm'] }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test the group identifier for the wheel group
+
+    describe groups.where { name == 'wheel' } do
+      it { should exist }
+      its('members') { should include 'root' }
+    end
+
+<br>
+
+## Properties
+
+### gids
+
+The `gids` property tests the named group identifier:
+
+    its('gids') { should eq 1234 }
+
+### names
+
+The `names` property tests the name field on a Windows group:
+
+   its('names') { should include 'Power Users' }
+
+### domains
+
+The `domains` property tests the domain on a Windows group:
+
+   its('domains') { should include 'WIN-CIV7VMLVHLD' }
+
+### members
+
+The `members` property tests the members that belong to a group:
+
+    its('members') { should include 'root' }
+    its('members') { should include 'Administrator' }
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### exist
+
+The `exist` matcher tests if the named user exists:
+
+    it { should exist }

--- a/docs/resources/groups.md.erb
+++ b/docs/resources/groups.md.erb
@@ -3,7 +3,7 @@ title: About the groups Resource
 platform: os
 ---
 
-# group
+# groups
 
 Use the `groups` InSpec audit resource to test multiple groups on the system.
 

--- a/lib/resources/groups.rb
+++ b/lib/resources/groups.rb
@@ -51,7 +51,7 @@ module Inspec::Resources
     filter.register_column(:names,     field: 'name')
           .register_column(:gids,      field: 'gid')
           .register_column(:domains,   field: 'domain')
-          .register_column(:members,   field: 'members')
+          .register_column(:members,   field: 'members', style: :simple)
     filter.install_filter_methods_on_resource(self, :collect_group_details)
 
     def to_s
@@ -73,10 +73,6 @@ module Inspec::Resources
   #   its('gid') { should eq 0 }
   # end
   #
-  # deprecated has matcher
-  # describe group('root') do
-  #  it { should have_gid 0 }
-  # end
   class Group < Inspec.resource(1)
     include GroupManagementSelector
 
@@ -112,13 +108,7 @@ module Inspec::Resources
       flatten_entry(group_info, 'gid')
     end
 
-    # implements rspec has matcher, to be compatible with serverspec
-    def has_gid?(compare_gid)
-      gid == compare_gid
-    end
-
     def members
-      return unless inspec.os.windows?
       flatten_entry(group_info, 'members')
     end
 
@@ -223,7 +213,7 @@ module Inspec::Resources
       end
 
       # ensure we have an array of groups
-      groups = [groups] if !groups.is_a?(Array)
+      groups = [groups] unless groups.is_a?(Array)
       groups
     end
   end

--- a/test/unit/resources/group_test.rb
+++ b/test/unit/resources/group_test.rb
@@ -12,14 +12,18 @@ describe 'Inspec::Resources::Group' do
     resource = MockLoader.new(:ubuntu1404).load_resource('group', 'root')
     _(resource.exists?).must_equal true
     _(resource.gid).must_equal 0
-    _(resource.has_gid?(0)).must_equal true
   end
 
   it 'verify group on ubuntu with mixed case' do
     resource = MockLoader.new(:ubuntu1404).load_resource('group', 'GroupWithCaps')
     _(resource.exists?).must_equal true
     _(resource.gid).must_equal 999
-    _(resource.has_gid?(999)).must_equal true
+  end
+
+  it 'verify group on ubuntu with members' do
+    resource = MockLoader.new(:ubuntu1404).load_resource('group', 'www-data')
+    _(resource.exists?).must_equal true
+    _(resource.members).must_equal "www-data,root"
   end
 
   # ubuntu with non-existent group
@@ -27,7 +31,6 @@ describe 'Inspec::Resources::Group' do
     resource = MockLoader.new(:ubuntu1404).load_resource('group', 'nogroup')
     _(resource.exists?).must_equal false
     _(resource.gid).must_be_nil
-    _(resource.has_gid?(0)).must_equal false
   end
 
   # mac
@@ -35,7 +38,6 @@ describe 'Inspec::Resources::Group' do
     resource = MockLoader.new(:osx104).load_resource('group', 'root')
     _(resource.exists?).must_equal true
     _(resource.gid).must_equal 0
-    _(resource.has_gid?(0)).must_equal true
   end
 
   # freebsd
@@ -43,7 +45,6 @@ describe 'Inspec::Resources::Group' do
     resource = MockLoader.new(:freebsd10).load_resource('group', 'root')
     _(resource.exists?).must_equal true
     _(resource.gid).must_equal 0
-    _(resource.has_gid?(0)).must_equal true
   end
 
   # windows with local group
@@ -51,7 +52,6 @@ describe 'Inspec::Resources::Group' do
     resource = MockLoader.new(:windows).load_resource('group', 'Administrators')
     _(resource.exists?).must_equal true
     _(resource.gid).must_equal 'S-1-5-32-544'
-    _(resource.has_gid?(0)).must_equal false
     _(resource.members).must_equal ['Administrators', 'Domain Admins']
   end
 
@@ -59,7 +59,6 @@ describe 'Inspec::Resources::Group' do
     resource = MockLoader.new(:windows).load_resource('group', 'Power Users')
     _(resource.exists?).must_equal true
     _(resource.gid).must_equal 'S-1-5-32-547'
-    _(resource.has_gid?(0)).must_equal false
     _(resource.members).must_equal []
   end
 
@@ -68,8 +67,7 @@ describe 'Inspec::Resources::Group' do
     resource = MockLoader.new(:windows).load_resource('group', 'dhcp')
     _(resource.exists?).must_equal false
     _(resource.gid).must_be_nil
-    _(resource.has_gid?(0)).must_equal false
-    _(resource.members).must_equal nil
+    _(resource.members).must_be_nil
   end
 
   # undefined
@@ -77,6 +75,5 @@ describe 'Inspec::Resources::Group' do
     resource = MockLoader.new(:undefined).load_resource('group', 'root')
     _(resource.exists?).must_equal false
     _(resource.gid).must_be_nil
-    _(resource.has_gid?(0)).must_equal false
   end
 end

--- a/test/unit/resources/groups_test.rb
+++ b/test/unit/resources/groups_test.rb
@@ -1,0 +1,89 @@
+# encoding: utf-8
+
+require 'helper'
+require 'inspec/resource'
+
+describe 'groups resource on unix platform' do
+  let(:resource) { MockLoader.new(:ubuntu1404).load_resource('groups') }
+
+  describe 'no arguments' do
+    it 'finds all group names' do
+      _(resource.names.count).must_equal 3
+      _(resource.names).must_equal %w(root www-data GroupWithCaps)
+    end
+
+    it 'finds all group gids' do
+      _(resource.gids.count).must_equal 3
+      _(resource.gids).must_equal [0, 33, 999]
+    end
+
+
+    it 'finds no group domains' do
+      _(resource.domains.count).must_equal 3
+      _(resource.domains).must_equal [nil, nil, nil]
+    end
+  end
+
+  describe 'where method' do
+    it 'retrieves entries via gid' do
+      _(resource.where{ gid == 33 }.entries.length).must_equal 1
+    end
+
+    it 'retrieves entries via name' do
+      _(resource.where{ name == 'www-data' }.entries.length).must_equal 1
+    end
+
+    it 'retrieves members via name' do
+      _(resource.where{ name == 'www-data' }.members).must_equal ['www-data,root']
+    end
+
+    it 'retrieves entries via members regexp' do
+      _(resource.where{ members =~ /root/ }.members).must_equal ['www-data,root']
+      _(resource.where{ members =~ /root/ }.exist?).must_equal true
+    end
+  end
+end
+
+describe 'groups resource on windows platform' do
+  let(:resource) { MockLoader.new(:windows).load_resource('groups') }
+
+  describe 'no arguments' do
+    it 'finds all group names' do
+      _(resource.names.count).must_equal 4
+      _(resource.names).must_equal ['Administrators', 'Guests', 'Power Users', 'Users']
+    end
+
+    it 'finds all group gids' do
+      _(resource.gids.count).must_equal 4
+      _(resource.gids).must_equal ["S-1-5-32-544", "S-1-5-32-546", "S-1-5-32-547", "S-1-5-32-545"]
+    end
+
+
+    it 'finds no group domains' do
+      _(resource.domains.count).must_equal 4
+      _(resource.domains).must_equal ['WIN-CIV7VMLVHLD', 'WIN-CIV7VMLVHLD',
+                                      'WIN-CIV7VMLVHLD', 'WIN-CIV7VMLVHLD']
+    end
+  end
+
+  describe 'where method' do
+    it 'retrieves entries via gid' do
+      _(resource.where{ gid == 'S-1-5-32-544' }.entries.length).must_equal 1
+    end
+
+    it 'retrieves entries via name' do
+      _(resource.where{ name == 'Administrators' }.entries.length).must_equal 1
+    end
+
+    it 'retrieves members via name' do
+      _(resource.where{ name == 'Administrators' }.members).must_equal ['Administrators', 'Domain Admins']
+      _(resource.where{ name == 'Administrators' }.exist?).must_equal true
+    end
+
+    it 'retrieves groups via included members' do
+      res = _(resource.where{ members.include? 'Guest' }.raw_data)
+      res.target.count.must_equal 1
+      res.target.first['name'].must_equal 'Guests'
+    end
+  end
+end


### PR DESCRIPTION
Please let me know if I missed anything. This should improve tests around the group resource and fix missing documentation as noted in #3422 

Changes:
Update existing documentation for group resource.
Add documentation for groups resource.
Update group resource tests to test members property.
Change groups resource members property to have simple style. (this
ensures members is a single array)
remove deprecated have_gid propery.
change `if !` to `unless`
Remove early return from members method. This prevented members from
working correctly on any OS other than Windows.
Add missing tests for the groups resource.

Fixes https://github.com/inspec/inspec/issues/3422