### PR TITLE
Turn off parallel testing (for now?)

### DIFF
--- a/test/functional/helper.rb
+++ b/test/functional/helper.rb
@@ -3,11 +3,6 @@ require 'train'
 
 ENV["CHEF_LICENSE"] = "accept-no-persist"
 
-require 'minitest/hell'
-class Minitest::Test
-  parallelize_me!
-end
-
 CMD = Train.create('local', command_runner: :generic).connection
 
 class Module

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -67,7 +67,6 @@ require 'mocha/setup'
 require 'inspec/log'
 require 'inspec/backend'
 require "helpers/mock_loader"
-require "minitest/hell"
 
 TMP_CACHE = {}
 
@@ -153,4 +152,12 @@ class Minitest::Test
     raise msg if Time.now > Time.local(y, m, d)
     skip msg
   end
+end
+
+class InspecTest < Minitest::Test
+  # shared stuff here
+end
+
+class ParallelTest < InspecTest
+  parallelize_me!
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -67,6 +67,7 @@ require 'mocha/setup'
 require 'inspec/log'
 require 'inspec/backend'
 require "helpers/mock_loader"
+require "minitest/hell"
 
 TMP_CACHE = {}
 

--- a/test/unit/profiles/control_eval_context_test.rb
+++ b/test/unit/profiles/control_eval_context_test.rb
@@ -38,8 +38,6 @@ EOF
   end
 
   it 'provides rules with access to the given DSL' do
-    skip_until 2019, 6, 13, "Totally breaks mocha! Remove and fix this by TODO 2019-06-13"
-
     profile_context.stubs(:current_load).returns({file: "<test content>"})
     eval_context.instance_eval(control_content)
     profile_context.all_rules.each do |rule|


### PR DESCRIPTION
This will slow our tests down but hopefully completely eliminate the remaining test instability we have.

This also changes the way that rspec & minitest interact again, as I found that the previous way wasn't sufficient for mocha to survive rspec's invocation.