### PR TITLE
Adds protection against zipslip vulnerability

### DIFF
--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -100,7 +100,7 @@ module Inspec
       walk_zip(@path) do |io|
         while (entry = io.get_next_entry)
           name = entry.name.sub(%r{/+$}, '')
-          @files.push(name) unless name.empty?
+          @files.push(name) unless name.empty? || name.squeeze('/') =~ %r{\.{2}(?:/|\z)}
         end
       end
     end
@@ -156,7 +156,7 @@ module Inspec
         @files = tar.find_all(&:file?)
 
         # delete all entries with no name
-        @files = @files.find_all { |x| !x.full_name.empty? }
+        @files = @files.find_all { |x| !x.full_name.empty? && x.full_name.squeeze('/') !~ %r{\.{2}(?:/|\z)} }
 
         # delete all entries that have a PaxHeader
         @files = @files.delete_if { |x| x.full_name.include?('PaxHeader/') }

--- a/test/unit/file_provider_test.rb
+++ b/test/unit/file_provider_test.rb
@@ -119,6 +119,28 @@ describe Inspec::ZipProvider do
       cls.new(rand.to_s).files.must_equal %w{zipzip}
     end
   end
+
+  describe 'paths outside of the archive ignored' do
+    # This is to test for the zipslip vulnerability
+    let(:cls) {
+      class MockZipSlipZipProvider < Inspec::ZipProvider
+        Entry = Struct.new(:name)
+        class List < Array
+          alias :get_next_entry :pop
+        end
+        private
+        def walk_zip(path, &callback)
+          list = List.new([Entry.new('../../blah'), Entry.new('zipzip'), Entry.new('../../haha')])
+          callback.call(list)
+        end
+      end
+      MockZipSlipZipProvider
+    }
+
+    it 'must contain all files' do
+      cls.new(rand.to_s).files.must_equal %w{zipzip}
+    end
+  end
 end
 
 
@@ -182,6 +204,24 @@ describe Inspec::TarProvider do
       cls.new(rand.to_s).files.must_equal %w{tartar}
     end
   end
+
+  describe 'applied to a tar with paths above dir' do
+    let(:cls) {
+      class MockZipSlipTarProvider < Inspec::TarProvider
+        Entry = Struct.new(:full_name, :file?)
+        private
+        def walk_tar(path, &callback)
+          callback.call([Entry.new('../haha', true), Entry.new('tartar', true), Entry.new('../../blah', true)])
+        end
+      end
+      MockZipSlipTarProvider
+    }
+
+    it 'must not contain all files' do
+      cls.new(rand.to_s).files.must_equal %w{tartar}
+    end
+  end
+
 end
 
 describe Inspec::RelativeFileProvider do


### PR DESCRIPTION
- Adds associated tests to validate paths can't be used.

Relates to: #3599
Signed-off-by: Harold Dost <h.dost@criteo.com>