### PR TITLE
Attribute-Input Rename: Add deprecation group

### DIFF
--- a/etc/deprecations.json
+++ b/etc/deprecations.json
@@ -14,6 +14,11 @@
     "filesystem_property_size": {
       "action": "ignore",
       "comment": "See #3778"
+    },
+    "rename_attributes_to_inputs": {
+      "action": "ignore",
+      "prefix": "InSpec Attributes are being renamed to InSpec Inputs to avoid confusion with Chef Attributes.",
+      "comment": "See #3802"
     }
   }
 }


### PR DESCRIPTION
As part of #3802, this simple PR adds a deprecation group to the list of deprecations, so that future code changes can reference it.

This PR does not depend on anything, but is not needed until after #3803.