### PR TITLE
lc/add-aws-platform-template

### DIFF
--- a/lib/plugins/inspec-init/lib/inspec-init/templates/profiles/aws/README.md
+++ b/lib/plugins/inspec-init/lib/inspec-init/templates/profiles/aws/README.md
@@ -1,0 +1,54 @@
+# Example InSpec Profile For AWS
+
+This example shows the implementation of an InSpec profile for AWS.
+
+##  Create a profile 
+
+```
+$ inspec init profile --platform aws aws-security
+Create new profile at /Users/liamcaproni/aws-security
+ * Create directory libraries
+ * Create file README.md
+ * Create directory controls
+ * Create file controls/example.rb
+ * Create file inspec.yml
+ * Create file attributes.yml
+ * Create file libraries/.gitkeep 
+ 
+```
+
+## Update `attributes.yml` to point to your custom VPC
+
+```
+aws_vpc_id: 'custom-vpc-id'
+```
+
+## Run the tests
+
+```
+$ cd aws-profile/
+$ inspec exec -t aws://eu-west-1/test-iam-profile  --attrs attributes.yml aws-security
+
+Profile: InSpec Profile (aws-security)
+Version: 0.1.0
+Target:  aws://eu-west-2
+
+  ✔  aws-vpc-check: Check to see if custom VPC exists.
+     ✔  VPC vpc-0014dad216b7664e3 should exist
+  ✔  aws-vpcs-check: Check in all the VPCs for default sg not allowing 22 inwards
+     ✔  EC2 Security Group sg-05cd285a7499ee2bf should allow in {:port=>22}
+     ✔  EC2 Security Group sg-0f0faf6d01eafc65d should allow in {:port=>22}
+     ✔  EC2 Security Group sg-0cb134808cb42f188 should allow in {:port=>22}
+     ✔  EC2 Security Group sg-06b2ae6dea43e32b6 should allow in {:port=>22}
+     ✔  EC2 Security Group sg-0fc81264868480768 should allow in {:port=>22}
+     ✔  EC2 Security Group sg-0cc3c94d414fdcd1b should allow in {:port=>22}
+     ✔  EC2 Security Group sg-0abe7f61 should allow in {:port=>22}
+     ✔  EC2 Security Group sg-0f346bed179f1e6ad should allow in {:port=>22}
+     ✔  EC2 Security Group sg-0ff737c3be7a370ab should allow in {:port=>22}
+     ✔  EC2 Security Group sg-0f37838285d37d035 should allow in {:port=>22}
+     ✔  EC2 Security Group sg-001651d64991000f7 should allow in {:port=>22}
+
+
+
+
+```

--- a/lib/plugins/inspec-init/lib/inspec-init/templates/profiles/aws/attributes.yml
+++ b/lib/plugins/inspec-init/lib/inspec-init/templates/profiles/aws/attributes.yml
@@ -1,0 +1,2 @@
+# Below is to be uncommented and set with your AWS Custom VPC ID:
+# aws_vpc_id: 'vpc-xxxxxxx'

--- a/lib/plugins/inspec-init/lib/inspec-init/templates/profiles/aws/controls/example.rb
+++ b/lib/plugins/inspec-init/lib/inspec-init/templates/profiles/aws/controls/example.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+title 'Sample Section'
+
+aws_vpc_id = attribute('aws_vpc_id')
+
+# you add controls here
+control 'aws-vpc-check' do                                                  # A unique ID for this control.
+  impact 1.0                                                                # The criticality, if this control fails.
+  title 'Check to see if custom VPC exists.'                                # A human-readable title
+  describe aws_vpc(aws_vpc_id) do                                           # The test itself.
+    it { should exist }
+  end
+end
+
+# Plural resources can be inspected to check for specific resource details.
+control 'aws-vpcs-check' do
+  impact 1.0
+  title 'Check in all the VPCs for default sg not allowing 22 inwards'
+  aws_vpcs.vpc_ids.each do |vpc_id|
+    describe aws_security_group(vpc_id: vpc_id, group_name: 'default') do
+      it { should allow_in(port: 22) }
+    end
+  end
+end

--- a/lib/plugins/inspec-init/lib/inspec-init/templates/profiles/aws/inspec.yml
+++ b/lib/plugins/inspec-init/lib/inspec-init/templates/profiles/aws/inspec.yml
@@ -1,0 +1,16 @@
+name: <%= name %>
+title: AWS InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile For AWS
+version: 0.1.0
+inspec_version: '>= 2.3.5'
+attributes:
+- name: aws_vpc_id
+  required: true
+  description: 'The Custom AWS VPC Id'
+  type: string
+supports:
+- platform: aws

--- a/lib/plugins/inspec-init/test/functional/inspec_init_test.rb
+++ b/lib/plugins/inspec-init/test/functional/inspec_init_test.rb
@@ -61,4 +61,16 @@ class InitCli < MiniTest::Test
       assert_includes Dir.entries(profile).join, 'README.md'
     end
   end
+
+  def test_generating_inspec_profile_aws
+    Dir.mktmpdir do |dir|
+      profile = File.join(dir,'test-aws-profile')
+      out = run_inspec_process("init profile --platform aws test-aws-profile", prefix: "cd #{dir} &&")
+      assert_equal 0, out.exit_status
+      assert_includes out.stdout, 'Create new profile at'
+      assert_includes out.stdout, profile
+      assert_includes Dir.entries(profile).join, 'inspec.yml'
+      assert_includes Dir.entries(profile).join, 'README.md'
+   end
+  end
 end


### PR DESCRIPTION
This change will allow AWS platform templates to be generated, currently base ones required to be generated - os - then amended to change the platform to aws.