### PR TITLE
Fixed up interactions between minitest & simplecov.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,19 +5,22 @@
 # Do not add any other code to this code block. Simplecov and
 # coveralls only until the next code block:
 
-require 'simplecov'
-require 'coveralls'
+if ENV['CI_ENABLE_COVERAGE']
+  require 'simplecov/no_defaults'
+  require "helpers/simplecov_minitest"
+  require 'coveralls'
 
-SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-])
+  SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ])
 
-SimpleCov.start do
-  add_filter '/test/'
-  add_group 'Resources', 'lib/resources'
-  add_group 'Matchers', 'lib/matchers'
-  add_group 'Backends', 'lib/inspec/backend'
+  SimpleCov.start do
+    add_filter '/test/'
+    add_group 'Resources', 'lib/resources'
+    add_group 'Matchers', 'lib/matchers'
+    add_group 'Backends', 'lib/inspec/backend'
+  end
 end
 
 ##

--- a/test/helpers/simplecov_minitest.rb
+++ b/test/helpers/simplecov_minitest.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Load default formatter gem
+require "simplecov-html"
+require "pathname"
+require "simplecov/profiles/root_filter"
+require "simplecov/profiles/test_frameworks"
+require "simplecov/profiles/bundler_filter"
+require "simplecov/profiles/rails"
+
+# Default configuration
+SimpleCov.configure do
+  formatter SimpleCov::Formatter::HTMLFormatter
+  load_profile "bundler_filter"
+  # Exclude files outside of SimpleCov.root
+  load_profile "root_filter"
+end
+
+# Gotta stash this a-s-a-p, see the CommandGuesser class and i.e. #110 for further info
+SimpleCov::CommandGuesser.original_run_command = "#{$PROGRAM_NAME} #{ARGV.join(' ')}"
+
+at_exit do
+  if defined? Minitest then
+    Minitest.after_run do
+      simplecov_at_exit
+    end
+  else
+    simplecov_at_exit
+  end
+end
+
+def simplecov_at_exit
+  # If we are in a different process than called start, don't interfere.
+  return if SimpleCov.pid != Process.pid
+
+  SimpleCov.set_exit_exception
+  SimpleCov.run_exit_tasks!
+end
+
+# Autoload config from ~/.simplecov if present
+require "simplecov/load_global_config"
+
+# Autoload config from .simplecov if present
+# Recurse upwards until we find .simplecov or reach the root directory
+
+config_path = Pathname.new(SimpleCov.root)
+loop do
+  filename = config_path.join(".simplecov")
+  if filename.exist?
+    begin
+      load filename
+    rescue LoadError, StandardError
+      $stderr.puts "Warning: Error occurred while trying to load #{filename}. " \
+        "Error message: #{$!.message}"
+    end
+    break
+  end
+  config_path, = config_path.split
+  break if config_path.root?
+end


### PR DESCRIPTION
Sometime during the 2.x's, `at_exit` changed its ordering. As a result,
a lot of things that were stacking `at_exit`'s broke. This is one of
those since both simplecov and minitest do their thing via `at_exit`.
This switches to simplecov w/ no defaults on, then replicates their
simplecov/defaults.rb with our own.

I'm going to try to get that entire file back upstream but it can live
here for now.

Signed-off-by: Ryan Davis <zenspider@chef.io>
