### PR TITLE
FilterTable: allow Strings or Symbols as fields

### DIFF
--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -106,7 +106,7 @@ module FilterTable
       # If we were provided params, interpret them as criteria to be evaluated
       # against the raw data. Criteria are assumed to be hash keys.
       conditions.each do |raw_field_name, desired_value|
-        raise(ArgumentError, "'#{raw_field_name}' is not a recognized criterion - expected one of #{list_fields.join(', ')}'") unless field?(raw_field_name)
+        raise(ArgumentError, "'#{decorate_symbols(raw_field_name)}' is not a recognized criterion - expected one of #{decorate_symbols(list_fields).join(', ')}'") unless field?(raw_field_name)
         populate_lazy_field(raw_field_name, desired_value) if is_field_lazy?(raw_field_name)
         new_criteria_string += " #{raw_field_name} == #{desired_value.inspect}"
         filtered_raw_data = filter_raw_data(filtered_raw_data, raw_field_name, desired_value)
@@ -175,7 +175,15 @@ module FilterTable
       # Currently we only know about a field if it is present in a at least one row of the raw data.
       # If we have no rows in the raw data, assume all fields are acceptable (and rely on failing to match on value, nil)
       return true if raw_data.empty?
-      list_fields.include?(proposed_field) || is_field_lazy?(proposed_field)
+
+      # Most resources have Symbol keys in their raw data.  Some have Strings (looking at you, `shadow`).
+      is_field = false
+      is_field ||= list_fields.include?(proposed_field.to_s)
+      is_field ||= list_fields.include?(proposed_field.to_sym)
+      is_field ||= is_field_lazy?(proposed_field.to_s)
+      is_field ||= is_field_lazy?(proposed_field.to_sym)
+
+      is_field
     end
 
     def to_s
@@ -240,6 +248,8 @@ module FilterTable
     end
 
     def filter_raw_data(current_raw_data, field, desired_value)
+      return [] if current_raw_data.empty?
+
       method_ref = case desired_value
                    when Float   then method(:matches_float)
                    when Integer then method(:matches_int)
@@ -247,10 +257,20 @@ module FilterTable
                    else              method(:matches)
                    end
 
+      assume_symbolic_keyed_data = current_raw_data.first.keys.first.is_a? Symbol
+      field = assume_symbolic_keyed_data ? field.to_sym : field.to_s
+
       current_raw_data.find_all do |row|
         next unless row.key?(field)
         method_ref.call(row[field], desired_value)
       end
+    end
+
+    def decorate_symbols(thing)
+      return thing.map {|t| decorate_symbols(t) } if thing.is_a?(Array)
+      return ':' + thing.to_s if thing.is_a? Symbol
+      return thing + ' (String)' if thing.is_a? String
+      return thing
     end
   end
 

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -267,10 +267,10 @@ module FilterTable
     end
 
     def decorate_symbols(thing)
-      return thing.map {|t| decorate_symbols(t) } if thing.is_a?(Array)
+      return thing.map { |t| decorate_symbols(t) } if thing.is_a?(Array)
       return ':' + thing.to_s if thing.is_a? Symbol
       return thing + ' (String)' if thing.is_a? String
-      return thing
+      thing
     end
   end
 

--- a/test/functional/filter_table_test.rb
+++ b/test/functional/filter_table_test.rb
@@ -8,11 +8,13 @@ describe '2943 inspec exec for filter table profile, method mode for `where' do
       '2943_pass_undeclared_field_in_hash',
       '2943_pass_irregular_row_key',
       '2943_pass_raise_error_when_key_not_in_data',
+      '2943_pass_allow_symbols_as_criteria_when_data_is_string_keyed',
+      '2943_pass_allow_strings_as_criteria_when_data_is_symbol_keyed',
       '2943_pass_no_error_when_no_data',
     ]
 
     cmd  = 'exec ' + File.join(profile_path, 'filter_table')
