### PR TITLE
Apply new UI code to CLI and plugin-manager-cli

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,8 @@
 version: "2"
 checks:
+  method-lines:
+    config:
+      threshold: 40
   file-lines:
     enabled: false
   identical-code:

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -123,15 +123,15 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       puts JSON.generate(result)
     else
       %w{location profile controls timestamp valid}.each do |item|
-        prepared_string = format('%-12s %s',
+        prepared_string = format("%-12s %s",
                                  "#{item.to_s.capitalize} :",
                                  result[:summary][item.to_sym])
         ui.plain_line(prepared_string)
       end
       puts
 
-      if result[:errors].empty? and result[:warnings].empty?
-        ui.plain_line('No errors or warnings')
+      if result[:errors].empty? && result[:warnings].empty?
+        ui.plain_line("No errors or warnings")
       else
         item_msg = lambda { |item|
           pos = [item[:file], item[:line], item[:column]].compact.join(":")
@@ -198,7 +198,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     result = profile.check
 
     if result && !o[:ignore_errors] == false
-      o[:logger].info 'Profile check failed. Please fix the profile before generating an archive.'
+      o[:logger].info "Profile check failed. Please fix the profile before generating an archive."
       return ui.exit Inspec::UI::EXIT_USAGE_ERROR
     end
 
@@ -308,7 +308,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     if o["format"] == "json"
       puts res.to_json
     else
-      ui.headline('Platform Details')
+      ui.headline("Platform Details")
       ui.plain Inspec::BaseCLI.format_platform_info(params: res, indent: 0, color: 36)
     end
   rescue ArgumentError, RuntimeError, Train::UserError => e

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -148,7 +148,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
         ui.plain_line("Summary:     #{errors}, #{warnings}")
       end
     end
-    ui.exit 1 unless result[:summary][:valid]
+    ui.exit Inspec::UI::EXIT_USAGE_ERROR unless result[:summary][:valid]
   rescue StandardError => e
     pretty_handle_exception(e)
   end
@@ -199,11 +199,11 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 
     if result && !o[:ignore_errors] == false
       o[:logger].info 'Profile check failed. Please fix the profile before generating an archive.'
-      return ui.exit 1
+      return ui.exit Inspec::UI::EXIT_USAGE_ERROR
     end
 
     # generate archive
-    ui.exit 1 unless profile.archive(o)
+    ui.exit Inspec::UI::EXIT_USAGE_ERROR unless profile.archive(o)
   rescue StandardError => e
     pretty_handle_exception(e)
   end
@@ -293,7 +293,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     ui.exit runner.run
   rescue ArgumentError, RuntimeError, Train::UserError => e
     $stderr.puts e.message
-    ui.exit 1
+    ui.exit Inspec::UI::EXIT_USAGE_ERROR
   rescue StandardError => e
     pretty_handle_exception(e)
   end
@@ -313,7 +313,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     end
   rescue ArgumentError, RuntimeError, Train::UserError => e
     $stderr.puts e.message
-    ui.exit 1
+    ui.exit Inspec::UI::EXIT_USAGE_ERROR
   rescue StandardError => e
     pretty_handle_exception(e)
   end
@@ -349,7 +349,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     # No InSpec tests - just print evaluation output.
     res = (res.respond_to?(:to_json) ? res.to_json : JSON.dump(res)) if o["reporter"]&.keys&.include?("json")
     puts res
-    ui.exit 0
+    ui.exit Inspec::UI::EXIT_NORMAL
   rescue RuntimeError, Train::UserError => e
     $stderr.puts e.message
   rescue StandardError => e
@@ -459,5 +459,5 @@ rescue Inspec::Plugin::V2::Exception => v2ex
   else
     Inspec::Log.error "Run again with --debug for a stacktrace."
   end
-  ui.exit 2
+  ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
 end

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -123,36 +123,32 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       puts JSON.generate(result)
     else
       %w{location profile controls timestamp valid}.each do |item|
-        puts format("%-12s %s", item.to_s.capitalize + ":",
-          mark_text(result[:summary][item.to_sym]))
+        prepared_string = format('%-12s %s',
+                                 (item.to_s.capitalize + ':'),
+                                 result[:summary][item.to_sym])
+        ui.plain_line(prepared_string)
       end
       puts
 
-      if result[:errors].empty? && result[:warnings].empty?
-        puts "No errors or warnings"
+      if result[:errors].empty? and result[:warnings].empty?
+        ui.plain_line('No errors or warnings')
       else
-        red    = "\033[31m"
-        yellow = "\033[33m"
-        rst    = "\033[0m"
-
         item_msg = lambda { |item|
           pos = [item[:file], item[:line], item[:column]].compact.join(":")
           pos.empty? ? item[:msg] : pos + ": " + item[:msg]
         }
-        result[:errors].each do |item|
-          puts "#{red}  ✖  #{item_msg.call(item)}#{rst}"
-        end
-        result[:warnings].each do |item|
-          puts "#{yellow}  !  #{item_msg.call(item)}#{rst}"
-        end
+
+        result[:errors].each { |item| ui.red " #{Inspec::UI::GLYPHS[:script_x]}  #{item_msg.call(item)}\n" }
+        result[:warnings].each { |item| ui.yellow " !  #{item_msg.call(item)}\n" }
 
         puts
-        puts format("Summary:     %s%d errors%s, %s%d warnings%s",
-          red, result[:errors].length, rst,
-          yellow, result[:warnings].length, rst)
+
+        errors = ui.red(result[:errors].length.to_s + ' errors', print: false)
+        warnings = ui.yellow(result[:warnings].length.to_s + ' warnings', print: false)
+        ui.plain_line("Summary:     #{errors}, #{warnings}")
       end
     end
-    exit 1 unless result[:summary][:valid]
+    ui.exit 1 unless result[:summary][:valid]
   rescue StandardError => e
     pretty_handle_exception(e)
   end
@@ -202,12 +198,12 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     result = profile.check
 
     if result && !o[:ignore_errors] == false
-      o[:logger].info "Profile check failed. Please fix the profile before generating an archive."
-      return exit 1
+      o[:logger].info 'Profile check failed. Please fix the profile before generating an archive.'
+      return ui.exit 1
     end
 
     # generate archive
-    exit 1 unless profile.archive(o)
+    ui.exit 1 unless profile.archive(o)
   rescue StandardError => e
     pretty_handle_exception(e)
   end
@@ -294,10 +290,10 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     runner = Inspec::Runner.new(o)
     targets.each { |target| runner.add_target(target) }
 
-    exit runner.run
+    ui.exit runner.run
   rescue ArgumentError, RuntimeError, Train::UserError => e
     $stderr.puts e.message
-    exit 1
+    ui.exit 1
   rescue StandardError => e
     pretty_handle_exception(e)
   end
@@ -312,12 +308,12 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     if o["format"] == "json"
       puts res.to_json
     else
-      headline("Platform Details")
-      puts Inspec::BaseCLI.format_platform_info(params: res, indent: 0, color: 36)
+      ui.headline('Platform Details')
+      ui.plain Inspec::BaseCLI.format_platform_info(params: res, indent: 0, color: 36)
     end
   rescue ArgumentError, RuntimeError, Train::UserError => e
     $stderr.puts e.message
-    exit 1
+    ui.exit 1
   rescue StandardError => e
     pretty_handle_exception(e)
   end
@@ -348,12 +344,12 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     end
 
     run_type, res = run_command(o)
-    exit res unless run_type == :ruby_eval
+    ui.exit res unless run_type == :ruby_eval
 
     # No InSpec tests - just print evaluation output.
     res = (res.respond_to?(:to_json) ? res.to_json : JSON.dump(res)) if o["reporter"]&.keys&.include?("json")
     puts res
-    exit 0
+    ui.exit 0
   rescue RuntimeError, Train::UserError => e
     $stderr.puts e.message
   rescue StandardError => e
@@ -463,5 +459,5 @@ rescue Inspec::Plugin::V2::Exception => v2ex
   else
     Inspec::Log.error "Run again with --debug for a stacktrace."
   end
-  exit 2
+  ui.exit 2
 end

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -124,7 +124,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     else
       %w{location profile controls timestamp valid}.each do |item|
         prepared_string = format('%-12s %s',
-                                 (item.to_s.capitalize + ':'),
+                                 ("#{item.to_s.capitalize} :"),
                                  result[:summary][item.to_sym])
         ui.plain_line(prepared_string)
       end
@@ -143,8 +143,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 
         puts
 
-        errors = ui.red(result[:errors].length.to_s + ' errors', print: false)
-        warnings = ui.yellow(result[:warnings].length.to_s + ' warnings', print: false)
+        errors = ui.red("#{result[:errors].length} errors", print: false)
+        warnings = ui.yellow("#{result[:warnings].length} warnings", print: false)
         ui.plain_line("Summary:     #{errors}, #{warnings}")
       end
     end

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -124,7 +124,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     else
       %w{location profile controls timestamp valid}.each do |item|
         prepared_string = format('%-12s %s',
-                                 ("#{item.to_s.capitalize} :"),
+                                 "#{item.to_s.capitalize} :",
                                  result[:summary][item.to_sym])
         ui.plain_line(prepared_string)
       end

--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -207,7 +207,7 @@ module InspecPlugins
 
         # Already installed?
         if registry.known_plugin?(plugin_name.to_sym)
-          ui.red("Plugin already installed - #{plugin_name} - Use '#{EXEC_NAME}" \
+          ui.red("Plugin already installed - #{plugin_name} - Use '#{EXEC_NAME} " \
                  "plugin list' to see previously installed plugin - " \
                  "installation failed.")
           ui.exit Inspec::UI::EXIT_PLUGIN_ERROR

--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -1,7 +1,7 @@
-require 'pathname'
-require 'inspec/plugin/v2'
-require 'inspec/plugin/v2/installer'
-require 'inspec/dist'
+require "pathname"
+require "inspec/plugin/v2"
+require "inspec/plugin/v2/installer"
+require "inspec/dist"
 
 module InspecPlugins
   module PluginManager
@@ -21,10 +21,10 @@ module InspecPlugins
         plugin_statuses.reject! { |s| %i{core bundle}.include?(s.installation_type) } unless options[:all]
 
         puts
-        ui.bold(format(' %-30s%-10s%-8s%-6s', 'Plugin Name', 'Version', 'Via', 'ApiVer'))
+        ui.bold(format(" %-30s%-10s%-8s%-6s", "Plugin Name", "Version", "Via", "ApiVer"))
         ui.line
         plugin_statuses.sort_by(&:name).each do |status|
-          ui.plain(format(' %-30s%-10s%-8s%-6s', status.name,
+          ui.plain(format(" %-30s%-10s%-8s%-6s", status.name,
                           make_pretty_version(status),
                           status.installation_type,
                           status.api_generation.to_s))
@@ -60,12 +60,12 @@ module InspecPlugins
         end
 
         puts
-        ui.bold(format(' %-30s%-50s', 'Plugin Name', 'Versions Available'))
+        ui.bold(format(" %-30s%-50s", "Plugin Name", "Versions Available"))
         ui.line
         search_results.keys.sort.each do |plugin_name|
           versions = options[:all] ? search_results[plugin_name] : [search_results[plugin_name].first]
-          versions = '(' + versions.join(', ') + ')'
-          ui.plain(format(' %-30s%-50s', plugin_name, versions))
+          versions = "(" + versions.join(", ") + ")"
+          ui.plain(format(" %-30s%-50s", plugin_name, versions))
         end
         ui.line
         ui.plain(" #{search_results.count} plugin(s) found")
@@ -145,7 +145,7 @@ module InspecPlugins
         status = Inspec::Plugin::V2::Registry.instance[plugin_name.to_sym]
         unless status
           ui.plain("#{ui.red('No such plugin installed:')} #{plugin_name} is not " \
-                 'installed - uninstall failed')
+                 "installed - uninstall failed")
           ui.exit Inspec::UI::EXIT_USAGE_ERROR
         end
         installer = Inspec::Plugin::V2::Installer.instance
@@ -156,11 +156,11 @@ module InspecPlugins
         installer.uninstall(plugin_name)
 
         if status.installation_type == :path
-          ui.bold(plugin_name + ' path-based plugin install has been ' \
-                  'uninstalled')
+          ui.bold(plugin_name + " path-based plugin install has been " \
+                  "uninstalled")
         else
           ui.bold(plugin_name + " plugin, version #{old_version}, has " \
-                  'been uninstalled')
+                  "been uninstalled")
         end
         ui.exit Inspec::UI::EXIT_NORMAL
       end
@@ -186,7 +186,7 @@ module InspecPlugins
         installer.install(plugin_name, gem_file: gem_file)
 
         ui.bold("#{plugin_name} plugin, version #{version}, installed from " \
-                'local .gem file')
+                "local .gem file")
         ui.exit Inspec::UI::EXIT_NORMAL
       end
 
@@ -209,7 +209,7 @@ module InspecPlugins
         if registry.known_plugin?(plugin_name.to_sym)
           ui.red("Plugin already installed - #{plugin_name} - Use '#{EXEC_NAME}" \
                  "plugin list' to see previously installed plugin - " \
-                 'installation failed.')
+                 "installation failed.")
           ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
         end
 
@@ -286,8 +286,8 @@ module InspecPlugins
         # Well, if we got here, parts[2] matches an inspec/train prefix, but we have no idea about anything.
         # Give up.
         ui.red("Unrecognizable plugin structure - #{parts[2]} - When " \
-               'installing from a path, please provide the path of the ' \
-               'entry point file - installation failed.')
+               "installing from a path, please provide the path of the " \
+               "entry point file - installation failed.")
         ui.exit Inspec::UI::EXIT_USAGE_ERROR
       end
 
