### PR TITLE
iis_app_pool: Fix PowerShell JSON parsing error

### DIFF
--- a/lib/resources/iis_app_pool.rb
+++ b/lib/resources/iis_app_pool.rb
@@ -86,6 +86,9 @@ class IisAppPool < Inspec.resource(1)
   def iis_app_pool
     return @cache unless @cache.nil?
 
+    # We use `-Compress` here to avoid a bug in PowerShell
+    # It does not affect validity of the output, only the representation
+    # See: https://github.com/inspec/inspec/pull/3842
     script = <<~EOH
       Import-Module WebAdministration
       If (Test-Path '#{@pool_path}') {

--- a/lib/resources/iis_app_pool.rb
+++ b/lib/resources/iis_app_pool.rb
@@ -89,7 +89,7 @@ class IisAppPool < Inspec.resource(1)
     script = <<~EOH
       Import-Module WebAdministration
       If (Test-Path '#{@pool_path}') {
-        Get-Item '#{@pool_path}' | Select-Object * | ConvertTo-Json
+        Get-Item '#{@pool_path}' | Select-Object * | ConvertTo-Json -Compress
       } Else {
         Write-Host '{}'
       }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -528,7 +528,7 @@ class MockLoader
       "curl -H 'Content-Type: application/json'  -u es_admin:password http://localhost:9200/_nodes" => cmd.call('elasticsearch-cluster-auth'),
       "curl -H 'Content-Type: application/json' http://elasticsearch.mycompany.biz:1234/_nodes" => cmd.call('elasticsearch-cluster-url'),
       # iis_app_pool resource
-      "Import-Module WebAdministration\nIf (Test-Path 'IIS:\\AppPools\\DefaultAppPool') {\n  Get-Item 'IIS:\\AppPools\\DefaultAppPool' | Select-Object * | ConvertTo-Json\n} Else {\n  Write-Host '{}'\n}\n" => cmd.call('iis-default-app-pool'),
+      "Import-Module WebAdministration\nIf (Test-Path 'IIS:\\AppPools\\DefaultAppPool') {\n  Get-Item 'IIS:\\AppPools\\DefaultAppPool' | Select-Object * | ConvertTo-Json -Compress\n} Else {\n  Write-Host '{}'\n}\n" => cmd.call('iis-default-app-pool'),
 
       # iis_site resource
       "Get-Website 'Default Web Site' | Select-Object -Property Name,State,PhysicalPath,bindings,ApplicationPool | ConvertTo-Json" => cmd.call('iis-default-web-site'),


### PR DESCRIPTION
This works around a current bug in PowerShell where the output cannot be parsed as JSON.

The `-Compress` flag does not affect the validity of the data.

See:
  https://stackoverflow.com/questions/23552000/convertto-json-throws-error-when-using-a-string-terminating-in-backslash
  https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/convertto-json?view=powershell-6

## Current output

```
inspec> iis_app_pool('DefaultAppPool').pool_name
Inspec::Exceptions::ResourceFailed: Unable to parse app pool JSON
from /home/jerry/Projects/github.com/inspec/inspec/lib/resources/iis_app_pool.rb:102:in `rescue in iis_app_pool'
Caused by JSON::ParserError: 785: unexpected token at ''
from /home/jerry/.gem/ruby/2.4.3/gems/json-2.2.0/lib/json/common.rb:156:in `parse'
```

```
inspec> cmd.command
=> "Import-Module WebAdministration\nIf (Test-Path 'IIS:\\AppPools\\DefaultAppPool') {\n  Get-Item 'IIS:\\AppPools\\DefaultAppPool' | Select-Object * | ConvertTo-Json\n} Else {\n  Write-Host '{}'\n}\n"
inspec> cmd.stderr
=> "The converted JSON string is in bad format.\nAt line:3 char:63\r\n+   Get-Item 'IIS:\\AppPools\\DefaultAppPool' | Select-Object * | ConvertTo-Json\r\n+                                                               ~~~~~~~~~~~~~~\n    + CategoryInfo          : InvalidOperation: (@{name=DefaultA...nElementSchema}:PSObject) [ConvertTo-Json], InvalidOperationException\n    + FullyQualifiedErrorId : JsonStringInBadFormat,Microsoft.PowerShell.Commands.ConvertToJsonCommand\n"
```

## New output

```
inspec> iis_app_pool('DefaultAppPool').pool_name
=> "DefaultAppPool"
```

```
inspec> cmd.command
=> "Import-Module WebAdministration\nIf (Test-Path 'IIS:\\AppPools\\DefaultAppPool') {\n  Get-Item 'IIS:\\AppPools\\DefaultAppPool' | Select-Object * | ConvertTo-Json -Compress\n} Else {\n  Write-Host '{}'\n}\n"
inspec> cmd.stderr
=> ""
```
