### PR TITLE
Emergency test fixes!

### DIFF
--- a/examples/plugins/inspec-resource-lister/test/helper.rb
+++ b/examples/plugins/inspec-resource-lister/test/helper.rb
@@ -23,3 +23,4 @@ require 'minitest/spec'
 require 'minitest/autorun'
 
 # You might want to put some debugging tools here.  We run tests to find bugs, after all.
+# require 'byebug'

--- a/examples/plugins/inspec-resource-lister/test/helper.rb
+++ b/examples/plugins/inspec-resource-lister/test/helper.rb
@@ -23,4 +23,3 @@ require 'minitest/spec'
 require 'minitest/autorun'
 
 # You might want to put some debugging tools here.  We run tests to find bugs, after all.
-require 'byebug'

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -2,6 +2,7 @@
 # author: Christoph Hartmann
 require 'inspec/dsl'
 require 'inspec/dsl_shared'
+require 'rspec/core/dsl'
 
 module Inspec
   #
@@ -19,7 +20,6 @@ module Inspec
     # @param [ResourcesDSL] resources_dsl which has all resources to attach
     # @return [RuleContext] the inner context of rules
     def self.rule_context(resources_dsl, profile_id)
-      require 'rspec/core/dsl'
       Class.new(Inspec::Rule) do
         include RSpec::Core::DSL
         with_resource_dsl resources_dsl

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -5,6 +5,7 @@ require 'rubygems/version'
 require 'rubygems/requirement'
 require 'semverse'
 require 'utils/spdx'
+require 'erb'
 
 module Inspec
   # Extract metadata.rb information
@@ -198,7 +199,6 @@ module Inspec
 
     def self.from_yaml(ref, content, profile_id, logger = nil)
       res = Metadata.new(ref, logger)
-      require 'erb'
       res.params = YAML.load(ERB.new(content).result)
       res.content = content
       finalize(res, profile_id, {}, logger)

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -11,6 +11,7 @@ require 'inspec/metadata'
 require 'inspec/config'
 require 'inspec/dependencies/cache'
 require 'inspec/dist'
+require 'inspec/runner_rspec'
 # spec requirements
 
 module Inspec
@@ -52,7 +53,6 @@ module Inspec
       @cache = Inspec::Cache.new(@conf[:vendor_cache])
 
       @test_collector = @conf.delete(:test_collector) || begin
-        require 'inspec/runner_rspec'
         RunnerRspec.new(@conf)
       end
 

--- a/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/test/helper.rb
+++ b/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/test/helper.rb
@@ -22,4 +22,3 @@ require 'inspec/plugin/v2'
 require 'minitest/autorun' # loads all styles and runs tests automatically
 
 # You might want to put some debugging tools here.  We run tests to find bugs, after all.
-require 'byebug'

--- a/test/functional/helper.rb
+++ b/test/functional/helper.rb
@@ -3,7 +3,6 @@
 
 require 'helper'
 require 'rbconfig'
-require 'byebug'
 require 'json'
 require 'fileutils'
 require 'yaml'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,13 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 
+##
+# Do not add any code above this line.
+
+##
+# Do not add any other code to this code block. Simplecov and
+# coveralls only until the next code block:
+
 require 'simplecov'
 require 'coveralls'
 
@@ -16,7 +23,58 @@ SimpleCov.start do
   add_group 'Backends', 'lib/inspec/backend'
 end
 
