### PR TITLE
Allow :value in addition to :default for setting attribute values

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -341,11 +341,13 @@ Attributes are frequently used to parameterize a profile for use in different en
 
 Attributes may contain the following options:
 
-* Use `default` to set a default value for the attribute.
+* Use `value` to set a value for the attribute.
 * Use `type` to restrict an attribute to a specific type (any, string, numeric, array, hash, boolean, regex).
-* Use `required` to mandate the attribute has a default value or a value from a attribute YAML file.
+* Use `required` to mandate the attribute has a value at the time of evaluation.
 * Use `description` to set a brief description for the attribute.
 
+
+## Setting Attributes in the Profile Metadata File
 
 You can specify attributes in your `inspec.yml` using the `attributes` setting. For example, to add a `user` attribute for your profile:
 
@@ -353,7 +355,7 @@ You can specify attributes in your `inspec.yml` using the `attributes` setting. 
 attributes:
   - name: user
     type: string
-    default: bob
+    value: bob
 ```
 
 Example of adding a array object of servers:
@@ -362,7 +364,7 @@ Example of adding a array object of servers:
 attributes:
   - name: servers
     type: array
-    default:
+    value:
       - server1
       - server2
       - server3
@@ -386,9 +388,11 @@ control 'system-users' do
 end
 ```
 
-For sensitive data it is recomended to use a secrets YAML file located on the local machine to populate the values of attributes. A secrets file will always overwrite a attributes default value. To use the secrets file run `inspec exec` and specify the path to that Yaml file using the `--attrs` attribute.
+## Setting Attributes in an External YAML Attributes File
 
-For example, a inspec.yml:
+For sensitive data it is recommended to use a YAML file located on the local machine to populate the values of attributes. To read values from a YAML file, use run `inspec exec` and specify the path to that YAML file using the `--attrs` attribute.
+
+For example, your profile's metadata file, inspec.yml:
 
 ```YAML
 attributes:
@@ -483,6 +487,14 @@ $ inspec exec examples/profile-attribute --attrs examples/linux.yml
 ```
 
 See the full example in the InSpec open source repository: [Example InSpec Profile with Attributes](https://github.com/chef/inspec/tree/master/examples/profile-attribute)
+
+## Attribute Value Precedence
+
+Attribute values are always set in the following precedence (highest to lowest):
+
+ 1. Values from a file specified on the command line using --attrs
+ 2. Values from a profile metadata file - an inspec.yml with an `attributes:` section
+ 3. Values provided directly in control code - `attribute('user', value: 'bob')`
 
 # Profile files
 

--- a/etc/deprecations.json
+++ b/etc/deprecations.json
@@ -2,5 +2,9 @@
   "file_version": "1.0.0",
   "unknown_group_action": "ignore",
   "groups": {
+    "attrs_value_replaces_default": {
+      "action": "ignore",
+      "prefix": "The 'default' option for attributes is being replaced by 'value' - please use it instead."
+    }
   }
 }

--- a/examples/profile-attribute/controls/example.rb
+++ b/examples/profile-attribute/controls/example.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-val_user = attribute('user', default: 'alice', description: 'An identification for the user')
+val_user = attribute('user', value: 'alice', description: 'An identification for the user')
 val_password = attribute('password', description: 'A value for the password')
 
 describe val_user do

--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -46,7 +46,12 @@ module Inspec
       @opts = options
       if @opts.key?(:default)
         Inspec.deprecate(:attrs_value_replaces_default, "attribute name: '#{name}'")
-        @opts[:value] = @opts.delete(:default)
+        if @opts.key?(:value)
+          Inspec::Log.warn "Attribute #{@name} created using both :default and :value options - ignoring :default"
+          @opts.delete(:default)
+        else
+          @opts[:value] = @opts.delete(:default)
+        end
       end
       @value = @opts[:value]
       validate_value_type(@value) if @opts.key?(:type) && @opts.key?(:value)

--- a/test/unit/attributes/attribute_test.rb
+++ b/test/unit/attributes/attribute_test.rb
@@ -52,6 +52,16 @@ describe Inspec::Attribute do
       attribute.value = 'new_value'
       attribute.value.must_equal 'new_value'
     end
+
+    it 'accepts the legacy ":default" option' do
+      attribute = Inspec::Attribute.new('test_attribute', default: 'a_default')
+      attribute.value.must_equal 'a_default'
+    end
+
+    it 'accepts the legacy ":default" and ":value" options' do
+      attribute = Inspec::Attribute.new('test_attribute', default: 'a_default', value: 'a_value')
+      attribute.value.must_equal 'a_value'
+    end
   end
 
   describe 'validate required method' do

--- a/test/unit/attributes/attribute_test.rb
+++ b/test/unit/attributes/attribute_test.rb
@@ -6,65 +6,70 @@ require 'inspec/objects/attribute'
 describe Inspec::Attribute do
   let(:attribute) { Inspec::Attribute.new('test_attribute') }
 
-  it 'returns the actual value, not the default, if one is assigned' do
-    attribute.value = 'new_value'
-    attribute.value.must_equal 'new_value'
-  end
-
   it 'support storing and returning false' do
     attribute.value = false
     attribute.value.must_equal false
   end
 
