### PR TITLE
Don't include plugin test files in the gem file

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
 
   spec.files = %w{README.md LICENSE} + Dir.glob('{bin,lib,etc}/**/*', File::FNM_DOTMATCH)
-                                          .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/ }
+                                          .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/ || f =~ %r{lib/plugins/.*/test/} }
 
   spec.executables   = %w{inspec}
   spec.require_paths = ['lib']

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.executables   = %w{inspec}
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+                           .reject { |f| File.directory?(f) || f =~ %r{lib/plugins/.*/test/} }
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.3'


### PR DESCRIPTION
One of the test files is causing chef omnibus failures on Solaris for some reason, but really there's no reason to ship all these test files in the install artifact. This slims down the gem and install size a good amount. I'm open to a better regex if someone has opinions.

Signed-off-by: Tim Smith <tsmith@chef.io>