### PR TITLE
Promote Hab package alongside Omnibus package

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -67,6 +67,7 @@ subscriptions:
   - workload: artifact_published:current:inspec:*
     actions:
       - built_in:tag_docker_image
+      - built_in:promote_habitat_packages
   - workload: artifact_published:stable:inspec:*
     actions:
       - bash:.expeditor/update_dockerfile.sh
@@ -74,4 +75,5 @@ subscriptions:
       - built_in:publish_rubygems
       - built_in:create_github_release
       - built_in:tag_docker_image
+      - built_in:promote_habitat_packages
       - built_in:notify_chefio_slack_channels


### PR DESCRIPTION
This change ensures we are promoting our Hab packages to `current` and
`stable` at the same time we execute said promotions for the Omnibus
packages.

Signed-off-by: Seth Chisamore <schisamo@chef.io>