### PR TITLE
Test execution changes for Rake, Travis, and Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ cache:
   - directories:
     - /home/travis/.rvm
 dist: xenial
+os:
+  - linux
+  - osx
+  - windows
 services:
 - docker
 bundler_args: "--without integration tools maintenance deploy"
@@ -22,92 +26,39 @@ env:
   - SLOW=1
 matrix:
   include:
-  - rvm: 2.4.5
-    env: UNIT_TESTS_24=1
-  - rvm: 2.5.5
-    env: UNIT_TESTS_25=1
   - rvm: 2.6.3
-    env: UNIT_TESTS_26=1
+  - rvm: 2.5.5
   - rvm: 2.4.5
-    script: bundle exec rake $SUITE
-    env: SUITE="test:functional"
-  - rvm: 2.5.5
-    script: bundle exec rake $SUITE
-    env: SUITE="test:functional"
-  - rvm: 2.6.2
-    script: bundle exec rake $SUITE
-    env: SUITE="test:functional"
-  - rvm: 2.5.5
-    script: bundle exec rake $SUITE
+  - script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-ubuntu-1604]
-  - rvm: 2.5.5
-    script: bundle exec rake $SUITE
+  - script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-ubuntu-1804]
-  - rvm: 2.5.5
-    script: bundle exec rake $SUITE
+  - script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-centos-6]
-  - rvm: 2.5.5
-    script: bundle exec rake $SUITE
+  - script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-centos-7]
-  - rvm: 2.5.5
-    script: bundle exec rake $SUITE
+  - script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-debian-8]
-  - rvm: 2.5.5
-    script: bundle exec rake $SUITE
+  - script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-debian-9]
-  - rvm: 2.5.5
-    script: bundle exec rake $SUITE
+  - script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-debian-10]
-  - rvm: 2.5.5
-    script: bundle exec rake $SUITE
+  - script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-oraclelinux-6]
-  - rvm: 2.5.5
-    script: bundle exec rake $SUITE
+  - script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-oraclelinux-7]
-  - rvm: 2.5.5
-    script: bundle exec rake $SUITE
+  - script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-fedora-29]
-  - rvm: 2.4.5
-    sudo: false
-    cache:
-      apt: true
-      bundle: true
-    addons:
-      apt:
-        packages:
-        - curl
-        - nodejs
-    env:
-      - AFFECTED_DIRS="www"
-      - secure: "jdzXUhP1o7RkfSikZLKgUcCIaKqLjqWa35dnxWnz7qAQ2draRKa7I7cXmUv76BZkW8HBUUH11dOi8YOVxPYPOzaqvcTCfqNqGVxsT9epgWa7rA8aXMXkECp548ry1rYJQpti9zpwsoe2GQyNPr9vNiWMiyj51CaABmZ6JzmFEEqlZc8vqpqWeqJvIqaibQGk7ByLKmi4R44fVwFKIG39RuxV+alc/G4nnQ2zmNTFuy8uFGs5EghQvRytzWY+s2AKtDiZ0YXYOII1Nl1unXNnNoQt9oI209ztlSm1+XOuTPelW6bEIx5i7OZFaSRPgJzWnkGN85C9nBE08L2az9Jz18/rYJF4fdVRttdGskueyYI21lh1FwlAg51ZG0RfLTYk2Pq+k4c+NO1cfmGcaXBwihfD5BWqrILU5HHkYszXCSmgl4hscC7/BS4Kgcq2z32JJwV8B+x4XngM0G4uzIn1Soia3lZXEKdnfVsxFDdMQ7FK60F3uQlq/44LRkZujRhqfAKOiz+0tsLexWzj7wK+DJY9Y00CUfh7xcxRxDxFNpOv1FWYFB9lUlaOt3HDHgUoksqbURiUzhOZZzTE/1MAtF2K6mbpME5CbN08J88L5JBlb+CX79XCzj30lNMeS0I/dCRQEmkygr2eJYxvRO2qsBNuphs4SWk8NZyS/llVZFI="
-    before_install: ./support/ci/fast_pass.sh || exit 0
-    script: ./support/ci/deploy_website_to_acceptance.sh
-
   allow_failures:
