### PR TITLE
Remove Habitat package run time dependencies from Habitat plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ Currently, this method of installation only supports Linux. See the [Habitat sit
 Download the `hab` binary from the [Habitat](https://www.habitat.sh/docs/get-habitat/) site.
 
 ```bash
-hab pkg install chef/inspec
-export PATH="$(hab pkg path core/ruby)/bin:$(hab pkg path chef/inspec)/bin:$PATH"
+hab pkg install chef/inspec --binlink
 
 inspec
 ```
@@ -452,4 +451,4 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License. 
+limitations under the License.

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -10,6 +10,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/coreutils
   core/cacerts
+  core/git
   core/ruby
 )
 pkg_build_deps=(

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -8,23 +8,9 @@ pkg_upstream_url=https://www.inspec.io/
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_deps=(
-  core/busybox-static
-  core/cacerts
   core/coreutils
-  core/libxml2
-  core/libxslt
-  core/net-tools
+  core/cacerts
   core/ruby
-
-  # Needed for some InSpec resources
-  core/bind
-  core/curl
-  core/docker
-  core/git
-  core/less
-  core/mysql-client
-  core/netcat
-  core/postgresql-client
 )
 pkg_build_deps=(
   core/gcc
@@ -34,11 +20,12 @@ pkg_build_deps=(
 )
 pkg_bin_dirs=(bin)
 
-do_prepare() {
+do_setup_environment() {
+  build_line 'Setting GEM_HOME="$pkg_prefix/lib"'
   export GEM_HOME="$pkg_prefix/lib"
-  build_line "Setting GEM_HOME=$GEM_HOME"
+
+  build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
-  build_line "Setting GEM_PATH=$GEM_PATH"
 }
 
 do_unpack() {
@@ -60,17 +47,23 @@ do_install() {
   wrap_inspec_bin
 }
 
-# Need to wrap the InSpec binary to ensure GEM_HOME/GEM_PATH is correct
+# Need to wrap the InSpec binary to ensure paths are correct
 wrap_inspec_bin() {
   local bin="$pkg_prefix/bin/$pkg_name"
   local real_bin="$GEM_HOME/gems/inspec-${pkg_version}/bin/inspec"
   build_line "Adding wrapper $bin to $real_bin"
   cat <<EOF > "$bin"
-#!$(pkg_path_for busybox-static)/bin/sh
+#!$(pkg_path_for bash)/bin/bash
 export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
 set -e
+
+# Set binary path that allows InSpec to use non-Hab pkg binaries
+export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# Set Ruby paths defined from 'do_setup_environment()'
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
+
 exec $(pkg_path_for core/ruby)/bin/ruby $real_bin \$@
 EOF
   chmod -v 755 "$bin"


### PR DESCRIPTION
This removes the runtime dependencies on Hab pkgs and instead modifies the `PATH` environment variable to use the OS binaries where the InSpec Habitat package is installed.

It should be noted that this is counter to what Habitat intends in most cases. In general, it is preferable to use only Habitat packages as runtime dependencies to get all the benefits that Habitat provides.

We elected not to do this for the InSpec Habitat package since the list of binaries that would need to be installed to support all InSpec resources would be prohibitively expensive (both in disk space and network requirements). If you wish to use Habitat packaged binaries with this package you can use:

`hab pkg install origin/my-binary --binlink`.