### PR TITLE
Clean up API doco

### DIFF
--- a/www/source/stylesheets/_nav.scss
+++ b/www/source/stylesheets/_nav.scss
@@ -1,9 +1,6 @@
 
 
 #main-nav {
-  position: fixed;
-  top: 0;
-  z-index: 1000;
   width: 100%;
   max-width: 100%;
   background: $color_white;


### PR DESCRIPTION
Right now the header being fixed to the window obscures the section
header for any API doco we provide. Not friendly to the user.

Signed-off-by: Ryan Davis <zenspider@chef.io>
