### PR TITLE
Remove extra files from inspec-core + file appbundling inspec

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -12,10 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/chef/inspec'
   spec.license       = 'Apache-2.0'
 
-  spec.files = %w{README.md MAINTAINERS.toml MAINTAINERS.md LICENSE
-                  inspec-core.gemspec Gemfile CHANGELOG.md} +
-               Dir.glob('{bin,lib,etc}/**/*', File::FNM_DOTMATCH)
-                  .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/ }
+  spec.files = %w{README.md LICENSE} + Dir.glob('{bin,lib,etc}/**/*', File::FNM_DOTMATCH)
+                                          .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/ }
 
   spec.executables   = %w{inspec}
   spec.require_paths = ['lib']

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/inspec/inspec'
   spec.license       = 'Apache-2.0'
 
-  spec.files = %w{README.md LICENSE} + Dir.glob(
+  # the gemfile and gemspec are necessary for appbundler so don't remove it
+  spec.files = %w{Gemfile inspec.gemspec README.md LICENSE} + Dir.glob(
     '{bin,lib,etc}/**/*', File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }
 


### PR DESCRIPTION
InSpec could no longer be appbundled since it was missing a gemfile and
gemspec. I added those back. I also trimmed down the gems in the
inspec-core gem.

Signed-off-by: Tim Smith <tsmith@chef.io>