### PR TITLE
Fixes corrupt plugins.json when testing a plugin outside of core

### DIFF
--- a/lib/plugins/shared/core_plugin_test_helper.rb
+++ b/lib/plugins/shared/core_plugin_test_helper.rb
@@ -133,6 +133,7 @@ module CorePluginFunctionalHelper
       'installation_type' => 'path',
       'installation_path' => path,
     }
+    data
   end
 
   def __make_empty_plugin_file_data_structure


### PR DESCRIPTION
This bug would appear if an externally developed plugin relied on the core's plugin test harness support, specifically calling `CorePluginFunctionalHelper::run_inspec_process_with_this_plugin`

The symptom would be that the process would error out, with a stderr including text similar to:
```
/Users/cwolfe/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/inspec-3.0.0/lib/inspec/plugin/v2/loader.rb:311:in `[]': no implicit conversion of String into Integer (TypeError)\n\tfrom /Users/cwolfe/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/inspec-3.0.0/lib/inspec/plugin/v2/loader.rb:311:in `validate_conf_file'\n\tfrom /Users/cwolfe/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/inspec-3.0.0/lib/inspec/plugin/v2/loader.rb:291:in `unpack_conf_file
```
etc.

The return value from the plugin file generation method was a bit wrong.