### PR TITLE
Added xml resource support for ints, bools, and string responses

### DIFF
--- a/docs/resources/xml.md.erb
+++ b/docs/resources/xml.md.erb
@@ -52,6 +52,8 @@ This file can be queried for attributes using:
       its('root/array[2]/element/@value') { should eq ['one', 'two'] }
       its('root/array[2]/element/attribute::value') { should eq ['one', 'two'] }
       its('root/array[2]/element[2]/attribute::value') { should eq ['two'] }
+      its('count(//*)') { should eq [42] }
+      its('boolean(root/array[2]/element[2]/@valid)') { should eq [false] }
     end
 
 where

--- a/lib/resources/xml.rb
+++ b/lib/resources/xml.rb
@@ -27,6 +27,8 @@ module Inspec::Resources
           output.push(element.to_s)
         elsif element.is_a?(REXML::Element)
           output.push(element.text)
+        elsif element.is_a?(Integer) || element.is_a?(TrueClass) || element.is_a?(FalseClass) || element.is_a?(String)
+          output.push(element)
         else
           raise Inspec::Exceptions::ResourceFailed, "Unknown XML object received (#{element.class}): #{element}"
         end

--- a/test/unit/resources/xml_test.rb
+++ b/test/unit/resources/xml_test.rb
@@ -43,4 +43,28 @@ describe 'Inspec::Resources::XML' do
       _(resource.send('/beans/bean[@id="dataSource"]/property[@name="url"]/@value')).must_equal ['jdbc:oracle:thin:@databaseserver.domain.tld:1521/DBO.DOMAIN.TLD']
     end
   end
+
+  describe 'when loading xml and requesting a count' do
+    let (:resource) { load_resource('xml', 'database.xml') }
+
+    it 'gets count of nodes in the document' do
+      _(resource.send('count(//*)')).must_equal [9]
+    end
+  end
+
+  describe 'when loading xml and evaluating a boolean result' do
+    let (:resource) { load_resource('xml', 'database.xml') }
+
+    it 'checks if a node is true-like' do
+      _(resource.send('boolean(/beans/bean/@lazy-init)')).must_equal [true]
+    end
+  end
+
+  describe 'when loading xml and evaluating a string result' do
+    let (:resource) { load_resource('xml', 'database.xml') }
+
+    it 'checks if a node is string-like' do
+      _(resource.send('concat(string(/beans/bean/@lazy-init)," <--")')).must_equal ["true <--"]
+    end
+  end
 end


### PR DESCRIPTION
Methods like…

* `count()` return `Integer` values
* `boolean()` return `TrueClass`/`FalseClass` values
* `concat()` return `String` values

…but threw exceptions because those types weren't supported.

This adds support to the `xml` resource, and adds tests to verify some of those examples.

Signed-off-by: Mark Hughes <greenantdotcom@users.noreply.github.com>