### PR TITLE
Change `Inspec ` to `InSpec ` where appropriate

### DIFF
--- a/GITHUB_LABELS.md
+++ b/GITHUB_LABELS.md
@@ -1,4 +1,4 @@
-# Inspec Project GitHub Labeling Policies
+# InSpec Project GitHub Labeling Policies
 
 ## Stakes
 
@@ -24,7 +24,7 @@ The colors don't mean anything at this point; we've generally just accepted the 
 
 Currently, we have one anti-goal:
 
-* Do not indicate priority or timeline information via labelling.  That's high-stakes, and quickly becomes out of date.  The Inspec team internally tracks its Chef, Inc. priorities; all other issues may be addressed on an as-needed, FOSS basis.
+* Do not indicate priority or timeline information via labelling.  That's high-stakes, and quickly becomes out of date.  The InSpec team internally tracks its Chef, Inc. priorities; all other issues may be addressed on an as-needed, FOSS basis.
 
 ### For Machines
 

--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Inspec uses Test Kitchen for its integration testing. Our current testing uses Docker as our backend. You should install and have Docker running befor you run any tests.
+InSpec uses Test Kitchen for its integration testing. Our current testing uses Docker as our backend. You should install and have Docker running befor you run any tests.
 
 ### How to run specific integrations
 
@@ -17,7 +17,7 @@ Example:
 bundle exec rake test:integration[default-ubuntu-1604]
 ```
 
-# Inspec Integrations
+# InSpec Integrations
 
 ### Test Kitchen
 

--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -256,7 +256,7 @@ module InspecPlugins::Sweeten
 end
 ```
 
-The Inspec plugin v2 system promises the following:
+The InSpec plugin v2 system promises the following:
 
 * The superclass will be an (indirect) subclass of Thor
 * The plugin system will handle registering the subcommand with Thor for you
@@ -266,7 +266,7 @@ The Inspec plugin v2 system promises the following:
 
 Within your `cli.rb`, you need to do two things:
 
