### PR TITLE
Fix @profile_name not initialized

### DIFF
--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -25,7 +25,7 @@ module Inspec
       @profile_id = profile_id
       @backend = backend
       @conf = conf.dup
-      @profile_name = @conf['profile'].profile_name || @profile_id if @conf['profile']
+      @profile_name = @conf.has_key?('profile') ? @conf['profile'].profile_name : @profile_id
       @skip_only_if_eval = @conf['check_mode']
       @rules = {}
       @control_subcontexts = []


### PR DESCRIPTION
I believe that if `@conf['profile']` doesn't exist @profile_name may not be initialized.

```
inspec-master/lib/inspec/profile_context.rb:35: warning: instance variable @profile_name not initialized
```

Signed-off-by: Miah Johnson <miah@chia-pet.org>