### PR TITLE
Add ed25519 gems in the omnibus group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gem 'ffi', '>= 1.9.14'
 group :omnibus do
   gem 'rb-readline'
   gem 'appbundler'
+  gem 'ed25519' # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
+  gem 'bcrypt_pbkdf' # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
 end
 
 group :test do


### PR DESCRIPTION
We want to have these installed in our omnibus package, but we can't
make them direct deps in train because then a gem install of inspec
would need compilers to install these gems.

Signed-off-by: Tim Smith <tsmith@chef.io>