### PR TITLE
Add SQLcl to Oracledb_session Doc

### DIFF
--- a/docs/resources/oracledb_session.md.erb
+++ b/docs/resources/oracledb_session.md.erb
@@ -31,6 +31,7 @@ where
 
 * `oracledb_session` declares a username and password with permission to run the query (required), and an optional parameters for host (default: `localhost`), SID (default: `nil`, which uses the default SID, and path to the sqlplus binary (default: `sqlplus`).
 * it is possible to run queries as sysdba/sysoper by using `as_db_role option`, see examples
+* SQLcl can be used in place of sqlplus. Use the `sqlcl_bin` option to set the sqlcl binary path instead of `sqlplus_bin`.
 * `query('QUERY')` contains the query to be run
 * `its('value') { should eq('') }` compares the results of the query against the expected result in the test
 


### PR DESCRIPTION
SQLcl can be used with the oracledb_session resource. It requires a slightly different option compared to sqlplus that wasn't previously noted in the documentation.