### PR TITLE
Add support for aws vpc names

### DIFF
--- a/docs/resources/aws_vpc.md.erb
+++ b/docs/resources/aws_vpc.md.erb
@@ -29,7 +29,7 @@ This resource first became available in v2.0.16 of InSpec.
 
 ## Syntax
 
-An `aws_vpc` resource block identifies a VPC by id. If no VPC ID is provided, the default VPC is used.
+An `aws_vpc` resource block identifies a VPC by id or Name tag. If no VPC ID or Name tag is provided, the default VPC is used.
 
     # Find the default VPC
     describe aws_vpc do
@@ -46,6 +46,10 @@ An `aws_vpc` resource block identifies a VPC by id. If no VPC ID is provided, th
       it { should exist }
     end
 
+    # Find a VPC by Name
+    describe aws_vpc(vpc_name: 'my-vpc') do
+      it { should exist }
+    end
 <br>
 
 ## Examples

--- a/lib/resources/aws/aws_vpc.rb
+++ b/lib/resources/aws/aws_vpc.rb
@@ -58,6 +58,8 @@ class AwsVpc < Inspec.resource(1)
     @exists = !vpc.empty?
     return unless @exists
 
+    raise ArgumentError, "#{to_s} matched multiple VPCs" if resp.vpcs.length > 1
+
     @cidr_block = vpc[:cidr_block]
     @dhcp_options_id = vpc[:dhcp_options_id]
     @instance_tenancy = vpc[:instance_tenancy]

--- a/lib/resources/aws/aws_vpc.rb
+++ b/lib/resources/aws/aws_vpc.rb
@@ -58,7 +58,7 @@ class AwsVpc < Inspec.resource(1)
     @exists = !vpc.empty?
     return unless @exists
 
-    raise ArgumentError, "#{to_s} matched multiple VPCs" if resp.vpcs.length > 1
+    raise ArgumentError, "#{self} matched multiple VPCs" if resp.vpcs.length > 1
 
     @cidr_block = vpc[:cidr_block]
     @dhcp_options_id = vpc[:dhcp_options_id]


### PR DESCRIPTION
Allows AWS VPCs to be identified by Name label:

    # Find a VPC by Name
    describe aws_vpc(vpc_name: 'my-vpc') do
      it { should exist }
    end
