### PR TITLE
Update test code to rename attribute() to input() in DSL

### DIFF
--- a/examples/profile-attribute/controls/example.rb
+++ b/examples/profile-attribute/controls/example.rb
@@ -1,5 +1,5 @@
-val_user = attribute('user', value: 'alice', description: 'An identification for the user')
-val_password = attribute('password', description: 'A value for the password')
+val_user = input('user', value: 'alice', description: 'An identification for the user')
+val_password = input('password', description: 'A value for the password')
 
 describe val_user do
   it { should eq 'bob' }

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -22,8 +22,6 @@ provisioner:
 verifier:
   name: inspec
   sudo: true
-  attributes:
-    verifier_attribute: 'Attribute Override!'
 
 platforms:
 - name: amazonlinux

--- a/test/integration/aws/default/verify/controls/aws_cloudtrail_trail.rb
+++ b/test/integration/aws/default/verify/controls/aws_cloudtrail_trail.rb
@@ -10,7 +10,7 @@ fixtures = {}
   'cloudtrail_trail_2_arn',
   'cloudtrail_trail_2_s3_bucket_name'
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/cloudtrail.tf',

--- a/test/integration/aws/default/verify/controls/aws_cloudwatch_alarm.rb
+++ b/test/integration/aws/default/verify/controls/aws_cloudwatch_alarm.rb
@@ -4,7 +4,7 @@ fixtures = {}
   'cloudwatch_alarm_1_metric_name',
   'cloudwatch_alarm_1_namespace',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
   fixture_name,
   default: "default.#{fixture_name}",
   description: 'See ../build/cloudwatch.tf',

--- a/test/integration/aws/default/verify/controls/aws_cloudwatch_log_metric_filter.rb
+++ b/test/integration/aws/default/verify/controls/aws_cloudwatch_log_metric_filter.rb
@@ -7,7 +7,7 @@ fixtures = {}
 'log_metric_filter_2_log_group_name',
 'log_metric_filter_2_pattern',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
   fixture_name,
   default: "default.#{fixture_name}",
   description: 'See ../build/cloudwatch.tf',

--- a/test/integration/aws/default/verify/controls/aws_config_delivery_channel.rb
+++ b/test/integration/aws/default/verify/controls/aws_config_delivery_channel.rb
@@ -6,7 +6,7 @@ fixtures = {}
   'delivery_channel_01_bucket_prefix',
   'sns_topic_for_delivery_channel_arn'
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/iam.tf',

--- a/test/integration/aws/default/verify/controls/aws_config_recorder.rb
+++ b/test/integration/aws/default/verify/controls/aws_config_recorder.rb
@@ -3,7 +3,7 @@ fixtures = {}
   'role_for_config_recorder_arn',
   'config_recorder_name',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/config.tf',

--- a/test/integration/aws/default/verify/controls/aws_ec2_instance.rb
+++ b/test/integration/aws/default/verify/controls/aws_ec2_instance.rb
@@ -12,7 +12,7 @@ fixtures = {}
   'ec2_instance_debian_id',  
   'ec2_ami_id_debian',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/ec2.tf',

--- a/test/integration/aws/default/verify/controls/aws_ec2_instances.rb
+++ b/test/integration/aws/default/verify/controls/aws_ec2_instances.rb
@@ -4,7 +4,7 @@ fixtures = {}
   'ec2_instance_centos_id',
   'ec2_instance_debian_id',  
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/ec2.tf',

--- a/test/integration/aws/default/verify/controls/aws_eks_cluster.rb
+++ b/test/integration/aws/default/verify/controls/aws_eks_cluster.rb
@@ -5,7 +5,7 @@ fixtures = {}
   'eks_cluster_security_group_id',
   'eks_vpc_subnets',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/eks.tf',

--- a/test/integration/aws/default/verify/controls/aws_elb.rb
+++ b/test/integration/aws/default/verify/controls/aws_elb.rb
@@ -13,7 +13,7 @@ fixtures = {}
   'elb_security_group_to_lb_id',
   'elb_vpc_id',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/ec2.tf',

