### PR TITLE
filesystem: improve Windows support

### DIFF
--- a/lib/resources/filesystem.rb
+++ b/lib/resources/filesystem.rb
@@ -5,7 +5,7 @@ module Inspec::Resources
     supports platform: 'windows'
     desc 'Use the filesystem InSpec resource to test file system'
     example "
-      'filesystem' currently not supported for Linux
+      
       describe filesystem('/') do
         its('size') { should be >= 32000 }
         its('type') { should eq false }

--- a/lib/resources/filesystem.rb
+++ b/lib/resources/filesystem.rb
@@ -56,9 +56,9 @@ module Inspec::Resources
     def name
       info = @fsman.info(@partition)
       info[:name]
-    end  
+    end
   end
-   
+
   class FsManagement
     attr_reader :inspec
     def initialize(inspec)
@@ -68,7 +68,7 @@ module Inspec::Resources
 
   class LinuxFileSystemResource < FsManagement
     def info(partition)
-      begin
+
         cmd = inspec.command("df #{partition} --output=size")
         raise Inspec::Exceptions::ResourceFailed, "Unable to get available space for partition #{partition}" if cmd.stdout.nil? || cmd.stdout.empty? || !cmd.exit_status.zero?
         value = cmd.stdout.gsub(/\dK-blocks[\r\n]/, '').strip
@@ -77,7 +77,7 @@ module Inspec::Resources
           size: value.to_i,
           filesystem: false,
         }
-      end
+
     end
   end
 

--- a/lib/resources/filesystem.rb
+++ b/lib/resources/filesystem.rb
@@ -20,7 +20,7 @@ module Inspec::Resources
     def initialize(partition)
       @partition = partition
       @cache = nil
-      #select file system manager
+      # select file system manager
       @fsman = nil
 
       os = inspec.os
@@ -33,7 +33,7 @@ module Inspec::Resources
       end
     end
 
-    def info 
+    def info
       return @cache if !@cache.nil?
       return {} if @fsman.nil?
       @fsman.info(@partition)
@@ -41,17 +41,18 @@ module Inspec::Resources
 
     def to_s
       "FileSystem #{@partition}"
-    end	
+    end
 
     def size
       info = @fsman.info(@partition)
       info[:size]
-    end		
+    end
 
     def filesystem
       info = @fsman.info(@partition)
       info[:filesystem]
     end
+
     def name
       info = @fsman.info(@partition)
       info[:name]
@@ -72,7 +73,7 @@ module Inspec::Resources
         raise Inspec::Exceptions::ResourceFailed, "Unable to get available space for partition #{partition}" if cmd.stdout.nil? || cmd.stdout.empty? || !cmd.exit_status.zero?
         value = cmd.stdout.gsub(/\dK-blocks[\r\n]/, '').strip
         {
-          name: partition,				
+          name: partition,
           size: value.to_i,
           filesystem: false,
         }
@@ -92,7 +93,7 @@ module Inspec::Resources
       begin
         fs = JSON.parse(cmd.stdout)
         rescue JSON::ParserError => e
-        raise Inspec::Exceptions::ResourceFailed,
+          raise Inspec::Exceptions::ResourceFailed,
           'Failed to parse JSON from Powershell. ' \
           "Error: #{e}"
         end
@@ -103,5 +104,5 @@ module Inspec::Resources
         filesystem: fs['FileSystem'],
       }
     end
-  end	
+  end
 end

--- a/lib/resources/filesystem.rb
+++ b/lib/resources/filesystem.rb
@@ -36,7 +36,7 @@ module Inspec::Resources
     def info
       return @cache if !@cache.nil?
       return {} if @fsman.nil?
-      @fsman.info(@partition)
+      @cache = @fsman.info(@partition)
     end
 
     def to_s

--- a/lib/resources/filesystem.rb
+++ b/lib/resources/filesystem.rb
@@ -1,113 +1,107 @@
 module Inspec::Resources
