### PR TITLE
Add Git SSH and HTTP basic auth support to `inspec exec`

### DIFF
--- a/lib/fetchers/git.rb
+++ b/lib/fetchers/git.rb
@@ -29,7 +29,11 @@ module Fetchers
     priority 200
 
     def self.resolve(target, opts = {})
-      new(target[:git], opts.merge(target)) if target.respond_to?(:has_key?) && target.key?(:git)
+      if target.is_a?(String)
+        new(target) if target.start_with?('git@') || target.end_with?('.git')
+      elsif target.respond_to?(:has_key?) && target.key?(:git)
+        new(target[:git], opts.merge(target))
+      end
     end
 
     def initialize(remote_url, opts = {})

--- a/lib/fetchers/git.rb
+++ b/lib/fetchers/git.rb
@@ -30,7 +30,7 @@ module Fetchers
 
     def self.resolve(target, opts = {})
       if target.is_a?(String)
-        new(target) if target.start_with?('git@') || target.end_with?('.git')
+        new(target, opts) if target.start_with?('git@') || target.end_with?('.git')
       elsif target.respond_to?(:has_key?) && target.key?(:git)
         new(target[:git], opts.merge(target))
       end

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -122,13 +122,8 @@ module Fetchers
     private
 
     def parse_uri(target)
-      if target.is_a?(String)
-        URI.parse(target)
-      elsif target[:url]
-        URI.parse(target[:url])
-      end
-    rescue URI::Error
-      nil
+      return URI.parse(target) if target.is_a?(String)
+      URI.parse(target[:url])
     end
 
     def sha256

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -168,9 +168,70 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     pretty_handle_exception(e)
   end
 
-  desc 'exec PATHS', 'run all test files at the specified PATH.'
+  desc 'exec LOCATIONS', 'run all test files at the specified LOCATIONS.'
   long_desc <<~EOT
