### PR TITLE
http resource: Add fallback to `#to_s`

### DIFF
--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -63,7 +63,11 @@ module Inspec::Resources
     end
 
     def to_s
-      "http #{http_method} on #{@url}"
+      if @opts and @url
+        "HTTP #{http_method} on #{@url}"
+      else
+        'HTTP Resource'
+      end
     end
 
     class Worker


### PR DESCRIPTION
This prevents a stack trace from being shown to the user if the `http` resource is used on an unsupported platform.

## Current Output

```
[~/Projects/github.com/inspec/inspec]$ inspec exec /tmp/example -t winrm://REDACTED@10.2.3.4
bundler: failed to load command: inspec (/home/jerry/.gem/ruby/2.4.3/bin/inspec)
NoMethodError: undefined method `fetch' for nil:NilClass
  /home/jerry/Projects/github.com/inspec/inspec/lib/resources/http.rb:62:in `http_method'
  /home/jerry/Projects/github.com/inspec/inspec/lib/resources/http.rb:67:in `to_s'
  /home/jerry/.gem/ruby/2.4.3/gems/rspec-core-3.8.0/lib/rspec/core/metadata.rb:180:in `build_description_from'
  /home/jerry/.gem/ruby/2.4.3/gems/rspec-core-3.8.0/lib/rspec/core/metadata.rb:133:in `populate'
  /home/jerry/.gem/ruby/2.4.3/gems/rspec-core-3.8.0/lib/rspec/core/metadata.rb:258:in `create'
  /home/jerry/.gem/ruby/2.4.3/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:422:in `set_it_up'
  /home/jerry/.gem/ruby/2.4.3/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:386:in `subclass'
  /home/jerry/.gem/ruby/2.4.3/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:260:in `block in define_example_group_method'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/runner_rspec.rb:27:in `example_group'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/runner.rb:323:in `rspec_failed_block'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/runner.rb:281:in `get_check_example'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/runner.rb:293:in `block in register_rule'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/runner.rb:292:in `each'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/runner.rb:292:in `flat_map'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/runner.rb:292:in `register_rule'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/runner.rb:110:in `block in load'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/runner.rb:109:in `each'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/runner.rb:109:in `load'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/runner.rb:116:in `run'
  /home/jerry/Projects/github.com/inspec/inspec/lib/inspec/cli.rb:265:in `exec'
  /home/jerry/.gem/ruby/2.4.3/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
  /home/jerry/.gem/ruby/2.4.3/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
  /home/jerry/.gem/ruby/2.4.3/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
  /home/jerry/.gem/ruby/2.4.3/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
  /home/jerry/Projects/github.com/inspec/inspec/bin/inspec:12:in `<top (required)>'
  /home/jerry/.gem/ruby/2.4.3/bin/inspec:23:in `load'
  /home/jerry/.gem/ruby/2.4.3/bin/inspec:23:in `<top (required)>'
```

## New Output

```
[~/Projects/github.com/inspec/inspec]$ inspec exec /tmp/example -t winrm://REDACTED@10.2.3.4

Profile: InSpec Profile (example)
Version: 0.1.0
Target:  winrm://azure@http://10.2.3.4:5985/wsman:3389

  ×  tmp-1.0: Create /tmp directory
     ×  HTTP Resource 
     Resource Http is not supported on platform windows_server_2012_r2_datacenter/6.3.9600.


Profile Summary: 0 successful controls, 1 control failure, 0 controls skipped
Test Summary: 0 successful, 1 failure, 0 skipped
```