-	class FileSystemResource < Inspec.resource(1)
-		name 'filesystem'
-		supports platform: 'linux'
-		supports platform: 'windows'
-		desc 'Use the filesystem InSpec resource to test file system'
-		example "
-			'filesystem' currently not supported for Linux
-			describe filesystem('/') do
-				its('size') { should be >= 32000 }
-				its('filesystem') { should eq false }
-			end
-			
-			describe filesystem('c:') do
-				its('size') { should be >= 90 }
-				its('filesystem') { should eq 'NTFS' }
-			end
-			
-		"
-		attr_reader :partition
+  class FileSystemResource < Inspec.resource(1)
+    name 'filesystem'
+    supports platform: 'linux'
+    supports platform: 'windows'
+    desc 'Use the filesystem InSpec resource to test file system'
+    example "
+      'filesystem' currently not supported for Linux
+      describe filesystem('/') do
+        its('size') { should be >= 32000 }
+        its('filesystem') { should eq false }
+      end
+      describe filesystem('c:') do
+        its('size') { should be >= 90 }
+        its('filesystem') { should eq 'NTFS' }
+      end
+    "
+    attr_reader :partition
 
-		def initialize(partition)
-			@partition = partition
-			@cache = nil
-			#select file system manager
-			@fsman = nil
-			
-			os = inspec.os
-			if os.linux?
-				@fsman = LinuxFileSystemResource.new(inspec)
-			elsif os.windows?
-				@fsman = WindowsFileSystemResource.new(inspec)
-			else
-				raise Inspec::Exceptions::ResourceSkipped, 'The `filesystem` resource is not supported on your OS yet.'
-			end
-		end
-		
-		def info 
-			return @cache if !@cache.nil?
+    def initialize(partition)
+      @partition = partition
+      @cache = nil
+      #select file system manager
+      @fsman = nil
 
-			return {} if @fsman.nil?
-			
-			@fsman.info(@partition)
-		end
+      os = inspec.os
+      if os.linux?
+        @fsman = LinuxFileSystemResource.new(inspec)
+      elsif os.windows?
+        @fsman = WindowsFileSystemResource.new(inspec)
+      else
+        raise Inspec::Exceptions::ResourceSkipped, 'The `filesystem` resource is not supported on your OS yet.'
+      end
+    end
 
-		
-		
-		def to_s
-			"FileSystem #{@partition}"
-		end	
+    def info 
+      return @cache if !@cache.nil?
+      return {} if @fsman.nil?
+      @fsman.info(@partition)
+    end
 
-		def size
-			info = @fsman.info(@partition)
-			info[:size]
-		end		
+    def to_s
+      "FileSystem #{@partition}"
+    end	
 
-		def filesystem
-			info = @fsman.info(@partition)
-			info[:filesystem]
-		end
-		
-	end
-	
-	class FsManagement
-		attr_reader :inspec
-		def initialize(inspec)
-			@inspec = inspec
-		end
-	end
-	
-	class LinuxFileSystemResource < FsManagement
-		def info(partition)
-			begin
-				cmd = inspec.command("df #{partition} --output=size")
-				raise Inspec::Exceptions::ResourceFailed, "Unable to get available space for partition #{partition}" if cmd.stdout.nil? || cmd.stdout.empty? || !cmd.exit_status.zero?
-				value = cmd.stdout.gsub(/\dK-blocks[\r\n]/, '').strip
+    def size
+      info = @fsman.info(@partition)
+      info[:size]
+    end		
 
-				{
-				  name: partition,				
-				  size: value.to_i,
-				  filesystem: false,
-				}
-			end
-		end
-	end
-	
-	class WindowsFileSystemResource < FsManagement
-		def info(partition)
+    def filesystem
+      info = @fsman.info(@partition)
+      info[:filesystem]
+    end
+    def name
+      info = @fsman.info(@partition)
+      info[:name]
+    end  
+  end
+   
+  class FsManagement
+    attr_reader :inspec
+    def initialize(inspec)
+      @inspec = inspec
+    end
+  end
 
