### PR TITLE
This needed to be a flat_map because :profiles was an array.

### DIFF
--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -167,7 +167,7 @@ module Inspec::Reporters
 
     def all_unique_controls
       @unique_controls ||= begin
-                             run_data[:profiles].map { |profile|
+                             run_data[:profiles].flat_map { |profile|
                                profile[:controls]
                              }.uniq
                            end


### PR DESCRIPTION
Entirely on me. Pushing this through to rectify my mistake in review.

Signed-off-by: Ryan Davis <zenspider@chef.io>
