### PR TITLE
Config file formalization and credential sets: part 3, credential sets

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -42,18 +42,14 @@ Config files must contain a top-level key, `version`, which indicates the file f
 }
 ```
 
+version
+: Should have the value '1.1'.
 
-### version
+cli_options
+: Any long-form command line option, without the leading dashes.
 
-Should have the value '1.1'.
-
-### cli_options
-
-Any long-form command line option, without the leading dashes.
-
-### credentials
-
-Train-transport-specific options. Store the options keyed first by transport name, then by a name you'll use later on. The combination of transport name and your chosen name can be used in the `--target` option to `inspec exec`, as `--target transport-name://connection-name`.
+credentials
+: Train-transport-specific options. Store the options keyed first by transport name, then by a name you'll use later on. The combination of transport name and your chosen name can be used in the `--target` option to `inspec exec`, as `--target transport-name://connection-name`.
 
 For example, if the config file contains:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -49,11 +49,11 @@ Should have the value '1.1'.
 
 ### cli_options
 
-In this key, you can place any long-form command line option, without the leading dashes.
+Any long-form command line option, without the leading dashes.
 
 ### credentials
 
-Under this key, you may store any Train-transport-specific options.  You store the options keyed first by transport name, then by a name you choose to refer to them later.  The combination of transport name and your chosen name can be used in the `--target` option to `inspec exec`, as `--target transport-name://connection-name`.
+Train-transport-specific options. Store the options keyed first by transport name, then by a name you'll use later on. The combination of transport name and your chosen name can be used in the `--target` option to `inspec exec`, as `--target transport-name://connection-name`.
 
 For example, if the config file contains:
 
@@ -72,7 +72,7 @@ For example, if the config file contains:
 }
 ```
 
-Then you can use `--target winrm://myconn` to connect to the host, with the given extra options.
+Then use `-t winrm://myconn` to connect to the host, with the given extra options.
 
 Each Train transport offers a variety of options. By using the credential set facility, you are able to easily set options that are not accessible via the Train URI.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,83 @@
