### PR TITLE
Minor require cleanup for telemetry.

### DIFF
--- a/lib/inspec/utils/telemetry.rb
+++ b/lib/inspec/utils/telemetry.rb
@@ -1,2 +1,3 @@
 require 'inspec/utils/telemetry/collector'
 require 'inspec/utils/telemetry/data_series'
+require 'inspec/utils/telemetry/global_methods'

--- a/lib/inspec/utils/telemetry/global_methods.rb
+++ b/lib/inspec/utils/telemetry/global_methods.rb
@@ -1,4 +1,4 @@
-require 'inspec/utils/telemetry'
+require 'inspec/utils/telemetry/collector'
 
 module Inspec
   # A Global method to add a data series object to the Telemetry Collection.

--- a/test/unit/utils/telemetry/collector_test.rb
+++ b/test/unit/utils/telemetry/collector_test.rb
@@ -1,5 +1,5 @@
 require 'inspec/utils/telemetry'
-require_relative '../../../helper.rb'
+require 'helper'
 
 class TestTelemetryCollector < Minitest::Test
   def setup

--- a/test/unit/utils/telemetry/data_series_test.rb
+++ b/test/unit/utils/telemetry/data_series_test.rb
@@ -1,6 +1,6 @@
 require 'inspec/utils/telemetry'
 require 'json'
-require_relative '../../../helper.rb'
+require 'helper'
 
 class TestTelemetryDataSeries < Minitest::Test
   def test_name

--- a/test/unit/utils/telemetry/global_methods_test.rb
+++ b/test/unit/utils/telemetry/global_methods_test.rb
@@ -1,5 +1,5 @@
 require 'inspec/utils/telemetry'
-require_relative '../../../helper.rb'
+require 'helper'
 
 class TestTelemetryGlobalMethods < Minitest::Test
   def setup


### PR DESCRIPTION
Changes `require_relative` to plain require and adds a missing require needed if global_methods_test was run by itself.