### PR TITLE
CI: Use 2.4.6, 2.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,61 +16,60 @@ matrix:
   include:
   - rvm: 2.3.8
     env: UNIT_TESTS_23=1
-  - rvm: 2.4.5
+  - rvm: 2.4.6
     env: UNIT_TESTS_24=1
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     env: UNIT_TESTS_25=1
   #- rvm: 2.6.1 # this needs a few fixes to get enabled
   #  bundler_args: "--without integration tools maintenance deploy"
   #  env: UNIT_TESTS_26=1
-  - rvm: 2.4.5
+  - rvm: 2.4.6
     script: bundle exec rake $SUITE
     env: SUITE="test:functional"
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     script: bundle exec rake $SUITE
     env: SUITE="test:functional"
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-ubuntu-1404]
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-ubuntu-1604]
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-ubuntu-1804]
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-centos-6]
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-centos-7]
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-debian-8]
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-debian-9]
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-oraclelinux-6]
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-oraclelinux-7]
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-fedora-29]
-  - rvm: 2.4.5
-    sudo: false
+  - rvm: 2.4.6
     cache:
       apt: true
       bundle: true


### PR DESCRIPTION
  - Also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration