### PR TITLE
Remove deprecated shadow matchers

### DIFF
--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -23,11 +23,11 @@ module Inspec::Resources
          'the system and/or as users that own running processes.'
     example "
       describe shadow do
-        its('user') { should_not include 'forbidden_user' }
+        its('users') { should_not include 'forbidden_user' }
       end
 
       describe shadow.user('bin') do
-        its('password') { should cmp 'x' }
+        its('passwords') { should cmp 'x' }
         its('count') { should eq 1 }
       end
     "
@@ -53,12 +53,6 @@ module Inspec::Resources
       .register_column(:inactive_days, field: 'inactive_days')
       .register_column(:expiry_dates, field: 'expiry_date')
       .register_column(:reserved, field: 'reserved')
-    # These are deprecated, but we need to "alias" them
-    filtertable
-      .register_custom_property(:user) { |table, value| table.resource.user(value) }
-      .register_custom_property(:password) { |table, value| table.resource.password(value) }
-      .register_custom_property(:last_change) { |table, value| table.resource.last_change(value) }
-      .register_custom_property(:expiry_date) { |table, value| table.resource.expiry_date(value) }
 
     filtertable.register_custom_property(:content) { |t, _|
       t.entries.map do |e|
@@ -86,38 +80,6 @@ module Inspec::Resources
       end
       content = res.map { |x| x.values.join(':') }.join("\n")
       Shadow.new(@path, content: content, filters: @filters + filters)
-    end
-
-    # Next 4 are deprecated methods.  We define them here so we can emit a deprecation message.
-    # They are also defined on the Table, above.
-    def user(query = nil)
-      warn '[DEPRECATION] The shadow `user` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `users` instead.'
-      query.nil? ? where.users : where('user' => query)
-    end
-
-    def password(query = nil)
-      warn '[DEPRECATION] The shadow `password` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `passwords` instead.'
-      query.nil? ? where.passwords : where('password' => query)
-    end
-
-    def last_change(query = nil)
-      warn '[DEPRECATION] The shadow `last_change` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `last_changes` instead.'
-      query.nil? ? where.last_changes : where('last_change' => query)
-    end
-
-    def expiry_date(query = nil)
-      warn '[DEPRECATION] The shadow `expiry_date` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `expiry_dates` instead.'
-      query.nil? ? where.expiry_dates : where('expiry_date' => query)
-    end
-
-    def lines
-      warn '[DEPRECATION] The shadow `lines` property is deprecated and will be removed' \
-        ' in InSpec 3.0.'
-      shadow_content.to_s.split("\n")
     end
 
     def to_s

--- a/test/unit/mock/profiles/profile-non-utf-8/README.md
+++ b/test/unit/mock/profiles/profile-non-utf-8/README.md
@@ -1,0 +1,3 @@
+# Non-UTF-8 Profile
+
+This profile contains a non-UTF-8 character in it's metadata

--- a/test/unit/mock/profiles/profile-non-utf-8/controls/example.rb
+++ b/test/unit/mock/profiles/profile-non-utf-8/controls/example.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'non-utf-8' do
+  impact 0.7
+  title 'Example control to make this a valid profile'
+  describe 1 do
+    it { should eq 1 }
+  end
+end

--- a/test/unit/mock/profiles/profile-non-utf-8/inspec.yml
+++ b/test/unit/mock/profiles/profile-non-utf-8/inspec.yml
@@ -1,0 +1,10 @@
+name: profile-non-utf-8
+title: InSpec Profile with a ’
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  platform: os

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -11,16 +11,16 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   it 'retrieve users via field' do
-    _(shadow.user).must_equal %w{root www-data}
+    _(shadow.users).must_equal %w{root www-data}
     _(shadow.count).must_equal 2
   end
 
   it 'retrieve passwords via field' do
-    _(shadow.password).must_equal %w{x !!}
+    _(shadow.passwords).must_equal %w{x !!}
   end
 
   it 'retrieve last password change via field' do
-    _(shadow.last_change).must_equal %w{1 10}
+    _(shadow.last_changes).must_equal %w{1 10}
   end
 
   it 'retrieve min password days via field' do
@@ -40,12 +40,7 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   it 'retrieve dates when account will expire via field' do
-    _(shadow.expiry_date).must_equal [nil, "60"]
-  end
-
-  it 'access all lines of the file' do
-    proc { _(shadow.lines[0]).must_equal 'root:x:1:2:3::::' }.must_output nil,
-      "[DEPRECATION] The shadow `lines` property is deprecated and will be removed in InSpec 3.0.\n"
+    _(shadow.expiry_dates).must_equal [nil, "60"]
   end
 
   it 'access all params of the file' do
@@ -56,34 +51,10 @@ describe 'Inspec::Resources::Shadow' do
     })
   end
 
-  it 'returns deprecation notice on user property' do
-    proc { _(shadow.user).must_equal %w{root www-data} }.must_output nil,
-      '[DEPRECATION] The shadow `user` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `users` instead.\n"
-  end
-
-  it 'returns deprecatation notice on password property' do
-    proc { _(shadow.password).must_equal %w{x !!} }.must_output nil,
-      '[DEPRECATION] The shadow `password` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `passwords` instead.\n"
-  end
-
-  it 'returns deprecation notice on last_change property' do
-    proc { _(shadow.last_change).must_equal %w{1 10} }.must_output nil,
-      '[DEPRECATION] The shadow `last_change` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `last_changes` instead.\n"
-  end
-
-  it 'returns deprecation notice on expiry_date property' do
-    proc { _(shadow.expiry_date).must_equal [nil, "60"] }.must_output nil,
-      '[DEPRECATION] The shadow `expiry_date` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `expiry_dates` instead.\n"
-  end
-
   describe 'multiple filters' do
     it 'filters with min_days and max_days' do
-      _(shadow.filter(min_days: 20, max_days: 30).user).must_equal ['www-data']
-      _(shadow.filter(last_change: 1, min_days: 2).user).must_equal ['root']
+      _(shadow.filter(min_days: 20, max_days: 30).users).must_equal ['www-data']
+      _(shadow.filter(last_change: 1, min_days: 2).users).must_equal ['root']
     end
   end
 
@@ -93,12 +64,8 @@ describe 'Inspec::Resources::Shadow' do
     it 'can read /etc/shadow and #filter matches user with no password and inactive_days' do
       users = shadow.filter(password: /[^x]/).entries.map { |x| x['user'] }
       users.each do |expected_user|
-        proc { expect(shadow.user(expected_user).users).must_equal(['www-data']) }.must_output nil,
-          '[DEPRECATION] The shadow `user` property is deprecated and will' \
-          " be removed in InSpec 3.0.  Please use `users` instead.\n"
-        proc { expect(shadow.user(expected_user).inactive_days).must_equal(['50']) }.must_output nil,
-          '[DEPRECATION] The shadow `user` property is deprecated and will' \
-          " be removed in InSpec 3.0.  Please use `users` instead.\n"
+        proc { expect(shadow.users(expected_user).users).must_equal(['www-data']) }.must_output nil
+        proc { expect(shadow.users(expected_user).inactive_days).must_equal(['50']) }.must_output nil
       end
     end
 


### PR DESCRIPTION
This is a breaking change that we have had warnings about for a while. However, this will break some profiles so it should be merged with caution.

If we chose not to merge this, we should change `warn` to `Inspec::Log.warn()` so the DEPRECATION warnings can be hidden.

Fixes #3631

EDIT: (@clintoncwolfe) add link to issue