### PR TITLE
Modernize use of Minitest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,7 +66,7 @@ Rake::TestTask.new do |t|
     'lib/plugins/inspec-*/test/unit/**/*_test.rb',
   ])
   t.warning = false
-  t.verbose = true
+  t.verbose = !!ENV["V"] # default to off. the test commands are _huge_.
   t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
 end
 

--- a/examples/plugins/inspec-resource-lister/test/functional/inspec_resource_lister_test.rb
+++ b/examples/plugins/inspec-resource-lister/test/functional/inspec_resource_lister_test.rb
@@ -6,7 +6,7 @@
 # Include our test harness
 require_relative '../helper'
 
-# Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
+# Because InSpec is a Spec-style test suite, we're going to use Minitest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.
 describe 'inspec list-resources core' do
   # Our helper.rb locates this library from the InSpec install that
@@ -34,7 +34,7 @@ describe 'inspec list-resources core' do
 
     # Some tests through here use minitest Expectations, which attach to all
     # Objects, and begin with 'must' (positive) or 'wont' (negative)
-    # See https://ruby-doc.org/stdlib-2.1.0/libdoc/minitest/rdoc/MiniTest/Expectations.html
+    # See http://docs.seattlerb.org/minitest/Minitest/Expectations.html
     it("should exit successfully") { outcome.exit_status.must_equal(0) }
     it("should be silent on stderr") { outcome.stderr.must_be_empty }
 

--- a/examples/plugins/inspec-resource-lister/test/unit/cli_args_test.rb
+++ b/examples/plugins/inspec-resource-lister/test/unit/cli_args_test.rb
@@ -7,7 +7,7 @@ require_relative '../helper'
 # Load the class under test, the CliCommand definition.
 require 'inspec-resource-lister/cli_command'
 
-# Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
+# Because InSpec is a Spec-style test suite, we're going to use Minitest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.
 describe InspecPlugins::ResourceLister::CliCommand do
 
@@ -28,7 +28,7 @@ describe InspecPlugins::ResourceLister::CliCommand do
 
     # Some tests through here use minitest Expectations, which attach to all
     # Objects, and begin with 'must' (positive) or 'wont' (negative)
-    # See https://ruby-doc.org/stdlib-2.1.0/libdoc/minitest/rdoc/MiniTest/Expectations.html
+    # See http://docs.seattlerb.org/minitest/Minitest/Expectations.html
 
     # Option count OK?
     it "should take one option" do

--- a/examples/plugins/inspec-resource-lister/test/unit/plugin_def_test.rb
+++ b/examples/plugins/inspec-resource-lister/test/unit/plugin_def_test.rb
@@ -7,7 +7,7 @@ require_relative '../helper'
 # Load the class under test, the Plugin definition.
 require 'inspec-resource-lister/plugin'
 
-# Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
+# Because InSpec is a Spec-style test suite, we're going to use Minitest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.
 
 describe InspecPlugins::ResourceLister::Plugin do
@@ -36,7 +36,7 @@ describe InspecPlugins::ResourceLister::Plugin do
 
   # Some tests through here use minitest Expectations, which attach to all
   # Objects, and begin with 'must' (positive) or 'wont' (negative)
-  # See https://ruby-doc.org/stdlib-2.1.0/libdoc/minitest/rdoc/MiniTest/Expectations.html
+  # See http://docs.seattlerb.org/minitest/Minitest/Expectations.html
 
   # The plugin system had an undocumented v1 API; this should be a v2 example.
   it "should be an api-v2 plugin" do

--- a/lib/plugins/inspec-artifact/test/functional/inspec_artifact_test.rb
+++ b/lib/plugins/inspec-artifact/test/functional/inspec_artifact_test.rb
@@ -4,7 +4,7 @@ require_relative '../../../shared/core_plugin_test_helper.rb'
 require 'fileutils'
 require 'securerandom'
 
-class ArtifactCli < MiniTest::Test
+class ArtifactCli < Minitest::Test
   include CorePluginFunctionalHelper
 
   def test_generating_archive_keys

--- a/lib/plugins/inspec-compliance/test/functional/inspec_compliance_test.rb
+++ b/lib/plugins/inspec-compliance/test/functional/inspec_compliance_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../../shared/core_plugin_test_helper.rb'
 
