### PR TITLE
Remove need for UUID detection for Automate report

### DIFF
--- a/lib/inspec/formatters/base.rb
+++ b/lib/inspec/formatters/base.rb
@@ -69,7 +69,6 @@ module Inspec::Formatters
         name: platform(:name),
         release: platform(:release),
         target: backend_target,
-        uuid: platform(:uuid),
       }
     end
 

--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -23,7 +23,7 @@ module Inspec::Reporters
       final_report[:type] = 'inspec_report'
 
       final_report[:end_time] = Time.now.utc.strftime('%FT%TZ')
-      final_report[:node_uuid] = @config['node_uuid'] || @run_data[:platform][:uuid]
+      final_report[:node_uuid] = @config['node_uuid'] || @config['target_id']
       raise Inspec::ReporterError, 'Cannot find a UUID for your node. Please specify one via json-config.' if final_report[:node_uuid].nil?
 
       final_report[:report_uuid] = @config['report_uuid'] || uuid_from_string(final_report[:end_time] + final_report[:node_uuid])


### PR DESCRIPTION
This reverts the reversion here: https://github.com/inspec/inspec/pull/3387

