### PR TITLE
small fix - fixes the apline `info` method

### DIFF
--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -258,7 +258,7 @@ module Inspec::Resources
       cmd = inspec.command("apk info -vv --no-network | grep #{package_name}")
       return {} if cmd.exit_status.to_i != 0
 
-      pkg_info = cmd.stdout.split("\n").reject! { |e| e =~ /^WARNING/i }
+      pkg_info = cmd.stdout.split("\n").delete_if { |e| e =~ /^WARNING/i }
       pkg = pkg_info[0].split(' - ')[0]
 
       {


### PR DESCRIPTION
Fixes #3480 

* updates the AlpinePkg class `info` method to use the `delete_if` method as the `reject!` method was returning nil.