### PR TITLE
Fix GitHub alert for rack dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,6 @@
 source 'https://rubygems.org'
 gemspec name: 'inspec'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
-  gem 'json', '~> 1.8'
-  gem 'rack', '< 2.0'
-end
-
 gem 'ffi', '>= 1.9.14'
 gem 'aws-sdk', '~> 2'
 


### PR DESCRIPTION
After digging I see that PR #975 fixed `bundle install` on 2.1.9 about two years ago. The minimum required version of Ruby for InSpec is 2.2. This updates our Gemfile to remove any logic for Ruby `< 2.2.2`.

The Gemfile should only be used for development...but I could be wrong here. Let me know if you think there will be any issues.