-class ComplianceCli < MiniTest::Test
+class ComplianceCli < Minitest::Test
   include CorePluginFunctionalHelper
 
   def test_help_output

--- a/lib/plugins/inspec-habitat/test/functional/inspec_habitat_test.rb
+++ b/lib/plugins/inspec-habitat/test/functional/inspec_habitat_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../../shared/core_plugin_test_helper.rb'
 require 'fileutils'
 
-class ProfileCli < MiniTest::Test
+class ProfileCli < Minitest::Test
   include CorePluginFunctionalHelper
 
   def setup

--- a/lib/plugins/inspec-habitat/test/unit/profile_test.rb
+++ b/lib/plugins/inspec-habitat/test/unit/profile_test.rb
@@ -3,7 +3,7 @@ require 'fileutils'
 require 'minitest/autorun'
 require_relative '../../lib/inspec-habitat/profile.rb'
 
-class InspecPlugins::Habitat::ProfileTest < MiniTest::Unit::TestCase
+class InspecPlugins::Habitat::ProfileTest < Minitest::Test
   def setup
     @tmpdir = Dir.mktmpdir
 
@@ -76,7 +76,7 @@ class InspecPlugins::Habitat::ProfileTest < MiniTest::Unit::TestCase
   end
 
   def test_create_rasies_if_habitat_is_not_installed
-    cmd = MiniTest::Mock.new
+    cmd = Minitest::Mock.new
     cmd.expect(:error?, true)
     cmd.expect(:run_command, nil)
 
@@ -163,12 +163,12 @@ class InspecPlugins::Habitat::ProfileTest < MiniTest::Unit::TestCase
   end
 
   def test_vendor_profile_dependencies_does_not_vendor_if_already_vendored
-    mock_lock_file = MiniTest::Mock.new
+    mock_lock_file = Minitest::Mock.new
     mock_lock_file.expect(:exist?, true)
-    mock_cache_path = MiniTest::Mock.new
+    mock_cache_path = Minitest::Mock.new
     mock_cache_path.expect(:exist?, true)
 
-    mock = MiniTest::Mock.new
+    mock = Minitest::Mock.new
     mock.expect(:lockfile, mock_lock_file)
     mock.expect(:cache_path, mock_cache_path)
 
@@ -180,10 +180,10 @@ class InspecPlugins::Habitat::ProfileTest < MiniTest::Unit::TestCase
   end
 
   def test_vendor_profile_dependencies
-    mock_lock_file = MiniTest::Mock.new
+    mock_lock_file = Minitest::Mock.new
     mock_lock_file.expect(:exist?, false)
 
-    mock = MiniTest::Mock.new
+    mock = Minitest::Mock.new
     mock.expect(:lockfile, mock_lock_file)
     mock.expect(:vendor!, nil)
     mock.expect(:make_readable, nil)
@@ -197,7 +197,7 @@ class InspecPlugins::Habitat::ProfileTest < MiniTest::Unit::TestCase
   end
 
   def test_verify_habitat_setup_raises_if_hab_version_errors
-    mock = MiniTest::Mock.new
+    mock = Minitest::Mock.new
     mock.expect(:run_command, nil)
     mock.expect(:error?, true)
     mock.expect(:stderr, 'This would be an error message')
@@ -210,7 +210,7 @@ class InspecPlugins::Habitat::ProfileTest < MiniTest::Unit::TestCase
   end
 
   def test_verify_habitat_setup_raises_if_not_habitat_origin
-    mock = MiniTest::Mock.new
+    mock = Minitest::Mock.new
     mock.expect(:run_command, nil)
     mock.expect(:error?, false)
 
@@ -226,7 +226,7 @@ class InspecPlugins::Habitat::ProfileTest < MiniTest::Unit::TestCase
   # end
 
   def test_upload_hart_raises_if_hab_pkg_upload_fails
-    mock = MiniTest::Mock.new
+    mock = Minitest::Mock.new
     mock.expect(:run_command, nil)
     mock.expect(:error?, true)
     mock.expect(:stdout, 'This would contain output from `hab`')

--- a/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/test/functional/inspec_plugin_template_test.rb
+++ b/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/test/functional/inspec_plugin_template_test.rb
@@ -6,7 +6,7 @@
 # Include our test harness
 require_relative '../helper'
 
-# Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
+# Because InSpec is a Spec-style test suite, we're going to use Minitest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.
 describe 'inspec list-resources core' do
   # Our helper.rb locates this library from the InSpec install that
@@ -34,7 +34,7 @@ describe 'inspec list-resources core' do
 
     # Some tests through here use minitest Expectations, which attach to all
     # Objects, and begin with 'must' (positive) or 'wont' (negative)
-    # See https://ruby-doc.org/stdlib-2.1.0/libdoc/minitest/rdoc/MiniTest/Expectations.html
+    # See http://docs.seattlerb.org/minitest/Minitest/Expectations.html
     it("should exit successfully") { outcome.exit_status.must_equal(0) }
     it("should be silent on stderr") { outcome.stderr.must_be_empty }
 

--- a/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/test/helper.rb
+++ b/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/test/helper.rb
@@ -19,8 +19,7 @@ require 'inspec/plugin/v2'
 # You can select from a number of test harnesses.  Since InSpec uses Spec-style controls
 # in profile code, you will probably want to use something like minitest/spec, which provides
 # Spec-style tests.
-require 'minitest/spec'
-require 'minitest/autorun'
+require 'minitest/autorun' # loads all styles and runs tests automatically
 
 # You might want to put some debugging tools here.  We run tests to find bugs, after all.
 require 'byebug'

--- a/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/test/unit/cli_args_test.rb
+++ b/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/test/unit/cli_args_test.rb
@@ -7,7 +7,7 @@ require_relative '../helper'
 # Load the class under test, the CliCommand definition.
 require '<%= plugin_name %>/cli_command'
 
-# Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
+# Because InSpec is a Spec-style test suite, we're going to use Minitest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.
 describe InspecPlugins::<%= module_name %>::CliCommand do
 
@@ -31,7 +31,7 @@ describe InspecPlugins::<%= module_name %>::CliCommand do
 
     # Some tests through here use minitest Expectations, which attach to all
     # Objects, and begin with 'must' (positive) or 'wont' (negative)
-    # See https://ruby-doc.org/stdlib-2.1.0/libdoc/minitest/rdoc/MiniTest/Expectations.html
+    # See http://docs.seattlerb.org/minitest/Minitest/Expectations.html
 
     # Option count OK?
     it "should take one option" do

--- a/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/test/unit/plugin_def_test.rb
+++ b/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/test/unit/plugin_def_test.rb
@@ -7,7 +7,7 @@ require_relative '../helper'
 # Load the class under test, the Plugin definition.
 require '<%= plugin_name %>/plugin'
 
-# Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
+# Because InSpec is a Spec-style test suite, we're going to use Minitest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.
 
 describe InspecPlugins::<%= module_name %>::Plugin do
@@ -36,7 +36,7 @@ describe InspecPlugins::<%= module_name %>::Plugin do
 
   # Some tests through here use minitest Expectations, which attach to all
   # Objects, and begin with 'must' (positive) or 'wont' (negative)
-  # See https://ruby-doc.org/stdlib-2.1.0/libdoc/minitest/rdoc/MiniTest/Expectations.html
+  # See http://docs.seattlerb.org/minitest/Minitest/Expectations.html
 
   # The plugin system had an undocumented v1 API; this should be a v2 example.
   it "should be an api-v2 plugin" do

--- a/lib/plugins/inspec-init/test/functional/inspec_init_plugin_test.rb
+++ b/lib/plugins/inspec-init/test/functional/inspec_init_plugin_test.rb
@@ -1,6 +1,6 @@
 require_relative '../../../shared/core_plugin_test_helper.rb'
 
-class InitPluginCli < MiniTest::Test
+class InitPluginCli < Minitest::Test
   include CorePluginFunctionalHelper
 
   def test_generating_inspec_plugin_correct_prefix_required

--- a/lib/plugins/inspec-init/test/functional/inspec_init_profile_test.rb
+++ b/lib/plugins/inspec-init/test/functional/inspec_init_profile_test.rb
@@ -3,7 +3,7 @@
 require 'yaml'
 require_relative '../../../shared/core_plugin_test_helper.rb'
 
