### PR TITLE
Appveyor Config Changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ cache:
 install:
   - systeminfo
   - winrm quickconfig -q
-  - SET PATH=C:\Ruby%ruby_version%-x64\bin;%PATH%
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%
   - ruby --version
   - gem --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,20 +11,21 @@ platform:
 environment:
   matrix:
     - name: unit-tests-ruby-2.4.4
-      ruby_version: "24"
+      ruby_version: "24-x64"
     - name: unit-tests-ruby-2.5
-      ruby_version: "25"
+      ruby_version: "25-x64"
     - name: unit-tests-ruby-2.6
-      ruby_version: "26"
+      ruby_version: "26-x64"
     - name: functional-tests-1
-      ruby_version: "26"
+      ruby_version: "26-x64"
     - name: functional-tests-2
-      ruby_version: "26"
+      ruby_version: "26-x64"
     - name: functional-tests-3
-      ruby_version: "26"
+      ruby_version: "26-x64"
 clone_folder: c:\projects\inspec
 clone_depth: 1
-
+# Disable MSBuild mode entirely
+build: off
 skip_commits:
   # version bumps by Expeditor happen as a separate commit after the merge, we can skip
   author: Chef Expeditor
@@ -51,7 +52,7 @@ cache:
 install:
   - systeminfo
   - winrm quickconfig -q
-  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - SET PATH=C:\Ruby%ruby_version%-x64\bin;%PATH%
   - echo %PATH%
   - ruby --version
   - gem --version


### PR DESCRIPTION
Enable 64bit Ruby for 24, 25, and 26.
Disable MSBuild mode entirely.

Signed-off-by: Miah Johnson <miah@chia-pet.org>