### PR TITLE
Add kitchen rake testing

### DIFF
--- a/kitchen/rake-tests/Gemfile
+++ b/kitchen/rake-tests/Gemfile
@@ -1,0 +1,4 @@
+source "https://www.rubygems.org"
+
+gem "test-kitchen"
+gem "kitchen-docker"

--- a/kitchen/rake-tests/bootstrap.sh
+++ b/kitchen/rake-tests/bootstrap.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+echo "STARTING PROVISIONER"
+
+export PATH=/opt/inspec/embedded/bin:$PATH
+cd /inspec
+gem install bundler
+bundle install
+gem build inspec
+gem install ./inspec-*.gem
+
+echo "ENDING PROVISIONER"

--- a/kitchen/rake-tests/kitchen.yml
+++ b/kitchen/rake-tests/kitchen.yml
@@ -1,0 +1,24 @@
+driver:
+  name: docker
+
+platforms:
+- name: ubuntu-18.04
+  driver_config:
+    image: ubuntu:18.04
+    platform: ubuntu
+    provision_command:
+      - curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -P inspec
+      - apt-get -y install build-essential
+    require_chef_omnibus: false
+    volume: <%= File.expand_path("../..", File.dirname(__FILE__)) %>:/inspec
+
+provisioner:
+  name: shell
+
+verifier:
+  name: shell
+  remote_exec: true
+  command: cd /inspec && PATH=/opt/inspec/embedded/bin:$PATH bundle exec rake test
+
+suites:
+- name: default


### PR DESCRIPTION
I'd suggest starting to structure kitchen testing like this with a
directory and subdirs to keep the kitchen testing gems out of the
root Gemfile entirely.

This still mounts the root dir in /inspec so the root Gemfile
is still what you're running the rake tests against.

By having an extra layer of subdirs, then you can split up different
use cases like the rake-testing vs. the audit cookbook testing.
Otherwise it'll be a mess of having to manage different kitchen.yml
files that require way too many different drivers/provisioners/verifiers
