### PR TITLE
Add -y to all apt-get update commands in integration tests

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -47,14 +47,14 @@ platforms:
     image: dokken/debian-8
     pid_one_command: /bin/systemd
     intermediate_instructions:
-      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get update -y
 
 - name: debian-9
   driver:
     image: dokken/debian-9
     pid_one_command: /bin/systemd
     intermediate_instructions:
-      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get update -y
 
 - name: fedora-29
   driver:
@@ -81,21 +81,21 @@ platforms:
     image: dokken/ubuntu-14.04
     pid_one_command: /sbin/init
     intermediate_instructions:
-      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get update -y
 
 - name: ubuntu-16.04
   driver:
     image: dokken/ubuntu-16.04
     pid_one_command: /bin/systemd
     intermediate_instructions:
-      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get update -y
 
 - name: ubuntu-18.04
   driver:
     image: dokken/ubuntu-18.04
     pid_one_command: /bin/systemd
     intermediate_instructions:
-      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get update -y
 
 suites:
 - name: default
@@ -104,7 +104,7 @@ suites:
   - recipe[audit]
   verifier:
     inspec_tests:
-      - test/integration/default
+      - test/integration/default -y
   attributes:
     audit:
       attributes:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -104,7 +104,7 @@ suites:
   - recipe[audit]
   verifier:
     inspec_tests:
-      - test/integration/default -y
+      - test/integration/default
   attributes:
     audit:
       attributes:


### PR DESCRIPTION
Intended to fix failing Debian 8 Travis CI tests, for example https://travis-ci.org/inspec/inspec/jobs/514248344

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>