### PR TITLE
Clean up unit test output

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -198,6 +198,7 @@ class MockLoader
       '/fakepath/fakefile' => emptyfile.call,
       'C:/fakepath/fakefile' => emptyfile.call,
       '/etc/cron.d/crondotd' => mockfile.call('crondotd'),
+      '/missing_file' => emptyfile.call,
     }
 
     # create all mock commands

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -508,7 +508,7 @@ class MockLoader
       '/sbin/service sshd status' => empty.call,
       'service apache2 status' => cmd_exit_1.call,
       'type "lsof"' => empty.call,
-
+      'test -f /etc/mysql/debian.cnf && cat /etc/mysql/debian.cnf' => empty.call,
       # http resource - remote worker'
       %{bash -c 'type "curl"'} => cmd.call('bash-c-type-curl'),
       "curl -i -X GET --connect-timeout 60 --max-time 120 'http://www.example.com'" => cmd.call('http-remote-no-options'),

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -229,6 +229,7 @@ class MockLoader
       'bash -c \'type "Rscript"\'' => empty.call,
       'bash -c \'type "perl"\'' => empty.call,
       'bash -c \'type "/sbin/auditctl"\'' => empty.call,
+      'bash -c \'type "sql"\'' => cmd_exit_1.call,
       'type "pwsh"' => empty.call,
       'type "netstat"' => empty.call,
       'sh -c \'find /etc/apache2/ports.conf -type l -maxdepth 1\'' => empty.call,

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -204,7 +204,7 @@ describe Fetchers::Url do
     describe 'when only password is specified' do
       let(:config) { { :password => 'dummy'} }
       it 'returns a hash containing http_basic_authentication setting as nil' do
-        subject.send(:http_opts)[:http_basic_authentication].must_equal nil
+        subject.send(:http_opts)[:http_basic_authentication].must_be_nil
       end
     end
 

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -110,7 +110,7 @@ describe Inspec::ProfileContext do
       end
     end
 
-    it 'does not provide the expect keyword in the global DLS' do
+    it 'does not provide the expect keyword in the global DSL' do
       load('expect(true).to_eq true').must_raise NoMethodError
     end
 

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -78,7 +78,7 @@ describe Inspec::ProfileContext do
     end
 
     it 'must provide file resource' do
-      load('print file("").type').must_output 'unknown'
+      load('print file("/etc/passwd").type').must_output 'file'
     end
 
     it 'must provide command resource' do

--- a/test/unit/resources/apt_test.rb
+++ b/test/unit/resources/apt_test.rb
@@ -54,11 +54,4 @@ describe 'Inspec::Resources::AptRepo' do
     _(resource.exists?).must_equal false
     _(resource.enabled?).must_equal false
   end
-
-  # check ppa resource
-  it 'check apt on ubuntu' do
-    resource = MockLoader.new(:ubuntu1504).load_resource('ppa', 'ubuntu-wine/ppa')
-    _(resource.exists?).must_equal true
-    _(resource.enabled?).must_equal true
-  end
 end

--- a/test/unit/resources/chocolatey_package_test.rb
+++ b/test/unit/resources/chocolatey_package_test.rb
@@ -13,7 +13,7 @@ describe 'Inspec::Resources::ChocoPkg' do
     pkg = { name: 'git', installed: false, version: nil, type: 'chocolatey' }
     resource = MockLoader.new(:windows).load_resource('chocolatey_package', 'git')
     _(resource.installed?).must_equal pkg[:installed]
-    _(resource.version).must_equal pkg[:version]
+    _(resource.version).must_be_nil
     _(resource.info).must_equal pkg
   end
 

--- a/test/unit/resources/nginx_conf_test.rb
+++ b/test/unit/resources/nginx_conf_test.rb
@@ -13,7 +13,7 @@ describe 'Inspec::Resources::NginxConf' do
   let(:nginx_conf) { MockLoader.new(:ubuntu1404).load_resource('nginx_conf') }
 
   it 'doesnt fail with a missing file' do
-    nginx_conf = MockLoader.new(:ubuntu1404).load_resource('nginx_conf', '/....missing_file')
+    nginx_conf = MockLoader.new(:ubuntu1404).load_resource('nginx_conf', '/missing_file')
     _(nginx_conf.params).must_equal({})
   end
 

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -13,7 +13,10 @@ describe 'Inspec::Resources::Processes' do
 
   it 'verify processes resource' do
     resource = MockLoader.new(:freebsd10).load_resource('processes', 'login -fp apop')
