### PR TITLE
Fix plugin install issues in different ruby envs

### DIFF
--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -404,7 +404,7 @@ module Inspec::Plugin::V2
 
         directories = [Gem::Specification.default_specifications_dir]
         if !defined?(::Bundler)
-          directories = Gem::Specification.dirs.find_all do |path|
+          directories += Gem::Specification.dirs.find_all do |path|
             !path.start_with?(Gem.user_dir)
           end
         end

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -390,27 +390,38 @@ module Inspec::Plugin::V2
     #                        Utilities
     #===================================================================#
 
-    # This class alows us to build a Vendor set with the gems that are
+    # This class alows us to build a Resolver set with the gems that are
     # already included either with Ruby or with the InSpec install
+    #
+    # This code is heavily based on:
+    # https://github.com/hashicorp/vagrant/blob/master/lib/vagrant/bundler.rb#L400
+    # https://github.com/hashicorp/vagrant/blob/master/lib/vagrant/bundler.rb#L565
     class InstalledVendorSet < Gem::Resolver::Set
       def initialize
         super
         @remote = false
         @specs = []
 
+        # Grab any pre loaded gems
         Gem::Specification.find_all do |spec|
           @specs << spec
         end
 
+        # find all gem specification directories
         directories = [Gem::Specification.default_specifications_dir]
         if !defined?(::Bundler)
+          # add in any others that do not start with the user directory
           directories += Gem::Specification.dirs.find_all do |path|
             !path.start_with?(Gem.user_dir)
           end
         end
+
+        # add them all to the specs array
         Gem::Specification.each_spec(directories) do |spec|
           @specs << spec
         end
+
+        # resolver expects one of each spec so uniq here.
         @specs.uniq!
       end
 

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -392,23 +392,31 @@ module Inspec::Plugin::V2
 
     # This class alows us to build a Vendor set with the gems that are
     # already included either with Ruby or with the InSpec install
-    class InstalledVendorSet < Gem::Resolver::VendorSet
+    class InstalledVendorSet < Gem::Resolver::Set
       def initialize
         super
+        @remote = false
+        @specs = []
 
         Gem::Specification.find_all do |spec|
-          @specs[spec.name] = spec
-          @directories[spec] = spec.gem_dir
+          @specs << spec
         end
 
+        directories = [Gem::Specification.default_specifications_dir]
         if !defined?(::Bundler)
           directories = Gem::Specification.dirs.find_all do |path|
             !path.start_with?(Gem.user_dir)
           end
-          Gem::Specification.each_spec(directories) do |spec|
-            @specs[spec.name] = spec
-            @directories[spec] = spec.gem_dir
-          end
+        end
+        Gem::Specification.each_spec(directories) do |spec|
+          @specs << spec
+        end
+        @specs.uniq!
+      end
+
+      def find_all(req)
+        @specs.select { |spec| req.match?(spec) }.map do |spec|
+          Gem::Resolver::InstalledSpecification.new(self, spec)
         end
       end
     end


### PR DESCRIPTION
Issue: Cannot install plugins using any omnibus system.

```
jquick@Jareds-MBP:~/Chef/inspec
(master)> inspec plugin install inspec-resource-lister
Unknown error occured  - installation failed.
```

```
jquick@Jareds-MBP:~/Chef/inspec
(master)> inspec plugin install ../train-consul/train-consul-0.1.0.gem
Traceback (most recent call last):
        17: from /Users/jquick/.gem/ruby/2.5.1/bin/inspec:23:in `<main>'
        16: from /Users/jquick/.gem/ruby/2.5.1/bin/inspec:23:in `load'
        15: from /Users/jquick/.gem/ruby/2.5.1/gems/inspec-2.3.23/bin/inspec:12:in `<top (required)>'
        14: from /Users/jquick/.gem/ruby/2.5.1/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
        13: from /Users/jquick/.gem/ruby/2.5.1/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
        12: from /Users/jquick/.gem/ruby/2.5.1/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
        11: from /Users/jquick/.gem/ruby/2.5.1/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
        10: from /Users/jquick/.gem/ruby/2.5.1/gems/thor-0.20.0/lib/thor.rb:238:in `block in subcommand'
         9: from /Users/jquick/.gem/ruby/2.5.1/gems/thor-0.20.0/lib/thor/invocation.rb:115:in `invoke'
         8: from /Users/jquick/.gem/ruby/2.5.1/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
         7: from /Users/jquick/.gem/ruby/2.5.1/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
         6: from /Users/jquick/.gem/ruby/2.5.1/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
         5: from /Users/jquick/.gem/ruby/2.5.1/gems/inspec-2.3.23/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb:94:in `install'
         4: from /Users/jquick/.gem/ruby/2.5.1/gems/inspec-2.3.23/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb:182:in `install_from_gemfile'
         3: from /Users/jquick/.gem/ruby/2.5.1/gems/inspec-2.3.23/lib/inspec/plugin/v2/installer.rb:65:in `install'
         2: from /Users/jquick/.gem/ruby/2.5.1/gems/inspec-2.3.23/lib/inspec/plugin/v2/installer.rb:267:in `install_from_gem_file'
         1: from /Users/jquick/.gem/ruby/2.5.1/gems/inspec-2.3.23/lib/inspec/plugin/v2/installer.rb:303:in `install_gem_to_plugins_dir'
/Users/jquick/.gem/ruby/2.5.1/gems/inspec-2.3.23/lib/inspec/plugin/v2/installer.rb:312:in `rescue in install_gem_to_plugins_dir': can't activate faraday-0.15.1, already activated faraday-0.15.3 (Inspec::Plugin::V2::InstallError)
```

This is showing up on all omnibus systems and the typical gem install. Currently plugin install only works with the source checkout.

The fix here is to include bundle gems and correct the installed ResolveSet when resolving.

Manual tested on:
• source
• gem
• omni (osx)
• omni (linux)
• omni (windows)

Manual testing commands:
```
inspec plugin search inspec- 
 (confirm results show up)
inspec plugin install inspec-resource-lister
 (confirm it installs)
inspec plugin install train-consul-0.1.0.gem
 (confirm it installs)
inspec detect -t consul://
 (confirm output is correct)
inspec listresources core
 (confirm results)
inspec plugin list
 (confirm you show the 2 plugins)
inspec uninstall inspec-resource-lister
 (confirm it uninstalls)
inspec uninstall train-consul
 (confirm it uninstalls)
```

Was able to install, use, search, and uninstall. Will have to add omni functional testing when we can.