### PR TITLE
Add caching to Inspec::Config

### DIFF
--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -30,6 +30,17 @@ module Inspec
       Inspec::Config.new({ backend: :mock }.merge(opts), StringIO.new('{}'))
     end
 
+    # Use this to get a cached version of the config.  This prevents you from
+    # being required to pass it around everywhere.
+    def self.cached
+      @cached_config
+    end
+
+    def self.cached=(cfg)
+      @cached_config ||= cfg
+    end
+
+    # This gets called when the first config is created.
     def initialize(cli_opts = {}, cfg_io = nil, command_name = nil)
       @command_name = command_name || (ARGV.empty? ? nil : ARGV[0].to_sym)
       @defaults = Defaults.for_command(@command_name)
@@ -40,6 +51,7 @@ module Inspec
 
       @merged_options = merge_options
       @final_options = finalize_options
+      self.class.cached = self
     end
 
     def diagnose

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -29,6 +29,31 @@ describe 'Inspec::Config' do
   end
 
   # ========================================================================== #
+  #                              Global Caching
+  # ========================================================================== #
+
+  describe 'caching' do
+    # Note that since unit tests are randomized, we have no idea what is in
+    # the cache.  We just want to validate that we get the same thing.
+    it 'should cache the config object' do
+      cfg_1 = Inspec::Config.new # in the unlikely event we are the first unit test
+
+      # Type check
+      cfg_cached = Inspec::Config.cached
+      cfg_cached.must_be_kind_of Inspec::Config
+
+      # Multiple calls to cached should return the same thing
+      cfg_2 = Inspec::Config.cached
+      cfg_2.must_equal cfg_cached
+
+      # Cached value unaffected by later instance creation
+      cfg_3 = Inspec::Config.new(shoe_size: 9)
+      cfg_4 = Inspec::Config.cached
+      cfg_4.must_equal cfg_cached
+    end
+  end
+
+  # ========================================================================== #
   #                              File Validation
   # ========================================================================== #
   describe 'when validating a file' do


### PR DESCRIPTION
Miah and I discovered that Config will usually want to act like a singleton; this adds a class-level cache which may be used to get a handle on the first instance.

Needed for both the Attributes and Telemetry work.


Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>