### PR TITLE
[ROLLUP] Formalize config file and add credset support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,10 @@
 # encoding: utf-8
 source 'https://rubygems.org'
+
+# Temporary
+# gem 'train', path: '../train'
+gem 'train', git: 'https://github.com/inspec/train.git', branch: 'cw/cred-set-support' 
+
 gemspec name: 'inspec'
 
 gem 'ffi', '>= 1.9.14'

--- a/lib/bundles/inspec-supermarket/cli.rb
+++ b/lib/bundles/inspec-supermarket/cli.rb
@@ -30,7 +30,7 @@ module Supermarket
     desc 'exec PROFILE', 'execute a Supermarket profile'
     exec_options
     def exec(*tests)
-      o = opts(:exec).dup
+      o = config
       diagnose(o)
       configure_logger(o)
 

--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -41,7 +41,7 @@ module Inspec
     # @param [Hash] config for the transport backend
     # @return [TransportBackend] enriched transport instance
     def self.create(config) # rubocop:disable Metrics/AbcSize
-      train_credentials = Train.unpack_target_creds(config)
+      train_credentials = config.unpack_train_credentials
       transport_name = Train.validate_backend(train_credentials)
       transport = Train.create(transport_name, train_credentials)
       if transport.nil?
@@ -85,9 +85,9 @@ module Inspec
 
       cls.new
     rescue Train::ClientError => e
-      raise "Client error, can't connect to '#{name}' backend: #{e.message}"
+      raise "Client error, can't connect to '#{transport_name}' backend: #{e.message}"
     rescue Train::TransportError => e
-      raise "Transport error, can't connect to '#{name}' backend: #{e.message}"
+      raise "Transport error, can't connect to '#{transport_name}' backend: #{e.message}"
     end
   end
 end

--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -41,16 +41,16 @@ module Inspec
     # @param [Hash] config for the transport backend
     # @return [TransportBackend] enriched transport instance
     def self.create(config) # rubocop:disable Metrics/AbcSize
-      conf = Train.target_config(config)
-      name = Train.validate_backend(conf)
-      transport = Train.create(name, conf)
+      train_credentials = Train.unpack_target_creds(config)
+      transport_name = Train.validate_backend(train_credentials)
+      transport = Train.create(transport_name, train_credentials)
       if transport.nil?
-        raise "Can't find transport backend '#{name}'."
+        raise "Can't find transport backend '#{transport_name}'."
       end
 
       connection = transport.connection
       if connection.nil?
-        raise "Can't connect to transport backend '#{name}'."
+        raise "Can't connect to transport backend '#{transport_name}'."
       end
 
       # Set caching settings. We always want to enable caching for

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -75,8 +75,9 @@ module Inspec
         desc: 'Whether to use disable sspi authentication, defaults to false (WinRM).'
       option :winrm_basic_auth, type: :boolean,
         desc: 'Whether to use basic authentication, defaults to false (WinRM).'
-      option :json_config, type: :string,
+      option :config, type: :string,
         desc: 'Read configuration from JSON file (`-` reads from stdin).'
+      option :json_config, type: :string, hide: true
       option :proxy_command, type: :string,
         desc: 'Specifies the command to use to connect to the server'
       option :bastion_host, type: :string,
@@ -118,7 +119,7 @@ module Inspec
         desc: 'Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.'
     end
 
