### PR TITLE
Fix Inspec::Attribute.to_ruby and add unit test

### DIFF
--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -93,7 +93,7 @@ module Inspec
     def to_ruby
       res = ["#{ruby_var_identifier} = attribute('#{@name}',{"]
       res.push "  title: '#{title}'," unless title.to_s.empty?
-      res.push "  default: #{default.inspect}," unless default.to_s.empty?
+      res.push "  value: #{value.inspect}," unless value.to_s.empty?
       res.push "  description: '#{description}'," unless description.to_s.empty?
       res.push '})'
       res.join("\n")

--- a/lib/inspec/objects/attribute.rb
+++ b/lib/inspec/objects/attribute.rb
@@ -94,6 +94,10 @@ module Inspec
       res = ["#{ruby_var_identifier} = attribute('#{@name}',{"]
       res.push "  title: '#{title}'," unless title.to_s.empty?
       res.push "  value: #{value.inspect}," unless value.to_s.empty?
+      # to_ruby may generate code that is to be used by older versions of inspec.
+      # Anything older than 3.4 will not recognize the value: option, so
+      # send the default: option as well. See #3759
+      res.push "  default: #{value.inspect}," unless value.to_s.empty?
       res.push "  description: '#{description}'," unless description.to_s.empty?
       res.push '})'
       res.join("\n")

--- a/test/unit/attributes/attribute_test.rb
+++ b/test/unit/attributes/attribute_test.rb
@@ -225,4 +225,16 @@ describe Inspec::Attribute do
       attribute.send(:valid_numeric?, '1/2').must_equal false
     end
   end
+
+  describe 'to_ruby method' do
+    it 'generates the code for the attribute' do
+      attribute = Inspec::Attribute.new('application_port', description: 'The port my application uses', value: 80)
+      attribute.to_ruby.must_equal <<-RUBY.chomp
+attr_application_port = attribute('application_port',{
+  value: 80,
+  description: 'The port my application uses',
+})
+RUBY
+    end
+  end
 end

--- a/test/unit/attributes/attribute_test.rb
+++ b/test/unit/attributes/attribute_test.rb
@@ -229,12 +229,22 @@ describe Inspec::Attribute do
   describe 'to_ruby method' do
     it 'generates the code for the attribute' do
       attribute = Inspec::Attribute.new('application_port', description: 'The port my application uses', value: 80)
-      attribute.to_ruby.must_equal <<-RUBY.chomp
-attr_application_port = attribute('application_port',{
-  value: 80,
-  description: 'The port my application uses',
-})
-RUBY
+
+      ruby_code = attribute.to_ruby
+      ruby_code.must_include "attr_application_port = " # Should assign to a var
+      ruby_code.must_include "attribute('application_port'" # Should have the DSL call
+      ruby_code.must_include 'value: 80'
+      ruby_code.must_include 'default: 80'
+      ruby_code.must_include "description: 'The port my application uses'"
+
+      # Try to eval the code to verify that the generated code was valid ruby.
+      # Note that the attribute() method is part of the DSL, so we need to
+      # alter the call into something that can respond - the constructor will do
+      ruby_code_for_eval = ruby_code.sub(/attribute\(/,'Inspec::Attribute.new(')
+
+      # This will throw exceptions if there is a problem
+      new_attr = eval(ruby_code_for_eval) # Could use ripper!
+      new_attr.value.must_equal 80
     end
   end
 end


### PR DESCRIPTION
#3756 introduced a regression, in which calling `to_ruby` on an Attribute object would throw an exception because it calls a method, `default`, which was renamed.

This PR fixes that.

Signed-off-by: James Stocks <jstocks@chef.io>