### PR TITLE
Require Ruby 2.4 or later

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,8 @@ Metrics/PerceivedComplexity:
   Max: 11
 NumericLiterals:
   MinDigits: 10
+Performance/RegexpMatch:
+  Enabled: false
 Security/YAMLLoad:
   Enabled: false
 Style/AndOr:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 ---
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
   - Gemfile
   - Rakefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ before_install:
 - bundle --version
 matrix:
   include:
-  - rvm: 2.3.8
-    env: UNIT_TESTS_23=1
   - rvm: 2.4.5
     env: UNIT_TESTS_24=1
   - rvm: 2.5.3

--- a/Gemfile
+++ b/Gemfile
@@ -27,10 +27,7 @@ group :test do
 end
 
 group :integration do
-  # this version check can be removed when inspec no longer support ruby 2.3
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
-    gem 'berkshelf', '~> 7'
-  end
+  gem 'berkshelf', '~> 7'
   gem 'test-kitchen', '>= 1.24'
   gem 'kitchen-vagrant'
   # we need winrm v2 support >= 0.15.1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ inspec exec test.rb -t docker://container_id
 
 ## Installation
 
-InSpec requires Ruby ( >2.3 ).
+InSpec requires Ruby ( >= 2.4 ).
 
 ### Install as package
 
@@ -454,4 +454,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,6 @@ platform:
 
 environment:
   matrix:
-    - name: unit-tests-ruby-2.3.3
-      ruby_version: "23"
     - name: unit-tests-ruby-2.4.4
       ruby_version: "24"
     - name: unit-tests-ruby-2.5.1

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = %w{inspec}
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency 'train-core', '~> 2.0'
   spec.add_dependency 'license-acceptance', '~> 0.2'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                            .reject { |f| File.directory?(f) || f =~ %r{lib/plugins/.*/test/} }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency 'train', '~> 2.0' # Inspec 4 must have train 2+
   # Train plugins we ship with InSpec


### PR DESCRIPTION
Ruby 2.3 is no longer supported. Drop this release from InSpec and
instead support the 3 latest Ruby releases.

Signed-off-by: Tim Smith <tsmith@chef.io>