+# The InSpec Configuration File
+
+This documents the InSpec configuration file format introduced in version 3.5 of InSpec.
+
+## Config File Location
+
+By default, InSpec looks for a config file in `~/.inspec/config.json`.  InSpec does not need a configuration file to run.
+
+You may also specify the location using `--config`.  For example, to run the shell using a config file in `/etc/inspec`, use `inspec shell --config /etc/inspec/config.json`.
+
+## Config File Format Versions
+
+Config files must contain a top-level key, `version`, which indicates the file format. This allows us to add new fields without breaking old installations.
+
+## Version 1.1
+
+### Complete Example
+
+```
+{
+  "version": "1.1",
+  "cli_options":{
+    "color": "true"
+  },
+  "credentials": {
+    "ssh": {
+      "my-target": {
+        "host":"somewhere.there.com",
+        "user":"bob"
+      }
+    }
+  },
+  "reporter": {
+    "automate" : {
+    "stdout" : false,
+    "url" : "https://YOUR_A2_URL/data-collector/v0/",
+    "token" : "YOUR_A2_ADMIN_TOKEN",
+    "insecure" : true,
+    "node_name" : "inspec_test_node",
+    "environment" : "prod"
+  }
+}
+```
+
+
+### version
+
+Should have the value '1.1'.
+
+### cli_options
+
+In this key, you can place any long-form command line option, without the leading dashes.
+
+### credentials
+
+Under this key, you may store any Train-transport-specific options.  You store the options keyed first by transport name, then by a name you choose to refer to them later.  The combination of transport name and your chosen name can be used in the `--target` option to `inspec exec`, as `--target transport-name://connection-name`.
+
+For example, if the config file contains:
+
+```
+{
+  "credentials": {
+    "winrm": {
+      "myconn": {
+        "user": "Administrator",
+        "host": "prod01.east.example.com",
+        "disable_sspi": true,
+        "connection_retries": 10
+      }
+    }
+  }
+}
+```
+
+Then you can use `--target winrm://myconn` to connect to the host, with the given extra options.
+
+Each Train transport offers a variety of options. By using the credential set facility, you are able to easily set options that are not accessible via the Train URI.
+
+You may have as many credential sets in the config file as you require.
+
+### reporter
+
+You may also set output (reporter) options in the config file.  See the [Reporters Page](https://www.inspec.io/docs/reference/reporters/) for details.

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,7 +34,7 @@ Config files must contain a top-level key, `version`, which indicates the file f
     "automate" : {
     "stdout" : false,
     "url" : "https://YOUR_A2_URL/data-collector/v0/",
-    "token" : "YOUR_A2_ADMIN_TOKEN",
+    "token" : "YOUR_A2_API_TOKEN",
     "insecure" : true,
     "node_name" : "inspec_test_node",
     "environment" : "prod"

--- a/docs/config.md
+++ b/docs/config.md
@@ -78,6 +78,12 @@ Each Train transport offers a variety of options. By using the credential set fa
 
 You may have as many credential sets in the config file as you require.
 
+If you use a target URI and the portion after the `://` cannot be matched to credential set name, InSpec will send the URI to Train to be parsed as a Train URI.  Thus, you can still do `ssh://someuser@myhost.com`.
+
+You can use a credential set, and then override individual options using command line options.
+
+Credential sets are intended to work hand-in-hand with the underlying credentials storage facility of the transport. For example, if you have a `~/.ssh/config` file specifying that the sally-key.pem file should be used with the host `somehost.com`, and you have a credential set that specifies that host, then when Train tries to connect to that host, the SSH library will automatically use the SSH config file to use the indicated key.
+
 ### reporter
 
 You may also set output (reporter) options in the config file.  See the [Reporters Page](https://www.inspec.io/docs/reference/reporters/) for details.

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -6,7 +6,9 @@ title: InSpec Reporters
 
 Introduced in InSpec 1.51.6
 
-InSpec allows you to output your test results to one or more reporters. You can configure the reporter(s) using either the `--config` (or `--json-config`, prior to v3.6) option or the `--reporter` option. While you can configure multiple reporters to write to different files, only one reporter can output to the screen(stdout).
+A `reporter` is a facility for formatting and delivering the results of an InSpec auditing run.
+
+InSpec allows you to output your test results to one or more reporters. Configure the reporter(s) using either the `--reporter` option or as part of the general config file using the `--config` (or `--json-config`, prior to v3.6) option. While you can configure multiple reporters to write to different files, only one reporter can output to the screen(stdout).
 
 ## Syntax
 
@@ -16,7 +18,7 @@ Output json to screen.
 
 ```bash
 inspec exec example_profile --reporter json
-or
+# or explicitly specifying output to STDOUT:
 inspec exec example_profile --reporter json:-
 ```
 
@@ -24,7 +26,7 @@ Output yaml to screen
 
 ```bash
 inspec exec example_profile --reporter yaml
-or
+# or
 inspec exec example_profile --reporter yaml:-
 ```
 
@@ -124,7 +126,7 @@ This renders html code to view your tests in a browser. It includes all the test
 
 ## Automate Reporter
 
-The automate reporter type is a special reporter used with the Automate 2 suite. To use this reporter you must pass in the correct configuration via a json config `--config`.
+The `automate` reporter type is a special reporter used with [Chef Automate](https://automate.chef.io/). To use this reporter you must pass in the correct configuration via a json config `--config`.
 
 Example config:
 

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -6,7 +6,7 @@ title: InSpec Reporters
 
 Introduced in InSpec 1.51.6
 
-InSpec allows you to output your test results to one or more reporters. You can configure the reporter(s) using either the `--json-config` option or the `--reporter` option. While you can configure multiple reporters to write to different files, only one reporter can output to the screen(stdout).
+InSpec allows you to output your test results to one or more reporters. You can configure the reporter(s) using either the `--config` (or `--json-config`, prior to v3.6) option or the `--reporter` option. While you can configure multiple reporters to write to different files, only one reporter can output to the screen(stdout).
 
 ## Syntax
 
@@ -52,7 +52,7 @@ If you wish to pass the profiles directly after specifying the reporters you wil
 inspec exec --reporter json junit:/tmp/junit.xml -- profile1 profile2
 ```
 
-If you are using the cli option `--json-config` you can also set reporters.
+If you are using the cli option `--config`, you can also set reporters.
 
 Output cli to screen.
 
@@ -124,7 +124,7 @@ This renders html code to view your tests in a browser. It includes all the test
 
 ## Automate Reporter
 
-The automate reporter type is a special reporter used with the Automate 2 suite. To use this reporter you must pass in the correct configuration via a json config `--json-config`.
+The automate reporter type is a special reporter used with the Automate 2 suite. To use this reporter you must pass in the correct configuration via a json config `--config`.
 
 Example config:
 

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -71,6 +71,8 @@ module Inspec
     #      transport name prefixed, which is stripped before being added
     #      to the creds hash)
     #  * the --target CLI option, which is interpreted:
+    #     - as a transport://credset format, which looks up the creds in
+    #       the config file in the credentials section
     #     - as an arbitrary URI, which is parsed by Train.unpack_target_from_uri
 
     def unpack_train_credentials
@@ -82,8 +84,9 @@ module Inspec
       credentials.merge!(_utc_generic_credentials)
 
       _utc_determine_backend(credentials)
-      credentials.merge!(Train.unpack_target_from_uri(final_options[:target] || '')) # TODO: this will be replaced with the credset work
       transport_name = credentials[:backend].to_s
+
+      _utc_merge_credset(credentials, transport_name)
       _utc_merge_transport_options(credentials, transport_name)
 
       # Convert to all-Symbol keys
@@ -135,6 +138,33 @@ module Inspec
         raise ArgumentError, "Could not recognize a backend from the target #{final_options[:target]} - use a URI format with the backend name as the URI schema.  Example: 'ssh://somehost.com' or 'transport://credset' or 'transport://' if credentials are provided outside of InSpec."
       end
       credentials[:backend] = transport_name.to_s # these are indeed stored in Train as Strings.
+    end
+
+    def _utc_merge_credset(credentials, transport_name)
+      # Look for Config File credentials/transport_name/credset
+      credset_name = _utc_find_credset_name(credentials, transport_name)
+
+      if credset_name
+        credset = @cfg_file_contents.dig('credentials', transport_name, credset_name)
+        if credset
+          credentials.merge!(credset)
+        else
+          # OK, we had a target that looked like transport://something
+          # But we don't know what that something is - there was no
+          # matching credset with it.  Let train parse it.
+          credentials.merge!(Train.unpack_target_from_uri(final_options[:target]))
+        end
+      elsif final_options.key?(:target)
+        # Not sure what target looked like at all!
+        # Let train parse it.
+        credentials.merge!(Train.unpack_target_from_uri(final_options[:target]))
+      end
+    end
+
+    def _utc_find_credset_name(_credentials, transport_name)
+      return nil unless final_options[:target]
+      match = final_options[:target].match(%r{^#{transport_name}://(?<credset_name>[a-z_\-0-9]+)$})
+      match ? match[:credset_name] : nil
     end
 
     #-----------------------------------------------------------------------#

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -163,7 +163,7 @@ module Inspec
 
     def _utc_find_credset_name(_credentials, transport_name)
       return nil unless final_options[:target]
-      match = final_options[:target].match(%r{^#{transport_name}://(?<credset_name>[a-z_\-0-9]+)$})
+      match = final_options[:target].match(%r{^#{transport_name}://(?<credset_name>[\w\d\-]+)$})
       match ? match[:credset_name] : nil
     end
 

--- a/lib/inspec/objects/input.rb
+++ b/lib/inspec/objects/input.rb
@@ -8,17 +8,16 @@ require 'utils/deprecation'
 module Inspec
   class Attribute
     # This only exists to create the Inspec::Attribute::DEFAULT_ATTRIBUTE symbol with a class
-    class DEFAULT_ATTRIBUTE; end
+    class DEFAULT_ATTRIBUTE; end # rubocop: disable Style/ClassAndModuleCamelCase
   end
 end
-
 
 module Inspec
   class Input
     # This special class is used to represent the value when an input has
     # not been assigned a value. This allows a user to explicitly assign nil
     # to an input.
-    class NO_VALUE_SET
+    class NO_VALUE_SET # rubocop: disable Style/ClassAndModuleCamelCase
       def initialize(name)
         @name = name
 
@@ -59,7 +58,6 @@ module Inspec
           super(klass)
         end
       end
-
     end
   end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -656,7 +656,7 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
       JSON.parse(json).select{|k,v| ['name', 'release'].include? k }
     end
     let(:run_result) { run_inspec_process('exec ' + File.join(profile_path, 'simple-metadata') + ' ' + cli_args, json: true) }
-    let(:seen_platform) { run_result.payload.json['platform'].select{|k,v| ['name', 'release'].include? k } }
+    let(:seen_platform) { run_result.payload.json['platform'].select{|k,v| ['name', 'release', 'target_id'].include? k } }
     let(:stderr) { run_result.stderr }
 
     describe 'when neither target nor backend is specified' do
@@ -708,6 +708,13 @@ Test Summary: \e[38;5;41m2 successful\e[0m, 0 failures, 0 skipped\n"
         stderr.must_include 'garble'
         stderr.must_include 'ssh://somehost.com'
         stderr.must_include 'transport://credset'
+      end
+    end
+
+    describe 'when a target URI with a known credset is used' do
+      let(:cli_args) { '--target mock://mycredset' + ' --config ' + File.join(config_dir_path, 'json-config', 'mock-credset.json') }
+      it 'should connect to the mock platform' do
+        seen_platform.must_equal({"name" => "mock","release" => "unknown","target_id" => "from-mock-credset-config-file"})
       end
     end
   end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -315,6 +315,53 @@ describe 'Inspec::Config' do
       end
     end
 
+    describe 'when creds are specified with a credset that contains odd characters' do
+      let(:file_fixture_name) { :match_checks_in_credset_names }
+      [
+        'ssh://TitleCase',
+        'ssh://snake_case',
+        'ssh://conta1nsnumeral5',
+      ].each do |target_uri|
+        it "should be able to unpack #{target_uri}" do
+          # let() caching breaks things here
+          cfg_io = StringIO.new(ConfigTestHelper.fixture(file_fixture_name))
+          cli_opts = { target: target_uri }
+          cfg = Inspec::Config.new({ target: target_uri }, cfg_io)
+          creds = cfg.unpack_train_credentials
+          creds.count.must_equal 2
+          creds[:backend].must_equal 'ssh'
+          creds[:found].must_equal 'yes'
+        end
+      end
+
+      [
+        'ssh://contains.dots',
+      ].each do |target_uri|
+        it "should handoff unpacking #{target_uri} to train" do
+          # let() caching breaks things here
+          cfg_io = StringIO.new(ConfigTestHelper.fixture(file_fixture_name))
+          cfg = Inspec::Config.new({ target: target_uri }, cfg_io)
+          creds = cfg.unpack_train_credentials
+
+          creds.count.must_equal 2
+          creds[:backend].must_equal 'ssh'
+          creds[:host].must_equal 'contains.dots'
+        end
+      end
+
+      [
+        'ssh://contains spaces',
+      ].each do |target_uri|
+        it "should be not able to unpack #{target_uri}" do
+          # let() caching breaks things here
+          cfg_io = StringIO.new(ConfigTestHelper.fixture(file_fixture_name))
+          cfg = Inspec::Config.new({ target: target_uri }, cfg_io)
+
+          assert_raises(Train::UserError) { creds = cfg.unpack_train_credentials }
+        end
+      end
+    end
+
     describe 'when creds are specified with a credset target_uri in a 1.1 file and a prefixed override on the CLI' do
       let(:file_fixture_name) { :basic }
       let(:cli_opts) { { target: 'ssh://set1', ssh_user: 'bob' } }
@@ -508,6 +555,31 @@ module ConfigTestHelper
         }
       }
       EOJ5
+    when :match_checks_in_credset_names
+      <<~EOJ6
+      {
+        "version": "1.1",
+        "credentials": {
+          "ssh": {
+            "TitleCase": {
+              "found": "yes"
+            },
+            "snake_case": {
+              "found": "yes"
+            },
+            "conta1nsnumeral5": {
+              "found": "yes"
+            },
+            "contains.dots": {
+              "found": "no"
+            },
+            "contains spaces": {
+              "found": "no"
+            }
+          }
+        }
+      }
+      EOJ6
     end
   end
   module_function :fixture

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -303,6 +303,30 @@ describe 'Inspec::Config' do
       end
     end
 
+    describe 'when creds are specified with a credset target_uri in a 1.1 file without transport prefixes' do
+      let(:file_fixture_name) { :basic }
+      let(:cli_opts) { { target: 'ssh://set1' }}
+      it 'should use the credset to lookup the creds in the file' do
+        expected = [:backend, :host, :user].sort
+        seen_fields.must_equal expected
+        creds[:backend].must_equal 'ssh'
+        creds[:host].must_equal 'some.host'
+        creds[:user].must_equal 'some_user'
+      end
+    end
+
+    describe 'when creds are specified with a credset target_uri in a 1.1 file and a prefixed override on the CLI' do
+      let(:file_fixture_name) { :basic }
+      let(:cli_opts) { { target: 'ssh://set1', ssh_user: 'bob' } }
+      it 'should use the credset to lookup the creds in the file then override the single value' do
+        expected = [:backend, :host, :user].sort
+        seen_fields.must_equal expected
+        creds[:backend].must_equal 'ssh'
+        creds[:host].must_equal 'some.host'
+        creds[:user].must_equal 'bob'
+      end
+    end
+
     describe 'when creds are specified with a non-credset target_uri' do
       let(:cfg_io) { nil }
       let(:cli_opts) { { target: 'ssh://bob@somehost' } }
@@ -424,6 +448,14 @@ module ConfigTestHelper
           "automate" : {
             "url": "http://some.where",
             "token" : "YOUR_A2_ADMIN_TOKEN"
+          }
+        },
+        "credentials": {
+          "ssh": {
+            "set1": {
+              "host": "some.host",
+              "user": "some_user"
+            }
           }
         }
       }

--- a/test/unit/mock/config_dirs/json-config/mock-credset.json
+++ b/test/unit/mock/config_dirs/json-config/mock-credset.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.1",
+  "cli_options": {
+    "target_id": "from-mock-credset-config-file"
+  },
+  "credentials": {
+    "mock": {
+      "mycredset": {
+        "a_setting": "a_value"
+      }
+    }
+  }
+}

--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -26,6 +26,8 @@ sidebar_links:
     link: "/docs/reference/matchers.html"
   - title: Reporters
     link: "/docs/reference/reporters.html"
+  - title: Configuration
+    link: "/docs/reference/config.html"
   - title: InSpec DSL
     link: "/docs/reference/dsl_inspec.html"
   - title: Profile Style guide


### PR DESCRIPTION
This is the last part of #3661, and a follow-on to #3750.

This PR adds the ability to add named sets of credentials (or more generally speaking, any options that a Train transport would accept) to the InSpec config file.

```
...
"credentials": {
  "ssh": {
    "myset1": {
      "user":"bob",
      "keepalive": true, 
      "hostname": "myhost",
    }
  }
}
...
```

The `--target` option is altered to allow a user to specify a credential set to use by `ssh://myset1` (more generally, `transport://credsetname`).

Notes on operation:
 * If a matching credential set can't be found, Train is asked to parse the `--target` value as a URI, preserving the previous behavior.
 * You can use a credential set, then override individual options on the CLI.