### PR TITLE
Remove be_immutable matcher

### DIFF
--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -427,11 +427,6 @@ The `be_grouped_into` matcher tests if the file exists as part of the named grou
 
     it { should be_grouped_into 'group' }
 
-### be_immutable
-
-The `be_immutable` matcher tests if the file is immutable, i.e. "cannot be changed":
-
-    it { should be_immutable }
 
 ### be\_linked\_to
 


### PR DESCRIPTION
Removing `be_immutable` matcher from InSpec documentation, due to lack of implementation.

Signed-off-by: Mary Jinglewski <mjinglewski@chef.io>