### PR TITLE
Further slim the files we ship in the gem artifact

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -13,10 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/inspec/inspec'
   spec.license       = 'Apache-2.0'
 
-  spec.files = %w{
-    README.md Rakefile MAINTAINERS.md LICENSE inspec.gemspec
-    Gemfile CHANGELOG.md .rubocop.yml
-  } + Dir.glob(
+  spec.files = %w{README.md LICENSE} + Dir.glob(
     '{bin,lib,etc}/**/*', File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }
 


### PR DESCRIPTION
The artifact doesn't need the gemspec, gemfile or rakefile since we're not shipping tests already. Also there's no need for the changelog or maintainer file. For those a user should reference the github repo since these files are buried deep on the filesystem and not designed to be read through.

Signed-off-by: Tim Smith <tsmith@chef.io>