### PR TITLE
Update the text on the generic default attribute

### DIFF
--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -17,11 +17,13 @@ module Inspec
     DEFAULT_ATTRIBUTE = Class.new do
       def initialize(name)
         @name = name
+
+        # output warn message if we are in a exec call
         Inspec::Log.warn(
           "Attribute '#{@name}' does not have a value. "\
           "Use --attrs to provide a value for '#{@name}' or specify a default  "\
           "value with `attribute('#{@name}', default: 'somedefault', ...)`.",
-        )
+        ) if Inspec::BaseCLI.inspec_cli_command == :exec
       end
 
       def method_missing(*_)

--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -17,19 +17,23 @@ module Inspec
     DEFAULT_ATTRIBUTE = Class.new do
       def initialize(name)
         @name = name
-      end
-
-      def method_missing(*_)
         Inspec::Log.warn(
-          "Returning DEFAULT_ATTRIBUTE for '#{@name}'. "\
+          "Attribute '#{@name}' does not have a value. "\
           "Use --attrs to provide a value for '#{@name}' or specify a default  "\
           "value with `attribute('#{@name}', default: 'somedefault', ...)`.",
         )
+      end
+
+      def method_missing(*_)
         self
       end
 
       def respond_to_missing?(_, _)
         true
+      end
+
+      def to_s
+        "Attribute '#{@name}' does not have a value. Skipping test."
       end
     end
 

--- a/test/unit/objects/attribute_test.rb
+++ b/test/unit/objects/attribute_test.rb
@@ -18,6 +18,7 @@ describe Inspec::Attribute do
 
   it 'returns the default value if no value is assigned' do
     attribute.value.must_be_kind_of Inspec::Attribute::DEFAULT_ATTRIBUTE
+    attribute.value.to_s.must_equal "Attribute 'test_attribute' does not have a value. Skipping test."
   end
 
   it 'has a default value that can be called like a nested map' do


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

Fixes https://github.com/inspec/inspec/issues/3443

New output:
```
(jq/update_fallback_attribute_text)> _inspec exec default_attribute.rb
[2018-10-12T16:40:35-04:00] WARN: Attribute 'password' does not have a value. Use --attrs to provide a value for 'password' or specify a default  value with `attribute('password', default: 'somedefault', ...)`.

Profile: tests from default_attribute.rb (tests from default_attribute.rb)
Version: (not specified)
Target:  local://

  ↺  Test using an attribute without a value: Attribute 'password' does not have a value. Skipping test.
     ↺  Attribute 'password' does not have a value. Skipping test.


Profile Summary: 0 successful controls, 0 control failures, 1 control skipped
Test Summary: 0 successful, 0 failures, 1 skipped
```