### PR TITLE
Enable user telemetry opt-in / opt-out on cli

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -39,6 +39,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   class_option :disable_user_plugins, type: :string, banner: '',
     desc: 'Disable loading all plugins that the user installed.'
 
+  class_option :telemetry, type: :boolean,
+    desc: 'Allow or disable telemetry', default: true
+
   require 'license_acceptance/cli_flags/thor'
   include LicenseAcceptance::CLIFlags::Thor
 

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -39,8 +39,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   class_option :disable_user_plugins, type: :string, banner: '',
     desc: 'Disable loading all plugins that the user installed.'
 
-  class_option :telemetry, type: :boolean,
-    desc: 'Allow or disable telemetry', default: true
+  class_option :enable_telemetry, type: :boolean,
+    desc: 'Allow or disable telemetry', default: false
 
   require 'license_acceptance/cli_flags/thor'
   include LicenseAcceptance::CLIFlags::Thor

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -67,6 +67,10 @@ module Inspec
       puts
     end
 
+    def telemetry_enabled?
+      final_options['telemetry']
+    end
+
     #-----------------------------------------------------------------------#
     #                      Train Credential Handling
     #-----------------------------------------------------------------------#

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -70,7 +70,7 @@ module Inspec
     # return all telemetry options from config
     # @return [Hash]
     def telemetry_options
-      final_options.select { |key,_| key.include?('telemetry') }
+      final_options.select { |key, _| key.include?('telemetry') }
     end
 
     #-----------------------------------------------------------------------#

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -67,8 +67,10 @@ module Inspec
       puts
     end
 
-    def telemetry_enabled?
-      final_options['telemetry']
+    # return all telemetry options from config
+    # @return [Hash]
+    def telemetry_options
+      final_options.select { |key,_| key.include?('telemetry') }
     end
 
     #-----------------------------------------------------------------------#

--- a/lib/inspec/utils/telemetry/collector.rb
+++ b/lib/inspec/utils/telemetry/collector.rb
@@ -12,6 +12,7 @@ module Inspec::Telemetry
       load_config
     end
 
+    # Allow loading a configuration, useful when testing.
     def load_config(config = Inspec::Config.cached)
       @config = config
     end

--- a/lib/inspec/utils/telemetry/collector.rb
+++ b/lib/inspec/utils/telemetry/collector.rb
@@ -11,6 +11,7 @@ module Inspec::Telemetry
 
     def initialize
       @data_series = []
+      @telemetry_toggled_off = false
       load_config
     end
 
@@ -29,13 +30,16 @@ module Inspec::Telemetry
     # telemetry, if not default to false.
     # @return [True, False]
     def telemetry_enabled?
-      config_telemetry_options.fetch('enable_telemetry', false)
+      if @telemetry_toggled_off
+        false
+      else
+        config_telemetry_options.fetch('enable_telemetry', false)
+      end
     end
 
     # A way to disable the telemetry system.
-    # @return [True]
     def disable_telemetry
-      @enabled = false
+      @telemetry_toggled_off = true
     end
 
     # The entire data series collection.

--- a/lib/inspec/utils/telemetry/collector.rb
+++ b/lib/inspec/utils/telemetry/collector.rb
@@ -1,3 +1,4 @@
+require 'inspec/config'
 require 'inspec/utils/telemetry/data_series'
 require 'singleton'
 

--- a/lib/inspec/utils/telemetry/collector.rb
+++ b/lib/inspec/utils/telemetry/collector.rb
@@ -7,6 +7,8 @@ module Inspec::Telemetry
   class Collector
     include Singleton
 
+    attr_reader :config
+
     def initialize
       @data_series = []
       load_config
@@ -23,15 +25,11 @@ module Inspec::Telemetry
       @data_series << data_series
     end
 
-    # Is the Telemetry system enabled or disabled?
-    # Always true until we add configuration parsing.
+    # The loaded configuration should have a option to configure
+    # telemetry, if not default to false.
     # @return [True, False]
     def telemetry_enabled?