-  - env:
-     - AFFECTED_DIRS="www"
-     - secure: "jdzXUhP1o7RkfSikZLKgUcCIaKqLjqWa35dnxWnz7qAQ2draRKa7I7cXmUv76BZkW8HBUUH11dOi8YOVxPYPOzaqvcTCfqNqGVxsT9epgWa7rA8aXMXkECp548ry1rYJQpti9zpwsoe2GQyNPr9vNiWMiyj51CaABmZ6JzmFEEqlZc8vqpqWeqJvIqaibQGk7ByLKmi4R44fVwFKIG39RuxV+alc/G4nnQ2zmNTFuy8uFGs5EghQvRytzWY+s2AKtDiZ0YXYOII1Nl1unXNnNoQt9oI209ztlSm1+XOuTPelW6bEIx5i7OZFaSRPgJzWnkGN85C9nBE08L2az9Jz18/rYJF4fdVRttdGskueyYI21lh1FwlAg51ZG0RfLTYk2Pq+k4c+NO1cfmGcaXBwihfD5BWqrILU5HHkYszXCSmgl4hscC7/BS4Kgcq2z32JJwV8B+x4XngM0G4uzIn1Soia3lZXEKdnfVsxFDdMQ7FK60F3uQlq/44LRkZujRhqfAKOiz+0tsLexWzj7wK+DJY9Y00CUfh7xcxRxDxFNpOv1FWYFB9lUlaOt3HDHgUoksqbURiUzhOZZzTE/1MAtF2K6mbpME5CbN08J88L5JBlb+CX79XCzj30lNMeS0I/dCRQEmkygr2eJYxvRO2qsBNuphs4SWk8NZyS/llVZFI="
-
-notifications:
-  slack:
-    secure: zwOu1gWt8wBDzlhXrYJ39jBDYTYj4Zb8/Z5XH6PalFOyYBytOLYqmpPzxw5KTzFapmcxYt1/biViX25+zapSSmDBuDa94ZneaXuCZAPXX0UJb82ORALMDsdbV1TkkS4Q6N4soigLJ5UaJwIgkZze9VtXeUvo3g8L8+mDYX4J0Poi7Kf/f1KZycNhgaVs7N/i2AI3lBeiVJv+giQbA99OR5dxPzkbx1BeZCK+W+YEPFmg1xycAItiHq0unT+kBN4pm9gW8TT1s/ZucUsKVu6Q8inw5N0PjZwboOkqsQFi5BweVicZBcbOVsW3Xs/f8DX2G823y73Al3QQg+ENxnIpizsHfjE+YzXUVsZ7v/UdsOq01Khxz1GK/X/PYrvIdHQKBwZ86RPJP61BvGIaQ4Hy6f9z+o2Tl/EaAmiOMScpdFi7sMskm8xknI0G24ZG5hkd7XNQ1eVvu33dvs+u12DsBGIylnwrppMDGnh022I5Hg8pS9tJ9gAsJlSFoIBn/yOryoFYb4avB8ujvN6+8cbZgkQ41k6ydqCHk2DxWmhsM4dUVXqC36sOePDE8a/DK5uQ057DSai5M+go5LeEJyK5r4fT5nbTk3nW6CGH0k2bPGWH5aP22mSKB9r2alDzqVfVyArfgtBIX2OXS/cZLER26a1EcB4mf3PMPDB06Aekyj0=
-    on_success: change
-    on_failure: always
-    on_pull_requests: false
-
-deploy:
-  provider: rubygems
-  on:
-    tags: true
-  api_key:
-    secure: uI2Zy3z4ljvOoG/6E4XPmSDg4QX5jmUfp6N9lzOfOosuZGjiGG6cWe4QMfidIz4/B5Ctp9X78bYCPxLkhCPmY9qcsR6eimQsC5AwGJhQF2Fz5fSX12LO+P4H7bis/A7cP+6QYNU8n9oXy6MYIdaw8aLJoEK4tKlNueWYhKG99O1taiF6qXsKkuNXZW7LT3B774IRCK0+BUknfW22ksAOeSpk10dkPXW5lEluXq/Q60L6+Cy01Yix1gLNav7ftMeOtE968mK3L1mzf0L3q8Tih3PLwEzYZRYQRTsd8f1J6XmNZtpdW5QiehvX08ZiFT28Dx15GMp5OKc7TnfU5avm8ryxFJB8xfdrkwNPf/UB3z1IVpHIJ6ZQlHDaiJBL429ZgYSCwrdk71IHWaAK4zSuOZyE+y9EmXbdgLLMgY6QIVrgoBLzzHLCQADXchrMaYR8LIkKI5euOfl3d96sSqXrIN/v1LSlPG/Z1LVO07cYarVGy3J/iM5aTghw3ixZcdlepGrU9DIxe7kRhmz7OLDGTZiPyRzXX1IRjaxSBMGmQSJVv6+r2UJRLmpC3W+1ysXY7nZtffzrFXHGacyvcIHxm8KSPvHgfloPvgFeebcTHcly50TOcZuBc4ZF9HZwWR5lEg/1OX5puBYE7IYfLyFm48+pqFk++tbn2glE742BhkY=
+  - script: bundle exec rake test
+    env: CI_ENABLE_COVERAGE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ branches:
     - /zenspider.*/
 language: ruby
 cache:
