### PR TITLE
Fix extra '&&' in windows functional tests, add diagnostics

### DIFF
--- a/test/functional/helper.rb
+++ b/test/functional/helper.rb
@@ -187,7 +187,7 @@ module FunctionalHelper
   def assemble_env_prefix(env = {})
     if is_windows?
       env_prefix = env.to_a.map { |assignment| "set #{assignment[0]}=#{assignment[1]}" }.join('&& ')
-      env_prefix += '&& '
+      env_prefix += '&& ' unless env_prefix.empty?
     else
       env_prefix = env.to_a.map { |assignment| "#{assignment[0]}=#{assignment[1]}" }.join(' ')
       env_prefix += ' '


### PR DESCRIPTION
This PR makes two changes to the functional test helper:

 1. Fixes a problem in which '&& ' was added as a spurious prefix to windows command invocations, which powershell did not like.
 2. Adds a method, `diagnose!`, to the run result object, which make it easy to dump the the invocation, STDOUT, and STDERR while running under CI.