### PR TITLE
 Build the InSpec gem directly in Kitchen so we can run locally 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -138,19 +138,7 @@ namespace :test do
     concurrency = ENV['CONCURRENCY'] || 1
     os = args[:os] || ENV['OS'] || ''
     ENV['DOCKER'] = 'true' if ENV['docker'].nil?
-    puts "Building current InSpec gem for audit cookbook testing..."
-    output = %x[gem build inspec-core.gemspec]
-    puts output
-    gem_name = output.split("\n")[-1].split(':')[1].strip
-    path = File.dirname(__FILE__)
-    File.rename(File.join(path, gem_name), File.join(path, 'inspec-core-local.gem'))
-    destination = File.join(path, 'test', 'cookbooks', 'os_prepare', 'files', 'inspec-core-local.gem')
-    begin
-      FileUtils.cp(File.join(path, 'inspec-core-local.gem'), destination)
-      sh("bundle exec kitchen test -c #{concurrency} #{os}")
-    ensure
-      FileUtils.rm(destination)
-    end
+    sh("bundle exec kitchen test -c #{concurrency} #{os}")
   end
   # Inject a prerequisite task
   task :'integration' => [:accept_license]

--- a/kitchen.chef.yml
+++ b/kitchen.chef.yml
@@ -36,7 +36,7 @@ platforms:
 ).each do |mac_version| %>
 - name: macos-<%= mac_version %>
   driver:
-    box: chef/macosx-<%= mac_version %> # private
+    box: chef/macos-<%= mac_version %> # private
     synced_folders:
     - ['..', '/Users/vagrant/chef']
     - ['../../omnibus', '/Users/vagrant/omnibus']

--- a/kitchen.chef.yml
+++ b/kitchen.chef.yml
@@ -57,11 +57,9 @@ platforms:
     - ['../..', '/vagrant/code']
 <% end %>
 
-<% [ '10.11', '11.3' ].each do |solaris_version| %>
 - name: solaris-<%= solaris_version %>
   driver:
-    box: chef/solaris-<%= solaris_version %>
-<% end %>
+    box: chef/solaris-11.3
 
 <% [ '11-sp2-x86_64' ].each do |sles_version| %>
 - name: sles-<%= sles_version %>

--- a/kitchen.chef.yml
+++ b/kitchen.chef.yml
@@ -61,11 +61,9 @@ platforms:
   driver:
     box: chef/solaris-11.3
 
-<% [ '11-sp2-x86_64' ].each do |sles_version| %>
 - name: sles-<%= sles_version %>
   driver:
-    box: chef/sles-<%= sles_version %>
-<% end %>
+    box: chef/sles-11-sp2-x86_64
 
 suites:
   - name: default

--- a/kitchen.chef.yml
+++ b/kitchen.chef.yml
@@ -9,6 +9,10 @@ verifier:
   name: inspec
   sudo: true
 
+lifecycle:
+  pre_converge:
+    - local: gem build inspec-core.gemspec --output test/cookbooks/os_prepare/files/inspec-core-local.gem
+
 platforms:
 # The following (private) boxes are shared via VagrantCloud and are only
 # available to users working for Chef. Sorry, it's about software licensing.

--- a/kitchen.chef.yml
+++ b/kitchen.chef.yml
@@ -24,7 +24,7 @@ platforms:
 # 3.  Do `vagrant login` with your VagrantCloud creds so that you can download
 #     the private boxes.
 #
-# The Mac OS X boxes are VMware only also. You can enable VMware Fusion
+# The macOS boxes are VMware only also. You can enable VMware Fusion
 # by activating the `.kitchen.vmware.yml` file with the `KITCHEN_LOCAL_YAML`
 # environment variable:
 #
@@ -34,7 +34,7 @@ platforms:
   10.11
   10.12
 ).each do |mac_version| %>
-- name: macosx-<%= mac_version %>
+- name: macos-<%= mac_version %>
   driver:
     box: chef/macosx-<%= mac_version %> # private
     synced_folders:

--- a/kitchen.vagrant.yml
+++ b/kitchen.vagrant.yml
@@ -9,6 +9,10 @@ verifier:
   name: inspec
   sudo: true
 
+lifecycle:
+  pre_converge:
+    - local: gem build inspec-core.gemspec --output test/cookbooks/os_prepare/files/inspec-core-local.gem
+
 platforms:
   - name: centos-6
   - name: centos-7

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -7,6 +7,10 @@ driver:
 transport:
   name: dokken
 
+lifecycle:
+  pre_converge:
+    - local: gem build inspec-core.gemspec --output test/cookbooks/os_prepare/files/inspec-core-local.gem
+
 provisioner:
   name: dokken
   client_rb:


### PR DESCRIPTION
Before you had to kick off kitchen via Rake as the Rake task build the local gem we injected into the cookbook. Now we do it within Test Kitchen using a feature that didn't exist when this was all written. Also --output is your friend and greatly reduces the complexity of all this.

This also has some cleanup for the private chef kitchen file to nuke some old platforms.