### PR TITLE
Adding --no-pager to service checks

### DIFF
--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -272,7 +272,7 @@ module Inspec::Resources
     end
 
     def info(service_name)
-      cmd = inspec.command("#{service_ctl} show --all #{service_name}")
+      cmd = inspec.command("#{service_ctl} show --no-pager --all #{service_name}")
       return nil if cmd.exit_status.to_i != 0
 
       # parse data

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -304,11 +304,11 @@ class MockLoader
       # upstart version on ubuntu
       'initctl --version' => cmd.call('initctl--version'),
       # show ssh service Centos 7
-      'systemctl show --all sshd' => cmd.call('systemctl-show-all-sshd'),
-      'systemctl show --all apache2' => cmd.call('systemctl-show-all-apache2'),
-      '/path/to/systemctl show --all sshd' => cmd.call('systemctl-show-all-sshd'),
-      'systemctl show --all dbus' => cmd.call('systemctl-show-all-dbus'),
-      '/path/to/systemctl show --all dbus' => cmd.call('systemctl-show-all-dbus'),
+      'systemctl show --no-pager --all sshd' => cmd.call('systemctl-show-all-sshd'),
+      'systemctl show --no-pager --all apache2' => cmd.call('systemctl-show-all-apache2'),
+      '/path/to/systemctl show --no-pager --all sshd' => cmd.call('systemctl-show-all-sshd'),
+      'systemctl show --no-pager --all dbus' => cmd.call('systemctl-show-all-dbus'),
+      '/path/to/systemctl show --no-pager --all dbus' => cmd.call('systemctl-show-all-dbus'),
       # services on macos
       'launchctl list' => cmd.call('launchctl-list'),
       # services on freebsd 10


### PR DESCRIPTION
Fixes #3546

When pty is used, not having --no-pager makes inspec hang during the test

Signed-off-by: Fernando Alex <jfernandoalex@gmail.com>