### PR TITLE
Adding a resource and doc for aws_sts_caller_identity

### DIFF
--- a/docs/resources/aws_sts_caller_identify.md.erb
+++ b/docs/resources/aws_sts_caller_identify.md.erb
@@ -1,0 +1,62 @@
+---
+title: About the aws_sts_caller_identity Resource
+---
+
+# aws\_sts\_caller\_identity
+
+Use the `aws_sts_caller_identity` InSpec audit resource to test properties of AWS credentials being used in the current InSpec scan.
+
+<br>
+
+## Syntax
+
+An `aws_sts_caller_identity` resource block tests can run matchers on the ARN of the AWS credentials being used in the scan.  You can also test if the credentials are in a GovCloud account.
+
+    # Check that the user running the scan is correct
+    describe aws_sts_caller_identity do
+      its("arn") { should match "arn:aws:iam::.*:user/human-user" }
+    end
+
+    # Test if the account is GovCloud
+    describe aws_sts_caller_identity do
+      it { should be_govcloud }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+    # Skip a check if GovCloud
+    if aws_sts_caller_identity.govcloud?
+      describe 'Skip Root User MFA check on GovCloud' do
+        skip
+      end
+    else
+      describe aws_iam_root_user do
+        it { should have_mfa_enabled }  
+      end
+    end
+
+<br>
+
+## Properties
+
+### arn
+
+The `arn` property identifies the AWS ARN of the credentials being used in the current InSpec scan.
+
+    describe aws_sts_caller_identity do
+      its('arn') { should match 'arn:aws:iam::.*:user/human-user' }
+    end
+
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### be\_govcloud
+
+The `be_govcloud` matcher tests if the account is a 'GovCloud' AWS Account.
+
+    it { should_not be_govcloud }

--- a/lib/resources/aws/aws_sts_caller_identity.rb
+++ b/lib/resources/aws/aws_sts_caller_identity.rb
@@ -1,0 +1,57 @@
+class AwsStsCallerIdentity < Inspec.resource(1)
+  name 'aws_sts_caller_identity'
+  desc 'Verifies settings for an AWS STS Caller Identity.'
+  example '
+    describe aws_sts_caller_identity do
+      its("arn") { should match "arn:aws:iam::.*:user/human-user" }
+    end
+
+    # Test if the account is GovCloud
+    describe aws_sts_caller_identity do
+      it { should be_govcloud }
+    end
+  '
+  supports platform: 'aws'
+  include AwsSingularResourceMixin
+
+  attr_reader :arn, :arn_components
+
+  def to_s
+    'AWS Security Token Service Caller Identity'
+  end
+
+  def govcloud?
+    arn_components[:partition] == 'aws-us-gov'
+  end
+
+  def arn_components
+    @arn_components = fetch_arn_components
+  end
+
+  private
+
+  def catch_aws_errors
+    yield
+  end
+
+  def fetch_from_api
+    backend = BackendFactory.create(inspec_runner)
+    gci_response = backend.get_caller_identity
+    @arn = gci_response.arn
+  end
+
+  def fetch_arn_components
+    @arn_components = Hash[ [:arn, :partition, :service, :region, :account_id, :resource].zip(@arn.split(':'))]
+  end
+
+  class Backend
+    class AwsClientApi < AwsBackendBase
+      BackendFactory.set_default_backend self
+      self.aws_client_class = Aws::STS::Client
+
+      def get_caller_identity
+        aws_service_client.get_caller_identity
+      end
+    end
+  end
+end


### PR DESCRIPTION
I have found this useful in changing behavior when scannign GovCloud accounts