### PR TITLE
Rename 'attribute' DSL method to 'input'

### DIFF
--- a/etc/deprecations.json
+++ b/etc/deprecations.json
@@ -6,6 +6,11 @@
       "action": "warn",
       "prefix": "The 'default' option for attributes is being replaced by 'value' - please use it instead."
     },
+    "attrs_dsl": {
+      "action": "ignore",
+      "comment": "See #3853",
+      "prefix": "The 'attribute' DSL keyword is being replaced by 'input' - please use it instead."
+    },
     "aws_resources_in_resource_pack": {
       "comment": "See #3822",
       "action": "warn",

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -26,8 +26,7 @@ module Inspec
         with_resource_dsl resources_dsl
 
         # allow attributes to be accessed within control blocks
-        # TODO: deprecate name, use input()
-        define_method :attribute do |input_name, options = {}|
+        define_method :input do |input_name, options = {}|
           if options.empty?
             # Simply an access, no event here
             Inspec::InputRegistry.find_or_register_input(input_name, profile_id).value
@@ -43,6 +42,11 @@ module Inspec
         # Will return nil on a miss.
         define_method :input_object do |input_name|
           Inspec::InputRegistry.find_or_register_input(input_name, profile_id)
+        end
+
+        define_method :attribute do |name, options = {}|
+          Inspec.deprecate(:attrs_dsl, "Input name: #{name}, Profile: #{profile_id}")
+          input(name, options)
         end
 
         # Support for Control DSL plugins.
@@ -182,9 +186,7 @@ module Inspec
           profile_context_owner.register_rule(control, &block) unless control.nil?
         end
 
-        # method for inputs; import input handling
-        # TODO: deprecate name, use input()
-        define_method :attribute do |input_name, options = {}|
+        define_method :input do |input_name, options = {}|
           if options.empty?
             # Simply an access, no event here
             Inspec::InputRegistry.find_or_register_input(input_name, profile_id).value
@@ -192,7 +194,7 @@ module Inspec
             options[:priority] = 20
             options[:provider] = :inline_control_code
             evt = Inspec::Input.infer_event(options)
-            Inspec::InputRegistry.find_or_register_input(input_name, profile_name, event: evt).value
+            Inspec::InputRegistry.find_or_register_input(input_name, profile_id, event: evt).value
           end
         end
 
@@ -200,6 +202,11 @@ module Inspec
         # Will return nil on a miss.
         define_method :input_object do |input_name|
           Inspec::InputRegistry.find_or_register_input(input_name, profile_id)
+        end
+
+        define_method :attribute do |name, options = {}|
+          Inspec.deprecate(:attrs_dsl, "Input name: #{name}, Profile: #{profile_id}")
+          input(name, options)
         end
 
         define_method :skip_control do |id|

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -35,7 +35,7 @@ module Inspec
             options[:priority] = 20
             options[:provider] = :inline_control_code
             evt = Inspec::Input.infer_event(options)
-            Inspec::InputRegistry.find_or_register_input(input_name, profile_name, event: evt).value
+            Inspec::InputRegistry.find_or_register_input(input_name, profile_id, event: evt).value
           end
         end
 

--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -65,14 +65,15 @@ end
 
 class RSpec::Core::ExampleGroup
   # This DSL method allows us to access the values of inputs within InSpec tests
-  def attribute(name)
-    Inspec::InputRegistry.find_or_register_input(name, self.class.metadata[:profile_id]).value
+  def attribute(name, options = {})
+    Inspec::InputRegistry.find_or_register_input(name, self.class.metadata[:profile_id], options).value
   end
   define_example_method :attribute
-  def input_obj(name)
-    Inspec::InputRegistry.find_or_register_input(name, self.class.metadata[:profile_id])
+
+  def input_object(name, options = {})
+    Inspec::InputRegistry.find_or_register_input(name, self.class.metadata[:profile_id], options)
   end
-  define_example_method :input_obj
+  define_example_method :input_object
 
   # Here, we have to ensure our method_missing gets called prior
   # to RSpec::Core::ExampleGroup.method_missing (the class method).

--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -65,15 +65,30 @@ end
 
 class RSpec::Core::ExampleGroup
   # This DSL method allows us to access the values of inputs within InSpec tests
-  def attribute(name, options = {})
-    Inspec::InputRegistry.find_or_register_input(name, self.class.metadata[:profile_id], options).value
+  def input(input_name, options = {})
+    profile_id = self.class.metadata[:profile_id]
+    if options.empty?
+      # Simply an access, no event here
+      Inspec::InputRegistry.find_or_register_input(input_name, profile_id).value
+    else
+      options[:priority] = 20
+      options[:provider] = :inline_control_code
+      evt = Inspec::Input.infer_event(options)
+      Inspec::InputRegistry.find_or_register_input(input_name, profile_id, event: evt).value
+    end
   end
-  define_example_method :attribute
+  define_example_method :input
 
-  def input_object(name, options = {})
-    Inspec::InputRegistry.find_or_register_input(name, self.class.metadata[:profile_id], options)
+  def input_object(name)
+    Inspec::InputRegistry.find_or_register_input(name, self.class.metadata[:profile_id])
   end
   define_example_method :input_object
+
+  def attribute(name, options = {})
+    Inspec.deprecate(:attrs_dsl, "Input name: #{name}, Profile: #{self.class.metadata[:profile_id]}")
+    input(name, options)
+  end
+  define_example_method :attribute
 
   # Here, we have to ensure our method_missing gets called prior
   # to RSpec::Core::ExampleGroup.method_missing (the class method).

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -61,10 +61,14 @@ describe 'inputs' do
     end
   end
 
-  describe 'when accessing inputs in a variety of scopes' do
-    it "is able to read the inputs" do
-      cmd = 'exec '
-      cmd += File.join(inputs_profiles_path, 'scoping')
+  describe 'when accessing inputs in a variety of scopes using the DSL' do
+    it "is able to read the inputs using the input keyword" do
+      cmd = "exec #{inputs_profiles_path}/scoping"
+      result = run_inspec_process(cmd, json: true)
+      result.must_have_all_controls_passing
+    end
+    it "is able to read the inputs using the legacy attribute keyword" do
+      cmd = "exec #{inputs_profiles_path}/legacy-attributes-dsl"
       result = run_inspec_process(cmd, json: true)
       result.must_have_all_controls_passing
     end
@@ -102,8 +106,5 @@ describe 'inputs' do
         result.must_have_all_controls_passing
       end
     end
-
-
-  #   # TODO - add test for backwards compatibility using 'attribute' in DSL
   end
 end

--- a/test/unit/mock/profiles/inputs/legacy-attributes-dsl/controls/legacy-dsl.rb
+++ b/test/unit/mock/profiles/inputs/legacy-attributes-dsl/controls/legacy-dsl.rb
@@ -1,26 +1,26 @@
 # This should simply not error
-unless input('test-01', value: 'test-01') == 'test-01'
+unless attribute('test-01', value: 'test-01') == 'test-01'
   raise 'Failed bare input access'
 end
 
-describe input('test-02', value: 'test-02') do
+describe attribute('test-02', value: 'test-02') do
   it { should cmp 'test-02' }
 end
 
 describe 'mentioning an input in a bare describe block as a redirected subject' do
-  subject { input('test-03', value: 'test-03') }
+  subject { attribute('test-03', value: 'test-03') }
   it { should cmp 'test-03' }
 end
 
 control 'test using an input inside a control block as the describe subject' do
-  describe input('test-04', value: 'test-04') do
+  describe attribute('test-04', value: 'test-04') do
     it { should cmp 'test-04' }
   end
 end
 
 control "test using inputs in the test its block" do
   describe 'test-05' do
-    it { should cmp input('test-05', value: 'test-05') }
+    it { should cmp attribute('test-05', value: 'test-05') }
   end
 end
 

--- a/test/unit/mock/profiles/inputs/legacy-attributes-dsl/inspec.yml
+++ b/test/unit/mock/profiles/inputs/legacy-attributes-dsl/inspec.yml
@@ -1,0 +1,8 @@
+name: legacy_attribute_dsl
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: A profile using the legacy attribute() syntax in control file code
+version: 0.1.0

--- a/test/unit/mock/profiles/inputs/scoping/inspec.yml
+++ b/test/unit/mock/profiles/inputs/scoping/inspec.yml
@@ -6,15 +6,3 @@ copyright_email: inspec@chef.io
 license: Apache-2.0
 summary: Profile to test reading attributes in a variety of scopes
 version: 0.1.0
-
-attributes:
-- name: test-01
-  value: test-01
-- name: test-02
-  value: test-02
-- name: test-03
-  value: test-03
-- name: test-04
-  value: test-04
-- name: test-05
-  value: test-05


### PR DESCRIPTION
As part of the attribute => input rename (#3802), this PR adds a new control DSL method, `input`, and makes `attribute` a wrapper for it, with an ignore-mode deprecation call.

The code could use some DRYing up - this code doesn't introduce any new duplication, but the existing method is defined in three places, with nearly the same implementation.

A 'new way' and 'old way' test fixture is provided.

Docs are intentionally omitted; we plan a big, nice new page detailing Inputs on #3880.

Partial fix on #3853 ; we also need a massive PR to go through and update all of the test fixtures and examples to use the new DSL method.