### PR TITLE
Allow add_test to accept negation

### DIFF
--- a/lib/inspec/objects/describe.rb
+++ b/lib/inspec/objects/describe.rb
@@ -57,8 +57,8 @@ module Inspec
       @variables = []
     end
 
-    def add_test(its, matcher, expectation)
-      test = Inspec::Describe::Test.new(its, matcher, expectation, false)
+    def add_test(its, matcher, expectation, negated=false)
+      test = Inspec::Describe::Test.new(its, matcher, expectation, negated)
       tests.push(test)
       test
     end

--- a/lib/inspec/objects/describe.rb
+++ b/lib/inspec/objects/describe.rb
@@ -57,8 +57,8 @@ module Inspec
       @variables = []
     end
 
-    def add_test(its, matcher, expectation, negated = false)
-      test = Inspec::Describe::Test.new(its, matcher, expectation, negated)
+    def add_test(its, matcher, expectation, opts = {})
+      test = Inspec::Describe::Test.new(its, matcher, expectation, opts[:negated])
       tests.push(test)
       test
     end

--- a/lib/inspec/objects/describe.rb
+++ b/lib/inspec/objects/describe.rb
@@ -57,7 +57,7 @@ module Inspec
       @variables = []
     end
 
-    def add_test(its, matcher, expectation, negated=false)
+    def add_test(its, matcher, expectation, negated = false)
       test = Inspec::Describe::Test.new(its, matcher, expectation, negated)
       tests.push(test)
       test

--- a/test/unit/dsl/describe_test.rb
+++ b/test/unit/dsl/describe_test.rb
@@ -132,7 +132,7 @@ end
 
     it 'is negated' do
       obj.qualifier = [['resource']]
-      obj.add_test(['explorer', 'exe'], 'cmp', 1, true)
+      obj.add_test(['explorer', 'exe'], 'cmp', 1, :negated => true)
       obj.to_ruby.must_equal '
 describe resource do
   its(["explorer", "exe"]) { should_not cmp 1 }
@@ -142,7 +142,7 @@ end
 
     it 'is not negated' do
       obj.qualifier = [['resource']]
-      obj.add_test(['explorer', 'exe'], 'cmp', 1, false)
+      obj.add_test(['explorer', 'exe'], 'cmp', 1, :negated => false)
       obj.to_ruby.must_equal '
 describe resource do
   its(["explorer", "exe"]) { should cmp 1 }

--- a/test/unit/dsl/describe_test.rb
+++ b/test/unit/dsl/describe_test.rb
@@ -129,5 +129,25 @@ describe resource do
 end
 '.strip
     end
+
+    it 'is negated' do
+      obj.qualifier = [['resource']]
+      obj.add_test(['explorer', 'exe'], 'cmp', 1, true)
+      obj.to_ruby.must_equal '
+describe resource do
+  its(["explorer", "exe"]) { should_not cmp 1 }
+end
+'.strip
+    end
+
+    it 'is not negated' do
+      obj.qualifier = [['resource']]
+      obj.add_test(['explorer', 'exe'], 'cmp', 1, false)
+      obj.to_ruby.must_equal '
+describe resource do
+  its(["explorer", "exe"]) { should cmp 1 }
+end
+'.strip
+    end
   end
 end


### PR DESCRIPTION
This will allow for negated tests to be generated with add_tests.

Signed-off-by: Rachel Rice <rrice@chef.io>