### PR TITLE
Add logger to train generic options

### DIFF
--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -9,6 +9,7 @@ module Inspec
     # These are options that apply to any transport
     GENERIC_CREDENTIALS = %w{
       backend
+      logger
       sudo
       sudo_password
       sudo_command


### PR DESCRIPTION
As described, adds `logger` to the list of options that InSpec will pass to every Train transport (like sudo options and shell options).  Without that, Train will create its own Logger, which defaults to STDOUT.

Fixes #3801 	
Fixes #3804 