### PR TITLE
habitat packaging: Fix inspec wrapper linking to /bin/bash instead of the bash hab package

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -55,7 +55,7 @@ wrap_inspec_bin() {
   local real_bin="$GEM_HOME/gems/inspec-${pkg_version}/bin/inspec"
   build_line "Adding wrapper $bin to $real_bin"
   cat <<EOF > "$bin"
-#!$(pkg_path_for bash)/bin/bash
+#!$(pkg_path_for core/bash)/bin/bash
 export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
 set -e
 

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -12,6 +12,7 @@ pkg_deps=(
   core/cacerts
   core/git
   core/ruby
+  core/bash
 )
 pkg_build_deps=(
   core/gcc


### PR DESCRIPTION
Adds missing `pkg_deps` for `core/bash`, otherwise
https://github.com/inspec/inspec/blob/master/habitat/plan.sh#L57 would
return an empty string for the pkg path and output `/bin/bash`
instead of the expected `/hab/pkgs/core/bash/.../bin/bash` path.

@jerryaldrichiii This looks like it might have been broken for some time but a recent update for #3645 caused this to fail on me

Signed-off-by: Will Fisher <wfisher@chef.io>