### PR TITLE
Ensure AwsResourceMixin returns a resource name in deprecation message

### DIFF
--- a/lib/resource_support/aws/aws_resource_mixin.rb
+++ b/lib/resource_support/aws/aws_resource_mixin.rb
@@ -1,6 +1,7 @@
 module AwsResourceMixin
   def initialize(resource_params = {})
-    Inspec.deprecate(:aws_resources_in_resource_pack, "Resource '#{@__resource_name__}'")
+    Inspec.deprecate(:aws_resources_in_resource_pack,
+                     "Resource '#{@__resource_name__ ||= self.class.to_s}'")
     validate_params(resource_params).each do |param, value|
       instance_variable_set(:"@#{param}", value)
     end


### PR DESCRIPTION
`@__resource_name` may be nil, so return our resource name via
`self.class.to_s`. This isn't perfect, is there something better to use
here?

before:
```
/home/travis/build/inspec/inspec/lib/resource_support/aws/aws_resource_mixin.rb:3: warning: instance variable @__resource_name__ not initialized
[2019-05-18T02:46:37+00:00] WARN: DEPRECATION: AWS resources shipped with core InSpec are being to moved to a resource pack for faster iteration. Please update your profiles to depend on git@github.com:inspec/inspec-aws.git . Resource ''
```
after:
```
.[2019-05-17T20:14:37-07:00] WARN: DEPRECATION: AWS resources shipped with core InSpec are being to moved to a resource pack for faster iteration. Please update your profiles to depend on git@github.com:inspec/inspec-aws.git . Resource 'AwsElbs'
```

AwsElbs? This is the `aws_elbs` resource, this is not user-friendly. :(