-			cmd = inspec.command <<-EOF.gsub(/^\s*/, '')
-			  $disk = Get-WmiObject Win32_LogicalDisk -Filter "DeviceID='#{partition}'"
-			  $disk.Size = $disk.Size / 1GB
-			  $disk | select -property DeviceID,Size,FileSystem | ConvertTo-Json
-			EOF
+  class LinuxFileSystemResource < FsManagement
+    def info(partition)
+      begin
+        cmd = inspec.command("df #{partition} --output=size")
+        raise Inspec::Exceptions::ResourceFailed, "Unable to get available space for partition #{partition}" if cmd.stdout.nil? || cmd.stdout.empty? || !cmd.exit_status.zero?
+        value = cmd.stdout.gsub(/\dK-blocks[\r\n]/, '').strip
+        {
+          name: partition,				
+          size: value.to_i,
+          filesystem: false,
+        }
+      end
+    end
+  end
 
-			raise Inspec::Exceptions::ResourceSkipped, "Unable to get available space for partition #{partition}" if cmd.stdout == '' || cmd.exit_status.to_i != 0
-				
-			begin
-				fs = JSON.parse(cmd.stdout)
-			rescue JSON::ParserError => e
-			  raise Inspec::Exceptions::ResourceFailed,
-				'Failed to parse JSON from Powershell. ' \
-				"Error: #{e}"
-			end
-									
-			{
-			  name: fs['DeviceID'],
-			  size: fs['Size'].to_i,
-			  filesystem: fs['FileSystem'],
-			}
-		end
-	end	
+  class WindowsFileSystemResource < FsManagement
+    def info(partition)
+      cmd = inspec.command <<-EOF.gsub(/^\s*/, '')
+        $disk = Get-WmiObject Win32_LogicalDisk -Filter "DeviceID='#{partition}'"
+        $disk.Size = $disk.Size / 1GB
+        $disk | select -property DeviceID,Size,FileSystem | ConvertTo-Json
+      EOF
+
+      raise Inspec::Exceptions::ResourceSkipped, "Unable to get available space for partition #{partition}" if cmd.stdout == '' || cmd.exit_status.to_i != 0
+      begin
+        fs = JSON.parse(cmd.stdout)
+        rescue JSON::ParserError => e
+        raise Inspec::Exceptions::ResourceFailed,
+          'Failed to parse JSON from Powershell. ' \
+          "Error: #{e}"
+        end
+
+      {
+        name: fs['DeviceID'],
+        size: fs['Size'].to_i,
+        filesystem: fs['FileSystem'],
+      }
+    end
+  end	
 end

--- a/lib/resources/filesystem.rb
+++ b/lib/resources/filesystem.rb
@@ -8,11 +8,11 @@ module Inspec::Resources
       'filesystem' currently not supported for Linux
       describe filesystem('/') do
         its('size') { should be >= 32000 }
-        its('filesystem') { should eq false }
+        its('type') { should eq false }
       end
       describe filesystem('c:') do
         its('size') { should be >= 90 }
-        its('filesystem') { should eq 'NTFS' }
+        its('type') { should eq 'NTFS' }
       end
     "
     attr_reader :partition
@@ -48,9 +48,9 @@ module Inspec::Resources
       info[:size]
     end
 
-    def filesystem
+    def type
       info = @fsman.info(@partition)
-      info[:filesystem]
+      info[:type]
     end
 
     def name
@@ -74,7 +74,7 @@ module Inspec::Resources
       {
         name: partition,
         size: value.to_i,
-        filesystem: false,
+        type: false,
       }
     end
   end
@@ -98,7 +98,7 @@ module Inspec::Resources
       {
         name: fs['DeviceID'],
         size: fs['Size'].to_i,
-        filesystem: fs['FileSystem'],
+        type: fs['FileSystem'],
       }
     end
   end

--- a/lib/resources/filesystem.rb
+++ b/lib/resources/filesystem.rb
@@ -1,31 +1,113 @@
 module Inspec::Resources