@@ -297,7 +297,7 @@ module InspecPlugins
           require entry_point
         rescue LoadError => ex
           ui.red("Plugin contains errors - #{plugin_name} - Encountered " \
-                 'errors while trying to test load the plugin entry point, ' \
+                 "errors while trying to test load the plugin entry point, " \
                  "resolved to #{entry_point} - installation failed")
           ui.plain ex.message
           ui.exit Inspec::UI::EXIT_USAGE_ERROR
@@ -310,16 +310,16 @@ module InspecPlugins
           registry_key = plugin_name.to_s.sub(/^train-/, "")
           unless Train::Plugins.registry.key?(registry_key)
             ui.red("Does not appear to be a plugin - #{plugin_name} - After " \
-                   'probe-loading the supposed plugin, it did not register ' \
-                   'itself to Train. Ensure something inherits from ' \
+                   "probe-loading the supposed plugin, it did not register " \
+                   "itself to Train. Ensure something inherits from " \
                    "'Train.plugin(1)' - installation failed.")
             ui.exit Inspec::UI::EXIT_USAGE_ERROR
           end
         else
           unless registry.known_plugin?(plugin_name.to_sym)
             ui.red("Does not appear to be a plugin - #{plugin_name} - After " \
-                   'probe-loading the supposed plugin, it did not register ' \
-                   'itself to InSpec. Ensure something inherits from ' \
+                   "probe-loading the supposed plugin, it did not register " \
+                   "itself to InSpec. Ensure something inherits from " \
                    "'Inspec.plugin(2)' - installation failed.")
             ui.exit Inspec::UI::EXIT_USAGE_ERROR
           end
