### PR TITLE
Incorrect mysql session failure when rows are returned starting with the string 'error'

### DIFF
--- a/lib/resources/mysql_session.rb
+++ b/lib/resources/mysql_session.rb
@@ -30,7 +30,7 @@ module Inspec::Resources
       mysql_cmd = create_mysql_cmd(q, db)
       cmd = inspec.command(mysql_cmd)
       out = cmd.stdout + "\n" + cmd.stderr
-      if out =~ /Can't connect to .* MySQL server/ || out.downcase =~ /^error/
+      if out =~ /Can't connect to .* MySQL server/ || out.downcase =~ /^error /
         # skip this test if the server can't run the query
         warn("Can't connect to MySQL instance for SQL checks.")
       end


### PR DESCRIPTION
See #3659 for further details.

Fixes #3659 	

EDIT: (@clintoncwolfe) move issue reference into PR body