### PR TITLE
Create omnibus buildkite pipelines

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -14,6 +14,11 @@ docker_images:
 
 pipelines:
   - habitat/build
+  - omnibus/release
+  - omnibus/adhoc:
+      definition: .expeditor/release.omnibus.yml
+      env:
+        - ADHOC: true
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -1,0 +1,27 @@
+---
+project-name: inspec
+config: omnibus/omnibus.rb
+test-path: omnibus/omnibus-test.sh
+test-path-windows: omnibus/omnibus-test.ps1
+builder-to-testers-map:
+  el-6-x86_64:
+    - el-6-x86_64
+  el-7-x86_64:
+    - el-7-x86_64
+  mac_os_x-10.12-x86_64:
+    - mac_os_x-10.12-x86_64
+    - mac_os_x-10.13-x86_64
+    - mac_os_x-10.14-x86_64
+  sles-11-x86_64:
+    - sles-11-x86_64
+  sles-12-x86_64:
+    - sles-12-x86_64
+    - sles-15-x86_64
+  ubuntu-14.04-x86_64:
+    - ubuntu-14.04-x86_64
+    - ubuntu-16.04-x86_64
+    - ubuntu-18.04-x86_64
+  windows-2012r2-x86_64:
+    - windows-2012-x86_64
+    - windows-2012r2-x86_64
+    - windows-2016-x86_64

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -1,0 +1,43 @@
+# Stop script execution when a non-terminating error occurs
+$ErrorActionPreference = "Stop"
+
+$channel = "$Env:CHANNEL"
+If ([string]::IsNullOrEmpty($channel)) { $channel = "unstable" }
+
+$product = "$Env:PRODUCT"
+If ([string]::IsNullOrEmpty($product)) { $product = "inspec" }
+
+$version = "$Env:VERSION"
+If ([string]::IsNullOrEmpty($version)) { $version = "latest" }
+
+Write-Output "--- Downloading $channel $product $version"
+$download_url = C:\opscode\omnibus-toolchain\embedded\bin\mixlib-install.bat download --url --channel "$channel" "$product" --version "$version"
+$package_file = "$Env:Temp\$(Split-Path -Path $download_url -Leaf)"
+Invoke-WebRequest -OutFile "$package_file" -Uri "$download_url"
+
+Write-Output "--- Checking that $package_file has been signed."
+If ((Get-AuthenticodeSignature "$package_file").Status -eq 'Valid') {
+  Write-Output "Verified $package_file has been signed."
+}
+Else {
+  Write-Output "Exiting with an error because $package_file has not been signed. Check your omnibus project config."
+  exit 1
+}
+
+Write-Output "--- Installing $channel $product $version"
+Start-Process "$package_file" /quiet -Wait
+
+Write-Output "--- Testing $channel $product $version"
+
+$INSTALL_DIR = "C:\opscode\inspec"
+$Env:PATH = "${INSTALL_DIR};${Env:PATH}"
+
+Write-Output "Running verification for $product"
+
+# Set GEM_HOME and GEM_PATH to verify our appbundle inspec shim is correctly
+# removing them from the environment while launching from our embedded ruby.
+$Env:GEM_HOME = "C:\SHOULD_NOT_EXIST"
+$Env:GEM_PATH = "C:\SHOULD_NOT_EXIST"
+
+Set-Location -Path C:\opscode\inspec\bin
+inspec version

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -ueo pipefail
+
+channel="${CHANNEL:-unstable}"
+product="${PRODUCT:-inspec}"
+version="${VERSION:-latest}"
+
+echo "--- Installing $channel $product $version"
+package_file="$(install-omnibus-product -c "$channel" -P "$product" -v "$version" | tail -n 1)"
+
+echo "--- Verifying omnibus package is signed"
+check-omnibus-package-signed "$package_file"
+
+echo "--- Testing $channel $product $version"
+
+export INSTALL_DIR=/opt/inspec
+export PATH=/opt/inspec/bin:$PATH
+
+echo "Verifying ownership of package files"
+
+NONROOT_FILES="$(find "$INSTALL_DIR" ! -uid 0 -print)"
+if [[ "$NONROOT_FILES" == "" ]]; then
+  echo "Packages files are owned by root.  Continuing verification."
+else
+  echo "Exiting with an error because the following files are not owned by root:"
+  echo "$NONROOT_FILES"
+  exit 1
+fi
+
+echo "Running verification for $product"
+
+# Set GEM_HOME and GEM_PATH to verify our appbundle inspec shim is correctly
+# removing them from the environment while launching from our embedded ruby.
+export GEM_HOME=/SHOULD_NOT_EXIST
+export GEM_PATH=/SHOULD_NOT_EXIST
+
+export PATH="$PATH:/usr/local/bin"
+inspec version


### PR DESCRIPTION
This creates buildkite pipelines that will be used for omnibus builds/tests. It does not actually replace the current build/test infrastructure. That will be done in a separate PR once we finish testing these new pipelines.