### PR TITLE
Allow 'Proprietary' as a valid license term.

### DIFF
--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -91,9 +91,9 @@ module Inspec
         warnings.push("Missing profile #{field} in #{ref}")
       end
 
-      # if version is set, ensure it is in SPDX format
-      if !params[:license].nil? && !Spdx.valid_license?(params[:license])
-        warnings.push("License '#{params[:license]}' needs to be in SPDX format. See https://spdx.org/licenses/.")
+      # if license is set, ensure it is in SPDX format or marked as proprietary
+      if !params[:license].nil? && !valid_license?(params[:license])
+        warnings.push("License '#{params[:license]}' needs to be in SPDX format or marked as 'Proprietary'. See https://spdx.org/licenses/.")
       end
 
       [errors, warnings]
@@ -110,6 +110,10 @@ module Inspec
       true
     rescue Semverse::InvalidVersionFormat
       false
+    end
+
+    def valid_license?(value)
+      value =~ /^Proprietary[,;]?\b/ || Spdx.valid_license?(value)
     end
 
     def method_missing(sth, *args)

--- a/test/unit/mock/profiles/license-proprietary/inspec.yml
+++ b/test/unit/mock/profiles/license-proprietary/inspec.yml
@@ -3,6 +3,6 @@ title: InSpec Profile
 maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
-license: Apache-2.0
+license: Proprietary, All rights reserved
 summary: An InSpec Compliance Profile
 version: 0.1.0

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -294,7 +294,7 @@ describe Inspec::Profile do
 
       it 'prints ok messages and counts the controls' do
         logger.expect :info, nil, ["Checking profile in #{home}/mock/profiles/#{profile_id}"]
-        logger.expect :warn, nil, ["License 'Invalid License Name' needs to be in SPDX format. See https://spdx.org/licenses/."]
+        logger.expect :warn, nil, ["License 'Invalid License Name' needs to be in SPDX format or marked as 'Proprietary'. See https://spdx.org/licenses/."]
         logger.expect :warn, nil, ['No controls or tests were defined.']
         logger.expect :info, nil, ["Metadata OK."]
 


### PR DESCRIPTION
Currently our supported profiles output a warning for every instance of `inspec check` because our license metadata `Proprietary, All rights reserved` is not considered valid.
This commit allows for a string beginning with `Proprietary` to be considered valid, as well as any valid SPDX value.

This is part of our overall desire to be able to use `inspec check` in CI and fail on warnings.

Signed-off-by: James Stocks <jstocks@chef.io>