### PR TITLE
Bump appveyor.yml to build on 2.6 for unit-tests-ruby-2.6.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ environment:
       ruby_version: "24"
     - name: unit-tests-ruby-2.5.1
       ruby_version: "25"
+    - name: unit-tests-ruby-2.6
+      ruby_version: "26"
     - name: functional-tests-1
       ruby_version: "25"
     - name: functional-tests-2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,11 @@ environment:
     - name: unit-tests-ruby-2.6
       ruby_version: "26"
     - name: functional-tests-1
-      ruby_version: "25"
+      ruby_version: "26"
     - name: functional-tests-2
-      ruby_version: "25"
+      ruby_version: "26"
     - name: functional-tests-3
-      ruby_version: "25"
+      ruby_version: "26"
 clone_folder: c:\projects\inspec
 clone_depth: 1
 


### PR DESCRIPTION
Fixes windows testing for this variant. (Untested)