-class InitCli < MiniTest::Test
+class InitCli < Minitest::Test
   include CorePluginFunctionalHelper
 
   def test_generating_inspec_profile

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
@@ -46,7 +46,7 @@ end
 #-----------------------------------------------------------------------------------------#
 #                                   inspec help
 #-----------------------------------------------------------------------------------------#
-class PluginManagerCliHelp < MiniTest::Test
+class PluginManagerCliHelp < Minitest::Test
   include CorePluginFunctionalHelper
 
   # Main inspec help subcommand listing
@@ -69,7 +69,7 @@ end
 #-----------------------------------------------------------------------------------------#
 #                                 inspec plugin list
 #-----------------------------------------------------------------------------------------#
-class PluginManagerCliList < MiniTest::Test
+class PluginManagerCliList < Minitest::Test
   include CorePluginFunctionalHelper
   include PluginManagerHelpers
 
@@ -139,7 +139,7 @@ end
 #-----------------------------------------------------------------------------------------#
 #                               inspec plugin search
 #-----------------------------------------------------------------------------------------#
-class PluginManagerCliSearch < MiniTest::Test
+class PluginManagerCliSearch < Minitest::Test
   include CorePluginFunctionalHelper
   include PluginManagerHelpers
 
@@ -248,7 +248,7 @@ end
 #-----------------------------------------------------------------------------------------#
 #                               inspec plugin install
 #-----------------------------------------------------------------------------------------#
-class PluginManagerCliInstall < MiniTest::Test
+class PluginManagerCliInstall < Minitest::Test
   include CorePluginFunctionalHelper # gives us instance methods, like `let` aliases inside test methods
   extend CorePluginFunctionalHelper  # gives us class methods, like `let` aliases out here outside test methods
 
@@ -581,7 +581,7 @@ end
 #-----------------------------------------------------------------------------------------#
 #                               inspec plugin update
 #-----------------------------------------------------------------------------------------#
-class PluginManagerCliUpdate < MiniTest::Test
+class PluginManagerCliUpdate < Minitest::Test
   include CorePluginFunctionalHelper
   include PluginManagerHelpers
 
@@ -654,7 +654,7 @@ end
 #-----------------------------------------------------------------------------------------#
 #                               inspec plugin uninstall
 #-----------------------------------------------------------------------------------------#
-class PluginManagerCliUninstall < MiniTest::Test
+class PluginManagerCliUninstall < Minitest::Test
   include CorePluginFunctionalHelper
   include PluginManagerHelpers
 

--- a/lib/plugins/inspec-plugin-manager-cli/test/unit/cli_args_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/unit/cli_args_test.rb
@@ -3,7 +3,7 @@ require_relative '../../../shared/core_plugin_test_helper.rb'
 #-----------------------------------------------------------------------#
 # Thor option defs
 #-----------------------------------------------------------------------#
-class PluginManagerCliOptions < MiniTest::Test
+class PluginManagerCliOptions < Minitest::Test
   include CorePluginUnitHelper
   let(:cli_class) { InspecPlugins::PluginManager::CliCommand }
 

--- a/lib/plugins/inspec-plugin-manager-cli/test/unit/plugin_def_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/unit/plugin_def_test.rb
@@ -3,7 +3,7 @@ require_relative '../../../shared/core_plugin_test_helper.rb'
 #-----------------------------------------------------------------------#
 # Plugin Definition
 #-----------------------------------------------------------------------#
-class PluginManagerCliDefinitionTests < MiniTest::Test
+class PluginManagerCliDefinitionTests < Minitest::Test
   include CorePluginUnitHelper
 
   def test_plugin_registered

--- a/lib/plugins/shared/core_plugin_test_helper.rb
+++ b/lib/plugins/shared/core_plugin_test_helper.rb
@@ -1,9 +1,6 @@
-
-# Load test harness - MiniTest
+# Load test harness - Minitest
 require 'minitest/autorun'
-require 'minitest/unit'
 require 'minitest/pride'
-require 'minitest/spec'
 
 # Data formats commonly used in testing
 require 'json'
@@ -15,7 +12,7 @@ require 'tmpdir'
 require 'pathname'
 require 'forwardable'
 
-# Configure MiniTest to expose things like `let`
+# Configure Minitest to expose things like `let`
 class Module
   include Minitest::Spec::DSL
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,7 +10,6 @@ SimpleCov.start do
 end
 
 require 'minitest/autorun'
