### PR TITLE
Allow end of options during Thor array parsing

### DIFF
--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -15,35 +15,41 @@ You can specify one or more reporters using the `--reporter` cli flag. You can a
 Output json to screen.
 
 ```bash
-inspec exec --reporter json
+inspec exec example_profile --reporter json
 or
-inspec exec --reporter json:-
+inspec exec example_profile --reporter json:-
 ```
 
 Output yaml to screen
 
 ```bash
-inspec exec --reporter yaml
+inspec exec example_profile --reporter yaml
 or
-inspec exec --reporter yaml:-
+inspec exec example_profile --reporter yaml:-
 ```
 
 Output cli to screen and write json to a file.
 
 ```bash
-inspec exec --reporter cli json:/tmp/output.json
+inspec exec example_profile --reporter cli json:/tmp/output.json
 ```
 
 Output nothing to screen and write junit and html to a file.
 
 ```bash
-inspec exec --reporter junit:/tmp/junit.xml html:www/index.html
+inspec exec example_profile --reporter junit:/tmp/junit.xml html:www/index.html
 ```
 
 Output json to screen and write to a file. Write junit to a file.
 
 ```bash
-inspec exec --reporter json junit:/tmp/junit.xml | tee out.json
+inspec exec example_profile --reporter json junit:/tmp/junit.xml | tee out.json
+```
+
+If you wish to pass the profiles directly after specifying the reporters you will need to use the end of options flag `--`.
+
+```bash
+inspec exec --reporter json junit:/tmp/junit.xml -- profile1 profile2
 ```
 
 If you are using the cli option `--json-config` you can also set reporters.

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -6,6 +6,20 @@ require 'thor'
 require 'inspec/log'
 require 'inspec/profile_vendor'
 
+# Allow end of options during array type parsing
+# https://github.com/erikhuda/thor/issues/631
+class Thor::Arguments
+  def parse_array(_name)
+    return shift if peek.is_a?(Array)
+    array = []
+    while current_is_value?
+      break unless @parsing_options
+      array << shift
+    end
+    array
+  end
+end
+
 module Inspec
   class BaseCLI < Thor
     class << self

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -28,6 +28,16 @@ describe 'inspec exec with json formatter' do
     JSON::Schema.validate(data, schema)
   end
 
+  it 'can execute a simple file while using end of options after reporter cli option' do
+    out = inspec('exec --no-create-lockfile --reporter json -- ' + example_control)
+    out.stderr.must_equal ''
+    out.exit_status.must_equal 0
+    data = JSON.parse(out.stdout)
+    sout = inspec('schema exec-json')
+    schema = JSON.parse(sout.stdout)
+    JSON::Schema.validate(data, schema)
+  end
+
   it 'can execute a profile and validate the json schema with target_id' do
     out = inspec('exec ' + example_profile + ' --reporter json --no-create-lockfile --target-id 1d3e399f-4d71-4863-ac54-84d437fbc444')
     out.stderr.must_equal ''


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

Fixes https://github.com/inspec/inspec/issues/3459

This change allows you to use the typical end of options `--` after the Thor array type. This will allow you to do executions like this:
```
inspec exec --reporter json -- profile
```