### PR TITLE
Use #key? rather than #has_key? in profile_name ternary

### DIFF
--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -25,7 +25,7 @@ module Inspec
       @profile_id = profile_id
       @backend = backend
       @conf = conf.dup
-      @profile_name = @conf.has_key?('profile') ? @conf['profile'].profile_name : @profile_id
+      @profile_name = @conf.key?('profile') ? @conf['profile'].profile_name : @profile_id
       @skip_only_if_eval = @conf['check_mode']
       @rules = {}
       @control_subcontexts = []


### PR DESCRIPTION
lib/inspec/profile_context.rb:28:29: C: [Corrected] Style/PreferredHashMethods: Use Hash#key? instead of Hash#has_key?.
      @profile_name = @conf.has_key?('profile') ? @conf['profile'].profile_name : @profile_id
                            ^^^^^^^^

355 files inspected, 1 offense detected, 1 offense corrected

Signed-off-by: Miah Johnson <miah@chia-pet.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