-    _(resource.list.length).must_equal 2      # until we deprecate
+
+    proc { resource.list.length.must_equal 2 }
+      .must_output nil, "[DEPRECATION] `processes.list` is deprecated. Please use `processes.entries` instead. It will be removed in version 4.0.\n"
+
     _(resource.entries.length).must_equal 2
     _(resource.entries[0].to_h).must_equal({
       label: nil,

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -11,16 +11,16 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   it 'retrieve users via field' do
-    _(shadow.user).must_equal %w{root www-data}
+    _(shadow.users).must_equal %w{root www-data}
     _(shadow.count).must_equal 2
   end
 
   it 'retrieve passwords via field' do
-    _(shadow.password).must_equal %w{x !!}
+    _(shadow.passwords).must_equal %w{x !!}
   end
 
   it 'retrieve last password change via field' do
-    _(shadow.last_change).must_equal %w{1 10}
+    _(shadow.last_changes).must_equal %w{1 10}
   end
 
   it 'retrieve min password days via field' do
@@ -40,7 +40,7 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   it 'retrieve dates when account will expire via field' do
-    _(shadow.expiry_date).must_equal [nil, "60"]
+    _(shadow.expiry_dates).must_equal [nil, "60"]
   end
 
   it 'access all lines of the file' do
@@ -82,8 +82,8 @@ describe 'Inspec::Resources::Shadow' do
 
   describe 'multiple filters' do
     it 'filters with min_days and max_days' do
-      _(shadow.filter(min_days: 20, max_days: 30).user).must_equal ['www-data']
-      _(shadow.filter(last_change: 1, min_days: 2).user).must_equal ['root']
+      _(shadow.filter(min_days: 20, max_days: 30).users).must_equal ['www-data']
+      _(shadow.filter(last_change: 1, min_days: 2).users).must_equal ['root']
     end
   end
 

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -34,14 +34,22 @@ describe 'Inspec::Resources::User' do
   end
 
   # serverspec compatibility tests (do not test matcher)
-  it 'verify serverspec compatibility' do
+  it 'returns deprecation notices' do
     resource = MockLoader.new(:ubuntu1404).load_resource('user', 'root')
-    _(resource.has_uid?(0)).must_equal true
-    _(resource.has_home_directory?('/root')).must_equal true
-    _(resource.has_login_shell?('/bin/bash')).must_equal true
-    _(resource.minimum_days_between_password_change).must_equal 0
-    _(resource.maximum_days_between_password_change).must_equal 99999
-    # _(resource.has_authorized_key?('abc')).must_equal true
+    proc { resource.has_uid?(0).must_equal true }
+      .must_output nil, "[DEPRECATION] has_uid? is deprecated. \n"
+    proc { resource.has_home_directory?('/root').must_equal true }
+      .must_output nil, "[DEPRECATION] has_home_directory? is deprecated. Please use: its('home')\n"
+    proc { resource.has_login_shell?('/bin/bash').must_equal true }
+      .must_output nil, "[DEPRECATION] has_login_shell? is deprecated. Please use: its('shell')\n"
+    proc { resource.minimum_days_between_password_change.must_equal 0 }
+      .must_output nil, "[DEPRECATION] minimum_days_between_password_change is deprecated. Please use: its('mindays')\n"
+    proc { resource.maximum_days_between_password_change.must_equal 99999 }
+      .must_output nil, "[DEPRECATION] maximum_days_between_password_change is deprecated. Please use: its('maxdays')\n"
+
+    assert_output(nil, "[DEPRECATION] has_authorized_key? is deprecated. \n") do
+      proc { resource.has_authorized_key?('abc') }.must_raise NotImplementedError
+    end
   end
 
   it 'read user on centos7' do

--- a/test/unit/resources/virtualization_test.rb
+++ b/test/unit/resources/virtualization_test.rb
@@ -4,15 +4,45 @@ require 'helper'
 require 'inspec/resource'
 
 describe 'Inspec::Resources::Virtualization' do
-  let(:resource) { MockLoader.new(:ubuntu).load_resource('virtualization') }
+  def mock_proc(mocked_files)
+    proc do |filename|
+      OpenStruct.new(
+        :exist? => mocked_files.include?(filename) ? false : true
+      )
+    end
+  end
 
   it 'fails the resource if OS is not Linux' do
-    resource = MockLoader.new(:windows).load_resource('virtualization')
-    resource.resource_failed?.must_equal true
+    mocked_files = []
+    mock_loader = MockLoader.new(:windows)
+    mock_loader.backend.stub :file, mock_proc(mocked_files) do
+      mock_resource = mock_loader.load_resource('virtualization')
+      mock_resource.resource_failed?.must_equal true
+    end
   end
 
   it 'returns nil for all properties if no virutalization platform is found' do
-    resource.system.must_be_nil
-    resource.role.must_be_nil
+    mocked_files = [
+      '/proc/xen/capabilities',
+      '/proc/modules',
+      '/proc/cpuinfo',
+      '/sys/devices/virtual/misc/kvm',
+      '/proc/bc/0',
+      '/proc/vz',
+      '/proc/bus/pci/devices',
+      '/proc/self/status',
+      '/proc/self/cgroup',
+      '/.dockerenv',
+      '/.dockerinit',
+      '/dev/lxd/sock',
+      '/var/lib/lxd/devlxd',
+    ]
+
+    mock_loader = MockLoader.new(:ubuntu)
+    mock_loader.backend.stub :file, mock_proc(mocked_files) do
+      mock_resource = mock_loader.load_resource('virtualization')
+      mock_resource.system.must_be_nil
+      mock_resource.role.must_be_nil
+    end
   end
 end

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -38,7 +38,7 @@ describe Inspec::Runner do
 
     describe 'testing runner.run exit codes' do
       it 'returns proper exit code when no profile is added' do
-        runner.run.must_equal 0
+        proc { runner.run.must_equal 0 }
       end
     end
 


### PR DESCRIPTION
This reduces the amount of extraneous unit test output. I was not able to get all of the extra output removed easily and have created https://github.com/inspec/inspec/issues/3741 and https://github.com/inspec/inspec/issues/3742 to track the remaining work. This gets us close though.

See:

[current_output.txt](https://github.com/inspec/inspec/files/2780720/current_output.txt) vs [cleaner_output.txt](https://github.com/inspec/inspec/files/2780721/cleaner_output.txt)

Many thanks to @miah helping me with this a while back!