### PR TITLE
Fix oracledb_session SQLCL and CSV output parsing

### DIFF
--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -99,7 +99,9 @@ module Inspec::Resources
     end
 
     def parse_csv_result(stdout)
-      output = stdout.delete(/\r/)
+      output = stdout.delete("\r")
+      # Remove blank first line if it exists
+      output = output.gsub(/^$\n/, '')
       table = CSV.parse(output, { headers: true })
 
       # convert to hash

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -40,7 +40,7 @@ module Inspec::Resources
       @su_user = opts[:as_os_user]
       @db_role = opts[:as_db_role]
 
-      # we prefer sqlci although it is way slower than sqlplus, but it understands csv properly
+      # we prefer sqlcl although it is way slower than sqlplus, but it understands csv properly
       @sqlcl_bin = opts[:sqlcl_bin] || 'sql' unless opts.key?(:sqlplus_bin) # don't use it if user specified sqlplus_bin option
       @sqlplus_bin = opts[:sqlplus_bin] || 'sqlplus'
 

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -41,7 +41,7 @@ module Inspec::Resources
       @db_role = opts[:as_db_role]
 
       # we prefer sqlci although it is way slower than sqlplus, but it understands csv properly
-      @sqlcl_bin = 'sql' unless opts.key?(:sqlplus_bin) # don't use it if user specified sqlplus_bin option
+      @sqlcl_bin = opts[:sqlcl_bin] || 'sql' unless opts.key?(:sqlplus_bin) # don't use it if user specified sqlplus_bin option
       @sqlplus_bin = opts[:sqlplus_bin] || 'sqlplus'
 
       return fail_resource "Can't run Oracle checks without authentication" if @su_user.nil? && (@user.nil? || @password.nil?)

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -68,11 +68,11 @@ module Inspec::Resources
       query = verify_query(escaped_query)
       query += ';' unless query.end_with?(';')
       if @db_role.nil?
-        command = %{#{bin} "#{@user}"/"#{@password}"@#{@host}:#{@port}/#{@service} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC}
+        command = %{#{bin} -S "#{@user}"/"#{@password}"@#{@host}:#{@port}/#{@service} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC}
       elsif @su_user.nil?
-        command = %{#{bin} "#{@user}"/"#{@password}"@#{@host}:#{@port}/#{@service} as #{@db_role} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC}
+        command = %{#{bin} -S "#{@user}"/"#{@password}"@#{@host}:#{@port}/#{@service} as #{@db_role} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC}
       else
-        command = %{su - #{@su_user} -c "env ORACLE_SID=#{@service} #{bin} / as #{@db_role} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC"}
+        command = %{su - #{@su_user} -c "env ORACLE_SID=#{@service} #{bin} -S / as #{@db_role} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC"}
       end
       cmd = inspec.command(command)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -473,7 +473,7 @@ class MockLoader
       "7d1a7a0f2bd1e7da9a6904e1f28981146ec01a0323623e12a8579d30a3960a79" => cmd.call('mssql-result'),
       # oracle
       "bash -c 'type \"sqlplus\"'" => cmd.call('oracle-cmd'),
-      "1998da5bc0f09bd5258fad51f45447556572b747f631661831d6fcb49269a448" => cmd.call('oracle-result'),
+      "bfff2fe305897dbd92d32be74662278dfd898c97fae5c34e929e40ad2d92732c" => cmd.call('oracle-result'),
       # nginx mock cmd
       %{nginx -V 2>&1} => cmd.call('nginx-v'),
       %{/usr/sbin/nginx -V 2>&1} => cmd.call('nginx-v'),


### PR DESCRIPTION
## Description

The `oracledb_session` resource is non-functional against the following: `Oracle Standard Edition One (11.2.0.4.v18)` on RDS using `sqlcl-18.3.0.259.2029`

* sqlcl_bin option isn't used if provided
* silent options for sqlcl and sqlplus binaries not passed, need to remove command prompt, command echoing and connection banners to avoid breaking CSV parsing
* Fix 'no implicit conversion of Regexp into String' with string `.delete`
* Leading blank line in output breaks CSV parsing

Potentially related to #3594

The CSV output is preferred but appears not to be covered with the unit test mocking (test/unit/mock/cmd/oracle-result is the HTML format)

## InSpec Version
3.0.52 (last change to `oracledb_session` resource was v2.2.35 in https://github.com/inspec/inspec/pull/3170)

## Replication Case
```ruby
control 'test' do
  impact 1.0
  title 'Test'
  desc 'Test oracledb_session'
  sql = oracledb_session(user: '<USER>', password: '<PASS>', host: '<HOST>', port: '1521', service: 'ORCL', sqlcl_bin: '<PATH TO SQLCL>')
  describe sql.query('select username, profile from dba_users;').column('profile') do
    it { should include 'DEFAULT' }
  end      

  describe sql.query('SELECT NAME AS VALUE FROM v$database;').row(0).column('value') do
    its('value') { should eq 'ORCL' }
  end
end
```

## Output
Before:
```
Profile: InSpec Profile (oracledb)
Version: 0.1.0
Target:  local://

  ×  test: TEST (2 failed)
     ×  [] should include "DEFAULT"
     expected [] to include "DEFAULT"
     ×  SQL Column value should eq "ORCL"

     expected: "ORCL"
          got: ""

     (compared using ==)
```
After:
```
Profile: InSpec Profile (oracledb)
Version: 0.1.0
Target:  local://

  ✔  test: TEST
     ✔  ["RDSADMIN", "RDSADMIN", "DEFAULT", "RDSADMIN", "DEFAULT", "DEFAULT", "DEFAULT", "RDSADMIN", "DEFAULT"] should include "DEFAULT"
     ✔  SQL Column value should eq "ORCL"

```