-  class FileSystemResource < Inspec.resource(1)
-    name 'filesystem'
-    supports platform: 'linux'
-    desc 'Use the filesystem InSpec resource to test file system'
-    example "
-      describe filesystem('/') do
-        its('size') { should be >= 32000 }
-      end
-    "
-    attr_reader :partition
+	class FileSystemResource < Inspec.resource(1)
+		name 'filesystem'
+		supports platform: 'linux'
+		supports platform: 'windows'
+		desc 'Use the filesystem InSpec resource to test file system'
+		example "
+			'filesystem' currently not supported for Linux
+			describe filesystem('/') do
+				its('size') { should be >= 32000 }
+				its('filesystem') { should eq false }
+			end
+			
+			describe filesystem('c:') do
+				its('size') { should be >= 90 }
+				its('filesystem') { should eq 'NTFS' }
+			end
+			
+		"
+		attr_reader :partition
 
-    def initialize(partition)
-      @partition = partition
-    end
+		def initialize(partition)
+			@partition = partition
+			@cache = nil
+			#select file system manager
+			@fsman = nil
+			
+			os = inspec.os
+			if os.linux?
+				@fsman = LinuxFileSystemResource.new(inspec)
+			elsif os.windows?
+				@fsman = WindowsFileSystemResource.new(inspec)
+			else
+				raise Inspec::Exceptions::ResourceSkipped, 'The `filesystem` resource is not supported on your OS yet.'
+			end
+		end
+		
+		def info 
+			return @cache if !@cache.nil?
 
-    def size
-      @size ||= begin
-        cmd = inspec.command("df #{partition} --output=size")
-        raise Inspec::Exceptions::ResourceFailed, "Unable to get available space for partition #{partition}" if cmd.stdout.nil? || cmd.stdout.empty? || !cmd.exit_status.zero?
+			return {} if @fsman.nil?
+			
+			@fsman.info(@partition)
+		end
 
-        value = cmd.stdout.gsub(/\dK-blocks[\r\n]/, '').strip
-        value.to_i
-      end
-    end
+		
+		
+		def to_s
+			"FileSystem #{@partition}"
+		end	
 
-    def to_s
-      "Filesystem #{partition}"
-    end
-  end
+		def size
+			info = @fsman.info(@partition)
+			info[:size]
+		end		
+
+		def filesystem
+			info = @fsman.info(@partition)
+			info[:filesystem]
+		end
+		
+	end
+	
+	class FsManagement
+		attr_reader :inspec
+		def initialize(inspec)
+			@inspec = inspec
+		end
+	end
+	
+	class LinuxFileSystemResource < FsManagement
+		def info(partition)
+			begin
+				cmd = inspec.command("df #{partition} --output=size")
+				raise Inspec::Exceptions::ResourceFailed, "Unable to get available space for partition #{partition}" if cmd.stdout.nil? || cmd.stdout.empty? || !cmd.exit_status.zero?
+				value = cmd.stdout.gsub(/\dK-blocks[\r\n]/, '').strip
+
+				{
+				  name: partition,				
+				  size: value.to_i,
+				  filesystem: false,
+				}
+			end
+		end
+	end
+	
+	class WindowsFileSystemResource < FsManagement
+		def info(partition)
+
+			cmd = inspec.command <<-EOF.gsub(/^\s*/, '')
+			  $disk = Get-WmiObject Win32_LogicalDisk -Filter "DeviceID='#{partition}'"
+			  $disk.Size = $disk.Size / 1GB
+			  $disk | select -property DeviceID,Size,FileSystem | ConvertTo-Json
+			EOF
+
+			raise Inspec::Exceptions::ResourceSkipped, "Unable to get available space for partition #{partition}" if cmd.stdout == '' || cmd.exit_status.to_i != 0
+				
+			begin
+				fs = JSON.parse(cmd.stdout)
+			rescue JSON::ParserError => e
+			  raise Inspec::Exceptions::ResourceFailed,
+				'Failed to parse JSON from Powershell. ' \
+				"Error: #{e}"
+			end
+									
+			{
+			  name: fs['DeviceID'],
+			  size: fs['Size'].to_i,
+			  filesystem: fs['FileSystem'],
+			}
+		end
+	end	
 end

