### PR TITLE
Just use math.

### DIFF
--- a/lib/inspec/resources/file.rb
+++ b/lib/inspec/resources/file.rb
@@ -155,10 +155,10 @@ module Inspec::Resources
       # to or less permissive than the desired mode (PASS). Otherwise, the files
       # mode is more permissive than the desired mode (FAIL).
 
-      max_mode = max_mode.rjust(4, '0')
-      binary_desired_mode = format('%04b', max_mode).to_i(2)
-      desired_mode_inverse = (binary_desired_mode ^ 0b111111111)
-      (desired_mode_inverse & file.mode).zero? ? false : true
+      max_mode = max_mode.to_i(8)
+      inv_mode = 0777 ^ max_mode
+
+      inv_mode & file.mode != 0
     end
 
     def to_s


### PR DESCRIPTION
I don't know what the reasoning is behind the rjust & the format
call... String converting between octal to binary in order to get an
integer? Instead, this converts from an octal string and uses
straight-forward binary manipulation and logic.

Please avoid `cond ? false : true` like constructs. Use `!cond` instead.

Signed-off-by: Ryan Davis <zenspider@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