-  it 'returns the default value if no value is assigned' do
-    attribute.value.must_be_kind_of Inspec::Attribute::DEFAULT_ATTRIBUTE
-    attribute.value.to_s.must_equal "Attribute 'test_attribute' does not have a value. Skipping test."
-  end
-
-  it 'has a default value that can be called like a nested map' do
-    attribute.value['hello']['world'][1][2]['three'].wont_be_nil
-  end
-
-  it 'has a default value that can take any nested method calls' do
-    attribute.value.call.some.fancy.functions.wont_be_nil
-  end
-
-  describe 'attribute with a default value set' do
-    it 'returns the user-configured default value if no value is assigned' do
-      attribute = Inspec::Attribute.new('test_attribute', default: 'default_value')
-      attribute.value.must_equal 'default_value'
+  describe 'the dummy value used when value is not set' do
+    it 'returns the actual value, not the dummy object, if one is assigned' do
+      attribute.value = 'new_value'
+      attribute.value.must_equal 'new_value'
     end
 
-    it 'returns the user-configured default value if no value is assigned (nil)' do
-      attribute = Inspec::Attribute.new('test_attribute', default: nil)
+    it 'returns the dummy value if no value is assigned' do
+      attribute.value.must_be_kind_of Inspec::Attribute::DEFAULT_ATTRIBUTE
+      attribute.value.to_s.must_equal "Attribute 'test_attribute' does not have a value. Skipping test."
+    end
+
+    it 'has a dummy value that can be called like a nested map' do
+      attribute.value['hello']['world'][1][2]['three'].wont_be_nil
+    end
+
+    it 'has a dummy value that can take any nested method calls' do
+      attribute.value.call.some.fancy.functions.wont_be_nil
+    end
+  end
+
+  describe 'attribute with a value set' do
+    it 'returns the user-configured value' do
+      attribute = Inspec::Attribute.new('test_attribute', value: 'some_value')
+      attribute.value.must_equal 'some_value'
+    end
+
+    it 'returns the user-configured value if nil is explicitly assigned' do
+      attribute = Inspec::Attribute.new('test_attribute', value: nil)
       attribute.value.must_be_nil
     end
 
-    it 'returns the user-configured default value if no value is assigned (false)' do
-      attribute = Inspec::Attribute.new('test_attribute', default: false)
+    it 'returns the user-configured value if false is explicitly assigned' do
+      attribute = Inspec::Attribute.new('test_attribute', value: false)
       attribute.value.must_equal false
     end
 
-    it 'returns value if overriding the default' do
-      attribute = Inspec::Attribute.new('test_attribute', default: 'default_value')
-      attribute.value = 'test_value'
-      attribute.value.must_equal 'test_value'
+    it 'returns a new value if the value has been assigned by value=' do
+      attribute = Inspec::Attribute.new('test_attribute', value: 'original_value')
+      attribute.value = 'new_value'
+      attribute.value.must_equal 'new_value'
     end
   end
 
   describe 'validate required method' do
-    it 'does not error if a default is set' do
-      attribute = Inspec::Attribute.new('test_attribute', default: 'default_value', required: true)
-      attribute.value.must_equal 'default_value'
+    it 'does not error if a value is set' do
+      attribute = Inspec::Attribute.new('test_attribute', value: 'some_value', required: true)
+      attribute.value.must_equal 'some_value'
     end
 
-    it 'does not error if a value is specified' do
+    it 'does not error if a value is specified by value=' do
       attribute = Inspec::Attribute.new('test_attribute', required: true)
       attribute.value = 'test_value'
       attribute.value.must_equal 'test_value'
     end
 
     it 'returns an error if no value is set' do
+      # Assigning the cli_command is needed because in check mode, we don't error
+      # on unset attributes. This is how you tell the attribute system we are not in
+      # check mode, apparently.
       Inspec::BaseCLI.inspec_cli_command = :exec
       attribute = Inspec::Attribute.new('test_attribute', required: true)
       ex = assert_raises(Inspec::Attribute::RequiredError) { attribute.value }

--- a/test/unit/mock/profiles/attributes/controls/flat.rb
+++ b/test/unit/mock/profiles/attributes/controls/flat.rb
@@ -10,8 +10,8 @@ tests = expecteds.keys.map do |test_name|
   {
     name: test_name,
     expected: expecteds[test_name],
-    attr_via_string: attribute(test_name.to_s, default: "#{test_name}_default"),
-    attr_via_symbol: attribute(test_name, default: "#{test_name}_default"),
+    attr_via_string: attribute(test_name.to_s, value: "#{test_name}_default"),
+    attr_via_symbol: attribute(test_name, value: "#{test_name}_default"),
   }
 end
 

--- a/test/unit/mock/profiles/attributes/controls/nested.rb
+++ b/test/unit/mock/profiles/attributes/controls/nested.rb
@@ -9,9 +9,9 @@ attr_names = [
 attrs = {}
 attr_names.each do |attr_name|
   # Store as a symbol-fetched attribute
-  attrs[attr_name] = attribute(attr_name, default: "#{attr_name}_sym_default")
+  attrs[attr_name] = attribute(attr_name, value: "#{attr_name}_sym_default")
   # .. and store under a string name, as a string-fetched attribute!
-  attrs[attr_name.to_s] = attribute(attr_name.to_s, default: "#{attr_name}_str_default")
+  attrs[attr_name.to_s] = attribute(attr_name.to_s, value: "#{attr_name}_str_default")
 end
 
 # For now, these all use string keys, as that is normal InSpec behavior


### PR DESCRIPTION
Closes #3756

This PR implements #3756, by using the word 'value' instead of 'default' to set attribute values. 

 * A deprecation group is added, action 'ignore'.
 * 'default' is still accepted, but internally is immediately converted to 'value'.
 * unit tests are added to check that the 'default' word still works
 * All test fixtures and examples are updated to use 'value'
 * The reference docs are updated.