### PR TITLE
Silence RSpec 'should' Warning

### DIFF
--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -1,5 +1,13 @@
 require 'inspec/attribute_registry'
+require 'rspec/core'
 require 'rspec/core/example_group'
+
+# Setup RSpec to allow use of `should` syntax without warnings
+RSpec.configure do |config|
+  config.expect_with(:rspec) do |rspec_expectations_config|
+    rspec_expectations_config.syntax = :should
+  end
+end
 
 # This file allows you to add ExampleGroups to be used in rspec tests
 #

--- a/test/functional/filter_table_test.rb
+++ b/test/functional/filter_table_test.rb
@@ -18,9 +18,7 @@ describe '2943 inspec exec for filter table profile, method mode for `where' do
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
-    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
-    output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
-    data = JSON.parse(output)
+    data = JSON.parse(cmd.stdout)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
     control_hash = {}
     failed_controls.each do |ctl|
@@ -69,9 +67,7 @@ describe '3103 default methods for filter table' do
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
-    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
-    output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
-    data = JSON.parse(output)
+    data = JSON.parse(cmd.stdout)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
     control_hash = {}
     failed_controls.each do |ctl|
@@ -105,9 +101,7 @@ describe '2370 lazy_load for filter table' do
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
-    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
-    output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
-    data = JSON.parse(output)
+    data = JSON.parse(cmd.stdout)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
     control_hash = {}
     failed_controls.each do |ctl|
@@ -175,9 +169,7 @@ describe '3110 do not expose block-valued properties in raw data' do
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
-    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
-    output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
-    data = JSON.parse(output)
+    data = JSON.parse(cmd.stdout)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
     control_hash = {}
     failed_controls.each do |ctl|

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -502,4 +502,14 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
       out.exit_status.must_equal 0
     end
   end
+
+  describe 'when using a profile that calls .should explicitly' do
+    let(:run_result) { inspec('exec ' + File.join(profile_path, 'rspec-should-deprecation')) }
+    it 'should suppress the RSpec deprecation warning' do
+      # Refs inspec github issue 952
+      run_result.exit_status.must_equal 0
+      run_result.stderr.must_be_empty
+      run_result.stdout.wont_include('1 deprecation warning total')
+    end
+  end
 end

--- a/test/unit/mock/profiles/rspec-should-deprecation/controls/explicit_should.rb
+++ b/test/unit/mock/profiles/rspec-should-deprecation/controls/explicit_should.rb
@@ -1,21 +1,3 @@
-title '`where` should reject unknown criteria'
-
-raw_data = [
-  { id: 1, name: 'Annie', shoe_size: 12},
-  { id: 2, name: 'Bobby', shoe_size: 10, favorite_color: 'purple'},
-]
-
-stringy_raw_data = [
-  { 'id' => 1, 'name' => 'Annie', 'shoe_size' => 12},
-  { 'id' => 2, 'name' => 'Bobby', 'shoe_size' => 10, 'favorite_color' => 'purple'},
-]
-
-# control '2943_pass_raise_error_when_key_not_in_data' do
-#   describe 'It should not tolerate criteria that are not keys of the raw data' do
-#     it { lambda { simple_plural(raw_data).where(hat_size: 'Why are these in eighths?') }.should raise_error ArgumentError }
-#   end
-# end
-
 control 'call-should-as-an-explicit-method' do
   describe 'It should work without issuing a deprecation warning' do
     it { 'a string'.should include 'ing' }

--- a/test/unit/mock/profiles/rspec-should-deprecation/controls/explicit_should.rb
+++ b/test/unit/mock/profiles/rspec-should-deprecation/controls/explicit_should.rb
@@ -1,0 +1,23 @@
+title '`where` should reject unknown criteria'
+
+raw_data = [
+  { id: 1, name: 'Annie', shoe_size: 12},
+  { id: 2, name: 'Bobby', shoe_size: 10, favorite_color: 'purple'},
+]
+
+stringy_raw_data = [
+  { 'id' => 1, 'name' => 'Annie', 'shoe_size' => 12},
+  { 'id' => 2, 'name' => 'Bobby', 'shoe_size' => 10, 'favorite_color' => 'purple'},
+]
+
+# control '2943_pass_raise_error_when_key_not_in_data' do
+#   describe 'It should not tolerate criteria that are not keys of the raw data' do
+#     it { lambda { simple_plural(raw_data).where(hat_size: 'Why are these in eighths?') }.should raise_error ArgumentError }
+#   end
+# end
+
+control 'call-should-as-an-explicit-method' do
+  describe 'It should work without issuing a deprecation warning' do
+    it { 'a string'.should include 'ing' }
+  end
+end

--- a/test/unit/mock/profiles/rspec-should-deprecation/inspec.yml
+++ b/test/unit/mock/profiles/rspec-should-deprecation/inspec.yml
@@ -1,0 +1,8 @@
+name: rspec-should-deprecation
+title: A profile to trigger an RSpec deprecation warning, refs github 952
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0


### PR DESCRIPTION
Fixes #952 

This PR adds a functional test to trigger a case in which RSpec prints a warning to STDERR, but worse, a summary of deprecations to STDOUT, which breaks JSON and other reporters.  The warning was an edge case, triggered by calling `.should` (note the dot) explicitly on any object, rather than as a DSL method. After adding the test, the PR adds configuration code to RSpec to inform it that we do intend to use `should`.

The InSpec project generally advises auditors to use the `should` syntax (as opposed to the RSpec-favored `expect` syntax) for readability.  You are of course free to use whatever syntax you please.