-    def self.detect(params: {}, indent: 0, color: 39)
+    def self.format_platform_info(params: {}, indent: 0, color: 39)
       str = ''
       params.each { |item, info|
         data = info
@@ -254,8 +255,8 @@ module Inspec
       # logging singleton Inspec::Log. Eventually it would be nice to
       # move internal debug logging to use this logging singleton.
       #
-      loc = if o.log_location
-              o.log_location
+      loc = if o['log_location']
+              o['log_location']
             elsif suppress_log_output?(o)
               STDERR
             else
@@ -263,14 +264,14 @@ module Inspec
             end
 
       Inspec::Log.init(loc)
-      Inspec::Log.level = get_log_level(o.log_level)
+      Inspec::Log.level = get_log_level(o['log_level'])
 
       o[:logger] = Logger.new(loc)
       # output json if we have activated the json formatter
       if o['log-format'] == 'json'
         o[:logger].formatter = Logger::JSONFormatter.new
       end
-      o[:logger].level = get_log_level(o.log_level)
+      o[:logger].level = get_log_level(o['log_level'])
     end
   end
 end

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -118,91 +118,6 @@ module Inspec
         desc: 'Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.'
     end
 
-    def self.default_options
-      {
-        exec: {
-          'reporter' => ['cli'],
-          'show_progress' => false,
-          'color' => true,
-          'create_lockfile' => true,
-          'backend_cache' => true,
-        },
-        shell: {
-          'reporter' => ['cli'],
-        },
-      }
-    end
-
-    def self.parse_reporters(opts) # rubocop:disable Metrics/AbcSize
-      # default to cli report for ad-hoc runners
-      opts['reporter'] = ['cli'] if opts['reporter'].nil?
-
-      # parse out cli to proper report format
-      if opts['reporter'].is_a?(Array)
-        reports = {}
-        opts['reporter'].each do |report|
-          reporter_name, target = report.split(':', 2)
-          if target.nil? || target.strip == '-'
-            reports[reporter_name] = { 'stdout' => true }
-          else
-            reports[reporter_name] = {
-              'file' => target,
-              'stdout' => false,
-            }
-            reports[reporter_name]['target_id'] = opts['target_id'] if opts['target_id']
-          end
-        end
-        opts['reporter'] = reports
-      end
-
-      # add in stdout if not specified
-      if opts['reporter'].is_a?(Hash)
-        opts['reporter'].each do |reporter_name, config|
-          opts['reporter'][reporter_name] = {} if config.nil?
-          opts['reporter'][reporter_name]['stdout'] = true if opts['reporter'][reporter_name].empty?
-          opts['reporter'][reporter_name]['target_id'] = opts['target_id'] if opts['target_id']
-        end
-      end
-
-      validate_reporters(opts['reporter'])
-      opts
-    end
-
-    def self.validate_reporters(reporters)
-      return if reporters.nil?
-
-      valid_types = [
-        'automate',
-        'cli',
-        'documentation',
-        'html',
-        'json',
-        'json-automate',
-        'json-min',
-        'json-rspec',
-        'junit',
-        'progress',
-        'yaml',
-      ]
-
-      reporters.each do |k, v|
-        raise NotImplementedError, "'#{k}' is not a valid reporter type." unless valid_types.include?(k)
-
-        next unless k == 'automate'
-        %w{token url}.each do |option|
-          raise Inspec::ReporterError, "You must specify a automate #{option} via the json-config." if v[option].nil?
-        end
-      end
-
-      # check to make sure we are only reporting one type to stdout
-      stdout = 0
-      reporters.each_value do |v|
-        stdout += 1 if v['stdout'] == true
-      end
-
-      raise ArgumentError, 'The option --reporter can only have a single report outputting to stdout.' if stdout > 1
-    end
-
     def self.detect(params: {}, indent: 0, color: 39)
       str = ''
       params.each { |item, info|
@@ -286,86 +201,12 @@ module Inspec
       false
     end
 
-    def diagnose(opts)
-      return unless opts['diagnose']
-      puts "InSpec version: #{Inspec::VERSION}"
-      puts "Train version: #{Train::VERSION}"
-      puts 'Command line configuration:'
-      pp options
-      puts 'JSON configuration file:'
-      pp options_json
-      puts 'Merged configuration:'
-      pp opts
-      puts
+    def diagnose(_ = nil)
+      config.diagnose
     end
 
-    def opts(type = nil)
-      o = merged_opts(type)
-
-      # Due to limitations in Thor it is not possible to set an argument to be
-      # both optional and its value to be mandatory. E.g. the user supplying
-      # the --password argument is optional and not always required, but
-      # whenever it is used, it requires a value. Handle options that were
-      # defined above and require a value here:
-      %w{password sudo-password}.each do |v|
-        id = v.tr('-', '_').to_sym
-        next unless o[id] == -1
-        raise ArgumentError, "Please provide a value for --#{v}. For example: --#{v}=hello."
-      end
-
-      # Infer `--sudo` if using `--sudo-password` without `--sudo`
-      if o[:sudo_password] && !o[:sudo]
-        o[:sudo] = true
-        warn 'WARN: `--sudo-password` used without `--sudo`. Adding `--sudo`.'
-      end
-
-      # check for compliance settings
-      if o['compliance']
-        require 'plugins/inspec-compliance/lib/inspec-compliance/api'
-        InspecPlugins::Compliance::API.login(o['compliance'])
-      end
-
-      o
-    end
-
-    def merged_opts(type = nil)
-      opts = {}
-
-      # start with default options if we have any
-      opts = BaseCLI.default_options[type] unless type.nil? || BaseCLI.default_options[type].nil?
-      opts['type'] = type unless type.nil?
-      Inspec::BaseCLI.inspec_cli_command = type
-
-      # merge in any options from json-config
-      json_config = options_json
-      opts.merge!(json_config)
-
-      # merge in any options defined via thor
-      opts.merge!(options)
-
-      # parse reporter options
-      opts = BaseCLI.parse_reporters(opts) if %i(exec shell).include?(type)
-
-      Thor::CoreExt::HashWithIndifferentAccess.new(opts)
-    end
-
-    def options_json
-      conffile = options['json_config']
-      @json ||= conffile ? read_config(conffile) : {}
-    end
-
-    def read_config(file)
-      if file == '-'
-        puts 'WARN: reading JSON config from standard input' if STDIN.tty?
-        config = STDIN.read
-      else
-        config = File.read(file)
-      end
-
-      JSON.parse(config)
-    rescue JSON::ParserError => e
-      puts "Failed to load JSON configuration: #{e}\nConfig was: #{config.inspect}"
-      exit 1
+    def config
+      @config ||= Inspec::Config.new(options) # 'options' here is CLI opts from Thor
     end
 
     # get the log level
@@ -409,7 +250,7 @@ module Inspec
 
     def configure_logger(o)
       #
-      # TODO(ssd): This is a big gross, but this configures the
+      # TODO(ssd): This is a bit gross, but this configures the
       # logging singleton Inspec::Log. Eventually it would be nice to
       # move internal debug logging to use this logging singleton.
       #

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -1,0 +1,279 @@
+# Represents InSpec configuration.  Merges defaults, config file options,
+# and CLI arguments.
+
+require 'pp'
+require 'stringio'
+
+module Inspec
+  class Config
+
+    extend Forwardable
+
+    def_delegators :@final_options, :each, :delete, :[], :[]=, :key?
+    attr_reader :final_options
+
+    def initialize(cli_opts = {}, cfg_io = nil, command_name = nil)
+      @command_name = command_name || ARGV[0].to_sym
+      @defaults = Defaults.for_command(command_name)
+
+      @cli_opts = cli_opts.dup
+
+      cfg_io = resolve_cfg_io(@cli_opts, cfg_io)
+      @cfg_file_contents = read_cfg_file_io(cfg_io)
+
+      @merged_options = merge_options
+      @final_options = finalize_options
+      @final_options = Thor::CoreExt::HashWithIndifferentAccess.new(@final_options)
+    end
+
+    def target_uri
+      # Default local:///
+      # May be on CLI as -t or --target
+      # May be in config file as cli_opts/target_uri
+    end
+
+    def fetch_credentials(transport_name, credset_name, options = {})
+      credential_option_defaults = options[:option_defaults]
+
+      # Start with defaults for options
+      # Look for credentials/tranport_name/credset
+      # Override with CLI args
+    end
+
+    def diagnose
+      return unless self[:diagnose]
+      puts "InSpec version: #{Inspec::VERSION}"
+      puts "Train version: #{Train::VERSION}"
+      puts 'Command line configuration:'
+      pp @cli_opts
+      puts 'JSON configuration file:'
+      pp @cfg_file_contents
+      puts 'Merged configuration:'
+      pp @merged_options
+      puts
+    end
+
+    private
+
+    #-----------------------------------------------------------------------#
+    #                         Reading Config Files
+    #-----------------------------------------------------------------------#
+    def resolve_cfg_io(cli_opts, cfg_io)
+      unless cfg_io
+        path = cli_opts[:config] || cli_opts[:json_config]
+        if path == '-'
+          Inspec::Log.warn 'Reading JSON config from standard input' if STDIN.tty?
+          path = STDIN
+        end
+        cfg_io = File.read(path) if path
+        cfg_io ||= StringIO.new('{ "version": "1.1" }')
+      end
+      cfg_io
+    end
+
+    def read_cfg_file_io(cfg_io)
+      contents = cfg_io.read
+      begin
+        @cfg_file_contents = JSON.parse(contents)
+        validate_config_file_contents!
+      rescue JSON::ParserError => e
+        raise Inspec::ConfigError::MalformedJson, "Failed to load JSON configuration: #{e}\nConfig was: #{contents}"
+      end
+      @cfg_file_contents
+    end
+
+    def file_version
+      @cfg_file_contents[:version] || :legacy
+    end
+
+    def config_file_cli_options
+      if file_version == :legacy
+        # Assume everything in the file is a CLI option
+        @cfg_file_contents
+      else
+        @cfg_file_contents[:cli_options] || {}
+      end
+    end
+
+    #-----------------------------------------------------------------------#
+    #                            Validation
+    #-----------------------------------------------------------------------#
+    def validate_config_file_contents!
+      version = @cfg_file_contents['version']
+
+      # Assume legacy format, which is unconstrained
+      return unless version
+
+      unless version == '1.1'
+        raise Inspec::ConfigError::Invalid, "Unsupported config file version '#{version}' - currently supported versions: 1.1"
+      end
+
+      valid_fields = ['version', 'cli_options', 'credentials', 'compliance', 'reporter'].sort
+      @cfg_file_contents.keys.each do |seen_field|
+        unless valid_fields.include?(seen_field)
+          raise Inspec::ConfigError::Invalid, "Unrecognized top-level configuration field #{seen_field}.  Recognized fields: #{valid_fields.join(', ')}"
+        end
+      end
+
+    end
+
+    def validate_reporters(reporters)
+      return if reporters.nil?
+      # TODO: move this into a reporter plugin type system
+      valid_types = [
+        'automate',
+        'cli',
+        'documentation',
+        'html',
+        'json',
+        'json-automate',
+        'json-min',
+        'json-rspec',
+        'junit',
+        'progress',
+        'yaml',
+      ]
+
+      reporters.each do |reporter_name, reporter_config|
+        raise NotImplementedError, "'#{reporter_name}' is not a valid reporter type." unless valid_types.include?(reporter_name)
+
+        next unless reporter_name == 'automate'
+        %w{token url}.each do |option|
+          raise Inspec::ReporterError, "You must specify a automate #{option} via the config file." if reporter_config[option].nil?
+        end
+      end
+
+      # check to make sure we are only reporting one type to stdout
+      stdout_reporters = 0
+      reporters.each_value do |reporter_config|
+        stdout_reporters += 1 if reporter_config['stdout'] == true
+      end
+
+      raise ArgumentError, 'The option --reporter can only have a single report outputting to stdout.' if stdout_reporters > 1
+    end
+
+    #-----------------------------------------------------------------------#
+    #                         Merging Options
+    #-----------------------------------------------------------------------#
+    def merge_options
+      options = {}
+
+      # Lowest precedence: default, which may vary by command
+      options.merge!(@defaults)
+
+      # Middle precedence: merge in any CLI options defined from the config file
+      options.merge!(config_file_cli_options)
+      # options.merge!(compliance_credentials)  # TODO: handle compliance server option reading
+
+      # Highest precedence: merge in any options defined via the CLI
+      options.merge!(@cli_opts)
+
+      options
+    end
+
+    #-----------------------------------------------------------------------#
+    #                          Finalization
+    #-----------------------------------------------------------------------#
+    def finalize_options
+      options = @merged_options.dup
+
+      finalize_set_top_level_command(options)
+      finalize_parse_reporters(options)
+      finalize_handle_sudo(options)
+      finalize_compliance_login(options)
+
+      options
+    end
+
+    def finalize_set_top_level_command(options)
+      options[:type] = @command_name
+      Inspec::BaseCLI.inspec_cli_command = @command_name # TODO: move to a more relevant location
+    end
+
+    def finalize_parse_reporters(options) # rubocop:disable Metrics/AbcSize
+      return unless [:exec, :shell].include? @command_name
+
+      # default to cli report for ad-hoc runners
+      options['reporter'] = ['cli'] if options['reporter'].nil?
+
+      # parse out cli to proper report format
+      if options['reporter'].is_a?(Array)
+        reports = {}
+        options['reporter'].each do |report|
+          reporter_name, destination = report.split(':', 2)
+          if destination.nil? || destination.strip == '-'
+            reports[reporter_name] = { 'stdout' => true }
+          else
+            reports[reporter_name] = {
+              'file' => destination,
+              'stdout' => false,
+            }
+            reports[reporter_name]['target_id'] = options['target_id'] if options['target_id']
+          end
+        end
+        options['reporter'] = reports
+      end
+
+      # add in stdout if not specified
+      if options['reporter'].is_a?(Hash)
+        options['reporter'].each do |reporter_name, config|
+          options['reporter'][reporter_name] = {} if config.nil?
+          options['reporter'][reporter_name]['stdout'] = true if options['reporter'][reporter_name].empty?
+          options['reporter'][reporter_name]['target_id'] = options['target_id'] if options['target_id']
+        end
+      end
+
+      validate_reporters(options['reporter'])
+      options
+    end
+
+    def finalize_handle_sudo(options)
+      # Due to limitations in Thor it is not possible to set an argument to be
+      # both optional and its value to be mandatory. E.g. the user supplying
+      # the --password argument is optional and not always required, but
+      # whenever it is used, it requires a value. Handle options that were
+      # defined above and require a value here:
+      %w{password sudo-password}.each do |option_name|
+        option_name_as_sym = option_name.tr('-', '_').to_sym
+        next unless options[option_name_as_sym] == -1
+        raise ArgumentError, "Please provide a value for --#{option_name}. For example: --#{option_name}=hello."
+      end
+
+      # Infer `--sudo` if using `--sudo-password` without `--sudo`
+      if options[:sudo_password] && !options[:sudo]
+        options[:sudo] = true
+        Inspec::Log.warn '`--sudo-password` used without `--sudo`. Adding `--sudo`.'
+      end
+    end
+
+    def finalize_compliance_login(_options)
+      # check for compliance settings
+      # This is always a hash, comes from config file, not CLI opts
+      # TODO
+      # if compliance_creds
+      #   require 'plugins/inspec-compliance/lib/inspec-compliance/api'
+      #   InspecPlugins::Compliance::API.login(compliance_creds)
+      # end
+    end
+  end
+
+  class Defaults
+    DEFAULTS = {
+      exec: {
+        'reporter' => ['cli'],
+        'show_progress' => false,
+        'color' => true,
+        'create_lockfile' => true,
+        'backend_cache' => true,
+      },
+      shell: {
+        'reporter' => ['cli'],
+      },
+    }.freeze
+
+    def self.for_command(command_name)
+      DEFAULTS[command_name] || {}
+    end
+  end
+
+end

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -3,6 +3,7 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 require 'inspec/log'
+require 'stringio'
 
 module Inspec::DSL
   def require_controls(id, &block)
@@ -77,7 +78,7 @@ module Inspec::DSL
   end
 
   def self.filter_included_controls(context, profile, &block)
-    mock = Inspec::Backend.create({ backend: 'mock' })
+    mock = Inspec::Backend.create(Inspec::Config.mock)
     include_ctx = Inspec::ProfileContext.for_profile(profile, mock, {})
     include_ctx.load(block) if block_given?
     # remove all rules that were not registered

--- a/lib/inspec/errors.rb
+++ b/lib/inspec/errors.rb
@@ -13,6 +13,11 @@ module Inspec
   class ReporterError < Error; end
   class ImpactError < Error; end
 
+  # Config file loading
+  class ConfigError < Error; end
+  class ConfigError::MalformedJson < ConfigError; end
+  class ConfigError::Invalid < ConfigError; end
+
   class Attribute
     class Error < Inspec::Error; end
     class ValidationError < Error

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -67,7 +67,8 @@ module Inspec
       new(reader, opts)
     end
 
-    def self.for_fetcher(fetcher, opts)
+    def self.for_fetcher(fetcher, config)
+      opts = config.respond_to?(:final_options) ? config.final_options : config
       opts[:vendor_cache] = opts[:vendor_cache] || Cache.new
       path, writable = fetcher.fetch
       for_path(path, opts.merge(target: fetcher.target, writable: writable))
@@ -113,7 +114,7 @@ module Inspec
       #
       # This will cause issues if a profile attempts to load a file via `inspec.profile.file`
       train_options = options.reject { |k, _| k == 'target' } # See https://github.com/chef/inspec/pull/1646
-      @backend = options[:backend].nil? ? Inspec::Backend.create(train_options) : options[:backend].dup
+      @backend = options[:backend].nil? ? Inspec::Backend.create(Inspec::Config.new(train_options)) : options[:backend].dup
       @runtime_profile = RuntimeProfile.new(self)
       @backend.profile = @runtime_profile
 

--- a/lib/inspec/profile_vendor.rb
+++ b/lib/inspec/profile_vendor.rb
@@ -2,6 +2,7 @@
 # author: Adam Leff
 
 require 'inspec/profile'
+require 'inspec/config'
 
 module Inspec
   class ProfileVendor
@@ -49,7 +50,7 @@ module Inspec
     def profile_opts
       {
         vendor_cache: Inspec::Cache.new(cache_path.to_s),
-        backend: Inspec::Backend.create(target: 'mock://'),
+        backend: Inspec::Backend.create(Inspec::Config.mock),
       }
     end
 

--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -104,7 +104,7 @@ module Inspec
       puts <<~EOF
         You are currently running on:
 
-        #{Inspec::BaseCLI.detect(params: ctx.platform.params, indent: 4, color: 39)}
+        #{Inspec::BaseCLI.format_platform_info(params: ctx.platform.params, indent: 4, color: 39)}
       EOF
     end
 

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -49,23 +49,11 @@ describe 'inspec archive' do
     end
   end
 
-  it 'archive wont overwrite existing files' do
+  it 'archive will overwrite existing files even without --overwrite' do
     prepare_examples('profile') do |dir|
       x = rand.to_s
       File.write(dst.path, x)
       out = inspec('archive ' + dir + ' --output ' + dst.path)
-      out.stderr.must_equal '' # uh...
-      out.stdout.must_include "Archive #{dst.path} exists already. Use --overwrite."
-      out.exit_status.must_equal 1
-      File.read(dst.path).must_equal x
-    end
-  end
-
-  it 'archive will overwrite files if necessary' do
-    prepare_examples('profile') do |dir|
-      x = rand.to_s
-      File.write(dst.path, x)
-      out = inspec('archive ' + dir + ' --output ' + dst.path + ' --overwrite')
       out.stderr.must_equal ''
       out.stdout.must_include 'Generate archive ' + dst.path
       out.exit_status.must_equal 0

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -3,9 +3,11 @@
 # author: Christoph Hartmann
 
 require 'functional/helper'
+require 'byebug'
 
 describe 'inspec exec' do
   include FunctionalHelper
+  let(:looks_like_a_stacktrace) { %r{lib/inspec/.+\.rb:\d+:in} }
 
   it 'can execute the profile' do
     out = inspec('exec ' + example_profile  + ' --no-create-lockfile')
@@ -377,6 +379,7 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
       str = "Sudo is only valid when running against a remote host. To run this locally with elevated privileges, run the command with `sudo ...`.\n"
       out.stderr.force_encoding(Encoding::UTF_8).must_include str
       out.exit_status.must_equal 1
+      # TODO: check for stacktrace
     end
   end
 
@@ -523,7 +526,7 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
     end
   end
 
-  describe 'when targeting private GitHub profiles' do
+  describe 'when using private GitHub profiles' do
     let(:private_profile) {
       URI.parse('https://github.com/chef/inspec-test-profile-private.git')
     }
@@ -532,11 +535,11 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
     # access to the private profile repo
     if ENV['INSPEC_TEST_SSH_KEY_PATH']
       it 'can use SSH + Git' do
-        target = 'git@' + private_profile.host + ':' + private_profile.path
+        profile_location = 'git@' + private_profile.host + ':' + private_profile.path
         ssh_prefix = 'GIT_SSH_COMMAND="ssh -i ' +
                      ENV['INSPEC_TEST_SSH_KEY_PATH'] +
                      '"'
-        inspec_command = 'exec ' + target + ' --reporter json-min'
+        inspec_command = 'exec ' + profile_location + ' --reporter json-min'
         out = inspec(inspec_command, ssh_prefix)
         JSON.parse(out.stdout)['controls'][0]['status'].must_equal 'passed'
         out.exit_status.must_equal 0
@@ -552,6 +555,151 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
         out = inspec(inspec_command)
         JSON.parse(out.stdout)['controls'][0]['status'].must_equal 'passed'
         out.exit_status.must_equal 0
+      end
+    end
+  end
+
+  describe 'when specifying a config file' do
+    let(:run_result) { run_inspec_process('exec ' + File.join(profile_path, 'simple-metadata') + ' ' + cli_args, json: true, env: env)}
+    let(:seen_target_id) { run_result.payload.json['platform']['target_id'] }
+    let(:stderr) { run_result.stderr }
+    let(:env) { {} }
+
+    describe 'when using the legacy --json-config option' do
+      let(:cli_args) { '--json-config ' + File.join(config_dir_path, 'json-config', 'good.json') }
+      it 'should see the custom target ID value' do
+        stderr.must_be_empty # TODO: one day deprecate the --json-config option
+        seen_target_id.must_equal 'from-config-file'
+      end
+    end
+
+    describe 'when using the --config option to read from a custom file' do
+      let(:cli_args) { '--config ' + File.join(config_dir_path, 'json-config', 'good.json') }
+      it 'should see the custom target ID value' do
+        stderr.must_be_empty
+        seen_target_id.must_equal 'from-config-file'
+      end
+    end
+
+    # Use bash redirection to populate STDIN
+    # unless windows?
+    #   describe 'when using the --config option to read from STDIN' do
+    #     let(:cli_args) { '--config ' + File.join(config_dir_path, 'json-config', 'good.json') }
+    #     it 'should see the custom target ID value' do
+    #       stderr.must_be_empty
+    #       seen_target_id.must_equal 'from-config-file'
+    #       # TODO
+    #     end
+    #   end
+    # end
+
+    describe 'when reading from the default location' do
+      # Should read from File.join(config_dir_path, 'fakehome-2', '.inspec', 'config.json')
+      let(:env) { { 'HOME' => File.join(config_dir_path, 'fakehome-2') } }
+      let(:cli_args) { '' }
+      it 'should see the homedir target ID value' do
+        stderr.must_be_empty
+        seen_target_id.must_equal 'from-fakehome-config-file'
+      end
+    end
+
+    describe 'when --config points to a nonexistant location' do
+      let(:cli_args) { '--config ' + 'no/such/path' }
+      it 'should issue an error with the file path' do
+        stderr.wont_match looks_like_a_stacktrace
+        run_result.exit_status.must_equal 1
+        stderr.must_include 'Could not read configuration file' # Should specify error
+        stderr.must_include 'no/such/path' # Should include error value seen
+      end
+    end
+
+    describe 'when --config points to a malformed file' do
+      let(:cli_args) { '--config ' + File.join(config_dir_path, 'json-config', 'malformed.json') }
+      it 'should issue an error with the parse message' do
+        stderr.wont_match looks_like_a_stacktrace
+        run_result.exit_status.must_equal 1
+        stderr.must_include 'Failed to load JSON'
+        stderr.must_include 'Config was:'
+      end
+    end
+
+    describe 'when --config points to an invalid file' do
+      let(:cli_args) { '--config ' + File.join(config_dir_path, 'json-config', 'invalid.json') }
+      it 'should issue an error with the parse message' do
+        stderr.wont_match looks_like_a_stacktrace
+        run_result.exit_status.must_equal 1
+        stderr.must_include 'Unrecognized top-level configuration'
+        stderr.must_include 'this_key_is_invalid'
+      end
+    end
+  end
+
+  describe 'when specifying the execution target' do
+    let(:local_plat) do
+      json = run_inspec_process('detect --format json', {}).stdout
+      # .slice is available in ruby 2.5+
+      JSON.parse(json).select{|k,v| ['name', 'release'].include? k }
+    end
+    let(:run_result) { run_inspec_process('exec ' + File.join(profile_path, 'simple-metadata') + ' ' + cli_args, json: true) }
+    let(:seen_platform) { run_result.payload.json['platform'].select{|k,v| ['name', 'release'].include? k } }
+    let(:stderr) { run_result.stderr }
+
+    describe 'when neither target nor backend is specified' do
+      let(:cli_args) { '' }
+      it 'should connect to the local platform' do
+        seen_platform.must_equal local_plat
+      end
+    end
+
+    describe 'when local:// is specified' do
+      let(:cli_args) { ' -t local:// ' }
+      it 'should connect to the local platform' do
+        seen_platform.must_equal local_plat
+      end
+    end
+
+    describe 'when an unrecognized backend is specified' do
+      let(:cli_args) { '-b garble ' }
+      it 'should exit with an error' do
+        run_result.exit_status.must_equal 1
+        stderr.wont_match looks_like_a_stacktrace
+        # "Can't find train plugin garble. Please install it first"
+        stderr.must_include 'Can\'t find train plugin'
+        stderr.must_include 'garble'
+      end
+    end
+
+    describe 'when an unrecognized target schema is specified' do
+      let(:cli_args) { '-t garble:// ' }
+      it 'should exit with an error' do
+        run_result.exit_status.must_equal 1
+        stderr.wont_match looks_like_a_stacktrace
+        # "Can't find train plugin garble. Please install it first"
+        stderr.must_include 'Can\'t find train plugin'
+        stderr.must_include 'garble'
+      end
+    end
+
+    describe 'when a schemaless URI is specified' do
+      let(:cli_args) { '-t garble ' }
+      it 'should exit with an error' do
+        run_result.exit_status.must_equal 1
+        stderr.wont_match looks_like_a_stacktrace
+        # "Could not recognize a backend from the target garble - use a URI
+        # format with the backend name as the URI schema.  Example: 'ssh://somehost.com'
+        # or 'transport://credset' or 'transport://' if credentials are provided
+        #  outside of InSpec."
+        stderr.must_include 'Could not recognize a backend'
+        stderr.must_include 'garble'
+        stderr.must_include 'ssh://somehost.com'
+        stderr.must_include 'transport://credset'
+      end
+    end
+
+    describe 'when a target URI with a known credset is used' do
+      let(:cli_args) { '--target mock://mycredset' + '--config ' + File.join(config_dir_path, 'json-config', 'mock-credset.json') }
+      it 'should connect to the mock platform' do
+        seen_platform.must_equal({"name":"mock","release":"unknown","target_id":"from-mock-credset-config-file"})
       end
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -34,6 +34,7 @@ require 'inspec/runner'
 require 'inspec/runner_mock'
 require 'inspec/globals'
 require 'inspec/impact'
+require 'inspec/config'
 require 'fetchers/mock'
 require 'inspec/dependencies/cache'
 
@@ -89,7 +90,7 @@ class MockLoader
     scriptpath = ::File.realpath(::File.dirname(__FILE__))
 
     # create mock backend
-    @backend = Inspec::Backend.create({ backend: :mock, verbose: true })
+    @backend = Inspec::Backend.create(Inspec::Config.mock)
     mock = @backend.backend
 
     # create all mock files

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -7,36 +7,6 @@ require 'thor'
 describe 'BaseCLI' do
   let(:cli) { Inspec::BaseCLI.new }
 
-  describe 'opts' do
-    it 'raises if `--password/--sudo-password` are used without value' do
-      default_options = { mock: { sudo_password: -1 } }
-      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
-
-      e = proc { cli.send(:opts, :mock) }.must_raise(ArgumentError)
-      e.message.must_match(/Please provide a value for --sudo-password/)
-    end
-
-    it 'assumes `--sudo` if `--sudo-password` is used without it' do
-      default_options = { mock: { sudo_password: 'p@ssw0rd' } }
-      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
-
-      opts = {}
-      out, err = capture_io do
-        cli.send(:opts, :mock)[:sudo].must_equal true
-      end
-      err.must_match /WARN: `--sudo-password` used without `--sudo`/
-    end
-
-    it 'calls `Compliance::API.login` if `opts[:compliance] is passed`' do
-      default_options = { mock: { compliance: 'mock' } }
-      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
-
-      InspecPlugins::Compliance::API.expects(:login).with('mock')
-
-      cli.send(:opts, :mock)
-    end
-  end
-
   describe 'detect command' do
     it 'verify platform detect' do
       hash = { name: 'test-os', families: 'aws, cloud', release: 'aws-sdk-v1' }
@@ -45,7 +15,7 @@ describe 'BaseCLI' do
   Families:  \e[1m\e[35maws, cloud\e[0m
   Release:   \e[1m\e[35maws-sdk-v1\e[0m
 EOF
-      _(Inspec::BaseCLI.detect(params: hash, indent: 2, color: 35)).must_equal expect
+      _(Inspec::BaseCLI.format_platform_info(params: hash, indent: 2, color: 35)).must_equal expect
     end
   end
 
@@ -90,40 +60,6 @@ EOF
     end
   end
 
-  describe 'parse_reporters' do
-    it 'parse cli reporters' do
-      opts = { 'reporter' => ['cli'] }
-      parsed = Inspec::BaseCLI.parse_reporters(opts)
-      expected_value = { 'reporter' => { 'cli' => { 'stdout' => true }}}
-      parsed.must_equal expected_value
-    end
-
-    it 'parses cli report and attaches target_id' do
-      opts = { 'reporter' => ['cli'], 'target_id' => '1d3e399f-4d71-4863-ac54-84d437fbc444' }
-      parsed = Inspec::BaseCLI.parse_reporters(opts)
-      expected_value = {"reporter"=>{"cli"=>{"stdout"=>true, "target_id"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}}, "target_id"=>"1d3e399f-4d71-4863-ac54-84d437fbc444"}
-      parsed.must_equal expected_value
-    end
-  end
-
-  describe 'validate_reporters' do
-    it 'valid reporter' do
-      stdout = { 'stdout' => true }
-      reporters = { 'json' => stdout }
-      Inspec::BaseCLI.validate_reporters(reporters)
-    end
-
-    it 'invalid reporter type' do
-      reporters = ['json', 'magenta']
-      proc { Inspec::BaseCLI.validate_reporters(reporters) }.must_raise NotImplementedError
-    end
-
-    it 'two reporters outputting to stdout' do
-      stdout = { 'stdout' => true }
-      reporters = { 'json' => stdout, 'cli' => stdout }
-      proc { Inspec::BaseCLI.validate_reporters(reporters) }.must_raise ArgumentError
-    end
-  end
 
   describe 'suppress_log_output?' do
     it 'suppresses json' do

--- a/test/unit/base_cli_test.rb
+++ b/test/unit/base_cli_test.rb
@@ -37,19 +37,7 @@ describe 'BaseCLI' do
     end
   end
 
-  describe 'merge_options' do
-    let(:default_options) do
-      { exec: { 'reporter' => ['json'], 'backend_cache' => false }}
-    end
-
-    it 'cli defaults populate correctly' do
-      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
-
-      opts = cli.send(:merged_opts, :exec)
-      expected = {"backend_cache"=>false, "reporter"=>{"json"=>{"stdout"=>true}}, "type"=>:exec}
-      opts.must_equal expected
-    end
-
+  describe 'detect command' do
     it 'verify platform detect' do
       hash = { name: 'test-os', families: 'aws, cloud', release: 'aws-sdk-v1' }
       expect = <<EOF
@@ -59,52 +47,8 @@ describe 'BaseCLI' do
 EOF
       _(Inspec::BaseCLI.detect(params: hash, indent: 2, color: 35)).must_equal expect
     end
-
-    it 'json-config options override cli defaults' do
-      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
-
-      parsed_json = { 'backend_cache' => true }
-      cli.expects(:options_json).returns(parsed_json)
-
-      opts = cli.send(:merged_opts, :exec)
-      expected = {"backend_cache"=>true, "reporter"=>{"json"=>{"stdout"=>true}}, "type"=>:exec}
-      opts.must_equal expected
-    end
-
-    it 'cli options override json-config and default' do
-      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
-
-      parsed_json = { 'backend_cache' => false }
-      cli.expects(:options_json).returns(parsed_json)
-
-      cli_options = { 'backend_cache' => true }
-      cli.instance_variable_set(:@options, cli_options)
-
-      opts = cli.send(:merged_opts, :exec)
-      expected = {"backend_cache"=>true, "reporter"=>{"json"=>{"stdout"=>true}}, "type"=>:exec}
-      opts.must_equal expected
-    end
-
-    it 'make sure shell does not get exec defaults' do
-      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
-
-      opts = cli.send(:merged_opts)
-      expected = {}
-      opts.must_equal expected
-    end
-
-    it 'make sure default reporter is overriden by json-config reporter' do
-      default_options['reporter'] = ['cli']
-      Inspec::BaseCLI.stubs(:default_options).returns(default_options)
-
-      parsed_json = { 'reporter' => ['json'] }
-      cli.expects(:options_json).returns(parsed_json)
-
-      opts = cli.send(:merged_opts, :exec)
-      expected = {"backend_cache"=>false, "reporter"=>{"json"=>{"stdout"=>true}}, "type"=>:exec}
-      opts.must_equal expected
-    end
   end
+
 
   describe 'configure_logger' do
     let(:options) do

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1,0 +1,303 @@
+
+require 'helper'
+require 'stringio'
+require 'byebug'
+
+require 'inspec/config'
+
+describe 'Inspec::Config' do
+
+  # ========================================================================== #
+  #                                Constructor
+  # ========================================================================== #
+  describe 'the constructor' do
+    describe 'when no args are provided' do
+      it 'should initialize properly' do
+        cfg = Inspec::Config.new
+        cfg.must_respond_to :final_options
+      end
+    end
+
+    describe 'when CLI args are provided' do
+      it 'should initialize properly' do
+        cfg = Inspec::Config.new({color: true, log_level: 'warn'})
+        cfg.must_respond_to :final_options
+      end
+    end
+  end
+
+  # ========================================================================== #
+  #                              File Validation
+  # ========================================================================== #
+  describe 'when validating a file' do
+    let(:cfg) { Inspec::Config.new({}, cfg_io) }
+    let(:cfg_io) { StringIO.new(ConfigTestHelper.fixture(fixture_name)) }
+
+    describe 'when the file is a legacy file' do
+      let(:fixture_name) { 'legacy' }
+      it 'should read the file successfully' do
+        # 2 config entries + 'type' flag
+        cfg.final_options.count.must_equal 2 + 1
+      end
+    end
+
+    describe 'when the file is a valid v1.1 file' do
+      let(:fixture_name) { 'basic' }
+      it 'should read the file successfully' do
+        cfg.final_options.count.must_equal 4 + 1
+      end
+    end
+
+    describe 'when the file is minimal' do
+      let(:fixture_name) { 'minimal' }
+      it 'should read the file successfully' do
+        cfg.final_options.count.must_equal 1 + 1
+      end
+    end
+
+    describe 'when the file has malformed json' do
+      let(:fixture_name) { 'malformed_json' }
+      it 'should throw an exception' do
+        ex = proc { cfg }.must_raise(Inspec::ConfigError::MalformedJson)
+        ex.message.must_include 'Failed to load JSON config'
+        ex.message.must_include 'unexpected token'
+        ex.message.must_include 'version'
+      end
+    end
+
+    describe 'when the file has a bad file version' do
+      let(:fixture_name) { 'bad_version' }
+      it 'should throw an exception' do
+        ex = proc { cfg }.must_raise(Inspec::ConfigError::Invalid)
+        ex.message.must_include 'Unsupported config file version'
+        ex.message.must_include '99.99'
+        ex.message.must_include '1.1'
+      end
+    end
+
+    describe 'when a 1.1 file has an invalid top-level entry' do
+      let(:fixture_name) { 'bad_top_level' }
+      it 'should throw an exception' do
+        ex = proc { cfg }.must_raise(Inspec::ConfigError::Invalid)
+        ex.message.must_include 'Unrecognized top-level'
+        ex.message.must_include 'unsupported_field'
+        ex.message.must_include 'compliance'
+      end
+    end
+  end
+
+  # ========================================================================== #
+  #                                 Defaults
+  # ========================================================================== #
+  describe 'reading defaults' do
+    let(:cfg) { Inspec::Config.new({}, nil, command) }
+    let(:final_options) { cfg.final_options }
+
+    describe 'when the exec command is used' do
+      let(:command) { :exec }
+      it 'should have the correct defaults' do
+        # final_options adds an entry for 'type'
+        final_options.keys.count.must_equal 6+1
+        final_options.keys.all? { |option_name| option_name.is_a? String }.must_equal true
+        final_options['reporter'].must_be_kind_of Hash
+        final_options['reporter'].count.must_equal 1
+        final_options['reporter'].keys.must_include 'cli'
+        final_options['show_progress'].must_equal false
+        final_options['color'].must_equal true
+        final_options['create_lockfile'].must_equal true
+        final_options['backend_cache'].must_equal true
+      end
+    end
+
+    describe 'when the shell command is used' do
+      let(:command) { :shell }
+      it 'should have the correct defaults' do
+        final_options.keys.count.must_equal 1+2
+        final_options.keys.all? { |option_name| option_name.is_a? String }.must_equal true
+        final_options['reporter'].must_be_kind_of Hash
+        final_options['reporter'].count.must_equal 1
+        final_options['reporter'].keys.must_include 'cli'
+      end
+    end
+  end
+
+  # ========================================================================== #
+  #                            Reading CLI Options
+  # ========================================================================== #
+  # The config facility supports passing in CLI options in the constructor, so
+  # that it can handle merging internally. That is tested here.
+  #
+  #  This is different than storing options
+  # in the config file with the same name as the CLI options, which is
+  # tested under 'CLI Options Stored in File'
+  describe 'reading CLI options' do
+    let(:cfg) { Inspec::Config.new(cli_opts) }
+    let(:final_options) { cfg.final_options }
+
+    describe 'when the CLI opts are present' do
+      let(:cli_opts) do
+        {
+          color: true,
+          'string_key' => 'string_value',
+          array_value: [1,2,3],
+        }
+      end
+
+      it 'should transparently round-trip the options' do
+        final_options.keys.count.must_equal 3 + 2
+        final_options[:color].must_equal true
+        final_options['color'].must_equal true
+        final_options['string_key'].must_equal 'string_value'
+        final_options[:string_key].must_equal 'string_value'
+        final_options['array_value'].must_equal [1,2,3]
+        final_options[:array_value].must_equal [1,2,3]
+      end
+    end
+  end
+
+  # ========================================================================== #
+  #                          CLI Options Stored in File
+  # ========================================================================== #
+  describe 'reading CLI options stored in the config file' do
+    let(:cfg) { Inspec::Config.new({}, cfg_io) }
+    let(:final_options) { cfg.final_options }
+
+    describe 'when the CLI opts are present in a 1.1 file' do
+    end
+    describe 'when the CLI opts are present in a legacy file' do
+    end
+  end
+
+  # ========================================================================== #
+  #                           Fetching Credentials
+  # ========================================================================== #
+  describe 'when fetching creds' do
+  end
+
+  # ========================================================================== #
+  #                             Merging Options
+  # ========================================================================== #
+  describe 'when merging options' do
+    describe 'when there is both a default and a config file setting' do
+    end
+
+    describe 'when there is both a default and a CLI option' do
+    end
+
+    describe 'when there is both a config file setting and a CLI option' do
+    end
+  end
+end
+
+module ConfigTestHelper
+  def fixture(fixture_name)
+    case fixture_name.to_sym
+    when :legacy
+      # TODO - this is dubious, but based on https://www.inspec.io/docs/reference/reporters/#automate-reporter
+      # Things that have 'compliance' as a toplevel have also been seen
+      <<~EOJ1
+      {
+        "color": "true",
+        "reporter": {
+          "automate" : {
+            "url" : "https://YOUR_A2_URL/data-collector/v0/",
+            "token" : "YOUR_A2_ADMIN_TOKEN"
+          }
+        }
+      }
+      EOJ1
+    when :basic
+      <<~EOJ2
+      {
+        "version": "1.1",
+        "cli_options": {
+          "create_lockfile": "false"
+        },
+        "reporter": {
+          "automate" : {
+            "token" : "YOUR_A2_ADMIN_TOKEN"
+          }
+        },
+        "credentials": {
+          "ssh": {
+            "set1": {
+              "host": "some.host",
+              "user": "some_user"
+            }
+          }
+        }
+      }
+      EOJ2
+    when :minimal
+      '{ "version": "1.1" }'
+    when :bad_version
+      '{ "version": "99.99" }'
+    when :bad_top_level
+      '{ "version": "1.1", "unsupported_field": "some_value" }'
+    when :malformed_json
+      '{ "version": "1.1", '
+    end
+  end
+  module_function :fixture
+end
+
+# describe 'merge_options' do
+#   let(:default_options) do
+#     { exec: { 'reporter' => ['json'], 'backend_cache' => false }}
+#   end
+
+#   it 'cli defaults populate correctly' do
+#     Inspec::BaseCLI.stubs(:default_options).returns(default_options)
+
+#     opts = cli.send(:merged_opts, :exec)
+#     expected = {"backend_cache"=>false, "reporter"=>{"json"=>{"stdout"=>true}}, "type"=>:exec}
+#     opts.must_equal expected
+#   end
+
+
+
+#   it 'json-config options override cli defaults' do
+#     Inspec::BaseCLI.stubs(:default_options).returns(default_options)
+
+#     parsed_json = { 'backend_cache' => true }
+#     cli.expects(:options_json).returns(parsed_json)
+
+#     opts = cli.send(:merged_opts, :exec)
+#     expected = {"backend_cache"=>true, "reporter"=>{"json"=>{"stdout"=>true}}, "type"=>:exec}
+#     opts.must_equal expected
+#   end
+
+#   it 'cli options override json-config and default' do
+#     Inspec::BaseCLI.stubs(:default_options).returns(default_options)
+
+#     parsed_json = { 'backend_cache' => false }
+#     cli.expects(:options_json).returns(parsed_json)
+
+#     cli_options = { 'backend_cache' => true }
+#     cli.instance_variable_set(:@options, cli_options)
+
+#     opts = cli.send(:merged_opts, :exec)
+#     expected = {"backend_cache"=>true, "reporter"=>{"json"=>{"stdout"=>true}}, "type"=>:exec}
+#     opts.must_equal expected
+#   end
+
+#   it 'make sure shell does not get exec defaults' do
+#     Inspec::BaseCLI.stubs(:default_options).returns(default_options)
+
+#     opts = cli.send(:merged_opts)
+#     expected = {}
+#     opts.must_equal expected
+#   end
+
+#   it 'make sure default reporter is overriden by json-config reporter' do
+#     default_options['reporter'] = ['cli']
+#     Inspec::BaseCLI.stubs(:default_options).returns(default_options)
+
+#     parsed_json = { 'reporter' => ['json'] }
+#     cli.expects(:options_json).returns(parsed_json)
+
+#     opts = cli.send(:merged_opts, :exec)
+#     expected = {"backend_cache"=>false, "reporter"=>{"json"=>{"stdout"=>true}}, "type"=>:exec}
+#     opts.must_equal expected
+#   end
+# end

--- a/test/unit/mock/config_dirs/fakehome-2/.inspec/config.json
+++ b/test/unit/mock/config_dirs/fakehome-2/.inspec/config.json
@@ -1,0 +1,6 @@
+{
+"version": "1.1",
+"cli_options": {
+  "target_id": "from-fakehome-config-file"
+}
+}

--- a/test/unit/mock/config_dirs/json-config/good.json
+++ b/test/unit/mock/config_dirs/json-config/good.json
@@ -1,0 +1,6 @@
+{
+"version": "1.1",
+"cli_options": {
+  "target_id": "from-config-file"
+}
+}

--- a/test/unit/mock/config_dirs/json-config/invalid.json
+++ b/test/unit/mock/config_dirs/json-config/invalid.json
@@ -1,0 +1,4 @@
+{
+"version": "1.1",
+"this_key_is_invalid": "yes"
+}

--- a/test/unit/mock/config_dirs/json-config/malformed.json
+++ b/test/unit/mock/config_dirs/json-config/malformed.json
@@ -1,0 +1,1 @@
+[asd9f78oihjasdfljkn

--- a/test/unit/mock/config_dirs/json-config/mock-credset.json
+++ b/test/unit/mock/config_dirs/json-config/mock-credset.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.1",
+  "cli_options": {
+    "target_id": "from-mock-credset-config-file"
+  },
+  "credentials": {
+    "mock": {
+      "mycredset": {
+        "a_setting": "a_value"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR:
  * Introduces `Inspec::Config`, which represents the configuration file
  * Adds a version field to the config file, and validates it when possible
  * Interacts with Train such that transport credentials are passes in more reliably without having to invent new URI schemes for each transport
  * Allows you to store as many credential sets as needed in the config file, with whatever options the transport needs
  * Unifies the URI scheme for the credset mechanism as `--target transport://credsetname`
  * Does its best to preserve functionality for Compliance and Automate, though those need to be tested manually
  * Allows you to use the more intuitive `--config` option.  `--json-config` remains supported but is now undocumented.

*NOTE 1*  This PR must be merged after https://github.com/inspec/train/pull/394 is merged and releases, and the train constraint adjusted accordingly.  A Gemfile entry for train pointing at the branch for 394 must also be removed.

*NOTE 2* This PR will likely be split into smaller pieces.

Closes #3661