### PR TITLE
Upgrade to Ruby 2.6.3

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -9,4 +9,4 @@ override :bundler, version: '1.17.3'
 # grab the current train release from rubygems.org
 train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
 override 'train', version: "v#{train_stable}"
-override 'ruby', version: '2.6.2'
+override 'ruby', version: '2.6.3'


### PR DESCRIPTION
It has a few bugfixes and support for the new Japanese cal.

Signed-off-by: Tim Smith <tsmith@chef.io>