-  - bundler
-  - directories:
+  bundler: true
+  directories:
     - /home/travis/.rvm
 dist: xenial
 os:
@@ -24,6 +24,7 @@ before_install:
 env:
   - SLOW=1
   - CI_ENABLE_COVERAGE=true SLOW=1
+script: bundle exec rake $SUITE
 matrix:
   fast_finish: true
   exclude:
@@ -35,37 +36,15 @@ matrix:
   - rvm: 2.6.3
   - rvm: 2.5.5
   - rvm: 2.4.5
-  - script: bundle exec rake $SUITE
-    bundler_args: "--without tools maintenance deploy"
-    env: SUITE=test:integration[default-ubuntu-1604]
-  - script: bundle exec rake $SUITE
-    bundler_args: "--without tools maintenance deploy"
-    env: SUITE=test:integration[default-ubuntu-1804]
-  - script: bundle exec rake $SUITE
-    bundler_args: "--without tools maintenance deploy"
-    env: SUITE=test:integration[default-centos-6]
-  - script: bundle exec rake $SUITE
-    bundler_args: "--without tools maintenance deploy"
-    env: SUITE=test:integration[default-centos-7]
-  - script: bundle exec rake $SUITE
-    bundler_args: "--without tools maintenance deploy"
-    env: SUITE=test:integration[default-debian-8]
-  - script: bundle exec rake $SUITE
-    bundler_args: "--without tools maintenance deploy"
-    env: SUITE=test:integration[default-debian-9]
-  - script: bundle exec rake $SUITE
-    bundler_args: "--without tools maintenance deploy"
-    env: SUITE=test:integration[default-debian-10]
-  - script: bundle exec rake $SUITE
-    bundler_args: "--without tools maintenance deploy"
-    env: SUITE=test:integration[default-oraclelinux-6]
-  - script: bundle exec rake $SUITE
-    bundler_args: "--without tools maintenance deploy"
-    env: SUITE=test:integration[default-oraclelinux-7]
-  - script: bundle exec rake $SUITE
-    bundler_args: "--without tools maintenance deploy"
-    env: SUITE=test:integration[default-fedora-29]
-
+  - env: SUITE=test:integration[default-ubuntu-1604]
+  - env: SUITE=test:integration[default-ubuntu-1804]
+  - env: SUITE=test:integration[default-centos-6]
+  - env: SUITE=test:integration[default-centos-7]
+  - env: SUITE=test:integration[default-debian-8]
+  - env: SUITE=test:integration[default-debian-9]
+  - env: SUITE=test:integration[default-debian-10]
+  - env: SUITE=test:integration[default-oraclelinux-6]
+  - env: SUITE=test:integration[default-oraclelinux-7]
+  - env: SUITE=test:integration[default-fedora-29]
   allow_failures:
   - env: CI_ENABLE_COVERAGE=true SLOW=1
