### PR TITLE
Configure expeditor to delete the branch after it is merged.

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -27,6 +27,7 @@ slack:
   notify_channel: inspec-notify
 
 github:
+  delete_branch_on_merge: true
   maintainer_group: chef/inspec-maintainers
   minor_bump_labels:
     - "Version: Bump Minor"


### PR DESCRIPTION
Earlier today @zenspider noticed that we had 200 branches! I cleaned up many stale branches that were mostly left over from older merge requests. This change configures expeditor to automatically perform this clean up so we don't have to =)