### PR TITLE
Add cloudtrail logging? method to validate that a cloudtrail is enabled.

### DIFF
--- a/docs/resources/aws_cloudtrail_trail.md.erb
+++ b/docs/resources/aws_cloudtrail_trail.md.erb
@@ -55,6 +55,12 @@ The following examples show how to use this InSpec audit resource.
       it { should be_encrypted }
     end
 
+### Test that the specified trail has logging turned on (ie is not disabled)
+
+    describe aws_cloudtrail_trail('trail-name') do
+      it { should be_logging }
+    end
+
 ### Test that the specified trail is a multi-region trail
 
     describe aws_cloudtrail_trail('trail-name') do

--- a/lib/resources/aws/aws_cloudtrail_trail.rb
+++ b/lib/resources/aws/aws_cloudtrail_trail.rb
@@ -41,6 +41,18 @@ class AwsCloudTrailTrail < Inspec.resource(1)
     end
   end
 
+  def logging?
+    query = { name: @trail_name }
+    catch_aws_errors do
+      begin
+        resp = BackendFactory.create(inspec_runner).get_trail_status(query).to_h
+        resp[:is_logging] unless resp[:is_logging].nil?
+      rescue Aws::CloudTrail::Errors::TrailNotFoundException
+        nil
+      end
+    end
+  end
+
   private
 
   def validate_params(raw_params)

--- a/test/unit/resources/aws_cloudtrail_trail_test.rb
+++ b/test/unit/resources/aws_cloudtrail_trail_test.rb
@@ -95,6 +95,12 @@ class AwsCloudTrailTrailPropertiesTest < Minitest::Test
     assert_equal(0, AwsCloudTrailTrail.new('test-trail-1').delivered_logs_days_ago)
     assert_nil(AwsCloudTrailTrail.new(trail_name: 'non-existant').delivered_logs_days_ago)
   end
+
+  def test_property_is_logging
+    assert_equal(true, AwsCloudTrailTrail.new('test-trail-1').logging?)
+    assert_equal(false, AwsCloudTrailTrail.new('test-trail-2').logging?)
+    assert_nil(AwsCloudTrailTrail.new(trail_name: 'non-existant').logging?)
+  end
 end
 
 
@@ -176,6 +182,12 @@ module MACTTSB
       fixtures = [
         OpenStruct.new({
           name: "test-trail-1",
+          is_logging: true,
+          latest_cloud_watch_logs_delivery_time: Time.now
+        }),
+        OpenStruct.new({
+          name: "test-trail-2",
+          is_logging: false,
           latest_cloud_watch_logs_delivery_time: Time.now
         })
       ]


### PR DESCRIPTION
Adds new check for logging enabled. This is useful because a key security and compliance issue is having the audit log turned off. This provides a check for that in inspec.

Usage:
```
describe aws_cloudtrail_trail('my_trail_name') do
    it { should be_logging }
  end
```

Testing:
An additional set of unit tests and a fixture have been added.

To test this run
```
bundle exec m ./test/unit/resources/aws_cloudtrail_trail_test.rb
```

![inspec_tests_run](https://user-images.githubusercontent.com/618759/54460586-2e718900-4727-11e9-9c8a-effcad5555cc.png)


Signed-off-by: Adrian Kierman <adriankierman@hotmail.com>