### PR TITLE
v4: Support AWS SDK v3 in Core AWS Resources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 # encoding: utf-8
 source 'https://rubygems.org'
 
+gem 'train-aws', path: '../train-aws'
+
 gemspec name: 'inspec'
 
 gem 'ffi', '>= 1.9.14'

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 # encoding: utf-8
 source 'https://rubygems.org'
 
-gem 'train-aws', path: '../train-aws'
-
 gemspec name: 'inspec'
 
 gem 'ffi', '>= 1.9.14'

--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -147,7 +147,10 @@ module Inspec
       end
 
       # rubocop:enable Lint/NestedMethodDefinition
-      if __resource_registry.key?(name)
+
+      # Warn if a resource pack is overwriting a core resource.
+      # Suppress warning if the resource is an AWS resource, see #3822
+      if __resource_registry.key?(name) && !name.start_with?('aws_')
         Inspec::Log.warn("Overwriting resource #{name}. To reference a specific version of #{name} use the resource() method")
       end
       __resource_registry[name] = cl

--- a/lib/resource_support/aws.rb
+++ b/lib/resource_support/aws.rb
@@ -1,7 +1,24 @@
 # Main AWS loader file.  The intent is for this to be
 # loaded only if AWS resources are needed.
 
-require 'aws-sdk' # TODO: split once ADK v3 is in use
+
+require 'aws-sdk-core'
+
+require 'aws-sdk-cloudtrail'
+require 'aws-sdk-cloudwatch'
+require 'aws-sdk-cloudwatchlogs'
+require 'aws-sdk-costandusagereportservice'
+require 'aws-sdk-configservice'
+require 'aws-sdk-ec2'
+require 'aws-sdk-ecs'
+require 'aws-sdk-eks'
+require 'aws-sdk-elasticloadbalancing'
+require 'aws-sdk-iam'
+require 'aws-sdk-kms'
+require 'aws-sdk-rds'
+require 'aws-sdk-s3'
+require 'aws-sdk-sqs'
+require 'aws-sdk-sns'
 
 require 'resource_support/aws/aws_backend_factory_mixin'
 require 'resource_support/aws/aws_resource_mixin'

--- a/lib/resource_support/aws.rb
+++ b/lib/resource_support/aws.rb
@@ -1,7 +1,6 @@
 # Main AWS loader file.  The intent is for this to be
 # loaded only if AWS resources are needed.
 
-
 require 'aws-sdk-core'
 
 require 'aws-sdk-cloudtrail'


### PR DESCRIPTION
NOTE: this PR targets version 4 of InSpec.

While AWS resources are being removed from core and placed in a resource pack (See #3822), we must retain them in core so we don't break profiles that have not yet been updated to use the resource pack.

This PR does two things:
 * Updates the `require` that previously pulled in `aws-sdk` v2, to pull in v3 and a handful of service gems
 * Suppresses the resource overwrite warning if the resource named is `aws_*`.  This quiets noise when a user DOES use the new resources.