### PR TITLE
Search the PATH for executables on many resources

### DIFF
--- a/lib/resources/iptables.rb
+++ b/lib/resources/iptables.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'utils/which'
+
 # Usage:
 # describe iptables do
 #   it { should have_rule('-P INPUT ACCEPT') }
@@ -70,11 +72,7 @@ module Inspec::Resources
     private
 
     def find_iptables_or_error
-      %w{/usr/sbin/iptables /sbin/iptables iptables}.each do |cmd|
-        return cmd if inspec.command(cmd).exist?
-      end
-
-      raise Inspec::Exceptions::ResourceFailed, 'Could not find `iptables`'
+      which('iptables')
     end
   end
 end

--- a/lib/resources/kernel_module.rb
+++ b/lib/resources/kernel_module.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'utils/which'
+
 module Inspec::Resources
   class KernelModule < Inspec.resource(1)
     name 'kernel_module'
@@ -41,11 +43,7 @@ module Inspec::Resources
     end
 
     def loaded?
-      if inspec.os.redhat? || inspec.os.name == 'fedora'
-        lsmod_cmd = '/sbin/lsmod'
-      else
-        lsmod_cmd = 'lsmod'
-      end
+      lsmod_cmd = which('lsmod')
 
       # get list of all modules
       cmd = inspec.command(lsmod_cmd)
@@ -81,19 +79,11 @@ module Inspec::Resources
     end
 
     def modinfo_cmd_for_os
-      if inspec.os.redhat? || inspec.os.name == 'fedora'
-        '/sbin/modinfo'
-      else
-        'modinfo'
-      end
+      which('modinfo')
     end
 
     def modprobe_cmd_for_os
-      if inspec.os.redhat? || inspec.os.name == 'fedora'
-        '/sbin/modprobe'
-      else
-        'modprobe'
-      end
+      which('modprobe')
     end
 
     def disabled_via_bin_true?

--- a/lib/resources/kernel_parameter.rb
+++ b/lib/resources/kernel_parameter.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'utils/which'
+
 module Inspec::Resources
   class KernelParameter < Inspec.resource(1)
     name 'kernel_parameter'
@@ -18,8 +20,12 @@ module Inspec::Resources
       return skip_resource 'The `kernel_parameter` resource is not supported on your OS.' if !inspec.os.linux?
     end
 
+    def sysctl_os_bin
+      which('sysctl')
+    end
+
     def value
-      cmd = inspec.command("/sbin/sysctl -q -n #{@parameter}")
+      cmd = inspec.command("#{sysctl_os_bin} -q -n #{@parameter}")
       return nil if cmd.exit_status != 0
       # remove whitespace
       cmd = cmd.stdout.chomp.strip

--- a/lib/resources/nginx.rb
+++ b/lib/resources/nginx.rb
@@ -2,6 +2,7 @@
 
 require 'pathname'
 require 'hashie/mash'
+require 'utils/which'
 
 module Inspec::Resources
   class Nginx < Inspec.resource(1)
@@ -21,7 +22,7 @@ module Inspec::Resources
     "
     attr_reader :params, :bin_dir
 
-    def initialize(nginx_path = '/usr/sbin/nginx')
+    def initialize(nginx_path = which('nginx'))
       return skip_resource 'The `nginx` resource is not yet available on your OS.' if inspec.os.windows?
       return skip_resource 'The `nginx` binary not found in the path provided.' unless inspec.command(nginx_path).exist?
 

--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'utils/which'
+
 # Resource to determine package information
 #
 # Usage:
@@ -193,7 +195,7 @@ module Inspec::Resources
   # MacOS / Darwin implementation
   class Brew < PkgManagement
     def info(package_name)
-      brew_path = inspec.command('brew').exist? ? 'brew' : '/usr/local/bin/brew'
+      brew_path = which('brew')
       cmd = inspec.command("#{brew_path} info --json=v1 #{package_name}")
 
       # If no available formula exists, then `brew` will exit non-zero

--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -2,6 +2,7 @@
 
 require 'hashie'
 require 'utils/file_reader'
+require 'utils/which'
 
 module Inspec::Resources
   class Runlevels < Hash
