### PR TITLE
aws_vpc: accept 17 hexadecimal characters for vpc_id

### DIFF
--- a/docs/resources/aws_vpc.md.erb
+++ b/docs/resources/aws_vpc.md.erb
@@ -37,7 +37,7 @@ An `aws_vpc` resource block identifies a VPC by id. If no VPC ID is provided, th
     end
 
     # Find a VPC by ID
-    describe aws_vpc('vpc-12345678') do
+    describe aws_vpc('vpc-12345678987654321') do
       it { should exist }
     end
 
@@ -55,6 +55,10 @@ The following examples show how to use this InSpec audit resource.
 ### Test that a VPC does not exist
 
     describe aws_vpc('vpc-87654321') do
+      it { should_not exist }
+    end
+
+    describe aws_vpc('vpc-abcd123454321dcba') do
       it { should_not exist }
     end
 

--- a/lib/resources/aws/aws_vpc.rb
+++ b/lib/resources/aws/aws_vpc.rb
@@ -30,8 +30,8 @@ class AwsVpc < Inspec.resource(1)
       allowed_scalar_type: String,
     )
 
-    if validated_params.key?(:vpc_id) && validated_params[:vpc_id] !~ /^vpc\-[0-9a-f]{8}/
-      raise ArgumentError, 'aws_vpc VPC ID must be in the format "vpc-" followed by 8 hexadecimal characters.'
+    if validated_params.key?(:vpc_id) && validated_params[:vpc_id] !~ /^vpc\-([0-9a-f]{8})|(^vpc\-[0-9a-f]{17})$/
+      raise ArgumentError, 'aws_vpc VPC ID must be in the format "vpc-" followed by 8 or 17 hexadecimal characters.'
     end
 
     validated_params

--- a/test/unit/resources/aws_vpc_test.rb
+++ b/test/unit/resources/aws_vpc_test.rb
@@ -16,12 +16,20 @@ class AwsVpcConstructorTest < Minitest::Test
     AwsVpc.new
   end
 
-  def test_accepts_vpc_id_as_scalar
+  def test_accepts_vpc_id_as_scalar_eight_sign
     AwsVpc.new('vpc-12345678')
   end
 
-  def test_accepts_vpc_id_as_hash
+  def test_accepts_vpc_id_as_scalar
+    AwsVpc.new('vpc-12345678987654321')
+  end
+
+  def test_accepts_vpc_id_as_hash_eight_sign
     AwsVpc.new(vpc_id: 'vpc-1234abcd')
+  end
+
+  def test_accepts_vpc_id_as_hash
+    AwsVpc.new(vpc_id: 'vpc-abcd123454321dcba')
   end
 
   def test_rejects_unrecognized_params
@@ -55,8 +63,12 @@ class AwsVpcRecallTest < Minitest::Test
     assert AwsVpc.new(vpc_id: 'vpc-12344321').exists?
   end
 
-  def test_search_miss_is_not_an_exception
+  def test_search_miss_is_not_an_exception_eight_sign
     refute AwsVpc.new(vpc_id: 'vpc-00000000').exists?
+  end
+
+  def test_search_miss_is_not_an_exception
+    refute AwsVpc.new(vpc_id: 'vpc-00000000000000000').exists?
   end
 end
 


### PR DESCRIPTION
Signed-off-by kchistova <kchistova@gmail.com>

Fixes #3518 	
EDIT: (@clintoncwolfe) - move issue ref to PR desc