### PR TITLE
Load the compliance plugin when the fetcher is needed

### DIFF
--- a/lib/inspec/fetcher.rb
+++ b/lib/inspec/fetcher.rb
@@ -45,5 +45,3 @@ require 'fetchers/git'
 
 # TODO: Remove in 4.0 when Compliance fetcher plugin is created
 require 'plugins/inspec-compliance/lib/inspec-compliance/api'
-require 'plugins/inspec-compliance/lib/inspec-compliance/configuration'
-require 'plugins/inspec-compliance/lib/inspec-compliance/target'

--- a/lib/inspec/fetcher.rb
+++ b/lib/inspec/fetcher.rb
@@ -42,3 +42,8 @@ end
 require 'fetchers/local'
 require 'fetchers/url'
 require 'fetchers/git'
+
+# TODO: Remove in 4.0 when Compliance fetcher plugin is created
+require 'plugins/inspec-compliance/lib/inspec-compliance/api'
+require 'plugins/inspec-compliance/lib/inspec-compliance/configuration'
+require 'plugins/inspec-compliance/lib/inspec-compliance/target'


### PR DESCRIPTION
When migrating `inspec-compliance` to a V2 plugin. This caused the plugin to be lazy loaded when needed.

Current core fetchers are still using the old v1 plugin system and do not play nice with the v2 ones. This change will load the compliance plugin so the fetcher is loaded into the system to be used. v1 plugins are being converted to v2 for 4.0 so this will be fixed.

This fixes #3598.