### PR TITLE
Update Ruby versions used for testing; fix Travis CI issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ bundler_args: "--without integration tools maintenance deploy"
 before_install:
 - gem update --system
 - gem --version
-- rvm @global do gem install bundler
 - bundle --version
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,41 +15,41 @@ before_install:
 - bundle --version
 matrix:
   include:
-  - rvm: 2.3.6
-  - rvm: 2.4.3
-  - rvm: 2.5.1
-  - rvm: 2.4.3
+  - rvm: 2.3.8
+  - rvm: 2.4.5
+  - rvm: 2.5.3
+  - rvm: 2.4.5
     script: bundle exec rake $SUITE
     env: SUITE="test:functional"
-  - rvm: 2.4.3
+  - rvm: 2.4.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-ubuntu-1204]
-  - rvm: 2.4.3
+  - rvm: 2.4.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-ubuntu-1604]
-  - rvm: 2.4.3
+  - rvm: 2.4.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-centos-68]
-  - rvm: 2.4.3
+  - rvm: 2.4.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-centos-7]
-  - rvm: 2.4.3
+  - rvm: 2.4.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-debian-8]
-  - rvm: 2.4.3
+  - rvm: 2.4.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-oracle-72]
-  - rvm: 2.4.3
+  - rvm: 2.4.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-fedora-24]
-  - rvm: 2.4.3
+  - rvm: 2.4.5
     sudo: false
     cache:
       apt: true

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -8,6 +8,7 @@ require 'fileutils'
 require 'rubygems/package'
 require 'rubygems/name_tuple'
 require 'rubygems/uninstaller'
+require 'rubygems/remote_fetcher'
 
 require 'inspec/plugin/v2/filter'
 

--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -37,7 +37,7 @@ end
 build_version Inspec::VERSION
 build_iteration 1
 
-override 'ruby', version: '2.5.1'
+override 'ruby', version: '2.5.3'
 # RubyGems 2.7.0 caused issues in the Jenkins pipelines, trouble installing bundler.
 # This issue is not evident in 2.6.x, hence the pin.
 override 'rubygems', version: '2.6.14'

--- a/test/unit/plugin/v2/installer_test.rb
+++ b/test/unit/plugin/v2/installer_test.rb
@@ -39,7 +39,7 @@ module InstallerTestHelpers
 
     @installer = Inspec::Plugin::V2::Installer.instance
     reset_globals
-    WebMock.disable_net_connect!(allow: 'api.rubygems.org')
+    WebMock.disable_net_connect!(allow: %r{(api\.)?rubygems\.org/.*})
   end
 
   def teardown


### PR DESCRIPTION
This PR updates Ruby versions used in CI testing to the latest patchlevels:
 * 2.3.6 => 2.3.8
 * 2.4.3 => 2.4.5
 * 2.5.1 => 2.5.3

Pile of bugfixes and 2 CVEs:

    CVE-2018-16396: Tainted flags are not propagated in Array#pack and String#unpack with some directives
    CVE-2018-16395: OpenSSL::X509::Name equality check does not work correctly

The upgrade has two other consequences:
 * bundler is now included with the version of rubygems included in each of these rubies.  Additionally, TravisCI's ruby build pack includes this newer rubygem; **this causes all TravisCI jobs to halt**, since we were installing bundler as a pre-install job, and it wanted overwrite confirmation.  Removing the extra install request resolved the issue.
 * rubygems has a few small internal changes that cause the plugin installer system to fail tests.  Both fixes are backward compatible.
   * It now hits both api.rubygems.org and plain rubygems.org in API requests. Our unit tests needed to be updated to allow this.
   * The search library, Gem::RemoteFetcher, is no longer auto-loaded; so we explicitly load it in the installer library.


Signed-off-by: Tim Smith <tsmith@chef.io>