### PR TITLE
Improve testing on inputs that do not have values

### DIFF
--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -106,4 +106,14 @@ describe 'inputs' do
 
   #   # TODO - add test for backwards compatibility using 'attribute' in DSL
   end
+
+  describe 'when using a profile with undeclared (valueless) inputs' do
+    it 'should warn about them and not abort the run' do
+      cmd = "exec #{inputs_profiles_path}/undeclared"
+      result = run_inspec_process(cmd, json: true)
+      result.stderr.must_include "WARN: Input 'undeclared_01'"
+      result.stderr.must_include 'does not have a value'
+      result.must_have_all_controls_passing
+    end
+  end
 end

--- a/test/unit/mock/profiles/inputs/undeclared/controls/undeclared.rb
+++ b/test/unit/mock/profiles/inputs/undeclared/controls/undeclared.rb
@@ -1,0 +1,28 @@
+control 'start_marker' do
+  describe('dummy_test_01') do
+    it { should cmp 'dummy_test_01'}
+  end
+end
+
+control 'undeclared_in_control_body' do
+  attribute('undeclared_01')
+  assignment_outcome = attribute('undeclared_02')
+  describe('dummy_test_02') do
+    it { should cmp 'dummy_test_02'}
+  end
+end
+
+control 'undeclared_in_only_if' do
+  only_if { attribute('undeclared_03') }
+  describe('dummy_test_03') do
+    it { should cmp 'dummy_test_03'}
+  end
+end
+
+attribute('undeclared_04')
+
+control 'end_marker' do
+  describe('dummy_test_04') do
+    it { should cmp 'dummy_test_04'}
+  end
+end

--- a/test/unit/mock/profiles/inputs/undeclared/inspec.yml
+++ b/test/unit/mock/profiles/inputs/undeclared/inspec.yml
@@ -1,0 +1,8 @@
+name: undeclared_attribute
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: A profile mentioning an attribute in a control file that has not otherwise been mentioned
+version: 0.1.0


### PR DESCRIPTION
Closes #3955 
Closes #3919 

3955 pointed out that InSpec v3 has undefined and unpleasant behavior around using inputs (attributes) that do not have values. In the input core overhaul, merged into inspec v4.2 and released on 4.3.2, this issues is resolved, but had no specific tests.

3919 pointed out that adding a description to an attribute was apparently enough to get inspec v3 to no longer complain about the valueless input. As v4.2+ does not exhibit this behavior, we just need tests to show that valueless attributes are accepted, without description. 

This PR adds such tests to cover both issues.
