### PR TITLE
Change usage of `Dir.home` to `Inspec.config_dir`

### DIFF
--- a/lib/inspec/plugin/v1/plugins.rb
+++ b/lib/inspec/plugin/v1/plugins.rb
@@ -34,7 +34,7 @@ module Inspec
       @paths += Dir[lib_home+'/inspec-*-*/lib/inspec-*rb']
 
       # traverse out of inspec-vX.Y.Z/lib/inspec/plugins.rb
-      @home = home || File.join(Dir.home, '.inspec', 'plugins')
+      @home = home || File.join(Inspec.config_dir, 'plugins')
       @paths += Dir[File.join(@home, '**{,/*/**}', '*.gemspec')]
                 .map { |x| File.dirname(x) }
                 .map { |x| Dir[File.join(x, 'lib', 'inspec-*.rb')] }

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/configuration.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/configuration.rb
@@ -5,7 +5,7 @@ module InspecPlugins
     # stores configuration on local filesystem
     class Configuration
       def initialize
-        @config_path = File.join(Dir.home, '.inspec', 'compliance')
+        @config_path = File.join(Inspec.config_dir, 'compliance')
         # ensure the directory is available
         unless File.directory?(@config_path)
           FileUtils.mkdir_p(@config_path)


### PR DESCRIPTION
This prevents errors on systems without `ENV['HOME']` (e.g. Habitat services) by allowing the specification of the location of `.inspec` via `ENV['INSPEC_CONFIG_DIR']`.