### PR TITLE
automate reporter: Add top-level 'passthrough' field

### DIFF
--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -28,10 +28,6 @@ module Inspec::Reporters
 
       final_report[:report_uuid] = @config['report_uuid'] || uuid_from_string(final_report[:end_time] + final_report[:node_uuid])
 
-      # optional json-config passthrough options
-      %w{node_name environment roles recipies job_uuid}.each do |option|
-        final_report[option.to_sym] = @config[option] unless @config[option].nil?
-      end
       final_report
     end
 

--- a/lib/inspec/reporters/json_automate.rb
+++ b/lib/inspec/reporters/json_automate.rb
@@ -17,7 +17,7 @@ module Inspec::Reporters
       # grab profiles from the json parent class
       @profiles = profiles
 
-      {
+      output = {
         platform: platform,
         profiles: merge_profiles,
         statistics: {
@@ -25,6 +25,12 @@ module Inspec::Reporters
         },
         version: run_data[:version],
       }
+
+      # optional json-config passthrough options
+      %w{node_name environment roles recipies job_uuid}.each do |option|
+        output[option.to_sym] = @config[option] unless @config[option].nil?
+      end
+      output
     end
 
     private

--- a/lib/inspec/reporters/json_automate.rb
+++ b/lib/inspec/reporters/json_automate.rb
@@ -27,7 +27,7 @@ module Inspec::Reporters
       }
 
       # optional json-config passthrough options
-      %w{node_name environment roles recipies job_uuid}.each do |option|
+      %w{node_name environment roles job_uuid}.each do |option|
         output[option.to_sym] = @config[option] unless @config[option].nil?
       end
       output

--- a/lib/inspec/reporters/json_automate.rb
+++ b/lib/inspec/reporters/json_automate.rb
@@ -27,7 +27,7 @@ module Inspec::Reporters
       }
 
       # optional json-config passthrough options
-      %w{node_name environment roles job_uuid}.each do |option|
+      %w{node_name environment roles job_uuid passthrough}.each do |option|
         output[option.to_sym] = @config[option] unless @config[option].nil?
       end
       output

--- a/test/functional/inspec_exec_automate_test.rb
+++ b/test/functional/inspec_exec_automate_test.rb
@@ -6,32 +6,43 @@ require 'tempfile'
 describe 'inspec exec automate' do
   include FunctionalHelper
 
-  let(:json_file) do
-    file = Tempfile.new('json.conf')
-    json = <<~EOF
-    {
-    "reporter": {
-        "automate" : {
-            "stdout" : false,
-            "url" : "https://fake_url_a2.com/data-collector/v0/",
-            "token" : "faketoken123",
-            "insecure" : true,
-            "node_uuid" : "test123"
-            }
-        }
-    }
-    EOF
-
-    file.write(json)
+  let(:config_path) do
+    file = Tempfile.new('config.json')
+    file.write(config_data)
     file.close
     file.path
   end
 
-  it 'fails when trying to send a report to a fake url' do
-    out = inspec('exec ' + example_profile  + ' --no-create-lockfile --json-config ' + json_file)
-    out.stderr.must_equal "Error generating reporter 'automate'\n"
-    out.exit_status.must_equal 1
-    stdout = out.stdout.force_encoding(Encoding::UTF_8)
-    stdout.must_include "ERROR: send_report: POST to /data-collector/v0/"
+  let(:invocation) do
+    cmd = 'exec '
+    cmd += example_profile + ' '
+    cmd += '--config ' + config_path
+    cmd += ' --no-create-lockfile '
+  end
+
+  let(:run_result) { run_inspec_process(invocation) }
+
+  describe 'when the the URL is fake' do
+    let(:config_data) do
+      data = <<~EOF
+      {
+      "reporter": {
+          "automate" : {
+              "stdout" : false,
+              "url" : "https://fake_url_a2.com/data-collector/v0/",
+              "token" : "faketoken123",
+              "insecure" : true,
+              "node_uuid" : "test123"
+              }
+          }
+      }
+      EOF
+    end
+
+    it 'should fail' do
+      run_result.stderr.must_equal "Error generating reporter 'automate'\n"
+      run_result.exit_status.must_equal 1
+      run_result.stdout.must_include "ERROR: send_report: POST to /data-collector/v0/"
+    end
   end
 end

--- a/test/functional/inspec_exec_automate_test.rb
+++ b/test/functional/inspec_exec_automate_test.rb
@@ -93,7 +93,7 @@ describe 'inspec exec automate' do
 
       # Added in InSpec v3.7.11+
       json.keys.must_include 'passthrough'
-      json['passthrough'].keys.sort.must_equal ['projects', 'another_tramp_datum']
+      json['passthrough'].keys.sort.must_equal ['another_tramp_datum', 'projects']
       json['passthrough']['projects'].must_equal ['alpha', 'beta']
 
     end


### PR DESCRIPTION

 * Adds a new option to the `json-automate` and `automate` reporters, `passthrough`. Whatever data is placed there in the config file will be exposed under the top-level field `passthrough`.
 * Removes the unused `recipies` (sic) field
 * Internally moves the implementation of passthrough fields from `automate` to the `json-automate` reporter. Since `automate` inherits from `json-automate`, this lets both reporters get the fields. Since `automate` is difficult to test, this allows the fields to be checked.
 * Adds functional tests to cover the changes 

Closes #3874 