### PR TITLE
allow bundler 2.x and bump integration gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'ffi', '>= 1.9.14'
 gem 'aws-sdk', '~> 2'
 
 group :test do
-  gem 'bundler', '~> 1.5'
+  gem 'bundler', '>= 1.5'
   gem 'minitest', '~> 5.5'
   gem 'rake', '>= 10'
   gem 'rubocop', '= 0.49.1'
@@ -22,8 +22,8 @@ group :test do
 end
 
 group :integration do
-  gem 'berkshelf', '~> 5.2'
-  gem 'test-kitchen', '~> 1.6'
+  gem 'berkshelf', '>= 7.0.7'
+  gem 'test-kitchen', '>=  1.24'
   gem 'kitchen-vagrant'
   # we need winrm v2 support >= 0.15.1
   gem 'kitchen-inspec', '>= 0.15.1'

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :test do
 end
 
 group :integration do
-  gem 'berkshelf', '>= 6.3.4'
+  gem 'berkshelf', '~> 5.2'
   gem 'test-kitchen', '>= 1.24'
   gem 'kitchen-vagrant'
   # we need winrm v2 support >= 0.15.1

--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ group :test do
 end
 
 group :integration do
-  gem 'berkshelf', '>= 7.0.7'
-  gem 'test-kitchen', '>=  1.24'
+  gem 'berkshelf', '>= 6.3.4'
+  gem 'test-kitchen', '>= 1.24'
   gem 'kitchen-vagrant'
   # we need winrm v2 support >= 0.15.1
   gem 'kitchen-inspec', '>= 0.15.1'


### PR DESCRIPTION
the bundler bump is necessary for work with bundler 2.x installed.

have to see if the berkshelf + test-kitchen bumps can go through without turning tests red, but this gets rid of berkshelf <= 6.x and the ridley / celluloid deps.