@@ -342,7 +342,7 @@ module InspecPlugins
         new_version = (post_installed_versions - pre_installed_versions).first
 
         ui.bold("#{plugin_name} plugin, version #{new_version}, installed " \
-                'from rubygems.org')
+                "from rubygems.org")
         ui.exit Inspec::UI::EXIT_NORMAL
       end
 
@@ -365,17 +365,17 @@ module InspecPlugins
         they_explicitly_asked_for_a_version = !options[:version].nil?
         what_we_would_install_is_already_installed = pre_installed_versions.include?(requested_version)
         if what_we_would_install_is_already_installed && they_explicitly_asked_for_a_version
-          ui.red('Plugin already installed at requested version - plugin ' \
+          ui.red("Plugin already installed at requested version - plugin " \
                  "#{plugin_name} #{requested_version} - refusing to install.")
         elsif what_we_would_install_is_already_installed && !they_explicitly_asked_for_a_version
-          ui.red('Plugin already installed at latest version - plugin ' \
+          ui.red("Plugin already installed at latest version - plugin " \
                  "#{plugin_name} #{requested_version} - refusing to install.")
         else
           # There are existing versions installed, but none of them are what was requested
           ui.red("Update required - plugin #{plugin_name}, requested " \
                  "#{requested_version}, have " \
                  "#{pre_installed_versions.join(', ')}; use `inspec " \
-                 'plugin update` - refusing to install.')
+                 "plugin update` - refusing to install.")
         end
 
         ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
@@ -386,13 +386,13 @@ module InspecPlugins
         installer.install(plugin_name, version: options[:version])
       rescue Inspec::Plugin::V2::PluginExcludedError => ex
         ui.red("Plugin on Exclusion List - #{plugin_name} is listed as an " \
-               'incompatible gem - refusing to install.')
+               "incompatible gem - refusing to install.")
         ui.plain("Rationale: #{ex.details.rationale}")