-    script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ before_install:
 - bundle --version
 env:
   - SLOW=1
-  - CI_ENABLE_COVERAGE=true
+  - CI_ENABLE_COVERAGE=true SLOW=1
 matrix:
   fast_finish: true
   exclude:
   - os: osx
-    env: CI_ENABLE_COVERAGE=true
+    env: CI_ENABLE_COVERAGE=true SLOW=1
   - os: linux
     env: SLOW=1
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
     - /home/travis/.rvm
 dist: xenial
 os:
+  - linux
   - osx
 services:
 - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 branches:
   only:
     - master
-    - 3-stable
+    - /.*-stable/
     - /cw.*/
     - /mj.*/
     - /zenspider.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,5 @@ matrix:
     env: SUITE=test:integration[default-fedora-29]
   allow_failures:
   - script: bundle exec rake test
+    os: linux
     env: CI_ENABLE_COVERAGE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ services:
 - docker
 bundler_args: "--without tools maintenance deploy"
 before_install:
-- "gem update --system '~> 3.0'"
+- "gem update --system '3.0'"
 - gem --version
 - bundle --version
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ env:
   - CI_ENABLE_COVERAGE=true
 matrix:
   fast_finish: true
+  exclude:
+  - os: osx
+    env: CI_ENABLE_COVERAGE=true
   include:
   - rvm: 2.6.3
   - rvm: 2.5.5
@@ -62,5 +65,4 @@ matrix:
     env: SUITE=test:integration[default-fedora-29]
   allow_failures:
   - script: bundle exec rake test
-    os: linux
     env: CI_ENABLE_COVERAGE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ matrix:
   - script: bundle exec rake $SUITE
     bundler_args: "--without tools maintenance deploy"
     env: SUITE=test:integration[default-fedora-29]
+
   allow_failures:
-  - script: bundle exec rake test
-    env: CI_ENABLE_COVERAGE=true SLOW=1
+  - env: CI_ENABLE_COVERAGE=true SLOW=1
+    script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ before_install:
 - bundle --version
 env:
   - SLOW=1
+  - CI_ENABLE_COVERAGE=true
 matrix:
+  fast_finish: true
   include:
   - rvm: 2.6.3
   - rvm: 2.5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ os:
   - osx
 services:
 - docker
-bundler_args: "--without integration tools maintenance deploy"
+bundler_args: "--without tools maintenance deploy"
 before_install:
 - gem --version
 - bundle --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ cache:
     - /home/travis/.rvm
 dist: xenial
 os:
-  - linux
   - osx
-  - windows
 services:
 - docker
 bundler_args: "--without integration tools maintenance deploy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ services:
 - docker
 bundler_args: "--without integration tools maintenance deploy"
 before_install:
-- gem update --system
 - gem --version
 - bundle --version
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ services:
 - docker
 bundler_args: "--without tools maintenance deploy"
 before_install:
+- "gem update --system '~> 3.0'"
 - gem --version
 - bundle --version
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
   exclude:
   - os: osx
     env: CI_ENABLE_COVERAGE=true
+  - os: linux
+    env: SLOW=1
   include:
   - rvm: 2.6.3
   - rvm: 2.5.5
@@ -65,4 +67,4 @@ matrix:
     env: SUITE=test:integration[default-fedora-29]
   allow_failures:
   - script: bundle exec rake test
