### PR TITLE
Fix archive with required attributes

### DIFF
--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -89,6 +89,9 @@ module Inspec
     private
 
     def validate_required(value)
+      # skip if we are not doing a exec (archive/vendor)
+      return unless Inspec::BaseCLI.inspec_cli_command == :exec
+
       # value will be set already if a secrets file was passed in
       if (!@opts.key?(:default) && value.nil?) || (@opts[:default].nil? && value.nil?)
         error = Inspec::Attribute::RequiredError.new

--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -89,7 +89,7 @@ module Inspec
     private
 
     def validate_required(value)
-      # skip if we are not doing a exec (archive/vendor)
+      # skip if we are not doing an exec call (archive/vendor/check)
       return unless Inspec::BaseCLI.inspec_cli_command == :exec
 
       # value will be set already if a secrets file was passed in

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -91,4 +91,16 @@ describe 'inspec archive' do
     files.must_include 'inspec.lock'
     files.select { |f| f =~ /vendor/ }.count.must_be :>, 1
   end
+
+  it 'can archive a profile with required attributes' do
+    archive_depends_path = File.join(profile_path, 'profile-with-required-attributes')
+
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.cp_r(archive_depends_path + '/.', tmpdir)
+
+      out = inspec('archive ' + tmpdir)
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+    end
+  end
 end

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -221,4 +221,16 @@ describe 'example inheritance profile' do
       end
     end
   end
+
+  it 'can vendor profile with required attributes' do
+    archive_depends_path = File.join(profile_path, 'profile-with-required-attributes')
+
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.cp_r(archive_depends_path + '/.', tmpdir)
+
+      out = inspec('vendor ' + tmpdir)
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+    end
+  end
 end

--- a/test/unit/mock/profiles/profile-with-required-attributes/controls/include.rb
+++ b/test/unit/mock/profiles/profile-with-required-attributes/controls/include.rb
@@ -1,0 +1,11 @@
+cis_level = attribute('cis_level')
+
+control 'control1' do
+  title 'title'
+
+  only_if { cis_level == 2 }
+
+  describe true do
+    it { should eq true}
+  end
+end

--- a/test/unit/mock/profiles/profile-with-required-attributes/inspec.yml
+++ b/test/unit/mock/profiles/profile-with-required-attributes/inspec.yml
@@ -1,0 +1,17 @@
+name: profile-with-required-attributes
+title: InSpec example for attributes override
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
+copyright_email: support@chef.io
+license: Apache-2.0
+summary: Demonstrates the use of InSpec profile inheritance
+version: 1.0.0
+supports:
+  - platform-family: unix
+  - platform-family: windows
+inspec_version: '>= 2.3.5'
+attributes:
+  - name: cis_level
+    required: true
+    description: 'CIS profile level to audit'
+    type: numeric

--- a/test/unit/objects/attribute_test.rb
+++ b/test/unit/objects/attribute_test.rb
@@ -64,9 +64,11 @@ describe Inspec::Attribute do
     end
 
     it 'returns an error if no value is set' do
+      Inspec::BaseCLI.inspec_cli_command = :exec
       attribute = Inspec::Attribute.new('test_attribute', required: true)
       ex = assert_raises(Inspec::Attribute::RequiredError) { attribute.value }
       ex.message.must_match /Attribute 'test_attribute' is required and does not have a value./
+      Inspec::BaseCLI.inspec_cli_command = nil
     end
   end
 


### PR DESCRIPTION
This allows profiles to be vendored and archived when they have required attributes.

Fixes #3464