### PR TITLE
Rename attributes -> inputs in profile metadata files

### DIFF
--- a/etc/deprecations.json
+++ b/etc/deprecations.json
@@ -11,6 +11,11 @@
       "comment": "See #3853",
       "prefix": "The 'attribute' DSL keyword is being replaced by 'input' - please use it instead."
     },
+    "attrs_rename_in_metadata": {
+      "action": "ignore",
+      "comment": "See 3854",
+      "prefix": "Inputs should be specified by using the 'inputs' key in profile metadata, not 'attributes'."
+    },
     "aws_resources_in_resource_pack": {
       "comment": "See #3822",
       "action": "warn",

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -221,26 +221,30 @@ module Inspec
         return
       end
 
-      raw_inputs.each do |input_orig|
-        input_options = input_orig.dup
-        input_name = input_options.delete(:name)
-        input_options[:provider] = :profile_metadata
-        input_options[:file] = File.join(profile_name, 'inspec.yml')
-        input_options[:priority] ||= 30
-        evt = Inspec::Input.infer_event(input_options)
+      raw_inputs.each { |i| handle_raw_input_from_metadata(i) }
+    end
 
-        # Profile metadata may set inputs in other profiles by naming them.
-        if input_options[:profile]
-          profile_name = input_options[:profile] || profile_name
-          # Override priority to force this to win.  Allow user to set their own priority.
-          evt.priority = input_orig[:priority] || 35
-        end
-        find_or_register_input(input_name,
-                               profile_name,
-                               type: input_options[:type],
-                               required: input_options[:required],
-                               event: evt)
+    def handle_raw_input_from_metadata(input_orig)
+      input_options = input_orig.dup
+      input_name = input_options.delete(:name)
+      input_options[:provider] = :profile_metadata
+      input_options[:file] = File.join(profile_name, 'inspec.yml')
+      input_options[:priority] ||= 30
+      evt = Inspec::Input.infer_event(input_options)
+
+      # Profile metadata may set inputs in other profiles by naming them.
+      if input_options[:profile]
+        profile_name = input_options[:profile] || profile_name
+        # Override priority to force this to win.  Allow user to set their own priority.
+        evt.priority = input_orig[:priority] || 35
       end
+      find_or_register_input(
+        input_name,
+        profile_name,
+        type: input_options[:type],
+        required: input_options[:required],
+        event: evt,
+      )
     end
 
     #-------------------------------------------------------------#

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -228,7 +228,7 @@ module Inspec
       input_options = input_orig.dup
       input_name = input_options.delete(:name)
       input_options[:provider] = :profile_metadata
-      input_options[:file] = File.join(profile_name, 'inspec.yml')
+      input_options[:file] = File.join(profile_name, "inspec.yml")
       input_options[:priority] ||= 30
       evt = Inspec::Input.infer_event(input_options)
 
@@ -243,7 +243,7 @@ module Inspec
         profile_name,
         type: input_options[:type],
         required: input_options[:required],
-        event: evt,
+        event: evt
       )
     end
 

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -221,10 +221,10 @@ module Inspec
         return
       end
 
-      raw_inputs.each { |i| handle_raw_input_from_metadata(i) }
+      raw_inputs.each { |i| handle_raw_input_from_metadata(i, profile_name) }
     end
 
-    def handle_raw_input_from_metadata(input_orig)
+    def handle_raw_input_from_metadata(input_orig, profile_name)
       input_options = input_orig.dup
       input_name = input_options.delete(:name)
       input_options[:provider] = :profile_metadata

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -79,7 +79,7 @@ describe "inputs" do
     end
   end
 
-  describe 'run profile with metadata inputs' do
+  describe "run profile with metadata inputs" do
 
     it "works when using the new 'inputs' key" do
       cmd = "exec #{inputs_profiles_path}/metadata-basic"
@@ -99,7 +99,7 @@ describe "inputs" do
       cmd = "exec "
       cmd += File.join(inputs_profiles_path, "metadata-empty")
       result = run_inspec_process(cmd, json: true)
-      result.stderr.must_include 'WARN: Inputs must be defined as an Array in metadata files. Skipping definition from profile-with-empty-attributes.'
+      result.stderr.must_include "WARN: Inputs must be defined as an Array in metadata files. Skipping definition from profile-with-empty-attributes."
       assert_exit_code 0, result
     end
 

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -79,7 +79,22 @@ describe "inputs" do
     end
   end
 
-  describe "run profile with metadata inputs" do
+  describe 'run profile with metadata inputs' do
+
+    it "works when using the new 'inputs' key" do
+      cmd = "exec #{inputs_profiles_path}/metadata-basic"
+      result = run_inspec_process(cmd, json: true)
+      result.must_have_all_controls_passing
+      result.stderr.must_be_empty
+    end
+
+    it "works when using the legacy 'attributes' key" do
+      cmd = "exec #{inputs_profiles_path}/metadata-legacy"
+      result = run_inspec_process(cmd, json: true)
+      result.must_have_all_controls_passing
+      # Will eventually issue deprecation warning
+    end
+
     it "does not error when inputs are empty" do
       cmd = "exec "
       cmd += File.join(inputs_profiles_path, "metadata-empty")

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -99,7 +99,7 @@ describe "inputs" do
       cmd = "exec "
       cmd += File.join(inputs_profiles_path, "metadata-empty")
       result = run_inspec_process(cmd, json: true)
-      result.stderr.must_include "WARN: Inputs must be defined as an Array. Skipping current definition."
+      result.stderr.must_include 'WARN: Inputs must be defined as an Array in metadata files. Skipping definition from profile-with-empty-attributes.'
       assert_exit_code 0, result
     end
 

--- a/test/unit/mock/profiles/inputs/metadata-basic/controls/metadata_controls.rb
+++ b/test/unit/mock/profiles/inputs/metadata-basic/controls/metadata_controls.rb
@@ -1,0 +1,5 @@
+control 'test_control_01' do
+  describe attribute('test_01') do
+    it { should cmp 'test_value_01' }
+  end
+end

--- a/test/unit/mock/profiles/inputs/metadata-basic/inspec.yml
+++ b/test/unit/mock/profiles/inputs/metadata-basic/inspec.yml
@@ -1,0 +1,11 @@
+name: metadata_basic
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: A profile with a single simple input defined in metadata
+version: 0.1.0
+inputs:
+- name: test_01
+  value: test_value_01

--- a/test/unit/mock/profiles/inputs/metadata-legacy/controls/metadata_controls.rb
+++ b/test/unit/mock/profiles/inputs/metadata-legacy/controls/metadata_controls.rb
@@ -1,0 +1,5 @@
+control 'test_control_01' do
+  describe attribute('test_01') do
+    it { should cmp 'test_value_01' }
+  end
+end

--- a/test/unit/mock/profiles/inputs/metadata-legacy/inspec.yml
+++ b/test/unit/mock/profiles/inputs/metadata-legacy/inspec.yml
@@ -1,0 +1,12 @@
+name: metadata_legacy
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: A profile with a single simple input defined in metadata, using the attributes key
+version: 0.1.0
+
+attributes: # Use legacy "attributes" key
+- name: test_01
+  value: test_value_01


### PR DESCRIPTION
Part of #3802
Closes #3854 

In the profile metadata file, we now look for `inputs:` and deprecate `attributes:`.  The deprecation is silent for now, both are accepted.

Functional tests updated, docs will be on #3880.

Not on this PR, we will need to do a bulk update of any test fixture or example profiles that use attributes in the metadata.