### PR TITLE
Plugin Type: DSLs

### DIFF
--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -404,7 +404,9 @@ The InSpec project does not consider the internal interfaces exposed to the DSL 
 
 #### Outer Profile DSL Context
 
-TODO
+When your mixin method is called, `self` will be an instance of an anonymous class representing the profile context being executed; each profile context gets its own anonymous class. No inheritance tree is provided; all meaningful functionality arrives through other DSL methods included.
+
+One useful thing you can do is create macros for generating controls: the `control` DSL keyword is available to you, so you can call it as you see fit to create new controls.
 
 #### Control DSL Context
 

--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -494,8 +494,13 @@ module InspecPlugins::ColorDSL
       InspecPlugins::ColorDSL::Red
     end
 
+    test_dsl :red do
+      require 'inspec-dsl-threshold/red'
+      InspecPlugins::ColorDSL::Red
+    end
+
   end
 end
 ```
 
-This approach may make sense among the three Profile DSLs; however the Resource DSL is quite different, and is unlikely to respond well to such an approach.
+This approach may make sense among the four Profile DSLs; however the Resource DSL is quite different, and is unlikely to respond well to such an approach.

--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -428,7 +428,9 @@ Within your mixin method, you have access the methods RSpec uses to manage an Ex
 
 #### Resource DSL
 
-TODO
+Within a Resource DSL method, `self` will be the Class of a Resource that is currently being defined.  Your superclass will be whatever was returned by Inspec.resource(API_VERSION), which will typically be Inspec::Resource.
+
+Resource DSL methods are especially useful for defining macros: adding properties and matchers to a resource.
 
 ### Implementation Module Layout Notes
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -18,11 +18,12 @@ Currently, each plugin can offer one or more of these capabilities:
 
  * define a new command-line-interface (CLI) command suite (`inspec` plugins)
  * connectivity to new types of hosts or cloud providers (`train` plugins)
+ * DSL extensions at the file, control, describe block, or test level
+* DSL extensions for custom resources
 
 Future work might include new capability types, such as:
 
  * reporters (output generators)
- * DSL extensions at the file, control, or test level
  * attribute fetchers to allow reading InSpec attributes from new sources (for example, a remote encrypted key-value store)
 
 ## How do I find out which plugins are available?

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -29,6 +29,34 @@ module Inspec
         define_method :attribute do |name|
           Inspec::AttributeRegistry.find_attribute(name, profile_id).value
         end
+
+        # Support for Control DSL plugins
+        def method_missing(method_name, *arguments, &block)
+          # Check to see if there is a control_dsl plugin activator hook with the method name
+          registry = Inspec::Plugin::V2::Registry.instance
+          hook = registry.find_activators(plugin_type: :control_dsl, activator_name: method_name).first
+          if hook
+            # OK, load the hook if it hasn't been already.  We'll then know a module,
+            # which we can then inject into the context
+            registry.activate(:control_dsl, method_name) unless hook.activated?
+            # Inject the module's methods into the context.
+             # implementation_class is the field name, but this is actually a module.
+            self.class.include(hook.implementation_class)
+            # Now that the module is loaded, it defined one or more methods
+            # (presumably the one we were looking for.)
+            # We still haven't called it, so do so now.
+            self.send(method_name, *arguments, &block)
+          else
+            # If we couldn't find a plugin to match, maybe something up above has it,
+            # or maybe it is just a unknown method error.
+            super
+          end
+        end
+
+        # Implement this so that calls to respond_to? will work correctly.
+        def respond_to_missing?(method_name, include_private = false)
+          Inspec::Plugin::V2::Registry.instance.find_activators(plugin_type: :control_dsl, activator_name: method_name) || super
+        end
       end
     end
 

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -40,12 +40,12 @@ module Inspec
             # which we can then inject into the context
             registry.activate(:control_dsl, method_name) unless hook.activated?
             # Inject the module's methods into the context.
-             # implementation_class is the field name, but this is actually a module.
+            # implementation_class is the field name, but this is actually a module.
             self.class.include(hook.implementation_class)
             # Now that the module is loaded, it defined one or more methods
             # (presumably the one we were looking for.)
             # We still haven't called it, so do so now.
-            self.send(method_name, *arguments, &block)
+            send(method_name, *arguments, &block)
           else
             # If we couldn't find a plugin to match, maybe something up above has it,
             # or maybe it is just a unknown method error.

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -55,10 +55,6 @@ module Inspec
           end
         end
 
-        # Implement this so that calls to respond_to? will work correctly.
-        def respond_to_missing?(method_name, include_private = false)
-          Inspec::Plugin::V2::Registry.instance.find_activators(plugin_type: :control_dsl, activator_name: method_name) || super
-        end
       end
     end
 
@@ -74,7 +70,6 @@ module Inspec
       profile_context_owner = profile_context
       profile_id = profile_context.profile_id
       rule_class = rule_context(resources_dsl, profile_id)
-
       Class.new do # rubocop:disable Metrics/BlockLength
         include Inspec::DSL
         include Inspec::DSL::RequireOverride

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -30,7 +30,9 @@ module Inspec
           Inspec::AttributeRegistry.find_attribute(name, profile_id).value
         end
 
-        # Support for Control DSL plugins
+        # Support for Control DSL plugins.
+        # This is called when an unknown method is encountered
+        # within a control block.
         def method_missing(method_name, *arguments, &block)
           # Check to see if there is a control_dsl plugin activator hook with the method name
           registry = Inspec::Plugin::V2::Registry.instance

--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -45,6 +45,7 @@ module Inspec
     # Even tho this is defined as an instance method, it gets added to
     # Inspec::Plugins::Resource via `extend`, so this is actually a class defintion.
     def method_missing(method_name, *arguments, &block)
+      require 'inspec/plugin/v2'
       # Check to see if there is a resource_dsl plugin activator hook with the method name
       registry = Inspec::Plugin::V2::Registry.instance
       hook = registry.find_activators(plugin_type: :resource_dsl, activator_name: method_name).first

--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -39,6 +39,33 @@ module Inspec
       __resource_registry[@name].example(example)
     end
 
+    # Support for Resource DSL plugins.
+    # This is called when an unknown method is encountered
+    # within a resource class definition.
+    # Even tho this is defined as an instance method, it gets added to
+    # Inspec::Plugins::Resource via `extend`, so this is actually a class defintion.
+    def method_missing(method_name, *arguments, &block)
+      # Check to see if there is a resource_dsl plugin activator hook with the method name
+      registry = Inspec::Plugin::V2::Registry.instance
+      hook = registry.find_activators(plugin_type: :resource_dsl, activator_name: method_name).first
+      if hook
+        # OK, load the hook if it hasn't been already.  We'll then know a module,
+        # which we can then inject into the resource
+        registry.activate(:resource_dsl, method_name) unless hook.activated?
+        # Inject the module's methods into the resource as class methods.
+        # implementation_class is the field name, but this is actually a module.
+        self.extend(hook.implementation_class)
+        # Now that the module is loaded, it defined one or more methods
+        # (presumably the one we were looking for.)
+        # We still haven't called it, so do so now.
+        send(method_name, *arguments, &block)
+      else
+        # If we couldn't find a plugin to match, maybe something up above has it,
+        # or maybe it is just a unknown method error.
+        super
+      end
+    end
+
     def __resource_registry
       Inspec::Resource.registry
     end

--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -54,7 +54,7 @@ module Inspec
         registry.activate(:resource_dsl, method_name) unless hook.activated?
         # Inject the module's methods into the resource as class methods.
         # implementation_class is the field name, but this is actually a module.
-        self.extend(hook.implementation_class)
+        extend(hook.implementation_class)
         # Now that the module is loaded, it defined one or more methods
         # (presumably the one we were looking for.)
         # We still haven't called it, so do so now.

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -104,25 +104,10 @@ module Inspec::Plugin::V2
 
         # OK, activate.
         if activate_me
-          activate(:cli_command, act.activator_name)
+          registry.activate(:cli_command, act.activator_name)
           act.implementation_class.register_with_thor
         end
       end
-    end
-
-    def activate(plugin_type, hook_name)
-      activator = registry.find_activators(plugin_type: plugin_type, activator_name: hook_name).first
-      # We want to capture literally any possible exception here, since we are storing them.
-      # rubocop: disable Lint/RescueException
-      begin
-        impl_class = activator.activation_proc.call
-        activator.activated?(true)
-        activator.implementation_class = impl_class
-      rescue Exception => ex
-        activator.exception = ex
-        Inspec::Log.error "Could not activate #{activator.plugin_type} hook named '#{activator.activator_name}' for plugin #{plugin_name}"
-      end
-      # rubocop: enable Lint/RescueException
     end
 
     def plugin_gem_path

--- a/lib/inspec/plugin/v2/plugin_types/dsl.rb
+++ b/lib/inspec/plugin/v2/plugin_types/dsl.rb
@@ -2,12 +2,8 @@
 
 module Inspec::Plugin::V2::PluginType
   class Dsl < Inspec::Plugin::V2::PluginBase
-    # This is a dummy plugin type that you can use
-    # for superclassing
-    register_plugin_type(:dsl)
-
-    # These are the actual plugintypes used for activation hooks.
     register_plugin_type(:control_dsl)
     register_plugin_type(:describe_dsl)
+    register_plugin_type(:test_dsl)
   end
 end

--- a/lib/inspec/plugin/v2/plugin_types/dsl.rb
+++ b/lib/inspec/plugin/v2/plugin_types/dsl.rb
@@ -2,6 +2,7 @@
 
 module Inspec::Plugin::V2::PluginType
   class Dsl < Inspec::Plugin::V2::PluginBase
+    register_plugin_type(:outer_profile_dsl)
     register_plugin_type(:control_dsl)
     register_plugin_type(:describe_dsl)
     register_plugin_type(:test_dsl)

--- a/lib/inspec/plugin/v2/plugin_types/dsl.rb
+++ b/lib/inspec/plugin/v2/plugin_types/dsl.rb
@@ -6,5 +6,6 @@ module Inspec::Plugin::V2::PluginType
     register_plugin_type(:control_dsl)
     register_plugin_type(:describe_dsl)
     register_plugin_type(:test_dsl)
+    register_plugin_type(:resource_dsl)
   end
 end

--- a/lib/inspec/plugin/v2/plugin_types/dsl.rb
+++ b/lib/inspec/plugin/v2/plugin_types/dsl.rb
@@ -1,0 +1,13 @@
+# All DSL plugin types are defined here.
+
+module Inspec::Plugin::V2::PluginType
+  class Dsl < Inspec::Plugin::V2::PluginBase
+    # This is a dummy plugin type that you can use
+    # for superclassing
+    register_plugin_type(:dsl)
+
+    # These are the actual plugintypes used for activation hooks.
+    register_plugin_type(:control_dsl)
+    register_plugin_type(:describe_dsl)
+  end
+end

--- a/lib/inspec/plugin/v2/registry.rb
+++ b/lib/inspec/plugin/v2/registry.rb
@@ -67,6 +67,21 @@ module Inspec::Plugin::V2
       end
     end
 
+    def activate(plugin_type, hook_name)
+      activator = find_activators(plugin_type: plugin_type, activator_name: hook_name).first
+      # We want to capture literally any possible exception here, since we are storing them.
+      # rubocop: disable Lint/RescueException
+      begin
+        impl_class = activator.activation_proc.call
+        activator.activated?(true)
+        activator.implementation_class = impl_class
+      rescue Exception => ex
+        activator.exception = ex
+        Inspec::Log.error "Could not activate #{activator.plugin_type} hook named '#{activator.activator_name}' for plugin #{plugin_name}"
+      end
+      # rubocop: enable Lint/RescueException
+    end
+
     def register(name, status)
       if known_plugin? name
         Inspec::Log.debug "PluginLoader: refusing to re-register plugin '#{name}': an existing plugin with that name was loaded via #{registry[name].installation_type}-loading from #{registry[name].entry_point}"

--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -27,7 +27,7 @@ module Inspec
         RSpec::Core::ExampleGroup.extend(hook.implementation_class)
 
         # We still haven't called the method we were looking for, so do so now.
-        self.send(method_name, *arguments, &block)
+        send(method_name, *arguments, &block)
       else
         super
       end
@@ -48,5 +48,4 @@ class RSpec::Core::ExampleGroup
   # Because it is a class method we're attempting to prepend, we must
   # prepend against the singleton class.
   singleton_class.prepend Inspec::DescribeDslLazyLoader
-
 end

--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -4,9 +4,9 @@ require 'rspec/core/example_group'
 
 # Any additions to RSpec::Core::ExampleGroup (the RSpec class behind describe blocks) should go here.
 
-# This module exists to intercept the method_missing class method on RSpec::Core::ExampleGroup
-# and is part of support for DSL plugintypes
 module Inspec
+  # This module exists to intercept the method_missing *class* method on RSpec::Core::ExampleGroup
+  # and is part of support for DSL plugintypes
   module DescribeDslLazyLoader
     # Support for Describe DSL plugins
     def method_missing(method_name, *arguments, &block)
@@ -33,6 +33,34 @@ module Inspec
       end
     end
   end
+
+  # This module exists to intercept the method_missing *instance* method on RSpec::Core::ExampleGroup
+  # and is part of support for DSL plugintypes
+  module TestDslLazyLoader
+    # Support for test DSL plugins
+    def method_missing(method_name, *arguments, &block)
+      # Check to see if there is a test_dsl plugin activator hook with the method name
+      registry = Inspec::Plugin::V2::Registry.instance
+      hook = registry.find_activators(plugin_type: :test_dsl, activator_name: method_name).first
+
+      if hook
+        # OK, load the hook if it hasn't been already.  We'll then know a module,
+        # which we can then inject into the context
+        registry.activate(:test_dsl, method_name) unless hook.activated?
+
+        # Inject the module's methods into the example group contexts.
+        # implementation_class is the field name, but this is actually a module.
+        # RSpec works by having these helper methods defined as instance methods.
+        # So, we use include to inject the new DSL methods.
+        RSpec::Core::ExampleGroup.include(hook.implementation_class)
+
+        # We still haven't called the method we were looking for, so do so now.
+        send(method_name, *arguments, &block)
+      else
+        super
+      end
+    end
+  end
 end
 
 class RSpec::Core::ExampleGroup
@@ -48,4 +76,9 @@ class RSpec::Core::ExampleGroup
   # Because it is a class method we're attempting to prepend, we must
   # prepend against the singleton class.
   singleton_class.prepend Inspec::DescribeDslLazyLoader
+
+  # Here, we have to ensure our method_missing gets called prior
+  # to RSpec::Core::ExampleGroup#method_missing (the instance method).
+  # So, we use prepend.
+  prepend Inspec::TestDslLazyLoader
 end

--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -1,12 +1,52 @@
 require 'inspec/attribute_registry'
+require 'inspec/plugin/v2'
 require 'rspec/core/example_group'
 
-# This file allows you to add ExampleGroups to be used in rspec tests
-#
+# Any additions to RSpec::Core::ExampleGroup (the RSpec class behind describe blocks) should go here.
+
+# This module exists to intercept the method_missing class method on RSpec::Core::ExampleGroup
+# and is part of support for DSL plugintypes
+module Inspec
+  module DescribeDslLazyLoader
+    # Support for Describe DSL plugins
+    def method_missing(method_name, *arguments, &block)
+      # Check to see if there is a describe_dsl plugin activator hook with the method name
+      registry = Inspec::Plugin::V2::Registry.instance
+      hook = registry.find_activators(plugin_type: :describe_dsl, activator_name: method_name).first
+
+      if hook
+        # OK, load the hook if it hasn't been already.  We'll then know a module,
+        # which we can then inject into the context
+        registry.activate(:describe_dsl, method_name) unless hook.activated?
+
+        # Inject the module's methods into the example group contexts.
+        # implementation_class is the field name, but this is actually a module.
+        # RSpec works by having these helper methods defined as class methods
+        # (see the definition of `let` as an example)
+        # So, we use extend to inject the new DSL methods.
+        RSpec::Core::ExampleGroup.extend(hook.implementation_class)
+
+        # We still haven't called the method we were looking for, so do so now.
+        self.send(method_name, *arguments, &block)
+      else
+        super
+      end
+    end
+  end
+end
+
 class RSpec::Core::ExampleGroup
   # This DSL method allows us to access the values of attributes within InSpec tests
   def attribute(name)
     Inspec::AttributeRegistry.find_attribute(name, self.class.metadata[:profile_id]).value
   end
   define_example_method :attribute
+
+  # Here, we have to ensure our method_missing gets called prior
+  # to RSpec::Core::ExampleGroup.method_missing (the class method).
+  # So, we use prepend.
+  # Because it is a class method we're attempting to prepend, we must
+  # prepend against the singleton class.
+  singleton_class.prepend Inspec::DescribeDslLazyLoader
+
 end

--- a/test/functional/helper.rb
+++ b/test/functional/helper.rb
@@ -154,7 +154,6 @@ module FunctionalHelper
   end
 
 
-
   # Copy all examples to a temporary directory for functional tests.
   # You can provide an optional directory which will be handed to your
   # test block with its absolute path. If nothing is provided you will

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -217,6 +217,7 @@ describe 'DSL plugin types support' do
   end
 
   describe 'resource dsl plugin type support' do
+    let(:profile_file) { 'unused' }
     it 'works correctly with test dsl extensions' do
       # We have to build a custom command line - need to load the whole profile,
       # so the libraries get loaded.
@@ -229,19 +230,22 @@ describe 'DSL plugin types support' do
       # We should have three controls; 01 and 03 just do a string match.
       # 02 uses the custom resource, which relies on calls to the resource DSL.
       # If the plugin exploded, we'd see rdsl-control-01 but not rdsl-control-02
+      json_result = run_result.payload.json
       results = json_result['profiles'][0]['controls']
       results.count.must_equal 3
 
-      # I spent a while trying to find a way to get the test to alter its name;
-      # that won't work for various setup reasons.
-      # So, it just throws an exception with the word 'edemame' in it.
-      second_result = json_result['profiles'][0]['controls'][0]['results'][1]
-      second_result.wont_be_nil
-      second_result['status'].must_equal 'failed'
-      second_result['message'].must_include 'edemame'
+      # Control 2 has 2 describes; one uses a simple explicit matcher,
+      # while the second uses a matcher defined via a macro provided by the resource DSL.
+      control2_results = results[1]['results']
+      control2_results[0]['status'].must_equal 'passed'
+      control2_results[0]['code_desc'].must_include 'favorite_berry'
+      control2_results[0]['code_desc'].must_include 'blendable'
+
+      control2_results[1]['status'].must_equal 'passed'
+      control2_results[1]['code_desc'].must_include 'favorite_berry'
+      control2_results[1]['code_desc'].must_include 'have drupals'
     end
   end
-
 end
 
 #=========================================================================================#

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -175,6 +175,27 @@ describe 'DSL plugin types support' do
       second_result['code_desc'].must_include 'aubergine'
     end
   end
+
+  describe 'test dsl plugin type support' do
+    let(:profile_file) { 'test_dsl.rb' }
+    it 'works correctly with test dsl extensions' do
+      run_result.stderr.must_equal ''
+
+      # The test_dsl.rb file has one control, with
+      # describe-01, describe-02 which contains a call to favorite_legume, then describe-03
+      # If the plugin exploded, we'd see describe-01 but not describe-02
+      results = json_result['profiles'][0]['controls'][0]['results']
+      results.count.must_equal 3
+
+      # I spent a while trying to find a way to get the test to alter its name;
+      # that won't work for various setup reasons.
+      # So, it just throws an exception with the word 'edemame' in it.
+      second_result = json_result['profiles'][0]['controls'][0]['results'][1]
+      second_result.wont_be_nil
+      second_result['status'].must_equal 'failed'
+      second_result['message'].must_include 'edemame'
+    end
+  end
 end
 
 #=========================================================================================#

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -137,6 +137,25 @@ describe 'DSL plugin types support' do
   let(:run_result) { run_inspec_with_plugin("exec #{fixture_path}",  plugin_path: dsl_plugin_path) }
   let(:json_result) { run_result.payload.json }
 
+  describe 'outer profile dsl plugin type support' do
+    let(:profile_file) { 'outer_profile_dsl.rb' }
+    it 'works correctly with outer_profile dsl extensions' do
+      run_result.stderr.must_equal ''
+
+      # The outer_profile_dsl.rb file has control-01, then a call to favorite_grain
+      # (which generates a control), then control-03.
+      # If the plugin exploded, we'd see control-01 but not control-03
+      controls = json_result['profiles'][0]['controls']
+      controls.count.must_equal 3
+
+      # We expect the second controls id to be 'sorghum'
+      # (this is the functionality of the outer_profile_dsl we installed)
+      generated_control = json_result['profiles'][0]['controls'][1]
+      generated_control['id'].must_equal 'sorghum'
+      generated_control['results'][0]['status'].must_equal 'passed'
+    end
+  end
+
   describe 'control dsl plugin type support' do
 
     let(:profile_file) { 'control_dsl.rb' }

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -215,6 +215,33 @@ describe 'DSL plugin types support' do
       second_result['message'].must_include 'edemame'
     end
   end
+
+  describe 'resource dsl plugin type support' do
+    it 'works correctly with test dsl extensions' do
+      # We have to build a custom command line - need to load the whole profile,
+      # so the libraries get loaded.
+      cmd = 'exec '
+      cmd += File.join(profile_path, 'dsl_plugins')
+      cmd += ' --controls=/^rdsl-control/ '
+      run_result = run_inspec_with_plugin(cmd, plugin_path: dsl_plugin_path)
+      run_result.stderr.must_equal ''
+
+      # We should have three controls; 01 and 03 just do a string match.
+      # 02 uses the custom resource, which relies on calls to the resource DSL.
+      # If the plugin exploded, we'd see rdsl-control-01 but not rdsl-control-02
+      results = json_result['profiles'][0]['controls']
+      results.count.must_equal 3
+
+      # I spent a while trying to find a way to get the test to alter its name;
+      # that won't work for various setup reasons.
+      # So, it just throws an exception with the word 'edemame' in it.
+      second_result = json_result['profiles'][0]['controls'][0]['results'][1]
+      second_result.wont_be_nil
+      second_result['status'].must_equal 'failed'
+      second_result['message'].must_include 'edemame'
+    end
+  end
+
 end
 
 #=========================================================================================#

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test.rb
@@ -1,0 +1,5 @@
+lib = File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require_relative 'inspec-dsl-test/version'
+require_relative 'inspec-dsl-test/plugin'

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/control_dsl.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/control_dsl.rb
@@ -1,8 +1,11 @@
 module InspecPlugins
   module DslTest
-    module ControlDsl01
-      def self.test_control_dsl_01
-        # uuhhh wat
+    module ControlDslFavoriteFruit
+      def favorite_fruit(fruit)
+        # Here, self is an instance of an anonymous class, derived from Inspec::Rule
+
+        # Our behavior is to add our favorite fruit to the descriptions of the control.
+        @descriptions[:favorite_fruit] = fruit
       end
     end
   end

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/control_dsl.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/control_dsl.rb
@@ -1,0 +1,9 @@
+module InspecPlugins
+  module DslTest
+    module ControlDsl01
+      def self.test_control_dsl_01
+        # uuhhh wat
+      end
+    end
+  end
+end

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/describe_dsl.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/describe_dsl.rb
@@ -1,0 +1,15 @@
+module InspecPlugins
+  module DslTest
+    module DescribeDslFavoriteVegetable
+      def favorite_vegetable(veggie)
+
+        # Inspec ignores example groups.  It only cares about examples.
+        # So, to have a visible effect in the reporter output, alter the examples.
+        examples.each do |example|
+          example.metadata[:full_description] += veggie
+        end
+
+      end
+    end
+  end
+end

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/outer_profile_dsl.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/outer_profile_dsl.rb
@@ -1,0 +1,14 @@
+module InspecPlugins
+  module DslTest
+    module OuterProfileDslFavoriteGrain
+      def favorite_grain(grain)
+        # Inject a new control
+        control(grain) do
+          describe(grain) do
+            it { should eq grain }
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/plugin.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/plugin.rb
@@ -15,6 +15,11 @@ module InspecPlugins
         require_relative 'describe_dsl'
         InspecPlugins::DslTest::DescribeDslFavoriteVegetable
       end
+
+      test_dsl :favorite_legume do
+        require_relative 'test_dsl'
+        InspecPlugins::DslTest::TestDslFavoriteLegume
+      end
     end
   end
 end

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/plugin.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/plugin.rb
@@ -25,6 +25,11 @@ module InspecPlugins
         require_relative 'test_dsl'
         InspecPlugins::DslTest::TestDslFavoriteLegume
       end
+
+      resource_dsl :food_type do
+        require_relative 'resource_dsl'
+        InspecPlugins::DslTest::ResourceDslFoodType
+      end
     end
   end
 end

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/plugin.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/plugin.rb
@@ -1,0 +1,15 @@
+require 'inspec/plugin/v2'
+
+module InspecPlugins
+  module DslTest
+
+    class Plugin < Inspec.plugin(2)
+      plugin_name :'inspec-dsl-test'
+
+      control_dsl :test_control_dsl_01 do
+        require_relative 'control_dsl'
+        InspecPlugins::DslTest::ControlDsl01
+      end
+    end
+  end
+end

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/plugin.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/plugin.rb
@@ -6,6 +6,11 @@ module InspecPlugins
     class Plugin < Inspec.plugin(2)
       plugin_name :'inspec-dsl-test'
 
+      outer_profile_dsl :favorite_grain do
+        require_relative 'outer_profile_dsl'
+        InspecPlugins::DslTest::OuterProfileDslFavoriteGrain
+      end
+
       control_dsl :favorite_fruit do
         require_relative 'control_dsl'
         InspecPlugins::DslTest::ControlDslFavoriteFruit

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/plugin.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/plugin.rb
@@ -6,9 +6,14 @@ module InspecPlugins
     class Plugin < Inspec.plugin(2)
       plugin_name :'inspec-dsl-test'
 
-      control_dsl :test_control_dsl_01 do
+      control_dsl :favorite_fruit do
         require_relative 'control_dsl'
-        InspecPlugins::DslTest::ControlDsl01
+        InspecPlugins::DslTest::ControlDslFavoriteFruit
+      end
+
+      describe_dsl :favorite_vegetable do
+        require_relative 'describe_dsl'
+        InspecPlugins::DslTest::DescribeDslFavoriteVegetable
       end
     end
   end

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/resource_dsl.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/resource_dsl.rb
@@ -1,0 +1,14 @@
+module InspecPlugins
+  module DslTest
+    module ResourceDslFoodType
+      def food_type(food)
+        if food == :berries
+          # OK, add an instance method to any berry resource
+          define_method :'have_drupals?' do
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/resource_dsl.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/resource_dsl.rb
@@ -4,7 +4,7 @@ module InspecPlugins
       def food_type(food)
         if food == :berries
           # OK, add an instance method to any berry resource
-          define_method :'have_drupals?' do
+          define_method :'has_drupals?' do
             true
           end
         end

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/test_dsl.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/test_dsl.rb
@@ -1,0 +1,12 @@
+module InspecPlugins
+  module DslTest
+    module TestDslFavoriteLegume
+      def favorite_legume(legume)
+        # This is an absurd thing to do, but we're just seeking a way to show that the
+        # plugin ran, in a way we can detect from the JSON reporter
+        # I just couldn't find a way to get to the metadata in a way that stuck; so this will do for testing.
+        raise "My favorite legume is #{legume}"
+      end
+    end
+  end
+end

--- a/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/version.rb
+++ b/test/unit/mock/plugins/inspec-dsl-test/lib/inspec-dsl-test/version.rb
@@ -1,0 +1,5 @@
+module InspecPlugins
+  module DslTest
+    VERSION = '0.1.0'.freeze
+  end
+end

--- a/test/unit/mock/profiles/dsl_plugins/controls/control_dsl.rb
+++ b/test/unit/mock/profiles/dsl_plugins/controls/control_dsl.rb
@@ -1,0 +1,15 @@
+control 'control-01' do
+
+  # A normal, if dull, example group
+  describe 'describe-01' do
+    it { should include '01' }
+  end
+
+  # Try to use a control_dsl extension
+  favorite_fruit 'Banana'
+
+  # A normal, if dull, example group
+  describe 'describe-02' do
+    it { should include '02' }
+  end
+end

--- a/test/unit/mock/profiles/dsl_plugins/controls/describe_dsl.rb
+++ b/test/unit/mock/profiles/dsl_plugins/controls/describe_dsl.rb
@@ -1,0 +1,18 @@
+control 'control-02' do
+
+  # A normal, if dull, example group
+  describe 'describe-01' do
+    it { should include '01' }
+  end
+
+  # A normal, if dull, example group
+  describe 'describe-02' do
+    it { should include '02' }
+    # Try to use a describe_dsl extension
+    favorite_vegetable 'aubergine'
+  end
+
+  describe 'describe-03' do
+    it { should include '03' }
+  end
+end

--- a/test/unit/mock/profiles/dsl_plugins/controls/outer_profile_dsl.rb
+++ b/test/unit/mock/profiles/dsl_plugins/controls/outer_profile_dsl.rb
@@ -1,0 +1,19 @@
+title 'spelt'
+
+control 'control-01' do
+  # A normal, if dull, example group
+  describe 'describe-01' do
+    it { should include '01' }
+  end
+end
+
+# Try to use a outer_profile_dsl extension
+# This will generate a new control
+favorite_grain 'sorghum'
+
+control 'control-03' do
+  # A normal, if dull, example group
+  describe 'describe-03' do
+    it { should include '03' }
+  end
+end

--- a/test/unit/mock/profiles/dsl_plugins/controls/resource_dsl.rb
+++ b/test/unit/mock/profiles/dsl_plugins/controls/resource_dsl.rb
@@ -5,11 +5,10 @@ control 'rdsl-control-01' do
   end
 end
 
-byebug
 control 'rdsl-control-02' do
   # Try to use a resource that uses a Resource DSL extension
   describe favorite_berry('gooseberry') do
-    it { should blend }
+    it { should be_blendable }
   end
 
   # This directly relies on the effects of the plugin

--- a/test/unit/mock/profiles/dsl_plugins/controls/resource_dsl.rb
+++ b/test/unit/mock/profiles/dsl_plugins/controls/resource_dsl.rb
@@ -1,0 +1,26 @@
+control 'rdsl-control-01' do
+  # A normal, if dull, example group
+  describe 'describe-01' do
+    it { should include '01' }
+  end
+end
+
+byebug
+control 'rdsl-control-02' do
+  # Try to use a resource that uses a Resource DSL extension
+  describe favorite_berry('gooseberry') do
+    it { should blend }
+  end
+
+  # This directly relies on the effects of the plugin
+  describe favorite_berry('hackberry') do
+    it { should have_drupals }
+  end
+end
+
+control 'rdsl-control-03' do
+  # A normal, if dull, example group
+  describe 'describe-03' do
+    it { should include '03' }
+  end
+end

--- a/test/unit/mock/profiles/dsl_plugins/controls/test_dsl.rb
+++ b/test/unit/mock/profiles/dsl_plugins/controls/test_dsl.rb
@@ -1,0 +1,20 @@
+control 'control-01' do
+
+  # A normal, if dull, example group
+  describe 'describe-01' do
+    it { should include '01' }
+  end
+
+  # A normal, if dull, example group
+  describe 'describe-02' do
+    it do
+      # Try to use a test_dsl extension
+      favorite_legume 'edemame'
+      should include '02'
+    end
+  end
+
+  describe 'describe-03' do
+    it { should include '03' }
+  end
+end

--- a/test/unit/mock/profiles/dsl_plugins/inspec.yml
+++ b/test/unit/mock/profiles/dsl_plugins/inspec.yml
@@ -1,0 +1,8 @@
+name: dsl_plugins
+title: A profile to exercise the DSL plugin types
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0

--- a/test/unit/mock/profiles/dsl_plugins/libraries/favorite_berry_resource.rb
+++ b/test/unit/mock/profiles/dsl_plugins/libraries/favorite_berry_resource.rb
@@ -1,32 +1,30 @@
 # encoding: utf-8
 
-module InspecCustomResources
-  class FavoriteBerry < Inspec.resource(1)
-    name 'favorite_berry'
-    desc 'Will it blend?'
-    example <<~EOE
-      describe favorite_berry('mulberry') do
-        it { should blend }
-        it { should have_drupes }
-      end
+class FavoriteBerry < Inspec.resource(1)
+  name 'favorite_berry'
+  desc 'Will it blend?'
+  example <<~EOE
+  describe favorite_berry('mulberry') do
+    it { should blend }
+    it { should have_drupes }
+  end
 
-      describe favorite_berry('raspberry pi 3') do
-        # Oh it will, regardless.
-        it { should_not blend }
-      end
-    EOE
+  describe favorite_berry('raspberry pi 3') do
+    # Oh it will, regardless.
+    it { should_not blend }
+  end
+  EOE
 
-    # This will install the instance method have_drupes?
-    food_type :berries
+  # This will install the instance method have_drupes?
+  food_type :berries
 
-    attr_reader :berry_name
+  attr_reader :berry_name
 
-    def initialize(berry_name)
-      @berry_name = berry_name
-    end
+  def initialize(berry_name)
+    @berry_name = berry_name
+  end
 
-    def blend?
-      true
-    end
+  def blendable?
+    true
   end
 end

--- a/test/unit/mock/profiles/dsl_plugins/libraries/favorite_berry_resource.rb
+++ b/test/unit/mock/profiles/dsl_plugins/libraries/favorite_berry_resource.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+
+module InspecCustomResources
+  class FavoriteBerry < Inspec.resource(1)
+    name 'favorite_berry'
+    desc 'Will it blend?'
+    example <<~EOE
+      describe favorite_berry('mulberry') do
+        it { should blend }
+        it { should have_drupes }
+      end
+
+      describe favorite_berry('raspberry pi 3') do
+        # Oh it will, regardless.
+        it { should_not blend }
+      end
+    EOE
+
+    # This will install the instance method have_drupes?
+    food_type :berries
+
+    attr_reader :berry_name
+
+    def initialize(berry_name)
+      @berry_name = berry_name
+    end
+
+    def blend?
+      true
+    end
+  end
+end

--- a/test/unit/plugin/v2/api_dsl_test.rb
+++ b/test/unit/plugin/v2/api_dsl_test.rb
@@ -13,6 +13,7 @@ module DslUnitTests
     :control_dsl,
     :describe_dsl,
     :test_dsl,
+    :resource_dsl,
   ].each do |plugin_type_under_test|
 
     Class.new(MiniTest::Test) do

--- a/test/unit/plugin/v2/api_dsl_test.rb
+++ b/test/unit/plugin/v2/api_dsl_test.rb
@@ -1,0 +1,42 @@
+# Tests for the *DSL plugin types
+
+require 'minitest/autorun'
+require 'minitest/test'
+require 'byebug'
+
+require_relative '../../../../lib/inspec/plugin/v2'
+
+module DslUnitTests
+
+  {
+    control_dsl: 'Inspec::Plugin::V2::PluginType::ControlDsl',
+  }.each do |plugin_type_under_test, base_class_under_test|
+
+    Class.new(MiniTest::Test) do
+      # Assign name to anonymous class, so test output is meaningful
+      Object.const_set(plugin_type_under_test.to_s.upcase + '_UnitTests', self)
+
+      # One day I will understand Ruby scoping and closures.
+      # Until then, re-expose these as class variables.
+      @@plugin_type = plugin_type_under_test
+      @@base_class = base_class_under_test
+
+      def test_calling_Inspec_dot_plugin_with_plugin_type_returns_the_base_class
+        klass = Inspec.plugin(2, @@plugin_type)
+        assert_kind_of Class, klass
+        assert_equal @@base_class, klass.name
+      end
+
+      def test_plugin_type_base_classes_can_be_accessed_by_name
+        klass = Inspec::Plugin::V2::PluginBase.base_class_for_type(@@plugin_type)
+        assert_kind_of Class, klass
+        assert_equal @@base_class, klass.name
+      end
+
+      def test_plugin_type_registers_an_activation_dsl_method
+        klass = Inspec::Plugin::V2::PluginBase
+        assert_respond_to klass, @@plugin_type, "Activation method for #{@@plugin_type}"
+      end
+    end
+  end
+end

--- a/test/unit/plugin/v2/api_dsl_test.rb
+++ b/test/unit/plugin/v2/api_dsl_test.rb
@@ -9,10 +9,11 @@ require_relative '../../../../lib/inspec/plugin/v2'
 module DslUnitTests
 
   [
+    :outer_profile_dsl,
     :control_dsl,
     :describe_dsl,
     :test_dsl,
-  ].each do |plugin_type_under_test, base_class_under_test|
+  ].each do |plugin_type_under_test|
 
     Class.new(MiniTest::Test) do
       # Assign name to anonymous class, so test output is meaningful

--- a/test/unit/plugin/v2/api_dsl_test.rb
+++ b/test/unit/plugin/v2/api_dsl_test.rb
@@ -11,6 +11,7 @@ module DslUnitTests
   [
     :control_dsl,
     :describe_dsl,
+    :test_dsl,
   ].each do |plugin_type_under_test, base_class_under_test|
 
     Class.new(MiniTest::Test) do

--- a/test/unit/plugin/v2/api_dsl_test.rb
+++ b/test/unit/plugin/v2/api_dsl_test.rb
@@ -8,29 +8,29 @@ require_relative '../../../../lib/inspec/plugin/v2'
 
 module DslUnitTests
 
-  {
-    control_dsl: 'Inspec::Plugin::V2::PluginType::ControlDsl',
-  }.each do |plugin_type_under_test, base_class_under_test|
+  [
+    :control_dsl,
+    :describe_dsl,
+  ].each do |plugin_type_under_test, base_class_under_test|
 
     Class.new(MiniTest::Test) do
       # Assign name to anonymous class, so test output is meaningful
       Object.const_set(plugin_type_under_test.to_s.upcase + '_UnitTests', self)
 
       # One day I will understand Ruby scoping and closures.
-      # Until then, re-expose these as class variables.
+      # Until then, re-expose this as class variable.
       @@plugin_type = plugin_type_under_test
-      @@base_class = base_class_under_test
 
       def test_calling_Inspec_dot_plugin_with_plugin_type_returns_the_base_class
         klass = Inspec.plugin(2, @@plugin_type)
         assert_kind_of Class, klass
-        assert_equal @@base_class, klass.name
+        assert_equal 'Inspec::Plugin::V2::PluginType::Dsl', klass.name
       end
 
       def test_plugin_type_base_classes_can_be_accessed_by_name
         klass = Inspec::Plugin::V2::PluginBase.base_class_for_type(@@plugin_type)
         assert_kind_of Class, klass
-        assert_equal @@base_class, klass.name
+        assert_equal 'Inspec::Plugin::V2::PluginType::Dsl', klass.name
       end
 
       def test_plugin_type_registers_an_activation_dsl_method

--- a/test/unit/plugin/v2/loader_test.rb
+++ b/test/unit/plugin/v2/loader_test.rb
@@ -187,7 +187,7 @@ class PluginLoaderTests < MiniTest::Test
     # Management methods for activation
     assert_respond_to status, :activators, 'A plugin status should respond to `activators`'
     assert_respond_to registry, :find_activators, 'Registry should respond to `find_activators`'
-    assert_respond_to loader, :activate, 'Loader should respond to `activate`'
+    assert_respond_to registry, :activate, 'Registry should respond to `activate`'
 
     # Finding an Activator
     assert_kind_of Array, status.activators, 'status should have an array for activators'
@@ -205,7 +205,7 @@ class PluginLoaderTests < MiniTest::Test
     assert_nil activator.implementation_class, 'Test activator should not know implementation class prior to activation'
     refute InspecPlugins::MeaningOfLife.const_defined?(:MockPlugin), 'impl_class should not be defined prior to activation'
 
-    loader.activate(:mock_plugin_type, :'meaning-of-life-the-universe-and-everything')
+    registry.activate(:mock_plugin_type, :'meaning-of-life-the-universe-and-everything')
 
     # Activation postconditions
     assert activator.activated?, 'Test activator should be activated after activate'


### PR DESCRIPTION
This PR adds 5 closely related plugin types, which allow a plugin to implement new DSL methods / keywords. The mechanism to activate the plugins are all very similar - basically, in a particular location in the code, `method_missing` is implemented, and is used to activate the particular type of DSL being requested.

4 of the DSL plugin types relate to code that could appear in a profile control file.

* outer_profile_dsl plugins allow you to extend the code in profile Ruby files that appear outside `control` or `describe` blocks.
* control_dsl plugins allow you to extend the code within `control` blocks.
* describe_dsl plugins allow you to extend the code within `describe` blocks.
* test_dsl plugins allow you to extend the code within `it`/`its` blocks.

Finally, the `resource_dsl` plugin allows you to extend the code used within custom resources.

Basic unit tests are provided to prove that the plugin types are properly defined.

A simple plugin fixture defining DSL hooks (based on favorite foods) is included, and is exercised through a set of functional tests.

The plugin developer docs are updated to describe the 5 DSLs.

*Note*: Implementing a plugin using any of the DSL plugin types is experimental.  The contexts that are exposed to the DSL methods are private and poorly documented. The InSpec project does not claim the APIs used by these plugin types are covered by SemVer.  Plugin authors are encouraged to pin tightly to the `inspec` gem in their gemspecs.

Motivation for this plugin comes from the desire to allow passionate community members to implement things like "2 out of 3" tests, example groups, improved serverspec compatibility, "they/their" and other "fluency" changes, as well as make it possible for future work by the InSpec team to be implemented as a core plugin, rather than a direct change to the main codebase.
