### PR TITLE
Attribute -> Input Rename: Rename dummy value class

### DIFF
--- a/lib/utils/pkey_reader.rb
+++ b/lib/utils/pkey_reader.rb
@@ -1,15 +1,15 @@
 module PkeyReader
   def read_pkey(filecontent, passphrase)
-    raise_if_default(passphrase)
+    raise_if_unset(passphrase)
 
     OpenSSL::PKey.read(filecontent, passphrase)
   rescue OpenSSL::PKey::PKeyError
     raise Inspec::Exceptions::ResourceFailed, 'passphrase error'
   end
 
-  def raise_if_default(passphrase)
-    if passphrase.is_a? Inspec::Attribute::DEFAULT_ATTRIBUTE
-      raise Inspec::Exceptions::ResourceFailed, 'Please provide default value for attribute'
+  def raise_if_unset(passphrase)
+    if passphrase.is_a? Inspec::Input::NO_VALUE_SET
+      raise Inspec::Exceptions::ResourceFailed, 'Please provide a value for input for openssl key passphrase'
     end
   end
 end

--- a/test/unit/inputs/input_registry_test.rb
+++ b/test/unit/inputs/input_registry_test.rb
@@ -14,7 +14,7 @@ describe Inspec::InputRegistry do
     it 'creates an input without options' do
       registry.register_input('test_input', 'dummy_profile')
       # confirm we get the dummy default
-      registry.find_input('test_input', 'dummy_profile').value.class.must_equal Inspec::Attribute::DEFAULT_ATTRIBUTE
+      registry.find_input('test_input', 'dummy_profile').value.class.must_equal Inspec::Input::NO_VALUE_SET
     end
 
     it 'creates an input with a default value' do

--- a/test/unit/inputs/input_test.rb
+++ b/test/unit/inputs/input_test.rb
@@ -18,8 +18,14 @@ describe Inspec::Input do
     end
 
     it 'returns the dummy value if no value is assigned' do
-      input.value.must_be_kind_of Inspec::Attribute::DEFAULT_ATTRIBUTE # TODO - test for new class too
+      input.value.must_be_kind_of Inspec::Input::NO_VALUE_SET
+      input.value.is_a?(Inspec::Input::NO_VALUE_SET).must_equal true
       input.value.to_s.must_equal "Input 'test_input' does not have a value. Skipping test."
+    end
+
+    it 'the dummy value responds true to the legacy class checks' do
+      input.value.is_a?(Inspec::Attribute::DEFAULT_ATTRIBUTE).must_equal true
+      input.value.must_be_kind_of Inspec::Attribute::DEFAULT_ATTRIBUTE
     end
 
     it 'has a dummy value that can be called like a nested map' do


### PR DESCRIPTION
This is part of #3802.

Closes #3761 

As the first user visible change, rename the class `Inspec::Attribute::DEFAULT_ATTRIBUTE` to `Inspec::Input::NO_VALUE_SET`. This class is used to represent the value of an attribute that has not had a value set.  This allows the user to distinguish from the case when a user has explicitly set nil, as well as avoiding 'No method on Nil::NilClass' errors.

As described in #3761, the term 'DEFAULT_ATTRIBUTE' is confusing; here it is renamed to `NO_VALUE SET` which is hopefully clearer.

Checking for the class of this value is known to be in the wild.  Thus, we override `is_a?` and `kind_of?` to intercept such queries, potentially issue a deprecation warning, and then lie to the type system.

