### PR TITLE
Use deprecation facility throughout code

### DIFF
--- a/docs/dev/deprecation.md
+++ b/docs/dev/deprecation.md
@@ -79,7 +79,7 @@ For all actions except `ignore`, a message is assembled, consisting of:
 
  * The string 'DEPRECATION'
  * The value of the `prefix` field of the group, if any
- * The specific message provided by the deprecation declaration
+ * The specific message provided by the deprecation declaration, if any
  * The value of the `suffix` field of the group, if any
  * If possible, the string '(used at ' followed by a `path/file.rb:lineno` to help the user locate the deprecation in *their code*.
 

--- a/etc/deprecations.json
+++ b/etc/deprecations.json
@@ -1,29 +1,108 @@
 {
   "file_version": "1.0.0",
-  "unknown_group_action": "ignore",
+  "unknown_group_action": "exit",
   "groups": {
     "attrs_value_replaces_default": {
       "action": "ignore",
       "prefix": "The 'default' option for attributes is being replaced by 'value' - please use it instead."
+    },
+    "aws_resources_in_resource_pack": {
+      "comment": "See #3822",
+      "action": "ignore",
+      "prefix": "AWS resources shipped with core InSpec are being to moved to a resource pack for faster iteration. Please update your profiles to depend on git@github.com:inspec/inspec-aws.git ."
     },
     "cli_option_json_config": {
       "action": "ignore",
       "prefix": "The --json-config option is being replaced by the --config option.",
       "comment": "See #3661"
     },
-    "filesystem_property_size": {
+    "file_resource_be_mounted_matchers": {
+      "action": "warn",
+      "suffix": "This will not be supported in InSpec 4.0."
+    },
+    "host_resource_proto_usage": {
+      "action": "warn",
+      "suffix": "This will not be supported in InSpec 4.0."
+    },
+    "inspec_ui_methods": {
+      "action": "ignore",
+      "suffix": "Please call `cli.ui` directly"
+    },
+    "mssql_session_pass_option": {
+      "action": "warn",
+      "suffix": "This will not be supported in InSpec 4.0."
+    },
+    "oracledb_session_pass_option": {
+      "action": "warn",
+      "suffix": "This will not be supported in InSpec 4.0."
+    },
+    "property_filesystem_size": {
       "action": "ignore",
       "comment": "See #3778"
+    },
+    "property_processes_list": {
+      "action": "warn",
+      "suffix": "This property will be removed in InSpec 4.0."
+    },
+    "properties_aws_iam_user": {
+      "action": "warn",
+      "suffix": "This property will be removed in InSpec 4.0."
+    },
+    "properties_shadow": {
+      "action": "warn",
+      "suffix": "This property will be removed in InSpec 3.0."
     },
     "rename_attributes_to_inputs": {
       "action": "ignore",
       "prefix": "InSpec Attributes are being renamed to InSpec Inputs to avoid confusion with Chef Attributes.",
       "comment": "See #3802"
     },
-    "aws_resources_in_resource_pack": {
-      "comment": "See #3822",
-      "action": "ignore",
-      "prefix": "AWS resources shipped with core InSpec are being to moved to a resource pack for faster iteration. Please update your profiles to depend on git@github.com:inspec/inspec-aws.git ."
+    "resource_apache": {
+      "action": "warn",
+      "suffix": "This resource will be removed in InSpec 4.0."
+    },
+    "resource_azure_generic_resource": {
+      "action": "warn",
+      "prefix": "The azure_generic_resource is deprecated. Please use a specific resource. See: 'https://github.com/inspec/inspec/issues/3131'"
+    },
+    "resource_iis_website": {
+      "action": "warn",
+      "suffix": "This resource will be removed in InSpec 4.0.",
+      "comment": "Needed for ServerSpec compatibility"
+    },
+    "resource_linux_kernel_parameter": {
+      "action": "warn",
+      "suffix": "This resource will be removed in InSpec 4.0.",
+      "comment": "Needed for ServerSpec compatibility"
+    },
+    "resource_ppa": {
+      "action": "warn",
+      "suffix": "This resource will be removed in InSpec 4.0.",
+      "comment": "Needed for ServerSpec compatibility"
+    },
+    "resource_script": {
+      "action": "warn",
+      "suffix": "This resource will be removed in InSpec 4.0"
+    },
+    "resource_user": {
+      "action": "warn",
+      "suffix": "This resource will be removed in InSpec 4.0."
+    },
+    "resource_windows_registry_key": {
+      "action": "warn",
+      "suffix": "This resource will be removed in InSpec 4.0.",
+      "comment": "Needed for ServerSpec compatibility"
+    },
+    "serverspec_compatibility": {
+      "action": "warn",
+      "suffix": "This is only allowed for compatibility with ServerSpec"
+    },
+    "supports_syntax": {
+      "action": "warn"
+    },
+    "wmi_non_hash_usage": {
+      "action": "warn",
+      "suffix": "This property will be removed in InSpec 4.0."
     }
   }
 }

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -162,28 +162,28 @@ module Inspec
       end
 
       def mark_text(text)
-        # TODO: - deprecate, call cli.ui directly
+        Inspec.deprecate(:inspec_ui_methods)
         # Note that this one doesn't automatically print
         ui.emphasis(text, print: false)
       end
 
       def headline(title)
-        # TODO: - deprecate, call cli.ui directly
+        Inspec.deprecate(:inspec_ui_methods)
         ui.headline(title)
       end
 
       def li(entry)
-        # TODO: - deprecate, call cli.ui directly
+        Inspec.deprecate(:inspec_ui_methods)
         ui.list_item(entry)
       end
 
       def plain_text(msg)
-        # TODO: - deprecate, call cli.ui directly
+        Inspec.deprecate(:inspec_ui_methods)
         ui.plain(msg + "\n")
       end
 
       def exit(code)
-        # TODO: - deprecate, call cli.ui directly
+        Inspec.deprecate(:inspec_ui_methods)
         ui.exit code
       end
     end

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -155,7 +155,7 @@ module Inspec
 
     def check_for_piped_config(cli_opts)
       cli_opt = cli_opts[:config] || cli_opts[:json_config]
-      Inspec.deprecate(:cli_option_json_config, '') if cli_opts.key?(:json_config)
+      Inspec.deprecate(:cli_option_json_config) if cli_opts.key?(:json_config)
 
       return nil unless cli_opt
       return nil unless cli_opt == '-'
@@ -167,7 +167,7 @@ module Inspec
 
     def determine_cfg_path(cli_opts)
       path = cli_opts[:config] || cli_opts[:json_config]
-      Inspec.deprecate(:cli_option_json_config, '') if cli_opts.key?(:json_config)
+      Inspec.deprecate(:cli_option_json_config) if cli_opts.key?(:json_config)
 
       if path.nil?
         default_path = File.join(Inspec.config_dir, 'config.json')

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -149,11 +149,9 @@ module Inspec
         nil
       when nil then nil
       else
-        logger ||= Logger.new(nil)
-        logger.warn(
-          "Do not use deprecated `supports: #{x}` syntax. Instead use:\n"\
-          "supports:\n  - os-family: #{x}\n\n",
-        )
+        Inspec.deprecate(:supports_syntax,
+                         "Do not use deprecated `supports: #{x}` syntax. Instead use:\n"\
+                         "supports:\n  - os-family: #{x}\n\n")
         { :'os-family' => x } # rubocop:disable Style/HashSyntax
       end
     end

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -107,6 +107,7 @@ end
 # Deprecated: You should not use this matcher anymore
 RSpec::Matchers.define :be_running do
   match do |service|
+    Inspec.deprecate(:serverspec_compatibility, 'The service `be_running?` matcher is deprecated.')
     service.running? == true
   end
 

--- a/lib/resources/apache.rb
+++ b/lib/resources/apache.rb
@@ -26,7 +26,7 @@ module Inspec::Resources
 
     attr_reader :service, :conf_dir, :conf_path, :user
     def initialize
-      warn '[DEPRECATED] The `apache` resource is deprecated and will be removed in InSpec 4.0'
+      Inspec.deprecate(:resource_apache, 'The apache resource is deprecated')
 
       if inspec.os.debian?
         @service = 'apache2'

--- a/lib/resources/apt.rb
+++ b/lib/resources/apt.rb
@@ -127,8 +127,6 @@ module Inspec::Resources
     end
   end
 
-  # for compatability with serverspec
-  # this is deprecated syntax and will be removed in future versions
   class PpaRepository < AptRepository
     name 'ppa'
 
@@ -143,7 +141,7 @@ module Inspec::Resources
     end
 
     def deprecated
-      warn '[DEPRECATION] `ppa(reponame)` is deprecated.  Please use `apt(reponame)` instead.'
+      Inspec.deprecate(:resource_ppa, 'The `ppa` resource is deprecated. Please use `apt`')
     end
   end
 end

--- a/lib/resources/aws/aws_iam_user.rb
+++ b/lib/resources/aws/aws_iam_user.rb
@@ -22,7 +22,7 @@ class AwsIamUser < Inspec.resource(1)
   alias has_console_password? has_console_password
 
   def name
-    warn "[DEPRECATION] - Property ':name' is deprecated on the aws_iam_user resource.  Use ':username' instead."
+    Inspec.deprecate(:properties_aws_iam_user, 'The aws_iam_users `name` property is deprecated. Please use `username` instead')
     username
   end
 
@@ -51,13 +51,13 @@ class AwsIamUser < Inspec.resource(1)
     )
     # If someone passed :name, rename it to :username
     if validated_params.key?(:name)
-      warn "[DEPRECATION] - Resource parameter ':name' is deprecated on the aws_iam_user resource.  Use ':username' instead."
+      Inspec.deprecate(:properties_aws_iam_user, 'The aws_iam_users `name` property is deprecated. Please use `username` instead')
       validated_params[:username] = validated_params.delete(:name)
     end
 
     # If someone passed :user, rename it to :aws_user_struct
     if validated_params.key?(:user)
-      warn "[DEPRECATION] - Resource parameter ':user' is deprecated on the aws_iam_user resource.  Use ':aws_user_struct' instead."
+      Inspec.deprecate(:properties_aws_iam_user, 'The aws_iam_users `user` property is deprecated. Please use `aws_user_struct` instead')
       validated_params[:aws_user_struct] = validated_params.delete(:user)
     end
 

--- a/lib/resources/azure/azure_generic_resource.rb
+++ b/lib/resources/azure/azure_generic_resource.rb
@@ -16,7 +16,7 @@ module Inspec::Resources
     attr_accessor :filter, :total, :counts, :name, :type, :location, :probes
 
     def initialize(opts = {})
-      warn "[DEPRECATED] use a specific azure resources instead of 'azure_generic_resource'. See https://github.com/inspec/inspec/issues/3131"
+      Inspec.deprecate(:resource_azure_generic_resource)
 
       # Call the parent class constructor
       super(opts)

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -98,7 +98,7 @@ module Inspec::Resources
       return file.mounted? if expected_options.nil?
 
       # deprecation warning, this functionality will be removed in future version
-      warn "[DEPRECATION] `be_mounted.with and be_mounted.only_with` are deprecated.  Please use `mount('#{source_path}')` instead."
+      Inspec.deprecate(:file_resource_be_mounted_matchers, 'The file resource `be_mounted.with` and `be_mounted.only_with` matchers are deprecated. Please use the `mount` resource instead')
 
       # we cannot read mount data on non-Linux systems
       return nil if !inspec.os.linux?

--- a/lib/resources/filesystem.rb
+++ b/lib/resources/filesystem.rb
@@ -52,7 +52,7 @@ module Inspec::Resources
     end
 
     def size
-      Inspec.deprecate(:filesystem_property_size, 'The `size` property did not reliably use the correct units.  Please use `size_kb` instead.')
+      Inspec.deprecate(:property_filesystem_size, 'The `size` property did not reliably use the correct units. Please use `size_kb` instead.')
       if inspec.os.windows?
         # On windows, we had a bug prior to #3767 in which the
         # 'size' value was be scaled to GB in powershell.

--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -49,7 +49,7 @@ module Inspec::Resources
       @port = params[:port]
 
       if params[:proto]
-        warn '[DEPRECATION] The `proto` parameter is deprecated. Use `protocol` instead.'
+        Inspec.deprecate(:host_resource_proto_usage, 'The host resource `proto` parameter is deprecated. Please use `protocol`.')
         @protocol = params[:proto]
       else
         @protocol = params.fetch(:protocol, 'icmp')
@@ -75,7 +75,7 @@ module Inspec::Resources
     end
 
     def proto
-      warn '[DEPRECATION] The `proto` method is deprecated. Use `protocol` instead.'
+      Inspec.deprecate(:host_resource_proto_usage, 'The host resource `proto` method is deprecated. Please use `protocol`.')
       protocol
     end
 

--- a/lib/resources/iis_site.rb
+++ b/lib/resources/iis_site.rb
@@ -134,8 +134,8 @@ module Inspec::Resources
     "
 
     def initialize(site_name)
+      Inspec.deprecate(:resource_iis_website, 'The `iis_website` resource is deprecated. Please use `iis_site` instead.')
       super(site_name)
-      warn '[DEPRECATION] `iis_website(site_name)` is deprecated.  Please use `iis_site(site_name)` instead.'
     end
 
     def in_app_pool?(app_pool)

--- a/lib/resources/kernel_parameter.rb
+++ b/lib/resources/kernel_parameter.rb
@@ -33,22 +33,17 @@ module Inspec::Resources
     end
   end
 
-  # for compatability with serverspec
-  # this is deprecated syntax and will be removed in future versions
   class LinuxKernelParameter < KernelParameter
     name 'linux_kernel_parameter'
 
     def initialize(parameter)
+      Inspec.deprecate(:resource_linux_kernel_parameter, 'The `linux_kernel_parameter` resource is deprecated. Please use `kernel_parameter`')
       super(parameter)
     end
 
     def value
-      deprecated
+      Inspec.deprecate(:resource_linux_kernel_parameter, 'The `linux_kernel_parameter` resource is deprecated. Please use `kernel_parameter`')
       super()
-    end
-
-    def deprecated
-      warn '[DEPRECATION] `linux_kernel_parameter(parameter)` is deprecated.  Please use `kernel_parameter(parameter)` instead.'
     end
 
     def to_s

--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -34,7 +34,7 @@ module Inspec::Resources
       @user = opts[:user]
       @password = opts[:password] || opts[:pass]
       if opts[:pass]
-        warn '[DEPRECATED] use `password` option to supply password instead of `pass`'
+        Inspec.deprecate(:mssql_session_pass_option, 'The mssql_session `pass` option is deprecated. Please use `password`.')
       end
       @local_mode = opts[:local_mode]
       unless local_mode?

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -28,7 +28,7 @@ module Inspec::Resources
       @user = opts[:user]
       @password = opts[:password] || opts[:pass]
       if opts[:pass]
-        warn '[DEPRECATED] use `password` option to supply password instead of `pass`'
+        Inspec.deprecate(:oracaldb_session_pass_option, 'The oracledb_session `pass` option is deprecated. Please use `password`.')
       end
 
       @host = opts[:host] || 'localhost'

--- a/lib/resources/powershell.rb
+++ b/lib/resources/powershell.rb
@@ -56,12 +56,8 @@ module Inspec::Resources
     name 'script'
 
     def initialize(script)
-      deprecated
+      Inspec.deprecate(:resource_script, 'The `script` resource is deprecated. Please use `powershell` instead.')
       super(script)
-    end
-
-    def deprecated
-      warn '[DEPRECATION] `script(script)` is deprecated.  Please use `powershell(script)` instead.'
     end
   end
 end

--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -56,7 +56,7 @@ module Inspec::Resources
     end
 
     def list
-      warn '[DEPRECATION] `processes.list` is deprecated. Please use `processes.entries` instead. It will be removed in version 4.0.'
+      Inspec.deprecate(:property_processes_list, 'The processes `list` property is deprecated. Please use `entries` instead.')
       @list
     end
 

--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -280,18 +280,12 @@ module Inspec::Resources
     end
   end
 
-  # for compatability with serverspec
-  # this is deprecated syntax and will be removed in future versions
   class WindowsRegistryKey < RegistryKey
     name 'windows_registry_key'
 
     def initialize(name)
-      deprecated
+      Inspec.deprecate(:resource_windows_registry_key, 'The `windows_registry_key` resource is deprecated. Please use `registry_key` instead.')
       super(name)
-    end
-
-    def deprecated
-      warn '[DEPRECATION] `windows_registry_key(reg_key)` is deprecated.  Please use `registry_key(\'path\to\key\')` instead.'
     end
   end
 end

--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -91,32 +91,27 @@ module Inspec::Resources
     # Next 4 are deprecated methods.  We define them here so we can emit a deprecation message.
     # They are also defined on the Table, above.
     def user(query = nil)
-      warn '[DEPRECATION] The shadow `user` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `users` instead.'
+      Inspec.deprecate(:properties_shadow, 'The shadow `user` property is deprecated. Please use `users` instead.')
       query.nil? ? where.users : where('user' => query)
     end
 
     def password(query = nil)
-      warn '[DEPRECATION] The shadow `password` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `passwords` instead.'
+      Inspec.deprecate(:properties_shadow, 'The shadow `password` property is deprecated. Please use `passwords` instead.')
       query.nil? ? where.passwords : where('password' => query)
     end
 
     def last_change(query = nil)
-      warn '[DEPRECATION] The shadow `last_change` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `last_changes` instead.'
+      Inspec.deprecate(:properties_shadow, 'The shadow `last_change` property is deprecated. Please use `last_changes` instead.')
       query.nil? ? where.last_changes : where('last_change' => query)
     end
 
     def expiry_date(query = nil)
-      warn '[DEPRECATION] The shadow `expiry_date` property is deprecated and will be removed' \
-       ' in InSpec 3.0.  Please use `expiry_dates` instead.'
+      Inspec.deprecate(:properties_shadow, 'The shadow `expiry_date` property is deprecated. Please use `expiry_dates` instead.')
       query.nil? ? where.expiry_dates : where('expiry_date' => query)
     end
 
     def lines
-      warn '[DEPRECATION] The shadow `lines` property is deprecated and will be removed' \
-        ' in InSpec 3.0.'
+      Inspec.deprecate(:properties_shadow, 'The shadow `lines` property is deprecated.')
       shadow_content.to_s.split("\n")
     end
 

--- a/lib/resources/users.rb
+++ b/lib/resources/users.rb
@@ -213,40 +213,36 @@ module Inspec::Resources
 
     # implement 'mindays' method to be compatible with serverspec
     def minimum_days_between_password_change
-      deprecated('minimum_days_between_password_change', "Please use: its('mindays')")
+      Inspec.deprecate(:resource_user, 'The user resource `minimum_days_between_password_change` property is deprecated. Please use `mindays`.')
       mindays
     end
 
     # implement 'maxdays' method to be compatible with serverspec
     def maximum_days_between_password_change
-      deprecated('maximum_days_between_password_change', "Please use: its('maxdays')")
+      Inspec.deprecate(:resource_user, 'The user resource `maximum_days_between_password_change` property is deprecated. Please use `maxdays`.')
       maxdays
     end
 
     # implements rspec has matcher, to be compatible with serverspec
     # @see: https://github.com/rspec/rspec-expectations/blob/master/lib/rspec/matchers/built_in/has.rb
     def has_uid?(compare_uid)
-      deprecated('has_uid?')
+      Inspec.deprecate(:serverspec_compatibility, 'The user resource `has_uid?` matcher is deprecated.')
       uid == compare_uid
     end
 
     def has_home_directory?(compare_home)
-      deprecated('has_home_directory?', "Please use: its('home')")
+      Inspec.deprecate(:resource_user, 'The user resource `has_home_directory?` matcher is deprecated. Please use `its(\'home\')`.')
       home == compare_home
     end
 
     def has_login_shell?(compare_shell)
-      deprecated('has_login_shell?', "Please use: its('shell')")
+      Inspec.deprecate(:resource_user, 'The user resource `has_login_shell?` matcher is deprecated. Please use `its(\'shell\')`.')
       shell == compare_shell
     end
 
     def has_authorized_key?(_compare_key)
-      deprecated('has_authorized_key?')
+      Inspec.deprecate(:resource_user, 'The user resource `has_authorized_key?` matcher is deprecated. There is no currently implemented alternative')
       raise NotImplementedError
-    end
-
-    def deprecated(name, alternative = nil)
-      warn "[DEPRECATION] #{name} is deprecated. #{alternative}"
     end
 
     def to_s

--- a/lib/resources/wmi.rb
+++ b/lib/resources/wmi.rb
@@ -26,11 +26,10 @@ module Inspec::Resources
 
     def initialize(wmiclass = nil, opts = nil)
       @options = opts || {}
-      # if wmiclass is not a hash, we have to handle deprecation behavior
       if wmiclass.is_a?(Hash)
         @options.merge!(wmiclass)
       else
-        warn '[DEPRECATION] `wmi(\'wmiclass\')` is deprecated.  Please use `wmi({class: \'wmiclass\'})` instead.'
+        Inspec.deprecate(:wmi_non_hash_usage, 'Using `wmi(\'wmisclass\')` is deprecated. Please use`wmi({class: \'wmisclass\'})`')
         @options[:class] = wmiclass
       end
     end

--- a/lib/utils/deprecation/global_method.rb
+++ b/lib/utils/deprecation/global_method.rb
@@ -1,7 +1,7 @@
 require 'utils/deprecation/deprecator'
 
 module Inspec
-  def self.deprecate(group, msg, opts = {})
+  def self.deprecate(group, msg = '', opts = {})
     config_io = opts.delete(:config_io)
     deprecator = Inspec::Deprecation::Deprecator.new(config_io: config_io)
     deprecator.handle_deprecation(group, msg, opts)

--- a/lib/utils/parser.rb
+++ b/lib/utils/parser.rb
@@ -88,7 +88,7 @@ module LinuxMountParser
       # parse options as array
       mount_options[:options] = mount[5].gsub(/\(|\)/, '').split(',')
     else
-      # parse options as serverspec uses it, tbis is deprecated
+      Inspec.deprecate(:serverspec_compatibility, 'Parsing mount options in this fashion is deprecated')
       mount_options[:options] = {}
       mount[5].gsub(/\(|\)/, '').split(',').each do |option|
         name, val = option.split('=')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -649,3 +649,13 @@ def load_resource(*args)
   m = MockLoader.new(:ubuntu1404)
   m.send('load_resource', *args)
 end
+
+# Used to capture `Inspec.deprecate()` with warn action
+def expect_deprecation_warning
+  @mock_logger = Minitest::Mock.new
+  @mock_logger.expect(:warn, nil, [/DEPRECATION/])
+  Inspec::Log.stub :warn, proc { |message| @mock_logger.warn(message) } do
+    yield
+  end
+  @mock_logger.verify
+end

--- a/test/unit/resources/powershell_test.rb
+++ b/test/unit/resources/powershell_test.rb
@@ -20,12 +20,14 @@ describe 'Inspec::Resources::PowershellScript' do
     _(resource.command).must_equal("pwsh -encodedCommand '#{base64_command}'")
   end
 
-  it 'properly generates command if deprecated `script` is used on Windows' do
-    Inspec::Resources::LegacyPowershellScript.any_instance.stubs(:deprecated)
-    resource = MockLoader.new(:windows).load_resource('script', 'Get-Help')
-    _(resource.command).must_equal 'Get-Help'
-
-    resource = MockLoader.new(:osx104).load_resource('script', 'Get-Help')
-    _(resource.command).must_equal("pwsh -encodedCommand '#{base64_command}'")
+  it 'properly generates command if deprecated `script` is used' do
+    expect_deprecation_warning do
+      resource = MockLoader.new(:windows).load_resource('script', 'Get-Help')
+      _(resource.command).must_equal 'Get-Help'
+    end
+    expect_deprecation_warning do
+      resource = MockLoader.new(:osx104).load_resource('script', 'Get-Help')
+      _(resource.command).must_equal("pwsh -encodedCommand '#{base64_command}'")
+    end
   end
 end

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -14,8 +14,9 @@ describe 'Inspec::Resources::Processes' do
   it 'verify processes resource' do
     resource = MockLoader.new(:freebsd10).load_resource('processes', 'login -fp apop')
 
-    proc { resource.list.length.must_equal 2 }
-      .must_output nil, "[DEPRECATION] `processes.list` is deprecated. Please use `processes.entries` instead. It will be removed in version 4.0.\n"
+    expect_deprecation_warning do
+      resource.list.length.must_equal 2
+    end
 
     _(resource.entries.length).must_equal 2
     _(resource.entries[0].to_h).must_equal({

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -44,8 +44,9 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   it 'access all lines of the file' do
-    proc { _(shadow.lines[0]).must_equal 'root:x:1:2:3::::' }.must_output nil,
-      "[DEPRECATION] The shadow `lines` property is deprecated and will be removed in InSpec 3.0.\n"
+    expect_deprecation_warning do
+      shadow.lines[0].must_equal 'root:x:1:2:3::::'
+    end
   end
 
   it 'access all params of the file' do
@@ -57,27 +58,27 @@ describe 'Inspec::Resources::Shadow' do
   end
 
   it 'returns deprecation notice on user property' do
-    proc { _(shadow.user).must_equal %w{root www-data} }.must_output nil,
-      '[DEPRECATION] The shadow `user` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `users` instead.\n"
+    expect_deprecation_warning do
+      shadow.user.must_equal %w{root www-data}
+    end
   end
 
   it 'returns deprecatation notice on password property' do
-    proc { _(shadow.password).must_equal %w{x !!} }.must_output nil,
-      '[DEPRECATION] The shadow `password` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `passwords` instead.\n"
+    expect_deprecation_warning do
+      shadow.password.must_equal %w{x !!}
+    end
   end
 
   it 'returns deprecation notice on last_change property' do
-    proc { _(shadow.last_change).must_equal %w{1 10} }.must_output nil,
-      '[DEPRECATION] The shadow `last_change` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `last_changes` instead.\n"
+    expect_deprecation_warning do
+      shadow.last_change.must_equal %w{1 10}
+    end
   end
 
   it 'returns deprecation notice on expiry_date property' do
-    proc { _(shadow.expiry_date).must_equal [nil, "60"] }.must_output nil,
-      '[DEPRECATION] The shadow `expiry_date` property is deprecated and will' \
-      " be removed in InSpec 3.0.  Please use `expiry_dates` instead.\n"
+    expect_deprecation_warning do
+      shadow.expiry_date.must_equal [nil, "60"]
+    end
   end
 
   describe 'multiple filters' do
@@ -92,13 +93,14 @@ describe 'Inspec::Resources::Shadow' do
 
     it 'can read /etc/shadow and #filter matches user with no password and inactive_days' do
       users = shadow.filter(password: /[^x]/).entries.map { |x| x['user'] }
+
       users.each do |expected_user|
-        proc { expect(shadow.user(expected_user).users).must_equal(['www-data']) }.must_output nil,
-          '[DEPRECATION] The shadow `user` property is deprecated and will' \
-          " be removed in InSpec 3.0.  Please use `users` instead.\n"
-        proc { expect(shadow.user(expected_user).inactive_days).must_equal(['50']) }.must_output nil,
-          '[DEPRECATION] The shadow `user` property is deprecated and will' \
-          " be removed in InSpec 3.0.  Please use `users` instead.\n"
+        expect_deprecation_warning do
+          shadow.user(expected_user).users.must_equal(['www-data'])
+        end
+        expect_deprecation_warning do
+          shadow.user(expected_user).inactive_days.must_equal(['50'])
+        end
       end
     end
 

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -36,18 +36,28 @@ describe 'Inspec::Resources::User' do
   # serverspec compatibility tests (do not test matcher)
   it 'returns deprecation notices' do
     resource = MockLoader.new(:ubuntu1404).load_resource('user', 'root')
-    proc { resource.has_uid?(0).must_equal true }
-      .must_output nil, "[DEPRECATION] has_uid? is deprecated. \n"
-    proc { resource.has_home_directory?('/root').must_equal true }
-      .must_output nil, "[DEPRECATION] has_home_directory? is deprecated. Please use: its('home')\n"
-    proc { resource.has_login_shell?('/bin/bash').must_equal true }
-      .must_output nil, "[DEPRECATION] has_login_shell? is deprecated. Please use: its('shell')\n"
-    proc { resource.minimum_days_between_password_change.must_equal 0 }
-      .must_output nil, "[DEPRECATION] minimum_days_between_password_change is deprecated. Please use: its('mindays')\n"
-    proc { resource.maximum_days_between_password_change.must_equal 99999 }
-      .must_output nil, "[DEPRECATION] maximum_days_between_password_change is deprecated. Please use: its('maxdays')\n"
 
-    assert_output(nil, "[DEPRECATION] has_authorized_key? is deprecated. \n") do
+    expect_deprecation_warning do
+      resource.has_uid?(0).must_equal true
+    end
+
+    expect_deprecation_warning do
+      resource.has_home_directory?('/root').must_equal true
+    end
+
+    expect_deprecation_warning do
+      resource.has_login_shell?('/bin/bash').must_equal true
+    end
+
+    expect_deprecation_warning do
+      resource.minimum_days_between_password_change.must_equal 0
+    end
+
+    expect_deprecation_warning do
+      resource.maximum_days_between_password_change.must_equal 99999
+    end
+
+    expect_deprecation_warning do
       proc { resource.has_authorized_key?('abc') }.must_raise NotImplementedError
     end
   end

--- a/test/unit/utils/deprecation_test.rb
+++ b/test/unit/utils/deprecation_test.rb
@@ -12,9 +12,9 @@ describe 'The global deprecation method' do
     it 'Inspec must have a class method' do
       Inspec.must_respond_to :deprecate
     end
-    it 'must take two required and one optional arg' do
+    it 'must take one required and two optional arg' do
       # See http://ruby-doc.org/core-2.5.3/Method.html#method-i-arity
-      Inspec.method(:deprecate).arity.must_equal(-3)
+      Inspec.method(:deprecate).arity.must_equal(-2)
     end
   end
 end


### PR DESCRIPTION
This converts all current deprecation warnings/TODOs to use the `Inspec.deprecate()` deprecation facility.

This also modifies `Inspec.deprecate()` to only require 1 argument.

This closes #3745 