### PR TITLE
Update train pin so inspec builds may succeed

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'train', '~> 1.5', '>= 1.6.3'
+  spec.add_dependency 'train', '~> 1.5', '>= 1.7.0'
   spec.add_dependency 'thor', '~> 0.20'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'method_source', '~> 0.8'


### PR DESCRIPTION
This moves us to train-1.7.0, whose major feature is that it no longer explicitly pins to a v1 bundler gem. This was breaking our CD pipeline, preventing releases.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

