### PR TITLE
Add term-ansicolor to inspec-core gem

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multipart-post'
   spec.add_dependency 'tty-table', '~> 0.10'
   spec.add_dependency 'tty-prompt', '~> 0.17'
+  spec.add_dependency 'term-ansicolor'
 end


### PR DESCRIPTION
Without this the following error occurs when using the embedded `inspec` in `chef-client`:

```
vagrant@default-ubuntu-1804:~$ inspec
Traceback (most recent call last):
        13: from /usr/local/bin/inspec:23:in `<main>'
        12: from /usr/local/bin/inspec:23:in `load'
        11: from /var/lib/gems/2.5.0/gems/inspec-core-3.6.1/bin/inspec:11:in `<top (required)>'                                                                                      
        10: from /var/lib/gems/2.5.0/gems/inspec-core-3.6.1/bin/inspec:11:in `require_relative'                                                                                      
         9: from /var/lib/gems/2.5.0/gems/inspec-core-3.6.1/lib/inspec/cli.rb:394:in `<top (required)>'                                                                              
         8: from /var/lib/gems/2.5.0/gems/inspec-core-3.6.1/lib/inspec/plugin/v2/loader.rb:86:in `activate_mentioned_cli_plugins'                                                    
         7: from /var/lib/gems/2.5.0/gems/inspec-core-3.6.1/lib/inspec/plugin/v2/loader.rb:86:in `each'                                                                              
         6: from /var/lib/gems/2.5.0/gems/inspec-core-3.6.1/lib/inspec/plugin/v2/loader.rb:105:in `block in activate_mentioned_cli_plugins'                                          
         5: from /var/lib/gems/2.5.0/gems/inspec-core-3.6.1/lib/inspec/plugin/v2/activator.rb:26:in `activate'                                                                       
         4: from /var/lib/gems/2.5.0/gems/inspec-core-3.6.1/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli.rb:13:in `block in <class:Plugin>'                   
         3: from /var/lib/gems/2.5.0/gems/inspec-core-3.6.1/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli.rb:13:in `require_relative'                          
         2: from /var/lib/gems/2.5.0/gems/inspec-core-3.6.1/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb:1:in `<top (required)>'               
         1: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- term/ansicolor (LoadError)         
```