### PR TITLE
Update to safe navigation exit code search

### DIFF
--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -84,7 +84,7 @@ module Inspec
     def exit_code
       return @rspec_exit_code if @formatter.results.empty?
       stats = @formatter.results[:statistics][:controls]
-      skipped = @formatter.results[:profiles].first[:status] == 'skipped'
+      skipped = @formatter.results&.fetch(:profiles, nil)&.first&.fetch(:status, nil) == 'skipped'
       if stats[:failed][:total] == 0 && stats[:skipped][:total] == 0 && !skipped
         0
       elsif stats[:failed][:total] > 0

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -36,6 +36,12 @@ describe Inspec::Runner do
       end
     end
 
+    describe 'testing runner.run exit codes' do
+      it 'returns proper exit code when no profile is added' do
+        runner.run.must_equal 0
+      end
+    end
+
     describe 'when backend caching is enabled' do
       it 'returns a backend with caching' do
         opts = { command_runner: :generic, backend_cache: true }


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

Currently there is an issue upstream in ChefClient where a runner is executed with no profiles added. In these cases we do not have any default profiles so we need to safe navigation the check.