-        ui.plain('Exclusion list location: ' +
-                 File.join(Inspec.src_root, 'etc', 'plugin_filters.json'))
-        ui.plain('If you disagree with this determination, please accept ' \
-                 'our apologies for the misunderstanding, and open an issue ' \
-                 'at https://github.com/inspec/inspec/issues/new')
+        ui.plain("Exclusion list location: " +
+                 File.join(Inspec.src_root, "etc", "plugin_filters.json"))
+        ui.plain("If you disagree with this determination, please accept " \
+                 "our apologies for the misunderstanding, and open an issue " \
+                 "at https://github.com/inspec/inspec/issues/new")
         ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
       rescue Inspec::Plugin::V2::InstallError
         raise if Inspec::Log.level == :debug
@@ -400,13 +400,13 @@ module InspecPlugins
         results = installer.search(plugin_name, exact: true)
         if results.empty?
           ui.red("No such plugin gem #{plugin_name} could be found on " \
-                 'rubygems.org - installation failed.')
+                 "rubygems.org - installation failed.")
         elsif options[:version] && !results[plugin_name].include?(options[:version])
           ui.red("No such version - #{plugin_name} exists, but no such " \
                  "version #{options[:version]} found on rubygems.org - " \
-                 'installation failed.')
+                 "installation failed.")
         else
