### PR TITLE
Fixed missing requires.

### DIFF
--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -3,6 +3,7 @@
 
 require 'pp'
 require 'stringio'
+require 'forwardable'
 
 module Inspec
   class Config

--- a/lib/plugins/inspec-compliance/test/unit/api_test.rb
+++ b/lib/plugins/inspec-compliance/test/unit/api_test.rb
@@ -1,4 +1,5 @@
 require 'minitest/autorun'
+require 'webmock/minitest'
 require 'mocha/setup'
 require_relative '../../lib/inspec-compliance/api.rb'
 


### PR DESCRIPTION
Telemetry tests were hitting inspec/config via a different route and
inspec/config uses forwardable w/o requiring.

lib/plugins/inspec-compliance/test/unit/api_test.rb had a test that
had never run before and required webmock.

Signed-off-by: Ryan Davis <zenspider@chef.io>