### PR TITLE
Do not lint test kitchen support files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ AllCops:
   - 'vendor/**/*'
   - 'lib/bundles/inspec-init/templates/**/*'
   - 'www/demo/**/*'
+  - 'kitchen/**/*'
 AlignParameters:
   Enabled: true
 BlockDelimiters:


### PR DESCRIPTION
Avoid CI failures in code installed by bundler, as seen [here](https://ci.appveyor.com/project/chef/inspec/builds/24577117/job/yib5uplg00fph44h).

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>
