### PR TITLE
Add inspec/train vault to plugin exclusion

### DIFF
--- a/etc/plugin_filters.json
+++ b/etc/plugin_filters.json
@@ -15,7 +15,15 @@
     },
     {
       "plugin_name": "inspec-release",
-      "rationale": "It is not plugin."
+      "rationale": "This gem is currently only a placeholder, waiting to be built."
+    },
+    {
+      "plugin_name": "inspec-vault",
+      "rationale": "This gem is currently only a placeholder, waiting to be built."
+    },
+    {
+      "plugin_name": "train-vault",
+      "rationale": "This gem is currently only a placeholder, waiting to be built."
     },
     {
       "plugin_name": "train-tax-calculator",


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This excludes the under construction gems `inspec-vault` and `train-vault`