### PR TITLE
inspec 2.x: Pin train to 1.7.1 to avoid train#404

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'train-core', '~> 1.5'
+  spec.add_dependency 'train-core', '~> 1.5', '= 1.7.1'
   spec.add_dependency 'thor', '~> 0.20'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'method_source', '~> 0.8'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'train', '~> 1.5'
+  spec.add_dependency 'train', '~> 1.5', '= 1.7.1'
   spec.add_dependency 'thor', '~> 0.20'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'method_source', '~> 0.8'


### PR DESCRIPTION
### NOTE: This PR is for 2.x series, should merge to branch 2-stable, NOT master

Pins the 2.x series to train 1.7.1, see https://github.com/inspec/train/issues/404

Closes #3787

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>