### PR TITLE
Make the postgres resource more defensive

### DIFF
--- a/lib/inspec/resources/postgres.rb
+++ b/lib/inspec/resources/postgres.rb
@@ -47,8 +47,8 @@ module Inspec::Resources
         @version = version_from_psql
         if @version.to_s.empty?
           if inspec.directory('/var/lib/pgsql/data').exist?
-            warn 'Unable to determine PostgreSQL version: psql did not return
-              a version number and unversioned data directories were found.'
+            warn 'Unable to determine PostgreSQL version: psql did not return' \
+                 'a version number and unversioned data directories were found.'
           else
             @version = version_from_dir('/var/lib/pgsql')
           end
@@ -131,7 +131,7 @@ module Inspec::Resources
         'main'
       else
         dirs = inspec.command("ls -d #{dir}/*/").stdout.lines
-        if dirs.count == 0
+        if dirs.empty?
           warn "No postgresql clusters configured or incorrect base dir #{dir}"
           return nil
         end

--- a/lib/inspec/resources/postgres.rb
+++ b/lib/inspec/resources/postgres.rb
@@ -15,7 +15,7 @@ module Inspec::Resources
       # print warnings if the dirs do not exist
       verify_dirs
 
-      if !@version.nil? && !@conf_dir.empty?
+      if !@version.to_s.empty? && !@conf_dir.to_s.empty?
         @conf_path = File.join @conf_dir, 'postgresql.conf'
       else
         @conf_path = nil
@@ -38,16 +38,17 @@ module Inspec::Resources
         # installed as well as multiple "clusters" to be configured.
         #
         @version = version_from_psql || version_from_dir('/etc/postgresql')
-        @cluster = cluster_from_dir("/etc/postgresql/#{@version}")
-        @conf_dir = "/etc/postgresql/#{@version}/#{@cluster}"
-        @data_dir = "/var/lib/postgresql/#{@version}/#{@cluster}"
+        if !@version.to_s.empty?
+          @cluster = cluster_from_dir("/etc/postgresql/#{@version}")
+          @conf_dir = "/etc/postgresql/#{@version}/#{@cluster}"
+          @data_dir = "/var/lib/postgresql/#{@version}/#{@cluster}"
+        end
       else
         @version = version_from_psql
-        if @version.nil?
+        if @version.to_s.empty?
           if inspec.directory('/var/lib/pgsql/data').exist?
             warn 'Unable to determine PostgreSQL version: psql did not return
-             a version number and unversioned data directories were found.'
-            nil
+              a version number and unversioned data directories were found.'
           else
             @version = version_from_dir('/var/lib/pgsql')
           end
@@ -130,6 +131,10 @@ module Inspec::Resources
         'main'
       else
         dirs = inspec.command("ls -d #{dir}/*/").stdout.lines
+        if dirs.count == 0
+          warn "No postgresql clusters configured or incorrect base dir #{dir}"
+          return nil
+        end
         first = dirs.first.chomp.split('/').last
         if dirs.count > 1
           warn "Multiple postgresql clusters configured or incorrect base dir #{dir}"


### PR DESCRIPTION
I've got the following exceptions from the postgres core resourse:

When scanning an ubuntu 18.04 server without postgres installed:
```
NoMethodError: undefined method `chomp' for nil:NilClass
  /Users/apop/git/inspec/lib/resources/postgres.rb:139:in `cluster_from_dir'
  /Users/apop/git/inspec/lib/resources/postgres.rb:43:in `determine_dirs'
  /Users/apop/git/inspec/lib/resources/postgres.rb:13:in `initialize'
  /Users/apop/git/inspec/lib/inspec/plugin/v1/plugin_types/resource.rb:96:in `initialize'
  /Users/apop/git/inspec/lib/inspec/resource.rb:51:in `new'
```

When scanning my osx laptop without postgres installed:
```
NoMethodError: undefined method `empty?' for nil:NilClass
  /Users/apop/git/inspec/lib/resources/postgres.rb:19:in `initialize'
  /Users/apop/git/inspec/lib/inspec/plugin/v1/plugin_types/resource.rb:96:in `initialize'
  /Users/apop/git/inspec/lib/inspec/resource.rb:51:in `new'
  /Users/apop/git/inspec/lib/inspec/resource.rb:51:in `block (3 levels) in create_dsl'
  ../postgres-baseline/controls/postgres_spec.rb:40:in `load_with_context'
```

The changes in this PR are increasing the defensiveness of the resource against unexpected setups.