### PR TITLE
Remove docs and examples directory from spec to reduce gem size.

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     README.md Rakefile MAINTAINERS.toml MAINTAINERS.md LICENSE inspec.gemspec
     Gemfile CHANGELOG.md .rubocop.yml
   } + Dir.glob(
-    '{bin,docs,examples,lib}/**/*', File::FNM_DOTMATCH
+    '{bin,lib}/**/*', File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }
 
   spec.executables   = %w{inspec}


### PR DESCRIPTION
@tas50 pointed out we could save some space by removing packaged docs and examples that we don't use.