### PR TITLE
Config file formalization and credential sets: part 2, using the Config system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,10 @@
 # encoding: utf-8
 source 'https://rubygems.org'
+
+# Temporary
+# gem 'train', path: '../train'
+gem 'train', git: 'https://github.com/inspec/train.git', branch: 'cw/cred-set-support'
+
 gemspec name: 'inspec'
 
 gem 'ffi', '>= 1.9.14'

--- a/lib/bundles/inspec-supermarket/cli.rb
+++ b/lib/bundles/inspec-supermarket/cli.rb
@@ -30,7 +30,7 @@ module Supermarket
     desc 'exec PROFILE', 'execute a Supermarket profile'
     exec_options
     def exec(*tests)
-      o = opts(:exec).dup
+      o = config
       diagnose(o)
       configure_logger(o)
 

--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -41,16 +41,16 @@ module Inspec
     # @param [Hash] config for the transport backend
     # @return [TransportBackend] enriched transport instance
     def self.create(config) # rubocop:disable Metrics/AbcSize
-      conf = Train.target_config(config)
-      name = Train.validate_backend(conf)
-      transport = Train.create(name, conf)
+      train_credentials = config.unpack_train_credentials
+      transport_name = Train.validate_backend(train_credentials)
+      transport = Train.create(transport_name, train_credentials)
       if transport.nil?
-        raise "Can't find transport backend '#{name}'."
+        raise "Can't find transport backend '#{transport_name}'."
       end
 
       connection = transport.connection
       if connection.nil?
-        raise "Can't connect to transport backend '#{name}'."
+        raise "Can't connect to transport backend '#{transport_name}'."
       end
 
       # Set caching settings. We always want to enable caching for
@@ -85,9 +85,9 @@ module Inspec
 
       cls.new
     rescue Train::ClientError => e
-      raise "Client error, can't connect to '#{name}' backend: #{e.message}"
+      raise "Client error, can't connect to '#{transport_name}' backend: #{e.message}"
     rescue Train::TransportError => e
-      raise "Transport error, can't connect to '#{name}' backend: #{e.message}"
+      raise "Transport error, can't connect to '#{transport_name}' backend: #{e.message}"
     end
   end
 end

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -15,6 +15,7 @@ require 'inspec/plugin/v2'
 require 'inspec/runner_mock'
 require 'inspec/env_printer'
 require 'inspec/schema'
+require 'inspec/config'
 
 class Inspec::InspecCLI < Inspec::BaseCLI
   class_option :log_level, aliases: :l, type: :string,
@@ -39,12 +40,12 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: 'A list of controls to include. Ignore all other tests.'
   profile_options
   def json(target)
-    o = opts.dup
+    o = config
     diagnose(o)
     o['log_location'] = STDERR
     configure_logger(o)
 
-    o[:backend] = Inspec::Backend.create(target: 'mock://')
+    o[:backend] = Inspec::Backend.create(Inspec::Config.mock)
     o[:check_mode] = true
     o[:vendor_cache] = Inspec::Cache.new(o[:vendor_cache])
 
@@ -75,9 +76,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :format, type: :string
   profile_options
   def check(path) # rubocop:disable Metrics/AbcSize
-    o = opts.dup
+    o = config
     diagnose(o)
-    o[:backend] = Inspec::Backend.create(target: 'mock://')
+    o[:backend] = Inspec::Backend.create(Inspec::Config.mock)
     o[:check_mode] = true
     o[:vendor_cache] = Inspec::Cache.new(o[:vendor_cache])
 
@@ -127,10 +128,10 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :overwrite, type: :boolean, default: false,
     desc: 'Overwrite existing vendored dependencies and lockfile.'
   def vendor(path = nil)
-    o = opts.dup
+    o = config
     configure_logger(o)
     o[:logger] = Logger.new(STDOUT)
-    o[:logger].level = get_log_level(o.log_level)
+    o[:logger].level = get_log_level(o[:log_level])
 
     vendor_deps(path, o)
   end
@@ -148,12 +149,12 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :ignore_errors, type: :boolean, default: false,
     desc: 'Ignore profile warnings.'
   def archive(path)
-    o = opts.dup
+    o = config
     diagnose(o)
 
     o[:logger] = Logger.new(STDOUT)