-    cmd += ' --reporter json --no-create-lockfile' 
+    cmd += ' --reporter json --no-create-lockfile'
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
@@ -41,7 +43,7 @@ describe '2943 inspec exec for filter table profile, method mode for `where' do
     failed_controls.each do |ctl|
       control_hash[ctl['id']] = ctl['results'][0]['message']
     end
-    controls.each do |expected_control| 
+    controls.each do |expected_control|
       control_hash.keys.must_include(expected_control)
     end
 
@@ -99,7 +101,7 @@ describe '2370 lazy_load for filter table' do
     ]
 
     cmd  = 'exec ' + File.join(profile_path, 'filter_table')
-    cmd += ' --reporter json --no-create-lockfile' 
+    cmd += ' --reporter json --no-create-lockfile'
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
@@ -128,7 +130,7 @@ describe '2370 lazy_load for filter table' do
     failed_controls.each do |ctl|
       control_hash[ctl['id']] = ctl['results'][0]['message']
     end
-    controls.each do |expected_control| 
+    controls.each do |expected_control|
       control_hash.keys.must_include(expected_control)
     end
 
@@ -156,7 +158,7 @@ describe '2929 exceptions in block-mode where' do
     control_hash.must_be_empty
     cmd.stderr.must_equal ''
     cmd.exit_status.must_equal 0
-  end  
+  end
 end
 
 describe '3110 do not expose block-valued properties in raw data' do
@@ -169,7 +171,7 @@ describe '3110 do not expose block-valued properties in raw data' do
     ]
 
     cmd  = 'exec ' + File.join(profile_path, 'filter_table')
-    cmd += ' --reporter json --no-create-lockfile' 
+    cmd += ' --reporter json --no-create-lockfile'
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -112,7 +112,7 @@ Test Summary: 0 successful, 0 failures, 0 skipped
   it 'executes only specified controls when selecting passing controls by regex' do
     out = inspec('exec ' + File.join(profile_path, 'filter_table') + ' --no-create-lockfile --controls \'/^2943_pass/\'')
     out.exit_status.must_equal 0
-    out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: \e[38;5;41m4 successful controls\e[0m, 0 control failures, 0 controls skipped"
+    out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: \e[38;5;41m6 successful controls\e[0m, 0 control failures, 0 controls skipped"
   end
 
   it 'executes only specified controls when selecting failing controls by regex' do

--- a/test/unit/mock/profiles/filter_table/controls/validate_criteria_as_params.rb
+++ b/test/unit/mock/profiles/filter_table/controls/validate_criteria_as_params.rb
@@ -5,6 +5,11 @@ raw_data = [
   { id: 2, name: 'Bobby', shoe_size: 10, favorite_color: 'purple'},
 ]
 
+stringy_raw_data = [
+  { 'id' => 1, 'name' => 'Annie', 'shoe_size' => 12},
+  { 'id' => 2, 'name' => 'Bobby', 'shoe_size' => 10, 'favorite_color' => 'purple'},
+]
+
 control '2943_pass_undeclared_field_in_hash' do
   title 'It should tolerate criteria that are keys of the raw data but are not declared as fields'
   # simple_plural only has one declared field, 'id'
@@ -40,3 +45,18 @@ control '2943_fail_derail_check' do
     it { should exist }
   end
 end
+
+control '2943_pass_allow_symbols_as_criteria_when_data_is_string_keyed' do
+  title 'It should tolerate criteria that are Symbols when the raw data is String-keyed'
+  describe simple_plural(stringy_raw_data).where(favorite_color: 'purple') do
+    it { should exist }
+  end
+end
+
+control '2943_pass_allow_strings_as_criteria_when_data_is_symbol_keyed' do
+  title 'It should tolerate criteria that are Strings when the raw data is Symbol-keyed'
+  describe simple_plural(raw_data).where('favorite_color' => 'purple') do
+    it { should exist }
+  end
+end
+


### PR DESCRIPTION
Allow strings or symbols to be used interchangeably in filtertable criteria.  Also, allow resources to use strings as fields for raw data (but please don't do that - look at you, `shadow` resource).

Also adds stuff to an error message to clarify expected types.

Functional tests to cover the repro case included.

Reported by @james-stocks