-          ui.red('Unknown error occured - installation failed.')
+          ui.red("Unknown error occured - installation failed.")
         end
         ui.exit Inspec::UI::EXIT_USAGE_ERROR
       end
@@ -424,8 +424,8 @@ module InspecPlugins
           elsif status.installation_type == :path
             ui.plain("#{ui.red('Cannot update path-based install:')} " \
                    "#{plugin_name} is installed via path reference; " \
-                   'use `inspec plugin uninstall` to remove - refusing to' \
-                   'update')
+                   "use `inspec plugin uninstall` to remove - refusing to" \
+                   "update")
             ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
           end
         end
@@ -437,7 +437,7 @@ module InspecPlugins
         if pre_update_versions.include?(latest_version)
           ui.plain("#{ui.red('Already installed at latest version:')} " \
                    "#{plugin_name} is at #{latest_version}, which the " \
-                   'latest - refusing to update')
+                   "latest - refusing to update")
           ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
         end
       end

--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -118,7 +118,7 @@ module InspecPlugins
         begin
           installer.update(plugin_name)
         rescue Inspec::Plugin::V2::UpdateError => ex
-          ui.red('Update error: ' + ex.message + ' - update failed')
+          ui.plain("#{ui.red('Update error:')} #{ex.message} - update failed")
           ui.exit Inspec::UI::EXIT_USAGE_ERROR
         end
         post_update_versions = installer.list_installed_plugin_gems.select { |spec| spec.name == plugin_name }.map { |spec| spec.version.to_s }
