### PR TITLE
Support cran packages for non-utf8 locales

### DIFF
--- a/lib/resources/cran.rb
+++ b/lib/resources/cran.rb
@@ -41,7 +41,7 @@ module Inspec::Resources
       #
       # So make sure command output is converted to unicode, as it returns ASCII-8BIT by default
       utf8_stdout = cmd.stdout.chomp.force_encoding(Encoding::UTF_8)
-      params = /^\[\d+\]\s+(?:\p{Initial_Punctuation})(.+)(?:\p{Final_Punctuation})$/.match(utf8_stdout)
+      params = /^\[\d+\]\s+(?:['\p{Initial_Punctuation}])(.+)(?:['\p{Final_Punctuation}])$/.match(utf8_stdout)
       @info[:installed] = !params.nil?
       return @info unless @info[:installed]
 


### PR DESCRIPTION
{Initial_Punctuation} {Final_Punctuation} does not include ```'```, which causes cran resource to fail when outputting to a non-utf8 locale tty.