### PR TITLE
fixes bug with running profiles that comes from authenticated URL

### DIFF
--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -210,6 +210,13 @@ module Inspec
       finalize(res, profile_id, {}, logger)
     end
 
+    def self.from_unrendered_yaml(ref, content, profile_id, logger = nil)
+      res = Metadata.new(ref, logger)
+      res.params = YAML.load(content)
+      res.content = content
+      finalize(res, profile_id, {}, logger)
+    end
+
     def self.from_ruby(ref, content, profile_id, logger = nil)
       res = Metadata.new(ref, logger)
       res.instance_eval(content, ref, 1)

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -456,7 +456,7 @@ module Inspec
 
     def lockfile
       @lockfile ||= if lockfile_exists?
-                      Inspec::Lockfile.from_content(@source_reader.target.read('inspec.lock'))
+                      Inspec::Lockfile.from_content(ERB.new(@source_reader.target.read('inspec.lock')).result)
                     else
                       generate_lockfile
                     end


### PR DESCRIPTION
This is fixed by generating the lock
file with the username/password data and makign sure we render it with
ERB before running the profile.

Signed-off-by: Noel Georgi <git@frezbo.com>