### PR TITLE
inspec-habitat: create mock backend properly 

### DIFF
--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -4,6 +4,7 @@
 # author: Christoph Hartmann
 
 require 'train'
+require 'inspec/config'
 
 module Inspec
   module Backend
@@ -41,6 +42,8 @@ module Inspec
     # @param [Hash] config for the transport backend
     # @return [TransportBackend] enriched transport instance
     def self.create(config) # rubocop:disable Metrics/AbcSize
+      config = Inspec::Config.new(config) if config.is_a?(Hash)
+
       train_credentials = config.unpack_train_credentials
       transport_name = Train.validate_backend(train_credentials)
       transport = Train.create(transport_name, train_credentials)

--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -39,11 +39,9 @@ module Inspec
 
     # Create the transport backend with aggregated resources.
     #
-    # @param [Hash] config for the transport backend
+    # @param [Inspec::Config] config for the transport backend
     # @return [TransportBackend] enriched transport instance
     def self.create(config) # rubocop:disable Metrics/AbcSize
-      config = Inspec::Config.new(config) if config.is_a?(Hash)
-
       train_credentials = config.unpack_train_credentials
       transport_name = Train.validate_backend(train_credentials)
       transport = Train.create(transport_name, train_credentials)

--- a/lib/plugins/inspec-habitat/lib/inspec-habitat/profile.rb
+++ b/lib/plugins/inspec-habitat/lib/inspec-habitat/profile.rb
@@ -103,7 +103,7 @@ module InspecPlugins
       def create_profile_object
         @profile = Inspec::Profile.for_target(
           path,
-          backend: Inspec::Backend.create(target: 'mock://'),
+          backend: Inspec::Backend.create(Inspec::Config.mock),
         )
       end
 

--- a/test/unit/backend_test.rb
+++ b/test/unit/backend_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'helper'
 
 describe 'Backend' do # rubocop:disable Metrics/BlockLength

--- a/test/unit/backend_test.rb
+++ b/test/unit/backend_test.rb
@@ -1,0 +1,102 @@
+# encoding: utf-8
+
+require 'helper'
+
+describe 'Backend' do # rubocop:disable Metrics/BlockLength
+  let(:backend) { Inspec::Backend.create(Inspec::Config.mock) }
+
+  describe 'create' do # rubocop:disable Metrics/BlockLength
+    it 'accepts a Hash' do
+      backend_from_hash = Inspec::Backend.create(backend: 'mock')
+      backend_from_hash.is_a?(Inspec::Backend::Base).must_equal true
+    end
+
+    it 'accepts an Inspec::Config' do
+      backend.is_a?(Inspec::Backend::Base).must_equal true
+    end
+
+    it 'raises an error if no transport backend can be found' do
+      Train.stub :create, nil do
+        err = proc { backend }.must_raise RuntimeError
+        err.message.must_equal "Can't find transport backend 'mock'."
+      end
+    end
+
+    it 'raises an error if no connection can be created' do
+      mock_transport = Minitest::Mock.new
+      mock_bad_connection = Minitest::Mock.new
+      mock_transport.expect :nil?, false
+      mock_transport.expect :connection, mock_bad_connection
+      mock_bad_connection.expect :nil?, true
+
+      Train.stub :create, mock_transport do
+        err = proc { backend }.must_raise RuntimeError
+        err.message.must_equal "Can't connect to transport backend 'mock'."
+      end
+    end
+
+    it 'enables/disables caching based on `config[:backend_cache]`' do
+      cache_enabled_backend = Inspec::Backend.create(backend_cache: true)
+      cache_enabled_backend.backend.cache_enabled?(:file).must_equal true
+      cache_enabled_backend.backend.cache_enabled?(:command).must_equal true
+
+      cache_disabled_backend = Inspec::Backend.create(backend_cache: false)
+      cache_disabled_backend.backend.cache_enabled?(:file).must_equal false
+      cache_disabled_backend.backend.cache_enabled?(:command).must_equal false
+    end
+
+    it 'enables caching when using a mock backend' do
+      backend.backend.cache_enabled?(:file).must_equal true
+      backend.backend.cache_enabled?(:command).must_equal true
+    end
+
+    it 'disables caching when `config[:debug_shell]` is true' do
+      debug_shell_backend = Inspec::Backend.create(debug_shell: true)
+      debug_shell_backend.backend.cache_enabled?(:file).must_equal false
+      debug_shell_backend.backend.cache_enabled?(:command).must_equal false
+    end
+
+    it 'captures Train::ClientError' do
+      Train.stub(:create, proc { raise Train::ClientError }) do
+        err = proc { backend }.must_raise RuntimeError
+        err.message.must_equal "Client error, can't connect to 'mock' backend: "
+      end
+    end
+
+    it 'captures Train::TransportError' do
+      Train.stub(:create, proc { raise Train::TransportError }) do
+        err = proc { backend }.must_raise RuntimeError
+        err.message.must_equal "Transport error, can't connect to 'mock' backend: "
+      end
+    end
+  end
+
+  describe 'version' do
+    it 'returns the current InSpec version' do
+      backend.version.must_equal Inspec::VERSION
+    end
+  end
+
+  describe 'local_transport?' do
+    it 'returns false when using a Mock transport' do
+      backend.local_transport?.must_equal false
+    end
+
+    it 'returns true when using a Local transport' do
+      local_backend = Inspec::Backend.create(Inspec::Config.new)
+      local_backend.local_transport?.must_equal true
+    end
+  end
+
+  describe 'to_s' do
+    it 'returns the correct string' do
+      backend.to_s.must_equal 'Inspec::Backend::Class'
+    end
+  end
+
+  describe 'inspect' do
+    it 'returns the correct string' do
+      backend.inspect.must_equal 'Inspec::Backend::Class @transport=Train::Transports::Mock::Connection'
+    end
+  end
+end