--- a/test/integration/aws/default/verify/controls/aws_elbs.rb
+++ b/test/integration/aws/default/verify/controls/aws_elbs.rb
@@ -13,7 +13,7 @@ fixtures = {}
   'elb_security_group_to_lb_id',
   'elb_vpc_id',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/ec2.tf',

--- a/test/integration/aws/default/verify/controls/aws_flow_log.rb
+++ b/test/integration/aws/default/verify/controls/aws_flow_log.rb
@@ -1,7 +1,7 @@
 fixtures = {}
 %w[flow_log_alpha_vpc_log_id flow_log_alpha_subnet_log_id
    flow_log_alpha_subnet_id flow_log_vpc_id].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/flow_log.tf',

--- a/test/integration/aws/default/verify/controls/aws_iam_access_key.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_access_key.rb
@@ -6,7 +6,7 @@ fixtures = {}
   'iam_access_key_recall_hit',
   'iam_access_key_recall_miss',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/iam.tf',

--- a/test/integration/aws/default/verify/controls/aws_iam_access_keys.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_access_keys.rb
@@ -4,7 +4,7 @@ fixtures = {}
   'iam_user_without_access_key',  
   'iam_access_key_recall_hit',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/iam.tf',

--- a/test/integration/aws/default/verify/controls/aws_iam_group.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_group.rb
@@ -3,7 +3,7 @@ fixtures = {}
   'iam_group_administrators',
   'iam_user_recall_hit'
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/iam.tf',

