### PR TITLE
Document additional usage of json resource

### DIFF
--- a/docs/resources/json.md.erb
+++ b/docs/resources/json.md.erb
@@ -47,8 +47,8 @@ where
 * `name` is a configuration setting in a JSON file
 * `should eq 'foo'` tests a value of `name` as read from a JSON file versus the value declared in the test
 
-The `json` resource can also be used with json formatted output from a command. 
-Using the same json as the previous exmaple, it can be queried using:
+The `json` resource can also be used with JSON formatted output from a command.
+Using the same JSON as the previous example, it can be queried using:
 
     describe json({ command: 'retrieve_data.py --json'}) do
       its('name') { should eq 'hello' }
@@ -56,7 +56,7 @@ Using the same json as the previous exmaple, it can be queried using:
       its(['array', 1]) { should eq 'one' }
     end
 
-Finally content can be passed directly to the resource:
+Finally, content can be passed directly to the resource:
 
     describe json({ content: '{\"item1\": { \"status\": \"available\" } }' }) do
       its(['item1', 'status']) { should cmp 'available' }
@@ -85,4 +85,3 @@ The `name` matcher tests the value of the filename as read from a JSON file vers
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
-

--- a/docs/resources/json.md.erb
+++ b/docs/resources/json.md.erb
@@ -47,6 +47,21 @@ where
 * `name` is a configuration setting in a JSON file
 * `should eq 'foo'` tests a value of `name` as read from a JSON file versus the value declared in the test
 
+The `json` resource can also be used with json formatted output from a command. 
+Using the same json as the previous exmaple, it can be queried using:
+
+    describe json({ command: 'retrieve_data.py --json'}) do
+      its('name') { should eq 'hello' }
+      its(['meta','creator']) { should eq 'John Doe' }
+      its(['array', 1]) { should eq 'one' }
+    end
+
+Finally content can be passed directly to the resource:
+
+    describe json({ content: '{\"item1\": { \"status\": \"available\" } }' }) do
+      its(['item1', 'status']) { should cmp 'available' }
+    end
+
 <br>
 
 ## Examples


### PR DESCRIPTION
The `command` and `content` usage seems to have been supported for some time, but is not included in the documentation.

ref:
* https://github.com/inspec/inspec/pull/1271