--- a/lib/resources/filesystem.rb
+++ b/lib/resources/filesystem.rb
@@ -5,7 +5,6 @@ module Inspec::Resources
     supports platform: 'windows'
     desc 'Use the filesystem InSpec resource to test file system'
     example "
-      
       describe filesystem('/') do
         its('size') { should be >= 32000 }
         its('type') { should eq false }

--- a/lib/resources/filesystem.rb
+++ b/lib/resources/filesystem.rb
@@ -68,16 +68,14 @@ module Inspec::Resources
 
   class LinuxFileSystemResource < FsManagement
     def info(partition)
-
-        cmd = inspec.command("df #{partition} --output=size")
-        raise Inspec::Exceptions::ResourceFailed, "Unable to get available space for partition #{partition}" if cmd.stdout.nil? || cmd.stdout.empty? || !cmd.exit_status.zero?
-        value = cmd.stdout.gsub(/\dK-blocks[\r\n]/, '').strip
-        {
-          name: partition,
-          size: value.to_i,
-          filesystem: false,
-        }
-
+      cmd = inspec.command("df #{partition} --output=size")
+      raise Inspec::Exceptions::ResourceFailed, "Unable to get available space for partition #{partition}" if cmd.stdout.nil? || cmd.stdout.empty? || !cmd.exit_status.zero?
+      value = cmd.stdout.gsub(/\dK-blocks[\r\n]/, '').strip
+      {
+        name: partition,
+        size: value.to_i,
+        filesystem: false,
+      }
     end
   end
 
@@ -92,12 +90,11 @@ module Inspec::Resources
       raise Inspec::Exceptions::ResourceSkipped, "Unable to get available space for partition #{partition}" if cmd.stdout == '' || cmd.exit_status.to_i != 0
       begin
         fs = JSON.parse(cmd.stdout)
-        rescue JSON::ParserError => e
-          raise Inspec::Exceptions::ResourceFailed,
-          'Failed to parse JSON from Powershell. ' \
-          "Error: #{e}"
-        end
-
+      rescue JSON::ParserError => e
+        raise Inspec::Exceptions::ResourceFailed,
+              'Failed to parse JSON from Powershell. ' \
+              "Error: #{e}"
+      end
       {
         name: fs['DeviceID'],
         size: fs['Size'].to_i,

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -547,6 +547,9 @@ class MockLoader
 
       # alpine package commands
       'apk info -vv --no-network | grep git' => cmd.call('apk-info-grep-git'),
+
+      # filesystem command
+      '2df93b941844efec1eee05c311cb4b4e8e3fd8b31808b785a70bd1a46298c716' => cmd.call('get-wmiobject-filesystem'),
     }
 
     # ports on linux

--- a/test/integration/default/controls/filesystem.rb
+++ b/test/integration/default/controls/filesystem.rb
@@ -4,10 +4,11 @@ if ENV['DOCKER']
 end
 
 if os.windows?
-  STDERR.puts "\033[1;33mTODO: Not running #{__FILE__.split("/").last} because we are not on Linux.\033[0m"
-  return
-end
-
-describe filesystem('/') do
-  its('size') { should be >= 1 }
+  describe filesystem('c:') do
+    its('size') { should be >= 1 }
+  end
+else
+  describe filesystem('/') do
+    its('size') { should be >= 1 }
+  end
 end

--- a/test/unit/mock/cmd/get-wmiobject-filesystem
+++ b/test/unit/mock/cmd/get-wmiobject-filesystem
@@ -1,0 +1,5 @@
+{
+    "DeviceID": "c:",
+    "Size": "100",
+    "FileSystem": "NTFS"
+}

--- a/test/unit/mock/cmd/get-wmiobject-filesystem
+++ b/test/unit/mock/cmd/get-wmiobject-filesystem
@@ -1,0 +1,5 @@
+  {
+   name: 'c:',
+   size: '100',
+   filesystem: 'NTFS',
+ }

--- a/test/unit/mock/cmd/get-wmiobject-filesystem
+++ b/test/unit/mock/cmd/get-wmiobject-filesystem
@@ -1,5 +1,0 @@
-  {
-   name: 'c:',
-   size: '100',
-   filesystem: 'NTFS',
- }

