### PR TITLE
inspec check: Send log to STDERR when running with --format json

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -84,9 +84,13 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   desc 'check PATH', 'verify all tests at the specified PATH'
   option :format, type: :string
   profile_options
-  def check(path) # rubocop:disable Metrics/AbcSize
+  def check(path) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
     o = config
     diagnose(o)
+    o['log_location'] = STDERR if o['format'] == 'json'
+    o['log_level'] ||= 'warn'
+    configure_logger(o)
+
     o[:backend] = Inspec::Backend.create(Inspec::Config.mock)
     o[:check_mode] = true
     o[:vendor_cache] = Inspec::Cache.new(o[:vendor_cache])

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -87,7 +87,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   def check(path) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
     o = config
     diagnose(o)
-    o['log_location'] = STDERR if o['format'] == 'json'
+    o['log_location'] ||= STDERR if o['format'] == 'json'
     o['log_level'] ||= 'warn'
     configure_logger(o)
 

--- a/test/functional/logging_test.rb
+++ b/test/functional/logging_test.rb
@@ -157,4 +157,16 @@ describe 'Deprecation Facility Behavior' do
       end
     end
   end
+
+  describe 'when inspec check is used in json mode against a profile with a deprecation' do
+    describe 'inspec check with json formatter' do
+      let(:profile_name) { 'check' }
+      it 'can check a profile and produce valid JSON' do
+        run_result = run_inspec_process('check ' + profile + ' --format json')
+        run_result.stdout.wont_include 'DEPRECATION'
+        run_result.stderr.must_include 'DEPRECATION'
+        JSON.parse(run_result.stdout) # No exception here
+      end
+    end
+  end
 end

--- a/test/unit/mock/profiles/deprecation/check/inspec.yml
+++ b/test/unit/mock/profiles/deprecation/check/inspec.yml
@@ -1,0 +1,13 @@
+name: deprecation-check
+title: Deprecation Testing profile, to trigger deprecations during inspec check
+maintainer: inspec@chef.io
+copyright: The Authors
+copyright_email: inspec@chef.io
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+
+# This test relies on these deprecation groups remaining :warn
+attributes:
+  - name: favorite_fruit
+    default: banana # This should trigger attrs_value_replaces_default


### PR DESCRIPTION
Fixes #3972 

Unlike most CLI commands, `inspec check` was not calling `configure_logger`. When `--format json` is provided, this could be disastrous, as log messages get mixed up in the JSON stream.

This PR adds a call to configure logger, conditionally sets the logging destination, and adds a functional test to verify it works.