-    o[:logger].level = get_log_level(o.log_level)
-    o[:backend] = Inspec::Backend.create(target: 'mock://')
+    o[:logger].level = get_log_level(o[:log_level])
+    o[:backend] = Inspec::Backend.create(Inspec::Config.mock)
 
     # Force vendoring with overwrite when archiving
     vendor_options = o.dup
@@ -241,7 +242,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   EOT
   exec_options
   def exec(*targets)
-    o = opts(:exec).dup
+    o = config
     diagnose(o)
     configure_logger(o)
 
@@ -260,14 +261,14 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   target_options
   option :format, type: :string
   def detect
-    o = opts(:detect).dup
+    o = config
     o[:command] = 'platform.params'
     (_, res) = run_command(o)
     if o['format'] == 'json'
       puts res.to_json
     else
       headline('Platform Details')
-      puts Inspec::BaseCLI.detect(params: res, indent: 0, color: 36)
+      puts Inspec::BaseCLI.format_platform_info(params: res, indent: 0, color: 36)
     end
   rescue ArgumentError, RuntimeError, Train::UserError => e
     $stderr.puts e.message
@@ -288,13 +289,13 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :distinct_exit, type: :boolean, default: true,
     desc: 'Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures.'
   def shell_func
-    o = opts(:shell).dup
+    o = config
     diagnose(o)
     o[:debug_shell] = true
 
     log_device = suppress_log_output?(o) ? nil : STDOUT
     o[:logger] = Logger.new(log_device)
-    o[:logger].level = get_log_level(o.log_level)
+    o[:logger].level = get_log_level(o[:log_level])
 
     if o[:command].nil?
       runner = Inspec::Runner.new(o)
@@ -333,7 +334,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   desc 'version', 'prints the version of this tool'
   option :format, type: :string
   def version
-    if opts['format'] == 'json'
+    if config['format'] == 'json'
       v = { version: Inspec::VERSION }
       puts v.to_json
     else
@@ -350,7 +351,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   private
 
   def run_command(opts)
-    runner = Inspec::Runner.new(opts)
+    runner = Inspec::Runner.new(Inspec::Config.new(opts))
     res = runner.eval_with_virtual_profile(opts[:command])
     runner.load
 

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -2,6 +2,7 @@
 # and CLI arguments.
 
 require 'pp'
+require 'stringio'
 
 module Inspec
   class Config
@@ -22,6 +23,11 @@ module Inspec
     # Many parts of InSpec expect to treat the Config as a Hash
     def_delegators :@final_options, :each, :delete, :[], :[]=, :key?
     attr_reader :final_options
+
+    # This makes it easy to make a config with a mock backend.
+    def self.mock
+      Inspec::Config.new({ backend: :mock }, StringIO.new('{}'))
+    end
 
     def initialize(cli_opts = {}, cfg_io = nil, command_name = nil)
       @command_name = command_name || (ARGV.empty? ? nil : ARGV[0].to_sym)
@@ -46,6 +52,89 @@ module Inspec
       puts 'Merged configuration:'
       pp @merged_options
       puts
