### PR TITLE
detect postgres 10 on centos properly

### DIFF
--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -9,6 +9,28 @@ module Inspec::Resources
 
     attr_reader :service, :data_dir, :conf_dir, :conf_path, :version, :cluster
     def initialize
+      # determine dirs and service based on versions
+      determine_dirs
+      determine_service
+
+      # print warnings if the dirs do not exist
+      verify_dirs
+
+      if !@version.nil? && !@conf_dir.empty?
+        @conf_path = File.join @conf_dir, 'postgresql.conf'
+      else
+        @conf_path = nil
+        return skip_resource 'Seems like PostgreSQL is not installed on your system'
+      end
+    end
+
+    def to_s
+      'PostgreSQL'
+    end
+
+    private
+
+    def determine_dirs
       if inspec.os.debian?
         #
         # https://wiki.debian.org/PostgreSql
@@ -33,30 +55,17 @@ module Inspec::Resources
         end
         @data_dir = locate_data_dir_location_by_version(@version)
       end
+      @conf_dir ||= @data_dir
+    end
 
+    def determine_service
       @service = 'postgresql'
       if @version.to_i >= 10
-        @service += "-#{@version.to_i}" 
+        @service += "-#{@version.to_i}"
       elsif @version.to_f >= 9.4
-       @service += "-#{@version}" 
-      end
-
-      @conf_dir ||= @data_dir
-
-      verify_dirs
-      if !@version.nil? && !@conf_dir.empty?
-        @conf_path = File.join @conf_dir, 'postgresql.conf'
-      else
-        @conf_path = nil
-        return skip_resource 'Seems like PostgreSQL is not installed on your system'
+        @service += "-#{@version}"
       end
     end
-
-    def to_s
-      'PostgreSQL'
-    end
-
-    private
 
     def verify_dirs
       warn "Default postgresql configuration directory: #{@conf_dir} does not exist. " \

--- a/lib/resources/postgres.rb
+++ b/lib/resources/postgres.rb
@@ -35,7 +35,12 @@ module Inspec::Resources
       end
 
       @service = 'postgresql'
-      @service += "-#{@version}" if @version.to_f >= 9.4
+      if @version.to_i >= 10
+        @service += "-#{@version.to_i}" 
+      elsif @version.to_f >= 9.4
+       @service += "-#{@version}" 
+      end
+
       @conf_dir ||= @data_dir
 
       verify_dirs
@@ -71,6 +76,8 @@ module Inspec::Resources
     def locate_data_dir_location_by_version(ver = @version)
       dir_list = [
         "/var/lib/pgsql/#{ver}/data",
+        # for 10, the versions are just stored in `10` although their version `10.7`
+        "/var/lib/pgsql/#{ver.to_i}/data",
         '/var/lib/pgsql/data',
         '/var/lib/postgres/data',
         '/var/lib/postgresql/data',


### PR DESCRIPTION
```
$ inspec shell -t ssh://vagrant@127.0.0.1:2222 --sudo
Welcome to the interactive InSpec Shell
To find out how to use it, type: help

You are currently running on:

    Name:      centos
    Families:  redhat, linux, unix, os
    Release:   7.4.1708
    Arch:      x86_64

inspec> command("psql --version").stdout.strip
=> "psql (PostgreSQL) 10.7"
inspec> command("ls '/var/lib/pgsql'").stdout
=> "10\n"
inspec> 
```

This work is related to https://github.com/dev-sec/postgres-baseline/pull/31 for additional postgres 10 support.

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>