-    env: CI_ENABLE_COVERAGE=true
+    env: CI_ENABLE_COVERAGE=true SLOW=1

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :test do
 end
 
 group :integration do
+  gem 'berkshelf'
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
   gem 'kitchen-inspec'

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ end
 
 group :integration do
   gem 'berkshelf'
+  gem 'chef', '< 15'
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
   gem 'kitchen-inspec'

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :test do
   gem 'webmock', '~> 3.0'
   gem 'passgen'
   gem 'm'
+  gem 'pry', '~> 0.10'
   gem 'pry-byebug'
 end
 
@@ -41,11 +42,6 @@ group :integration do
   gem 'kitchen-inspec', '>= 0.15.1'
   gem 'kitchen-ec2'
   gem 'kitchen-dokken'
-end
-
-group :tools do
-  gem 'pry', '~> 0.10'
-  gem 'license_finder'
   gem 'git', '~> 1.4'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -35,14 +35,13 @@ group :test do
 end
 
 group :integration do
-  gem 'berkshelf', '~> 7'
-  gem 'test-kitchen', '~> 1.17'
+  gem 'berkshelf'
+  gem 'test-kitchen'
   gem 'kitchen-vagrant'
-  # we need winrm v2 support >= 0.15.1
-  gem 'kitchen-inspec', '>= 0.15.1'
+  gem 'kitchen-inspec'
   gem 'kitchen-ec2'
   gem 'kitchen-dokken'
-  gem 'git', '~> 1.4'
+  gem 'git'
 end
 
 # gems for Maintainers.md generation

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ group :test do
 end
 
 group :integration do
-  gem 'berkshelf'
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
   gem 'kitchen-inspec'

--- a/Rakefile
+++ b/Rakefile
@@ -62,9 +62,11 @@ Rake::TestTask.new do |t|
   t.libs << 'test'
   t.test_files = Dir.glob([
     'test/unit/**/*_test.rb',
+    'test/functional/**/*_test.rb',
     'lib/plugins/inspec-*/test/unit/**/*_test.rb',
+    'lib/plugins/inspec-*/test/functional/**/*_test.rb',
   ])
-  t.warning = false
+  t.warning = true
   t.verbose = !!ENV["V"] # default to off. the test commands are _huge_.
   t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
 end
@@ -121,31 +123,25 @@ namespace :test do
       'test/functional/**/*_test.rb',
       'lib/plugins/inspec-*/test/functional/**/*_test.rb',
     ])
-    t.warning = false # This just complains about things in underlying libraries
+    t.warning = true
     t.verbose = true
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end
   # Inject a prerequisite task
   task :functional => [:accept_license]
 
-  # Functional tests on Windows take a bit to run. This
-  # optionally takes a env to breake the tests up into 3 workers.
-  Rake::TestTask.new(:'functional:windows') do |t, args|
-    files = Dir.glob('test/functional/*_test.rb').sort
-    if ENV['WORKER_NUMBER']
-      count = (files.count / 3).abs+1
-      start = (ENV['WORKER_NUMBER'].to_i - 1) * count
-      files = files[start..start+count-1]
-    end
-
+  Rake::TestTask.new(:unit) do |t|
     t.libs << 'test'
-    t.test_files = files
-    t.warning = false # This just complains about things in underlying libraries
+    t.test_files = Dir.glob([
+      'test/unit/**/*_test.rb',
+      'lib/plugins/inspec-*/test/unit/**/*_test.rb',
+    ])
+    t.warning = true
     t.verbose = true
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end
   # Inject a prerequisite task
-  task :'functional:windows' => [:accept_license]
+  task :functional => [:accept_license]
 
   task :resources do
     tests = Dir['test/unit/resource/*_test.rb']

--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,6 @@ rescue LoadError
   puts 'contrib tasks are unavailable because the git gem is not available.'
 end
 
-# Rubocop
 begin
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new(:lint)
@@ -48,35 +47,25 @@ task :install do
   sh("rake install")
 end
 
