### PR TITLE
Modify URL fetcher to accept URI

### DIFF
--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -24,6 +24,8 @@ module Fetchers
         resolve_from_string(target[:url], opts, target[:username], target[:password])
       elsif target.is_a?(String)
         resolve_from_string(target, opts)
+      elsif target.is_a?(URI)
+        resolve_from_string(target.to_s, opts)
       end
     end
 
@@ -94,7 +96,7 @@ module Fetchers
     attr_reader :files, :archive_path
 
     def initialize(url, opts)
-      @target = url
+      @target = url.to_s
       @target_uri = url.is_a?(URI) ? url : parse_uri(url)
       @insecure = opts['insecure']
       @token = opts['token']

--- a/lib/fetchers/url.rb
+++ b/lib/fetchers/url.rb
@@ -95,7 +95,7 @@ module Fetchers
 
     def initialize(url, opts)
       @target = url
-      @target_uri = parse_uri(@target)
+      @target_uri = url.is_a?(URI) ? url : parse_uri(url)
       @insecure = opts['insecure']
       @token = opts['token']
       @config = opts

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -34,7 +34,14 @@ describe Fetchers::Url do
       res.expects(:open).returns(mock_open)
       _(res).must_be_kind_of Fetchers::Url
       _(res.resolved_source).must_equal({url: 'https://chef.io/some.tar.gz', sha256: expected_shasum})
+    end
 
+    it 'handles an https URI' do
+      uri = URI.parse('https://chef.io/some.tar.gz')
+      res = Fetchers::Url.resolve(uri)
+      res.expects(:open).returns(mock_open)
+      _(res).must_be_kind_of Fetchers::Url
+      _(res.resolved_source).must_equal({url: 'https://chef.io/some.tar.gz', sha256: expected_shasum})
     end
 
     it 'doesnt handle other schemas' do


### PR DESCRIPTION
When https://github.com/inspec/inspec/pull/3562 was merged it added a method to parse a URI passed as a URL. However, some users (at least the Audit cookbook) were passing a URI and not a URL so there is no need to parse it.

This adds code to use the URI if a URI was passed.

Many thanks to @teknofire for discovering this and submitting a very detailed issue.

This closes #3626