### PR TITLE
Update to Ruby 2.6.2 and Rubygems 3.0.3

### DIFF
--- a/omnibus/.gitignore
+++ b/omnibus/.gitignore
@@ -2,11 +2,11 @@
 .bundle
 .cache/*
 .kitchen/
-.kitchen.local.yml
 vendor/bundle
 pkg/*
-.vagrant
+kitchen.local.yml
 bin/*
 files/**/cache/
 vendor/cookbooks
 Berksfile.lock
+Gemfile.local

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -14,6 +14,12 @@ group :development do
 
   # Use Test Kitchen with Vagrant for converging the build environment
   gem 'kitchen-vagrant', '>= 1.3.1'
-  gem 'test-kitchen',    '>= 1.21'
+  gem 'test-kitchen', '>= 1.23'
   gem 'winrm-fs', '~> 1.0'
 end
+
+instance_eval(ENV['GEMFILE_MOD']) if ENV['GEMFILE_MOD']
+
+# If you want to load debugging tools into the bundle exec sandbox,
+# add these additional dependencies into Gemfile.local
+eval_gemfile(__FILE__ + '.local') if File.exist?(__FILE__ + '.local')

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,16 +1,6 @@
 # encoding: utf-8
 source 'https://rubygems.org'
 
-# Install omnibus
-# Sadly due to an ongoing msys2 issue, producing windows builds requires
-# the two branches below.
-# gem 'omnibus', github: 'chef/omnibus', branch: 'ksubrama/gcc_investigate'
-
-# Use Chef's software definitions. It is recommended that you write your own
-# software definitions, but you can clone/fork Chef's to get you started.
-# gem 'omnibus-software', github: 'chef/omnibus-software', branch: 'ksubrama/ruby23'
-
-# Use entries from chef's Gemfile
 gem 'omnibus', git: 'https://github.com/chef/omnibus', branch: 'master'
 gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software', branch: 'master'
 
@@ -23,7 +13,7 @@ group :development do
   gem 'berkshelf', '>= 7.0'
 
   # Use Test Kitchen with Vagrant for converging the build environment
-  gem 'kitchen-vagrant', '~> 1.3.1'
-  gem 'test-kitchen',    '~> 1.21'
+  gem 'kitchen-vagrant', '>= 1.3.1'
+  gem 'test-kitchen',    '>= 1.21'
   gem 'winrm-fs', '~> 1.0'
 end

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -12,14 +12,14 @@ the required gems are installed:
 $ bundle install --binstubs
 ```
 
-Usage
------
+## Usage
+
 ### Build
 
 You create a platform-specific package using the `build project` command:
 
 ```shell
-$ bin/omnibus build inspec
+$ bundle exec omnibus build inspec
 ```
 
 The platform/architecture type of the package created will match the platform
@@ -33,34 +33,30 @@ You can clean up all temporary files generated during the build process with
 the `clean` command:
 
 ```shell
-$ bin/omnibus clean inspec
-```
+$ bundle exec omnibus clean inspec
 
 Adding the `--purge` purge option removes __ALL__ files generated during the
 build including the project install directory (`/opt/inspec`) and
 the package cache directory (`/var/cache/omnibus/pkg`):
 
 ```shell
-$ bin/omnibus clean inspec --purge
+$ bundle exec omnibus clean inspec --purge
 ```
 
 ### Publish
 
-Omnibus has a built-in mechanism for releasing to a variety of "backends", such
-as Amazon S3. You must set the proper credentials in your `omnibus.rb` config
-file or specify them via the command line.
+Omnibus has a built-in mechanism for releasing to a variety of "backends", such as Amazon S3 and Artifactory. You must set the proper credentials in your `omnibus.rb` config file or specify them via the command line.
 
 ```shell