-# update command output for demo
-desc 'Run inspec commands and save results to www/app/responses'
-task :update_demo do
-  ruby 'www/tutorial/scripts/build_simulator_runtime.rb'
-  ruby 'www/tutorial/scripts/run_simulator_recording.rb'
-end
+GLOBS = [
+  "test/unit/**/*_test.rb",
+  "test/functional/**/*_test.rb",
+  "lib/plugins/inspec-*/test/**/*_test.rb",
+]
 
 # run tests
 task default: [:lint, :test]
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
-  t.test_files = Dir.glob([
-    'test/unit/**/*_test.rb',
-    'test/functional/**/*_test.rb',
-    'lib/plugins/inspec-*/test/unit/**/*_test.rb',
-    'lib/plugins/inspec-*/test/functional/**/*_test.rb',
-  ])
+  t.test_files = Dir[*GLOBS].sort
   t.warning = true
   t.verbose = !!ENV["V"] # default to off. the test commands are _huge_.
   t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
 end
 
 namespace :test do
-  GLOBS = [
-    "test/unit/**/*_test.rb",
-    "test/functional/**/*_test.rb",
-    "lib/plugins/inspec-*/test/**/*_test.rb",
-  ]
+
 
   task :list do
     puts Dir[*GLOBS].sort

--- a/Rakefile
+++ b/Rakefile
@@ -113,7 +113,7 @@ namespace :test do
       'lib/plugins/inspec-*/test/functional/**/*_test.rb',
     ])
     t.warning = true
-    t.verbose = true
+    t.verbose = !!ENV["V"] # default to off. the test commands are _huge_.
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end
   # Inject a prerequisite task
@@ -126,7 +126,7 @@ namespace :test do
       'lib/plugins/inspec-*/test/unit/**/*_test.rb',
     ])
     t.warning = true
-    t.verbose = true
+    t.verbose = !!ENV["V"] # default to off. the test commands are _huge_.
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end
   # Inject a prerequisite task

--- a/Rakefile
+++ b/Rakefile
@@ -399,18 +399,3 @@ task :release_docker do
   sh('sh', '-c', cmd)
 end
 
-desc 'Release the website [deprecated]'
-task :www do
-  puts 'The Rake tasks for releasing the website are now in the www/ directory.'
-  puts 'Run `cd www` and then `rake --tasks` for a list of the www-related tasks available.'
-  exit(1)
-end
-
-namespace :www do
-  desc 'Release the website [deprecated]'
-  task :release do
-    puts 'The Rake tasks for releasing the website are now in the www/ directory.'
-    puts 'Run `cd www` and then `rake --tasks` for a list of the www-related tasks available.'
-    exit(1)
-  end
-end

--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,7 @@ namespace :test do
   Rake::TestTask.new(:default) do |t|
     t.libs << 'test'
     t.test_files = Dir[*GLOBS].sort
-    t.warning = true
+    t.warning = ENV.fetch("W", true)
     t.verbose = !!ENV["V"] # default to off. the test commands are _huge_.
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end
@@ -112,7 +112,7 @@ namespace :test do
       'test/functional/**/*_test.rb',
       'lib/plugins/inspec-*/test/functional/**/*_test.rb',
     ])
-    t.warning = true
+    t.warning = ENV.fetch("W", true)
     t.verbose = !!ENV["V"] # default to off. the test commands are _huge_.
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end
@@ -125,7 +125,7 @@ namespace :test do
       'test/unit/**/*_test.rb',
       'lib/plugins/inspec-*/test/unit/**/*_test.rb',
     ])
-    t.warning = true
+    t.warning = ENV.fetch("W", true)
     t.verbose = !!ENV["V"] # default to off. the test commands are _huge_.
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end

--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,7 @@ namespace :test do
   Rake::TestTask.new(:default) do |t|
     t.libs << 'test'
     t.test_files = Dir[*GLOBS].sort
