### PR TITLE
Fix TravisCI hanging due to Bundler being installed twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ bundler_args: "--without integration tools maintenance deploy"
 before_install:
 - gem update --system
 - gem --version
-- rvm @global do gem install bundler
 - bundle --version
 matrix:
   include:


### PR DESCRIPTION
Remove bundle install command from travis config, as it is already installed with Ruby.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>