### PR TITLE
Flag `rubocop:disable` comments as something to be fixed.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,6 +8,7 @@ plugins:
     config:
       strings:
         - TODO
+        - rubocop:disable
   flog:
     enabled: true
   markdownlint:


### PR DESCRIPTION
Now `# rubocop:disable` type comments will get called out by codeclimate.