### PR TITLE
Fix AWS tests found during ChefStyle spike

### DIFF
--- a/test/unit/resources/aws_elb_test.rb
+++ b/test/unit/resources/aws_elb_test.rb
@@ -13,15 +13,15 @@ class AwsElbConstructorTest < Minitest::Test
   end
 
   def test_empty_params_rejected
-    assert_raises(ArgumentError) { AwsElb.new }    
+    assert_raises(ArgumentError) { AwsElb.new }
   end
 
   def test_string_accepted
-    AwsElb.new 'my-elb'    
+    AwsElb.new 'my-elb'
   end
 
   def test_hash_accepted
-    AwsElb.new elb_name: 'my-elb'    
+    AwsElb.new elb_name: 'my-elb'
   end
 
   def test_rejects_unrecognized_params
@@ -49,7 +49,7 @@ class AwsElbFilterCriteriaTest < Minitest::Test
     assert_equal('kangaroo', elb.elb_name)
   end
 
-  def test_recall_when_provided_a_string
+  def test_recall_when_provided_a_symbol
     elb = AwsElb.new elb_name: 'kang-the-alien'
     assert elb.exists?
     assert_equal('kang-the-alien', elb.elb_name)
@@ -92,7 +92,7 @@ class AwsElbProperties < Minitest::Test
     assert_kind_of(Array, @miss.external_ports)
     assert_empty(@miss.external_ports)
   end
-  
+
   def test_property_with_instance_ids
     assert_includes(@roo.instance_ids, 'i-87654321')
     assert_includes(@kang.instance_ids, 'i-12345678')
@@ -186,7 +186,7 @@ module MAESB
               'us-east-1b',
               'us-east-1c',
             ],
-            dns_name: '12345678.us-east-2.aws.amazon.com',            
+            dns_name: '12345678.us-east-2.aws.amazon.com',
             load_balancer_name: 'kangaroo',
             listener_descriptions: [
               Aws::ElasticLoadBalancing::Types::ListenerDescription.new(
@@ -216,7 +216,7 @@ module MAESB
               'us-east-1a',
               'us-east-1e',
             ],
-            dns_name: '999999.us-east-1.aws.amazon.com',            
+            dns_name: '999999.us-east-1.aws.amazon.com',
             load_balancer_name: 'gamma',
             listener_descriptions: [
               Aws::ElasticLoadBalancing::Types::ListenerDescription.new(
@@ -246,18 +246,18 @@ module MAESB
 
       if query[:load_balancer_names]
         result = data.load_balancer_descriptions.select do |lbd|
-          query[:load_balancer_names].include? lbd.load_balancer_name 
+          query[:load_balancer_names].include? lbd.load_balancer_name
         end
         if result.empty?
           raise Aws::ElasticLoadBalancing::Errors::LoadBalancerNotFound.new(nil, nil)
-        else 
+        else
           Aws::ElasticLoadBalancing::Types::DescribeAccessPointsOutput.new(
             load_balancer_descriptions: result
           )
         end
       else
         data
-      end 
+      end
     end
   end
 end

--- a/test/unit/resources/aws_iam_group_test.rb
+++ b/test/unit/resources/aws_iam_group_test.rb
@@ -55,7 +55,7 @@ end
 #=============================================================================#
 #                               Properties
 #=============================================================================#
-class AwsIamGroupRecallTest < Minitest::Test
+class AwsIamGroupPropertiesTest < Minitest::Test
 
   def setup
     AwsIamGroup::BackendFactory.select(MAIGSB::Basic)

--- a/test/unit/resources/aws_route_table_test.rb
+++ b/test/unit/resources/aws_route_table_test.rb
@@ -5,11 +5,11 @@ class EmptyAwsRouteTableTest < Minitest::Test
     AwsRouteTable::BackendFactory.select(AwsMRtbB::Empty)
   end
 
-  def test_search_hit_via_scalar_works
-    assert_empty AwsRouteTable.new[:routetables]
+  def test_search_hit_via_scalar_works_symbol
+    refute AwsRouteTable.new(route_table_id: 'rtb-123abcde').exists?
   end
 
-  def test_search_hit_via_scalar_works
+  def test_search_hit_via_scalar_works_string
     refute AwsRouteTable.new('rtb-123abcde').exists?
   end
 end

--- a/test/unit/resources/aws_security_group_test.rb
+++ b/test/unit/resources/aws_security_group_test.rb
@@ -10,7 +10,7 @@ class AwsSGSConstructor < Minitest::Test
   def setup
     AwsSecurityGroup::BackendFactory.select(AwsMESGSB::Empty)
   end
-  
+
   def test_constructor_no_args_raises
     assert_raises(ArgumentError) { AwsSecurityGroup.new }
   end
@@ -25,7 +25,7 @@ class AwsSGSConstructor < Minitest::Test
       group_id: 'sg-1234abcd',
       vpc_id: 'vpc-1234abcd',
       group_name: 'some-group',
-    }.each do |param, value| 
+    }.each do |param, value|
       AwsSecurityGroup.new(param => value)
     end
   end
@@ -35,7 +35,7 @@ class AwsSGSConstructor < Minitest::Test
       id: 'sg-xyz-123',
       group_id: '1234abcd',
       vpc_id: 'vpc_1234abcd',
-    }.each do |param, value| 
+    }.each do |param, value|
       assert_raises(ArgumentError) { AwsSecurityGroup.new(param => value) }
     end
   end
