### PR TITLE
Pin train to 1.5.11

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'train-core', '~> 1.5', '>= 1.5.6'
+  spec.add_dependency 'train-core', '~> 1.5', '>= 1.5.11'
   spec.add_dependency 'thor', '~> 0.20'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'method_source', '~> 0.8'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'train', '~> 1.5', '>= 1.5.6'
+  spec.add_dependency 'train', '~> 1.5', '>= 1.5.11'
   spec.add_dependency 'thor', '~> 0.20'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'method_source', '~> 0.8'


### PR DESCRIPTION
Train 1.5.11 includes a fix for Amazon Linux 2 OS detection:
* https://github.com/inspec/train/blob/master/CHANGELOG.md#v1511-2018-12-10
* Full set of changes: https://github.com/inspec/train/compare/v1.5.6...v1.5.11

Currently, Inspec fails on the latest version of the Amazon Linux 2 docker image with the following:
```
/opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/helpers/os_linux.rb:16:in `redhatish_version': undefined method `[]' for nil:NilClass (NoMethodError)", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/specifications/os.rb:194:in `block in load'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:46:in `instance_eval'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:46:in `block in scan_children'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `each'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `scan_children'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:60:in `scan_family_children'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:51:in `block in scan_children'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `each'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `scan_children'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:60:in `scan_family_children'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:51:in `block in scan_children'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `each'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `scan_children'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:60:in `scan_family_children'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:51:in `block in scan_children'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `each'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `scan_children'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:33:in `block in scan'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:27:in `each'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:27:in `scan'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect.rb:9:in `scan'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/plugins/base_connection.rb:114:in `platform'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/transports/local.rb:46:in `select_runner'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/transports/local.rb:27:in `initialize'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/transports/local.rb:17:in `new'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/transports/local.rb:17:in `connection'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/lib/inspec/backend.rb:51:in `create'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/lib/inspec/runner.rb:66:in `configure_transport'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/lib/inspec/runner.rb:58:in `initialize'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/lib/inspec/cli.rb:242:in `new'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/lib/inspec/cli.rb:242:in `exec'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'", u"\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/bin/inspec:12:in `<top (required)>'", u"\tfrom /opt/inspec/bin/inspec:106:in `load'", u"\tfrom /opt/inspec/bin/inspec:106:in `<main>'"], u'changed': True, u'stdout': u'', '_ansible_item_result': True, u'msg': u'non-zero return code', u'delta': u'0:00:02.895363', 'stdout_lines': [], '_ansible_item_label': u'/tmp/molecule/inspec/test_default.rb', u'end': u'2018-12-08 20:12:36.634760', '_ansible_no_log': False, 'item': u'/tmp/molecule/inspec/test_default.rb', u'cmd': [u'/opt/inspec/bin/inspec', u'exec', u'/tmp/molecule/inspec/test_default.rb', u'--no-color', u'--reporter', u'progress'], u'failed': True, u'stderr': u"/opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/helpers/os_linux.rb:16:in `redhatish_version': undefined method `[]' for nil:NilClass (NoMethodError)\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/specifications/os.rb:194:in `block in load'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:46:in `instance_eval'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:46:in `block in scan_children'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `each'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `scan_children'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:60:in `scan_family_children'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:51:in `block in scan_children'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `each'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `scan_children'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:60:in `scan_family_children'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:51:in `block in scan_children'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `each'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `scan_children'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:60:in `scan_family_children'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:51:in `block in scan_children'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `each'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:45:in `scan_children'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:33:in `block in scan'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:27:in `each'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect/scanner.rb:27:in `scan'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/platforms/detect.rb:9:in `scan'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/plugins/base_connection.rb:114:in `platform'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/transports/local.rb:46:in `select_runner'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/transports/local.rb:27:in `initialize'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/transports/local.rb:17:in `new'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/train-1.5.6/lib/train/transports/local.rb:17:in `connection'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/lib/inspec/backend.rb:51:in `create'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/lib/inspec/runner.rb:66:in `configure_transport'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/lib/inspec/runner.rb:58:in `initialize'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/lib/inspec/cli.rb:242:in `new'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/lib/inspec/cli.rb:242:in `exec'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'\n\tfrom /opt/inspec/embedded/lib/ruby/gems/2.5.0/gems/inspec-3.0.64/bin/inspec:12:in `<top (required)>'\n\tfrom /opt/inspec/bin/inspec:106:in `load'\n\tfrom /opt/inspec/bin/inspec:106:in `<main>'
```

Signed-off-by: Jared Ledvina <jared@techsmix.net>