### PR TITLE
Stabilize profile export functional test

### DIFF
--- a/test/functional/inspec_json_profile_test.rb
+++ b/test/functional/inspec_json_profile_test.rb
@@ -131,17 +131,18 @@ describe 'inspec json' do
   end
 
   describe 'inspec json with a inheritance profile' do
-    let(:profile) { File.join(examples_path, 'meta-profile') }
+    let(:profile) { File.join(profile_path, 'export-json', 'empty-wrapper') }
 
-    it 'can execute a profile inheritance' do
+    it 'can export a profile that uses inheritance' do
       out = inspec('json ' + profile)
+      out.stderr.must_be_empty
       out.exit_status.must_equal 0
-      JSON.load(out.stdout).must_be_kind_of Hash
-    end
 
-    it 'populates code from child profiles' do
-      out = inspec('json ' + profile)
+      # This will throw an exception if it is garbled
       json = JSON.load(out.stdout)
+      # and here we verify (very passingly!) that is a structure we expect
+      json.must_be_kind_of Hash
+
       json['controls'].each do |control|
         control['code'].empty?.must_equal false
       end

--- a/test/unit/mock/profiles/export-json/empty-wrapper/controls/includes.rb
+++ b/test/unit/mock/profiles/export-json/empty-wrapper/controls/includes.rb
@@ -1,0 +1,4 @@
+# encoding: utf-8
+
+# import full profile
+include_controls 'simple-profile'

--- a/test/unit/mock/profiles/export-json/empty-wrapper/inspec.yml
+++ b/test/unit/mock/profiles/export-json/empty-wrapper/inspec.yml
@@ -1,0 +1,11 @@
+name: empty-wrapper
+title: Empty Wrapper Profile
+maintainer: InSpec Authors
+copyright: InSpec Authors
+copyright_email: support@chef.io
+license: Apache-2.0
+summary: An InSpec Profile that is only consuming dependencies
+version: 0.2.0
+depends:
+  - name: simple-profile
+    path: ../simple-profile

--- a/test/unit/mock/profiles/export-json/simple-profile/controls/basic.rb
+++ b/test/unit/mock/profiles/export-json/simple-profile/controls/basic.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+# you add controls here
+control 'tmp-1.0' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/export-json/simple-profile/inspec.yml
+++ b/test/unit/mock/profiles/export-json/simple-profile/inspec.yml
@@ -1,0 +1,10 @@
+name: simple-profile
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: support@chef.io
+license: Apache-2.0
+summary: A very simple InSpec Compliance Profile
+version: 0.1.0
+supports:
+  platform: os


### PR DESCRIPTION
The profile export command, `inspec json`, has a functional test that verifies it works when targeting a profile with a dependency.  As written, the test pointed at a dependency maintained by the devsec project.  Whenever the dependent repo would change, the checksum would change, causing the lockfile to go stale and the test to fail.  [example](https://travis-ci.org/inspec/inspec/jobs/473136872#L1122) 

Since we don't care about fetching in this test, this PR changes the test to examine a local profile using the `path:` fetcher, so that the checksum will never go stale again.

Refs #3694, #3351 