### PR TITLE
Removed unneeded 'supports: windows'

### DIFF
--- a/lib/inspec/resources/mssql_session.rb
+++ b/lib/inspec/resources/mssql_session.rb
@@ -11,7 +11,6 @@ module Inspec::Resources
   # @see https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-connect-and-query-sqlcmd
   class MssqlSession < Inspec.resource(1)
     name 'mssql_session'
-    supports platform: 'windows'
     desc 'Use the mssql_session InSpec audit resource to test SQL commands run against a MS Sql Server database.'
     example <<~EXAMPLE
       # Using SQL authentication


### PR DESCRIPTION
Microsoft now support `sqlcmd` on all platforms so we can support
all platforms as runners. Without this I cannot run mssql profiles from
osx or linux runners.

https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-2017#os-x-1011-el-capitan-and-macos-1012-sierra

Signed-off-by: Aaron Lippold <lippold@gmail.com>