@@ -53,7 +53,7 @@ class AwsSGSProperties < Minitest::Test
   def setup
     AwsSecurityGroup::BackendFactory.select(AwsMESGSB::Basic)
   end
-  
+
   def test_property_group_id
     assert_equal('sg-12345678', AwsSecurityGroup.new('sg-12345678').group_id)
     assert_nil(AwsSecurityGroup.new(group_name: 'my-group').group_id)
@@ -107,7 +107,7 @@ end
 #                               Matchers
 #=============================================================================#
 
-class AwsSGSProperties < Minitest::Test
+class AwsSGSMatchers < Minitest::Test
   def setup
     AwsSecurityGroup::BackendFactory.select(AwsMESGSB::Basic)
   end
@@ -156,7 +156,7 @@ class AwsSGSProperties < Minitest::Test
     assert(sg.allow_in_only?(from_port: 9001, to_port: 9003, position: 3), "exact range matching on port with allow_in_only")
 
     # Protocol
-    assert(sg.allow_in?(protocol: 'tcp'), "match on tcp protocol, unpinned")    
+    assert(sg.allow_in?(protocol: 'tcp'), "match on tcp protocol, unpinned")
     assert(sg.allow_in?(protocol: 'tcp', position: 1), "match on tcp protocol")
     assert(sg.allow_in?(protocol: 'any', position: 2), "match on our 'any' alias protocol")
     assert(sg.allow_in?(protocol: '-1', position: 2), "match on AWS spec '-1 for any' protocol")
@@ -270,7 +270,7 @@ module AwsMESGSB
               to_port: 22,
               ip_protocol: 'tcp',
               ip_ranges: [
-                # Apparently AWS returns these as plain hashes, 
+                # Apparently AWS returns these as plain hashes,
                 # nested in two levels of Structs.
                 {cidr_ip:"10.1.2.0/24"},
                 {cidr_ip:"10.1.3.0/24"},
@@ -312,7 +312,7 @@ module AwsMESGSB
                 {cidr_ipv_6:"2001:db8::/122"}
               ]
             }),
-          ],          
+          ],
         }),
         OpenStruct.new({
           description: 'Open Group',
@@ -329,7 +329,7 @@ module AwsMESGSB
               ]
             }),
           ],
-          ip_permissions_egress: [],          
+          ip_permissions_egress: [],
         }),
         OpenStruct.new({
           description: 'Open Group',


### PR DESCRIPTION
While doing https://github.com/inspec/inspec/pull/3732 I found a few style issues with the AWS tests.

This fixes those style issues and also fixes a duplicated test method name.