@@ -132,14 +133,14 @@ module Inspec::Resources
         if version > 7
           Systemd.new(inspec, service_ctl)
         else
-          SysV.new(inspec, service_ctl || '/usr/sbin/service')
+          SysV.new(inspec, service_ctl || which('service'))
         end
       elsif %w{redhat fedora centos oracle cloudlinux}.include?(platform)
         version = os[:release].to_i
         if (%w{redhat centos oracle cloudlinux}.include?(platform) && version >= 7) || (platform == 'fedora' && version >= 15)
           Systemd.new(inspec, service_ctl)
         else
-          SysV.new(inspec, service_ctl || '/sbin/service')
+          SysV.new(inspec, service_ctl || which('service'))
         end
       elsif %w{wrlinux}.include?(platform)
         SysV.new(inspec, service_ctl)
@@ -157,7 +158,7 @@ module Inspec::Resources
         if os[:release].to_i >= 12
           Systemd.new(inspec, service_ctl)
         else
-          SysV.new(inspec, service_ctl || '/sbin/service')
+          SysV.new(inspec, service_ctl || which('service'))
         end
       elsif %w{aix}.include?(platform)
         SrcMstr.new(inspec)

--- a/lib/resources/zfs_dataset.rb
+++ b/lib/resources/zfs_dataset.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'utils/which'
+
 module Inspec::Resources
   class ZfsDataset < Inspec.resource(1)
     name 'zfs_dataset'
@@ -24,7 +26,7 @@ module Inspec::Resources
 
     # method called by 'it { should exist }'
     def exists?
-      inspec.command("/sbin/zfs get -Hp all #{@zfs_dataset}").exit_status == 0
+      inspec.command("#{zfs_os_cmd} get -Hp all #{@zfs_dataset}").exit_status == 0
     end
 
     def mounted?
@@ -36,8 +38,12 @@ module Inspec::Resources
       "ZFS Dataset #{@zfs_dataset}"
     end
 
+    def zfs_os_cmd
+      which('zfs')
+    end
+
     def gather
-      cmd = inspec.command("/sbin/zfs get -Hp all #{@zfs_dataset}")
+      cmd = inspec.command("#{zfs_os_cmd} get -Hp all #{@zfs_dataset}")
       return nil if cmd.exit_status.to_i != 0
 
       # parse data

--- a/lib/resources/zfs_pool.rb
+++ b/lib/resources/zfs_pool.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'utils/which'
+
 module Inspec::Resources
   class ZfsPool < Inspec.resource(1)
     name 'zfs_pool'
@@ -21,9 +23,13 @@ module Inspec::Resources
       @params = gather
     end
 
+    def zpool_os_cmd
+      which('zpool')
+    end
+
     # method called by 'it { should exist }'
     def exists?
-      inspec.command("/sbin/zpool get -Hp all #{@zfs_pool}").exit_status == 0
+      inspec.command("#{zpool_os_cmd} get -Hp all #{@zfs_pool}").exit_status == 0
     end
 
     def to_s
@@ -31,7 +37,7 @@ module Inspec::Resources
     end
 
     def gather
-      cmd = inspec.command("/sbin/zpool get -Hp all #{@zfs_pool}")
+      cmd = inspec.command("#{zpool_os_cmd} get -Hp all #{@zfs_pool}")
       return nil if cmd.exit_status.to_i != 0
 
       # parse data

--- a/lib/utils/which.rb
+++ b/lib/utils/which.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+
+# Cross-platform way of finding an executable in the $PATH.
+#
+#   which('ruby') #=> /usr/bin/ruby
+def which(cmd)
+  exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+  ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+    exts.each { |ext|
+      exe = File.join(path, "#{cmd}#{ext}")
+      return exe if File.executable?(exe) && !File.directory?(exe)
+    }
+  end
+
+  raise Inspec::Exceptions::ResourceFailed, "Command not found: `#{cmd}`"
+end


### PR DESCRIPTION
As the title suggests.

More details in #3746 

On doing this more formally across the board, would it be a case of following the same pattern here? or would there be a better way to do this?

