### PR TITLE
Improvements to the functional helper run_inspec_process

### DIFF
--- a/test/functional/helper.rb
+++ b/test/functional/helper.rb
@@ -114,8 +114,8 @@ module FunctionalHelper
     prefix = opts[:cwd] ? 'cd ' + opts[:cwd] + ' && ' : ''
     prefix += opts[:prefix] || ''
     prefix += assemble_env_prefix(opts[:env])
-    command_line += ' --reporter json ' if opts[:json]
-    command_line += ' --no-create-lockfile ' unless opts[:lock]
+    command_line += ' --reporter json ' if opts[:json] && command_line =~ /\bexec\b/
+    command_line += ' --no-create-lockfile ' if (!opts[:lock]) && command_line =~ /\bexec\b/
 
     run_result = nil
     if opts[:tmpdir]

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -2,6 +2,50 @@
 require 'functional/helper'
 
 #=========================================================================================#
+#                                Support
+#=========================================================================================#
+module PluginFunctionalHelper
+  include FunctionalHelper
+
+  def run_inspec_with_plugin(command, opts)
+    pre = Proc.new do |tmp_dir|
+      content = JSON.generate(__make_plugin_file_data_structure_with_path(opts[:plugin_path]))
+      File.write(File.join(tmp_dir, 'plugins.json'), content)
+    end
+
+    opts.merge!({
+      pre_run: pre,
+      tmpdir: true,
+      json: true,
+      env: {
+        "INSPEC_CONFIG_DIR" => '.' # We're in tmpdir
+      }
+    })
+    run_inspec_process(command, opts)
+  end
+
+  def __make_plugin_file_data_structure_with_path(path)
+    # TODO: dry this up, refs #3350
+    plugin_name = File.basename(path, '.rb')
+    data = __make_empty_plugin_file_data_structure
+    data['plugins'] << {
+      'name' => plugin_name,
+      'installation_type' => 'path',
+      'installation_path' => path,
+    }
+    data
+  end
+
+  def __make_empty_plugin_file_data_structure
+    # TODO: dry this up, refs #3350
+    {
+      'plugins_config_version' => '1.0.0',
+      'plugins' => [],
+    }
+  end
+end
+
+#=========================================================================================#
 #                                Loader Errors
 #=========================================================================================#
 describe 'plugin loader' do

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -1,49 +1,6 @@
 # Functional tests related to plugin facility
 require 'functional/helper'
 
-#=========================================================================================#
-#                                Support
-#=========================================================================================#
-module PluginFunctionalHelper
-  include FunctionalHelper
-
-  def run_inspec_with_plugin(command, opts)
-    pre = Proc.new do |tmp_dir|
-      content = JSON.generate(__make_plugin_file_data_structure_with_path(opts[:plugin_path]))
-      File.write(File.join(tmp_dir, 'plugins.json'), content)
-    end
-
-    opts.merge!({
-      pre_run: pre,
-      tmpdir: true,
-      json: true,
-      env: {
-        "INSPEC_CONFIG_DIR" => '.' # We're in tmpdir
-      }
-    })
-    run_inspec_process(command, opts)
-  end
-
-  def __make_plugin_file_data_structure_with_path(path)
-    # TODO: dry this up, refs #3350
-    plugin_name = File.basename(path, '.rb')
-    data = __make_empty_plugin_file_data_structure
-    data['plugins'] << {
-      'name' => plugin_name,
-      'installation_type' => 'path',
-      'installation_path' => path,
-    }
-    data
-  end
-
-  def __make_empty_plugin_file_data_structure
-    # TODO: dry this up, refs #3350
-    {
-      'plugins_config_version' => '1.0.0',
-      'plugins' => [],
-    }
-  end
-end
 
 #=========================================================================================#
 #                                Loader Errors


### PR DESCRIPTION
This PR adds features I keep dragging around with me from branch to branch.  It only affects the functional test helper, so this is real "inside baseball" stuff.

It adds a `run_inspec_helper` method, similar to that available in the plugin test harness.  Its main difference is that it can take a hash of options, and then later commits build on that to allow running with a tmpdir created, generating a temporary plugin file, and automatically processing JSON ourput.