+    end
+
+    #-----------------------------------------------------------------------#
+    #                      Train Credential Handling
+    #-----------------------------------------------------------------------#
+
+    # Returns a Hash with Symbol keys as follows:
+    #   backend: machine name of the Train transport needed
+    #   If present, any of the GENERIC_CREDENTIALS.
+    #   All other keys are specific to the backend.
+    #
+    # The credentials are gleaned from:
+    #  * the Train transport defaults. Train handles this on transport creation,
+    #      so this method doesn't load defaults.
+    #  * individual InSpec CLI options (which in many cases may have the
+    #      transport name prefixed, which is stripped before being added
+    #      to the creds hash)
+    #  * the --target CLI option, which is interpreted:
+    #     - as an arbitrary URI, which is parsed by Train.unpack_target_from_uri
+
+    def unpack_train_credentials
+      # Internally, use indifferent access while we build the creds
+      credentials = Thor::CoreExt::HashWithIndifferentAccess.new({})
+
+      # Helper methods prefixed with _utc_ (Unpack Train Credentials)
+
+      credentials.merge!(_utc_generic_credentials)
+
+      _utc_determine_backend(credentials)
+      # credentials.merge!(Train.unpack_target_from_uri(final_options[:target])) # TODO: this will be replaced with the credset work
+      credentials.merge!(Train.target_config(final_options)) # TODO: this will be replaced with the credset work
+      transport_name = credentials[:backend].to_s
+      _utc_merge_transport_options(credentials, transport_name)
+
+      # Convert to all-Symbol keys
+      credentials.each_with_object({}) do |(option, value), creds|
+        creds[option.to_sym] = value
+        creds
+      end
+    end
+
+    private
+
+    def _utc_merge_transport_options(credentials, transport_name)
+      # Ask Train for the names of the transport options
+      transport_options = Train.options(transport_name).keys.map(&:to_s)
+
+      # If there are any options with those (unprefixed) names, merge them in.
+      unprefixed_transport_options = final_options.select do |option_name, _value|
+        transport_options.include? option_name # e.g., 'host'
+      end
+      credentials.merge!(unprefixed_transport_options)
+
+      # If there are any prefixed options, merge them in, stripping the prefix.
+      transport_prefix = transport_name.downcase.tr('-', '_') + '_'
+      transport_options.each do |bare_option_name|
+        prefixed_option_name = transport_prefix + bare_option_name.to_s
+        if final_options.key?(prefixed_option_name)
+          credentials[bare_option_name.to_s] = final_options[prefixed_option_name]
+        end
+      end
+    end
+
+    # fetch any info that applies to all transports (like sudo information)
+    def _utc_generic_credentials
+      @final_options.select { |option, _value| GENERIC_CREDENTIALS.include?(option) }
+    end
+
+    def _utc_determine_backend(credentials)
+      return if credentials.key?(:backend)
+
+      # Default to local
+      unless @final_options.key?(:target)
+        credentials[:backend] = 'local'
+        return
+      end
+
+      # Look into target
+      %r{^(?<transport_name>[a-z_\-0-9]+)://.*$} =~ final_options[:target]
+      unless transport_name
+        raise ArgumentError, "Could not recognize a backend from the target #{final_options[:target]} - use a URI format with the backend name as the URI schema.  Example: 'ssh://somehost.com' or 'transport://credset' or 'transport://' if credentials are provided outside of InSpec."
+      end
+      credentials[:backend] = transport_name.to_s # these are indeed stored in Train as Strings.
     end
 
     #-----------------------------------------------------------------------#

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -81,8 +81,7 @@ module Inspec
       credentials.merge!(_utc_generic_credentials)
 
       _utc_determine_backend(credentials)
-      # credentials.merge!(Train.unpack_target_from_uri(final_options[:target])) # TODO: this will be replaced with the credset work
-      credentials.merge!(Train.target_config(final_options)) # TODO: this will be replaced with the credset work
+      credentials.merge!(Train.unpack_target_from_uri(final_options[:target] || '')) # TODO: this will be replaced with the credset work
       transport_name = credentials[:backend].to_s
       _utc_merge_transport_options(credentials, transport_name)
 

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -3,6 +3,7 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 require 'inspec/log'
+require 'stringio'
 
 module Inspec::DSL
   def require_controls(id, &block)
@@ -77,7 +78,7 @@ module Inspec::DSL
   end
 
   def self.filter_included_controls(context, profile, &block)
-    mock = Inspec::Backend.create({ backend: 'mock' })
+    mock = Inspec::Backend.create(Inspec::Config.mock)
     include_ctx = Inspec::ProfileContext.for_profile(profile, mock, {})
     include_ctx.load(block) if block_given?
     # remove all rules that were not registered

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -67,7 +67,8 @@ module Inspec
       new(reader, opts)
     end
 
-    def self.for_fetcher(fetcher, opts)
+    def self.for_fetcher(fetcher, config)
+      opts = config.respond_to?(:final_options) ? config.final_options : config
       opts[:vendor_cache] = opts[:vendor_cache] || Cache.new
       path, writable = fetcher.fetch
       for_path(path, opts.merge(target: fetcher.target, writable: writable))
@@ -113,7 +114,7 @@ module Inspec
       #
       # This will cause issues if a profile attempts to load a file via `inspec.profile.file`
       train_options = options.reject { |k, _| k == 'target' } # See https://github.com/chef/inspec/pull/1646
-      @backend = options[:backend].nil? ? Inspec::Backend.create(train_options) : options[:backend].dup
+      @backend = options[:backend].nil? ? Inspec::Backend.create(Inspec::Config.new(train_options)) : options[:backend].dup
       @runtime_profile = RuntimeProfile.new(self)
       @backend.profile = @runtime_profile
 

--- a/lib/inspec/profile_vendor.rb
+++ b/lib/inspec/profile_vendor.rb
@@ -2,6 +2,7 @@
 # author: Adam Leff
 
 require 'inspec/profile'
+require 'inspec/config'
 
 module Inspec
   class ProfileVendor
@@ -49,7 +50,7 @@ module Inspec
     def profile_opts
       {
         vendor_cache: Inspec::Cache.new(cache_path.to_s),
-        backend: Inspec::Backend.create(target: 'mock://'),
+        backend: Inspec::Backend.create(Inspec::Config.mock),
       }
     end
 

--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -104,7 +104,7 @@ module Inspec
       puts <<~EOF
         You are currently running on:
 
-        #{Inspec::BaseCLI.detect(params: ctx.platform.params, indent: 4, color: 39)}
+        #{Inspec::BaseCLI.format_platform_info(params: ctx.platform.params, indent: 4, color: 39)}
       EOF
     end
 

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -49,23 +49,11 @@ describe 'inspec archive' do
     end
   end
 
-  it 'archive wont overwrite existing files' do
+  it 'archive will overwrite existing files even without --overwrite' do
     prepare_examples('profile') do |dir|
       x = rand.to_s
       File.write(dst.path, x)
       out = inspec('archive ' + dir + ' --output ' + dst.path)
-      out.stderr.must_equal '' # uh...
-      out.stdout.must_include "Archive #{dst.path} exists already. Use --overwrite."
-      out.exit_status.must_equal 1
-      File.read(dst.path).must_equal x
-    end
-  end
-
-  it 'archive will overwrite files if necessary' do
-    prepare_examples('profile') do |dir|
-      x = rand.to_s
-      File.write(dst.path, x)
-      out = inspec('archive ' + dir + ' --output ' + dst.path + ' --overwrite')
       out.stderr.must_equal ''
       out.stdout.must_include 'Generate archive ' + dst.path
       out.exit_status.must_equal 0

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -34,6 +34,7 @@ require 'inspec/runner'
 require 'inspec/runner_mock'
 require 'inspec/globals'
 require 'inspec/impact'
+require 'inspec/config'
 require 'fetchers/mock'
 require 'inspec/dependencies/cache'
 
@@ -89,7 +90,7 @@ class MockLoader
     scriptpath = ::File.realpath(::File.dirname(__FILE__))
 
     # create mock backend
-    @backend = Inspec::Backend.create({ backend: :mock, verbose: true })
+    @backend = Inspec::Backend.create(Inspec::Config.mock)
     mock = @backend.backend
 
     # create all mock files

--- a/test/unit/mock/config_dirs/.inspec/config.json
+++ b/test/unit/mock/config_dirs/.inspec/config.json
@@ -1,6 +1,0 @@
-{
-"version": "1.1",
-"cli_options": {
-  "target_id": "from-fakehome-config-file"
-}
-}

--- a/test/unit/mock/config_dirs/fakehome-2/.inspec/config.json
+++ b/test/unit/mock/config_dirs/fakehome-2/.inspec/config.json
@@ -1,0 +1,6 @@
+{
+"version": "1.1",
+"cli_options": {
+  "target_id": "from-fakehome-config-file"
+}
+}

--- a/test/unit/mock/config_dirs/json-config/good.json
+++ b/test/unit/mock/config_dirs/json-config/good.json
@@ -1,0 +1,6 @@
+{
+"version": "1.1",
+"cli_options": {
+  "target_id": "from-config-file"
+}
+}

--- a/test/unit/mock/config_dirs/json-config/invalid.json
+++ b/test/unit/mock/config_dirs/json-config/invalid.json
@@ -1,0 +1,4 @@
+{
+"version": "1.1",
+"this_key_is_invalid": "yes"
+}

--- a/test/unit/mock/config_dirs/json-config/malformed.json
+++ b/test/unit/mock/config_dirs/json-config/malformed.json
@@ -1,0 +1,1 @@
+[asd9f78oihjasdfljkn


### PR DESCRIPTION
This is part 2 of #3709.

This PR alters the CLI and some related code to rely on the Inspec::Config class introduced on #3710 .

Prerequisites: this PR must be merged after #3710 and after https://github.com/inspec/train/pull/394

NOTE: This PR contains a modification to the Gemfile, which must be removed prior to merge; after https://github.com/inspec/train/pull/394 the modification may be removed.