### PR TITLE
Fixed Wrong References to pg_hba in postgres_ident_conf documentation

### DIFF
--- a/docs/resources/postgres_ident_conf.md.erb
+++ b/docs/resources/postgres_ident_conf.md.erb
@@ -5,7 +5,7 @@ platform: linux
 
 # postgres\_ident\_conf
 
-Use the `postgres_ident_conf` InSpec audit resource to test the client authentication data defined in the pg_hba.conf file.
+Use the `postgres_ident_conf` InSpec audit resource to test the client authentication data defined in the pg_ident.conf file.
 
 <br>
 
@@ -47,14 +47,14 @@ where
 
 `address` returns a an array of strings that matches the where condition of the filter table
 
-    describe pg_hba_conf.where { pg_username == 'name' } do
+    describe pg_ident_conf.where { pg_username == 'name' } do
       its('map_name') { should eq ['value'] }
     end
 ### pg_username([String])
 
 `pg_username` returns a an array of strings that matches the where condition of the filter table
 
-    describe pg_hba_conf.where { pg_username == 'name' } do
+    describe pg_ident_conf.where { pg_username == 'name' } do
       its('pg_username') { should eq ['value'] }
     end
 
@@ -62,7 +62,7 @@ where
 
 `system_username` returns a an array of strings that matches the where condition of the filter table
 
-    describe pg_hba_conf.where { pg_username == 'name' } do
+    describe pg_ident_conf.where { pg_username == 'name' } do
       its('system_username') { should eq ['value'] }
     end
 


### PR DESCRIPTION
In [documentation](https://www.inspec.io/docs/reference/resources/postgres_ident_conf) for the `postgres_ident_conf` resource, there are some references to `pg_hba` which should be `pg_ident`.
I've added fixes for these cases.
Obvious fix.