### PR TITLE
Update formatting of heading on doc for aws_config_delivery_channel

### DIFF
--- a/docs/resources/aws_config_delivery_channel.md.erb
+++ b/docs/resources/aws_config_delivery_channel.md.erb
@@ -2,7 +2,7 @@
 title: About the aws_config_delivery_channel Resource
 ---
 
-# aws_config_delivery_channel
+# aws\_config\_delivery\_channel
 
 The AWS Config service can monitor and record changes to your AWS resource configurations. A Delivery Channel can record the changes
 to an S3 Bucket, an SNS or both.


### PR DESCRIPTION
Heading is displaying incorrect on https://www.inspec.io/docs/reference/resources/aws_config_delivery_channel/