### PR TITLE
Added protection for the case where the file is nil.

### DIFF
--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -49,7 +49,7 @@ module Inspec::Resources
       path basename source source_path uid gid
     }.each do |m|
       define_method m.to_sym do |*args|
-        file.method(m.to_sym).call(*args)
+        file.method(m.to_sym).call(*args) unless file.nil?
       end
     end
 


### PR DESCRIPTION
This small fix is to prevent an exception for InSpec cloud profile transports.  The issue is well described here: https://github.com/inspec/inspec-gcp/issues/61 

Instead of an exception traceback, users see something more meaningful e.g.
```
$ bundle exec inspec exec . -t gcp://

Profile: InSpec Profile (gcp-file)
Version: 0.1.0
Target:  gcp://<service-account>.iam.gserviceaccount.com

  ×  tmp-1.0: Create /tmp directory
     ×  File
     Resource File is not supported on platform gcp/google-api-client-v0.23.9.

  File
     ×  Resource File is not supported on platform gcp/google-api-client-v0.23.9.

Profile Summary: 0 successful controls, 1 control failure, 0 controls skipped
Test Summary: 0 successful, 2 failures, 0 skipped
``` 

Signed-off-by: Stuart Paterson <spaterson@chef.io>