-require 'minitest/autorun'
+##
+#
+# Do not add any other code from here until the end of this code
+# block.
+#
+# Before ANYTHING else happens, this must happen:
+#
+# 1) require minitest/autorun
+# 2) alias describe to mt_describe
+# 3) require rspec
+# 4) disable_monkey_patching from rspec
+# 5) alias mt_describe back to describe using change_global_dsl.
+#
+# Explanation: eventually, our tests get around to inspec/runner_rspec
+# (and a few others), and they load rspec. When rspec loads, it
+# creates it's own global `describe` method, overwriting minitest's.
+# When you tell RSpec to disable_monkey_patching, instead of using
+# remove_method, they use undef_method, which blocks access to our
+# Kernel.describe. We then need to go back in and reactivate it in
+# order for our tests to finish declaring their tests and eventually
+# actually running.
+#
+# Before this, the tests would get to the point of loading rspec, then
+# all subsequently loaded spec-style tests would just disappear into
+# the aether. Differences in test load order created differences in
+# test count and vast differences in test time (which should have been
+# a clue that something was up--windows is just NOT THAT FAST).
+#
+# The OTHER way to fix this is to ban spec style tests in our
+# codebase. This is a more rational approach but requires more work. I
+# need these tests up and all running and dependable. We can make them
+# right later.
+
+require "minitest/autorun"
+
+module Kernel
+  alias mt_describe describe
+end
+
+require "rspec"
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+end
+
+RSpec::Core::DSL.change_global_dsl do
+  alias describe mt_describe
+end
+
+# End of rspec vs minitest fight
+########################################################################
+
 require 'webmock/minitest'
 require 'mocha/setup'
 require 'fileutils'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -25,7 +25,6 @@ require 'tempfile'
 require 'tmpdir'
 require 'zip'
 require 'json'
-require 'byebug'
 
 require 'inspec/base_cli'
 require 'inspec/version'

--- a/test/unit/fetchers/fetchers_test.rb
+++ b/test/unit/fetchers/fetchers_test.rb
@@ -5,7 +5,7 @@ require 'helper'
 require 'bundles/inspec-supermarket/target'
 require 'bundles/inspec-supermarket/api'
 
-describe Inspec::Fetcher do
+describe "Inspec::Fetcher" do
   it 'loads the local fetcher for this file' do
     res = Inspec::Fetcher.resolve(__FILE__)
     res.must_be_kind_of Fetchers::Local

--- a/test/unit/helper.rb
+++ b/test/unit/helper.rb
@@ -5,6 +5,4 @@ require 'minitest/pride'
 require 'json'
 require 'ostruct'
 
-require 'byebug'
-
 require_relative 'lib/resource_support/aws'

--- a/test/unit/plugin/v2/api_cli_test.rb
+++ b/test/unit/plugin/v2/api_cli_test.rb
@@ -1,5 +1,4 @@
 require 'minitest/autorun'
-require 'byebug'
 
 require_relative '../../../../lib/inspec/plugin/v2'
 

--- a/test/unit/plugin/v2/api_dsl_test.rb
+++ b/test/unit/plugin/v2/api_dsl_test.rb
@@ -1,7 +1,6 @@
 # Tests for the *DSL plugin types
 
 require 'minitest/autorun'
-require 'byebug'
 
 require_relative '../../../../lib/inspec/plugin/v2'
 

--- a/test/unit/plugin/v2/api_dsl_test.rb
+++ b/test/unit/plugin/v2/api_dsl_test.rb
@@ -14,7 +14,7 @@ module DslUnitTests
     :resource_dsl,
   ].each do |plugin_type_under_test|
 
-    Class.new(Minitest::Test) do
+    describe plugin_type_under_test do
       # Assign name to anonymous class, so test output is meaningful
       Object.const_set(plugin_type_under_test.to_s.upcase + '_UnitTests', self)
 

--- a/test/unit/plugin/v2/installer_test.rb
+++ b/test/unit/plugin/v2/installer_test.rb
@@ -8,8 +8,6 @@ require 'json'
 require_relative '../../../../lib/inspec/plugin/v2'
 require_relative '../../../../lib/inspec/plugin/v2/installer'
 
-require 'byebug'
-
 module InstallerTestHelpers
   def reset_globals
     ENV['HOME'] = @orig_home


### PR DESCRIPTION
This fixes our test framework contention and normalizes the number of tests we run regardless of platform/version.

This also cleans up a number of issues that made it harder to debug than it should have been. I'd like to push us towards more consistency, esp on the test side of things. We need to have them deterministic and absolutely dependable.

See commentary in individual commits.