### PR TITLE
Remove the omnibus override to use train 1.X

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,3 +1,1 @@
-
-# Temporary - inspec 3.x must use train 1.7+
-override 'train', version: '1.7.4'
+# this file is used to override versions of packages in the omnibus build


### PR DESCRIPTION
We don't want this anymore

Signed-off-by: Tim Smith <tsmith@chef.io>