### PR TITLE
Add json metadata for skipped profiles

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -236,7 +236,7 @@ module Inspec
         if supports_platform? && !d.supports_platform?
           # since ruby 1.9 hashes are ordered so we can just use index values here
           metadata.dependencies[i][:skipped] = true
-          msg = "This OS/platform (#{d.backend.platform.name}/#{d.backend.platform.release}) is not supported by this profile."
+          msg = "Skipping profile: '#{d.name}' on unsupported platform: '#{d.backend.platform.name}/#{d.backend.platform.release}'."
           metadata.dependencies[i][:skip_message] = msg
           next
         end
@@ -303,7 +303,7 @@ module Inspec
 
       if !supports_platform?
         res[:skipped] = true
-        msg = "This OS/platform (#{backend.platform.name}/#{backend.platform.release}) is not supported by this profile."
+        msg = "Skipping profile: '#{name}' on unsupported platform: '#{backend.platform.name}/#{backend.platform.release}'."
         res[:skip_message] = msg
       end
 

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -235,10 +235,12 @@ module Inspec
         # this metadata if the parent profile is supported.
         if supports_platform? && !d.supports_platform?
           # since ruby 1.9 hashes are ordered so we can just use index values here
-          metadata.dependencies[i][:skipped] = true
+          metadata.dependencies[i][:status] = 'skipped'
           msg = "Skipping profile: '#{d.name}' on unsupported platform: '#{d.backend.platform.name}/#{d.backend.platform.release}'."
           metadata.dependencies[i][:skip_message] = msg
           next
+        else
+          metadata.dependencies[i][:status] = 'loaded'
         end
         c = d.load_libraries
         @runner_context.add_resources(c)
@@ -302,9 +304,11 @@ module Inspec
       res[:parent_profile] = parent_profile unless parent_profile.nil?
 
       if !supports_platform?
-        res[:skipped] = true
+        res[:status] = 'skipped'
         msg = "Skipping profile: '#{name}' on unsupported platform: '#{backend.platform.name}/#{backend.platform.release}'."
         res[:skip_message] = msg
+      else
+        res[:status] = 'loaded'
       end
 
       # convert legacy os-* supports to their platform counterpart

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -239,10 +239,10 @@ module Inspec
           msg = "Skipping profile: '#{d.name}' on unsupported platform: '#{d.backend.platform.name}/#{d.backend.platform.release}'."
           metadata.dependencies[i][:skip_message] = msg
           next
-        else
+        elsif metadata.dependencies[i]
           # Currently wrapper profiles will load all dependencies, and then we
           # load them again when we dive down. This needs to be re-done.
-          metadata.dependencies[i][:status] = 'loaded' if metadata.dependencies[i]
+          metadata.dependencies[i][:status] = 'loaded'
         end
         c = d.load_libraries
         @runner_context.add_resources(c)
@@ -266,7 +266,7 @@ module Inspec
       info(load_params.dup)
     end
 
-    def info(res = params.dup) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def info(res = params.dup) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
       # add information about the controls
       res[:controls] = res[:controls].map do |id, rule|
         next if id.to_s.empty?

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -240,7 +240,9 @@ module Inspec
           metadata.dependencies[i][:skip_message] = msg
           next
         else
-          metadata.dependencies[i][:status] = 'loaded'
+          # Currently wrapper profiles will load all dependencies, and then we
+          # load them again when we dive down. This needs to be re-done.
+          metadata.dependencies[i][:status] = 'loaded' if metadata.dependencies[i]
         end
         c = d.load_libraries
         @runner_context.add_resources(c)

--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -44,7 +44,7 @@ module Inspec::Reporters
 
     def render
       run_data[:profiles].each do |profile|
-        if profile[:skipped] == true
+        if profile[:status] == 'skipped'
           platform = run_data[:platform]
           output("Skipping profile: '#{profile[:name]}' on unsupported platform: '#{platform[:name]}/#{platform[:release]}'.")
           next

--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -44,6 +44,11 @@ module Inspec::Reporters
 
     def render
       run_data[:profiles].each do |profile|
+        if profile[:skipped] == true
+          platform = run_data[:platform]
+          output("Skipping profile: '#{profile[:name]}' on unsupported platform: '#{platform[:name]}/#{platform[:release]}'.")
+          next
+        end
         @control_count = 0
         output('')
         print_profile_header(profile)

--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -112,6 +112,8 @@ module Inspec::Reporters
           depends: p[:depends],
           groups: profile_groups(p),
           controls: profile_controls(p),
+          skipped: p[:skipped],
+          skip_message: p[:skip_message],
         }
         profiles << profile.reject { |_k, v| v.nil? }
       end

--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -112,7 +112,7 @@ module Inspec::Reporters
           depends: p[:depends],
           groups: profile_groups(p),
           controls: profile_controls(p),
-          skipped: p[:skipped],
+          status: p[:status],
           skip_message: p[:skip_message],
         }
         profiles << profile.reject { |_k, v| v.nil? }

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -96,8 +96,8 @@ module Inspec
         end
 
         @attributes = profile.runner_context.attributes if @attributes.empty?
-        test = profile.collect_tests
-        all_controls += tests unless test.nil?
+        tests = profile.collect_tests
+        all_controls += tests unless tests.nil?
       end
 
       all_controls.each do |rule|

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -89,7 +89,7 @@ module Inspec
         profile_context.dependencies.list.values.each do |requirement|
           unless requirement.profile.supports_platform?
             Inspec::Log.warn "Skipping profile: '#{requirement.profile.name}'" \
