### PR TITLE
inspec exec: new CLI option '--sort-files' to sort files before executing controls

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -117,6 +117,8 @@ module Inspec
         desc: 'Show progress while executing tests.'
       option :distinct_exit, type: :boolean, default: true,
         desc: 'Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.'
+      option :sort_files, type: :boolean, default: false,
+        desc: 'Sort the files in the controls folder before execution. (default: false)'
     end
 
     def self.format_platform_info(params: {}, indent: 0, color: 39)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -301,6 +301,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: 'A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell'
   option :distinct_exit, type: :boolean, default: true,
     desc: 'Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures.'
+  option :sort_files, type: :boolean, default: false,
+    desc: 'Sort the files in the controls folder before execution. (default: false)'
+
   def shell_func
     o = config
     diagnose(o)

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -256,6 +256,10 @@ module Inspec
       parent.binread(abs_path(file))
     end
 
+    def sort_files
+      @files.sort!
+    end
+
     private
 
     def get_prefix(fs)

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -55,6 +55,7 @@ module Inspec
     def self.for_path(path, opts)
       file_provider = FileProvider.for_path(path)
       rp = file_provider.relative_provider
+      rp.sort_files if opts[:sort_files]
 
       # copy embedded dependencies into global cache
       copy_deps_into_cache(rp, opts) unless opts[:vendor_cache].nil?

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -205,6 +205,7 @@ module Inspec
                                            vendor_cache: @cache,
                                            backend: @backend,
                                            controls: @controls,
+                                           sort_files: @conf['sort_files'],
                                            inputs: @conf[:attributes]) # TODO: read form :inputs here (user visible)
       raise "Could not resolve #{target} to valid input." if profile.nil?
       @target_profiles << profile if supports_profile?(profile)

