### PR TITLE
Bump website from 3.0 to 4.

### DIFF
--- a/www/source/downloads.html.slim
+++ b/www/source/downloads.html.slim
@@ -26,7 +26,7 @@ header.bg-gradient.margin-top-offset.short-bg.relative
             ' Installable packages that include everything you need to write and execute profiles
           a.button.btn-lg.btn-purple.shadow-dark.margin-top-xs href="https://downloads.chef.io/inspec"
             i.fa.fa-cloud-download
-            span download inspec 3.0
+            span download inspec 4
         .triangle-right
     .large-6.medium-6.mobile-12.columns.margin-under-xs
       .box-white.shadow.strict-center.fit-height.relative.slide-up.z-20

--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -16,7 +16,7 @@ header.bg-gradient.margin-top-offset.short-bg.relative
         .row.align.columns.margin-top-sm.mobile-row-btn
           a.button.btn-lg.btn-purple.shadow-dark.margin-right-xs.mobile-row-btn href="/downloads"
             i.fa.fa-cloud-download
-            span download inspec 3.0
+            span download inspec 4
           a.button.btn-lg.btn-white-o.shadow-dark.mobile-row-btn href="/tutorials" browse tutorials
         a class="github-button" href="https://github.com/chef/inspec" data-size="large" data-show-count="true" aria-label="Star chef/inspec on GitHub" Star
 
@@ -27,24 +27,23 @@ header.bg-gradient.margin-top-offset.short-bg.relative
   /! announcement
   .row.columns
     .box-white.shadow.z-20.slide-left
-      h3.large-11.medium-11 Announcing InSpec 3.0
-      p.large-11.medium-11 Plugin system, global attributes, enchanced skip messaging, and more.
+      h3.large-11.medium-11 Announcing InSpec 4
+      p.large-11.medium-11 Inputs system overhaul, updated AWS-SDK to v3, support for the new Chef License, and many bugfixes and minor features
       #expand
         .margin-top-sm.brdr-left.large-11.medium-11
           .margin-left-sm
             h4.t-purple core
-            p New plugin system for InSpec CLI and Train
-            p Enhanced "only_if" skip messaging
-            p Unsupported profiles are now hidden from output
-            p Attributes are now specified in <a href="/docs/reference/profiles/">inspec.yml</a>
-            p Text based severity (e.g. "impact 'low'" )
-            p Tons of security/bug fixes and improvements
+            p Inputs system overhaul - more consistent, extensible, and predictable
+            p Updated AWS-SDK to v3
+            p Laying the foundation for opt-in telemetry
+            p Support for the new Chef License
+            p Add support for more_permissive_than? on the File resource
+            p many other minor bugfixes!
         .margin-top-sm.brdr-left.large-11.medium-11
           .margin-left-sm
-            h4.t-purple cloud
-            p
-              | New <a href="http://www.inspec.io/docs/reference/resources/#azure-resources">Azure</a> and <a href="/docs/reference/resources/#gcp-resources">GCP resources</a>
-            p Support for VMware ESXi via PowerCLI (Even on Linux!)
+            h4.t-purple inspec-bin
+            p Moved the `inspec` executable to a separate gem, `inspec-bin`.  This allows use of the `inspec` gem as a library without the licensing restrictions placed on the executable.
+            p This release is the first to require accepting a license before using it as an executable.
       .margin-top-xs
         a#expandBtn Show all new features
   /!  canvas elements

--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -38,7 +38,7 @@ header.bg-gradient.margin-top-offset.short-bg.relative
             p Laying the foundation for opt-in telemetry
             p Support for the new Chef License
             p Add support for more_permissive_than? on the File resource
-            p many other minor bugfixes!
+            p Many other minor bugfixes!
         .margin-top-sm.brdr-left.large-11.medium-11
           .margin-left-sm
             h4.t-purple inspec-bin

--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -42,7 +42,7 @@ header.bg-gradient.margin-top-offset.short-bg.relative
         .margin-top-sm.brdr-left.large-11.medium-11
           .margin-left-sm
             h4.t-purple inspec-bin
-            p Moved the `inspec` executable to a separate gem, `inspec-bin`.  This allows use of the `inspec` gem as a library without the licensing restrictions placed on the executable.
+            p Moved the `inspec` executable to a separate gem, `inspec-bin`. This allows the use of the `inspec` gem as a library without the licensing restrictions placed on the executable.
             p This release is the first to require accepting a license before using it as an executable.
       .margin-top-xs
         a#expandBtn Show all new features

--- a/www/source/layouts/_footer.slim
+++ b/www/source/layouts/_footer.slim
@@ -8,7 +8,7 @@ footer#main-footer.dark-bg
       .strict-center
         a.button.btn-lg.btn-purple.shadow-dark.margin-right-xs.mobile-row-btn href="/downloads"
           i.fa.fa-cloud-download
-          span download InSpec 3.0
+          span download InSpec 4
         a.button.btn-lg.btn-white-o.shadow-dark.mobile-row-btn href="/tutorials" browse tutorials
 
   .flex.align

--- a/www/source/layouts/layout.slim
+++ b/www/source/layouts/layout.slim
@@ -110,11 +110,11 @@ html
 
       $(function() {
         $("#expand").hide();
-        $("#expandBtn").html("Show all new InSpec 3.0 features");
+        $("#expandBtn").html("Show all new InSpec 4 features");
 
          $('#expandBtn').click(function() {
             $('#expand').slideToggle("fast");
-            $(this).html($(this).html() == 'Collapse new InSpec 3.0 features' ? 'Show all new InSpec 3.0 features' : 'Collapse new InSpec 3.0 features');
+            $(this).html($(this).html() == 'Collapse new InSpec 4 features' ? 'Show all new InSpec 4 features' : 'Collapse new InSpec 4 features');
          });
       });
 


### PR DESCRIPTION
Specifically using "4" so we don't have to bump on every minor
release.

I mish-mashed the bullet points from 2 different sources. It is
probably wrong or confusing and I'd like extra scrutiny there.

I don't remember slim AT ALL and probably got some stuff wrong.

This should fix #4020.

Signed-off-by: Ryan Davis <zenspider@chef.io>