### PR TITLE
Fix promotion of the inspec-bin gem in Expeditor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -6,8 +6,7 @@ product_key: inspec
 rubygems:
  - inspec
  - inspec-core
- - inspec-bin:
-     gemspec_path: ./inspec-bin/
+ - inspec-bin
 
 docker_images:
   - inspec:


### PR DESCRIPTION
The previous config failed to promote inspec-bin to stable.

Signed-off-by: Tim Smith <tsmith@chef.io>