### PR TITLE
More meaningful error when including controls from a missing dependency

### DIFF
--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -55,17 +55,17 @@ module Inspec::DSL
     profile_id = opts[:profile_id]
     dep_entry = dependencies.list[profile_id]
 
-    # do not load any controls if the profile is not supported
-    return unless dep_entry.profile.supports_platform?
-
     if dep_entry.nil?
       raise <<~EOF
-        Cannot load #{profile_id} since it is not listed as a dependency of #{bind_context.profile_name}.
+        Cannot load '#{profile_id}' since it is not listed as a dependency of #{bind_context.profile_name}.
 
         Dependencies available from this context are:
             #{dependencies.list.keys.join("\n    ")}
       EOF
     end
+
+    # Do not load any controls if the profile is not supported
+    return unless dep_entry.profile.supports_platform?
 
     context = dep_entry.profile.runner_context
     # if we don't want all the rules, then just make 1 pass to get all rule_IDs

--- a/test/functional/inspec_check_test.rb
+++ b/test/functional/inspec_check_test.rb
@@ -88,6 +88,15 @@ describe 'inspec check' do
       out.exit_status.must_equal 1
       out.stdout.must_include 'inspec.yml and inspec.lock are out-of-sync. Please re-vendor with `inspec vendor`.'
       out.stdout.must_include 'Cannot find linux-baseline in lockfile. Please re-vendor with `inspec vendor`.'
-    end    
+    end
+  end
+
+  describe 'inspec check with invalid `include_controls` reference' do
+    it 'raises an error matching /Cannot load \'invalid_name\'/' do
+      invalid_profile = File.join(profile_path, 'invalid-include-controls')
+      out = inspec('check ' + invalid_profile)
+      out.exit_status.must_equal 1
+      out.stderr.must_match /Cannot load 'invalid_name'/
+    end
   end
 end

--- a/test/functional/inspec_check_test.rb
+++ b/test/functional/inspec_check_test.rb
@@ -96,7 +96,8 @@ describe 'inspec check' do
       invalid_profile = File.join(profile_path, 'invalid-include-controls')
       out = inspec('check ' + invalid_profile)
       out.exit_status.must_equal 1
-      out.stderr.must_match /Cannot load 'invalid_name'/
+      out.stderr.must_match /Cannot load 'no_such_profile'/
+      out.stderr.must_match /not listed as a dependency/
     end
   end
 end

--- a/test/unit/mock/profiles/invalid-include-controls/README.md
+++ b/test/unit/mock/profiles/invalid-include-controls/README.md
@@ -1,3 +1,0 @@
-# Invalid Include Controls
-
-This profile contains an `include_controls` line with a invalid reference

--- a/test/unit/mock/profiles/invalid-include-controls/README.md
+++ b/test/unit/mock/profiles/invalid-include-controls/README.md
@@ -1,0 +1,3 @@
+# Invalid Include Controls
+
+This profile contains an `include_controls` line with a invalid reference

--- a/test/unit/mock/profiles/invalid-include-controls/controls/example.rb
+++ b/test/unit/mock/profiles/invalid-include-controls/controls/example.rb
@@ -1,0 +1,4 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+include_controls 'invalid_name'

--- a/test/unit/mock/profiles/invalid-include-controls/controls/example.rb
+++ b/test/unit/mock/profiles/invalid-include-controls/controls/example.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 # copyright: 2018, The Authors
 
-include_controls 'invalid_name'
+include_controls 'no_such_profile'

--- a/test/unit/mock/profiles/invalid-include-controls/inspec.yml
+++ b/test/unit/mock/profiles/invalid-include-controls/inspec.yml
@@ -1,0 +1,10 @@
+name: invalid-include-controls
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  platform: os

--- a/test/unit/mock/profiles/invalid-include-controls/inspec.yml
+++ b/test/unit/mock/profiles/invalid-include-controls/inspec.yml
@@ -1,10 +1,10 @@
 name: invalid-include-controls
-title: InSpec Profile
+title: Invalid Include Controls
 maintainer: The Authors
 copyright: The Authors
-copyright_email: you@example.com
+copyright_email: humans@chef.io
 license: Apache-2.0
-summary: An InSpec Compliance Profile
+summary: This profile contains an `include_controls` line with a invalid reference
 version: 0.1.0
 supports:
   platform: os


### PR DESCRIPTION
This changes the error message from using a bad reference in
`include_controls` from:

```
NoMethodError: undefined method `profile' for nil:NilClass
```

To one detailing that the profile cannot be loaded since it isn't listed
as a dependency.

This closes #3769.