### PR TITLE
Update sunset messages on 2 resources

### DIFF
--- a/docs/resources/apache.md.erb
+++ b/docs/resources/apache.md.erb
@@ -5,9 +5,9 @@ platform: linux
 
 # apache
 
-Use the `apache` Chef InSpec audit resource to test the state of the Apache server on Linux/Unix systems.
+<p class="warning">This resource is deprecated and should not be used. It was removed in Chef InSpec 4.0.  The documentation below is preserved as a reference. Replacement functionality is available in the [apache_conf](apache_conf/) resource.</p>
 
-<p class="warning">This resource is deprecated and should not be used. It will be removed in Chef InSpec 3.0.</p>
+Use the `apache` Chef InSpec audit resource to test the state of the Apache server on Linux/Unix systems.
 
 <br>
 
@@ -15,11 +15,11 @@ Use the `apache` Chef InSpec audit resource to test the state of the Apache serv
 
 ### Installation
 
-This resource is distributed along with Chef InSpec itself. You can use it automatically.
+This resource was distributed along with Chef InSpec itself.
 
 ### Version
 
-This resource first became available in v1.51.15 of InSpec.
+This resource first became available in v1.51.15 of InSpec and was removed in version 4.0.
 
 ## Syntax
 

--- a/docs/resources/azure_generic_resource.md.erb
+++ b/docs/resources/azure_generic_resource.md.erb
@@ -4,7 +4,7 @@ title: About the azure_generic_resource Resource
 
 # azure\_generic\_resource
 
-<p class="warning">This resource is deprecated and should not be used. It will be removed in Chef InSpec 3.0.</p>
+<p class="warning">This resource is deprecated and should not be used. It will be removed in Chef InSpec 5.0. Instead of using any of the demonstration Azure resources included with Chef InSpec, use the [`inspec-azure`](https://github.com/inspec/inspec-azure) resource pack, which offers rich functionality and specific resources to fit many common use cases.</p>
 
 Use the `azure_generic_resource` Chef InSpec audit resource to test any valid Azure Resource. This is very useful if you need to test something that we do not yet have a specific Chef InSpec resource for.
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Updates the deprecation warning on `apache` and `azure_generic_resource` to be more specific about their fate, and to suggest alternatives.  Availability for `apache` was recast into the past tense.

After merge, will require a website push.

Docs change only, no tests.

## Related Issue

Fixes #4021 

<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
