### PR TITLE
json resource: Add handling for `command:` error

### DIFF
--- a/lib/inspec/resources/json.rb
+++ b/lib/inspec/resources/json.rb
@@ -93,25 +93,17 @@ module Inspec::Resources
     end
 
     def load_raw_from_command(command)
-      command_result = inspec.command(command)
+      result = inspec.command(command)
 
-      case command_result.exit_status
-      when 0
+      return result.stdout unless result.stdout.empty?
 
-        # TODO: Handle case where command exits 0 but STDERR is found.
+      msg = if result.stderr.empty?
+              "No JSON output, STDERR was empty"
+            else
+              "No JSON output, STDERR:\n #{result.stderr}"
+            end
 
-        if command_result.stdout.empty?
-          raise Inspec::Exceptions::ResourceSkipped, "No output from command: #{command}"
-        end
-      else
-        if command_result.stderr.empty?
-          raise Inspec::Exceptions::ResourceFailed, "Command exited non-zero but STDERR was empty"
-        else
-          raise Inspec::Exceptions::ResourceFailed, "Command exited non-zero. Error:\n #{command_result.stderr}"
-        end
-      end
-
-      command_result.stdout
+      raise Inspec::Exceptions::ResourceFailed, msg
     end
 
     # for resources the subclass JsonConfig, this allows specification of the resource

--- a/test/unit/resources/json_test.rb
+++ b/test/unit/resources/json_test.rb
@@ -86,39 +86,61 @@ describe "Inspec::Resources::JSON" do
     end
   end
 
-  describe "#load_raw_from_command" do
-    let(:cmd_str)  { "curl localhost" }
-    let(:resource) { Inspec::Resources::JsonConfig.allocate }
-    let(:inspec)   { mock }
-    let(:command)  { mock }
+  describe ":command" do
+    # CASES:
+    #
+    # stdout:good,  stderr:empty
+    # stdout:bad,   stderr:empty
+    # stdout:empty, stderr:msg
+    # stdout:empty, stderr:empty
 
-    before do
-      resource.stubs(:inspec).returns(inspec)
-      inspec.expects(:command).with(cmd_str).returns(command)
+    # TODO: abstract and push up
+    def run_json_cmd(cmd)
+      backend = Inspec::Backend.create(Inspec::Config.new)
+      klass   = Inspec::Resource.registry["json"]
+
+      klass.new(backend, "json", command: cmd)
     end
 
-    it "skips the resource if command exits zero and stdout is empty" do
-      command.expects(:exit_status).returns(0)
-      command.expects(:stdout).returns("")
-      proc { resource.send(:load_raw_from_command, cmd_str) }.must_raise Inspec::Exceptions::ResourceSkipped
+    # TODO: push up
+    def assert_resource_skipped(res, msg)
+      assert_predicate res, :resource_skipped?
+      refute_predicate res, :resource_failed?
+
+      assert_includes res.resource_exception_message, msg
     end
 
-    it "fails the resource if the command exits non-zero and stderr is not empty" do
-      command.expects(:exit_status).returns(1)
-      command.expects(:stderr).returns("This is a fake stderr message").twice
-      proc { resource.send(:load_raw_from_command, cmd_str) }.must_raise Inspec::Exceptions::ResourceFailed
+    # TODO: push up
+    def assert_resource_failed(res, msg)
+      refute_predicate res, :resource_skipped?
+      assert_predicate res, :resource_failed?
+
+      assert_includes res.resource_exception_message, msg
     end
 
-    it "fails the resource if the command exits non-zero and stderr is empty" do
-      command.expects(:exit_status).returns(1)
-      command.expects(:stderr).returns("")
-      proc { resource.send(:load_raw_from_command, cmd_str) }.must_raise Inspec::Exceptions::ResourceFailed
+    it "good stdout, empty stderr" do
+      resource = run_json_cmd %(ruby -rjson -e "h={'result'=>true}; puts h.to_json")
+
+      assert_equal %({"result":true}), resource.raw_content.chomp
+      assert_equal({ "result" => true }, resource.params)
     end
 
-    it "returns the command output" do
-      command.expects(:exit_status).returns(0)
-      command.expects(:stdout).returns("json goes here").twice
-      resource.send(:load_raw_from_command, cmd_str).must_equal "json goes here"
+    it "bad stdout, empty stderr" do
+      resource = run_json_cmd "echo 'not-valid-json'"
+
+      assert_resource_failed resource, "unexpected token at 'not-valid-json"
+    end
+
+    it "empty stdout, message in stderr" do
+      resource = run_json_cmd "echo bad args 1>&2 && false"
+
+      assert_resource_failed resource, "No JSON output, STDERR:"
+    end
+
+    it "empty stdout, empty stderr" do
+      resource = run_json_cmd %{ruby -e "exit 1"}
+
+      assert_resource_failed resource, "No JSON output, STDERR was empty"
     end
   end
 end

--- a/test/unit/resources/json_test.rb
+++ b/test/unit/resources/json_test.rb
@@ -132,7 +132,9 @@ describe "Inspec::Resources::JSON" do
     end
 
     it "empty stdout, message in stderr" do
-      resource = run_json_cmd "echo bad args 1>&2 && false"
+      skip "Bug #4465: does not work on windows w/ transport==local" if windows?
+
+      resource = run_json_cmd %{abort 'bad args'"}
 
       assert_resource_failed resource, "No JSON output, STDERR:"
     end


### PR DESCRIPTION
This provides the user with messages if `json(command: 'command_that_errors')` exits non-zero and/or has STDERR.

Without this the resource will report "No output from command" when really the output is contained in STDERR.