### PR TITLE
Include train-habitat gem with InSpec

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -25,6 +25,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'train', '~> 1.5', '>= 1.7.2'
+  # Train plugins we ship with InSpec
+  spec.add_dependency 'train-habitat', '~> 0.1'
+
+  # Implementation dependencies
   spec.add_dependency 'thor', '~> 0.20'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
   spec.add_dependency 'method_source', '~> 0.8'


### PR DESCRIPTION
Includes the train-habitat gem with InSpec (not with inspec-core).

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>