### PR TITLE
Add support for tags to aws_vpcs

### DIFF
--- a/docs/resources/aws_vpcs.md.erb
+++ b/docs/resources/aws_vpcs.md.erb
@@ -83,6 +83,15 @@ Filters the results to include only those VPCs that have the given DHCP Option S
       it { should_not exist }
     end
 
+### tags
+
+Check the VPC with Name tag 'my-vpc' exists and is unique
+
+    # Check 'my-vpc' exists
+    describe aws_vpcs.where{ !tags.nil? and tags.find { |h| h[:key] == 'Name' }[:value] == 'my-vpc' }
+      its('count') { should cmp 1 }
+    end
+
 ## Properties
 
 ### cidr_blocks

--- a/lib/resources/aws/aws_vpcs.rb
+++ b/lib/resources/aws/aws_vpcs.rb
@@ -15,6 +15,7 @@ class AwsVpcs < Inspec.resource(1)
   filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }
   filter.register_column(:cidr_blocks, field: :cidr_block)
         .register_column(:vpc_ids, field: :vpc_id)
+        .register_column(:tags, field: :tags)
   # We need a dummy here, so FilterTable will define and populate the dhcp_options_id field
   filter.register_column(:dummy, field: :dhcp_options_id)
         .register_column(:dhcp_options_ids) { |obj| obj.entries.map(&:dhcp_options_id).uniq }

--- a/test/unit/resources/aws_vpcs_test.rb
+++ b/test/unit/resources/aws_vpcs_test.rb
@@ -65,6 +65,14 @@ class AwsVpcsFilterCriteriaTest < Minitest::Test
     miss = AwsVpcs.new.where(:dhcp_options_id => 'dopt-12345678')
     refute(miss.exists?)
   end
+
+  def test_filter_with_name_tag
+    hit = AwsVpcs.new.where { tags.find { |h| h[:key] == 'Name' }[:value] == 'dev-vpc' }
+    assert(hit.exists?)
+
+    miss = AwsVpcs.new.where { tags.find { |h| h[:key] == 'Name' }[:value] == 'prod-vpc' }
+    refute(miss.exists?)
+  end
 end
 
 #=============================================================================#
@@ -94,6 +102,10 @@ class AwsVpcsProperties < Minitest::Test
     # Should be de-duplicated
     assert_equal(1, @vpcs.dhcp_options_ids.count)
   end
+
+  def test_property_tags
+    refute_empty(@vpcs.tags)
+  end
 end
 #=============================================================================#
 #                               Test Fixtures
@@ -114,7 +126,11 @@ module MAVPB
           state: 'available',
           vpc_id: 'vpc-aaaabbbb',
           instance_tenancy: 'default',
-          is_default: true
+          is_default: true,
+          tags: [{
+            key: 'Name',
+            value: 'dev-vpc'
+          }]
         }),
         OpenStruct.new({
           cidr_block: '10.1.0.0/16',
@@ -122,7 +138,11 @@ module MAVPB
           state: 'available',
           vpc_id: 'vpc-12344321',
           instance_tenancy: 'default',
-          is_default: false
+          is_default: false,
+          tags: [{
+            key: 'Name',
+            value: 'test-vpc'
+          }]
         }),
       ]
 


### PR DESCRIPTION
Adds tag property to aws_vpcs to allow tag based queries:

```
  # check 'my-vpc' exists and is unique
  describe aws_vpcs.where{ !tags.nil? and tags.find{|h| h[:key] == 'Name'}[:value] == 'my-vpc'} do
    its('count') { should cmp 1 }
  end
```