-require 'minitest/spec'
 require 'webmock/minitest'
 require 'mocha/setup'
 require 'fileutils'

--- a/test/unit/helper.rb
+++ b/test/unit/helper.rb
@@ -1,5 +1,4 @@
 require 'minitest/autorun'
-require 'minitest/unit'
 require 'minitest/pride'
 
 # Data formats commonly used in testing

--- a/test/unit/plugin/v1/plugin_test.rb
+++ b/test/unit/plugin/v1/plugin_test.rb
@@ -4,7 +4,6 @@
 
 # TODO: do not use helper, since all plugins are loaded statically
 require 'minitest/autorun'
-require 'minitest/spec'
 require 'mocha/setup'
 
 require 'inspec/plugin/v1/plugin_types/cli'

--- a/test/unit/plugin/v2/api_base_test.rb
+++ b/test/unit/plugin/v2/api_base_test.rb
@@ -1,9 +1,8 @@
 require 'minitest/autorun'
-require 'minitest/test'
 
 require_relative '../../../../lib/inspec/plugin/v2'
 
-class PluginV2VersionedApiTests < MiniTest::Test
+class PluginV2VersionedApiTests < Minitest::Test
   # you can call Inspec.plugin(2) and get the plugin base class
   def test_calling_Inspec_dot_plugin_with_2_returns_the_plugin_base_class
     klass = Inspec.plugin(2)
@@ -19,7 +18,7 @@ class PluginV2VersionedApiTests < MiniTest::Test
 
 end
 
