### PR TITLE
Mention inspec-bin gem in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ inspec exec test.rb -t docker://container_id
 
 ## Installation
 
-Chef InSpec requires Ruby ( >= 2.4 ). 
+Chef InSpec requires Ruby ( >= 2.4 ).
 
 Note: Versions of Chef InSpec 4.0 and later require accepting the EULA to use. Please visit the [license acceptance page](https://docs.chef.io/chef_license_accept.html) on the Chef docs site for more information.
 
@@ -85,11 +85,18 @@ For Ubuntu:
 apt-get -y install ruby ruby-dev gcc g++ make
 ```
 
-To install inspec from [rubygems](https://rubygems.org/):
+To install the `inspec` executable, which requires accepting the [Chef License](https://docs.chef.io/chef_license_accept.html), run:
+
+```bash
+gem install inspec-bin
+```
+
+You may also use `inspec` as a library, with no executable; this does not require accepting the license. To install the library as a gem, run:
 
 ```bash
 gem install inspec
 ```
+
 
 ### Usage via Docker
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To install the `inspec` executable, which requires accepting the [Chef License](
 gem install inspec-bin
 ```
 
-You may also use `inspec` as a library, with no executable; this does not require accepting the license. To install the library as a gem, run:
+You may also use `inspec` as a library, with no executable. This does not require accepting the license. To install the library as a gem, run:
 
 ```bash
 gem install inspec

--- a/www/source/downloads.html.slim
+++ b/www/source/downloads.html.slim
@@ -70,12 +70,12 @@ header.bg-gradient.margin-top-offset.short-bg.relative
             ' Chef InSpec is included in the
             a href="https://downloads.chef.io/chefdk" ChefDK
             '  and is available as a standalone
-            a href="https://rubygems.org/gems/inspec" Ruby gem
+            a href="https://rubygems.org/gems/inspec-bin" Ruby gem
             ' .
           .pad-under-xs
             .box-code.shadow.box-code-overwrite.margin-top-xs
              i#copy.fa.fa-copy.copy.t-purple.mobile-hide onclick="copyToClipboard('#ruby-users-install')"
-             code#ruby-users-install gem install inspec
+             code#ruby-users-install gem install inspec-bin
         .triangle-right
 
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Splits the gem download links in the README to offer `inspec-bin` (as an executable) and `inspec` (as a library).

Changes the name of the gem offered to download on the website download page from `inspec` to `inspec-bin`.

Note that after merge, a website push will be required.

Docs only changes, no tests.

## Related Issue

Fixes #4145

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
