### PR TITLE
Remove the deprecated linux_kernel_parameter resource test

### DIFF
--- a/test/integration/default/controls/kernel_parameter_spec.rb
+++ b/test/integration/default/controls/kernel_parameter_spec.rb
@@ -52,9 +52,4 @@ if os.linux?
   describe kernel_parameter('net.ipv4.conf.all.forwarding') do
     its('value') { should eq test_values[:forwarding] }
   end
-
-  # serverspec compatability
-  describe linux_kernel_parameter('net.ipv4.conf.all.forwarding') do
-    its('value') { should eq test_values[:forwarding] }
-  end
 end


### PR DESCRIPTION
## Description
This was testing serverspec compatibility, but those days are long past us and this is a deprecated resource now. This will quiet our tests up a bit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
