### PR TITLE
Fixes resource example indentation

### DIFF
--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -80,19 +80,6 @@ module Inspec
       "\e[1m\e[39m#{x}\e[0m"
     end
 
-    def print_example(example)
-      # determine min whitespace that can be removed
-      min = nil
-      example.lines.each do |line|
-        if !line.strip.empty? # ignore empty lines
-          line_whitespace = line.length - line.lstrip.length
-          min = line_whitespace if min.nil? || line_whitespace < min
-        end
-      end
-      # remove whitespace from each line
-      example.gsub(/\n\s{#{min}}/, "\n")
-    end
-
     def intro
       puts 'Welcome to the interactive InSpec Shell'
       puts "To find out how to use it, type: #{mark 'help'}"
@@ -142,8 +129,8 @@ module Inspec
         end
 
         unless topic_info.example.nil?
-          info += "#{mark 'Example:'}\n"
-          info += "#{print_example(topic_info.example)}\n\n"
+          info += "#{mark 'Example:'}\n\n"
+          info += "#{topic_info.example}\n\n"
         end
 
         info += "#{mark 'Web Reference:'}\n\n"

--- a/lib/resources/aide_conf.rb
+++ b/lib/resources/aide_conf.rb
@@ -9,7 +9,7 @@ module Inspec::Resources
     supports platform: 'unix'
     desc 'Use the aide_conf InSpec audit resource to test the rules established for
       the file integrity tool AIDE. Controlled by the aide.conf file typically at /etc/aide.conf.'
-    example "
+    example <<~EXAMPLE
       describe aide_conf do
         its('selection_lines') { should include '/sbin' }
       end
@@ -21,7 +21,7 @@ module Inspec::Resources
       describe aide_conf.all_have_rule('sha512') do
         it { should eq true }
       end
-    "
+    EXAMPLE
 
     attr_reader :params
 

--- a/lib/resources/apache.rb
+++ b/lib/resources/apache.rb
@@ -6,7 +6,7 @@ module Inspec::Resources
     name 'apache'
     supports platform: 'unix'
     desc 'Use the apache InSpec audit resource to retrieve Apache environment settings.'
-    example "
+    example <<~EXAMPLE
       describe apache do
         its ('service') { should cmp 'apache2' }
       end
@@ -22,7 +22,7 @@ module Inspec::Resources
       describe apache do
         its ('user') { should cmp 'www-data' }
       end
-    "
+    EXAMPLE
 
     attr_reader :service, :conf_dir, :conf_path, :user
     def initialize

--- a/lib/resources/apache_conf.rb
+++ b/lib/resources/apache_conf.rb
@@ -11,11 +11,11 @@ module Inspec::Resources
     supports platform: 'linux'
     supports platform: 'debian'
     desc 'Use the apache_conf InSpec audit resource to test the configuration settings for Apache. This file is typically located under /etc/apache2 on the Debian and Ubuntu platforms and under /etc/httpd on the Fedora, CentOS, Red Hat Enterprise Linux, and Arch Linux platforms. The configuration settings may vary significantly from platform to platform.'
-    example "
+    example <<~EXAMPLE
       describe apache_conf do
         its('setting_name') { should eq 'value' }
       end
-    "
+    EXAMPLE
 
     include FindFiles
     include FileReader

--- a/lib/resources/apt.rb
+++ b/lib/resources/apt.rb
@@ -31,12 +31,12 @@ module Inspec::Resources
     name 'apt'
     supports platform: 'unix'
     desc 'Use the apt InSpec audit resource to verify Apt repositories on the Debian and Ubuntu platforms, and also PPA repositories on the Ubuntu platform.'
-    example "
+    example <<~EXAMPLE
       describe apt('nginx/stable') do
         it { should exist }
         it { should be_enabled }
       end
-    "
+    EXAMPLE
 
     def initialize(ppa_name)
       @deb_url = nil

--- a/lib/resources/audit_policy.rb
+++ b/lib/resources/audit_policy.rb
@@ -26,11 +26,11 @@ module Inspec::Resources
     name 'audit_policy'
     supports platform: 'windows'
     desc 'Use the audit_policy InSpec audit resource to test auditing policies on the Microsoft Windows platform. An auditing policy is a category of security-related events to be audited. Auditing is disabled by default and may be enabled for categories like account management, logon events, policy changes, process tracking, privilege use, system events, or object access. For each enabled auditing category property, the auditing level may be set to No Auditing, Not Specified, Success, Success and Failure, or Failure.'
-    example "
+    example <<~EXAMPLE
       describe audit_policy do
         its('parameter') { should eq 'value' }
       end
-    "
+    EXAMPLE
 
     def method_missing(method)
       key = method.to_s

--- a/lib/resources/auditd.rb
+++ b/lib/resources/auditd.rb
@@ -14,7 +14,7 @@ module Inspec::Resources
     name 'auditd'
     supports platform: 'unix'
     desc 'Use the auditd InSpec audit resource to test the rules for logging that exist on the system. The audit.rules file is typically located under /etc/audit/ and contains the list of rules that define what is captured in log files. These rules are output using the auditcl -l command.'
-    example "
+    example <<~EXAMPLE
       describe auditd.syscall('chown').where {arch == 'b32'} do
         its('action') { should eq ['always'] }
         its('list') { should eq ['exit'] }
@@ -27,7 +27,7 @@ module Inspec::Resources
       describe auditd do
         its('lines') { should include %r(-w /etc/ssh/sshd_config) }
       end
-    "
+    EXAMPLE
 
     def initialize
       unless inspec.command('/sbin/auditctl').exist?

--- a/lib/resources/auditd_conf.rb
+++ b/lib/resources/auditd_conf.rb
@@ -9,11 +9,11 @@ module Inspec::Resources
     name 'auditd_conf'
     supports platform: 'unix'
     desc "Use the auditd_conf InSpec audit resource to test the configuration settings for the audit daemon. This file is typically located under /etc/audit/auditd.conf' on UNIX and Linux platforms."
-    example "
+    example <<~EXAMPLE
       describe auditd_conf do
         its('space_left_action') { should eq 'email' }
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/aws/aws_billing_report.rb
+++ b/lib/resources/aws/aws_billing_report.rb
@@ -2,7 +2,7 @@ class AwsBillingReport < Inspec.resource(1)
   name 'aws_billing_report'
   supports platform: 'aws'
   desc 'Verifies settings for AWS Cost and Billing Reports.'
-  example "
+  example <<~EXAMPLE
     describe aws_billing_report('inspec1') do
       its('report_name') { should cmp 'inspec1' }
       its('time_unit') { should cmp 'hourly' }
@@ -10,7 +10,8 @@ class AwsBillingReport < Inspec.resource(1)
 
     describe aws_billing_report(report: 'inspec1') do
       it { should exist }
-    end"
+    end
+  EXAMPLE
 
   include AwsSingularResourceMixin
 

--- a/lib/resources/aws/aws_billing_reports.rb
+++ b/lib/resources/aws/aws_billing_reports.rb
@@ -4,17 +4,18 @@ class AwsBillingReports < Inspec.resource(1)
   name 'aws_billing_reports'
   supports platform: 'aws'
   desc 'Verifies settings for AWS Cost and Billing Reports.'
-  example "
-      describe aws_billing_reports do
-        its('report_names') { should include 'inspec1' }
-        its('s3_buckets') { should include 'inspec1-s3-bucket' }
-      end
+  example <<~EXAMPLE
+    describe aws_billing_reports do
+      its('report_names') { should include 'inspec1' }
+      its('s3_buckets') { should include 'inspec1-s3-bucket' }
+    end
 
-     describe aws_billing_reports.where { report_name =~ /inspec.*/ } do
-       its ('report_names') { should include ['inspec1'] }
-       its ('time_units') { should include ['DAILY'] }
-       its ('s3_buckets') { should include ['inspec1-s3-bucket'] }
-     end"
+    describe aws_billing_reports.where { report_name =~ /inspec.*/ } do
+      its ('report_names') { should include ['inspec1'] }
+      its ('time_units') { should include ['DAILY'] }
+      its ('s3_buckets') { should include ['inspec1-s3-bucket'] }
+    end
+  EXAMPLE
 
   include AwsPluralResourceMixin
 

--- a/lib/resources/aws/aws_cloudtrail_trail.rb
+++ b/lib/resources/aws/aws_cloudtrail_trail.rb
@@ -1,11 +1,11 @@
 class AwsCloudTrailTrail < Inspec.resource(1)
   name 'aws_cloudtrail_trail'
   desc 'Verifies settings for an individual AWS CloudTrail Trail'
-  example "
+  example <<~EXAMPLE
     describe aws_cloudtrail_trail('trail-name') do
       it { should exist }
     end
-  "
+  EXAMPLE
 
   supports platform: 'aws'
 

--- a/lib/resources/aws/aws_cloudtrail_trails.rb
+++ b/lib/resources/aws/aws_cloudtrail_trails.rb
@@ -1,11 +1,11 @@
 class AwsCloudTrailTrails < Inspec.resource(1)
   name 'aws_cloudtrail_trails'
   desc 'Verifies settings for AWS CloudTrail Trails in bulk'
-  example '
+  example <<~EXAMPLE
     describe aws_cloudtrail_trails do
       it { should exist }
     end
-  '
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_cloudwatch_alarm.rb
+++ b/lib/resources/aws/aws_cloudwatch_alarm.rb
@@ -1,14 +1,14 @@
 class AwsCloudwatchAlarm < Inspec.resource(1)
   name 'aws_cloudwatch_alarm'
-  desc <<-EOD
-  # Look for a specific alarm
-  aws_cloudwatch_alarm(
-    metric_name: 'my-metric-name',
-    metric_namespace: 'my-metric-namespace',
-  ) do
-    it { should exist }
-  end
-  EOD
+  desc <<~EXAMPLE
+    # Look for a specific alarm
+    aws_cloudwatch_alarm(
+      metric_name: 'my-metric-name',
+      metric_namespace: 'my-metric-namespace',
+    ) do
+      it { should exist }
+    end
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_cloudwatch_log_metric_filter.rb
+++ b/lib/resources/aws/aws_cloudwatch_log_metric_filter.rb
@@ -1,25 +1,25 @@
 class AwsCloudwatchLogMetricFilter < Inspec.resource(1)
   name 'aws_cloudwatch_log_metric_filter'
   desc 'Verifies individual Cloudwatch Log Metric Filters'
-  example <<-EOX
-  # Look for a LMF by its filter name and log group name.  This combination
-  # will always either find at most one LMF - no duplicates.
-  describe aws_cloudwatch_log_metric_filter(
-    filter_name: 'my-filter',
-    log_group_name: 'my-log-group'
-  ) do
-    it { should exist }
-  end
+  example <<~EXAMPLE
+    # Look for a LMF by its filter name and log group name.  This combination
+    # will always either find at most one LMF - no duplicates.
+    describe aws_cloudwatch_log_metric_filter(
+      filter_name: 'my-filter',
+      log_group_name: 'my-log-group'
+    ) do
+      it { should exist }
+    end
 
-  # Search for an LMF by pattern and log group.
-  # This could result in an error if the results are not unique.
-  describe aws_cloudwatch_log_metric_filter(
-    log_group_name:  'my-log-group',
-    pattern: 'my-filter'
-  ) do
-    it { should exist }
-  end
-EOX
+    # Search for an LMF by pattern and log group.
+    # This could result in an error if the results are not unique.
+    describe aws_cloudwatch_log_metric_filter(
+      log_group_name:  'my-log-group',
+      pattern: 'my-filter'
+    ) do
+      it { should exist }
+    end
+  EXAMPLE
   supports platform: 'aws'
   include AwsSingularResourceMixin
   attr_reader :filter_name, :log_group_name, :metric_name, :metric_namespace, :pattern

--- a/lib/resources/aws/aws_config_delivery_channel.rb
+++ b/lib/resources/aws/aws_config_delivery_channel.rb
@@ -1,13 +1,13 @@
 class AwsConfigDeliveryChannel < Inspec.resource(1)
   name 'aws_config_delivery_channel'
   desc 'Verifies settings for AWS Config Delivery Channel'
-  example "
+  example <<~EXAMPLE
     describe aws_config_delivery_channel do
       it { should exist }
       its('s3_bucket_name') { should eq 'my_bucket' }
       its('sns_topic_arn') { should eq arn:aws:sns:us-east-1:721741954427:sns_topic' }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_config_recorder.rb
+++ b/lib/resources/aws/aws_config_recorder.rb
@@ -1,14 +1,14 @@
 class AwsConfigurationRecorder < Inspec.resource(1)
   name 'aws_config_recorder'
   desc 'Verifies settings for AWS Configuration Recorder'
-  example "
+  example <<~EXAMPLE
     describe aws_config_recorder('My_Recorder') do
       it { should exist }
       it { should be_recording }
       it { should be_all_supported }
       it { should have_include_global_resource_types }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_ebs_volume.rb
+++ b/lib/resources/aws/aws_ebs_volume.rb
@@ -2,7 +2,7 @@ class AwsEbsVolume < Inspec.resource(1)
   name 'aws_ebs_volume'
   desc 'Verifies settings for an EBS volume'
 
-  example <<-EOX
+  example <<~EXAMPLE
     describe aws_ebs_volume('vol-123456') do
       it { should be_encrypted }
       its('size') { should cmp 8 }
@@ -12,7 +12,7 @@ class AwsEbsVolume < Inspec.resource(1)
       its('encrypted') { should eq true }
       its('iops') { should cmp 100 }
     end
-EOX
+  EXAMPLE
   supports platform: 'aws'
 
   # TODO: rewrite to avoid direct injection, match other resources, use AwsSingularResourceMixin

--- a/lib/resources/aws/aws_ebs_volumes.rb
+++ b/lib/resources/aws/aws_ebs_volumes.rb
@@ -1,11 +1,11 @@
 class AwsEbsVolumes < Inspec.resource(1)
   name 'aws_ebs_volumes'
   desc 'Verifies settings for AWS EBS Volumes in bulk'
-  example '
+  example <<~EXAMPLE
     describe aws_ebs_volumes do
       it { should exist }
     end
-  '
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_ec2_instance.rb
+++ b/lib/resources/aws/aws_ec2_instance.rb
@@ -3,7 +3,7 @@ class AwsEc2Instance < Inspec.resource(1)
   name 'aws_ec2_instance'
   desc 'Verifies settings for an EC2 instance'
 
-  example <<-EOX
+  example <<~EXAMPLE
     describe aws_ec2_instance('i-123456') do
       it { should be_running }
       it { should have_roles }
@@ -13,7 +13,7 @@ class AwsEc2Instance < Inspec.resource(1)
       it { should be_running }
       it { should have_roles }
     end
-EOX
+  EXAMPLE
   supports platform: 'aws'
 
   # TODO: rewrite to avoid direct injection, match other resources, use AwsSingularResourceMixin

--- a/lib/resources/aws/aws_ec2_instances.rb
+++ b/lib/resources/aws/aws_ec2_instances.rb
@@ -1,11 +1,11 @@
 class AwsEc2Instances < Inspec.resource(1)
   name 'aws_ec2_instances'
   desc 'Verifies settings for AWS EC2 Instances in bulk'
-  example '
+  example <<~EXAMPLE
     describe aws_ec2_instances do
       it { should exist }
     end
-  '
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_ecs_cluster.rb
+++ b/lib/resources/aws/aws_ecs_cluster.rb
@@ -2,11 +2,11 @@ class AwsEcsCluster < Inspec.resource(1)
   name 'aws_ecs_cluster'
   desc 'Verifies settings for an ECS cluster'
 
-  example <<-EOX
+  example <<~EXAMPLE
     describe aws_ecs_cluster('default') do
       it { should exist }
     end
-EOX
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_eks_cluster.rb
+++ b/lib/resources/aws/aws_eks_cluster.rb
@@ -2,11 +2,11 @@ class AwsEksCluster < Inspec.resource(1)
   name 'aws_eks_cluster'
   desc 'Verifies settings for an EKS cluster'
 
-  example <<-EOX
+  example <<~EXAMPLE
     describe aws_eks_cluster('default') do
       it { should exist }
     end
-EOX
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_elb.rb
+++ b/lib/resources/aws/aws_elb.rb
@@ -1,11 +1,11 @@
 class AwsElb < Inspec.resource(1)
   name 'aws_elb'
   desc 'Verifies settings for AWS Elastic Load Balancer'
-  example "
+  example <<~EXAMPLE
     describe aws_elb('myelb') do
       it { should exist }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_elbs.rb
+++ b/lib/resources/aws/aws_elbs.rb
@@ -1,11 +1,11 @@
 class AwsElbs < Inspec.resource(1)
   name 'aws_elbs'
   desc 'Verifies settings for AWS ELBs (classic Elastic Load Balancers) in bulk'
-  example '
+  example <<~EXAMPLE
     describe aws_elbs do
       it { should exist }
     end
-  '
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_flow_log.rb
+++ b/lib/resources/aws/aws_flow_log.rb
@@ -2,11 +2,11 @@ class AwsFlowLog < Inspec.resource(1)
   name 'aws_flow_log'
   supports platform: 'aws'
   desc 'This resource is used to test the attributes of a Flow Log.'
-  example <<~EOT
+  example <<~EXAMPLE
     describe aws_flow_log('fl-9c718cf5') do
       it { should exist }
     end
-    EOT
+  EXAMPLE
 
   include AwsSingularResourceMixin
 

--- a/lib/resources/aws/aws_iam_access_key.rb
+++ b/lib/resources/aws/aws_iam_access_key.rb
@@ -1,14 +1,14 @@
 class AwsIamAccessKey < Inspec.resource(1)
   name 'aws_iam_access_key'
   desc 'Verifies settings for an individual IAM access key'
-  example "
+  example <<~EXAMPLE
     describe aws_iam_access_key(username: 'username', id: 'access-key id') do
       it { should exist }
       it { should_not be_active }
       its('create_date') { should be > Time.now - 365 * 86400 }
       its('last_used_date') { should be > Time.now - 90 * 86400 }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_iam_access_keys.rb
+++ b/lib/resources/aws/aws_iam_access_keys.rb
@@ -1,11 +1,11 @@
 class AwsIamAccessKeys < Inspec.resource(1)
   name 'aws_iam_access_keys'
   desc 'Verifies settings for AWS IAM Access Keys in bulk'
-  example '
+  example <<~EXAMPLE
     describe aws_iam_access_keys do
       it { should_not exist }
     end
-  '
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_iam_group.rb
+++ b/lib/resources/aws/aws_iam_group.rb
@@ -1,11 +1,11 @@
 class AwsIamGroup < Inspec.resource(1)
   name 'aws_iam_group'
   desc 'Verifies settings for AWS IAM Group'
-  example "
+  example <<~EXAMPLE
     describe aws_iam_group('mygroup') do
       it { should exist }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_iam_groups.rb
+++ b/lib/resources/aws/aws_iam_groups.rb
@@ -1,11 +1,11 @@
 class AwsIamGroups < Inspec.resource(1)
   name 'aws_iam_groups'
   desc 'Verifies settings for AWS IAM groups in bulk'
-  example '
+  example <<~EXAMPLE
     describe aws_iam_groups do
       it { should exist }
     end
-  '
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_iam_password_policy.rb
+++ b/lib/resources/aws/aws_iam_password_policy.rb
@@ -3,7 +3,7 @@ class AwsIamPasswordPolicy < Inspec.resource(1)
   name 'aws_iam_password_policy'
   desc 'Verifies iam password policy'
 
-  example <<-EOX
+  example <<~EXAMPLE
     describe aws_iam_password_policy do
       its('requires_lowercase_characters?') { should be true }
     end
@@ -11,7 +11,7 @@ class AwsIamPasswordPolicy < Inspec.resource(1)
     describe aws_iam_password_policy do
       its('requires_uppercase_characters?') { should be true }
     end
-EOX
+  EXAMPLE
   supports platform: 'aws'
 
   # TODO: rewrite to avoid direct injection, match other resources, use AwsSingularResourceMixin

--- a/lib/resources/aws/aws_iam_policies.rb
+++ b/lib/resources/aws/aws_iam_policies.rb
@@ -1,11 +1,11 @@
 class AwsIamPolicies < Inspec.resource(1)
   name 'aws_iam_policies'
   desc 'Verifies settings for AWS IAM Policies in bulk'
-  example '
+  example <<~EXAMPLE
     describe aws_iam_policies do
       it { should exist }
     end
-  '
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -5,11 +5,11 @@ require 'uri'
 class AwsIamPolicy < Inspec.resource(1)
   name 'aws_iam_policy'
   desc 'Verifies settings for individual AWS IAM Policy'
-  example "
+  example <<~EXAMPLE
     describe aws_iam_policy('AWSSupportAccess') do
       it { should be_attached }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_iam_role.rb
+++ b/lib/resources/aws/aws_iam_role.rb
@@ -1,11 +1,11 @@
 class AwsIamRole < Inspec.resource(1)
   name 'aws_iam_role'
   desc 'Verifies settings for an IAM Role'
-  example "
+  example <<~EXAMPLE
     describe aws_iam_role('my-role') do
       it { should exist }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_iam_root_user.rb
+++ b/lib/resources/aws/aws_iam_root_user.rb
@@ -1,11 +1,11 @@
 class AwsIamRootUser < Inspec.resource(1)
   name 'aws_iam_root_user'
   desc 'Verifies settings for AWS root account'
-  example "
+  example <<~EXAMPLE
     describe aws_iam_root_user do
       it { should have_access_key }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   # TODO: rewrite to avoid direct injection, match other resources, use AwsSingularResourceMixin

--- a/lib/resources/aws/aws_iam_user.rb
+++ b/lib/resources/aws/aws_iam_user.rb
@@ -5,14 +5,14 @@
 class AwsIamUser < Inspec.resource(1)
   name 'aws_iam_user'
   desc 'Verifies settings for AWS IAM user'
-  example "
+  example <<~EXAMPLE
     describe aws_iam_user(username: 'test_user') do
       it { should have_mfa_enabled }
       it { should_not have_console_password }
       it { should_not have_inline_user_policies }
       it { should_not have_attached_user_policies }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_iam_users.rb
+++ b/lib/resources/aws/aws_iam_users.rb
@@ -5,7 +5,7 @@
 class AwsIamUsers < Inspec.resource(1)
   name 'aws_iam_users'
   desc 'Verifies settings for AWS IAM users'
-  example '
+  example <<~EXAMPLE
     describe aws_iam_users.where(has_mfa_enabled?: false) do
       it { should_not exist }
     end
@@ -18,7 +18,7 @@ class AwsIamUsers < Inspec.resource(1)
     describe aws_iam_users.where(has_attached_policies?: true) do
       it { should_not exist }
     end
-  '
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_kms_key.rb
+++ b/lib/resources/aws/aws_kms_key.rb
@@ -1,11 +1,11 @@
 class AwsKmsKey < Inspec.resource(1)
   name 'aws_kms_key'
   desc 'Verifies settings for an individual AWS KMS Key'
-  example "
+  example <<~EXAMPLE
     describe aws_kms_key('arn:aws:kms:us-east-1::key/4321dcba-21io-23de-85he-ab0987654321') do
       it { should exist }
     end
-  "
+  EXAMPLE
 
   supports platform: 'aws'
 

--- a/lib/resources/aws/aws_kms_keys.rb
+++ b/lib/resources/aws/aws_kms_keys.rb
@@ -1,11 +1,11 @@
 class AwsKmsKeys < Inspec.resource(1)
   name 'aws_kms_keys'
   desc 'Verifies settings for AWS KMS Keys in bulk'
-  example '
+  example <<~EXAMPLE
     describe aws_kms_keys do
       it { should exist }
     end
-  '
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_rds_instance.rb
+++ b/lib/resources/aws/aws_rds_instance.rb
@@ -2,11 +2,11 @@
 class AwsRdsInstance < Inspec.resource(1)
   name 'aws_rds_instance'
   desc 'Verifies settings for an rds instance'
-  example "
+  example <<~EXAMPLE
     describe aws_rds_instance(db_instance_identifier: 'test-instance-id') do
       it { should exist }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_route_table.rb
+++ b/lib/resources/aws/aws_route_table.rb
@@ -1,11 +1,11 @@
 class AwsRouteTable < Inspec.resource(1)
   name 'aws_route_table'
   desc 'Verifies settings for an AWS Route Table'
-  example "
+  example <<~EXAMPLE
     describe aws_route_table do
       its('route_table_id') { should cmp 'rtb-05462d2278326a79c' }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_route_tables.rb
+++ b/lib/resources/aws/aws_route_tables.rb
@@ -1,11 +1,11 @@
 class AwsRouteTables < Inspec.resource(1)
   name 'aws_route_tables'
   desc 'Verifies settings for AWS Route Tables in bulk'
-  example '
+  example <<~EXAMPLE
     describe aws_route_tables do
       it { should exist }
     end
-  '
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_s3_bucket.rb
+++ b/lib/resources/aws/aws_s3_bucket.rb
@@ -2,11 +2,11 @@
 class AwsS3Bucket < Inspec.resource(1)
   name 'aws_s3_bucket'
   desc 'Verifies settings for a s3 bucket'
-  example "
+  example <<~EXAMPLE
     describe aws_s3_bucket(bucket_name: 'test_bucket') do
       it { should exist }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_s3_bucket_object.rb
+++ b/lib/resources/aws/aws_s3_bucket_object.rb
@@ -2,12 +2,12 @@
 class AwsS3BucketObject < Inspec.resource(1)
   name 'aws_s3_bucket_object'
   desc 'Verifies settings for a s3 bucket object'
-  example "
+  example <<~EXAMPLE
     describe aws_s3_bucket_object(bucket_name: 'bucket_name', key: 'file_name') do
       it { should exist }
       it { should_not be_public }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_s3_buckets.rb
+++ b/lib/resources/aws/aws_s3_buckets.rb
@@ -3,11 +3,11 @@
 class AwsS3Buckets < Inspec.resource(1)
   name 'aws_s3_buckets'
   desc 'Verifies settings for AWS S3 Buckets in bulk'
-  example "
+  example <<~EXAMPLE
     describe aws_s3_bucket do
       its('bucket_names') { should eq ['my_bucket'] }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_security_group.rb
+++ b/lib/resources/aws/aws_security_group.rb
@@ -4,11 +4,11 @@ require 'ipaddr'
 class AwsSecurityGroup < Inspec.resource(1)
   name 'aws_security_group'
   desc 'Verifies settings for an individual AWS Security Group.'
-  example "
+  example <<~EXAMPLE
   describe aws_security_group('sg-12345678') do
     it { should exist }
   end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_security_group.rb
+++ b/lib/resources/aws/aws_security_group.rb
@@ -5,9 +5,9 @@ class AwsSecurityGroup < Inspec.resource(1)
   name 'aws_security_group'
   desc 'Verifies settings for an individual AWS Security Group.'
   example <<~EXAMPLE
-  describe aws_security_group('sg-12345678') do
-    it { should exist }
-  end
+    describe aws_security_group('sg-12345678') do
+      it { should exist }
+    end
   EXAMPLE
   supports platform: 'aws'
 

--- a/lib/resources/aws/aws_security_groups.rb
+++ b/lib/resources/aws/aws_security_groups.rb
@@ -1,7 +1,7 @@
 class AwsSecurityGroups < Inspec.resource(1)
   name 'aws_security_groups'
   desc 'Verifies settings for AWS Security Groups in bulk'
-  example <<-EOX
+  example <<~EXAMPLE
     # Verify that you have security groups defined
     describe aws_security_groups do
       it { should exist }
@@ -11,7 +11,7 @@ class AwsSecurityGroups < Inspec.resource(1)
     describe aws_security_groups do
       its('entries.count') { should be > 1 }
     end
-EOX
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_sns_subscription.rb
+++ b/lib/resources/aws/aws_sns_subscription.rb
@@ -1,7 +1,7 @@
 class AwsSnsSubscription < Inspec.resource(1)
   name 'aws_sns_subscription'
   desc 'Verifies settings for an SNS Subscription'
-  example "
+  example <<~EXAMPLE
     describe aws_sns_subscription('arn:aws:sns:us-east-1::test-topic-01:b214aff5-a2c7-438f-a753-8494493f2ff6') do
       it { should_not have_raw_message_delivery }
       it { should be_confirmation_authenticated }
@@ -10,7 +10,7 @@ class AwsSnsSubscription < Inspec.resource(1)
       its('endpoint') { should cmp 'arn:aws:sqs:us-east-1::test-queue-01' }
       its('protocol') { should cmp 'sqs' }
     end
-  "
+  EXAMPLE
 
   supports platform: 'aws'
 

--- a/lib/resources/aws/aws_sns_topic.rb
+++ b/lib/resources/aws/aws_sns_topic.rb
@@ -1,12 +1,12 @@
 class AwsSnsTopic < Inspec.resource(1)
   name 'aws_sns_topic'
   desc 'Verifies settings for an SNS Topic'
-  example "
+  example <<~EXAMPLE
     describe aws_sns_topic('arn:aws:sns:us-east-1:123456789012:some-topic') do
       it { should exist }
       its('confirmed_subscription_count') { should_not be_zero }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_sns_topics.rb
+++ b/lib/resources/aws/aws_sns_topics.rb
@@ -1,11 +1,11 @@
 class AwsSnsTopics < Inspec.resource(1)
   name 'aws_sns_topics'
   desc 'Verifies settings for SNS Topics in bulk'
-  example "
+  example <<~EXAMPLE
     describe aws_sns_topics do
       its('topic_arns') { should include '' }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_sqs_queue.rb
+++ b/lib/resources/aws/aws_sqs_queue.rb
@@ -3,12 +3,12 @@ require 'uri'
 class AwsSqsQueue < Inspec.resource(1)
   name 'aws_sqs_queue'
   desc 'Verifies settings for an SQS Queue'
-  example "
+  example <<~EXAMPLE
     describe aws_sqs_queue('https://sqs.ap-southeast-2.amazonaws.com/519527725796/QueueName') do
       it { should exist }
       its('visiblity_timeout') { should be 300}
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_subnet.rb
+++ b/lib/resources/aws/aws_subnet.rb
@@ -1,12 +1,12 @@
 class AwsSubnet < Inspec.resource(1)
   name 'aws_subnet'
   desc 'This resource is used to test the attributes of a VPC subnet'
-  example "
+  example <<~EXAMPLE
     describe aws_subnet(subnet_id: 'subnet-12345678') do
       it { should exist }
       its('cidr_block') { should eq '10.0.1.0/24' }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_subnets.rb
+++ b/lib/resources/aws/aws_subnets.rb
@@ -1,14 +1,14 @@
 class AwsSubnets < Inspec.resource(1)
   name 'aws_subnets'
   desc 'Verifies settings for VPC Subnets in bulk'
-  example "
+  example <<~EXAMPLE
     # you should be able to test the cidr_block of a subnet
     describe aws_subnets.where(vpc_id: 'vpc-123456789') do
       its('subnet_ids') { should eq ['subnet-12345678', 'subnet-87654321'] }
       its('cidr_blocks') { should eq ['172.31.96.0/20'] }
       its('states') { should_not include 'pending' }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/aws/aws_vpc.rb
+++ b/lib/resources/aws/aws_vpc.rb
@@ -1,12 +1,12 @@
 class AwsVpc < Inspec.resource(1)
   name 'aws_vpc'
   desc 'Verifies settings for AWS VPC'
-  example "
+  example <<~EXAMPLE
     describe aws_vpc do
       it { should be_default }
       its('cidr_block') { should cmp '10.0.0.0/16' }
     end
-  "
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsSingularResourceMixin

--- a/lib/resources/aws/aws_vpcs.rb
+++ b/lib/resources/aws/aws_vpcs.rb
@@ -1,11 +1,11 @@
 class AwsVpcs < Inspec.resource(1)
   name 'aws_vpcs'
   desc 'Verifies settings for AWS VPCs in bulk'
-  example '
+  example <<~EXAMPLE
     describe aws_vpcs do
       it { should exist }
     end
-  '
+  EXAMPLE
   supports platform: 'aws'
 
   include AwsPluralResourceMixin

--- a/lib/resources/bash.rb
+++ b/lib/resources/bash.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     name 'bash'
     supports platform: 'unix'
     desc 'Run a command or script in BASH.'
-    example "
+    example <<~EXAMPLE
       describe bash('ls -al /') do
         its('stdout') { should match /bin/ }
         its('stderr') { should eq '' }
@@ -20,7 +20,7 @@ module Inspec::Resources
 
       # Specify arguments (defaults to -c)
       bash('...', args: '-x -c')
-    "
+    EXAMPLE
 
     def initialize(command, options = {})
       @raw_command = command

--- a/lib/resources/bond.rb
+++ b/lib/resources/bond.rb
@@ -8,11 +8,11 @@ module Inspec::Resources
     name 'bond'
     supports platform: 'unix'
     desc 'Use the bond InSpec audit resource to test a logical, bonded network interface (i.e. "two or more network interfaces aggregated into a single, logical network interface"). On Linux platforms, any value in the /proc/net/bonding directory may be tested.'
-    example "
+    example <<~EXAMPLE
       describe bond('bond0') do
         it { should exist }
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/bridge.rb
+++ b/lib/resources/bridge.rb
@@ -11,12 +11,12 @@ module Inspec::Resources
     name 'bridge'
     supports platform: 'unix'
     desc 'Use the bridge InSpec audit resource to test basic network bridge properties, such as name, if an interface is defined, and the associations for any defined interface.'
-    example "
+    example <<~EXAMPLE
       describe bridge 'br0' do
         it { should exist }
         it { should have_interface 'eth0' }
       end
-    "
+    EXAMPLE
 
     def initialize(bridge_name)
       @bridge_name = bridge_name

--- a/lib/resources/chocolatey_package.rb
+++ b/lib/resources/chocolatey_package.rb
@@ -7,12 +7,12 @@ module Inspec::Resources
     name 'chocolatey_package'
     supports platform: 'windows'
     desc 'Use the chocolatey_package InSpec audit resource to test if the named package and/or package version is installed on the system.'
-    example <<-EOH
+    example <<~EXAMPLE
       describe chocolatey_package('git') do
         it { should be_installed }
         its('version') { should eq '2.15.1' }
       end
-    EOH
+    EXAMPLE
 
     attr_reader :package_name
 

--- a/lib/resources/command.rb
+++ b/lib/resources/command.rb
@@ -7,7 +7,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the command InSpec audit resource to test an arbitrary command that is run on the system.'
-    example "
+    example <<~EXAMPLE
       describe command('ls -al /') do
         its('stdout') { should match /bin/ }
         its('stderr') { should eq '' }
@@ -18,7 +18,7 @@ module Inspec::Resources
       describe command('ls') do
         it { should exist }
       end
-    "
+    EXAMPLE
 
     attr_reader :command
 

--- a/lib/resources/cpan.rb
+++ b/lib/resources/cpan.rb
@@ -11,11 +11,11 @@ module Inspec::Resources
     name 'cpan'
     supports platform: 'unix'
     desc 'Use the `cpan` InSpec audit resource to test Perl modules that are installed by system packages or the CPAN installer.'
-    example "
+    example <<~EXAMPLE
       describe cpan('DBD::Pg') do
         it { should be_installed }
       end
-    "
+    EXAMPLE
 
     def initialize(package_name, perl_lib_path = nil)
       @package_name = package_name

--- a/lib/resources/cran.rb
+++ b/lib/resources/cran.rb
@@ -11,11 +11,11 @@ module Inspec::Resources
     name 'cran'
     supports platform: 'unix'
     desc 'Use the `cran` InSpec audit resource to test R modules that are installed from CRAN package repository.'
-    example "
+    example <<~EXAMPLE
       describe cran('DBI') do
         it { should be_installed }
       end
-    "
+    EXAMPLE
 
     def initialize(package_name)
       @package_name = package_name

--- a/lib/resources/crontab.rb
+++ b/lib/resources/crontab.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     name 'crontab'
     supports platform: 'unix'
     desc 'Use the crontab InSpec audit resource to test the contents of the crontab for a given user which contains information about scheduled tasks owned by that user.'
-    example "
+    example <<~EXAMPLE
       describe crontab(user: 'root') do
         its('commands') { should include '/path/to/some/script' }
       end
@@ -29,7 +29,7 @@ module Inspec::Resources
       describe crontab(path: '/etc/cron.d/some_crontab') do
         its('commands') { should include '/path/to/some/script' }
       end
-    "
+    EXAMPLE
 
     attr_reader :params
 

--- a/lib/resources/csv.rb
+++ b/lib/resources/csv.rb
@@ -7,11 +7,11 @@ module Inspec::Resources
   class CsvConfig < JsonConfig
     name 'csv'
     desc 'Use the csv InSpec audit resource to test configuration data in a CSV file.'
-    example "
+    example <<~EXAMPLE
       describe csv('example.csv') do
         its('name') { should eq(['John', 'Alice']) }
       end
-    "
+    EXAMPLE
 
     # override the parse method from JsonConfig
     # Assuming a header row of name,col1,col2, it will output an array of hashes like so:

--- a/lib/resources/dh_params.rb
+++ b/lib/resources/dh_params.rb
@@ -11,7 +11,7 @@ class DhParams < Inspec.resource(1)
     parameters.
   '
 
-  example "
+  example <<~EXAMPLE
     describe dh_params('/path/to/file.dh_pem') do
       it { should be_dh_params }
       it { should be_valid }
@@ -21,7 +21,7 @@ class DhParams < Inspec.resource(1)
       its('pem') { should eq '-----BEGIN DH PARAMETERS...' }
       its('text') { should eq 'PKCS#3 DH Parameters: (2048 bit)...' }
     end
-  "
+  EXAMPLE
 
   include FileReader
 

--- a/lib/resources/directory.rb
+++ b/lib/resources/directory.rb
@@ -8,11 +8,11 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the directory InSpec audit resource to test if the file type is a directory. This is equivalent to using the file InSpec audit resource and the be_directory matcher, but provides a simpler and more direct way to test directories. All of the matchers available to file may be used with directory.'
-    example "
+    example <<~EXAMPLE
       describe directory('path') do
         it { should be_directory }
       end
-    "
+    EXAMPLE
 
     def exist?
       file.exist? && file.directory?

--- a/lib/resources/docker.rb
+++ b/lib/resources/docker.rb
@@ -94,7 +94,7 @@ module Inspec::Resources
       A resource to retrieve information about docker
     "
 
-    example "
+    example <<~EXAMPLE
       describe docker.containers do
         its('images') { should_not include 'u12:latest' }
       end
@@ -127,7 +127,7 @@ module Inspec::Resources
           its(%w(HostConfig Privileged)) { should_not cmp true }
         end
       end
-    "
+    EXAMPLE
 
     def containers
       DockerContainerFilter.new(parse_containers)

--- a/lib/resources/docker_container.rb
+++ b/lib/resources/docker_container.rb
@@ -11,7 +11,7 @@ module Inspec::Resources
     name 'docker_container'
     supports platform: 'unix'
     desc ''
-    example "
+    example <<~EXAMPLE
       describe docker_container('an-echo-server') do
         it { should exist }
         it { should be_running }
@@ -28,7 +28,7 @@ module Inspec::Resources
         it { should exist }
         it { should be_running }
       end
-    "
+    EXAMPLE
 
     def initialize(opts = {})
       # if a string is provided, we expect it is the name

--- a/lib/resources/docker_image.rb
+++ b/lib/resources/docker_image.rb
@@ -11,7 +11,7 @@ module Inspec::Resources
     name 'docker_image'
     supports platform: 'unix'
     desc ''
-    example "
+    example <<~EXAMPLE
       describe docker_image('alpine:latest') do
         it { should exist }
         its('id') { should_not eq '' }
@@ -27,7 +27,7 @@ module Inspec::Resources
       describe docker_image(id: '4a415e366388') do
         it { should exist }
       end
-    "
+    EXAMPLE
 
     def initialize(opts = {})
       # do sanitizion of input values

--- a/lib/resources/docker_plugin.rb
+++ b/lib/resources/docker_plugin.rb
@@ -5,7 +5,7 @@ module Inspec::Resources
     name 'docker_plugin'
     supports platform: 'unix'
     desc 'Retrieves info about docker plugins'
-    example "
+    example <<~EXAMPLE
       describe docker_plugin('rexray/ebs') do
         it { should exist }
         its('id') { should_not eq '0ac30b93ad40' }
@@ -20,7 +20,7 @@ module Inspec::Resources
       describe docker_plugin(id: '4a415e366388') do
         it { should exist }
       end
-    "
+    EXAMPLE
 
     def initialize(opts = {})
       # do sanitizion of input values

--- a/lib/resources/docker_service.rb
+++ b/lib/resources/docker_service.rb
@@ -11,7 +11,7 @@ module Inspec::Resources
     name 'docker_service'
     supports platform: 'unix'
     desc 'Swarm-mode service'
-    example "
+    example <<~EXAMPLE
       describe docker_service('service1') do
         it { should exist }
         its('id') { should_not eq '' }
@@ -27,7 +27,7 @@ module Inspec::Resources
       describe docker_service(image: 'alpine:latest') do
         it { should exist }
       end
-    "
+    EXAMPLE
 
     def initialize(opts = {})
       # do sanitizion of input values

--- a/lib/resources/elasticsearch.rb
+++ b/lib/resources/elasticsearch.rb
@@ -11,7 +11,7 @@ module Inspec::Resources
     desc "Use the Elasticsearch InSpec audit resource to test the status of nodes in
       an Elasticsearch cluster."
 
-    example "
+    example <<~EXAMPLE
       describe elasticsearch('http://eshost.mycompany.biz:9200/', username: 'elastic', password: 'changeme', ssl_verify: false) do
         its('node_count') { should >= 3 }
       end
@@ -21,7 +21,7 @@ module Inspec::Resources
         its('os') { should_not include 'MacOS' }
         its('version') { should cmp > 1.2.0 }
       end
-    "
+    EXAMPLE
 
     filter = FilterTable.create
     filter.register_custom_matcher(:exists?) { |x| !x.entries.empty? }

--- a/lib/resources/etc_fstab.rb
+++ b/lib/resources/etc_fstab.rb
@@ -9,7 +9,7 @@ module Inspec::Resources
     name 'etc_fstab'
     supports platform: 'unix'
     desc 'Use the etc_fstab InSpec audit resource to check the configuration of the etc/fstab file.'
-    example "
+    example <<~EXAMPLE
       nfs_systems = etc_fstab.nfs_file_systems.entries
       nfs_systems.each do |file_system|
         describe file_system do
@@ -22,7 +22,7 @@ module Inspec::Resources
       describe etc_fstab do
         its ('home_mount_options') { should include 'nosuid' }
       end
-    "
+    EXAMPLE
 
     attr_reader :params
 

--- a/lib/resources/etc_group.rb
+++ b/lib/resources/etc_group.rb
@@ -30,13 +30,13 @@ module Inspec::Resources
     name 'etc_group'
     supports platform: 'unix'
     desc 'Use the etc_group InSpec audit resource to test groups that are defined on Linux and UNIX platforms. The /etc/group file stores details about each group---group name, password, group identifier, along with a comma-separate list of users that belong to the group.'
-    example "
+    example <<~EXAMPLE
       describe etc_group do
         its('gids') { should_not contain_duplicates }
         its('groups') { should include 'my_user' }
         its('users') { should include 'my_user' }
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/etc_hosts.rb
+++ b/lib/resources/etc_hosts.rb
@@ -10,13 +10,13 @@ class EtcHosts < Inspec.resource(1)
   supports platform: 'windows'
   desc 'Use the etc_hosts InSpec audit resource to find an
     ip_address and its associated hosts'
-  example "
+  example <<~EXAMPLE
     describe etc_hosts.where { ip_address == '127.0.0.1' } do
       its('ip_address') { should cmp '127.0.0.1' }
       its('primary_name') { should cmp 'localhost' }
       its('all_host_names') { should eq [['localhost', 'localhost.localdomain', 'localhost4', 'localhost4.localdomain4']] }
     end
-  "
+  EXAMPLE
 
   attr_reader :params
 

--- a/lib/resources/etc_hosts_allow_deny.rb
+++ b/lib/resources/etc_hosts_allow_deny.rb
@@ -9,12 +9,12 @@ module Inspec::Resources
     supports platform: 'unix'
     desc 'Use the etc_hosts_allow InSpec audit resource to test the connections
           the client will allow. Controlled by the /etc/hosts.allow file.'
-    example "
+    example <<~EXAMPLE
       describe etc_hosts_allow.where { daemon == 'ALL' } do
         its('client_list') { should include ['127.0.0.1', '[::1]'] }
         its('options') { should eq [[]] }
       end
-    "
+    EXAMPLE
 
     attr_reader :params
 
@@ -91,12 +91,12 @@ module Inspec::Resources
     supports platform: 'unix'
     desc 'Use the etc_hosts_deny InSpec audit resource to test the connections
           the client will deny. Controlled by the /etc/hosts.deny file.'
-    example "
+    example <<~EXAMPLE
       describe etc_hosts_deny.where { daemon_list == 'ALL' } do
         its('client_list') { should eq [['127.0.0.1', '[::1]']] }
         its('options') { should eq [] }
       end
-    "
+    EXAMPLE
 
     def initialize(path = nil)
       return skip_resource '`etc_hosts_deny` is not supported on your OS' unless inspec.os.linux?

--- a/lib/resources/file.rb
+++ b/lib/resources/file.rb
@@ -22,7 +22,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the file InSpec audit resource to test all system file types, including files, directories, symbolic links, named pipes, sockets, character devices, block devices, and doors.'
-    example "
+    example <<~EXAMPLE
       describe file('path') do
         it { should exist }
         it { should be_file }
@@ -32,7 +32,7 @@ module Inspec::Resources
         it { should be_owned_by 'root' }
         its('mode') { should cmp '0644' }
       end
-    "
+    EXAMPLE
 
     attr_reader :file, :mount_options
     def initialize(path)

--- a/lib/resources/filesystem.rb
+++ b/lib/resources/filesystem.rb
@@ -4,7 +4,7 @@ module Inspec::Resources
     supports platform: 'linux'
     supports platform: 'windows'
     desc 'Use the filesystem InSpec resource to test file system'
-    example "
+    example <<~EXAMPLE
       describe filesystem('/') do
         its('size_kb') { should be >= 32000 }
         its('free_kb') { should be >= 3200 }
@@ -17,7 +17,7 @@ module Inspec::Resources
         its('type') { should cmp 'NTFS' }
         its('percent_free') { should be >= 20 }
       end
-    "
+    EXAMPLE
     attr_reader :partition
 
     def initialize(partition)

--- a/lib/resources/firewalld.rb
+++ b/lib/resources/firewalld.rb
@@ -10,7 +10,7 @@ module Inspec::Resources
     name 'firewalld'
     supports platform: 'linux'
     desc 'Use the firewalld resource to check and see if firewalld is configured to grand or deny access to specific hosts or services'
-    example "
+    example <<~EXAMPLE
       describe firewalld do
         it { should be_running }
         its('default_zone') { should eq 'public' }
@@ -23,7 +23,7 @@ module Inspec::Resources
         its('sources') { should cmp ['ssh', 'icmp'] }
         its('services') { should cmp ['192.168.1.0/24', '192.168.1.2'] }
       end
-    "
+    EXAMPLE
 
     attr_reader :params
 

--- a/lib/resources/gem.rb
+++ b/lib/resources/gem.rb
@@ -6,12 +6,12 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the gem InSpec audit resource to test if a global gem package is installed.'
-    example "
+    example <<~EXAMPLE
       describe gem('rubocop') do
         it { should be_installed }
         its('version') { should eq '0.33.0' }
       end
-    "
+    EXAMPLE
 
     attr_reader :gem_binary
 

--- a/lib/resources/groups.rb
+++ b/lib/resources/groups.rb
@@ -28,7 +28,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the group InSpec audit resource to test groups on the system. Groups can be filtered.'
-    example "
+    example <<~EXAMPLE
       describe groups.where { name == 'root'} do
         its('names') { should eq ['root'] }
         its('gids') { should eq [0] }
@@ -38,7 +38,7 @@ module Inspec::Resources
         its('names') { should eq ['Administrators'] }
         its('gids') { should eq ['S-1-5-32-544'] }
       end
-    "
+    EXAMPLE
 
     def initialize
       # select group manager
@@ -80,7 +80,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the group InSpec audit resource to test groups on the system.'
-    example "
+    example <<~EXAMPLE
       describe group('root') do
         it { should exist }
         its('gid') { should eq 0 }
@@ -89,7 +89,7 @@ module Inspec::Resources
       describe group('Administrators') do
         its('members') { should include 'Administrator' }
       end
-    "
+    EXAMPLE
 
     def initialize(groupname)
       @group = groupname

--- a/lib/resources/grub_conf.rb
+++ b/lib/resources/grub_conf.rb
@@ -7,7 +7,7 @@ class GrubConfig < Inspec.resource(1)
   name 'grub_conf'
   supports platform: 'unix'
   desc 'Use the grub_conf InSpec audit resource to test the boot config of Linux systems that use Grub.'
-  example "
+  example <<~EXAMPLE
     describe grub_conf('/etc/grub.conf',  'default') do
       its('kernel') { should include '/vmlinuz-2.6.32-573.7.1.el6.x86_64' }
       its('initrd') { should include '/initramfs-2.6.32-573.el6.x86_64.img=1' }
@@ -19,7 +19,7 @@ class GrubConfig < Inspec.resource(1)
     describe grub_conf('/etc/grub.conf',  'CentOS (2.6.32-573.12.1.el6.x86_64)') do
       its('kernel') { should include 'audit=1' }
     end
-  "
+  EXAMPLE
 
   include FileReader
 

--- a/lib/resources/host.rb
+++ b/lib/resources/host.rb
@@ -30,7 +30,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the host InSpec audit resource to test the name used to refer to a specific host and its availability, including the Internet protocols and ports over which that host name should be available.'
-    example "
+    example <<~EXAMPLE
       describe host('example.com') do
         it { should be_reachable }
         it { should be_resolvable }
@@ -40,7 +40,7 @@ module Inspec::Resources
       describe host('example.com', port: '80', protocol: 'tcp') do
         it { should be_reachable }
       end
-    "
+    EXAMPLE
 
     attr_reader :hostname, :port, :protocol
 

--- a/lib/resources/http.rb
+++ b/lib/resources/http.rb
@@ -12,7 +12,7 @@ module Inspec::Resources
     name 'http'
     supports platform: 'unix'
     desc 'Use the http InSpec audit resource to test http call.'
-    example "
+    example <<~EXAMPLE
       describe http('http://localhost:8080/ping', auth: {user: 'user', pass: 'test'}, params: {format: 'html'}) do
         its('status') { should cmp 200 }
         its('body') { should cmp 'pong' }
@@ -23,7 +23,7 @@ module Inspec::Resources
         its('Content-Length') { should cmp 258 }
         its('Content-Type') { should cmp 'text/html; charset=UTF-8' }
       end
-    "
+    EXAMPLE
 
     def initialize(url, opts = {})
       @url = url

--- a/lib/resources/iis_app.rb
+++ b/lib/resources/iis_app.rb
@@ -7,7 +7,7 @@ module Inspec::Resources
     name 'iis_app'
     supports platform: 'windows'
     desc 'Tests IIS application configuration on windows. Supported in server 2012+ only'
-    example "
+    example <<~EXAMPLE
       describe iis_app('/myapp', 'Default Web Site') do
         it { should exist }
         it { should have_application_pool('MyAppPool') }
@@ -16,7 +16,7 @@ module Inspec::Resources
         it { should have_physical_path('C:\\inetpub\\wwwroot\\myapp') }
         it { should have_path('\\My Application') }
       end
-    "
+    EXAMPLE
 
     def initialize(path, site_name)
       @path = path

--- a/lib/resources/iis_app_pool.rb
+++ b/lib/resources/iis_app_pool.rb
@@ -7,14 +7,14 @@ class IisAppPool < Inspec.resource(1)
   name 'iis_app_pool'
   desc 'Tests IIS application pool configuration on windows.'
   supports platform: 'windows'
-  example <<~EOH
+  example <<~EXAMPLE
     describe iis_app_pool('DefaultAppPool') do
       it { should exist }
       its('enable32bit') { should cmp 'True' }
       its('runtime_version') { should eq 'v4.0' }
       its('pipeline_mode') { should eq 'Integrated' }
     end
-  EOH
+  EXAMPLE
 
   def initialize(pool_name)
     @pool_name = pool_name

--- a/lib/resources/iis_site.rb
+++ b/lib/resources/iis_site.rb
@@ -18,7 +18,7 @@ module Inspec::Resources
     name 'iis_site'
     supports platform: 'windows'
     desc 'Tests IIS site configuration on windows. Supported in server 2012+ only'
-    example "
+    example <<~EXAMPLE
       describe iis_site('Default Web Site') do
         it { should exist }
         it { should be_running }
@@ -27,7 +27,7 @@ module Inspec::Resources
         it { should have_binding('net.pipe *') }
         it { should have_path('C:\\inetpub\\wwwroot') }
       end
-    "
+    EXAMPLE
 
     def initialize(site_name)
       @site_name = site_name
@@ -125,13 +125,13 @@ module Inspec::Resources
   class IisSiteServerSpec < IisSite
     name 'iis_website'
     desc 'Tests IIS site configuration on windows. Deprecated, use `iis_site` instead.'
-    example "
+    example <<~EXAMPLE
       describe iis_website('Default Website') do
         it{ should exist }
         it{ should be_running }
         it{ should be_in_app_pool('Default App Pool') }
       end
-    "
+    EXAMPLE
 
     def initialize(site_name)
       super(site_name)

--- a/lib/resources/inetd_conf.rb
+++ b/lib/resources/inetd_conf.rb
@@ -9,13 +9,13 @@ module Inspec::Resources
     name 'inetd_conf'
     supports platform: 'unix'
     desc 'Use the inetd_conf InSpec audit resource to test if a service is enabled in the inetd.conf file on Linux and UNIX platforms. inetd---the Internet service daemon---listens on dedicated ports, and then loads the appropriate program based on a request. The inetd.conf file is typically located at /etc/inetd.conf and contains a list of Internet services associated to the ports on which that service will listen. Only enabled services may handle a request; only services that are required by the system should be enabled.'
-    example "
+    example <<~EXAMPLE
       describe inetd_conf do
         its('shell') { should eq nil }
         its('login') { should eq nil }
         its('exec') { should eq nil }
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/ini.rb
+++ b/lib/resources/ini.rb
@@ -8,11 +8,11 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the ini InSpec audit resource to test data in a INI file.'
-    example "
+    example <<~EXAMPLE
       descibe ini do
         its('auth_protocol') { should eq 'https' }
       end
-    "
+    EXAMPLE
     # override file load and parse hash with simple config
     def parse(content)
       SimpleConfig.new(content).params

--- a/lib/resources/interface.rb
+++ b/lib/resources/interface.rb
@@ -8,13 +8,13 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the interface InSpec audit resource to test basic network adapter properties, such as name, status, and link speed (in MB/sec).'
-    example "
+    example <<~EXAMPLE
       describe interface('eth0') do
         it { should exist }
         it { should be_up }
         its('speed') { should eq 1000 }
       end
-    "
+    EXAMPLE
     def initialize(iface)
       @iface = iface
 

--- a/lib/resources/iptables.rb
+++ b/lib/resources/iptables.rb
@@ -24,11 +24,11 @@ module Inspec::Resources
     name 'iptables'
     supports platform: 'linux'
     desc 'Use the iptables InSpec audit resource to test rules that are defined in iptables, which maintains tables of IP packet filtering rules. There may be more than one table. Each table contains one (or more) chains (both built-in and custom). A chain is a list of rules that match packets. When the rule matches, the rule defines what target to assign to the packet.'
-    example "
+    example <<~EXAMPLE
       describe iptables do
         it { should have_rule('-P INPUT ACCEPT') }
       end
-    "
+    EXAMPLE
 
     def initialize(params = {})
       @table = params[:table]

--- a/lib/resources/json.rb
+++ b/lib/resources/json.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
   class JsonConfig < Inspec.resource(1)
     name 'json'
     desc 'Use the json InSpec audit resource to test data in a JSON file.'
-    example "
+    example <<~EXAMPLE
       describe json('policyfile.lock.json') do
         its(['cookbook_locks','omnibus','version']) { should eq('2.2.0') }
       end
@@ -20,8 +20,7 @@ module Inspec::Resources
       describe json({ content: '{\"item1\": { \"status\": \"available\" } }' }) do
         its(['item1', 'status']) { should cmp 'available' }
       end
-
-    "
+    EXAMPLE
 
     include ObjectTraverser
     include FileReader

--- a/lib/resources/kernel_module.rb
+++ b/lib/resources/kernel_module.rb
@@ -12,7 +12,7 @@ module Inspec::Resources
     or if a module is disabled via a fake install using the `bin_true` or `bin_false`
     method.'
 
-    example "
+    example <<~EXAMPLE
 
     describe kernel_module('video') do
       it { should be_loaded }
@@ -32,7 +32,7 @@ module Inspec::Resources
     describe kernel_module('dhcp') do
       it { should_not be_loaded }
     end
-    "
+    EXAMPLE
 
     def initialize(modulename = nil)
       @module = modulename

--- a/lib/resources/kernel_module.rb
+++ b/lib/resources/kernel_module.rb
@@ -13,25 +13,24 @@ module Inspec::Resources
     method.'
 
     example <<~EXAMPLE
+      describe kernel_module('video') do
+        it { should be_loaded }
+        it { should_not be_disabled }
+        it { should_not be_blacklisted }
+      end
 
-    describe kernel_module('video') do
-      it { should be_loaded }
-      it { should_not be_disabled }
-      it { should_not be_blacklisted }
-    end
+      describe kernel_module('sstfb') do
+        it { should_not be_loaded }
+        it { should be_disabled }
+      end
 
-    describe kernel_module('sstfb') do
-      it { should_not be_loaded }
-      it { should be_disabled }
-    end
+      describe kernel_module('floppy') do
+        it { should be_blacklisted }
+      end
 
-    describe kernel_module('floppy') do
-      it { should be_blacklisted }
-    end
-
-    describe kernel_module('dhcp') do
-      it { should_not be_loaded }
-    end
+      describe kernel_module('dhcp') do
+        it { should_not be_loaded }
+      end
     EXAMPLE
 
     def initialize(modulename = nil)

--- a/lib/resources/kernel_parameter.rb
+++ b/lib/resources/kernel_parameter.rb
@@ -5,11 +5,11 @@ module Inspec::Resources
     name 'kernel_parameter'
     supports platform: 'unix'
     desc 'Use the kernel_parameter InSpec audit resource to test kernel parameters on Linux platforms.'
-    example "
+    example <<~EXAMPLE
       describe kernel_parameter('net.ipv4.conf.all.forwarding') do
         its('value') { should eq 0 }
       end
-    "
+    EXAMPLE
 
     def initialize(parameter = nil)
       @parameter = parameter

--- a/lib/resources/key_rsa.rb
+++ b/lib/resources/key_rsa.rb
@@ -11,7 +11,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'public/private RSA key pair test'
-    example "
+    example <<~EXAMPLE
       describe key_rsa('/etc/pki/www.mywebsite.com.key') do
         its('public_key') { should match /BEGIN RSA PUBLIC KEY/ }
       end
@@ -20,7 +20,7 @@ module Inspec::Resources
         it { should be_private }
         it { should be_public }
       end
-    "
+    EXAMPLE
 
     include FileReader
     include PkeyReader

--- a/lib/resources/ksh.rb
+++ b/lib/resources/ksh.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     name 'ksh'
     supports platform: 'unix'
     desc 'Run a command or script in KornShell.'
-    example "
+    example <<~EXAMPLE
       describe ksh('ls -al /') do
         its('stdout') { should match /bin/ }
         its('stderr') { should eq '' }
@@ -20,7 +20,7 @@ module Inspec::Resources
 
       # Specify arguments (defaults to -c)
       ksh('...', args: '-x -c')
-    "
+    EXAMPLE
 
     def initialize(command, options = {})
       @raw_command = command

--- a/lib/resources/limits_conf.rb
+++ b/lib/resources/limits_conf.rb
@@ -9,11 +9,11 @@ module Inspec::Resources
     name 'limits_conf'
     supports platform: 'unix'
     desc 'Use the limits_conf InSpec audit resource to test configuration settings in the /etc/security/limits.conf file. The limits.conf defines limits for processes (by user and/or group names) and helps ensure that the system on which those processes are running remains stable. Each process may be assigned a hard or soft limit.'
-    example "
+    example <<~EXAMPLE
       describe limits_conf do
         its('*') { should include ['hard','core','0'] }
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/login_def.rb
+++ b/lib/resources/login_def.rb
@@ -21,11 +21,11 @@ module Inspec::Resources
     name 'login_defs'
     supports platform: 'unix'
     desc 'Use the login_defs InSpec audit resource to test configuration settings in the /etc/login.defs file. The logins.defs file defines site-specific configuration for the shadow password suite on Linux and UNIX platforms, such as password expiration ranges, minimum/maximum values for automatic selection of user and group identifiers, or the method with which passwords are encrypted.'
-    example "
+    example <<~EXAMPLE
       describe login_defs do
         its('ENCRYPT_METHOD') { should eq 'SHA512' }
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/mount.rb
+++ b/lib/resources/mount.rb
@@ -7,7 +7,7 @@ module Inspec::Resources
     name 'mount'
     supports platform: 'unix'
     desc 'Use the mount InSpec audit resource to test if mount points.'
-    example "
+    example <<~EXAMPLE
       describe mount('/') do
         it { should be_mounted }
         its('count') { should eq 1 }
@@ -16,7 +16,7 @@ module Inspec::Resources
         its('options') { should eq ['rw', 'mode=620'] }
         its('options') { should include 'nodev' }
       end
-    "
+    EXAMPLE
     attr_reader :file
 
     def initialize(path)

--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -14,7 +14,7 @@ module Inspec::Resources
     name 'mssql_session'
     supports platform: 'windows'
     desc 'Use the mssql_session InSpec audit resource to test SQL commands run against a MS Sql Server database.'
-    example "
+    example <<~EXAMPLE
       # Using SQL authentication
       sql = mssql_session(user: 'myuser', pass: 'mypassword')
       describe sql.query('SELECT * FROM table').row(0).column('columnname') do
@@ -27,7 +27,7 @@ module Inspec::Resources
         its('value') { should_not be_empty }
         its('value') { should cmp == 1 }
       end
-    "
+    EXAMPLE
 
     attr_reader :user, :password, :host, :port, :instance, :local_mode, :db_name
     def initialize(opts = {})

--- a/lib/resources/mysql_conf.rb
+++ b/lib/resources/mysql_conf.rb
@@ -31,7 +31,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the mysql_conf InSpec audit resource to test the contents of the configuration file for MySQL, typically located at /etc/mysql/my.cnf or /etc/my.cnf.'
-    example "
+    example <<~EXAMPLE
       describe mysql_conf('path') do
         its('setting') { should eq 'value' }
       end
@@ -45,7 +45,7 @@ module Inspec::Resources
       describe mysql_conf do
         its(['mariadb', 'max-connections']) { should_not be_nil }
       end
-    "
+    EXAMPLE
 
     include FindFiles
     include FileReader

--- a/lib/resources/mysql_session.rb
+++ b/lib/resources/mysql_session.rb
@@ -9,12 +9,12 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the mysql_session InSpec audit resource to test SQL commands run against a MySQL database.'
-    example "
+    example <<~EXAMPLE
       sql = mysql_session('my_user','password','host')
       describe sql.query('show databases like \'test\';') do
         its('stdout') { should_not match(/test/) }
       end
-    "
+    EXAMPLE
 
     def initialize(user = nil, pass = nil, host = 'localhost', port = nil, socket = nil)
       @user = user

--- a/lib/resources/nginx.rb
+++ b/lib/resources/nginx.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     name 'nginx'
     supports platform: 'unix'
     desc 'Use the nginx InSpec audit resource to test information about your NGINX instance.'
-    example "
+    example <<~EXAMPLE
       describe nginx do
         its('conf_path') { should cmp '/etc/nginx/nginx.conf' }
       end
@@ -18,7 +18,7 @@ module Inspec::Resources
       describe nginx do
         its('modules') { should include 'my_module' }
       end
-    "
+    EXAMPLE
     attr_reader :params, :bin_dir
 
     def initialize(nginx_path = '/usr/sbin/nginx')

--- a/lib/resources/nginx_conf.rb
+++ b/lib/resources/nginx_conf.rb
@@ -19,10 +19,10 @@ module Inspec::Resources
     desc 'Use the nginx_conf InSpec resource to test configuration data '\
          'for the NginX web server located in /etc/nginx/nginx.conf on '\
          'Linux and UNIX platforms.'
-    example "
+    example <<~EXAMPLE
       describe nginx_conf.params ...
       describe nginx_conf('/path/to/my/nginx.conf').params ...
-    "
+    EXAMPLE
 
     extend Forwardable
 

--- a/lib/resources/npm.rb
+++ b/lib/resources/npm.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the npm InSpec audit resource to test if a global npm package is installed. npm is the the package manager for Nodejs packages, such as bower and StatsD.'
-    example "
+    example <<~EXAMPLE
       describe npm('bower') do
         it { should be_installed }
       end
@@ -16,7 +16,7 @@ module Inspec::Resources
       describe npm('tar', path: '/path/to/project') do
         it { should be_installed }
       end
-    "
+    EXAMPLE
 
     def initialize(package_name, opts = {})
       @package_name = package_name

--- a/lib/resources/ntp_conf.rb
+++ b/lib/resources/ntp_conf.rb
@@ -9,12 +9,12 @@ module Inspec::Resources
     name 'ntp_conf'
     supports platform: 'unix'
     desc 'Use the ntp_conf InSpec audit resource to test the synchronization settings defined in the ntp.conf file. This file is typically located at /etc/ntp.conf.'
-    example "
+    example <<~EXAMPLE
       describe ntp_conf do
         its('server') { should_not eq nil }
         its('restrict') { should include '-4 default kod notrap nomodify nopeer noquery'}
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/oneget.rb
+++ b/lib/resources/oneget.rb
@@ -12,12 +12,12 @@ module Inspec::Resources
     name 'oneget'
     supports platform: 'windows'
     desc 'Use the oneget InSpec audit resource to test if the named package and/or package version is installed on the system. This resource uses OneGet, which is part of the Windows Management Framework 5.0 and Windows 10. This resource uses the Get-Package cmdlet to return all of the package names in the OneGet repository.'
-    example "
+    example <<~EXAMPLE
       describe oneget('zoomit') do
         it { should be_installed }
         its('version') { should eq '1.2.3' }
       end
-    "
+    EXAMPLE
 
     def initialize(package_name)
       @package_name = package_name

--- a/lib/resources/oracledb_session.rb
+++ b/lib/resources/oracledb_session.rb
@@ -15,12 +15,12 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the oracledb_session InSpec resource to test commands against an Oracle database'
-    example "
+    example <<~EXAMPLE
       sql = oracledb_session(user: 'my_user', pass: 'password')
       describe sql.query(\"SELECT UPPER(VALUE) AS VALUE FROM V$PARAMETER WHERE UPPER(NAME)='AUDIT_SYS_OPERATIONS'\").row(0).column('value') do
         its('value') { should eq 'TRUE' }
       end
-    "
+    EXAMPLE
 
     attr_reader :user, :password, :host, :service, :as_os_user, :as_db_role
     # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity

--- a/lib/resources/os.rb
+++ b/lib/resources/os.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the os InSpec audit resource to test the platform on which the system is running.'
-    example "
+    example <<~EXAMPLE
       describe os[:family] do
         it { should eq 'redhat' }
       end
@@ -20,7 +20,7 @@ module Inspec::Resources
       describe os.linux? do
         it { should eq true }
       end
-    "
+    EXAMPLE
 
     # reuse helper methods from backend
     %w{aix? redhat? debian? suse? bsd? solaris? linux? unix? windows? hpux? darwin?}.each do |os_family|

--- a/lib/resources/os_env.rb
+++ b/lib/resources/os_env.rb
@@ -16,11 +16,11 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the os_env InSpec audit resource to test the environment variables for the platform on which the system is running.'
-    example "
+    example <<~EXAMPLE
       describe os_env('VARIABLE') do
         its('matcher') { should eq 1 }
       end
-    "
+    EXAMPLE
 
     def initialize(env = nil, target = nil)
       @osenv = env

--- a/lib/resources/package.rb
+++ b/lib/resources/package.rb
@@ -12,13 +12,13 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the package InSpec audit resource to test if the named package and/or package version is installed on the system.'
-    example "
+    example <<~EXAMPLE
       describe package('nginx') do
         it { should be_installed }
         it { should_not be_held } # for dpkg platforms that support holding a version from being upgraded
         its('version') { should eq 1.9.5 }
       end
-    "
+    EXAMPLE
     def initialize(package_name, opts = {}) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       @package_name = package_name
       @name = @package_name

--- a/lib/resources/packages.rb
+++ b/lib/resources/packages.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     name 'packages'
     supports platform: 'unix'
     desc 'Use the packages InSpec audit resource to test properties for multiple packages installed on the system'
-    example "
+    example <<~EXAMPLE
       describe packages(/xserver-xorg.*/) do
         its('entries') { should be_empty }
       end
@@ -18,7 +18,7 @@ module Inspec::Resources
       describe packages(/vi.+/).where { status != 'installed' } do
         its('statuses') { should be_empty }
       end
-    "
+    EXAMPLE
 
     def initialize(pattern)
       os = inspec.os

--- a/lib/resources/parse_config.rb
+++ b/lib/resources/parse_config.rb
@@ -18,7 +18,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the parse_config InSpec audit resource to test arbitrary configuration files.'
-    example "
+    example <<~EXAMPLE
       output = command('some-command').stdout
       describe parse_config(output, { data_config_option: value } ) do
         its('setting') { should eq 1 }
@@ -41,7 +41,7 @@ module Inspec::Resources
       describe parse_config(output2, options2 ).params['listen queue'].to_i do
         it { should be < 100 }
       end
-    "
+    EXAMPLE
 
     include FileReader
 
@@ -94,11 +94,11 @@ module Inspec::Resources
   class PConfigFile < PConfig
     name 'parse_config_file'
     desc 'Use the parse_config_file InSpec resource to test arbitrary configuration files. It works identically to parse_config. Instead of using a command output, this resource works with files.'
-    example "
+    example <<~EXAMPLE
       describe parse_config_file('/path/to/file') do
         its('setting') { should eq 1 }
       end
-    "
+    EXAMPLE
 
     def initialize(path, opts = nil)
       super(nil, opts)

--- a/lib/resources/passwd.rb
+++ b/lib/resources/passwd.rb
@@ -19,7 +19,7 @@ module Inspec::Resources
     name 'passwd'
     supports platform: 'unix'
     desc 'Use the passwd InSpec audit resource to test the contents of /etc/passwd, which contains the following information for users that may log into the system and/or as users that own running processes.'
-    example "
+    example <<~EXAMPLE
       describe passwd do
         its('users') { should_not include 'forbidden_user' }
       end
@@ -32,7 +32,7 @@ module Inspec::Resources
         # find all users with a nologin shell
         its('users') { should_not include 'my_login_user' }
       end
-    "
+    EXAMPLE
 
     include PasswdParser
     include FileReader

--- a/lib/resources/pip.rb
+++ b/lib/resources/pip.rb
@@ -12,7 +12,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the pip InSpec audit resource to test packages that are installed using the pip installer.'
-    example "
+    example <<~EXAMPLE
       describe pip('Jinja2') do
         it { should be_installed }
       end
@@ -21,7 +21,7 @@ module Inspec::Resources
         it { should be_installed }
         its('version') { should eq('1.11.4')}
       end
-    "
+    EXAMPLE
 
     def initialize(package_name, pip_path = nil)
       @package_name = package_name

--- a/lib/resources/platform.rb
+++ b/lib/resources/platform.rb
@@ -4,7 +4,7 @@ module Inspec::Resources
   class PlatformResource < Inspec.resource(1)
     name 'platform'
     desc 'Use the platform InSpec resource to test the platform on which the system is running.'
-    example "
+    example <<~EXAMPLE
       describe platform do
         its('name') { should eq 'redhat' }
       end
@@ -12,7 +12,7 @@ module Inspec::Resources
       describe platform do
         it { should be_in_family('unix') }
       end
-    "
+    EXAMPLE
 
     def initialize
       @platform = inspec.backend.platform

--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -12,7 +12,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc "Use the port InSpec audit resource to test basic port properties, such as port, process, if it's listening."
-    example "
+    example <<~EXAMPLE
       describe port(80) do
         it { should be_listening }
         its('protocols') {should eq ['tcp']}
@@ -22,7 +22,7 @@ module Inspec::Resources
       describe port.where { protocol =~ /tcp/ && port > 80 } do
         it { should_not be_listening }
       end
-    "
+    EXAMPLE
 
     def initialize(*args)
       args.unshift(nil) if args.length <= 1 # add the ip address to the front

--- a/lib/resources/postgres_conf.rb
+++ b/lib/resources/postgres_conf.rb
@@ -12,11 +12,11 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the postgres_conf InSpec audit resource to test the contents of the configuration file for PostgreSQL, typically located at /etc/postgresql/<version>/main/postgresql.conf or /var/lib/postgres/data/postgresql.conf, depending on the platform.'
-    example "
+    example <<~EXAMPLE
       describe postgres_conf do
         its('max_connections') { should eq '5' }
       end
-    "
+    EXAMPLE
 
     include FindFiles
     include FileReader

--- a/lib/resources/postgres_hba_conf.rb
+++ b/lib/resources/postgres_hba_conf.rb
@@ -9,11 +9,11 @@ module Inspec::Resources
     supports platform: 'unix'
     desc 'Use the `postgres_hba_conf` InSpec audit resource to test the client
           authentication data defined in the pg_hba.conf file.'
-    example "
+    example <<~EXAMPLE
       describe postgres_hba_conf.where { type == 'local' } do
         its('auth_method') { should eq ['peer'] }
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/postgres_ident_conf.rb
+++ b/lib/resources/postgres_ident_conf.rb
@@ -9,11 +9,11 @@ module Inspec::Resources
     supports platform: 'unix'
     desc 'Use the postgres_ident_conf InSpec audit resource to test the client
           authentication data is controlled by a pg_ident.conf file.'
-    example "
+    example <<~EXAMPLE
       describe postgres_ident_conf.where { pg_username == 'acme_user' } do
         its('map_name') { should eq ['ssl-test'] }
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/postgres_session.rb
+++ b/lib/resources/postgres_session.rb
@@ -26,7 +26,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the postgres_session InSpec audit resource to test SQL commands run against a PostgreSQL database.'
-    example "
+    example <<~EXAMPLE
       sql = postgres_session('username', 'password', 'host')
       query('sql_query', ['database_name'])` contains the query and (optional) database to execute
 
@@ -38,7 +38,7 @@ module Inspec::Resources
       describe sql.query('SELECT * FROM pg_shadow WHERE passwd IS NULL;') do
         its('output') { should eq '' }
       end
-    "
+    EXAMPLE
 
     def initialize(user, pass, host = nil)
       @user = user || 'postgres'

--- a/lib/resources/powershell.rb
+++ b/lib/resources/powershell.rb
@@ -7,7 +7,7 @@ module Inspec::Resources
     supports platform: 'windows'
     supports platform: 'unix'
     desc 'Use the powershell InSpec audit resource to test a Windows PowerShell script on the Microsoft Windows platform.'
-    example "
+    example <<~EXAMPLE
       script = <<-EOH
         # your powershell script
       EOH
@@ -15,7 +15,7 @@ module Inspec::Resources
       describe powershell(script) do
         its('matcher') { should eq 'output' }
       end
-    "
+    EXAMPLE
 
     def initialize(script)
       # PowerShell is the default shell on Windows, use the `command` resource

--- a/lib/resources/processes.rb
+++ b/lib/resources/processes.rb
@@ -10,7 +10,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the processes InSpec audit resource to test properties for programs that are running on the system.'
-    example "
+    example <<~EXAMPLE
       describe processes('mysqld') do
         its('entries.length') { should eq 1 }
         its('users') { should eq ['mysql'] }
@@ -25,7 +25,7 @@ module Inspec::Resources
       describe processes do
         its('entries.length') { should be <= 100 }
       end
-    "
+    EXAMPLE
 
     def initialize(grep = /.*/)
       @grep = grep

--- a/lib/resources/rabbitmq_conf.rb
+++ b/lib/resources/rabbitmq_conf.rb
@@ -10,11 +10,11 @@ module Inspec::Resources
     desc 'Use the rabbitmq_config InSpec resource to test configuration data '\
          'for the RabbitMQ service located in /etc/rabbitmq/rabbitmq.config on '\
          'Linux and UNIX platforms.'
-    example "
+    example <<~EXAMPLE
       describe rabbitmq_config.params('rabbit', 'ssl_listeners') do
         it { should cmp 5671 }
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/registry_key.rb
+++ b/lib/resources/registry_key.rb
@@ -50,11 +50,11 @@ module Inspec::Resources
     name 'registry_key'
     supports platform: 'windows'
     desc 'Use the registry_key InSpec audit resource to test key values in the Microsoft Windows registry.'
-    example "
+    example <<~EXAMPLE
       describe registry_key('path\to\key') do
         its('name') { should eq 'value' }
       end
-    "
+    EXAMPLE
 
     def initialize(name, reg_key = nil)
       # if we have one parameter, we use it as name

--- a/lib/resources/security_identifier.rb
+++ b/lib/resources/security_identifier.rb
@@ -6,12 +6,12 @@ module Inspec::Resources
     name 'security_identifier'
     supports platform: 'windows'
     desc 'Resource that returns a Security Identifier for a given entity name in Windows.'
-    example <<-EOD
+    example <<~EXAMPLE
       describe security_identifier(group: 'Everyone') do
         it { should exist }
         its('sid') { should eq 'S-1-1-0' }
       end
-    EOD
+    EXAMPLE
 
     def initialize(opts = {})
       supported_opt_keys = [:user, :group, :unspecified]

--- a/lib/resources/security_policy.rb
+++ b/lib/resources/security_policy.rb
@@ -69,7 +69,7 @@ module Inspec::Resources
     name 'security_policy'
     supports platform: 'windows'
     desc 'Use the security_policy InSpec audit resource to test security policies on the Microsoft Windows platform.'
-    example "
+    example <<~EXAMPLE
       describe security_policy do
         its('SeNetworkLogonRight') { should include 'S-1-5-11' }
       end
@@ -77,7 +77,7 @@ module Inspec::Resources
       describe security_policy(translate_sid: true) do
         its('SeNetworkLogonRight') { should include 'NT AUTHORITY\\Authenticated Users' }
       end
-    "
+    EXAMPLE
 
     def initialize(opts = {})
       @translate_sid = opts[:translate_sid] || false

--- a/lib/resources/service.rb
+++ b/lib/resources/service.rb
@@ -71,7 +71,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the service InSpec audit resource to test if the named service is installed, running and/or enabled.'
-    example "
+    example <<~EXAMPLE
       describe service('service_name') do
         it { should be_installed }
         it { should be_enabled }
@@ -87,7 +87,7 @@ module Inspec::Resources
       describe service('service_name').params do
         its('UnitFileState') { should eq 'enabled' }
       end
-    "
+    EXAMPLE
 
     attr_reader :service_ctl
 
@@ -658,7 +658,7 @@ module Inspec::Resources
     name 'systemd_service'
     supports platform: 'unix'
     desc 'Use the systemd_service InSpec audit resource to test if the named service (controlled by systemd) is installed, running and/or enabled.'
-    example "
+    example <<~EXAMPLE
       # to override service mgmt auto-detection
       describe systemd_service('service_name') do
         it { should be_installed }
@@ -670,7 +670,7 @@ module Inspec::Resources
       describe systemd_service('service_name', '/path/to/systemctl') do
         it { should be_running }
       end
-    "
+    EXAMPLE
 
     def select_service_mgmt
       Systemd.new(inspec, service_ctl)
@@ -681,7 +681,7 @@ module Inspec::Resources
     name 'upstart_service'
     supports platform: 'unix'
     desc 'Use the upstart_service InSpec audit resource to test if the named service (controlled by upstart) is installed, running and/or enabled.'
-    example "
+    example <<~EXAMPLE
       # to override service mgmt auto-detection
       describe upstart_service('service_name') do
         it { should be_installed }
@@ -693,7 +693,7 @@ module Inspec::Resources
       describe upstart_service('service_name', '/path/to/initctl') do
         it { should be_running }
       end
-    "
+    EXAMPLE
 
     def select_service_mgmt
       Upstart.new(inspec, service_ctl)
@@ -704,7 +704,7 @@ module Inspec::Resources
     name 'sysv_service'
     supports platform: 'unix'
     desc 'Use the sysv_service InSpec audit resource to test if the named service (controlled by SysV) is installed, running and/or enabled.'
-    example "
+    example <<~EXAMPLE
       # to override service mgmt auto-detection
       describe sysv_service('service_name') do
         it { should be_installed }
@@ -716,7 +716,7 @@ module Inspec::Resources
       describe sysv_service('service_name', '/path/to/service') do
         it { should be_running }
       end
-    "
+    EXAMPLE
 
     def select_service_mgmt
       SysV.new(inspec, service_ctl)
@@ -727,7 +727,7 @@ module Inspec::Resources
     name 'bsd_service'
     supports platform: 'unix'
     desc 'Use the bsd_service InSpec audit resource to test if the named service (controlled by BSD init) is installed, running and/or enabled.'
-    example "
+    example <<~EXAMPLE
       # to override service mgmt auto-detection
       describe bsd_service('service_name') do
         it { should be_installed }
@@ -739,7 +739,7 @@ module Inspec::Resources
       describe bsd_service('service_name', '/path/to/service') do
         it { should be_running }
       end
-    "
+    EXAMPLE
 
     def select_service_mgmt
       BSDInit.new(inspec, service_ctl)
@@ -750,7 +750,7 @@ module Inspec::Resources
     name 'launchd_service'
     supports platform: 'unix'
     desc 'Use the launchd_service InSpec audit resource to test if the named service (controlled by launchd) is installed, running and/or enabled.'
-    example "
+    example <<~EXAMPLE
       # to override service mgmt auto-detection
       describe launchd_service('service_name') do
         it { should be_installed }
@@ -762,7 +762,7 @@ module Inspec::Resources
       describe launchd_service('service_name', '/path/to/launchctl') do
         it { should be_running }
       end
-    "
+    EXAMPLE
 
     def select_service_mgmt
       LaunchCtl.new(inspec, service_ctl)
@@ -773,7 +773,7 @@ module Inspec::Resources
     name 'runit_service'
     supports platform: 'unix'
     desc 'Use the runit_service InSpec audit resource to test if the named service (controlled by runit) is installed, running and/or enabled.'
-    example "
+    example <<~EXAMPLE
       # to override service mgmt auto-detection
       describe runit_service('service_name') do
         it { should be_installed }
@@ -785,7 +785,7 @@ module Inspec::Resources
       describe runit_service('service_name', '/path/to/sv') do
         it { should be_running }
       end
-    "
+    EXAMPLE
 
     def select_service_mgmt
       Runit.new(inspec, service_ctl)

--- a/lib/resources/shadow.rb
+++ b/lib/resources/shadow.rb
@@ -21,7 +21,7 @@ module Inspec::Resources
     desc 'Use the shadow InSpec resource to test the contents of /etc/shadow, '\
          'which contains information for users that may log into '\
          'the system and/or as users that own running processes.'
-    example "
+    example <<~EXAMPLE
       describe shadow do
         its('user') { should_not include 'forbidden_user' }
       end
@@ -30,7 +30,7 @@ module Inspec::Resources
         its('password') { should cmp 'x' }
         its('count') { should eq 1 }
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/ssh_conf.rb
+++ b/lib/resources/ssh_conf.rb
@@ -9,13 +9,13 @@ module Inspec::Resources
     name 'ssh_config'
     supports platform: 'unix'
     desc 'Use the `ssh_config` InSpec audit resource to test OpenSSH client configuration data located at `/etc/ssh/ssh_config` on Linux and Unix platforms.'
-    example "
+    example <<~EXAMPLE
       describe ssh_config do
         its('cipher') { should contain '3des' }
         its('port') { should eq '22' }
         its('hostname') { should include('example.com') }
       end
-    "
+    EXAMPLE
 
     include FileReader
 
@@ -80,11 +80,11 @@ module Inspec::Resources
     name 'sshd_config'
     supports platform: 'unix'
     desc 'Use the sshd_config InSpec audit resource to test configuration data for the Open SSH daemon located at /etc/ssh/sshd_config on Linux and UNIX platforms. sshd---the Open SSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command execution, and data exchanges.'
-    example "
+    example <<~EXAMPLE
       describe sshd_config do
         its('Protocol') { should eq '2' }
       end
-    "
+    EXAMPLE
 
     def initialize(path = nil)
       super(path || '/etc/ssh/sshd_config')

--- a/lib/resources/ssl.rb
+++ b/lib/resources/ssl.rb
@@ -16,7 +16,7 @@ class SSL < Inspec.resource(1)
     SSL test resource
   "
 
-  example "
+  example <<~EXAMPLE
     describe ssl(port: 443) do
       it { should be_enabled }
     end
@@ -30,7 +30,7 @@ class SSL < Inspec.resource(1)
     describe ssl(port: 443).ciphers(/rc4/i) do
       it { should_not be_enabled }
     end
-  "
+  EXAMPLE
 
   VERSIONS = [
     'ssl2',

--- a/lib/resources/sys_info.rb
+++ b/lib/resources/sys_info.rb
@@ -7,11 +7,11 @@ module Inspec::Resources
     supports platform: 'windows'
 
     desc 'Use the user InSpec system resource to test for operating system properties.'
-    example "
+    example <<~EXAMPLE
       describe sys_info do
         its('hostname') { should eq 'example.com' }
       end
-    "
+    EXAMPLE
 
     # returns the hostname of the local system
     def hostname

--- a/lib/resources/toml.rb
+++ b/lib/resources/toml.rb
@@ -7,13 +7,13 @@ module Inspec::Resources
   class TomlConfig < JsonConfig
     name 'toml'
     desc 'Use the toml InSpec resource to test configuration data in a TOML file'
-    example "
+    example <<~EXAMPLE
       describe toml('default.toml') do
         its('key') { should eq('value') }
         its (['arr', 1]) { should eq 2 }
         its (['mytable', 'key1']) { should eq 'value1' }
       end
-    "
+    EXAMPLE
 
     def parse(content)
       Tomlrb.parse(content)

--- a/lib/resources/users.rb
+++ b/lib/resources/users.rb
@@ -56,13 +56,13 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the users InSpec audit resource to test local user profiles. Users can be filtered by groups to which they belong, the frequency of required password changes, the directory paths to home and shell.'
-    example "
+    example <<~EXAMPLE
       describe users.where { uid == 0 }.entries do
         it { should eq ['root'] }
         its('uids') { should eq [1234] }
         its('gids') { should eq [1234] }
       end
-    "
+    EXAMPLE
     def initialize
       # select user provider
       @user_provider = select_user_manager(inspec.os)
@@ -141,13 +141,13 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the user InSpec audit resource to test user profiles, including the groups to which they belong, the frequency of required password changes, the directory paths to home and shell.'
-    example "
+    example <<~EXAMPLE
       describe user('root') do
         it { should exist }
         its('uid') { should eq 1234 }
         its('gid') { should eq 1234 }
       end
-    "
+    EXAMPLE
     def initialize(username = nil)
       @username = username
       # select user provider

--- a/lib/resources/vbscript.rb
+++ b/lib/resources/vbscript.rb
@@ -23,7 +23,7 @@ module Inspec::Resources
     name 'vbscript'
     supports platform: 'windows'
     desc ''
-    example "
+    example <<~EXAMPLE
       script = <<-EOH
         # you vbscript
       EOH
@@ -31,7 +31,7 @@ module Inspec::Resources
       describe vbscript(script) do
         its('stdout') { should eq 'output' }
       end
-    "
+    EXAMPLE
 
     def initialize(vbscript)
       @seperator = SecureRandom.uuid

--- a/lib/resources/virtualization.rb
+++ b/lib/resources/virtualization.rb
@@ -7,7 +7,7 @@ module Inspec::Resources
     name 'virtualization'
     supports platform: 'linux'
     desc 'Use the virtualization InSpec audit resource to test the virtualization platform on which the system is running'
-    example "
+    example <<~EXAMPLE
       describe virtualization do
         its('system') { should eq 'docker' }
       end
@@ -22,7 +22,7 @@ module Inspec::Resources
         end
         only_if { virtualization.system == 'docker' }
       end
-    "
+    EXAMPLE
 
     def initialize
       @virtualization_data = Hashie::Mash.new

--- a/lib/resources/windows_feature.rb
+++ b/lib/resources/windows_feature.rb
@@ -5,7 +5,7 @@ module Inspec::Resources
     name 'windows_feature'
     supports platform: 'windows'
     desc 'Use the windows_feature InSpec audit resource to test features on Microsoft Windows.'
-    example <<-EOX
+    example <<~EXAMPLE
       # By default this resource will use Get-WindowsFeature.
       # Failing that, it will use DISM.
 
@@ -23,7 +23,7 @@ module Inspec::Resources
       describe windows_feature('IIS-WebServer') do
         it { should be_installed }
       end
-    EOX
+    EXAMPLE
 
     def initialize(feature, method = nil)
       @feature = feature

--- a/lib/resources/windows_hotfix.rb
+++ b/lib/resources/windows_hotfix.rb
@@ -5,11 +5,11 @@ module Inspec::Resources
     name 'windows_hotfix'
     supports platform: 'windows'
     desc 'Use the windows_hotfix InSpec audit resource to test if the hotfix has been installed on the Windows system.'
-    example "
+    example <<~EXAMPLE
       describe windows_hotfix('KB4012212') do
         it { should be_installed }
       end
-    "
+    EXAMPLE
 
     attr_accessor :content
 

--- a/lib/resources/windows_task.rb
+++ b/lib/resources/windows_task.rb
@@ -4,7 +4,7 @@ module Inspec::Resources
     name 'windows_task'
     supports platform: 'windows'
     desc 'Use the windows_task InSpec audit resource to test task schedules on Microsoft Windows.'
-    example "
+    example <<~EXAMPLE
       describe windows_task('\\Microsoft\\Windows\\Time Synchronization\\SynchronizeTime') do
         it { should be_enabled }
       end
@@ -23,7 +23,7 @@ module Inspec::Resources
         its('task_to_run') { should cmp '%Windir%\\system32\\appidpolicyconverter.exe' }
         its('run_as_user') { should eq 'LOCAL SERVICE' }
       end
-    "
+    EXAMPLE
 
     def initialize(taskuri)
       @taskuri = taskuri

--- a/lib/resources/wmi.rb
+++ b/lib/resources/wmi.rb
@@ -11,7 +11,7 @@ module Inspec::Resources
     name 'wmi'
     supports platform: 'windows'
     desc 'request wmi information'
-    example "
+    example <<~EXAMPLE
       describe wmi({
         class: 'RSOP_SecuritySettingNumeric',
         namespace: 'root\\rsop\\computer',
@@ -19,7 +19,7 @@ module Inspec::Resources
       }) do
          its('Setting') { should eq true }
       end
-    "
+    EXAMPLE
 
     include ObjectTraverser
     attr_accessor :content

--- a/lib/resources/x509_certificate.rb
+++ b/lib/resources/x509_certificate.rb
@@ -10,7 +10,7 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Used to test x.509 certificates'
-    example "
+    example <<~EXAMPLE
       describe x509_certificate('/etc/pki/www.mywebsite.com.pem') do
         its('subject') { should match /CN=My Website/ }
         its('validity_in_days') { should be > 30 }
@@ -31,7 +31,7 @@ module Inspec::Resources
         its('key_length') { should be >= 2048 }
         its('extensions.subjectKeyIdentifier') { should cmp 'A5:16:0B:12:F4:48:0F:06:6C:32:29:67:98:12:DF:3D:0D:75:9D:5C' }
       end
-    "
+    EXAMPLE
 
     include FileReader
 

--- a/lib/resources/xinetd.rb
+++ b/lib/resources/xinetd.rb
@@ -9,7 +9,7 @@ module Inspec::Resources
     name 'xinetd_conf'
     supports platform: 'unix'
     desc 'Xinetd services configuration.'
-    example "
+    example <<~EXAMPLE
       describe xinetd_conf.services('chargen') do
         its('socket_types') { should include 'dgram' }
       end
@@ -17,7 +17,7 @@ module Inspec::Resources
       describe xinetd_conf.services('chargen').socket_types('dgram') do
         it { should be_disabled }
       end
-    "
+    EXAMPLE
 
     include XinetdParser
     include FileReader

--- a/lib/resources/xml.rb
+++ b/lib/resources/xml.rb
@@ -6,12 +6,12 @@ module Inspec::Resources
     supports platform: 'unix'
     supports platform: 'windows'
     desc 'Use the xml InSpec resource to test configuration data in an XML file'
-    example "
+    example <<~EXAMPLE
       describe xml('default.xml') do
         its('key/sub_key') { should eq(['value']) }
         its(['root/name.with.a.period']) { should cmp 'so_many_dots' }
       end
-    "
+    EXAMPLE
 
     def parse(content)
       require 'rexml/document'

--- a/lib/resources/yaml.rb
+++ b/lib/resources/yaml.rb
@@ -11,7 +11,7 @@ module Inspec::Resources
   class YamlConfig < JsonConfig
     name 'yaml'
     desc 'Use the yaml InSpec audit resource to test configuration data in a YAML file.'
-    example "
+    example <<~EXAMPLE
       describe yaml('config.yaml') do
         its(['driver', 'name']) { should eq 'vagrant' }
       end
@@ -23,7 +23,7 @@ module Inspec::Resources
       describe yaml({ content: \"key1: value1\nkey2: value2\" }) do
         its('key2') { should cmp 'value2' }
       end
-    "
+    EXAMPLE
 
     # override file load and parse hash from yaml
     def parse(content)

--- a/lib/resources/yum.rb
+++ b/lib/resources/yum.rb
@@ -32,12 +32,12 @@ module Inspec::Resources
     name 'yum'
     supports platform: 'unix'
     desc 'Use the yum InSpec audit resource to test the configuration of Yum repositories.'
-    example "
+    example <<~EXAMPLE
       describe yum.repo('name') do
         it { should exist }
         it { should be_enabled }
       end
-    "
+    EXAMPLE
 
     # returns all repositories
     # works as following:

--- a/lib/resources/zfs_dataset.rb
+++ b/lib/resources/zfs_dataset.rb
@@ -8,12 +8,12 @@ module Inspec::Resources
       Use the zfs_dataset InSpec audit resource to test if the named
       ZFS Dataset is present and/or has certain properties.
     "
-    example "
+    example <<~EXAMPLE
       describe zfs_dataset('tank/tmp') do
         its('exec') { should eq('off') }
         its('setuid') { should eq('off') }
       end
-    "
+    EXAMPLE
 
     def initialize(zfs_dataset)
       return skip_resource 'The `zfs_dataset` resource is not supported on your OS yet.' if !inspec.os.bsd?

--- a/lib/resources/zfs_pool.rb
+++ b/lib/resources/zfs_pool.rb
@@ -8,11 +8,11 @@ module Inspec::Resources
       Use the zfs_pool InSpec audit resource to test if the named
       ZFS Pool is present and/or has certain properties.
     "
-    example "
+    example <<~EXAMPLE
       describe zfs_pool('tank') do
         its('failmode') { should eq('continue') }
       end
-    "
+    EXAMPLE
 
     def initialize(zfs_pool)
       return skip_resource 'The `zfs_pool` resource is not supported on your OS yet.' if !inspec.os.bsd?


### PR DESCRIPTION
The opening and closing mechanic varied between all the various resources. This changes them all to use a HEREDOC with a tilde to remove leading whitespace. This removes the need for the special method to trim the `#print_example` method from shell.

## BEFORE

![2019-03-19_08-34-01](https://user-images.githubusercontent.com/244426/54613279-6ed34e80-4a28-11e9-86b1-ff1bef59ff1e.png)

## AFTER

![2019-03-19_09-00-44](https://user-images.githubusercontent.com/244426/54613294-7561c600-4a28-11e9-85f5-40c4e0920f7f.png)
