### PR TITLE
Replace jsonschema with json-schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ group :test do
   gem 'mocha', '~> 1.1'
   gem 'ruby-progressbar', '~> 1.8'
   gem 'webmock', '~> 3.0'
-  gem 'jsonschema', '~> 2.0.2'
   gem 'passgen'
   gem 'm'
   gem 'pry-byebug'

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'train-core', '~> 2.0'
   spec.add_dependency 'license-acceptance', '>= 0.2.13', '< 2.0'
   spec.add_dependency 'thor', '~> 0.20'
-  spec.add_dependency 'json-schema'
+  spec.add_dependency 'json-schema', '~> 2.8'
   spec.add_dependency 'method_source', '~> 0.8'
   spec.add_dependency 'rubyzip', '~> 1.1'
   spec.add_dependency 'rspec', '~> 3'

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'train-core', '~> 2.0'
   spec.add_dependency 'license-acceptance', '>= 0.2.13', '< 2.0'
   spec.add_dependency 'thor', '~> 0.20'
-  spec.add_dependency 'json', '>= 1.8', '< 3.0'
+  spec.add_dependency 'json-schema'
   spec.add_dependency 'method_source', '~> 0.8'
   spec.add_dependency 'rubyzip', '~> 1.1'
   spec.add_dependency 'rspec', '~> 3'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   # Implementation dependencies
   spec.add_dependency 'license-acceptance', '>= 0.2.13', '< 2.0'
   spec.add_dependency 'thor', '~> 0.20'
-  spec.add_dependency 'json-schema'
+  spec.add_dependency 'json-schema', '~> 2.8'
   spec.add_dependency 'method_source', '~> 0.8'
   spec.add_dependency 'rubyzip', '~> 1.2', '>= 1.2.2'
   spec.add_dependency 'rspec', '~> 3'

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   # Implementation dependencies
   spec.add_dependency 'license-acceptance', '>= 0.2.13', '< 2.0'
   spec.add_dependency 'thor', '~> 0.20'
-  spec.add_dependency 'json', '>= 1.8', '< 3.0'
+  spec.add_dependency 'json-schema'
   spec.add_dependency 'method_source', '~> 0.8'
   spec.add_dependency 'rubyzip', '~> 1.2', '>= 1.2.2'
   spec.add_dependency 'rspec', '~> 3'

--- a/test/functional/inspec_check_test.rb
+++ b/test/functional/inspec_check_test.rb
@@ -1,5 +1,4 @@
 require 'functional/helper'
-require 'jsonschema'
 require 'tmpdir'
 
 describe 'inspec check' do

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -1,5 +1,5 @@
 require 'functional/helper'
-require 'jsonschema'
+require 'json-schema'
 
 describe 'inspec exec with json formatter' do
   include FunctionalHelper
@@ -11,7 +11,7 @@ describe 'inspec exec with json formatter' do
     data = JSON.parse(out.stdout)
     sout = inspec('schema exec-json')
     schema = JSON.parse(sout.stdout)
-    JSON::Schema.validate(data, schema)
+    JSON::Validator.validate(schema, data).wont_equal false
   end
 
   it 'can execute a profile and validate the json schema' do
@@ -21,7 +21,7 @@ describe 'inspec exec with json formatter' do
     data = JSON.parse(out.stdout)
     sout = inspec('schema exec-json')
     schema = JSON.parse(sout.stdout)
-    JSON::Schema.validate(data, schema)
+    JSON::Validator.validate(schema, data).wont_equal false
   end
 
   it 'can execute a simple file while using end of options after reporter cli option' do
@@ -31,7 +31,7 @@ describe 'inspec exec with json formatter' do
     data = JSON.parse(out.stdout)
     sout = inspec('schema exec-json')
     schema = JSON.parse(sout.stdout)
-    JSON::Schema.validate(data, schema)
+    JSON::Validator.validate(schema, data).wont_equal false
   end
 
   it 'can execute a profile and validate the json schema with target_id' do
@@ -42,7 +42,7 @@ describe 'inspec exec with json formatter' do
     data['platform']['target_id'].must_equal '1d3e399f-4d71-4863-ac54-84d437fbc444'
     sout = inspec('schema exec-json')
     schema = JSON.parse(sout.stdout)
-    JSON::Schema.validate(data, schema)
+    JSON::Validator.validate(schema, data).wont_equal false
   end
 
   it 'does not report skipped dependent profiles' do

--- a/test/functional/inspec_exec_jsonmin_test.rb
+++ b/test/functional/inspec_exec_jsonmin_test.rb
@@ -1,5 +1,5 @@
 require 'functional/helper'
-require 'jsonschema'
+require 'json-schema'
 
 describe 'inspec exec' do
   include FunctionalHelper
@@ -11,7 +11,7 @@ describe 'inspec exec' do
     data = JSON.parse(out.stdout)
     sout = inspec('schema exec-jsonmin')
     schema = JSON.parse(sout.stdout)
-    JSON::Schema.validate(data, schema)
+    JSON::Validator.validate(schema, data).wont_equal false
   end
 
   it 'can execute a simple file with the mini json formatter and validate its schema' do
@@ -21,7 +21,7 @@ describe 'inspec exec' do
     data = JSON.parse(out.stdout)
     sout = inspec('schema exec-jsonmin')
     schema = JSON.parse(sout.stdout)
-    JSON::Schema.validate(data, schema)
+    JSON::Validator.validate(schema, data).wont_equal false
   end
 
   it 'does not contain any dupilcate results with describe.one' do


### PR DESCRIPTION
This replaces jsonschema with json-schema. I've also dropped the external  json requirement since Ruby ships with it. The tests were also updated to test the result. jsonschema was also a Gemfile dependency when it should have been in the gemspec.

fixes https://github.com/inspec/inspec/issues/4129  https://github.com/inspec/inspec/issues/4002