-class PluginV2BaseMgmtMethods < MiniTest::Test
+class PluginV2BaseMgmtMethods < Minitest::Test
   def test_plugin_v2_management_class_methods_present
     [
       :base_class_for_type,
@@ -39,7 +38,7 @@ class PluginV2BaseMgmtMethods < MiniTest::Test
   end
 end
 
-class PluginV2BaseDslMethods < MiniTest::Test
+class PluginV2BaseDslMethods < Minitest::Test
   def test_plugin_v2_dsl_methods_present
     [
       :plugin_name,

--- a/test/unit/plugin/v2/api_cli_test.rb
+++ b/test/unit/plugin/v2/api_cli_test.rb
@@ -1,10 +1,9 @@
 require 'minitest/autorun'
-require 'minitest/test'
 require 'byebug'
 
 require_relative '../../../../lib/inspec/plugin/v2'
 
-class CliCommandSuperclassTests < MiniTest::Test
+class CliCommandSuperclassTests < Minitest::Test
   # you can call Inspec.plugin(2, :cli_command) and get the plugin base class
   def test_calling_Inspec_dot_plugin_with_cli_returns_the_cli_base_class
     klass = Inspec.plugin(2, :cli_command)
@@ -29,7 +28,7 @@ class CliCommandSuperclassTests < MiniTest::Test
   end
 end
 
-class CliCommandPluginV2API < MiniTest::Test
+class CliCommandPluginV2API < Minitest::Test
   def test_cli_command_api_methods_present
     # instance methods
     [

--- a/test/unit/plugin/v2/api_dsl_test.rb
+++ b/test/unit/plugin/v2/api_dsl_test.rb
@@ -1,7 +1,6 @@
 # Tests for the *DSL plugin types
 
 require 'minitest/autorun'
-require 'minitest/test'
 require 'byebug'
 
 require_relative '../../../../lib/inspec/plugin/v2'
@@ -16,7 +15,7 @@ module DslUnitTests
     :resource_dsl,
   ].each do |plugin_type_under_test|
 
-    Class.new(MiniTest::Test) do
+    Class.new(Minitest::Test) do
       # Assign name to anonymous class, so test output is meaningful
       Object.const_set(plugin_type_under_test.to_s.upcase + '_UnitTests', self)
 

--- a/test/unit/plugin/v2/back_compat_test.rb
+++ b/test/unit/plugin/v2/back_compat_test.rb
@@ -1,9 +1,8 @@
 require 'minitest/autorun'
-require 'minitest/test'
 require_relative '../../../../lib/inspec'
 
 module PluginV2BackCompat
-  class PluginV1TypeClassFetchers < MiniTest::Test
+  class PluginV1TypeClassFetchers < Minitest::Test
 
     # Note: we can't call klass.name, because that is redefined as a setter.
 

--- a/test/unit/plugin/v2/installer_test.rb
+++ b/test/unit/plugin/v2/installer_test.rb
@@ -1,5 +1,4 @@
 require 'minitest/autorun'
-require 'minitest/test'
 # Other unit tests include the webmock framework, which is process-wide.
 # We need to disable it, or else mock many, many rubygems API calls.
 require 'webmock/minitest'
@@ -62,7 +61,7 @@ end
 #-----------------------------------------------------------------------#
 # basics
 #-----------------------------------------------------------------------#
-class PluginInstallerBasicTests < MiniTest::Test
+class PluginInstallerBasicTests < Minitest::Test
   include InstallerTestHelpers
 
   # it's a singleton
@@ -90,7 +89,7 @@ end
 #-----------------------------------------------------------------------#
 # Installing
 #-----------------------------------------------------------------------#
-class PluginInstallerInstallationTests < MiniTest::Test
+class PluginInstallerInstallationTests < Minitest::Test
   include InstallerTestHelpers
 
   # While this is a negative test case on the prefix checking, there are
@@ -250,7 +249,7 @@ end
 #-----------------------------------------------------------------------#
 # Updating
 #-----------------------------------------------------------------------#
-class PluginInstallerUpdaterTests < MiniTest::Test
+class PluginInstallerUpdaterTests < Minitest::Test
   include InstallerTestHelpers
 
   def test_update_using_path_not_allowed
@@ -342,7 +341,7 @@ end
 #-----------------------------------------------------------------------#
 # Uninstalling
 #-----------------------------------------------------------------------#
-class PluginInstallerUninstallTests < MiniTest::Test
+class PluginInstallerUninstallTests < Minitest::Test
   include InstallerTestHelpers
 
   def test_uninstalling_a_nonexistant_plugin_is_an_error
@@ -432,7 +431,7 @@ end
 #-----------------------------------------------------------------------#
 # Searching
 #-----------------------------------------------------------------------#
-class PluginInstallerSearchTests < MiniTest::Test
+class PluginInstallerSearchTests < Minitest::Test
   include InstallerTestHelpers
 
   def test_search_for_plugin_by_exact_name

--- a/test/unit/plugin/v2/loader_test.rb
+++ b/test/unit/plugin/v2/loader_test.rb
@@ -1,12 +1,11 @@
 # Unit tests for Inspec::PluginLoader and Registry
 
 require 'minitest/autorun'
-require 'minitest/test'
 require_relative '../../../../lib/inspec/plugin/v2'
 
 require 'train' # Needed for Train plugin testing
 
-class PluginLoaderTests < MiniTest::Test
+class PluginLoaderTests < Minitest::Test
 
   @@orig_home = Dir.home
 

--- a/test/unit/plugin/v2/plugin_conf_test.rb
+++ b/test/unit/plugin/v2/plugin_conf_test.rb
@@ -1,4 +1,3 @@
-require 'minitest/spec'
 require 'minitest/autorun'
 require 'tmpdir'
 require_relative '../../../../lib/inspec/plugin/v2'

--- a/test/unit/ui_test.rb
+++ b/test/unit/ui_test.rb
@@ -1,7 +1,6 @@
 # require 'helper'
 
-require 'minitest'
-require 'minitest/spec'
+require 'minitest/autorun'
 require 'inspec/ui'
 require 'inspec/base_cli'
 require 'inspec/errors'

--- a/test/unit/utils/deprecation_test.rb
+++ b/test/unit/utils/deprecation_test.rb
@@ -1,5 +1,4 @@
-require 'minitest'
-require 'minitest/spec'
+require 'minitest/autorun'
 require 'stringio'
 
 require 'utils/deprecation'


### PR DESCRIPTION
+ Turn off verbosity in Rakefile by default. Use `rake V=1` to turn back on.
+ MiniTest -> Minitest everywhere.
+ MiniTest::Unit::TestCase -> Minitest::Test everywhere.
+ Updated minitest doco urls to official and up-to-date site.
+ Normalize requires. Only needs "minitest/autorun" and "minitest/pride".

This is a low priority and can wait.