### PR TITLE
Add `--help` to CLI plugin activation criteria

### DIFF
--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -89,13 +89,9 @@ module Inspec::Plugin::V2
         # all following ||= ops.
         activate_me = false
 
-        # If the user invoked `inspec help`, activate all CLI plugins, so they can
-        # display their usage message.
-        activate_me ||= cli_args.first == 'help'
-
-        # Likewise, if they invoked simply `inspec`, they are confused, and need
-        # usage info.
-        activate_me ||= cli_args.empty?
+        # If the user invoked `inspec help`, `inspec --help`, or only `inspec`
+        # then activate all CLI plugins so they can display their usage message.
+        activate_me ||= ['help', '--help', nil].include?(cli_args.first)
 
         # If there is anything in the CLI args with the same name, activate it.
         # This is the expected usual activation for individual plugins.

--- a/test/functional/inspec_test.rb
+++ b/test/functional/inspec_test.rb
@@ -28,4 +28,16 @@ describe 'command tests' do
       out.exit_status.must_equal 0
     end
   end
+
+  describe 'help' do
+    it 'outputs the same message when using `help`, `--help`, or no args' do
+      outputs = [
+        inspec('help').stdout,
+        inspec('--help').stdout,
+        inspec('').stdout,
+      ]
+
+      outputs.uniq.length.must_equal 1
+    end
+  end
 end

--- a/test/functional/inspec_test.rb
+++ b/test/functional/inspec_test.rb
@@ -30,14 +30,42 @@ describe 'command tests' do
   end
 
   describe 'help' do
-    it 'outputs the same message when using `help`, `--help`, or no args' do
-      outputs = [
+    let(:outputs) {
+      [
         inspec('help').stdout,
         inspec('--help').stdout,
         inspec('').stdout,
       ]
+    }
 
+    it 'outputs the same message regardless of invocation' do
       outputs.uniq.length.must_equal 1
+    end
+
+    it 'outputs both core commands and v2 CLI plugins' do
+      commands = %w{
+        archive
+        artifact
+        check
+        compliance
+        detect
+        env
+        exec
+        habitat
+        help
+        init
+        json
+        plugin
+        shell
+        supermarket
+        vendor
+        version
+      }
+      outputs.each do |output|
+        commands.each do |subcommand|
+          output.must_include('inspec ' + subcommand)
+        end
+      end
     end
   end
 end

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -63,25 +63,6 @@ end
 # See lib/plugins/inspec-plugin-manager-cli/test
 
 #=========================================================================================#
-#                                CLI Usage Messaging
-#=========================================================================================#
-describe 'plugin cli usage message integration' do
-  include FunctionalHelper
-
-  [' help', ''].each do |invocation|
-    it "includes v2 plugins in `inspec#{invocation}` output" do
-      outcome = inspec(invocation)
-      outcome.stderr.must_equal ''
-
-      # These are some subcommands provided by core v2 plugins
-      ['habitat', 'artifact'].each do |subcommand|
-        outcome.stdout.must_include('inspec ' + subcommand)
-      end
-    end
-  end
-end
-
-#=========================================================================================#
 #                           DSL Plugin Support
 #=========================================================================================#
 


### PR DESCRIPTION
This ensures that all the following result in the same CLI output:
  - `inspec`
  - `inspec help`
  - `inspec --help`

This closes #3753.