### PR TITLE
Add debug and sort options for plugins

### DIFF
--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -133,6 +133,9 @@ module Inspec::Plugin::V2
         end
       end
 
+      # sort tuples
+      matched_tuples.sort! {|a,b| b.first.version <=> a.first.version}
+
       gem_info = {}
       matched_tuples.each do |tuple|
         gem_info[tuple.first.name] ||= []

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -119,7 +119,7 @@ module Inspec::Plugin::V2
     # @option opts [TrueClass, FalseClass] :exact If true, use plugin_search_term exactly.  If false (default), append a wildcard.
     # @option opts [Symbol] :scope Which versions to search for.  :released (default) - all released versions.  :prerelease - Also include versioned marked prerelease. :latest - only return one version, the latest one.
     # @return [Hash of Arrays] - Keys are String names of gems, arrays contain String versions.
-    def search(plugin_query, opts = {})
+    def search(plugin_query, opts = {}) # rubocop: disable Metrics/AbcSize
       validate_search_opts(plugin_query, opts)
 
       fetcher = Gem::SpecFetcher.fetcher
@@ -134,7 +134,7 @@ module Inspec::Plugin::V2
       end
 
       # sort tuples
-      matched_tuples.sort! {|a,b| b.first.version <=> a.first.version}
+      matched_tuples.sort! { |a, b| b.first.version <=> a.first.version }
 
       gem_info = {}
       matched_tuples.each do |tuple|

--- a/lib/inspec/plugin/v2/plugin_types/cli.rb
+++ b/lib/inspec/plugin/v2/plugin_types/cli.rb
@@ -2,6 +2,17 @@ require 'inspec/base_cli'
 
 module Inspec::Plugin::V2::PluginType
   class CliCommand < Inspec::BaseCLI
+
+    # initalize log options for plugins
+    def initialize(args, options, config)
+      super(args, options, config)
+      class_options = config.fetch(:class_options, nil)
+      if class_options
+        Inspec::Log.init(class_options['log_location']) if class_options.key?('log_location')
+        Inspec::Log.level = get_log_level(class_options['log_level']) if class_options.key?('log_level')
+      end
+    end
+
     # This class MUST inherit from Thor, which makes it a bit awkward to register the plugin subtype
     # Since we can't inherit from PluginBase, we use the two-arg form of register_plugin_type
     Inspec::Plugin::V2::PluginBase.register_plugin_type(:cli_command, self)
@@ -23,5 +34,12 @@ module Inspec::Plugin::V2::PluginType
       # Register with Thor
       Inspec::InspecCLI.register(self, subcommand_name, @usage_msg, @desc_msg, {})
     end
+
+    # Allow plugins to use inspec log settings
+    class_option :log_level, type: :string,
+                 desc: 'Set the log level: info (default), debug, warn, error'
+
+    class_option :log_location, type: :string,
+                desc: 'Location to send diagnostic log messages to. (default: STDOUT or Inspec::Log.error)'
   end
 end

--- a/lib/inspec/plugin/v2/plugin_types/cli.rb
+++ b/lib/inspec/plugin/v2/plugin_types/cli.rb
@@ -2,7 +2,6 @@ require 'inspec/base_cli'
 
 module Inspec::Plugin::V2::PluginType
   class CliCommand < Inspec::BaseCLI
-
     # initalize log options for plugins
     def initialize(args, options, config)
       super(args, options, config)

--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -367,6 +367,7 @@ module InspecPlugins
         puts 'If you disagree with this determination, please accept our apologies for the misunderstanding, and open an issue at https://github.com/inspec/inspec/issues/new'
         exit 2
       rescue Inspec::Plugin::V2::InstallError
+        raise if Inspec::Log.level == :debug
         results = installer.search(plugin_name, exact: true)
         if results.empty?
           puts(red { 'No such plugin gem ' } + plugin_name + ' could be found on rubygems.org - installation failed.')

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
@@ -567,6 +567,14 @@ class PluginManagerCliInstall < MiniTest::Test
       assert_includes refusal_message, 'github.com/inspec/inspec/issues/new'
     end
   end
+
+  def test_error_install_with_debug_enabled
+    install_result = run_inspec_process_with_this_plugin('plugin install inspec-test-fixture -v 0.1.1 --log-level debug')
+
+    assert_equal 1, install_result.exit_status, 'Exit status should be 1'
+    assert_includes install_result.stdout, 'DEBUG'
+    assert_includes install_result.stderr, "can't activate rake"
+  end
 end
 
 


### PR DESCRIPTION
This pr forces sorting on plugin search and also allows `--log-level` to be used for plugins. Using a value of `debug` will output a stack trace of why a plugin could not be installed instead of the generic error.