-      if @config.telemetry_enabled?.nil?
-        @enabled = true
-      else
-        @enabled = @config.telemetry_enabled?
-      end
+      config_telemetry_options.fetch("enable_telemetry", false)
     end
 
     # A way to disable the telemetry system.
@@ -65,6 +63,13 @@ module Inspec::Telemetry
     # @return [True]
     def reset
       @data_series = []
+    end
+
+    private
+
+    # Minimize exposure of Inspec::Config interface
+    def config_telemetry_options
+      config.telemetry_options
     end
   end
 end

--- a/lib/inspec/utils/telemetry/collector.rb
+++ b/lib/inspec/utils/telemetry/collector.rb
@@ -29,7 +29,7 @@ module Inspec::Telemetry
     # telemetry, if not default to false.
     # @return [True, False]
     def telemetry_enabled?
-      config_telemetry_options.fetch("enable_telemetry", false)
+      config_telemetry_options.fetch('enable_telemetry', false)
     end
 
     # A way to disable the telemetry system.

--- a/lib/inspec/utils/telemetry/collector.rb
+++ b/lib/inspec/utils/telemetry/collector.rb
@@ -64,9 +64,11 @@ module Inspec::Telemetry
     end
 
     # Blanks the contents of the data series collection.
+    # Reset telemetry toggle
     # @return [True]
-    def reset
+    def reset!
       @data_series = []
+      @telemetry_toggled_off = false
     end
 
     private

--- a/lib/inspec/utils/telemetry/collector.rb
+++ b/lib/inspec/utils/telemetry/collector.rb
@@ -8,7 +8,11 @@ module Inspec::Telemetry
 
     def initialize
       @data_series = []
-      @enabled = true
+      load_config
+    end
+
+    def load_config(config = Inspec::Config.cached)
+      @config = config
     end
 
     # Add a data series to the collection.
@@ -21,7 +25,11 @@ module Inspec::Telemetry
     # Always true until we add configuration parsing.
     # @return [True, False]
     def telemetry_enabled?
-      @enabled
+      if @config.telemetry_enabled?.nil?
+        @enabled = true
+      else
+        @enabled = @config.telemetry_enabled?
+      end
     end
 
     # A way to disable the telemetry system.

--- a/test/unit/utils/telemetry/collector_test.rb
+++ b/test/unit/utils/telemetry/collector_test.rb
@@ -42,9 +42,19 @@ class TestTelemetryCollector < Minitest::Test
   end
 
   def test_telemetry_enabled
-    @collector.load_config(Inspec::Config.mock("enable_telemetry"=>false))
-    refute @collector.telemetry_enabled?
-    @collector.load_config(Inspec::Config.mock("enable_telemetry"=>true))
+    @collector.load_config(Inspec::Config.mock('enable_telemetry'=>true))
     assert @collector.telemetry_enabled?
+  end
+
+  def test_telemetry_disabled
+    @collector.load_config(Inspec::Config.mock('enable_telemetry'=>false))
+    refute @collector.telemetry_enabled?
+  end
+
+  def test_disable_telemetry
+    @collector.load_config(Inspec::Config.mock('enable_telemetry'=>true))
+    assert @collector.telemetry_enabled?
+    @collector.disable_telemetry
+    refute @collector.telemetry_enabled?
   end
 end

--- a/test/unit/utils/telemetry/collector_test.rb
+++ b/test/unit/utils/telemetry/collector_test.rb
@@ -40,4 +40,14 @@ class TestTelemetryCollector < Minitest::Test
     @collector.reset
     assert_equal 0, @collector.list_data_series.count
   end
+
+  def test_telemetry_disabled
+    @collector.load_config(Inspec::Config.mock(telemetry: false))
+    refute @collector.telemetry_enabled?
+  end
+
+  def test_telemetry_enabled
+    @collector.load_config(Inspec::Config.mock(telemetry: true))
+    assert @collector.telemetry_enabled?
+  end
 end

