### PR TITLE
Temporarily pin train to 1.7.1

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'train-core', '~> 1.5', '>= 1.6.3'
+  spec.add_dependency 'train-core', '~> 1.5', '= 1.7.1' # 1.7.2 has a regression introduced by train #394
   spec.add_dependency 'thor', '~> 0.20'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'method_source', '~> 0.8'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'train', '~> 1.5', '>= 1.7.0'
+  spec.add_dependency 'train', '~> 1.5', '= 1.7.1' # 1.7.2 has a regression introduced by train #394
   spec.add_dependency 'thor', '~> 0.20'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'method_source', '~> 0.8'


### PR DESCRIPTION
https://github.com/inspec/train/pull/394, released in train-1.7.2 introduced a regression - see https://github.com/inspec/train/issues/404

This PR simply does an exact pin to train-1.7.1 in the gemspecs, so we can fix the build.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>