@@ -144,7 +144,7 @@ module InspecPlugins
       def uninstall(plugin_name)
         status = Inspec::Plugin::V2::Registry.instance[plugin_name.to_sym]
         unless status
-          ui.red("No such plugin installed: #{plugin_name} is not " \
+          ui.plain("#{ui.red('No such plugin installed:')} #{plugin_name} is not " \
                  'installed - uninstall failed')
           ui.exit Inspec::UI::EXIT_USAGE_ERROR
         end
@@ -192,7 +192,7 @@ module InspecPlugins
 
       def install_from_path(path)
         unless File.exist? path
-          ui.red('No such source code path ' + path + ' - installation failed.')
+          ui.red("No such source code path #{path} - installation failed.")
           ui.exit Inspec::UI::EXIT_USAGE_ERROR
         end
 
@@ -419,12 +419,13 @@ module InspecPlugins
           # Check for path install
           status = Inspec::Plugin::V2::Registry.instance[plugin_name.to_sym]
           if !status
-            ui.red("No such plugin installed: #{plugin_name} - update failed")
+            ui.plain("#{ui.red('No such plugin installed:')} #{plugin_name} - update failed")
             ui.exit Inspec::UI::EXIT_USAGE_ERROR
           elsif status.installation_type == :path
-            ui.red("Cannot update path-based install: #{plugin_name} is " \
-                   'installed via path reference; use `inspec plugin ' \
-                   'uninstall` to remove - refusing to update')
+            ui.plain("#{ui.red('Cannot update path-based install:')} " \
+                   "#{plugin_name} is installed via path reference; " \
+                   'use `inspec plugin uninstall` to remove - refusing to' \
+                   'update')
             ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
           end
         end
@@ -434,8 +435,9 @@ module InspecPlugins
         latest_version = latest_version[plugin_name]&.last
 
         if pre_update_versions.include?(latest_version)
-          ui.red("Already installed at latest version: #{plugin_name} is at " \
-                 "#{latest_version}, which the latest - refusing to update")
+          ui.plain("#{ui.red('Already installed at latest version:')} " \
+                   "#{plugin_name} is at #{latest_version}, which the " \
+                   'latest - refusing to update')
           ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
         end
       end

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
@@ -718,7 +718,7 @@ class PluginManagerCliUpdate < Minitest::Test
     update_result = run_inspec_process_with_this_plugin("plugin update inspec-test-fixture-nonesuch")
 
     skip_windows!
-    assert_match(/No such plugin installed: .+ - update failed/, update_result.stdout)
+    assert_match(/No such plugin installed:.+ - update failed/, update_result.stdout)
 
     assert_empty update_result.stderr
 
@@ -808,7 +808,7 @@ class PluginManagerCliUninstall < Minitest::Test
 
     skip_windows!
     refute_includes "Inspec::Plugin::V2::UnInstallError", uninstall_result.stdout # Stacktrace marker
-    assert_match(/No such plugin installed: .+ - uninstall failed/, uninstall_result.stdout)
+    assert_match(/No such plugin installed:.+ - uninstall failed/, uninstall_result.stdout)
 
     assert_empty uninstall_result.stderr
 


### PR DESCRIPTION
This PR replaces existing 'red', 'bold' and 'puts '-' * 50' type code with the new UI code. My goal was simply updating the code to use the new UI, I didn't attempt to do things better. =)

I think when we discuss overhauling the UI/UX of InSpec we should create some templates for UI output so that we can further simplify this code.

ref: https://github.com/inspec/inspec/issues/3715