### PR TITLE
Add a deprecation group for core AWS resources

### DIFF
--- a/etc/deprecations.json
+++ b/etc/deprecations.json
@@ -19,6 +19,11 @@
       "action": "ignore",
       "prefix": "InSpec Attributes are being renamed to InSpec Inputs to avoid confusion with Chef Attributes.",
       "comment": "See #3802"
+    },
+    "aws_resources_in_resource_pack": {
+      "comment": "See #3822",
+      "action": "ignore",
+      "prefix": "AWS resources shipped with core InSpec are being to moved to a resource pack for faster iteration. Please update your profiles to depend on git@github.com:inspec/inspec-aws.git ."
     }
   }
 }

--- a/lib/resource_support/aws/aws_resource_mixin.rb
+++ b/lib/resource_support/aws/aws_resource_mixin.rb
@@ -1,5 +1,6 @@
 module AwsResourceMixin
   def initialize(resource_params = {})
+    Inspec.deprecate(:aws_resources_in_resource_pack, "Resource '#{@__resource_name__}'")
     validate_params(resource_params).each do |param, value|
       instance_variable_set(:"@#{param}", value)
     end


### PR DESCRIPTION
As part of #3822, this PR adds an inactive deprecation group, then adjusts the AWS resource mixin to call the deprecation hook when a core AWS resource is accessed.

While this PR has the deprecation set to 'ignore' (so it behaves silently), here is sample output when set to 'warn' mode:

![screen shot 2019-02-20 at 18 06 01](https://user-images.githubusercontent.com/156460/53131265-3e3bea00-353a-11e9-9227-1b92eeda33df.png)
![screen shot 2019-02-20 at 18 06 16](https://user-images.githubusercontent.com/156460/53131270-41cf7100-353a-11e9-8d27-1d45acba43f4.png)
