### PR TITLE
Improve ss parsing code for IPv6 addresses

### DIFF
--- a/lib/resources/port.rb
+++ b/lib/resources/port.rb
@@ -569,6 +569,10 @@ module Inspec::Resources
       # example: ::ffff:10.0.2.15:9200
       host.delete!('::ffff:') if host.start_with?('::ffff:')
 
+      # To remove brackets that might surround the IPv6 address
+      # example: [::] and [fe80::dc11:b9b6:514b:134]%eth0:123
+      host = host.tr('[]', '')
+
       # if there's an interface name in the local address, which is common for
       # IPv6 listeners, strip that out too.
       # example: fe80::a00:27ff:fe32:ed09%enp0s3

--- a/test/unit/resources/port_linuxports_test.rb
+++ b/test/unit/resources/port_linuxports_test.rb
@@ -1,0 +1,70 @@
+require 'helper'
+require 'inspec/resource'
+
+class TestLinuxPorts < Minitest::Test
+  def setup
+    @linuxports = Inspec::Resources::LinuxPorts.new('')
+  end
+
+  def test_parse_ss_line_asterisk
+    ss_line = 'tcp    LISTEN     0      128                                                 *:22                                                              *:*                   users:(("sshd",pid=1222,fd=3)) ino:15973 sk:2 <->'
+
+    assert_equal ({"port"=>22,
+                   "address"=>"0.0.0.0",
+                   "protocol"=>"tcp",
+                   "process"=>"sshd",
+                   "pid"=>1222}),
+                   @linuxports.parse_ss_line(ss_line)
+  end
+
+  def test_parse_ss_line_ipv4
+    ss_line = 'tcp    LISTEN     0      128                                                 192.168.1.1:22                                                              *:*                   users:(("sshd",pid=1222,fd=3)) ino:15973 sk:2 <->'
+
+    assert_equal ({"port"=>22,
+                   "address"=>"192.168.1.1",
+                   "protocol"=>"tcp",
+                   "process"=>"sshd",
+                   "pid"=>1222}),
+                   @linuxports.parse_ss_line(ss_line)
+  end
+
+  def test_parse_ss_line_ipv6
+    ss_line = 'tcp    LISTEN     0      128                   fe80::a00:27ff:fe32:ed09%enp0s3:9200                                                           :::*                   users:(("java",pid=1722,fd=124)) uid:112 ino:19542 sk:9 v6only:1 <->'
+    assert_equal ({"port"=>9200,
+                   "address"=>"fe80::a00:27ff:fe32:ed09",
+                   "protocol"=>"tcp6",
+                   "process"=>"java",
+                   "pid"=>1722}),
+                   @linuxports.parse_ss_line(ss_line)
+  end
+
+  def test_parse_ss_line_ipv6_wildcard
+    ss_line = 'tcp    LISTEN     0      128                                                :::22                                                             :::*                   users:(("sshd",pid=1222,fd=4)) ino:15982 sk:3 v6only:1 <->'
+    assert_equal ({"port"=>22,
+                   "address"=>"::",
+                   "protocol"=>"tcp6",
+                   "process"=>"sshd",
+                   "pid"=>1222}),
+                   @linuxports.parse_ss_line(ss_line)
+  end
+
+  def test_parse_ss_line_ipv6_wildcard_brackets
+    ss_line = 'tcp    LISTEN     0      128                                                [::]:22                                                             :::*                   users:(("sshd",pid=1222,fd=4)) ino:15982 sk:3 v6only:1 <->'
+    assert_equal ({"port"=>22,
+                   "address"=>"::",
+                   "protocol"=>"tcp6",
+                   "process"=>"sshd",
+                   "pid"=>1222}),
+                   @linuxports.parse_ss_line(ss_line)
+  end
+
+  def test_parse_ss_line_ipv6_address_brackets
+    ss_line = 'tcp    LISTEN     0      128                   [fe80::a00:27ff:fe32:ed09]%enp0s3:9200                                                           :::*                   users:(("java",pid=1722,fd=124)) uid:112 ino:19542 sk:9 v6only:1 <->'
+    assert_equal ({"port" => 9200,
+                  "address" => "fe80::a00:27ff:fe32:ed09",
+                  "protocol" => "tcp6",
+                  "process" =>"java",
+                  "pid" => 1722}),
+                   @linuxports.parse_ss_line(ss_line)
+  end
+end


### PR DESCRIPTION
Some versions of `ss` wrap IPv6 addresses in brackets, eg:

```
[fe80::dc11:b9b6:514b:134]%eth0:123
[::]
```

This change removes all brackets during parsing.

Without this change, invalid host entries cause stacktraces when passed to the ssl resource as SSLShake will try to do an host address lookup on a invalid host.

```
@@ -1 +1,10 @@
-""
+"/home/miah/projects/github/.gems/inspec-master/ruby/2.6.0/gems/sslshake-1.3.0/lib/sslshake.rb:21:in `getaddrinfo': getaddrinfo: No address associated with hostname (SocketError)
+\tfrom /home/miah/projects/github/.gems/inspec-master/ruby/2.6.0/gems/sslshake-1.3.0/lib/sslshake.rb:21:in `socket'
+\tfrom /home/miah/projects/github/.gems/inspec-master/ruby/2.6.0/gems/sslshake-1.3.0/lib/sslshake.rb:55:in `hello'
+\tfrom /home/miah/projects/github/inspec-master/lib/resources/ssl.rb:70:in `block (2 levels) in <class:SSL>'
+\tfrom /home/miah/projects/github/.gems/inspec-master/ruby/2.6.0/gems/parallel-1.17.0/lib/parallel.rb:504:in `call_with_index'
+\tfrom /home/miah/projects/github/.gems/inspec-master/ruby/2.6.0/gems/parallel-1.17.0/lib/parallel.rb:360:in `block (2 levels) in work_in_threads'
+\tfrom /home/miah/projects/github/.gems/inspec-master/ruby/2.6.0/gems/parallel-1.17.0/lib/parallel.rb:515:in `with_instrumentation'
+\tfrom /home/miah/projects/github/.gems/inspec-master/ruby/2.6.0/gems/parallel-1.17.0/lib/parallel.rb:359:in `block in work_in_threads'
+\tfrom /home/miah/projects/github/.gems/inspec-master/ruby/2.6.0/gems/parallel-1.17.0/lib/parallel.rb:209:in `block (3 levels) in in_threads'
```

Signed-off-by: Miah Johnson <miah@chia-pet.org>