### PR TITLE
security_policy: fix fetching policy when name has spaces

### DIFF
--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -138,7 +138,7 @@ module Inspec::Resources
 
       conf = SimpleConfig.new(
         @content,
-        assignment_regex: /^\s*(.*)=\s*(\S*)\s*$/,
+        assignment_regex: /^\s*(.*)=\s*([\S[:space:]]*)\s+$/,
       )
       @params = convert_hash(conf.params)
     end
@@ -149,7 +149,7 @@ module Inspec::Resources
       if val =~ /^\d+$/
         val.to_i
       # special handling for SID array
-      elsif val =~ /[,]{0,1}\*\S/
+      elsif val =~ /[,]{0,1}\*\S|\,\D\S*$/
         if @translate_sid
           val.split(',').map { |v|
             object_name = inspec.command("(New-Object System.Security.Principal.SecurityIdentifier(\"#{v.sub('*S', 'S')}\")).Translate( [System.Security.Principal.NTAccount]).Value").stdout.to_s.strip


### PR DESCRIPTION
Sorry but my english is bad.

The issue occur when get value of security police that contains a name with spaces:
Policy status:
![screenshot_20181205_212338](https://user-images.githubusercontent.com/16336554/49541781-15f60500-f8d4-11e8-9654-52c470f5e128.png)

Value report from inspec shell
![screenshot_20181205_211707](https://user-images.githubusercontent.com/16336554/49541824-2dcd8900-f8d4-11e8-8017-ce4e44359086.png)

If show security_policy.params, can see that SeDenyInteractiveLogonRight have a parse error
![screenshot_20181205_211937](https://user-images.githubusercontent.com/16336554/49541926-69685300-f8d4-11e8-8dd3-b06010ed5fc2.png)

After update the regex, the value show ok
![screenshot_20181205_212922](https://user-images.githubusercontent.com/16336554/49542091-dda2f680-f8d4-11e8-9947-3aa9ddbb6c2f.png)

![screenshot_20181205_213031](https://user-images.githubusercontent.com/16336554/49542147-075c1d80-f8d5-11e8-8a54-e24619bd94ff.png)

thx, regards