--- a/test/unit/utils/telemetry/collector_test.rb
+++ b/test/unit/utils/telemetry/collector_test.rb
@@ -41,13 +41,10 @@ class TestTelemetryCollector < Minitest::Test
     assert_equal 0, @collector.list_data_series.count
   end
 
-  def test_telemetry_disabled
-    @collector.load_config(Inspec::Config.mock(telemetry: false))
-    refute @collector.telemetry_enabled?
-  end
-
   def test_telemetry_enabled
-    @collector.load_config(Inspec::Config.mock(telemetry: true))
+    @collector.load_config(Inspec::Config.mock("enable_telemetry"=>false))
+    refute @collector.telemetry_enabled?
+    @collector.load_config(Inspec::Config.mock("enable_telemetry"=>true))
     assert @collector.telemetry_enabled?
   end
 end

--- a/test/unit/utils/telemetry/collector_test.rb
+++ b/test/unit/utils/telemetry/collector_test.rb
@@ -4,7 +4,7 @@ require_relative '../../../helper.rb'
 class TestTelemetryCollector < Minitest::Test
   def setup
     @collector = Inspec::Telemetry::Collector.instance
-    @collector.reset
+    @collector.reset!
   end
 
   def test_collector_singleton
@@ -37,7 +37,7 @@ class TestTelemetryCollector < Minitest::Test
   def test_reset_singleton
     data_series = Inspec::Telemetry::DataSeries.new('/resource/File')
     @collector.add_data_series(data_series)
-    @collector.reset
+    @collector.reset!
     assert_equal 0, @collector.list_data_series.count
   end
 

--- a/test/unit/utils/telemetry/global_methods_test.rb
+++ b/test/unit/utils/telemetry/global_methods_test.rb
@@ -5,7 +5,7 @@ class TestTelemetryGlobalMethods < Minitest::Test
   def setup
     @collector = Inspec::Telemetry::Collector.instance
     @collector.load_config(Inspec::Config.mock('enable_telemetry'=>true))
-    @collector.reset
+    @collector.reset!
   end
 
   def test_record_telemetry_data

--- a/test/unit/utils/telemetry/global_methods_test.rb
+++ b/test/unit/utils/telemetry/global_methods_test.rb
@@ -4,7 +4,7 @@ require_relative '../../../helper.rb'
 class TestTelemetryGlobalMethods < Minitest::Test
   def setup
     @collector = Inspec::Telemetry::Collector.instance
-    @collector.load_config(Inspec::Config.mock(telemetry: true))
+    @collector.load_config(Inspec::Config.mock('enable_telemetry'=>true))
     @collector.reset
   end
 

--- a/test/unit/utils/telemetry/global_methods_test.rb
+++ b/test/unit/utils/telemetry/global_methods_test.rb
@@ -25,4 +25,9 @@ class TestTelemetryGlobalMethods < Minitest::Test
     assert_equal ['serverspec_compat'], depgrp.data
     assert_equal :deprecation_group, depgrp.name
   end
+
+  def test_telemetry_disabled
+    @collector.load_config(Inspec::Config.mock(telemetry: false))
+    refute Inspec.record_telemetry_data(:deprecation_group, 'serverspec_compat')
+  end
 end

--- a/test/unit/utils/telemetry/global_methods_test.rb
+++ b/test/unit/utils/telemetry/global_methods_test.rb
@@ -4,6 +4,7 @@ require_relative '../../../helper.rb'
 class TestTelemetryGlobalMethods < Minitest::Test
   def setup
     @collector = Inspec::Telemetry::Collector.instance
+    @collector.load_config(Inspec::Config.mock(telemetry: true))
     @collector.reset
   end
 


### PR DESCRIPTION
This adds `--enable-telemetry` and `--no-enable-telemetry` to the cli. Currently telemetry is enabled by default.

I wanted to also add the ability to opt-out and specify additional configuration via our config file, but thats going to require another issue as its not as straight forward (our config file is versioned and making changes is currently non-trivial).

closes https://github.com/inspec/inspec/issues/3849