### PR TITLE
Updates the init profile description to show proper usage

### DIFF
--- a/lib/plugins/inspec-init/lib/inspec-init/cli_plugin.rb
+++ b/lib/plugins/inspec-init/lib/inspec-init/cli_plugin.rb
@@ -7,7 +7,7 @@ module InspecPlugins
       #-------------------------------------------------------------------#
       #                 inspec init plugin
       #-------------------------------------------------------------------#
-      desc 'PLUGIN_NAME [options]', 'Generates an InSpec plugin, which can extend the functionality of InSpec itself.'
+      desc 'plugin PLUGIN_NAME [options]', 'Generates an InSpec plugin, which can extend the functionality of InSpec itself.'
       # General options
       option :prompt, type: :boolean, default: true, desc: 'Interactively prompt for information to put in your generated plugin.'
       option :detail, type: :string, default: 'full', desc: "How detailed of a plugin to generate. 'full' is a normal full gem with tests; 'core' has tests but no gemspec; 'test-fixture' is stripped down for a test fixture."


### PR DESCRIPTION
## Description

Similar to the "init profile", the "init plugin" needs the name of the sub-command in the description. Otherwise it looks as though you don't need to specify the sub-command to create a plugin:

```bash
$ inspec init
Commands:
  inspec init PLUGIN_NAME [options]   # Generates an InSpec plugin, which can exten...
  inspec init help [COMMAND]          # Describe subcommands or one specific subcom...
  inspec init profile [OPTIONS] NAME  # Generate a new profile

Options:
  [--log-level=LOG_LEVEL]        # Set the log level: info (default), debug, warn, error
  [--log-location=LOG_LOCATION]  # Location to send diagnostic log messages to. (default: STDOUT or Inspec::Log.error)
```

It should read:

```bash
$ inspec init
Commands:
  inspec init plugin PLUGIN_NAME [options]   # Generates an InSpec plugin, which can exten...
  inspec init help [COMMAND]          # Describe subcommands or one specific subcom...
  inspec init profile [OPTIONS] NAME  # Generate a new profile

Options:
  [--log-level=LOG_LEVEL]        # Set the log level: info (default), debug, warn, error
  [--log-location=LOG_LOCATION]  # Location to send diagnostic log messages to. (default: STDOUT or Inspec::Log.error)
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
