### PR TITLE
sort control filenames

### DIFF
--- a/lib/source_readers/inspec.rb
+++ b/lib/source_readers/inspec.rb
@@ -47,7 +47,7 @@ module SourceReaders
       tests = @target.files.find_all do |path|
         path.start_with?('controls') && path.end_with?('.rb')
       end
-      Hash[tests.map { |x| [x, @target.read(x)] }.delete_if { |_file, contents| contents.nil? }]
+      Hash[tests.sort.map { |x| [x, @target.read(x)] }.delete_if { |_file, contents| contents.nil? }]
     end
 
     def load_libs


### PR DESCRIPTION
Often controls filenames are numbered, sorting them makes the output more logical instead of randomized.

This also enables our use case: Running inspec with attributes file 'exceptions.yml' that contains exceptions. The profile controls folder contains files like file-01.rb, file-02.rb etc. and a zzSkip_Control.rb This last file contains no tests only logic that iterates over all controls, if a control is in the exceptions file it is skipped. This enables a multi layered model; controls defined in exceptions.yml are skipped during the profile handling, instead of the skip_control examples that require a 'master' profile to skip exceptions in 'child' profile.

Also, the 'master'-'child' model only can handle a single layer, the multi layer model can have multiple layers; layer 3 profile (the one that is executed) depends on layer 2 profiles, depends on layer 1 profiles. The skip_control is available on each layer when using the technique as described above.

Fixes #3797 (sort control files)

EDIT: link to open issue