--- a/test/unit/resources/filesystem_test.rb
+++ b/test/unit/resources/filesystem_test.rb
@@ -2,27 +2,23 @@ require 'helper'
 require 'inspec/resource'
 
 describe 'Inspec::Resources::FileSystemResource' do
-  describe 'when loading filesystem in linux' do
-    let (:resource) { load_resource('filesystem', '/') }
-
-    it 'resolves the / partition' do
-      _(resource.partition).must_equal '/'
-    end
-
-    it 'has more than 1 MB' do
-      _(resource.size).must_be :>=, 1
-    end
-
-    it 'must equal 28252316 MB' do
-      _(resource.size).must_equal 28252316
-    end
+  # arch linux
+  it 'verify filesystem on linux' do
+    resource = MockLoader.new(:arch).load_resource('filesystem','/') 
+    _(resource.size).must_be :>=, 1
+    _(resource.partition).must_equal '/'
+    _(resource.size).must_equal 28252316
   end
-  describe 'when loading filesystem in unsupported OS family' do
-    it 'fails on Windows' do
-      resource_fail = MockLoader.new(:windows).load_resource('filesystem', '/')
-      resource_fail.check_supports.must_equal false
-    end
+  
+  # arch windows
+  it 'verify filesystem on windows' do
+    resource = MockLoader.new(:arch).load_resource('filesystem','c:')
+    _(resource.size).must_be :>=, 1
+    _(resource.name).must_equal 'c:'
+  end
 
+  # unsuported
+  describe 'when loading filesystem in unsupported OS family' do
     it 'fails on FreeBSD (unix-like)' do
       resource_fail = MockLoader.new(:freebsd10).load_resource('filesystem', '/')
       resource_fail.check_supports.must_equal false

--- a/test/unit/resources/filesystem_test.rb
+++ b/test/unit/resources/filesystem_test.rb
@@ -6,7 +6,7 @@ describe 'Inspec::Resources::FileSystemResource' do
   it 'verify filesystem on linux' do
     resource = MockLoader.new(:ubuntu1404).load_resource('filesystem','/') 
     _(resource.size).must_be :>=, 1
-    _(resource.partition).must_equal '/'
+    _(resource.name).must_equal '/'
   end
   
   # arch windows

--- a/test/unit/resources/filesystem_test.rb
+++ b/test/unit/resources/filesystem_test.rb
@@ -16,7 +16,7 @@ describe 'Inspec::Resources::FileSystemResource' do
     _(resource.name).must_equal 'c:'
   end
 
-  # unsuported
+  # unsuported os
   describe 'when loading filesystem in unsupported OS family' do
     it 'fails on FreeBSD (unix-like)' do
       resource_fail = MockLoader.new(:freebsd10).load_resource('filesystem', '/')

--- a/test/unit/resources/filesystem_test.rb
+++ b/test/unit/resources/filesystem_test.rb
@@ -4,15 +4,14 @@ require 'inspec/resource'
 describe 'Inspec::Resources::FileSystemResource' do
   # arch linux
   it 'verify filesystem on linux' do
-    resource = MockLoader.new(:arch).load_resource('filesystem','/') 
+    resource = MockLoader.new(:ubuntu1404).load_resource('filesystem','/') 
     _(resource.size).must_be :>=, 1
     _(resource.partition).must_equal '/'
-    _(resource.size).must_equal 28252316
   end
   
   # arch windows
   it 'verify filesystem on windows' do
-    resource = MockLoader.new(:arch).load_resource('filesystem','c:')
+    resource = MockLoader.new(:windows).load_resource('filesystem','c:')
     _(resource.size).must_be :>=, 1
     _(resource.name).must_equal 'c:'
   end


### PR DESCRIPTION
improve filesystem.rb to support windows.
Split into 2 classes LinuxFileSystemResource / WindowsFileSystemResource
Add filesystem to verify a FS-type ( currently not for linux because missing test server )
Size on Windows is converted to GB - discussion about this welcome

Signed-off-by: markus hackethal <mh@it31.de>