-    Loads the given profile(s) and fetches their dependencies if needed.  Then connects to the target and executes any controls contained in the profiles.  One or more reporters are used to generate output.  If all tests passed (no fails, no skips) exit code 0 is returned.  If some tests skipped but none failed, exit code 101 is returned. If at least one test failed, exit code 100 is returned.  If inspec failed for any other reason, exit code 1 is returned.
+    Loads the given profile(s) and fetches their dependencies if needed. Then
+    connects to the target and executes any controls contained in the profiles.
+    One or more reporters are used to generate output. If all tests passed
+    (no fails, no skips) exit code 0 is returned. If some tests skipped but
+    none failed, exit code 101 is returned. If at least one test failed, exit
+    code 100 is returned. If inspec failed for any other reason, exit code 1
+    is returned.
+
+    Below are some examples of using `exec` with different test LOCATIONS:
+
+    Automate:
+      ```
+      inspec compliance login
+      inspec exec compliance://username/linux-baseline
+      ```
+
+    Supermarket:
+      ```
+      inspec exec supermarket://username/linux-baseline
+      ```
+
+    Local profile (executes all tests in `controls/`):
+      ```
+      inspec exec /path/to/profile
+      ```
+
+    Local single test (doesn't allow attributes or custom resources)
+      ```
+      inspec exec /path/to/a_test.rb
+      ```
+
+    Git via SSH (uses SSH keys if repo is private):
+      ```
+      inspec exec git@github.com:dev-sec/linux-baseline.git
+      ```
+
+    Git via HTTPS (.git is required):
+      ```
+      inspec exec https://github.com/dev-sec/linux-baseline.git
+      ```
+
+    Private Git via HTTPS (.git is required):
+      ```
+      inspec exec https://API_TOKEN@github.com/dev-sec/linux-baseline.git
+      ```
+
+    Private Git via HTTPS and cached credentials (.git is required):
+      ```
+      git config credential.helper cache
+      git ls-remote https://github.com/dev-sec/linux-baseline.git
+      inspec exec https://github.com/dev-sec/linux-baseline.git
+      ```
+
+    Web hosted fileshare (supports .zip):
+      ```
+      inspec exec https://webserver/linux-baseline.tar.gz
+      ```
+
+    Web hosted fileshare with basic authentication (supports .zip):
+      ```
+      inspec exec https://username:password@webserver/linux-baseline.tar.gz
+      ```
   EOT
   exec_options
   def exec(*targets)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -201,29 +201,29 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       inspec exec /path/to/a_test.rb
       ```
 
-    Git via SSH (uses SSH keys if repo is private):
+    Git via SSH
       ```
       inspec exec git@github.com:dev-sec/linux-baseline.git
       ```
 
-    Git via HTTPS (.git is required):
+    Git via HTTPS (.git suffix is required):
       ```
       inspec exec https://github.com/dev-sec/linux-baseline.git
       ```
 
-    Private Git via HTTPS (.git is required):
+    Private Git via HTTPS (.git suffix is required):
       ```
       inspec exec https://API_TOKEN@github.com/dev-sec/linux-baseline.git
       ```
 
-    Private Git via HTTPS and cached credentials (.git is required):
+    Private Git via HTTPS and cached credentials (.git suffix is required):
       ```
       git config credential.helper cache
       git ls-remote https://github.com/dev-sec/linux-baseline.git
       inspec exec https://github.com/dev-sec/linux-baseline.git
       ```
 
-    Web hosted fileshare (supports .zip):
+    Web hosted fileshare (also supports .zip):
       ```
       inspec exec https://webserver/linux-baseline.tar.gz
       ```

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -56,21 +56,21 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     out = inspec("exec --help")
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
-    out.stdout.must_include "Usage:\n  inspec exec PATHS"
+    out.stdout.must_include "Usage:\n  inspec exec LOCATIONS"
   end
 
   it 'can execute help after exec command' do
     out = inspec("exec help")
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
-    out.stdout.must_include "Usage:\n  inspec exec PATHS"
+    out.stdout.must_include "Usage:\n  inspec exec LOCATIONS"
   end
 
   it 'can execute help before exec command' do
     out = inspec("help exec")
     out.stderr.must_equal ''
     out.exit_status.must_equal 0
-    out.stdout.must_include "Usage:\n  inspec exec PATHS"
+    out.stdout.must_include "Usage:\n  inspec exec LOCATIONS"
   end
 
   it 'can execute the profile with a target_id passthrough' do

--- a/test/unit/fetchers/git_test.rb
+++ b/test/unit/fetchers/git_test.rb
@@ -11,6 +11,18 @@ describe Fetchers::Git do
     _(reg['git']).must_equal fetcher
   end
 
+  it 'handles sources beginning with `git@`' do
+    f = fetcher.resolve('git@github.com:foo/bar')
+    f.wont_be_nil
+    f.must_be_kind_of Fetchers::Git
+  end
+
+  it 'handles sources ending with `.git`' do
+    f = fetcher.resolve('https://github.com/foo/bar.git')
+    f.wont_be_nil
+    f.must_be_kind_of Fetchers::Git
+  end
+
   it "handles sources specified by a :git key" do
     f = fetcher.resolve({git: "https://example.com/foo.gi"})
     f.wont_be_nil


### PR DESCRIPTION
This adds support and documentation for the following `inspec exec` usages:
                      
Git via SSH (uses SSH keys if repo is private):     
```                                                                                                                                   
inspec exec git@github.com:dev-sec/linux-baseline.git
```                                                                                                                              
                                                      
Git via HTTPS (.git is required):                                                                                                        
```          
inspec exec https://github.com/dev-sec/linux-baseline.git
```               
                          
Private Git via HTTPS (.git is required):
```
inspec exec https://API_TOKEN@github.com/dev-sec/linux-baseline.git
```                              
                                                 
Private Git via HTTPS and cached credentials (.git is required):
```                                                     
git config credential.helper cache                       
git ls-remote https://github.com/dev-sec/linux-baseline.git
inspec exec https://github.com/dev-sec/linux-baseline.git
```                      
                                  
Web hosted fileshare (supports .zip): 
```              
inspec exec https://webserver/linux-baseline.tar.gz
```                                                                                                    
                                            
Web hosted fileshare with basic authentication (supports .zip):
```                                   
inspec exec https://username:password@webserver/linux-baseline.tar.gz
```

This closes #3555 