### PR TITLE
Improve omnibus test scripts

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -29,9 +29,10 @@ Start-Process "$package_file" /quiet -Wait
 
 Write-Output "--- Testing $channel $product $version"
 
-$Env:PATH = "C:\opscode\inspec\bin;${Env:PATH}"
-
 Write-Output "Running verification for $product"
+
+# reload Env:PATH to ensure it gets any changes that the install made (e.g. C:\opscode\inspec\bin\ )
+$Env:PATH = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
 # Set GEM_HOME and GEM_PATH to verify our appbundle inspec shim is correctly
 # removing them from the environment while launching from our embedded ruby.
@@ -39,3 +40,4 @@ $Env:GEM_HOME = "C:\SHOULD_NOT_EXIST"
 $Env:GEM_PATH = "C:\SHOULD_NOT_EXIST"
 
 inspec version
+If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -13,11 +13,9 @@ check-omnibus-package-signed "$package_file"
 
 echo "--- Testing $channel $product $version"
 
-export INSTALL_DIR=/opt/inspec
-export PATH="/opt/inspec/bin:$PATH"
-
 echo "Verifying ownership of package files"
 
+export INSTALL_DIR=/opt/inspec
 NONROOT_FILES="$(find "$INSTALL_DIR" ! -uid 0 -print)"
 if [[ "$NONROOT_FILES" == "" ]]; then
   echo "Packages files are owned by root.  Continuing verification."
@@ -34,5 +32,4 @@ echo "Running verification for $product"
 export GEM_HOME=/SHOULD_NOT_EXIST
 export GEM_PATH=/SHOULD_NOT_EXIST
 
-export PATH="$PATH:/usr/local/bin"
 inspec version


### PR DESCRIPTION
* Reload Env:PATH to get changes from inspec installation
* Do not add inspec's bin path to bash's PATH environment variable

By avoiding explicitly making changes to PATH or changing directory into the project's bin directory we force the tests to completely rely on the results of the projects' install scripts.