### PR TITLE
Backport compliance namespace and add testing for A2 audit report.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,11 @@ transport:
 
 provisioner:
   name: dokken
+  client_rb:
+    data_collector.server_url: <%= ENV['COLLECTOR_URL'] %>
+    data_collector.token: <%= ENV['COLLECTOR_TOKEN'] %>
+    ssl_verify_mode: :verify_none
+    verify_api_cert: false
 
 verifier:
   name: inspec
@@ -90,7 +95,9 @@ suites:
     audit:
       attributes:
         audit_attribute: 'Attribute Override!'
-      reporter: 'json-file'
+      insecure: true
+      reporter: ['json-file','chef-automate']
+      fetcher: 'chef-automate'
       json_file:
         location: /tmp/json_export.json
       profiles:

--- a/lib/bundles/inspec-compliance/api.rb
+++ b/lib/bundles/inspec-compliance/api.rb
@@ -2,3 +2,6 @@
 # TODO: Remove in inspec 4.0
 
 require 'plugins/inspec-compliance/lib/inspec-compliance/api'
+
+# Backport old namespace
+Compliance = InspecPlugins::Compliance unless defined?(Compliance)

--- a/lib/bundles/inspec-compliance/configuration.rb
+++ b/lib/bundles/inspec-compliance/configuration.rb
@@ -2,3 +2,6 @@
 # TODO: Remove in inspec 4.0
 
 require 'plugins/inspec-compliance/lib/inspec-compliance/configuration'
+
+# Backport old namespace
+Compliance = InspecPlugins::Compliance unless defined?(Compliance)

--- a/lib/bundles/inspec-compliance/http.rb
+++ b/lib/bundles/inspec-compliance/http.rb
@@ -2,3 +2,6 @@
 # TODO: Remove in inspec 4.0
 
 require 'plugins/inspec-compliance/lib/inspec-compliance/http'
+
+# Backport old namespace
+Compliance = InspecPlugins::Compliance unless defined?(Compliance)

--- a/lib/bundles/inspec-compliance/support.rb
+++ b/lib/bundles/inspec-compliance/support.rb
@@ -2,3 +2,6 @@
 # TODO: Remove in inspec 4.0
 
 require 'plugins/inspec-compliance/lib/inspec-compliance/support'
+
+# Backport old namespace
+Compliance = InspecPlugins::Compliance unless defined?(Compliance)

--- a/lib/bundles/inspec-compliance/target.rb
+++ b/lib/bundles/inspec-compliance/target.rb
@@ -2,3 +2,6 @@
 # TODO: Remove in inspec 4.0
 
 require 'plugins/inspec-compliance/lib/inspec-compliance/target'
+
+# Backport old namespace
+Compliance = InspecPlugins::Compliance unless defined?(Compliance)


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This fixes the current audit fetcher issue with the new compliance plugin. This change backports the Compliance namespace when legacy paths are used. It also updates our travis tests to send to the acceptance A2 box.