--- a/test/integration/aws/default/verify/controls/aws_iam_groups.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_groups.rb
@@ -2,7 +2,7 @@ fixtures = {}
 [
   'iam_group_administrators',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/iam.tf',

--- a/test/integration/aws/default/verify/controls/aws_iam_policy.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_policy.rb
@@ -3,7 +3,7 @@ fixtures = {}
   'aws_iam_policy_alpha_name',
   'aws_iam_policy_beta_name',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/iam.tf',

--- a/test/integration/aws/default/verify/controls/aws_iam_root_user.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_root_user.rb
@@ -2,7 +2,7 @@ fixtures = {}
 [
   'aws_account_id',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/iam.tf',

--- a/test/integration/aws/default/verify/controls/aws_iam_user.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_user.rb
@@ -20,7 +20,7 @@ fixtures = {}
   'iam_policy_user_attached_0i_2a_2_arn',
   'iam_policy_user_attached_0i_2a_2_name',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/iam.tf',

--- a/test/integration/aws/default/verify/controls/aws_iam_users.rb
+++ b/test/integration/aws/default/verify/controls/aws_iam_users.rb
@@ -14,7 +14,7 @@ fixtures = {}
   'iam_policy_user_attached_0i_2a_2_arn',
   'iam_policy_user_attached_0i_2a_2_name',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/iam.tf',

--- a/test/integration/aws/default/verify/controls/aws_kms_key.rb
+++ b/test/integration/aws/default/verify/controls/aws_kms_key.rb
@@ -5,7 +5,7 @@ fixtures = {}
   'kms_key_disabled_key_id',
   'kms_key_enabled_key_description'
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
   fixture_name,
   default: "default.#{fixture_name}",
   description: 'See ../build/kms.tf',

--- a/test/integration/aws/default/verify/controls/aws_rds_instance.rb
+++ b/test/integration/aws/default/verify/controls/aws_rds_instance.rb
@@ -2,7 +2,7 @@ fixtures = {}
 [
   'rds_db_instance_id',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/rds.tf',

--- a/test/integration/aws/default/verify/controls/aws_route_table.rb
+++ b/test/integration/aws/default/verify/controls/aws_route_table.rb
@@ -3,7 +3,7 @@ fixtures = {}
   'route_table_1_id',
   'route_table_1_vpc_id',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/route_table.tf',

--- a/test/integration/aws/default/verify/controls/aws_route_tables.rb
+++ b/test/integration/aws/default/verify/controls/aws_route_tables.rb
@@ -4,7 +4,7 @@ fixtures = {}
   'route_table_2_id',
   'route_table_1_vpc_id',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/ec2.tf',

--- a/test/integration/aws/default/verify/controls/aws_s3_bucket.rb
+++ b/test/integration/aws/default/verify/controls/aws_s3_bucket.rb
@@ -10,7 +10,7 @@ fixtures = {}
   's3_bucket_access_logging_enabled_name',
   's3_bucket_access_logging_not_enabled_name',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/s3.tf',

--- a/test/integration/aws/default/verify/controls/aws_s3_buckets.rb
+++ b/test/integration/aws/default/verify/controls/aws_s3_buckets.rb
@@ -3,7 +3,7 @@ fixtures = {}
   's3_bucket_public_name',
   's3_bucket_private_name',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/s3.tf',

--- a/test/integration/aws/default/verify/controls/aws_security_group.rb
+++ b/test/integration/aws/default/verify/controls/aws_security_group.rb
@@ -7,7 +7,7 @@ fixtures = {}
   'ec2_security_group_gamma_group_id',
   'ec2_security_group_alpha_group_name',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/ec2.tf',

--- a/test/integration/aws/default/verify/controls/aws_security_groups.rb
+++ b/test/integration/aws/default/verify/controls/aws_security_groups.rb
@@ -3,7 +3,7 @@ fixtures = {}
   'ec2_security_group_default_vpc_id',
   'ec2_security_group_default_group_id',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/ec2.tf',

--- a/test/integration/aws/default/verify/controls/aws_sns_subscription.rb
+++ b/test/integration/aws/default/verify/controls/aws_sns_subscription.rb
@@ -5,7 +5,7 @@ fixtures = {}
   'sqs_for_sub_03_arn',
   'aws_account_id',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/sns.tf',

--- a/test/integration/aws/default/verify/controls/aws_sns_topic.rb
+++ b/test/integration/aws/default/verify/controls/aws_sns_topic.rb
@@ -4,7 +4,7 @@ fixtures = {}
   'sns_topic_with_subscription_arn',
   'sns_topic_no_subscription_arn',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
   fixture_name,
   default: "default.#{fixture_name}",
   description: 'See ../build/sns.tf',

--- a/test/integration/aws/default/verify/controls/aws_sns_topics.rb
+++ b/test/integration/aws/default/verify/controls/aws_sns_topics.rb
@@ -2,7 +2,7 @@ fixtures = {}
 [
   'sns_topic_recall_hit_arn',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/sns.tf',

--- a/test/integration/aws/default/verify/controls/aws_sqs_queue.rb
+++ b/test/integration/aws/default/verify/controls/aws_sqs_queue.rb
@@ -3,7 +3,7 @@ fixtures = {}
   'sqs_queue_1_url',
   'sqs_queue_2_url',  
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
   fixture_name,
   default: "default.#{fixture_name}",
   description: 'See ../build/sqs.tf',

--- a/test/integration/aws/default/verify/controls/aws_subnet.rb
+++ b/test/integration/aws/default/verify/controls/aws_subnet.rb
@@ -4,7 +4,7 @@ fixtures = {}
   'subnet_01_id',
   'subnet_01_az',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/ec2.tf',

--- a/test/integration/aws/default/verify/controls/aws_subnets.rb
+++ b/test/integration/aws/default/verify/controls/aws_subnets.rb
@@ -3,7 +3,7 @@ fixtures = {}
   'subnet_01_id',
   'subnet_vpc_id',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/ec2.tf',

--- a/test/integration/aws/default/verify/controls/aws_vpc.rb
+++ b/test/integration/aws/default/verify/controls/aws_vpc.rb
@@ -8,7 +8,7 @@ fixtures = {}
   'vpc_non_default_instance_tenancy',
   'vpc_non_default_dhcp_options_id',    
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/ec2.tf',

--- a/test/integration/aws/default/verify/controls/aws_vpcs.rb
+++ b/test/integration/aws/default/verify/controls/aws_vpcs.rb
@@ -8,7 +8,7 @@ fixtures = {}
   'vpc_non_default_instance_tenancy',
   'vpc_non_default_dhcp_options_id',    
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/ec2.tf',

--- a/test/integration/aws/minimal/verify/controls/aws_iam_root_user.rb
+++ b/test/integration/aws/minimal/verify/controls/aws_iam_root_user.rb
@@ -2,7 +2,7 @@ fixtures = {}
 [
   'aws_account_id',
 ].each do |fixture_name|
-  fixtures[fixture_name] = attribute(
+  fixtures[fixture_name] = input(
     fixture_name,
     default: "default.#{fixture_name}",
     description: 'See ../build/iam.tf',

--- a/test/integration/default/controls/audit_spec.rb
+++ b/test/integration/default/controls/audit_spec.rb
@@ -23,14 +23,6 @@ control 'Test audit cookbook json output' do
   end
 end
 
-# test kitchen verify attr passthrough
-attr = attribute('verifier_attribute', default: 'none') # TODO: update test-kitchen to replace attribute -> input
-control 'validate verifier attribute override' do
-  describe attr do
-    it { should eq 'Attribute Override!' }
-  end
-end
-
 # make sure all tests passed
 file = file('/tmp/json_export.json')
 if file.exist?

--- a/test/unit/inputs/input_test.rb
+++ b/test/unit/inputs/input_test.rb
@@ -37,14 +37,14 @@ describe Inspec::Input do
       # Should have the DSL call. This should be attribute(), not input(), for the
       # foreseeable future, to maintain backwards compatibility.
       ruby_code.must_include "attribute('application_port'"
-      ruby_code.must_include 'value: 80'
-      ruby_code.must_include 'default: 80'
+      ruby_code.must_include "value: 80"
+      ruby_code.must_include "default: 80"
       ruby_code.must_include "description: 'The port my application uses'"
 
       # Try to eval the code to verify that the generated code was valid ruby.
       # Note that the input() method is part of the DSL, so we need to
       # alter the call into something that can respond - the constructor will do
-      ruby_code_for_eval = ruby_code.sub(/attribute\(/,'Inspec::Input.new(')
+      ruby_code_for_eval = ruby_code.sub(/attribute\(/, "Inspec::Input.new(")
 
       # This will throw exceptions if there is a problem
       new_attr = eval(ruby_code_for_eval) # rubocop:disable Security/Eval # Could use ripper!

--- a/test/unit/inputs/input_test.rb
+++ b/test/unit/inputs/input_test.rb
@@ -34,15 +34,17 @@ describe Inspec::Input do
 
       ruby_code = input.to_ruby
       ruby_code.must_include "attr_application_port = " # Should assign to a var
-      ruby_code.must_include "attribute('application_port'" # Should have the DSL call
-      ruby_code.must_include "value: 80"
-      ruby_code.must_include "default: 80"
+      # Should have the DSL call. This should be attribute(), not input(), for the
+      # foreseeable future, to maintain backwards compatibility.
+      ruby_code.must_include "attribute('application_port'"
+      ruby_code.must_include 'value: 80'
+      ruby_code.must_include 'default: 80'
       ruby_code.must_include "description: 'The port my application uses'"
 
       # Try to eval the code to verify that the generated code was valid ruby.
-      # Note that the attribute() method is part of the DSL, so we need to
+      # Note that the input() method is part of the DSL, so we need to
       # alter the call into something that can respond - the constructor will do
-      ruby_code_for_eval = ruby_code.sub(/attribute\(/, "Inspec::Input.new(")
+      ruby_code_for_eval = ruby_code.sub(/input\(/,'Inspec::Input.new(')
 
       # This will throw exceptions if there is a problem
       new_attr = eval(ruby_code_for_eval) # rubocop:disable Security/Eval # Could use ripper!

--- a/test/unit/inputs/input_test.rb
+++ b/test/unit/inputs/input_test.rb
@@ -44,7 +44,7 @@ describe Inspec::Input do
       # Try to eval the code to verify that the generated code was valid ruby.
       # Note that the input() method is part of the DSL, so we need to
       # alter the call into something that can respond - the constructor will do
-      ruby_code_for_eval = ruby_code.sub(/input\(/,'Inspec::Input.new(')
+      ruby_code_for_eval = ruby_code.sub(/attribute\(/,'Inspec::Input.new(')
 
       # This will throw exceptions if there is a problem
       new_attr = eval(ruby_code_for_eval) # rubocop:disable Security/Eval # Could use ripper!

--- a/test/unit/mock/profiles/inputs/basic/controls/flat.rb
+++ b/test/unit/mock/profiles/inputs/basic/controls/flat.rb
@@ -10,7 +10,7 @@ tests = expecteds.keys.map do |test_name|
   {
     name: test_name,
     expected: expecteds[test_name],
-    input_via_string: attribute(test_name.to_s, value: "#{test_name}_default"),
+    input_via_string: input(test_name.to_s, value: "#{test_name}_default"),
   }
 end
 

--- a/test/unit/mock/profiles/inputs/basic/controls/nested.rb
+++ b/test/unit/mock/profiles/inputs/basic/controls/nested.rb
@@ -9,9 +9,9 @@ input_names = [
 inputs = {}
 input_names.each do |input_name|
   # Store as a symbol-fetched input
-  inputs[input_name] = attribute(input_name, value: "#{input_name}_sym_default")
+  inputs[input_name] = input(input_name, value: "#{input_name}_sym_default")
   # .. and store under a string name, as a string-fetched input!
-  inputs[input_name.to_s] = attribute(input_name.to_s, value: "#{input_name}_str_default")
+  inputs[input_name.to_s] = input(input_name.to_s, value: "#{input_name}_str_default")
 end
 
 # For now, these all use string keys, as that is normal InSpec behavior

--- a/test/unit/mock/profiles/inputs/inheritance/child-01/controls/child-01-controls.rb
+++ b/test/unit/mock/profiles/inputs/inheritance/child-01/controls/child-01-controls.rb
@@ -1,12 +1,12 @@
 control 'child-01-control-01' do
-  describe attribute('test-01') do
+  describe input('test-01') do
     # This is an independent value, inheritance-child-01/test-01
     it { should cmp 'value-from-child-01-metadata' }
   end
 end
 
 control 'child-01-control-02' do
-  describe attribute('test-02') do
+  describe input('test-02') do
     # This value was set by the wrapper, inheritance-child-01/test-02
     it { should cmp 'value-from-wrapper-metadata' }
   end

--- a/test/unit/mock/profiles/inputs/inheritance/child-02/controls/child-02-controls.rb
+++ b/test/unit/mock/profiles/inputs/inheritance/child-02/controls/child-02-controls.rb
@@ -1,5 +1,5 @@
 control 'child-02-control-01' do
-  describe attribute('test-03') do
+  describe input('test-03') do
     # This value was set by the wrapper via an alias, inheritance-child-02/test-02
     it { should cmp 'value-from-wrapper-metadata' }
   end

--- a/test/unit/mock/profiles/inputs/inheritance/wrapper/controls/wrapper-controls.rb
+++ b/test/unit/mock/profiles/inputs/inheritance/wrapper/controls/wrapper-controls.rb
@@ -5,7 +5,7 @@ include_controls('inheritance-child-01')
 include_controls('inheritance-child-02-aliased')
 
 control 'wrapper-control-01' do
-  describe attribute('test-01') do
+  describe input('test-01') do
     # This is an independent value, inheritance-wrapper/test-01
     it { should cmp 'value-from-wrapper-metadata' }
   end

--- a/test/unit/mock/profiles/inputs/metadata-required/controls/mention-required.rb
+++ b/test/unit/mock/profiles/inputs/metadata-required/controls/mention-required.rb
@@ -1,1 +1,1 @@
-attribute('a_required_input')
+input('a_required_input')

--- a/test/unit/mock/profiles/inputs/plugin/controls/plugin_controls.rb
+++ b/test/unit/mock/profiles/inputs/plugin/controls/plugin_controls.rb
@@ -1,17 +1,17 @@
 control 'only_in_plugin' do
-  describe attribute('test_only_in_plugin') do
+  describe input('test_only_in_plugin') do
     it { should cmp 'only_in_plugin' }
   end
 end
 
 control 'collide_plugin_higher' do
-  describe attribute('test_collide_plugin_higher', value: 'wrong', priority: 10) do
+  describe input('test_collide_plugin_higher', value: 'wrong', priority: 10) do
     it { should cmp 'collide_plugin_higher' }
   end
 end
 
 control 'collide_inline_higher' do
-  describe attribute('test_collide_inline_higher', value: 'collide_inline_higher', priority: 70) do
+  describe input('test_collide_inline_higher', value: 'collide_inline_higher', priority: 70) do
     it { should cmp 'collide_inline_higher' }
   end
 end
@@ -19,7 +19,7 @@ end
 control 'event_log' do
   # This attribute is set here here in the DSL and in the plugin
   # An attribute with this history should have 3 events - a create, a DSL set, and a plugin fetch.
-  attribute('test_event_log', value: 'setting_in_dsl')
+  input('test_event_log', value: 'setting_in_dsl')
 
   # Fetch the attribute object from the registry
   input_obj = Inspec::InputRegistry.find_or_register_input('test_event_log', 'input-test-fixture')

--- a/test/unit/mock/profiles/inputs/undeclared/controls/undeclared.rb
+++ b/test/unit/mock/profiles/inputs/undeclared/controls/undeclared.rb
@@ -5,21 +5,21 @@ control 'start_marker' do
 end
 
 control 'undeclared_in_control_body' do
-  attribute('undeclared_01')
-  assignment_outcome = attribute('undeclared_02')
+  input('undeclared_01')
+  assignment_outcome = input('undeclared_02')
   describe('dummy_test_02') do
     it { should cmp 'dummy_test_02'}
   end
 end
 
 control 'undeclared_in_only_if' do
-  only_if { attribute('undeclared_03') }
+  only_if { input('undeclared_03') }
   describe('dummy_test_03') do
     it { should cmp 'dummy_test_03'}
   end
 end
 
-attribute('undeclared_04')
+input('undeclared_04')
 
 control 'end_marker' do
   describe('dummy_test_04') do

--- a/test/unit/mock/profiles/old-examples/profile-attribute/controls/example.rb
+++ b/test/unit/mock/profiles/old-examples/profile-attribute/controls/example.rb
@@ -1,5 +1,5 @@
-val_user = attribute('user', value: 'alice', description: 'An identification for the user')
-val_password = attribute('password', description: 'A value for the password')
+val_user = input('user', value: 'alice', description: 'An identification for the user')
+val_password = input('password', description: 'A value for the password')
 
 describe val_user do
   it { should eq 'bob' }

--- a/test/unit/mock/profiles/profile-with-required-inputs/controls/include.rb
+++ b/test/unit/mock/profiles/profile-with-required-inputs/controls/include.rb
@@ -1,4 +1,4 @@
-cis_level = attribute('cis_level')
+cis_level = input('cis_level')
 
 control 'control1' do
   title 'title'


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
After #4008 renamed `attribute()` to `input()` in the DSL, all of our test fixtures that mention `attribute()` would one day emit deprecation warnings. This PR mechanically performs a bulk replace on the first commit. A code example is also included.

In addition, it was found that we were testing kitchen-inspec in this codebase, which didn't make sense - it is explicitly tested in its own codebase, where it should be.

Finally, a DSL-related bit of testing code was updated regarding how inputs are marshalled under `to_ruby`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Part of #3802
Followup to #4008
Closes #4149

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
