### PR TITLE
Plugins: Relocate plugin activate() method to Activator class, add simpler search method

### DIFF
--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -40,7 +40,7 @@ module Inspec
           if hook
             # OK, load the hook if it hasn't been already.  We'll then know a module,
             # which we can then inject into the context
-            registry.activate(:control_dsl, method_name) unless hook.activated?
+            hook.activate unless hook.activated?
             # Inject the module's methods into the context.
             # implementation_class is the field name, but this is actually a module.
             self.class.include(hook.implementation_class)

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -40,7 +40,8 @@ module Inspec
           if hook
             # OK, load the hook if it hasn't been already.  We'll then know a module,
             # which we can then inject into the context
-            hook.activate unless hook.activated?
+            hook.activate
+
             # Inject the module's methods into the context.
             # implementation_class is the field name, but this is actually a module.
             self.class.include(hook.implementation_class)

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -38,7 +38,7 @@ module Inspec::DSL
     if hook
       # OK, load the hook if it hasn't been already.  We'll then know a module,
       # which we can then inject into the context
-      hook.activate unless hook.activated?
+      hook.activate
       # Inject the module's methods into the context
       # implementation_class is the field name, but this is actually a module.
       self.class.include(hook.implementation_class)

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -38,7 +38,7 @@ module Inspec::DSL
     if hook
       # OK, load the hook if it hasn't been already.  We'll then know a module,
       # which we can then inject into the context
-      registry.activate(:outer_profile_dsl, method_name) unless hook.activated?
+      hook.activate unless hook.activated?
       # Inject the module's methods into the context
       # implementation_class is the field name, but this is actually a module.
       self.class.include(hook.implementation_class)

--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -52,7 +52,7 @@ module Inspec
       if hook
         # OK, load the hook if it hasn't been already.  We'll then know a module,
         # which we can then inject into the resource
-        registry.activate(:resource_dsl, method_name) unless hook.activated?
+        hook.activate unless hook.activated?
         # Inject the module's methods into the resource as class methods.
         # implementation_class is the field name, but this is actually a module.
         extend(hook.implementation_class)

--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -52,7 +52,7 @@ module Inspec
       if hook
         # OK, load the hook if it hasn't been already.  We'll then know a module,
         # which we can then inject into the resource
-        hook.activate unless hook.activated?
+        hook.activate
         # Inject the module's methods into the resource as class methods.
         # implementation_class is the field name, but this is actually a module.
         extend(hook.implementation_class)

--- a/lib/inspec/plugin/v2/activator.rb
+++ b/lib/inspec/plugin/v2/activator.rb
@@ -17,5 +17,26 @@ module Inspec::Plugin::V2
       return self[:'activated?'] if new_value.nil?
       self[:'activated?'] = new_value
     end
+
+    # Load a plugin, but if an error is encountered, store it and continue
+    def activate
+      return if activated?
+      # rubocop: disable Lint/RescueException
+      begin
+        impl_class = self[:activation_proc].call
+        self[:'activated?'] = true
+        self[:implementation_class] = impl_class
+      rescue Exception => ex
+        exception = ex
+        Inspec::Log.error "Could not activate #{self[:plugin_type]} hook named '#{self[:activator_name]}' for plugin #{self[:plugin_name]}"
+      end
+      # rubocop: enable Lint/RescueException
+    end
+
+    # Load a plugin, but if an error is encountered, re-throw it
+    def activate!
+      activate
+      raise exception if exception
+    end
   end
 end

--- a/lib/inspec/plugin/v2/activator.rb
+++ b/lib/inspec/plugin/v2/activator.rb
@@ -3,7 +3,7 @@ module Inspec::Plugin::V2
     :plugin_name,
     :plugin_type,
     :activator_name,
-    :'activated?',
+    :activated?,
     :exception,
     :activation_proc,
     :implementation_class,
@@ -14,8 +14,8 @@ module Inspec::Plugin::V2
     end
 
     def activated?(new_value = nil)
-      return self[:'activated?'] if new_value.nil?
-      self[:'activated?'] = new_value
+      return self[:activated?] if new_value.nil?
+      self[:activated?] = new_value
     end
 
     # Load a plugin, but if an error is encountered, store it and continue
@@ -24,7 +24,7 @@ module Inspec::Plugin::V2
       # rubocop: disable Lint/RescueException
       begin
         impl_class = self[:activation_proc].call
-        self[:'activated?'] = true
+        self[:activated?] = true
         self[:implementation_class] = impl_class
       rescue Exception => ex
         self[:exception] = ex

--- a/lib/inspec/plugin/v2/activator.rb
+++ b/lib/inspec/plugin/v2/activator.rb
@@ -27,7 +27,7 @@ module Inspec::Plugin::V2
         self[:'activated?'] = true
         self[:implementation_class] = impl_class
       rescue Exception => ex
-        exception = ex
+        self[:exception] = ex
         Inspec::Log.error "Could not activate #{self[:plugin_type]} hook named '#{self[:activator_name]}' for plugin #{self[:plugin_name]}"
       end
       # rubocop: enable Lint/RescueException

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -102,7 +102,7 @@ module Inspec::Plugin::V2
 
         # OK, activate.
         if activate_me
-          registry.activate(:cli_command, act.activator_name)
+          act.activate
           act.implementation_class.register_with_thor
         end
       end

--- a/lib/inspec/plugin/v2/registry.rb
+++ b/lib/inspec/plugin/v2/registry.rb
@@ -67,6 +67,17 @@ module Inspec::Plugin::V2
       end
     end
 
