### PR TITLE
Alter supermarket fetch test to use json to examine results

### DIFF
--- a/test/functional/helper.rb
+++ b/test/functional/helper.rb
@@ -87,16 +87,21 @@ module FunctionalHelper
 
   def inspec(commandline, prefix = nil)
     if is_windows?
-      result = CMD.run_command("cmd /C \"#{prefix} bundle exec ruby #{exec_inspec} #{commandline}\"")
+      invocation  = "cmd /C \"#{prefix} bundle exec ruby #{exec_inspec} #{commandline}\""
+      result = CMD.run_command(invocation)
       result.stdout.encode!(universal_newline: true)
       result.stderr.encode!(universal_newline: true)
       convert_windows_output(result.stdout)
       # remove the CLIXML header trash in windows
       result.stderr.gsub!("#< CLIXML\n", '')
-      Inspec::FuncTestRunResult.new(result)
+      ftrr = Inspec::FuncTestRunResult.new(result)
     else
-      Inspec::FuncTestRunResult.new(CMD.run_command("#{prefix} #{exec_inspec} #{commandline}"))
+      invocation = "#{prefix} #{exec_inspec} #{commandline}"
+      ftrr = Inspec::FuncTestRunResult.new(CMD.run_command(invocation))
     end
+
+    ftrr.payload.invocation = invocation
+    ftrr
   end
 
   def inspec_with_env(commandline, env = {})
@@ -174,7 +179,7 @@ module FunctionalHelper
   def assemble_env_prefix(env = {})
     if is_windows?
       env_prefix = env.to_a.map { |assignment| "set #{assignment[0]}=#{assignment[1]}" }.join('&& ')
-      env_prefix += '&& '
+      env_prefix += '&& ' unless env_prefix.empty?
     else
       env_prefix = env.to_a.map { |assignment| "#{assignment[0]}=#{assignment[1]}" }.join(' ')
       env_prefix += ' '

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -354,12 +354,14 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
     end
 
     it 'can run supermarket profiles from inspec.yml' do
-      out = inspec("exec #{File.join(profile_path, 'supermarket-dep')} --no-create-lockfile")
-      if is_windows?
-        out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: \e[38;5;41m1 successful control\e[0m, \e[38;5;9m1 control failure\e[0m, 0 controls skipped\n"
-      else
-        out.stdout.force_encoding(Encoding::UTF_8).must_include "Profile Summary: \e[38;5;41m2 successful controls\e[0m, 0 control failures, 0 controls skipped\n"
-      end
+      run_result = run_inspec_process("exec #{File.join(profile_path, 'supermarket-dep')}", json: true)
+
+      # The test only runs controls from the 2nd profile
+      json_result = run_result.payload.json["profiles"][1]["controls"]
+      json_result[0]["results"][0]["status"].must_equal "passed"
+
+      # Expect one control failure on windows, apparently
+      json_result[1]["results"][0]["status"].must_equal (is_windows? ? 'failed' : 'passed')
     end
   end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -356,6 +356,10 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
     it 'can run supermarket profiles from inspec.yml' do
       run_result = run_inspec_process("exec #{File.join(profile_path, 'supermarket-dep')}", json: true)
 
+      # Intentional failure to cause appveyor to print output
+      run_result.stdout.must_equal ''
+      run_result.stderr.must_equal ''
+
       # The test only runs controls from the 2nd profile
       json_result = run_result.payload.json["profiles"][1]["controls"]
       json_result[0]["results"][0]["status"].must_equal "passed"

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -357,8 +357,11 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
       run_result = run_inspec_process("exec #{File.join(profile_path, 'supermarket-dep')}", json: true)
 
       # Intentional failure to cause appveyor to print output
-      run_result.stdout.must_equal ''
-      run_result.stderr.must_equal ''
+      msg = ''
+      msg += "\nInvocation:\n" + run_result.payload.invocation
+      msg += "\nSTDOUT:\n" + run_result.stdout
+      msg += "\nSTDERR:\n" + run_result.stderr
+      msg.must_equal ''
 
       # The test only runs controls from the 2nd profile
       json_result = run_result.payload.json["profiles"][1]["controls"]


### PR DESCRIPTION
We've been seeing intermittent appveyor failures on the functional tests, like [here](https://ci.appveyor.com/project/chef/inspec/builds/21272175/job/ky57jiygmys5tnk8)

```
 1) Failure:
inspec exec::when using profiles on the supermarket#test_0002_can run supermarket profiles from inspec.yml [C:/projects/inspec/test/functional/inspec_exec_test.rb:359]:
Expected # encoding: UTF-8
"[2018-12-28T17:16:13+00:00] WARN: URL target https://github.com/nathenharvey/tmp_compliance_profile/ transformed to https://github.com/nathenharvey/tmp_compliance_profile/archive/master.tar.gz. Consider using the git fetcher\n" to include # encoding: UTF-8
"Profile Summary: \e[38;5;41m1 successful control\e[0m, \e[38;5;9m1 control failure\e[0m, 0 controls skipped\n".

```

The test is examining the passed test count by looking for the counts in STDOUT.  On Windows, this is failing; regardless of platform, it's hard to see what is expected.

This PR modifies the test to use the `run_inspec_process` in JSON mode so we can pick apart the results without worrying as much about formatting.

