### PR TITLE
When mssql response is parsed, header might be nil.

### DIFF
--- a/lib/resources/mssql_session.rb
+++ b/lib/resources/mssql_session.rb
@@ -108,7 +108,7 @@ module Inspec::Resources
       results = table.map { |row|
         res = {}
         headers.each { |header|
-          res[header.downcase] = row[header]
+          res[header.downcase] = row[header] if header
         }
         Hashie::Mash.new(res)
       }


### PR DESCRIPTION
Only set and downcase header if its not nil.

FTR:
```
Inspec::Resources::MssqlSession#test_0007_verify mssql_session configuration with local mode:
NoMethodError: undefined method `downcase' for nil:NilClass
    /home/miah/projects/github/inspec-master/lib/resources/mssql_session.rb:111:in `block (2 levels) in parse_csv_result'
    /home/miah/projects/github/inspec-master/lib/resources/mssql_session.rb:110:in `each'
    /home/miah/projects/github/inspec-master/lib/resources/mssql_session.rb:110:in `block in parse_csv_result'
    /home/miah/.rubies/ruby-2.6.2/lib/ruby/2.6.0/csv/table.rb:337:in `each'
    /home/miah/.rubies/ruby-2.6.2/lib/ruby/2.6.0/csv/table.rb:337:in `each'
    /home/miah/projects/github/inspec-master/lib/resources/mssql_session.rb:108:in `map'
    /home/miah/projects/github/inspec-master/lib/resources/mssql_session.rb:108:in `parse_csv_result'
    /home/miah/projects/github/inspec-master/lib/resources/mssql_session.rb:80:in `query'
    /home/miah/projects/github/inspec-master/lib/resources/mssql_session.rb:95:in `test_connection'
    /home/miah/projects/github/inspec-master/lib/resources/mssql_session.rb:54:in `initialize'
    /home/miah/projects/github/inspec-master/lib/inspec/plugin/v1/plugin_types/resource.rb:96:in `initialize'
    /home/miah/projects/github/inspec-master/test/helper.rb:591:in `new'
    /home/miah/projects/github/inspec-master/test/helper.rb:591:in `load_resource'
    /home/miah/projects/github/inspec-master/test/helper.rb:655:in `load_resource'
    /home/miah/projects/github/inspec-master/test/unit/resources/mssql_session_test.rb:59:in `block (2 levels) in <top (required)>'

```

Signed-off-by: Miah Johnson <miah@chia-pet.org>