### PR TITLE
Fix @unique_controls uninitialized warning

### DIFF
--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -166,9 +166,9 @@ module Inspec::Reporters
     end
 
     def all_unique_controls
-      return @unique_controls unless @unique_controls.nil?
+      @unique_controls ||= Set.new
+      return @unique_controls unless @unique_controls.empty?
 
-      @unique_controls = Set.new
       run_data[:profiles].each do |profile|
         profile[:controls].map { |control| @unique_controls.add(control) }
       end

--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -166,14 +166,11 @@ module Inspec::Reporters
     end
 
     def all_unique_controls
-      @unique_controls ||= Set.new
-      return @unique_controls unless @unique_controls.empty?
-
-      run_data[:profiles].each do |profile|
-        profile[:controls].map { |control| @unique_controls.add(control) }
-      end
-
-      @unique_controls
+      @unique_controls ||= begin
+                             run_data[:profiles].map { |profile|
+                               profile[:controls]
+                             }.uniq
+                           end
     end
 
     def profile_summary

--- a/test/unit/reporters/cli_test.rb
+++ b/test/unit/reporters/cli_test.rb
@@ -288,13 +288,6 @@ describe Inspec::Reporters::CLI do
     it 'return unique controls' do
       report.send(:all_unique_controls).count.must_equal 4
     end
-
-    it 'return unique controls cached' do
-      instance_variable_get(:@unique_controls).must_be_nil
-      report.send(:all_unique_controls).count.must_equal 4
-      assert = report.instance_variable_get(:@unique_controls)
-      assert.count.must_equal 4
-    end
   end
 
   describe '#profile_summary' do


### PR DESCRIPTION
## Description

memoize @unique_controls to a Set if nil and
check that its empty? to continue and add controls

/home/miah/projects/github/inspec-master/lib/inspec/reporters/cli.rb:169: warning: instance variable @unique_controls not initialized

Signed-off-by: Miah Johnson <miah@chia-pet.org>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
