### PR TITLE
Revert setting RSpec expectation syntax to 'should' mode

### DIFF
--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -1,13 +1,5 @@
 require 'inspec/attribute_registry'
-require 'rspec/core'
 require 'rspec/core/example_group'
-
-# Setup RSpec to allow use of `should` syntax without warnings
-RSpec.configure do |config|
-  config.expect_with(:rspec) do |rspec_expectations_config|
-    rspec_expectations_config.syntax = :should
-  end
-end
 
 # This file allows you to add ExampleGroups to be used in rspec tests
 #

--- a/test/functional/filter_table_test.rb
+++ b/test/functional/filter_table_test.rb
@@ -69,7 +69,8 @@ describe '3103 default methods for filter table' do
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
-    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
+    # RSpec keeps issuing a deprecation count to stdout
+    # See https://github.com/inspec/inspec/pull/3560
     output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
     data = JSON.parse(output)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
@@ -105,7 +106,8 @@ describe '2370 lazy_load for filter table' do
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
-    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
+    # RSpec keeps issuing a deprecation count to stdout
+    # See https://github.com/inspec/inspec/pull/3560
     output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
     data = JSON.parse(output)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
@@ -175,7 +177,8 @@ describe '3110 do not expose block-valued properties in raw data' do
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
-    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
+    # RSpec keeps issuing a deprecation count to stdout
+    # See https://github.com/inspec/inspec/pull/3560
     output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
     data = JSON.parse(output)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }

--- a/test/functional/filter_table_test.rb
+++ b/test/functional/filter_table_test.rb
@@ -18,7 +18,9 @@ describe '2943 inspec exec for filter table profile, method mode for `where' do
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
-    data = JSON.parse(cmd.stdout)
+    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
+    output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
+    data = JSON.parse(output)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
     control_hash = {}
     failed_controls.each do |ctl|
@@ -67,7 +69,9 @@ describe '3103 default methods for filter table' do
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
-    data = JSON.parse(cmd.stdout)
+    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
+    output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
+    data = JSON.parse(output)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
     control_hash = {}
     failed_controls.each do |ctl|
@@ -101,7 +105,9 @@ describe '2370 lazy_load for filter table' do
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
-    data = JSON.parse(cmd.stdout)
+    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
+    output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
+    data = JSON.parse(output)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
     control_hash = {}
     failed_controls.each do |ctl|
@@ -169,7 +175,9 @@ describe '3110 do not expose block-valued properties in raw data' do
     cmd += ' --controls ' + controls.join(' ')
     cmd = inspec(cmd)
 
-    data = JSON.parse(cmd.stdout)
+    # RSpec keeps issuing a deprecation count to stdout; I can't seem to disable it.
+    output = cmd.stdout.split("\n").reject {|line| line =~ /deprecation/}.join("\n")
+    data = JSON.parse(output)
     failed_controls = data['profiles'][0]['controls'].select { |ctl| ctl['results'][0]['status'] == 'failed' }
     control_hash = {}
     failed_controls.each do |ctl|

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -515,16 +515,6 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
     end
   end
 
-  describe 'when using a profile that calls .should explicitly' do
-    let(:run_result) { inspec('exec ' + File.join(profile_path, 'rspec-should-deprecation')) }
-    it 'should suppress the RSpec deprecation warning' do
-      # See: https://github.com/inspec/inspec/issues/952
-      run_result.exit_status.must_equal 0
-      run_result.stderr.must_be_empty
-      run_result.stdout.wont_include('1 deprecation warning total')
-    end
-  end
-
   describe 'when targeting private GitHub profiles' do
     let(:private_profile) {
       URI.parse('https://github.com/chef/inspec-test-profile-private.git')

--- a/test/unit/mock/profiles/rspec-should-deprecation/controls/explicit_should.rb
+++ b/test/unit/mock/profiles/rspec-should-deprecation/controls/explicit_should.rb
@@ -1,5 +1,0 @@
-control 'call-should-as-an-explicit-method' do
-  describe 'It should work without issuing a deprecation warning' do
-    it { 'a string'.should include 'ing' }
-  end
-end

--- a/test/unit/mock/profiles/rspec-should-deprecation/inspec.yml
+++ b/test/unit/mock/profiles/rspec-should-deprecation/inspec.yml
@@ -1,8 +1,0 @@
-name: rspec-should-deprecation
-title: A profile to trigger an RSpec deprecation warning, refs github 952
-maintainer: The Authors
-copyright: The Authors
-copyright_email: you@example.com
-license: Apache-2.0
-summary: An InSpec Compliance Profile
-version: 0.1.0


### PR DESCRIPTION
This PR reverts #3560, with the only change beyond the reversion being to add explanatory comments to a test.

#3560, included in inspec 3.0.46, explicitly set the RSpec expectation syntax to be `should` mode (as opposed to `expect` mode, or not setting it at all).  This fixed #952, but also broke `expect` syntax.  

While the InSpec project docs do not mention `expect` and generally prefer `should` for readability for non-programmers, RSpec has been moving to `expect` for a while, and many developers prefer it and have implemented their profiles using it. As a project, we don't want to insist on `should`; and besides, the circumstance in which #952 occurred are very rare and avoidable.

Hence the reversion.

Fixes #3616 