-$ bin/omnibus publish path/to/*.deb --backend s3
+$ bundle exec omnibus publish path/to/*.deb --backend s3
 ```
 
 ### Help
 
-Full help for the Omnibus command line interface can be accessed with the
-`help` command:
+Full help for the Omnibus command line interface can be accessed with the `help` command:
 
 ```shell
-$ bin/omnibus help
+$ bundle exec omnibus help
 ```
 
 Version Manifest

--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -38,7 +38,7 @@ build_version Inspec::VERSION
 build_iteration 1
 
 # Load dynamically updated overrides
-overrides_path = File.expand_path('../../../../omnibus_overrides.rb', current_file)
+overrides_path = File.expand_path('../../../../omnibus_overrides.rb', __FILE__)
 instance_eval(IO.read(overrides_path), overrides_path)
 
 dependency 'preparation'
@@ -58,10 +58,8 @@ dependency 'ruby-cleanup'
 
 package :rpm do
   signing_passphrase ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']
-  unless rhel? && platform_version.satisfies?('< 6')
-    compression_level 1
-    compression_type :xz
-  end
+  compression_level 1
+  compression_type :xz
 end
 
 package :deb do

--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -39,7 +39,7 @@ build_iteration 1
 
 # Load dynamically updated overrides
 overrides_path = File.expand_path('../../../../omnibus_overrides.rb', __FILE__)
-instance_eval(IO.read(overrides_path), overrides_path)
+instance_eval(File.read(overrides_path), overrides_path)
 
 dependency 'preparation'
 

--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -37,14 +37,9 @@ end
 build_version Inspec::VERSION
 build_iteration 1
 
-override 'ruby', version: '2.5.3'
-# RubyGems 2.7.0 caused issues in the Jenkins pipelines, trouble installing bundler.
-# This issue is not evident in 2.6.x, hence the pin.
-override 'rubygems', version: '2.6.14'
-
-# grab the current train release from rubygems.org
-train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
-override 'train', version: "v#{train_stable}"
+# Load dynamically updated overrides
+overrides_path = File.expand_path('../../../../omnibus_overrides.rb', current_file)
+instance_eval(IO.read(overrides_path), overrides_path)
 
 dependency 'preparation'
 

--- a/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
+++ b/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: Copyright 2014-2016, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -29,8 +29,6 @@ platforms:
     run_list: apt::default
   - name: debian-9
     run_list: apt::default
-  - name: ubuntu-14.04
-    run_list: apt::default
   - name: ubuntu-16.04
     run_list: apt::default
   - name: ubuntu-18.04

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -36,21 +36,9 @@ s3_access_key  ENV['AWS_ACCESS_KEY_ID']
 s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
 s3_bucket      'opscode-omnibus-cache'
 
-# Customize compiler bits
-# ------------------------------
-# solaris_compiler 'gcc'
-
-# Configure retries
-# similar settings to chef/chef
-# ------------------------------
 build_retries 3
 fetcher_retries 3
 fetcher_read_timeout 120
-
-# Load additional software
-# ------------------------------
-# software_gems ['omnibus-software']
-# local_software_dirs ['/path/to/local/software']
 
 # Windows architecture defaults
 # ------------------------------

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,1 +1,12 @@
-# this file is used to override versions of packages in the omnibus build
+# THIS IS NOW HAND MANAGED, JUST EDIT THE THING
+# .travis.yml and appveyor.yml consume this,
+# try to keep it machine-parsable.
+#
+# NOTE: You MUST update omnibus-software when adding new versions of
+# software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
+override :rubygems, version: '3.0.3'
+override :bundler, version: '1.17.3'
+# grab the current train release from rubygems.org
+train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
+override 'train', version: "v#{train_stable}"
+override 'ruby', version: '2.6.2'


### PR DESCRIPTION
We thought we were riding the latest, but actually the overrides file wasn't wired up the same way it is in Chef. This properly sources that file and does a few other syncs from the chef config so we can diff things more easily.

This resolves:

- CVE-2019-8320: Delete directory using symlink when decompressing tar
- CVE-2019-8321: Escape sequence injection vulnerability in verbose
- CVE-2019-8322: Escape sequence injection vulnerability in gem owner
- CVE-2019-8323: Escape sequence injection vulnerability in API response handling
- CVE-2019-8324: Installing a malicious gem may lead to arbitrary code execution
- CVE-2019-8325: Escape sequence injection vulnerability in errors
- Prevent path traversal when writing to a symlinked basedir outside of the root. Discovered by nmalkin and David Fifield, fixed by Jonathan Claudius and Samuel Giddins.
- Fix possible Unsafe Object Deserialization Vulnerability in gem owner. Fixed by Jonathan Claudius.
- Strictly interpret octal fields in tar headers. Discoved by plover, fixed by Samuel Giddins.
- Raise a security error when there are duplicate files in a package. Discovered by plover, fixed by Samuel Giddins.
- Enforce URL validation on spec homepage attribute. Discovered by Yasin Soliman, fixed by Jonathan Claudius.
- Mitigate XSS vulnerability in homepage attribute when displayed via gem server. Discovered by Yasin Soliman, fixed by Jonathan Claudius.
- Prevent Path Traversal issue during gem installation. Discovered by nmalkin and David Fifield.




Signed-off-by: Tim Smith <tsmith@chef.io>