-    t.warning = ENV.fetch("W", true)
+    t.warning = !!ENV["W"]
     t.verbose = !!ENV["V"] # default to off. the test commands are _huge_.
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end
@@ -112,7 +112,7 @@ namespace :test do
       'test/functional/**/*_test.rb',
       'lib/plugins/inspec-*/test/functional/**/*_test.rb',
     ])
-    t.warning = ENV.fetch("W", true)
+    t.warning = !!ENV["W"]
     t.verbose = !!ENV["V"] # default to off. the test commands are _huge_.
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end
@@ -125,7 +125,7 @@ namespace :test do
       'test/unit/**/*_test.rb',
       'lib/plugins/inspec-*/test/unit/**/*_test.rb',
     ])
-    t.warning = ENV.fetch("W", true)
+    t.warning = !!ENV["W"]
     t.verbose = !!ENV["V"] # default to off. the test commands are _huge_.
     t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
   end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,11 @@ platform:
 
 environment:
   matrix:
+    - name: ruby-2.6
       ruby_version: "26-x64"
+    - name: ruby-2.5
       ruby_version: "25-x64"
+    - name: ruby-2.4
       ruby_version: "24-x64"
 clone_folder: c:\projects\inspec
 clone_depth: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,18 +10,9 @@ platform:
 
 environment:
   matrix:
-    - name: unit-tests-ruby-2.4.4
-      ruby_version: "24-x64"
-    - name: unit-tests-ruby-2.5
+      ruby_version: "26-x64"
       ruby_version: "25-x64"
-    - name: unit-tests-ruby-2.6
-      ruby_version: "26-x64"
-    - name: functional-tests-1
-      ruby_version: "26-x64"
-    - name: functional-tests-2
-      ruby_version: "26-x64"
-    - name: functional-tests-3
-      ruby_version: "26-x64"
+      ruby_version: "24-x64"
 clone_folder: c:\projects\inspec
 clone_depth: 1
 # Disable MSBuild mode entirely
@@ -67,32 +58,3 @@ test_script:
   - SET SPEC_OPTS=--format progress
   - SET SLOW=1
   - bundle exec rake
-
-for:
-  -
-    matrix:
-      only:
-        - name: functional-tests-1
-    test_script:
-      - SET SPEC_OPTS=--format progress
-      - SET WORKER_NUMBER=1
-      - SET SLOW=1
-      - bundle exec rake test:functional:windows
-  -
-    matrix:
-      only:
-        - name: functional-tests-2
-    test_script:
-      - SET SPEC_OPTS=--format progress
-      - SET WORKER_NUMBER=2
-      - SET SLOW=1
-      - bundle exec rake test:functional:windows
-  -
-    matrix:
-      only:
-        - name: functional-tests-3
-    test_script:
-      - SET SPEC_OPTS=--format progress
-      - SET WORKER_NUMBER=3
-      - SET SLOW=1
-      - bundle exec rake test:functional:windows

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,10 +15,11 @@ if ENV['CI_ENABLE_COVERAGE']
     Coveralls::SimpleCov::Formatter
   ])
 
+if ENV['CI_ENABLE_COVERAGE']
   SimpleCov.start do
     add_filter '/test/'
-    add_group 'Resources', 'lib/resources'
-    add_group 'Matchers', 'lib/matchers'
+    add_group 'Resources', ['lib/resources', 'lib/inspec/resources']
+    add_group 'Matchers', ['lib/matchers', 'lib/inspec/matchers']
     add_group 'Backends', 'lib/inspec/backend'
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,7 +15,6 @@ if ENV['CI_ENABLE_COVERAGE']
     Coveralls::SimpleCov::Formatter
   ])
 
-if ENV['CI_ENABLE_COVERAGE']
   SimpleCov.start do
     add_filter '/test/'
     add_group 'Resources', ['lib/resources', 'lib/inspec/resources']

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,9 +6,9 @@
 # coveralls only until the next code block:
 
 if ENV['CI_ENABLE_COVERAGE']
