### PR TITLE
Add CLI options to disable loading plugins

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -32,6 +32,12 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   class_option :interactive, type: :boolean,
     desc: 'Allow or disable user interaction'
 
+  class_option :disable_core_plugins, type: :string, banner: '', # Actually a boolean, but this suppresses the creation of a --no-disable...
+    desc: 'Disable loading all plugins that are shipped in the lib/plugins directory of InSpec. Useful in development.'
+
+  class_option :disable_user_plugins, type: :string, banner: '',
+    desc: 'Disable loading all plugins that the user installed.'
+
   desc 'json PATH', 'read all tests in PATH and generate a JSON summary'
   option :output, aliases: :o, type: :string,
     desc: 'Save the created profile to a path'

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -378,8 +378,10 @@ begin
     end
   end
 
-  # Load v2 plugins
-  v2_loader = Inspec::Plugin::V2::Loader.new
+  # Load v2 plugins.  Manually check for plugin disablement.
+  omit_core = ARGV.delete('--disable-core-plugins')
+  omit_user = ARGV.delete('--disable-user-plugins')
+  v2_loader = Inspec::Plugin::V2::Loader.new(omit_core_plugins: omit_core, omit_user_plugins: omit_user)
   v2_loader.load_all
   v2_loader.exit_on_load_error
   v2_loader.activate_mentioned_cli_plugins

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -14,8 +14,10 @@ module Inspec::Plugin::V2
     def initialize(options = {})
       @options = options
       @registry = Inspec::Plugin::V2::Registry.instance
-      @conf_file = Inspec::Plugin::V2::ConfigFile.new
-      read_conf_file_into_registry
+      unless options[:omit_user_plugins]
+        @conf_file = Inspec::Plugin::V2::ConfigFile.new
+        read_conf_file_into_registry
+      end
 
       # Old-style (v0, v1) co-distributed plugins were called 'bundles'
       # and were located in lib/bundles

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -25,6 +25,32 @@ describe 'plugin loader' do
 end
 
 #=========================================================================================#
+#                              Disabling Plugins
+#=========================================================================================#
+describe 'when disabling plugins' do
+  include FunctionalHelper
+
+  describe 'when disabling the core plugins' do
+    it 'should not be able to use core-provided commands' do
+      run_result = run_inspec_process('--disable-core-plugins habitat')
+      run_result.stderr.must_include 'Could not find command "habitat".'
+      # One might think that this should be code 2 (plugin error)
+      # But because the core plugins are not loaded, 'habitat' is not
+      # a known command, which makes it a usage error, code 1.
+      run_result.exit_status.must_equal 1
+    end
+  end
+
+  describe 'when disabling the user plugins' do
+    it 'should not be able to use user commands' do
+      run_result = run_inspec_process('--disable-user-plugins meaningoflife answer', env: { INSPEC_CONFIG_DIR: File.join(config_dir_path, 'meaning_by_path') })
+      run_result.stderr.must_include 'Could not find command "meaningoflife"'
+      run_result.exit_status.must_equal 1
+    end
+  end
+end
+
+#=========================================================================================#
 #                           CliCommand plugin type
 #=========================================================================================#
 describe 'cli command plugins' do
@@ -61,6 +87,20 @@ end
 #                           inspec plugin command
 #=========================================================================================#
 # See lib/plugins/inspec-plugin-manager-cli/test
+
+#=========================================================================================#
+#                                Plugin Disable Messaging
+#=========================================================================================#
+describe 'disable plugin usage message integration' do
+  include FunctionalHelper
+
+  it "mentions the --disable-{user,core}-plugins options" do
+    outcome = inspec('help')
+    ['--disable-user-plugins', '--disable-core-plugins'].each do |option|
+      outcome.stdout.must_include(option)
+    end
+  end
+end
 
 #=========================================================================================#
 #                           DSL Plugin Support


### PR DESCRIPTION
From time to time, it is useful to disable loading user or core plugins, especially during testing. This PR does that by adding two new options, `--disable-user-plugins` and `--disable-core-plugins`.  

Disabling user plugins is useful when your plugin setup is corrupted. This would allow (for example) `inspec plugin uninstall inspec-bad-plugin --disable-user-plugins`, without resorting to locating and removing the user plugin directory.

Disabling core plugins is needed when testing plugins that may talk to each other - in this case, to isolate user attribute provider plugins during testing.

Simple tests are provided to ensure the two options work, and that they are included in usage help.