-             " on unsupported platform: '#{@backend.platform.name}'."
+             " on unsupported platform: '#{@backend.platform.name}/#{@backend.platform.release}'."
             next
           end
           @test_collector.add_profile(requirement.profile)

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -80,6 +80,8 @@ module Inspec
 
       @target_profiles.each do |profile|
         @test_collector.add_profile(profile)
+        next unless profile.supports_platform?
+
         write_lockfile(profile) if @create_lockfile
         profile.locked_dependencies
         profile_context = profile.load_libraries
@@ -94,7 +96,8 @@ module Inspec
         end
 
         @attributes = profile.runner_context.attributes if @attributes.empty?
-        all_controls += profile.collect_tests
+        test = profile.collect_tests
+        all_controls += tests unless test.nil?
       end
 
       all_controls.each do |rule|
@@ -205,10 +208,6 @@ module Inspec
         raise 'This profile requires InSpec version '\
              "#{profile.metadata.inspec_requirement}. You are running "\
              "InSpec v#{Inspec::VERSION}.\n"
-      end
-
-      if !profile.supports_platform?
-        raise "This OS/platform (#{@backend.platform.name}/#{@backend.platform.release}) is not supported by this profile."
       end
 
       true

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -84,11 +84,12 @@ module Inspec
     def exit_code
       return @rspec_exit_code if @formatter.results.empty?
       stats = @formatter.results[:statistics][:controls]
-      if stats[:failed][:total] == 0 && stats[:skipped][:total] == 0
+      skipped = @formatter.results[:profiles].first[:status] == 'skipped'
+      if stats[:failed][:total] == 0 && stats[:skipped][:total] == 0 && !skipped
         0
       elsif stats[:failed][:total] > 0
         @conf['distinct_exit'] ? 100 : 1
-      elsif stats[:skipped][:total] > 0
+      elsif stats[:skipped][:total] > 0 || skipped
         @conf['distinct_exit'] ? 101 : 0
       else
         @rspec_exit_code

--- a/lib/inspec/schema.rb
+++ b/lib/inspec/schema.rb
@@ -137,6 +137,8 @@ module Inspec
         'copyright_email' => { 'type' => 'string', 'optional' => true },
         'license' => { 'type' => 'string', 'optional' => true },
         'summary' => { 'type' => 'string', 'optional' => true },
+        'status' => { 'type' => 'string', 'optional' => false },
+        'skip_message' => { 'type' => 'string', 'optional' => true },
 
         'supports' => {
           'type' => 'array',

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -122,6 +122,7 @@ describe 'inspec exec with json formatter' do
         "version" => "1.0.0",
         "sha256" => "9ce86873d1e0c450ec739883dfe39828b481697f573304ad24c835885085b132",
         "supports" => [{"platform-family" => "unix"}, {"platform-family"=>"windows"}],
+        "status" => "loaded",
         "attributes" => []
       })
 

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -79,7 +79,7 @@ describe 'inspec exec with json formatter' do
 
   it 'flags profile with correct status when not supported' do
     out = inspec('exec ' + File.join(profile_path, 'skippy-profile-os') + ' --reporter json --no-create-lockfile')
-    out.exit_status.must_equal 0
+    out.exit_status.must_equal 101
     data = JSON.parse(out.stdout)
     profile = data['profiles'].first
     profile['status'].must_equal 'skipped'

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -161,9 +161,9 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     let(:out) { inspec('exec ' + File.join(profile_path, 'skippy-profile-os') + ' --no-create-lockfile') }
     let(:json) { JSON.load(out.stdout) }
 
-    it 'exits with an error' do
-      out.stderr.must_match(/^This OS\/platform \(.+\) is not supported by this profile.$/)
-      out.exit_status.must_equal 1
+    it 'exits with skip message' do
+      out.stdout.must_include("Skipping profile: 'skippy' on unsupported platform:")
+      out.exit_status.must_equal 0
     end
   end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -163,7 +163,7 @@ Test Summary: 0 successful, 0 failures, 0 skipped
 
     it 'exits with skip message' do
       out.stdout.must_include("Skipping profile: 'skippy' on unsupported platform:")
-      out.exit_status.must_equal 0
+      out.exit_status.must_equal 101
     end
   end
 

--- a/test/unit/mock/profiles/unsupported_dependencies/wrapper-profile/inspec.yml
+++ b/test/unit/mock/profiles/unsupported_dependencies/wrapper-profile/inspec.yml
@@ -6,8 +6,6 @@ copyright_email: you@example.com
 license: Apache-2.0
 summary: An InSpec wrapper profile for unsupported dependencies
 version: 0.1.0
-# supports:
-#   platform-family: 'bash'
 depends:
   - name: child_profile
     path: ../child_profile

--- a/test/unit/mock/profiles/unsupported_dependencies/wrapper-profile/inspec.yml
+++ b/test/unit/mock/profiles/unsupported_dependencies/wrapper-profile/inspec.yml
@@ -6,8 +6,9 @@ copyright_email: you@example.com
 license: Apache-2.0
 summary: An InSpec wrapper profile for unsupported dependencies
 version: 0.1.0
+# supports:
+#   platform-family: 'bash'
 depends:
   - name: child_profile
     path: ../child_profile
-  - name: child_profile2
-    path: ../child_profile2
+  - path: ../child_profile2


### PR DESCRIPTION
This change adds the new `status` and optional `skip_message` to the json reports. It changes the behavior when a main profile is not supported. Instead of exiting error with a message we will output that we have skipped the profile and continue as expected.

Fixes https://github.com/inspec/inspec/issues/3488