+    # Convenience method for when you expect exactly one
+    def find_activator(filters = {})
+      matched_plugins = find_activators(filters)
+      if matched_plugins.count > 1
+        raise Inspec::Plugin::V2::LoadError.new("Plugin hooks search returned multiple results for filter #{filters.inspect} - use more filters, or use find_activators (plural)")
+      elsif matched_plugins.empty?
+        raise Inspec::Plugin::V2::LoadError.new("Plugin hooks search returned zero results for filter #{filters.inspect}")
+      end
+      matched_plugins.first
+    end
+
     def register(name, status)
       if known_plugin? name
         Inspec::Log.debug "PluginLoader: refusing to re-register plugin '#{name}': an existing plugin with that name was loaded via #{registry[name].installation_type}-loading from #{registry[name].entry_point}"

--- a/lib/inspec/plugin/v2/registry.rb
+++ b/lib/inspec/plugin/v2/registry.rb
@@ -67,21 +67,6 @@ module Inspec::Plugin::V2
       end
     end
 
-    def activate(plugin_type, hook_name)
-      activator = find_activators(plugin_type: plugin_type, activator_name: hook_name).first
-      # We want to capture literally any possible exception here, since we are storing them.
-      # rubocop: disable Lint/RescueException
-      begin
-        impl_class = activator.activation_proc.call
-        activator.activated?(true)
-        activator.implementation_class = impl_class
-      rescue Exception => ex
-        activator.exception = ex
-        Inspec::Log.error "Could not activate #{activator.plugin_type} hook named '#{activator.activator_name}' for plugin #{plugin_name}"
-      end
-      # rubocop: enable Lint/RescueException
-    end
-
     def register(name, status)
       if known_plugin? name
         Inspec::Log.debug "PluginLoader: refusing to re-register plugin '#{name}': an existing plugin with that name was loaded via #{registry[name].installation_type}-loading from #{registry[name].entry_point}"

--- a/lib/inspec/plugin/v2/registry.rb
+++ b/lib/inspec/plugin/v2/registry.rb
@@ -71,9 +71,9 @@ module Inspec::Plugin::V2
     def find_activator(filters = {})
       matched_plugins = find_activators(filters)
       if matched_plugins.count > 1
-        raise Inspec::Plugin::V2::LoadError.new("Plugin hooks search returned multiple results for filter #{filters.inspect} - use more filters, or use find_activators (plural)")
+        raise Inspec::Plugin::V2::LoadError, "Plugin hooks search returned multiple results for filter #{filters.inspect} - use more filters, or use find_activators (plural)"
       elsif matched_plugins.empty?
-        raise Inspec::Plugin::V2::LoadError.new("Plugin hooks search returned zero results for filter #{filters.inspect}")
+        raise Inspec::Plugin::V2::LoadError, "Plugin hooks search returned zero results for filter #{filters.inspect}"
       end
       matched_plugins.first
     end

--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -17,7 +17,7 @@ module Inspec
       if hook
         # OK, load the hook if it hasn't been already.  We'll then know a module,
         # which we can then inject into the context
-        registry.activate(:describe_dsl, method_name) unless hook.activated?
+        hook.activate unless hook.activated?
 
         # Inject the module's methods into the example group contexts.
         # implementation_class is the field name, but this is actually a module.
@@ -46,7 +46,7 @@ module Inspec
       if hook
         # OK, load the hook if it hasn't been already.  We'll then know a module,
         # which we can then inject into the context
-        registry.activate(:test_dsl, method_name) unless hook.activated?
+        hook.activate unless hook.activated?
 
         # Inject the module's methods into the example group contexts.
         # implementation_class is the field name, but this is actually a module.

--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -17,7 +17,7 @@ module Inspec
       if hook
         # OK, load the hook if it hasn't been already.  We'll then know a module,
         # which we can then inject into the context
-        hook.activate unless hook.activated?
+        hook.activate
 
         # Inject the module's methods into the example group contexts.
         # implementation_class is the field name, but this is actually a module.
@@ -46,7 +46,7 @@ module Inspec
       if hook
         # OK, load the hook if it hasn't been already.  We'll then know a module,
         # which we can then inject into the context
-        hook.activate unless hook.activated?
+        hook.activate
 
         # Inject the module's methods into the example group contexts.
         # implementation_class is the field name, but this is actually a module.

--- a/test/unit/plugin/v2/loader_test.rb
+++ b/test/unit/plugin/v2/loader_test.rb
@@ -187,7 +187,6 @@ class PluginLoaderTests < MiniTest::Test
     # Management methods for activation
     assert_respond_to status, :activators, 'A plugin status should respond to `activators`'
     assert_respond_to registry, :find_activators, 'Registry should respond to `find_activators`'
-    assert_respond_to registry, :activate, 'Registry should respond to `activate`'
 
     # Finding an Activator
     assert_kind_of Array, status.activators, 'status should have an array for activators'
@@ -205,7 +204,7 @@ class PluginLoaderTests < MiniTest::Test
     assert_nil activator.implementation_class, 'Test activator should not know implementation class prior to activation'
     refute InspecPlugins::MeaningOfLife.const_defined?(:MockPlugin), 'impl_class should not be defined prior to activation'
 
-    registry.activate(:mock_plugin_type, :'meaning-of-life-the-universe-and-everything')
+    activator.activate
 
     # Activation postconditions
     assert activator.activated?, 'Test activator should be activated after activate'


### PR DESCRIPTION
This pays some technical debt from the early days of writing the plugin system. At first, Activators were bare structs, containers for data with no behavior.  It was the registry's job to find activators, and then activate them.

Over time, those two operations fell into a clear pattern: search the registry for an activator using certain criteria, take the first match, and then pass its ids to Registry to have it activated. That was silly, since you already had an Activator object as the result of the first search.

This PR:
 * Puts the activate() method in Activator where it belongs
 * Adds a convenience method to Registry which searches for Activators with the assumption you expect exactly one match.
