### PR TITLE
Remove EOL Ubuntu / macOS platform testing

### DIFF
--- a/kitchen.chef.yml
+++ b/kitchen.chef.yml
@@ -27,9 +27,8 @@ platforms:
 #   KITCHEN_LOCAL_YAML=.kitchen.vmware.yml kitchen converge inspec-macosx-109
 #
 <% %w(
-  10.9
-  10.10
   10.11
+  10.12
 ).each do |mac_version| %>
 - name: macosx-<%= mac_version %>
   driver:

--- a/kitchen.vagrant.yml
+++ b/kitchen.vagrant.yml
@@ -18,7 +18,6 @@ platforms:
   - name: fedora-29
   - name: freebsd-11
   - name: opensuseleap-42
-  - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: ubuntu-18.04
 


### PR DESCRIPTION
Remove testing for EOL Ubuntu 14.04
Remove testing for EOL macOS 10.9/10.10

Signed-off-by: Tim Smith <tsmith@chef.io>