### PR TITLE
Allow help args after Thor commands

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -297,8 +297,11 @@ begin
   # This allows you to use any of the normal help commands after the normal args.
   help_commands = ['-h', '--help', 'help']
   (help_commands & ARGV).each do |cmd|
-    match = ARGV.delete(cmd)
-    ARGV.size > 1 ? ARGV.insert(-2, match) : ARGV.unshift(match)
+    # move the help argument to one place behind the end for Thor to digest
+    if ARGV.size > 1
+      match = ARGV.delete(cmd)
+      ARGV.insert(-2, match)
+    end
   end
 
   # Load v2 plugins

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -293,6 +293,14 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 end
 
 begin
+  # Handle help commands
+  # This allows you to use any of the normal help commands after the normal args.
+  help_commands = ['-h', '--help', 'help']
+  (help_commands & ARGV).each do |cmd|
+    match = ARGV.delete(cmd)
+    ARGV.size > 1 ? ARGV.insert(-2, match) : ARGV.unshift(match)
+  end
+
   # Load v2 plugins
   v2_loader = Inspec::Plugin::V2::Loader.new
   v2_loader.load_all

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -52,8 +52,22 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     File.stat("#{outpath}/foo/bar/test.json").size.must_be :>, 0
   end
 
-  it 'can execute the exec help' do
+  it 'can execute --help after exec command' do
     out = inspec("exec --help")
+    out.stderr.must_equal ''
+    out.exit_status.must_equal 0
+    out.stdout.must_include "Usage:\n  inspec exec PATHS"
+  end
+
+  it 'can execute help after exec command' do
+    out = inspec("exec help")
+    out.stderr.must_equal ''
+    out.exit_status.must_equal 0
+    out.stdout.must_include "Usage:\n  inspec exec PATHS"
+  end
+
+  it 'can execute help before exec command' do
+    out = inspec("help exec")
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
     out.stdout.must_include "Usage:\n  inspec exec PATHS"

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -52,6 +52,13 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     File.stat("#{outpath}/foo/bar/test.json").size.must_be :>, 0
   end
 
+  it 'can execute the exec help' do
+    out = inspec("exec --help")
+    out.stderr.must_equal ''
+    out.exit_status.must_equal 0
+    out.stdout.must_include "Usage:\n  inspec exec PATHS"
+  end
+
   it 'can execute the profile with a target_id passthrough' do
     outpath = Dir.tmpdir
     out = inspec("exec #{example_profile} --no-create-lockfile --target-id 1d3e399f-4d71-4863-ac54-84d437fbc444")


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

This will allow the common `-h, --help, help` args after the Thor command.

Ex:
```
jquick@Jareds-MBP:~/Chef/inspec
(jq/cli_help_commands)> _inspec exec help
Usage:
  inspec exec PATHS
...

jquick@Jareds-MBP:~/Chef/inspec
(jq/cli_help_commands)> _inspec plugin -h
Commands:
  inspec plugin help [COMMAND]               # Describe subcommands or one specific subcommand
  inspec plugin install [-v VERSION] PLUGIN  # Installs a plugin from rubygems.org, a gemfile, or a path 
...

jquick@Jareds-MBP:~/Chef/inspec
(jq/cli_help_commands)> _inspec habitat profile --help
Commands:
  inspec habitat profile create PATH     # Create a one-time Habitat artifact for the profile found at PATH
  inspec habitat profile help [COMMAND]  # Describe subcommands or one specific subcommand
...

jquick@Jareds-MBP:~/Chef/inspec
(jq/cli_help_commands)> _inspec habitat help profile
Commands:
  inspec habitat profile create PATH     # Create a one-time Habitat artifact for the profile found at PATH
  inspec habitat profile help [COMMAND]  # Describe subcommands or one specific subcommand
...
```