### PR TITLE
www: remove jquery sticky on the sidebar

### DIFF
--- a/www/source/javascripts/all.js
+++ b/www/source/javascripts/all.js
@@ -1,7 +1,6 @@
 //= require vendor/jquery.min
 //= require vendor/foundation.min
 //= require jquery.enllax.min
-//= require jquery.sticky
 //= require highlight.min
 //= require nav
 //= require particles

--- a/www/source/layouts/layout.slim
+++ b/www/source/layouts/layout.slim
@@ -39,15 +39,6 @@ html
 
     javascript:
 
-     //initiate sticky sidebar from jquery.sticky.js
-
-      if (window.innerWidth > 640) { //don't fix on mobile
-        $('#sidebar').stick_in_parent();
-      }
-
-
-    javascript:
-
       function initSlideGroup(group) {
         var prev = -1;
         var links = $(group).find('a')


### PR DESCRIPTION
the sticky sidebar is really annoying when the window is too small as it moves offscreen or doesnt allow clicking entries at the  bottom