### PR TITLE
Stop using method(...).call(...)

### DIFF
--- a/lib/inspec/resources/file.rb
+++ b/lib/inspec/resources/file.rb
@@ -47,8 +47,8 @@ module Inspec::Resources
       product_version file_version version? md5sum sha256sum
       path basename source source_path uid gid
     }.each do |m|
-      define_method m.to_sym do |*args|
-        file.method(m.to_sym).call(*args)
+      define_method m do |*args|
+        file.send(m, *args)
       end
     end
 

--- a/lib/inspec/resources/x509_certificate.rb
+++ b/lib/inspec/resources/x509_certificate.rb
@@ -46,8 +46,8 @@ module Inspec::Resources
 
     # Forward these methods directly to OpenSSL::X509::Certificate instance
     %w{version not_before not_after signature_algorithm public_key}.each do |m|
-      define_method m.to_sym do |*args|
-        @cert.method(m.to_sym).call(*args)
+      define_method m do |*args|
+        @cert.send(m, *args)
       end
     end
 

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -261,7 +261,7 @@ module FilterTable
 
       current_raw_data.find_all do |row|
         next unless row.key?(field)
-        self.send(method_ref, row[field], desired_value)
+        send(method_ref, row[field], desired_value)
       end
     end
 
@@ -358,7 +358,7 @@ module FilterTable
         resource_class.send(:define_method, method_name) do |*args, &block|
           begin
             # self here is the resource instance
-            filter_table_instance = table_class.new(self, self.send(raw_data_fetcher_method_name), ' with')
+            filter_table_instance = table_class.new(self, send(raw_data_fetcher_method_name), ' with')
             filter_table_instance.send(method_name, *args, &block)
           rescue Inspec::Exceptions::ResourceFailed, Inspec::Exceptions::ResourceSkipped => e
             FilterTable::ExceptionCatcher.new(resource_class, e)

--- a/lib/utils/filter.rb
+++ b/lib/utils/filter.rb
@@ -250,10 +250,10 @@ module FilterTable
       return [] if current_raw_data.empty?
 
       method_ref = case desired_value
-                   when Float   then method(:matches_float)
-                   when Integer then method(:matches_int)
-                   when Regexp  then method(:matches_regex)
-                   else              method(:matches)
+                   when Float   then :matches_float
+                   when Integer then :matches_int
+                   when Regexp  then :matches_regex
+                   else              :matches
                    end
 
       assume_symbolic_keyed_data = current_raw_data.first.keys.first.is_a? Symbol
@@ -261,7 +261,7 @@ module FilterTable
 
       current_raw_data.find_all do |row|
         next unless row.key?(field)
-        method_ref.call(row[field], desired_value)
+        self.send(method_ref, row[field], desired_value)
       end
     end
 
@@ -355,11 +355,11 @@ module FilterTable
       # the tests are run.
       methods_to_install_on_resource_class = @filter_methods + @custom_properties.keys
       methods_to_install_on_resource_class.each do |method_name|
-        resource_class.send(:define_method, method_name.to_sym) do |*args, &block|
+        resource_class.send(:define_method, method_name) do |*args, &block|
           begin
             # self here is the resource instance
-            filter_table_instance = table_class.new(self, method(raw_data_fetcher_method_name).call, ' with')
-            filter_table_instance.method(method_name.to_sym).call(*args, &block)
+            filter_table_instance = table_class.new(self, self.send(raw_data_fetcher_method_name), ' with')
+            filter_table_instance.send(method_name, *args, &block)
           rescue Inspec::Exceptions::ResourceFailed, Inspec::Exceptions::ResourceSkipped => e
             FilterTable::ExceptionCatcher.new(resource_class, e)
           end


### PR DESCRIPTION
Use send. It's **vastly** faster:

```
Comparison:
                send:  6364383.9 i/s
         method+call:  2530347.8 i/s - 2.52x  slower
```

Also removed a bunch of unnecessary to_sym's. Ruby doesn't care.

Signed-off-by: Ryan Davis <zenspider@chef.io>
