### PR TITLE
Adjust version number for availability of aws_sqs_queue

### DIFF
--- a/docs/resources/aws_sqs_queue.md.erb
+++ b/docs/resources/aws_sqs_queue.md.erb
@@ -16,7 +16,7 @@ This resource is distributed along with InSpec itself. You can use it automatica
 
 ### Version
 
-This resource first became available in v3.1.4 of InSpec.
+This resource first became available in v3.2.5 of InSpec.
 
 ## Syntax
 


### PR DESCRIPTION
Trivial change, mainly to cause rebuild