### PR TITLE
Fix error on empty attributes yaml

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -132,6 +132,8 @@ module Inspec
           name = attr_dup.delete(:name)
           @runner_context.register_attribute(name, attr_dup)
         end
+      elsif metadata.params.key?(:attributes)
+        Inspec::Log.warn 'Attributes must be defined as an Array. Skipping current definition.'
       end
     end
 

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -126,7 +126,7 @@ module Inspec
     end
 
     def register_metadata_attributes
-      if metadata.params.key?(:attributes)
+      if metadata.params.key?(:attributes) && metadata.params[:attributes].is_a?(Array)
         metadata.params[:attributes].each do |attribute|
           attr_dup = attribute.dup
           name = attr_dup.delete(:name)

--- a/test/functional/attributes_test.rb
+++ b/test/functional/attributes_test.rb
@@ -38,7 +38,7 @@ describe 'attributes' do
       cmd += File.join(profile_path, 'profile-with-empty-attributes')
       cmd += ' --no-create-lockfile'
       out = inspec(cmd)
-      out.stderr.must_equal ''
+      out.stdout.must_include 'WARN: Attributes must be defined as an Array. Skipping current definition.'
       out.exit_status.must_equal 0
     end
 

--- a/test/functional/attributes_test.rb
+++ b/test/functional/attributes_test.rb
@@ -33,6 +33,15 @@ describe 'attributes' do
       out.exit_status.must_equal 0
     end
 
+    it "does not error when attributes are empty" do
+      cmd = 'exec '
+      cmd += File.join(profile_path, 'profile-with-empty-attributes')
+      cmd += ' --no-create-lockfile'
+      out = inspec(cmd)
+      out.stderr.must_equal ''
+      out.exit_status.must_equal 0
+    end
+
     it "errors with invalid attribute types" do
       cmd = 'exec '
       cmd += File.join(profile_path, 'invalid_attributes')

--- a/test/unit/mock/profiles/profile-with-empty-attributes/inspec.yml
+++ b/test/unit/mock/profiles/profile-with-empty-attributes/inspec.yml
@@ -1,0 +1,9 @@
+name: profile-with-empty-attributes
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+attributes:


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

Fixes https://github.com/inspec/inspec/issues/3466

This makes sure the `attributes` param is an array before trying digest it.