### PR TITLE
Fixes a test interaction bug between installer and loader.

### DIFF
--- a/test/unit/plugin/v2/loader_test.rb
+++ b/test/unit/plugin/v2/loader_test.rb
@@ -162,7 +162,7 @@ class PluginLoaderTests < Minitest::Test
   end
 
   def test_load_mock_plugin_by_gem
-    ENV['INSPEC_CONFIG_DIR'] = File.join(@config_dir_path, 'test-fixture-1-float')
+    ENV['INSPEC_CONFIG_DIR'] = File.join(@config_dir_path, 'test-fixture-2-float')
 
     reg = Inspec::Plugin::V2::Registry.instance
     plugin_name = :'inspec-test-fixture'


### PR DESCRIPTION
Not sure how it was supposed to work in the first place. The plugin in
question depends on ordinal_array and that wasn't in that fixture dir.
Switching to 2 is all it apparently needed.

This does cause yet another double-load warning (VERSION already
defined). I don't know how we're supposed to get around that with the
way we've set up these tests.

Signed-off-by: Ryan Davis <zenspider@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
