### PR TITLE
Disable warnings for functional tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -76,7 +76,7 @@ namespace :test do
       'test/functional/**/*_test.rb',
       'lib/plugins/inspec-*/test/functional/**/*_test.rb',
     ])
-    t.warning = true
+    t.warning = false
     t.verbose = true
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end
@@ -93,7 +93,7 @@ namespace :test do
 
     t.libs << 'test'
     t.test_files = files
-    t.warning = true
+    t.warning = false
     t.verbose = true
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end


### PR DESCRIPTION
AWS-SDK 3 adds a vast number of method redefinitions; the output is very large. We usually get better visibility into this sort of issue in *our* code in the unit tests, anyway.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>