### PR TITLE
postgres_session: Fix postgres directory searching on non-debian os

### DIFF
--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -77,10 +77,7 @@ module Inspec::Resources
         '/var/lib/postgresql/data',
       ]
 
-      dir_list.each do |dir|
-        data_dir_loc = dir if inspec.directory(dir).exist?
-        break if inspec.directory(dir).exist?
-      end
+      data_dir_loc = dir_list.detect { |i| inspec.directory(i).exist? }
       
       if data_dir_loc.nil?
         warn 'Unable to find the PostgreSQL data_dir in expected location(s), please

--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -81,7 +81,7 @@ module Inspec::Resources
         data_dir_loc = dir if inspec.directory(dir).exist?
         break if inspec.directory(dir).exist?
       end
-
+      
       if data_dir_loc.nil?
         warn 'Unable to find the PostgreSQL data_dir in expected location(s), please
         execute "psql -t -A -p <port> -h <host> -c "show hba_file";" as the PostgreSQL

--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -69,7 +69,6 @@ module Inspec::Resources
     end
 
     def locate_data_dir_location_by_version(ver = @version)
-      data_dir_loc = nil
       dir_list = [
         "/var/lib/pgsql/#{ver}/data",
         '/var/lib/pgsql/data',

--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -78,7 +78,7 @@ module Inspec::Resources
       ]
 
       data_dir_loc = dir_list.detect { |i| inspec.directory(i).exist? }
-      
+
       if data_dir_loc.nil?
         warn 'Unable to find the PostgreSQL data_dir in expected location(s), please
         execute "psql -t -A -p <port> -h <host> -c "show hba_file";" as the PostgreSQL

--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -79,7 +79,7 @@ module Inspec::Resources
 
       dir_list.each do |dir|
         data_dir_loc = dir if inspec.directory(dir).exist?
-	break if inspec.directory(dir).exist?
+        break if inspec.directory(dir).exist?
       end
 
       if data_dir_loc.nil?

--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -79,7 +79,7 @@ module Inspec::Resources
 
       dir_list.each do |dir|
         data_dir_loc = dir if inspec.directory(dir).exist?
-        break
+	break if inspec.directory(dir).exist?
       end
 
       if data_dir_loc.nil?


### PR DESCRIPTION
Only break the postgres data directory search when the directory is found.  Fixes #3707