--- a/test/functional/inspec_exec_sort-control.rb
+++ b/test/functional/inspec_exec_sort-control.rb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+
+require 'functional/helper'
+
+describe 'inspec exec --sort-controls' do
+  include FunctionalHelper
+  let(:looks_like_a_stacktrace) { %r{lib/inspec/.+\.rb:\d+:in} }
+
+  describe 'when passing in multiple profiles given an inherited profile that has more that one test per control block' do
+     # Control files will be sorted 'within a single profile'. Controls within a control file will not be sorted.
+     # --sort-files is of no use on filesystems/OS that have autosort, like Windows has.
+     # therefor, the default behaviour of 'random' order cannot be tested.
+  
+     it 'sorts the controls within a single profile' do
+#       let(:out) { inspec('exec ' + File.join(profile_path, 'sort-controls', 'profile_layer_top') + ' --sort-controls --no-create-lockfile') }
+       out = inspec('exec ' + File.join(profile_path, 'sort-controls', 'profile_layer_top') + ' --sort-controls --no-create-lockfile')
+       out.stderr.must_equal ''
+       out.exit_status.must_equal 0
+       stdout = out.stdout.force_encoding(Encoding::UTF_8)
+       stdout.must_include "
+\e[38;5;41m  \u2714  test-1a: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+\e[38;5;41m  \u2714  test-2a: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+\e[38;5;41m  \u2714  test-3a: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+"
+       stdout.must_include "
+\e[38;5;41m  \u2714  test-1d: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+\e[38;5;41m  \u2714  test-2d: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+\e[38;5;41m  \u2714  test-3d: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+"
+       stdout.must_include "
+\e[38;5;41m  \u2714  test-1c: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+\e[38;5;41m  \u2714  test-2c: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+\e[38;5;41m  \u2714  test-3c: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+"
+       stdout.must_include "
+\e[38;5;41m  \u2714  test-1b: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+\e[38;5;41m  \u2714  test-2b: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+\e[38;5;41m  \u2714  test-3b: Create /tmp directory\e[0m
+\e[38;5;41m     \u2714  File /tmp should be directory\e[0m
+"
+       end
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_a/controls/include_profile_layer_d.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_a/controls/include_profile_layer_d.rb
@@ -1,0 +1,5 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'include_profile_layer_d'
+include_controls 'profile_layer_d'

--- a/test/unit/mock/profiles/sort-controls/profile_layer_a/controls/test-1a.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_a/controls/test-1a.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-1a'
+
+control 'test-1a' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_a/controls/test-2a.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_a/controls/test-2a.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-2a'
+include_controls 'profile_layer_c'
+
+control 'test-2a' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_a/controls/test-3a.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_a/controls/test-3a.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-3a'
+
+control 'test-3a' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_a/inspec.yml
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_a/inspec.yml
@@ -1,0 +1,13 @@
+name: profile_layer_a
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+depends:
+  - name: profile_layer_d
+    path: ../profile_layer_d
+  - name: profile_layer_c
+    path: ../profile_layer_c

--- a/test/unit/mock/profiles/sort-controls/profile_layer_b/controls/test-1b.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_b/controls/test-1b.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-1b'
+
+control 'test-1b' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_b/controls/test-2b.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_b/controls/test-2b.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-2b'
+
+control 'test-2b' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_b/controls/test-3b.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_b/controls/test-3b.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-3b'
+
+control 'test-3b' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_b/inspec.yml
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_b/inspec.yml
@@ -1,0 +1,8 @@
+name: profile_layer_b
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0

--- a/test/unit/mock/profiles/sort-controls/profile_layer_c/controls/test-1c.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_c/controls/test-1c.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-1c'
+
+control 'test-1c' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_c/controls/test-2c.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_c/controls/test-2c.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-2c'
+
+control 'test-2c' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_c/controls/test-3c.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_c/controls/test-3c.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-3c'
+
+control 'test-3c' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_c/inspec.yml
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_c/inspec.yml
@@ -1,0 +1,8 @@
+name: profile_layer_c
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0

--- a/test/unit/mock/profiles/sort-controls/profile_layer_d/controls/test-1d.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_d/controls/test-1d.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-1d'
+
+control 'test-1d' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_d/controls/test-2d.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_d/controls/test-2d.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-2d'
+
+control 'test-2d' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_d/controls/test-3d.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_d/controls/test-3d.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'test-3d'
+
+control 'test-3d' do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title 'Create /tmp directory'             # A human-readable title
+  desc 'An optional description...'
+  describe file('/tmp') do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/unit/mock/profiles/sort-controls/profile_layer_d/inspec.yml
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_d/inspec.yml
@@ -1,0 +1,8 @@
+name: profile_layer_d
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0

--- a/test/unit/mock/profiles/sort-controls/profile_layer_top/controls/profile_layer_include_ab.rb
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_top/controls/profile_layer_include_ab.rb
@@ -1,0 +1,7 @@
+# encoding: utf-8
+# copyright: 2015, The Authors
+
+title 'profile_layer_include'
+include_controls 'profile_layer_b'
+include_controls 'profile_layer_a'
+

--- a/test/unit/mock/profiles/sort-controls/profile_layer_top/inspec.yml
+++ b/test/unit/mock/profiles/sort-controls/profile_layer_top/inspec.yml
@@ -1,0 +1,13 @@
+name: profile_layer_top
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+depends:
+  - name: profile_layer_a
+    path: ../profile_layer_a
+  - name: profile_layer_b
+    path: ../profile_layer_b

--- a/test/unit/mock/profiles/sort-controls/readme.txt
+++ b/test/unit/mock/profiles/sort-controls/readme.txt
@@ -1,0 +1,48 @@
+
+# Legend:
+# - 'profile name'
+# - \file name\
+# - [control within file]
+
+
+'profile_layer_top'                # top level profile, includes 2 profiles
+   - 'profile_layer_a'             # profile first layer, contains 5 control files holding 3 tests + 2 inheritances 
+   |      |
+   |      - \test-1a               # Control file test-1A .. test-3A must be sorted 
+   |      |    [test-1a]           # test-1a controls file contains test 'test-1a'
+   |      - \test-3a   
+   |      |    [test-3a            # test-3a controls file contains test 'test-3a'
+   |      - \test-2a               # test-2a controls file contains test & include
+   |      |    [test-2a]                    
+   |      |    'profile_layer_c'   # profile included by test-2a controls file 
+   |      |       |
+   |      |       - \test-1c       # Controls test-1C...test-3C must be sorted
+   |      |       |    [test-1c]
+   |      |       - \test-2c
+   |      |       |    [test-2c]
+   |      |       - \test-3c
+   |      |       |    [test-3c]
+   |      - 'profile_layer_d'        
+   |             |
+   |             - \test-1d
+   |             |    [test-1d]
+   |             - \test-2d
+   |             |    [test-2d]
+   |             - \test-3d
+   |                  [test-3d]
+   |
+   - 'profile_layer_b'
+          - \test-1b
+          |    [test-1b]
+          - \test-2b
+          |    [test-2b]
+          - \test-3b
+               [test-3b]
+
+
+# Expected output of the overview 
+# (the order of the lines can vary, the order within a profile is sorted):
+# - (test-1a, test-2a, test-3a),
+# - (test-1d, test-2d, test-3d),
+# - (test-1c, test-2c, test-3c),
+# - (test-1b, test-2b, test-3b)


### PR DESCRIPTION
Add parameter '--sort_files' for 'inspec exec' to sort files before executing controls.

Often controls filenames are numbered, sorting them makes the output
logical instead of randomized.

This also enables our use case: Running inspec with attributes file
'exceptions.yml' that contains exceptions. The profile controls folder
contains files like file-01.rb, file-02.rb etc. and a zzSkip_Control.rb
This last file contains no tests, only logic that iterates over all
controls; When a control is defined in an (--attrs) exceptions file it
will be skipped.

This enables a multi layered model; controls defined in exceptions.yml
are skipped during the profile handling, instead of the skip_control
examples that require a 'master' profile to skip exceptions in 'child'
profile.

Also, the 'master'-'child' model only can handle a single layer, the
multi layer model can have multiple layers; layer 3 profile (the one
that is executed) depends on layer 2 profiles, depends on layer 1
profiles. The skip_control is available on each layer when using the
technique as described above.

Signed-off-by: Mike Schmeitz <mike.schmeitz@ictelligent.nl>