### PR TITLE
Add Coveralls.io support to InSpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :omnibus do
 end
 
 group :test do
+  gem 'coveralls', require: false
   gem 'minitest', '~> 5.5'
   gem 'rake', '>= 10'
   gem 'rubocop', '= 0.49.1'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Slack](https://community-slack.chef.io/badge.svg)](https://community-slack.chef.io/)
 [![Build Status Master](https://travis-ci.org/inspec/inspec.svg?branch=master)](https://travis-ci.org/inspec/inspec)
 [![Build Status Master](https://ci.appveyor.com/api/projects/status/github/inspec/inspec?branch=master&svg=true&passingText=master%20-%20Ok&pendingText=master%20-%20Pending&failingText=master%20-%20Failing)](https://ci.appveyor.com/project/Chef/inspec/branch/master)
+[![Coverage Status](https://coveralls.io/repos/github/inspec/inspec/badge.svg?branch=master)](https://coveralls.io/github/inspec/inspec?branch=master)
 
 InSpec is an open-source testing framework for infrastructure with a human- and machine-readable language for specifying compliance, security and policy requirements.
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,13 @@
 # encoding: utf-8
-# author: Dominik Richter
-# author: Christoph Hartmann
+
 require 'simplecov'
+require 'coveralls'
+
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+])
+
 SimpleCov.start do
   add_filter '/test/'
   add_group 'Resources', 'lib/resources'


### PR DESCRIPTION
The goal with this PR is to add 'coveralls' to our pipeline. This means all PR's would get checked for test coverage and coveralls would give us a inline report. This would be useful for contributors getting immediate feedback and help make sure we all do better with test coverage.

I also have a similar PR to add codeclimate which can also do test coverage (but I haven't enabled that feature as it requires changing travis/appveyor settings). codeclimate is mostly focused on code complexity and maintainability.

https://coveralls.io/github/inspec/inspec

https://github.com/inspec/inspec/pull/4044

Signed-off-by: Miah Johnson <miah@chia-pet.org>