-* Inform Inspec of your subcommand's usage and description, so the `help` commands will work properly
+* Inform InSpec of your subcommand's usage and description, so the `help` commands will work properly
 * Implement your subcommands and options using the Thor DSL
 
 See also: [Thor homepage](http://whatisthor.com/) and [Thor docs](https://www.rubydoc.info/github/wycats/thor/Thor).

--- a/docs/resources/aws_security_group.md.erb
+++ b/docs/resources/aws_security_group.md.erb
@@ -222,7 +222,7 @@ A Number totalling the number of individual rules defined - It is a sum of the c
 
 A String in the format 'vpc-' followed by 8 hexadecimal characters reflecting VPC that contains the Security Group.
 
-    # Inspec the VPC ID of a particular Group
+    # Inspect the VPC ID of a particular Group
     describe aws_security_group('sg-12345678') do
       its('vpc_id') { should cmp 'vpc-12345678' }
     end

--- a/docs/resources/azure_generic_resource.md.erb
+++ b/docs/resources/azure_generic_resource.md.erb
@@ -6,7 +6,7 @@ title: About the azure_generic_resource Resource
 
 <p class="warning">This resource is deprecated and should not be used. It will be removed in InSpec 3.0.</p>
 
-Use the `azure_generic_resource` InSpec audit resource to test any valid Azure Resource. This is very useful if you need to test something that we do not yet have a specific Inspec resource for.
+Use the `azure_generic_resource` InSpec audit resource to test any valid Azure Resource. This is very useful if you need to test something that we do not yet have a specific InSpec resource for.
 
 ## Availability
 
@@ -98,7 +98,7 @@ When the options have been set as well as the environment variables, the environ
 
 The properties that can be tested are entirely dependent on the Azure Resource that is under scrutiny. That means the properties vary. The best way to see what is available please use the [Azure Resources Portal](https://resources.azure.com) to select the resource you are interested in and see what can be tested.
 
-This resource allows you to test _any_ valid Azure Resource. The trade off for this is that the language to check each item is not as natural as it would be for a native Inspec resource.
+This resource allows you to test _any_ valid Azure Resource. The trade off for this is that the language to check each item is not as natural as it would be for a native InSpec resource.
 
 <br>
 
@@ -180,4 +180,4 @@ This InSpec audit resource has the following special matchers. For a full list o
 
 Please see the integration tests for in depth examples of how this resource can be used.
 
-[Inspec Integration Tests for Azure Generic Resources](https://github.com/chef/inspec/tree/master/test/integration/azure/verify/controls)
+[InSpec Integration Tests for Azure Generic Resources](https://github.com/chef/inspec/tree/master/test/integration/azure/verify/controls)

--- a/docs/resources/azure_virtual_machine.md.erb
+++ b/docs/resources/azure_virtual_machine.md.erb
@@ -262,7 +262,7 @@ If boot diagnostics are enabled for the machine they will be saved in a storage 
 
 There are a number of built in comparison operators that are available to test the result with an expected value.
 
-For information on all that are available please refer to the [Inspec Matchers Reference](https://www.inspec.io/docs/reference/matchers/) page.
+For information on all that are available please refer to the [InSpec Matchers Reference](https://www.inspec.io/docs/reference/matchers/) page.
 
 ### boot\_diagnostics?
 

--- a/docs/resources/registry_key.md.erb
+++ b/docs/resources/registry_key.md.erb
@@ -170,24 +170,24 @@ Any name with a dot will not work as expected: <code>its('explorer.exe') { shoul
     # ...or provide the name in an array
     its(['explorer.exe']) { should eq 'test' }
 
-The latter workaround may be preferable because upon failure, Inspec will present the expected and actual values:
+The latter workaround may be preferable because upon failure, InSpec will present the expected and actual values:
 
     inspec> describe registry_key('HKEY_USERS\S-1-5-20\Software\Policies\Microsoft\Windows\Control Panel\Desktop') do
     inspec>   its(["SCRNSAVE.EXE"]) { should eq "FlyingToasters.scr" }
     inspec> end
-    
+
     Profile: inspec-shell
     Version: (not specified)
-    
+
       Registry Key HKEY_USERS\S-1-5-20\Software\Policies\Microsoft\Windows\Control Panel\Desktop
          ×  ["SCRNSAVE.EXE"] should eq "FlyingToasters.scr"
 
          expected: "FlyingToasters.scr"
               got: "scrnsave.scr"
-    
+
          (compared using ==)
-    
-    
+
+
     Test Summary: 0 successful, 1 failure, 0 skipped
 
 `have_property_value` only presents a false assertion:

--- a/examples/profile/controls/gordon.rb
+++ b/examples/profile/controls/gordon.rb
@@ -17,7 +17,7 @@ control 'gordon-1.0' do
   tag 'gordon'
   ref 'Gordon Requirements 1.0', uri: 'http://...'
 
-  # Test using the custom gordon_config Inspec resource
+  # Test using the custom gordon_config InSpec resource
   # Find the resource content here: ../libraries/
   describe gordon_config do
     it { should exist }

--- a/lib/bundles/inspec-supermarket/cli.rb
+++ b/lib/bundles/inspec-supermarket/cli.rb
@@ -69,6 +69,6 @@ module Supermarket
     end
   end
 
-  # register the subcommand to Inspec CLI registry
+  # register the subcommand to InSpec CLI registry
   Inspec::Plugins::CLI.add_subcommand(SupermarketCLI, 'supermarket', 'supermarket SUBCOMMAND ...', 'Supermarket commands', {})
 end

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -305,7 +305,7 @@ begin
   ctl = Inspec::PluginCtl.new
   ctl.list.each { |x| ctl.load(x) }
 
-  # load v1 CLI plugins before the Inspec CLI has been started
+  # load v1 CLI plugins before the InSpec CLI has been started
   Inspec::Plugins::CLI.subcommands.each { |_subcommand, params|
     Inspec::InspecCLI.register(
       params[:klass],

--- a/lib/inspec/secrets/yaml.rb
+++ b/lib/inspec/secrets/yaml.rb
@@ -24,7 +24,7 @@ module Secrets
         @attributes = nil
       end
     rescue => e
-      raise "Error reading Inspec attributes: #{e}"
+      raise "Error reading InSpec attributes: #{e}"
     end
   end
 end

--- a/lib/plugins/inspec-artifact/lib/inspec-artifact/base.rb
+++ b/lib/plugins/inspec-artifact/lib/inspec-artifact/base.rb
@@ -87,7 +87,7 @@ module InspecPlugins
           p = Pathname.new(path_to_profile)
           p = p.join('inspec.yml')
           if not p.exist?
-            raise "#{path_to_profile} doesn't appear to be a valid Inspec profile"
+            raise "#{path_to_profile} doesn't appear to be a valid InSpec profile"
           end
           yaml = YAML.load_file(p.to_s)
           yaml = yaml.to_hash
@@ -101,7 +101,7 @@ module InspecPlugins
           end
         rescue => e
           # rewrap it and pass it up to the CLI
-          raise "Error reading Inspec profile metadata: #{e}"
+          raise "Error reading InSpec profile metadata: #{e}"
         end
 
         yaml

--- a/lib/plugins/inspec-artifact/lib/inspec-artifact/cli.rb
+++ b/lib/plugins/inspec-artifact/lib/inspec-artifact/cli.rb
@@ -12,7 +12,7 @@ require_relative 'base'
 #
 #
 # .IAF file format
-#   .iaf = "Inspec Artifact File", easy to rename if you'd like something more appropriate.
+#   .iaf = "InSpec Artifact File", easy to rename if you'd like something more appropriate.
 #   The iaf file wraps a binary artifact with some metadata. The first implementation
 #   looks like this:
 #
@@ -62,8 +62,8 @@ require_relative 'base'
 #   private keys. We should establish a common key directory (similar to /hab/cache/keys
 #   or ~/.hab/cache/keys in Habitat).
 #
-# Extracting artifacts outside of Inspec
-#   As in Habitat, the artifact format for Inspec allows the use of common
+# Extracting artifacts outside of InSpec
+#   As in Habitat, the artifact format for InSpec allows the use of common
 #   Unix tools to read the header and body of an artifact.
 # To extract the header from a .iaf:
 #        sed '/^$/q' foo.iaf

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
@@ -260,7 +260,7 @@ module InspecPlugins
       end
     end
 
-    # register the subcommand to Inspec CLI registry
+    # register the subcommand to InSpec CLI registry
     # Inspec::Plugins::CLI.add_subcommand(InspecPlugins::ComplianceCLI, 'compliance', 'compliance SUBCOMMAND ...', 'Chef InspecPlugins::Compliance commands', {})
   end
 end

--- a/lib/resources/aws/aws_iam_user.rb
+++ b/lib/resources/aws/aws_iam_user.rb
@@ -97,7 +97,7 @@ class AwsIamUser < Inspec.resource(1)
     mfa_info = backend.list_mfa_devices(user_name: username)
     @has_mfa_enabled = !mfa_info.mfa_devices.empty?
 
-    # TODO: consider returning Inspec AwsIamAccessKey objects
+    # TODO: consider returning InSpec AwsIamAccessKey objects
     @access_keys = backend.list_access_keys(user_name: username).access_key_metadata
     # If the above call fails, we get nil here; but we promise access_keys will be an array.
     @access_keys ||= []

--- a/lib/resources/azure/azure_generic_resource.rb
+++ b/lib/resources/azure/azure_generic_resource.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     name 'azure_generic_resource'
 
     desc '
-      Inspec Resource to interrogate any Resource type in Azure
+      InSpec Resource to interrogate any Resource type in Azure
     '
 
     supports platform: 'azure'

--- a/lib/resources/azure/azure_resource_group.rb
+++ b/lib/resources/azure/azure_resource_group.rb
@@ -7,7 +7,7 @@ module Inspec::Resources
     name 'azure_resource_group'
 
     desc '
-      Inspec Resource to get metadata about a specific Resource Group
+      InSpec Resource to get metadata about a specific Resource Group
     '
 
     supports platform: 'azure'

--- a/lib/resources/azure/azure_virtual_machine.rb
+++ b/lib/resources/azure/azure_virtual_machine.rb
@@ -7,7 +7,7 @@ module Inspec::Resources
     name 'azure_virtual_machine'
 
     desc '
-      Inspec Resource to test Azure Virtual Machines
+      InSpec Resource to test Azure Virtual Machines
     '
 
     supports platform: 'azure'
@@ -122,7 +122,7 @@ module Inspec::Resources
     #
     # This allows the use of
     #   it { should have_password_authentication }
-    # within the Inspec profile
+    # within the InSpec profile
     #
     # @return boolean
     def has_password_authentication?
@@ -146,7 +146,7 @@ module Inspec::Resources
     #
     # This allows the use of
     #    it { should have_custom_data }
-    # within the Inspec Profile
+    # within the InSpec Profile
     #
     # @return boolean
     def has_custom_data?
@@ -168,7 +168,7 @@ module Inspec::Resources
     #
     # This allows the use of
     #    it { should have_ssh_keys }
-    # within the Inspec Profile
+    # within the InSpec Profile
     #
     # @return boolean
     def has_ssh_keys?

--- a/lib/resources/azure/azure_virtual_machine_data_disk.rb
+++ b/lib/resources/azure/azure_virtual_machine_data_disk.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     name 'azure_virtual_machine_data_disk'
 
     desc '
-      Inspec Resource to ensure that the data disks attached to a machine are correct
+      InSpec Resource to ensure that the data disks attached to a machine are correct
     '
 
     supports platform: 'azure'

--- a/lib/resources/chocolatey_package.rb
+++ b/lib/resources/chocolatey_package.rb
@@ -6,7 +6,7 @@ module Inspec::Resources
   class ChocoPkg < Inspec.resource(1)
     name 'chocolatey_package'
     supports platform: 'windows'
-    desc 'Use the chocolatey_package Inspec audit resource to test if the named package and/or package version is installed on the system.'
+    desc 'Use the chocolatey_package InSpec audit resource to test if the named package and/or package version is installed on the system.'
     example <<-EOH
       describe chocolatey_package('git') do
         it { should be_installed }

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -73,7 +73,7 @@ describe 'inspec exec with json formatter' do
         "license" => "Apache-2.0",
         "summary" => "Demonstrates the use of InSpec Compliance Profile",
         "version" => "1.0.0",
-        "sha256" => "9ce86873d1e0c450ec739883dfe39828b481697f573304ad24c835885085b132",
+        "sha256" => "7acce309d89d995a908fcd1c7daaaae65954d252d4de1b90ae52416b4e67d2f3",
         "supports" => [{"platform-family" => "unix"}, {"platform-family"=>"windows"}],
         "attributes" => []
       })

--- a/test/integration/azure/build/azure.tf
+++ b/test/integration/azure/build/azure.tf
@@ -40,7 +40,7 @@ resource "azurerm_resource_group" "rg" {
   location = "${var.location}"
 
   tags {
-    CreatedBy = "Inspec Azure Integration Tests"
+    CreatedBy = "InSpec Azure Integration Tests"
   }
 }
 
@@ -183,7 +183,7 @@ resource "azurerm_virtual_machine" "vm_linux_internal" {
     disable_password_authentication = false
   }
 
-  # Add boot diagnostics to the machine. These will be added to the 
+  # Add boot diagnostics to the machine. These will be added to the
   # created storage acccount
   boot_diagnostics {
     enabled     = true

--- a/test/integration/azure/verify/controls/generic_resources.rb
+++ b/test/integration/azure/verify/controls/generic_resources.rb
@@ -21,6 +21,6 @@ control 'azure-generic-resource-group-resources-1.0' do
     it { should have_tags }
     its('tag_count') { should be 1 }
     its('tags') { should include 'CreatedBy' }
-    its('CreatedBy_tag') { should cmp 'Inspec Azure Integration Tests' }
+    its('CreatedBy_tag') { should cmp 'InSpec Azure Integration Tests' }
   end
 end

--- a/test/integration/azure/verify/controls/resource_group.rb
+++ b/test/integration/azure/verify/controls/resource_group.rb
@@ -19,7 +19,7 @@ control 'azure-resource-group-1.0' do
     it { should have_tags }
     its('tag_count') { should be 1 }
     its('tags') { should include 'CreatedBy' }
-    its('CreatedBy_tag') { should cmp 'Inspec Azure Integration Tests' }
+    its('CreatedBy_tag') { should cmp 'InSpec Azure Integration Tests' }
 
     # How many resources are in the resource group in total
     its('total') { should eq 13 }

--- a/test/unit/mock/config_dirs/train-test-fixture/gems/2.3.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
+++ b/test/unit/mock/config_dirs/train-test-fixture/gems/2.3.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.name          = "train-test-fixture"
   spec.version       = '0.1.0'
-  spec.authors       = ["Inspec core engineering team"]
+  spec.authors       = ["InSpec core engineering team"]
   spec.email         = ["hello@chef.io"]
   spec.license       = 'Apache-2.0'
 

--- a/test/unit/mock/config_dirs/train-test-fixture/gems/2.3.0/specifications/train-test-fixture-0.1.0.gemspec
+++ b/test/unit/mock/config_dirs/train-test-fixture/gems/2.3.0/specifications/train-test-fixture-0.1.0.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
-  s.authors = ["Inspec core engineering team".freeze]
+  s.authors = ["InSpec core engineering team".freeze]
   s.date = "2018-09-26"
   s.description = "Train plugin used in testing Train's plugin loader and InSpec's plugin manager.\nThis plugin does things that a normal plugin should not.  Do not use it as an\nexample or as a starting point for plugin of your own.  For that, please see\nhttps://github.com/inspec/train/tree/master/examples/plugins\n".freeze
   s.email = ["hello@chef.io".freeze]

--- a/test/unit/mock/config_dirs/train-test-fixture/gems/2.4.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
+++ b/test/unit/mock/config_dirs/train-test-fixture/gems/2.4.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.name          = "train-test-fixture"
   spec.version       = '0.1.0'
-  spec.authors       = ["Inspec core engineering team"]
+  spec.authors       = ["InSpec core engineering team"]
   spec.email         = ["hello@chef.io"]
   spec.license       = 'Apache-2.0'
 

--- a/test/unit/mock/config_dirs/train-test-fixture/gems/2.4.0/specifications/train-test-fixture-0.1.0.gemspec
+++ b/test/unit/mock/config_dirs/train-test-fixture/gems/2.4.0/specifications/train-test-fixture-0.1.0.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
-  s.authors = ["Inspec core engineering team".freeze]
+  s.authors = ["InSpec core engineering team".freeze]
   s.date = "2018-09-26"
   s.description = "Train plugin used in testing Train's plugin loader and InSpec's plugin manager.\nThis plugin does things that a normal plugin should not.  Do not use it as an\nexample or as a starting point for plugin of your own.  For that, please see\nhttps://github.com/inspec/train/tree/master/examples/plugins\n".freeze
   s.email = ["hello@chef.io".freeze]

--- a/test/unit/mock/config_dirs/train-test-fixture/gems/2.5.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
+++ b/test/unit/mock/config_dirs/train-test-fixture/gems/2.5.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.name          = "train-test-fixture"
   spec.version       = '0.1.0'
-  spec.authors       = ["Inspec core engineering team"]
+  spec.authors       = ["InSpec core engineering team"]
   spec.email         = ["hello@chef.io"]
   spec.license       = 'Apache-2.0'
 

--- a/test/unit/mock/config_dirs/train-test-fixture/gems/2.5.0/specifications/train-test-fixture-0.1.0.gemspec
+++ b/test/unit/mock/config_dirs/train-test-fixture/gems/2.5.0/specifications/train-test-fixture-0.1.0.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
-  s.authors = ["Inspec core engineering team".freeze]
+  s.authors = ["InSpec core engineering team".freeze]
   s.date = "2018-09-26"
   s.description = "Train plugin used in testing Train's plugin loader and InSpec's plugin manager.\nThis plugin does things that a normal plugin should not.  Do not use it as an\nexample or as a starting point for plugin of your own.  For that, please see\nhttps://github.com/inspec/train/tree/master/examples/plugins\n".freeze
   s.email = ["hello@chef.io".freeze]

--- a/test/unit/plugin/v2/installer_test.rb
+++ b/test/unit/plugin/v2/installer_test.rb
@@ -244,7 +244,7 @@ class PluginInstallerInstallationTests < MiniTest::Test
     ENV['INSPEC_CONFIG_DIR'] = File.join(@config_dir_path, 'empty')
 
     # Here, 'inspec-core', 'inspec-multi-server', and 'train-tax-collector'
-    # are the names of real rubygems.  They are not InSPec/Train plugins, though,
+    # are the names of real rubygems.  They are not InSpec/Train plugins, though,
     # and installing them would be a jam-up.
     # This is configured in 'etc/plugin-filter.json'.
     [

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -52,7 +52,7 @@ class AwsIamUserRecallTest < Minitest::Test
   def test_search_hit_via_hash_works
     user = AwsIamUser.new(username: 'erin')
     assert user.exists?
-    assert_equal('erin', user.username)    
+    assert_equal('erin', user.username)
   end
 end
 
@@ -79,7 +79,7 @@ class AwsIamUserPropertiesTest < Minitest::Test
     assert_includes(leslie.attached_policy_names, 'AdministratorAccess')
     assert_equal(1, leslie.attached_policy_arns.count)
     assert_includes(leslie.attached_policy_arns, 'arn:aws:iam::aws:policy/AdministratorAccess')
-    
+
     jared = AwsIamUser.new('jared')
     assert_equal(2, jared.attached_policy_names.count)
     assert_includes(jared.attached_policy_names, 'ReadOnlyAccess')
@@ -98,7 +98,7 @@ class AwsIamUserPropertiesTest < Minitest::Test
     assert_equal(2, leslie.inline_policy_names.count)
     assert_includes(leslie.inline_policy_names, 'leslie-inline-01')
     assert_includes(leslie.inline_policy_names, 'leslie-inline-02')
-    
+
     jared = AwsIamUser.new('jared')
     assert_equal(1, jared.inline_policy_names.count)
     assert_includes(jared.inline_policy_names, 'jared-inline-01')
@@ -124,15 +124,15 @@ class AwsIamUserPropertiesTest < Minitest::Test
     keys = AwsIamUser.new('erin').access_keys
     assert_kind_of(Array, keys)
     assert_equal(keys.length, 2)
-    # We don't currently promise that the results 
-    # will be Inspec resource objects.
-    # assert_kind_of(AwsIamAccessKey, keys.first)    
+    # We don't currently promise that the results
+    # will be InSpec resource objects.
+    # assert_kind_of(AwsIamAccessKey, keys.first)
   end
 
   def test_property_access_keys_negative
     keys = AwsIamUser.new('leslie').access_keys
     assert_kind_of(Array, keys)
-    assert(keys.empty?)    
+    assert(keys.empty?)
   end
 end
 
@@ -195,29 +195,29 @@ module MAIUB
       people = {
         'erin' => OpenStruct.new({
           user: OpenStruct.new({
-            arn: "arn:aws:iam::123456789012:user/erin", 
-            create_date: Time.parse("2016-09-21T23:03:13Z"), 
-            path: "/", 
-            user_id: "AKIAIOSFODNN7EXAERIN", 
-            user_name: "erin", 
+            arn: "arn:aws:iam::123456789012:user/erin",
+            create_date: Time.parse("2016-09-21T23:03:13Z"),
+            path: "/",
+            user_id: "AKIAIOSFODNN7EXAERIN",
+            user_name: "erin",
           }),
         }),
         'leslie' => OpenStruct.new({
           user: OpenStruct.new({
-            arn: "arn:aws:iam::123456789012:user/leslie", 
-            create_date: Time.parse("2017-09-21T23:03:13Z"), 
-            path: "/", 
-            user_id: "AKIAIOSFODNN7EXAERIN", 
-            user_name: "leslie", 
+            arn: "arn:aws:iam::123456789012:user/leslie",
+            create_date: Time.parse("2017-09-21T23:03:13Z"),
+            path: "/",
+            user_id: "AKIAIOSFODNN7EXAERIN",
+            user_name: "leslie",
           }),
         }),
         'jared' => OpenStruct.new({
           user: OpenStruct.new({
-            arn: "arn:aws:iam::123456789012:user/jared", 
-            create_date: Time.parse("2017-09-21T23:03:13Z"), 
-            path: "/", 
-            user_id: "AKIAIOSFODNN7EXAERIN", 
-            user_name: "jared", 
+            arn: "arn:aws:iam::123456789012:user/jared",
+            create_date: Time.parse("2017-09-21T23:03:13Z"),
+            path: "/",
+            user_id: "AKIAIOSFODNN7EXAERIN",
+            user_name: "jared",
           }),
         }),
       }
@@ -323,7 +323,7 @@ module MAIUB
         ),
         'leslie' => Aws::IAM::Types::ListUserPoliciesResponse.new(
           policy_names: ['leslie-inline-01', 'leslie-inline-02'],
-        ), 
+        ),
         'jared' => Aws::IAM::Types::ListUserPoliciesResponse.new(
           policy_names: ['jared-inline-01'],
         )

--- a/test/unit/resources/x509_certificate_test.rb
+++ b/test/unit/resources/x509_certificate_test.rb
@@ -12,19 +12,23 @@ describe 'Inspec::Resources::X509Certificate' do
     )
   }
 
+  # TODO: Regenerate certificate using `InSpec` not `Inspec`
   it 'verify subject distingushed name' do
     _(resource_cert.send('subject_dn')).must_match 'Inspec Test Certificate'
   end
 
+  # TODO: Regenerate certificate using `InSpec` not `Inspec`
   it 'parses the certificate subject' do
     _(resource_cert.send('subject').CN).must_equal 'Inspec Test Certificate'
     _(resource_cert.send('subject').emailAddress).must_equal 'support@chef.io'
   end
 
+  # TODO: Regenerate certificate using `InSpec` not `Inspec`
   it 'verify issue distingushed name' do
     _(resource_cert.send('issuer_dn')).must_match 'Inspec Test CA'
   end
 
+  # TODO: Regenerate certificate using `InSpec` not `Inspec`
   it 'parses the issuer' do
     _(resource_cert.send('issuer').CN).must_equal 'Inspec Test CA'
   end

--- a/www/source/legal/licensing.html.slim
+++ b/www/source/legal/licensing.html.slim
@@ -7,7 +7,7 @@ title: Licensing
     h2 Legal/Licensing
 
     p
-      | Inspec is an open source product governed by the Apache 2.0 license.
+      | InSpec is an open source product governed by the Apache 2.0 license.
         The license is reproduced here in its entirety.
 
 

--- a/www/source/legal/trademark-policy.html.slim
+++ b/www/source/legal/trademark-policy.html.slim
@@ -1,5 +1,5 @@
 ---
-title: Inspec - Trademark Policy
+title: InSpec - Trademark Policy
 ---
 .row.margin-both-offset.columns
   .block
@@ -15,7 +15,7 @@ title: Inspec - Trademark Policy
     p This Policy, prepared by Chef, sets out rules for proper use of the Chef Marks. Some, but not all, Chef Marks include the following:
     ul
       li Chef and Chef Logo
-      li Inspec and Inspec Logo
+      li InSpec and InSpec Logo
       li Compliance at Velocity
       li CODE CAN
       li RULE THE CLOUD


### PR DESCRIPTION
This also changes a few other misspellings I saw while verifying the automation. Example: `InSPec`.

Oh, and extra white space was caught in the reap because of how I have `vim` setup.

This PR brought to you by a couple sips of strong coffee and clever use of pipes, `grep`, and `vim`.