### PR TITLE
Allow http resource to follow redirects

### DIFF
--- a/docs/resources/http.md.erb
+++ b/docs/resources/http.md.erb
@@ -23,7 +23,7 @@ This resource first became available in v1.10.0 of InSpec.
 
 An `http` resource block declares the configuration settings to be tested:
 
-    describe http('url', auth: {user: 'user', pass: 'test'}, params: {params}, method: 'method', headers: {headers}, data: data, open_timeout: 60, read_timeout: 60, ssl_verify: true) do
+    describe http('url', auth: {user: 'user', pass: 'test'}, params: {params}, method: 'method', headers: {headers}, data: data, open_timeout: 60, read_timeout: 60, ssl_verify: true, max_redirects: 3) do
       its('status') { should eq number }
       its('body') { should eq 'body' }
       its('headers.name') { should eq 'header' }
@@ -40,6 +40,7 @@ where
 * `open_timeout` may be specified for a timeout for opening connections (default to 60)
 * `read_timeout` may be specified for a timeout for reading connections (default to 60)
 * `ssl_verify` may be specified to enable or disable verification of SSL certificates (default to `true`)
+* `max_redirects` may be specified to control how many HTTP Redirects to follow (defaults to `0`)
 
 <br>
 
@@ -84,7 +85,7 @@ In InSpec 2.0, the HTTP test will automatically execute remotely whenever InSpec
 
 ## Parameters
 
-* `url`, `auth`, `params`, `method`, `headers`, `data`, `open_timeout`, `read_timeout`, `ssl_verify`
+* `url`, `auth`, `params`, `method`, `headers`, `data`, `open_timeout`, `read_timeout`, `ssl_verify`, `max_redirects`
 
 ## Parameter Examples
 
@@ -165,6 +166,17 @@ In InSpec 2.0, the HTTP test will automatically execute remotely whenever InSpec
 
     describe http('http://localhost:8080/ping',
                   ssl_verify: true) do
+      ...
+    end
+
+<br>
+
+### max_redirects
+
+`max_redirects` may be specified to control how many HTTP Redirects to follow (default to 0).
+
+    describe http('http://localhost:8080/ping',
+                  max_redirects: 3) do
       ...
     end
 

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sslshake', '~> 1.2'
   spec.add_dependency 'parallel', '~> 1.9'
   spec.add_dependency 'faraday', '>=0.9.0'
+  spec.add_dependency 'faraday_middleware', '~> 0.12.2'
   spec.add_dependency 'tomlrb', '~> 1.2'
   spec.add_dependency 'addressable', '~> 2.4'
   spec.add_dependency 'parslet', '~> 1.5'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -515,6 +515,7 @@ class MockLoader
       # http resource - remote worker'
       %{bash -c 'type "curl"'} => cmd.call('bash-c-type-curl'),
       "curl -i -X GET --connect-timeout 60 --max-time 120 'http://www.example.com'" => cmd.call('http-remote-no-options'),
+      "curl -i -X GET --connect-timeout 60 --max-time 120 --location --max-redirs 1 'http://www.example.com'" => cmd.call('http-remote-max-redirs'),
       "curl -i -X GET --connect-timeout 60 --max-time 120 --user 'user:pass' 'http://www.example.com'" => cmd.call('http-remote-basic-auth'),
       'f77ebcedaf6fbe8f02d2f9d4735a90c12311d2ca4b43ece9efa2f2e396491747' => cmd.call('http-remote-post'),
       "curl -i -X GET --connect-timeout 60 --max-time 120 -H 'accept: application/json' -H 'foo: bar' 'http://www.example.com'" => cmd.call('http-remote-headers'),

--- a/test/unit/mock/cmd/http-remote-max-redirs
+++ b/test/unit/mock/cmd/http-remote-max-redirs
@@ -1,0 +1,21 @@
+HTTP/1.1 301 Moved Permanently
+Date: Sat, 13 Oct 2018 05:06:12 GMT
+Content-Type: text/html
+Content-Length: 186
+Connection: keep-alive
+Server: gws
+Location: http://example.com
+
+HTTP/1.1 200 OK
+Date: Sat, 13 Oct 2018 05:06:12 GMT
+Expires: -1
+Cache-Control: private, max-age=0
+Content-Type: text/html; charset=ISO-8859-1
+Server: gws
+X-XSS-Protection: 1; mode=block
+X-Frame-Options: SAMEORIGIN
+Accept-Ranges: none
+Vary: Accept-Encoding
+Transfer-Encoding: chunked
+
+followed redirect


### PR DESCRIPTION
By specifying a `max_redirects` attribute, the `http` resource worker will follow any HTTP Redirect response (301, 302, etc...) up to the limit defined by this attribute. For a local worker, exceeding that limit will raise a `FaradayMiddleware::RedirectLimitReached` exception. For a remote worker, the curl command will exit without populating the `status` and `body` properties.

This is a first cut a solution for enabling this feature. Another option I considered was introducing two attributes: `follow_redirects` as a boolean defaulted to `false` and `max_redirects` as an integer defaulted to `3` which is consistent with `faraday` (curl defaults to 50 which seems excessive). In this alternate implementation, users would only have to provide the `follow_redirects` attribute to the resource to enable the behavior without having to think or worry about setting a redirect limit for most use cases. 

However, when you do need to control the limit there are more knobs to turn which could appear as clutter in the resource of the user's profile. Which is why this solution opts for the single `max_redirects` to enable and limit the behavior. I'm not married to either option so I'm curious to hear other opinions in terms of user experience or preference.

Also - I'm having a weird issue where running the unit test for the http resource does not produce consistent results on my local dev workstation. The majority of the time the tests pass but if I try to run the `rake test` task multiple times in a row I'll see this error:

```
# Running:

.............E.......

Finished in 1.165437s, 18.0190 runs/s, 48.0506 assertions/s.

  1) Error:
Inspec::Resources::Http::InSpec::Resources::Http::Worker::Local::request with redirect enabled#test_0002_does not exceed max_redirects:
NameError: uninitialized constant FaradayMiddleware::RedirectLimitReached
Did you mean?  FaradayMiddleware::RedirectLimitReached
    /Users/kwalters/code/cattywampus/inspec/test/unit/resources/http_test.rb:50:in `block (4 levels) in <top (required)>'

21 runs, 56 assertions, 0 failures, 1 errors, 0 skips
```

I've tried to look into why there's this 10-20% chance that the Faraday exception class isn't loaded when the tests run, but I couldn't figure it out...