We can either leave this as a small PR, or fix all of the executables now?

A quick stab with grep gives me the below?

```
morganj@localhost> grep -rn "/bin\|/usr\|/sbin" lib/resources
lib/resources/docker_container.rb:23:        its('command') { should eq 'nc -ll -p 1234 -e /bin/cat' }
lib/resources/ksh.rb:13:        its('stdout') { should match /bin/ }
lib/resources/ksh.rb:19:      ksh('...', path: '/usr/bin/ksh93')
lib/resources/kernel_module.rb:45:        lsmod_cmd = '/sbin/lsmod'
lib/resources/kernel_module.rb:85:        '/sbin/modinfo'
lib/resources/kernel_module.rb:93:        '/sbin/modprobe'
lib/resources/pip.rb:20:      describe pip('django', '/path/to/virtualenv/bin/pip') do
lib/resources/iptables.rb:73:      %w{/usr/sbin/iptables /sbin/iptables iptables}.each do |cmd|
lib/resources/zfs_dataset.rb:27:      inspec.command("/sbin/zfs get -Hp all #{@zfs_dataset}").exit_status == 0
lib/resources/zfs_dataset.rb:40:      cmd = inspec.command("/sbin/zfs get -Hp all #{@zfs_dataset}")
lib/resources/gem.rb:27:                        '/opt/chef/embedded/bin/gem'
lib/resources/gem.rb:30:                      '/opt/opscode/embedded/bin/gem'
lib/resources/aide_conf.rb:14:        its('selection_lines') { should include '/sbin' }
lib/resources/aide_conf.rb:17:      describe aide_conf.where { selection_line == '/bin' } do
lib/resources/parse_config.rb:6:#  audit = command('/sbin/auditctl -l').stdout
lib/resources/zfs_pool.rb:26:      inspec.command("/sbin/zpool get -Hp all #{@zfs_pool}").exit_status == 0
lib/resources/zfs_pool.rb:34:      cmd = inspec.command("/sbin/zpool get -Hp all #{@zfs_pool}")
lib/resources/nginx.rb:15:      describe nginx('/etc/sbin/') do
lib/resources/nginx.rb:24:    def initialize(nginx_path = '/usr/sbin/nginx')
lib/resources/file.rb:194:        perm_cmd = "su -s /bin/sh -c \"test -#{flag} #{path}\" #{user}"
lib/resources/auditd.rb:33:      unless inspec.command('/sbin/auditctl').exist?
lib/resources/auditd.rb:35:              'Command `/sbin/auditctl` does not exist'
lib/resources/auditd.rb:38:      auditctl_cmd = '/sbin/auditctl -l'
lib/resources/auditd.rb:73:      @status_content ||= inspec.command('/sbin/auditctl -s').stdout.chomp
lib/resources/bash.rb:13:        its('stdout') { should match /bin/ }
lib/resources/bash.rb:19:      bash('...', path: '/bin/bash')
lib/resources/command.rb:12:        its('stdout') { should match /bin/ }
lib/resources/users.rb:115:  #   its('shell') { should eq '/bin/bash' }
lib/resources/users.rb:127:  #   it { should have_login_shell '/bin/bash' }
lib/resources/users.rb:408:      # returns: root:x:0:0:root:/root:/bin/bash
lib/resources/users.rb:541:      # returns: root:*:0:0:Charlie &:/root:/bin/csh
lib/resources/package.rb:196:      brew_path = inspec.command('brew').exist? ? 'brew' : '/usr/local/bin/brew'
lib/resources/service.rb:111:      #   Systemd runs with PID 1 as /sbin/init.
lib/resources/service.rb:112:      #   Upstart runs with PID 1 as /sbin/upstart.
lib/resources/service.rb:114:      # Upstart runs with PID 1 as /sbin/init.
lib/resources/service.rb:135:          SysV.new(inspec, service_ctl || '/usr/sbin/service')
lib/resources/service.rb:142:          SysV.new(inspec, service_ctl || '/sbin/service')
lib/resources/service.rb:160:          SysV.new(inspec, service_ctl || '/sbin/service')
```

Let me know.