--- a/test/unit/backend_test.rb
+++ b/test/unit/backend_test.rb
@@ -6,11 +6,6 @@ describe 'Backend' do # rubocop:disable Metrics/BlockLength
   let(:backend) { Inspec::Backend.create(Inspec::Config.mock) }
 
   describe 'create' do # rubocop:disable Metrics/BlockLength
-    it 'accepts a Hash' do
-      backend_from_hash = Inspec::Backend.create(backend: 'mock')
-      backend_from_hash.is_a?(Inspec::Backend::Base).must_equal true
-    end
-
     it 'accepts an Inspec::Config' do
       backend.is_a?(Inspec::Backend::Base).must_equal true
     end
@@ -36,11 +31,13 @@ describe 'Backend' do # rubocop:disable Metrics/BlockLength
     end
 
     it 'enables/disables caching based on `config[:backend_cache]`' do
-      cache_enabled_backend = Inspec::Backend.create(backend_cache: true)
+      cache_enabled_config = Inspec::Config.new(backend_cache: true)
+      cache_enabled_backend = Inspec::Backend.create(cache_enabled_config)
       cache_enabled_backend.backend.cache_enabled?(:file).must_equal true
       cache_enabled_backend.backend.cache_enabled?(:command).must_equal true
 
-      cache_disabled_backend = Inspec::Backend.create(backend_cache: false)
+      cache_disabled_config = Inspec::Config.new(backend_cache: false)
+      cache_disabled_backend = Inspec::Backend.create(cache_disabled_config)
       cache_disabled_backend.backend.cache_enabled?(:file).must_equal false
       cache_disabled_backend.backend.cache_enabled?(:command).must_equal false
     end
@@ -51,7 +48,8 @@ describe 'Backend' do # rubocop:disable Metrics/BlockLength
     end
 
     it 'disables caching when `config[:debug_shell]` is true' do
-      debug_shell_backend = Inspec::Backend.create(debug_shell: true)
+      debug_shell_config = Inspec::Config.new(debug_shell: true)
+      debug_shell_backend = Inspec::Backend.create(debug_shell_config)
       debug_shell_backend.backend.cache_enabled?(:file).must_equal false
       debug_shell_backend.backend.cache_enabled?(:command).must_equal false
     end


### PR DESCRIPTION
With the changes in PR #3750 `Inspec::Backend.create` needs to support both being passed a Hash and being passed an Inspec::Config. This adds a line to convert a passed Hash to an Inspec::Config.

This also adds unit tests for Inspec::Backend because they were missing.