### PR TITLE
port: Correctly detect FreeBSD

### DIFF
--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -66,7 +66,7 @@ module Inspec::Resources
         LsofPorts.new(inspec)
       elsif os.windows?
         WindowsPorts.new(inspec)
-      elsif ['freebsd'].include?(os[:family])
+      elsif ['bsd'].include?(os[:family])
         FreeBsdPorts.new(inspec)
       elsif os.solaris?
         SolarisPorts.new(inspec)

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -63,10 +63,12 @@ module Inspec::Resources
         AixPorts.new(inspec)
       elsif os.darwin?
         # Darwin: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man8/lsof.8.html
+        # Careful: make sure darwin comes before BSD, below
         LsofPorts.new(inspec)
       elsif os.windows?
         WindowsPorts.new(inspec)
-      elsif 'freebsd'.include?(os[:family])
+      elsif os.bsd?
+        # Relies on sockstat, usually present on FreeBSD and NetBSD (but not MacOS X)
         FreeBsdPorts.new(inspec)
       elsif os.solaris?
         SolarisPorts.new(inspec)

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -66,7 +66,7 @@ module Inspec::Resources
         LsofPorts.new(inspec)
       elsif os.windows?
         WindowsPorts.new(inspec)
-      elsif ['bsd'].include?(os[:family])
+      elsif 'freebsd'.include?(os[:family])
         FreeBsdPorts.new(inspec)
       elsif os.solaris?
         SolarisPorts.new(inspec)


### PR DESCRIPTION
This PR adopts #3565 and was originally contributed by @dijit .

Fixes #3563 

This PR corrects the portability conditionals in the `port` resource for FreeBSD.  After the platform API changes, that code would never match; this change makes it match for anything in the BSD family (except Darwin/MacOS X, which matches earlier).

Manually tested; we have a FreeBSD config in our kitchen.vagrant.yml, but is broken and cannot converge (though it can get to the point where it is running, and SSH is listening)
<img width="784" alt="screen shot 2018-11-05 at 19 07 34" src="https://user-images.githubusercontent.com/156460/48034605-1a40ce00-e12e-11e8-81be-308518d747cc.png">
