### PR TITLE
Don't read the configuration twice

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -364,7 +364,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   private
 
   def run_command(opts)
-    runner = Inspec::Runner.new(Inspec::Config.new(opts))
+    runner = Inspec::Runner.new(opts)
     res = runner.eval_with_virtual_profile(opts[:command])
     runner.load
 


### PR DESCRIPTION
We recently found that reading configuration from stdin is broken as
of 3.6.  This appears to be the result of attempting to read the
configuration twice. Since STDIN may be a pipe, reading from it a
second time yields nothing, leading to a json parse error:

```
Failed to load JSON configuration: 765: unexpected token at ''
Config was:
```

This is a likely incomplete fix. The gist here is that we are calling
Inspec::Config.new twice, leading to multiple reads of STDIN.  Here is
output from a instrumented inspec showing the issue:

```
RETURNING STDIN: #<IO:0x00007f7ef00a1920>
READING STDIN from /Users/ssd/.chefdk/gem/ruby/2.5.0/gems/inspec-3.6.2/lib/inspec/config.rb:38:in `initialize'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/inspec-3.6.2/lib/inspec/base_cli.rb:210:in `new'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/inspec-3.6.2/lib/inspec/base_cli.rb:210:in `config'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/inspec-3.6.2/lib/inspec/cli.rb:277:in `detect'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/inspec-3.6.2/bin/inspec:12:in `<top (required)>'
/opt/chefdk/embedded/bin/inspec:23:in `load'
/opt/chefdk/embedded/bin/inspec:23:in `<main>'
RETURNING STDIN: #<IO:0x00007f7ef00a1920>
READING STDIN from /Users/ssd/.chefdk/gem/ruby/2.5.0/gems/inspec-3.6.2/lib/inspec/config.rb:38:in `initialize'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/inspec-3.6.2/lib/inspec/cli.rb:367:in `new'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/inspec-3.6.2/lib/inspec/cli.rb:367:in `run_command'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/inspec-3.6.2/lib/inspec/cli.rb:279:in `detect'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
/Users/ssd/.chefdk/gem/ruby/2.5.0/gems/inspec-3.6.2/bin/inspec:12:in `<top (required)>'
/opt/chefdk/embedded/bin/inspec:23:in `load'
/opt/chefdk/embedded/bin/inspec:23:in `<main>'
Failed to load JSON configuration: 765: unexpected token at ''
Config was:
```

removing the second call to Inspec::Config.new fixes the problem, but
I haven't looked at the surrounding code to see if this is really OK.
I know it did work in my one example.

Consider this, bug-report-via-incomplete-PR (refs #3792)

Signed-off-by: Steven Danna <steve@chef.io>