### PR TITLE
Fix two misrendering hyperlinks in resource docs

### DIFF
--- a/docs/resources/apache.md.erb
+++ b/docs/resources/apache.md.erb
@@ -5,7 +5,7 @@ platform: linux
 
 # apache
 
-<p class="warning">This resource is deprecated and should not be used. It was removed in Chef InSpec 4.0.  The documentation below is preserved as a reference. Replacement functionality is available in the [apache_conf](apache_conf/) resource.</p>
+<p class="warning">This resource is deprecated and should not be used. It was removed in Chef InSpec 4.0.  The documentation below is preserved as a reference. Replacement functionality is available in the `apache_conf` resource.</p>
 
 Use the `apache` Chef InSpec audit resource to test the state of the Apache server on Linux/Unix systems.
 

--- a/docs/resources/apache.md.erb
+++ b/docs/resources/apache.md.erb
@@ -5,7 +5,7 @@ platform: linux
 
 # apache
 
-<p class="warning">This resource is deprecated and should not be used. It was removed in Chef InSpec 4.0.  The documentation below is preserved as a reference. Replacement functionality is available in the `apache_conf` resource.</p>
+**Warning**:This resource is deprecated and should not be used. It was removed in Chef InSpec 4.0.  The documentation below is preserved as a reference. Replacement functionality is available in the [`apache_conf`](/docs/reference/resources/apache_conf) resource.
 
 Use the `apache` Chef InSpec audit resource to test the state of the Apache server on Linux/Unix systems.
 

--- a/docs/resources/azure_generic_resource.md.erb
+++ b/docs/resources/azure_generic_resource.md.erb
@@ -4,7 +4,7 @@ title: About the azure_generic_resource Resource
 
 # azure\_generic\_resource
 
-<p class="warning">This resource is deprecated and should not be used. It will be removed in Chef InSpec 5.0. Instead of using any of the demonstration Azure resources included with Chef InSpec, use the `inspec-azure` resource pack from https://github.com/inspec/inspec-azure, which offers rich functionality and specific resources to fit many common use cases.</p>
+**Warning**: This resource is deprecated and should not be used. It will be removed in Chef InSpec 5.0. Instead of using any of the demonstration Azure resources included with Chef InSpec, use the [`inspec-azure`](https://github.com/inspec/inspec-azure) resource pack, which offers rich functionality and specific resources to fit many common use cases.
 
 Use the `azure_generic_resource` Chef InSpec audit resource to test any valid Azure Resource. This is very useful if you need to test something that we do not yet have a specific Chef InSpec resource for.
 

--- a/docs/resources/azure_generic_resource.md.erb
+++ b/docs/resources/azure_generic_resource.md.erb
@@ -4,7 +4,7 @@ title: About the azure_generic_resource Resource
 
 # azure\_generic\_resource
 
-<p class="warning">This resource is deprecated and should not be used. It will be removed in Chef InSpec 5.0. Instead of using any of the demonstration Azure resources included with Chef InSpec, use the [`inspec-azure`](https://github.com/inspec/inspec-azure) resource pack, which offers rich functionality and specific resources to fit many common use cases.</p>
+<p class="warning">This resource is deprecated and should not be used. It will be removed in Chef InSpec 5.0. Instead of using any of the demonstration Azure resources included with Chef InSpec, use the `inspec-azure` resource pack from https://github.com/inspec/inspec-azure, which offers rich functionality and specific resources to fit many common use cases.</p>
 
 Use the `azure_generic_resource` Chef InSpec audit resource to test any valid Azure Resource. This is very useful if you need to test something that we do not yet have a specific Chef InSpec resource for.
 


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

#4163 and #4164 added website hyperlinks that sure look like they should render, but didn't. Turns out they were wrapped in `<p>` tags, which disabled markdown processing. This PR fixes that.

We'll need a website push after this is merged.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
