### PR TITLE
Wrap resources in backticks and remove resource name capitalizing

### DIFF
--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -174,12 +174,12 @@ module Inspec
 
           unless profile_context_owner.profile_supports_platform?
             platform = inspec.platform
-            msg = "Profile #{profile_context_owner.profile_id} is not supported on platform #{platform.name}/#{platform.release}."
+            msg = "Profile `#{profile_context_owner.profile_id}` is not supported on platform #{platform.name}/#{platform.release}."
             ::Inspec::Rule.set_skip_rule(control, true, msg)
           end
 
           unless profile_context_owner.profile_supports_inspec_version?
-            msg = "Profile #{profile_context_owner.profile_id} is not supported on InSpec version (#{Inspec::VERSION})."
+            msg = "Profile `#{profile_context_owner.profile_id}` is not supported on InSpec version (#{Inspec::VERSION})."
             ::Inspec::Rule.set_skip_rule(control, true, msg)
           end
 

--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -118,7 +118,7 @@ module Inspec
 
         def check_supports
           status = inspec.platform.supported?(@supports)
-          fail_msg = "Resource #{@__resource_name__.capitalize} is not supported on platform #{inspec.platform.name}/#{inspec.platform.release}."
+          fail_msg = "Resource `#{@__resource_name__}` is not supported on platform #{inspec.platform.name}/#{inspec.platform.release}."
           fail_resource(fail_msg) unless status
           status
         end

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -216,9 +216,9 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     let(:out) { inspec('exec ' + File.join(profile_path, 'aws-profile')) }
     let(:stdout) { out.stdout.force_encoding(Encoding::UTF_8) }
     it 'exits with an error' do
-      stdout.must_include 'Resource Aws_iam_users is not supported on platform'
-      stdout.must_include 'Resource Aws_iam_access_keys is not supported on platform'
-      stdout.must_include 'Resource Aws_s3_bucket is not supported on platform'
+      stdout.must_include 'Resource `aws_iam_users` is not supported on platform'
+      stdout.must_include 'Resource `aws_iam_access_keys` is not supported on platform'
+      stdout.must_include 'Resource `aws_s3_bucket` is not supported on platform'
       stdout.must_include '3 failures'
       out.exit_status.must_equal 100
     end

--- a/test/unit/resources/crontab_test.rb
+++ b/test/unit/resources/crontab_test.rb
@@ -160,7 +160,7 @@ describe 'Inspec::Resources::Crontab' do
       resource = MockLoader.new(:windows).load_resource('crontab', { user: 'special' })
       _(resource.resource_failed?).must_equal true
       _(resource.resource_exception_message)
-        .must_equal 'Resource Crontab is not supported on platform windows/6.2.9200.'
+        .must_equal 'Resource `crontab` is not supported on platform windows/6.2.9200.'
     end
 
     it 'raises error when no user or path supplied' do

--- a/test/unit/resources/shadow_test.rb
+++ b/test/unit/resources/shadow_test.rb
@@ -153,7 +153,7 @@ describe 'Inspec::Resources::Shadow' do
       resource = MockLoader.new(:windows).load_resource('shadow')
       _(resource.resource_failed?).must_equal true
       _(resource.resource_exception_message)
-        .must_equal 'Resource Shadow is not supported on platform windows/6.2.9200.'
+        .must_equal 'Resource `shadow` is not supported on platform windows/6.2.9200.'
     end
   end
 end

--- a/test/unit/resources/wmi_test.rb
+++ b/test/unit/resources/wmi_test.rb
@@ -27,6 +27,6 @@ describe 'Inspec::Resources::WMI' do
     resource = MockLoader.new(:ubuntu1404).load_resource('wmi', {class: 'win32_service', filter: "name like '%winrm%'" })
     _(resource.resource_failed?).must_equal true
     _(resource.resource_exception_message)
-      .must_equal 'Resource Wmi is not supported on platform ubuntu/14.04.'
+      .must_equal 'Resource `wmi` is not supported on platform ubuntu/14.04.'
   end
 end


### PR DESCRIPTION
For consistency with other error messages, I wrapped resources between backticks.
I also removed an unnecessary capitalization of resource names in error messages.