-  require 'simplecov/no_defaults'
+  require "simplecov/no_defaults"
   require "helpers/simplecov_minitest"
-  require 'coveralls'
+  require "coveralls"
 
   SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,

--- a/www/Rakefile
+++ b/www/Rakefile
@@ -62,18 +62,18 @@ namespace :www do # rubocop:disable Metrics/BlockLength
     Verify.file('build/javascripts/all.js')
     Verify.file('build/stylesheets/site.css')
   end
-  task :site => [:accept_license]
+  task site: [:accept_license]
 
   desc 'Assemble the website site from middleman'
   task :assemble do
     Log.section 'Copy only tutorial into middleman build directory'
     sh('rsync -a --exclude=index.html build/')
   end
-  task :assemble => [:accept_license]
+  task assemble: [:accept_license]
 
   desc 'Builds the full site locally'
   task build: ['www:site', 'www:assemble']
-  task :build => [:accept_license]
+  task build: [:accept_license]
 
   task :clean do
     dst = 'build'

--- a/www/Rakefile
+++ b/www/Rakefile
@@ -31,6 +31,27 @@ task :default do
 end
 
 namespace :www do # rubocop:disable Metrics/BlockLength
+
+  task :accept_license do
+    FileUtils.mkdir_p(File.join(Dir.home, '.chef', 'accepted_licenses'))
+    # If the user has not accepted the license, touch the acceptance
+    # file, but also touch a marker that it is only for testing.
+    unless File.exist?(File.join(Dir.home, '.chef', 'accepted_licenses', 'inspec'))
+      puts "\n\nTemporarily accepting Chef user license for the duration of testing...\n"
+      FileUtils.touch(File.join(Dir.home, '.chef', 'accepted_licenses', 'inspec'))
+      FileUtils.touch(File.join(Dir.home, '.chef', 'accepted_licenses', 'inspec.for_testing'))
+    end
+
+    # Regardless of what happens, when this process exits, check for cleanup.
+    at_exit do
+      if File.exist?(File.join(Dir.home, '.chef', 'accepted_licenses', 'inspec.for_testing'))
+        puts "\n\nRemoving temporary Chef user license acceptance file that was placed for test duration.\n"
+        FileUtils.rm_f(File.join(Dir.home, '.chef', 'accepted_licenses', 'inspec'))
+        FileUtils.rm_f(File.join(Dir.home, '.chef', 'accepted_licenses', 'inspec.for_testing'))
+      end
+    end
+  end
+
   desc 'Builds the middleman site'
   task :site do
     Log.section 'Build middleman project'
@@ -41,15 +62,18 @@ namespace :www do # rubocop:disable Metrics/BlockLength
     Verify.file('build/javascripts/all.js')
     Verify.file('build/stylesheets/site.css')
   end
+  task :site => [:accept_license]
 
   desc 'Assemble the website site from middleman'
   task :assemble do
     Log.section 'Copy only tutorial into middleman build directory'
     sh('rsync -a --exclude=index.html build/')
   end
+  task :assemble => [:accept_license]
 
   desc 'Builds the full site locally'
   task build: ['www:site', 'www:assemble']
+  task :build => [:accept_license]
 
   task :clean do
     dst = 'build'


### PR DESCRIPTION
I made default task now perform lint, and 'test'
'test' now does unit and functional. Sorry executing tests is going to be slow, but we won't miss anything.
You can still use `rake test:functional` and `rake test:unit`
Wrapped test coverage setup in an environment variable named CI_ENABLE_COVERAGE
You can now set 'W' and 'V' environment variables to enable Warnings, and Verbose output during testing.

I've also reconfigured travis. 
I removed a bunch of old deploy logic.
Sorted ruby versions newest to oldest.
Jobs in the matrix will automatically use the newest ruby after the sort.
Added a coverage job for coveralls reporting that is allowed to fail.
Added a macos builder.

Because we no longer have 3 functional test tasks for windows anymore the appveyor configuration is greatly simplified.