### PR TITLE
Speed up inspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 - gem --version
 - bundle --version
 env:
-  - SLOW=1
+  - SLOW=1 NO_AWS=1
   - CI_ENABLE_COVERAGE=true SLOW=1
 script: bundle exec rake $SUITE
 matrix:
@@ -31,7 +31,7 @@ matrix:
   - os: osx
     env: CI_ENABLE_COVERAGE=true SLOW=1
   - os: linux
-    env: SLOW=1
+    env: SLOW=1 NO_AWS=1
   include:
   - rvm: 2.6.3
   - rvm: 2.5.5

--- a/inspec-bin/bin/inspec
+++ b/inspec-bin/bin/inspec
@@ -7,6 +7,5 @@ Encoding.default_internal = Encoding::UTF_8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require "inspec"
 require "inspec/cli"
 Inspec::InspecCLI.start(ARGV)

--- a/lib/fetchers/mock.rb
+++ b/lib/fetchers/mock.rb
@@ -1,3 +1,5 @@
+require "inspec/fetcher"
+
 module Fetchers
   class Mock < Inspec.fetcher(1)
     name "mock"

--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -2,6 +2,7 @@
 
 require "train"
 require "inspec/config"
+require "inspec/version"
 
 module Inspec
   module Backend

--- a/lib/inspec/backend.rb
+++ b/lib/inspec/backend.rb
@@ -3,6 +3,7 @@
 require "train"
 require "inspec/config"
 require "inspec/version"
+require "inspec/resource"
 
 module Inspec
   module Backend

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -1,7 +1,8 @@
 require "thor"
 require "inspec/log"
-require "inspec/profile_vendor"
 require "inspec/ui"
+require "inspec/config"
+require "inspec/utils/deprecation/global_method"
 
 # Allow end of options during array type parsing
 # https://github.com/erikhuda/thor/issues/631
@@ -233,6 +234,8 @@ module Inspec
     end
 
     def vendor_deps(path, opts)
+      require "inspec/profile_vendor"
+
       profile_path = path || Dir.pwd
       profile_vendor = Inspec::ProfileVendor.new(profile_path)
 

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -1,6 +1,9 @@
 # Copyright 2015 Dominik Richter
 
 require "inspec/utils/deprecation/deprecator"
+require "inspec/dist"
+require "inspec/backend"
+require "inspec/dependencies/cache"
 
 module Inspec # TODO: move this somewhere "better"?
   autoload :BaseCLI,       "inspec/base_cli"
@@ -61,8 +64,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "A list of controls to include. Ignore all other tests."
   profile_options
   def json(target)
-    require 'inspec/resources'
-    require 'json'
+    require "inspec/resources"
+    require "json"
 
     o = config
     diagnose(o)
@@ -100,7 +103,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :format, type: :string
   profile_options
   def check(path) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
-    require 'inspec/resources'
+    require "inspec/resources"
 
     o = config
     diagnose(o)
@@ -158,7 +161,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :overwrite, type: :boolean, default: false,
     desc: "Overwrite existing vendored dependencies and lockfile."
   def vendor(path = nil)
-    require 'inspec/resources'
+    require "inspec/resources"
 
     o = config
     configure_logger(o)
@@ -181,7 +184,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :ignore_errors, type: :boolean, default: false,
     desc: "Ignore profile warnings."
   def archive(path)
-    require 'inspec/resources'
+    require "inspec/resources"
 
     o = config
     diagnose(o)
@@ -367,7 +370,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 
   desc "schema NAME", "print the JSON schema", hide: true
   def schema(name)
-    require 'inspec/schema'
+    require "inspec/schema"
 
     puts Inspec::Schema.json(name)
   rescue StandardError => e
@@ -382,7 +385,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       v = { version: Inspec::VERSION }
       puts v.to_json
     else
-      require 'inspec/utils/latest_version'
+      require "inspec/utils/latest_version"
       puts Inspec::VERSION
       # display outdated version
       # TODO: remove this. Don't notify of update to a gem when they install omnibus
@@ -394,9 +397,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   end
   map %w{-v --version} => :version
 
-  desc 'nothing', 'does nothing'
+  desc "nothing", "does nothing"
   def nothing
-    puts 'you did nothing'
+    puts "you did nothing"
   end
 
   private
@@ -452,6 +455,8 @@ end
 #---------------------------------------------------------------------#
 # Plugin Loading
 #---------------------------------------------------------------------#
+require "inspec/plugin/v2"
+
 begin
   # Load v2 plugins.  Manually check for plugin disablement.
   omit_core = ARGV.delete("--disable-core-plugins")

--- a/lib/inspec/fetcher.rb
+++ b/lib/inspec/fetcher.rb
@@ -35,6 +35,7 @@ module Inspec
   end
 end
 
+# TODO: remove. require up, not down.
 require "fetchers/local"
 require "fetchers/url"
 require "fetchers/git"

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -1,4 +1,5 @@
 require "rubygems/package"
+require "pathname"
 require "zlib"
 require "zip"
 

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -3,6 +3,7 @@ require "singleton"
 require "inspec/objects/input"
 require "inspec/secrets"
 require "inspec/exceptions"
+require "inspec/plugin/v2"
 
 module Inspec
   # The InputRegistry's responsibilities include:

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -4,7 +4,6 @@ require "logger"
 require "rubygems/version"
 require "rubygems/requirement"
 require "semverse"
-require "erb"
 
 require "inspec/version"
 require "inspec/utils/spdx"
@@ -200,6 +199,7 @@ module Inspec
     end
 
     def self.from_yaml(ref, content, profile_id, logger = nil)
+      require "erb"
       res = Metadata.new(ref, logger)
       res.params = YAML.load(ERB.new(content).result)
       res.content = content

--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -1,3 +1,5 @@
+require "inspec/exceptions"
+
 module Inspec
   module ResourceBehaviors
     def to_s

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -2,15 +2,10 @@
 
 require "forwardable"
 require "openssl"
+require "pathname"
 require "inspec/input_registry"
-require "inspec/polyfill"
-require "inspec/cached_fetcher"
-require "inspec/file_provider"
+require "inspec/cached_fetcher" # TODO: split or rename
 require "inspec/source_reader"
-require "inspec/metadata"
-require "inspec/backend"
-require "inspec/rule"
-require "inspec/log"
 require "inspec/profile_context"
 require "inspec/runtime_profile"
 require "inspec/method_source"

--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -1,5 +1,6 @@
 # copyright: 2015, Vulcano Security GmbH
 require "inspec/plugin/v1"
+require "inspec/utils/deprecation/global_method" # for resources
 
 module Inspec
   class ProfileNotFound < StandardError; end

--- a/lib/inspec/resources.rb
+++ b/lib/inspec/resources.rb
@@ -4,6 +4,8 @@ require "inspec/resource"
 # This relies on AWS being stripped from the inspec-core gem
 inspec_core_only = !File.exist?(File.join(File.dirname(__FILE__), "..", "resource_support", "aws.rb"))
 
+require "rspec/matchers"
+
 # Do not attempt to load cloud resources if we are in inspec-core mode
 unless inspec_core_only
   require "resource_support/aws"

--- a/lib/inspec/resources.rb
+++ b/lib/inspec/resources.rb
@@ -2,7 +2,7 @@ require "inspec/resource"
 
 # Detect if we are running the stripped-down inspec-core
 # This relies on AWS being stripped from the inspec-core gem
-inspec_core_only = !File.exist?(File.join(File.dirname(__FILE__), "..", "resource_support", "aws.rb"))
+inspec_core_only = ENV["NO_AWS"] || !File.exist?(File.join(File.dirname(__FILE__), "..", "resource_support", "aws.rb"))
 
 require "rspec/matchers"
 

--- a/lib/inspec/resources/command.rb
+++ b/lib/inspec/resources/command.rb
@@ -1,5 +1,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
+require "inspec/resource"
+
 module Inspec::Resources
   class Cmd < Inspec.resource(1)
     name "command"

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -9,6 +9,7 @@ require "inspec/metadata"
 require "inspec/config"
 require "inspec/dependencies/cache"
 require "inspec/dist"
+require "inspec/resources"
 require "inspec/reporters"
 require "inspec/runner_rspec"
 # spec requirements

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -1,6 +1,8 @@
 require "rspec/core"
 require "rspec/its"
 require "inspec/formatters"
+require "matchers/matchers"
+require "inspec/rspec_extensions"
 
 # There be dragons!! Or borgs, or something...
 # This file and all its contents cannot be unit-tested. both test-suits

--- a/lib/inspec/ui.rb
+++ b/lib/inspec/ui.rb
@@ -1,6 +1,3 @@
-require "tty-table"
-require "tty-prompt"
-
 module Inspec
   # Provides simple terminal UI interaction primitives for CLI commands and plugins.
   class UI
@@ -158,6 +155,8 @@ module Inspec
     #   t << ['', '', 1]
     #  end
     def table(opts = { print: true })
+      require "inspec/ui_table_helper"
+
       the_table = TableHelper.new
       yield(the_table)
 
@@ -172,13 +171,6 @@ module Inspec
       padding = [0, 1, 0, 1] # T R B L
       result = the_table.render(render_mode, filter: colorizer, padding: padding) + "\n"
       print_or_return(result, opts[:print])
-    end
-
-    class TableHelper < TTY::Table
-      def header=(ary)
-        cells = ary.dup.map { |label| { value: label, alignment: :center } }
-        @header = TTY::Table::Header.new(cells)
-      end
     end
 
     #=========================================================================#
@@ -212,6 +204,8 @@ module Inspec
       unless interactive?
         raise Inspec::UserInteractionRequired, "Somthing is trying to ask the user a question, but interactivity is disabled."
       end
+      require "tty-prompt"
+
       @prompt ||= TTY::Prompt.new
     end
   end

--- a/lib/inspec/ui_table_helper.rb
+++ b/lib/inspec/ui_table_helper.rb
@@ -1,0 +1,12 @@
+require "tty-table"
+
+module Inspec
+  class UI
+    class TableHelper < TTY::Table
+      def header=(ary)
+        cells = ary.dup.map { |label| { value: label, alignment: :center } }
+        @header = TTY::Table::Header.new(cells)
+      end
+    end
+  end
+end

--- a/lib/inspec/utils/pkey_reader.rb
+++ b/lib/inspec/utils/pkey_reader.rb
@@ -1,3 +1,5 @@
+require "inspec/objects/input"
+
 module PkeyReader
   def read_pkey(filecontent, passphrase)
     raise_if_unset(passphrase)

--- a/lib/plugins/inspec-habitat/test/unit/profile_test.rb
+++ b/lib/plugins/inspec-habitat/test/unit/profile_test.rb
@@ -1,6 +1,7 @@
 require "mixlib/log"
 require "fileutils"
 require "minitest/autorun"
+require "inspec/backend"
 require_relative "../../lib/inspec-habitat/profile.rb"
 
 class InspecPlugins::Habitat::ProfileTest < Minitest::Test

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -1,5 +1,7 @@
 require "functional/helper"
 require "tmpdir"
+require "zip"
+require "rubygems/package"
 
 describe "inspec archive" do
   include FunctionalHelper

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -217,6 +217,7 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     let(:out) { inspec("exec " + File.join(profile_path, "aws-profile")) }
     let(:stdout) { out.stdout.force_encoding(Encoding::UTF_8) }
     it "exits with an error" do
+      skip if ENV["NO_AWS"]
       stdout.must_include "Resource `aws_iam_users` is not supported on platform"
       stdout.must_include "Resource `aws_iam_access_keys` is not supported on platform"
       stdout.must_include "Resource `aws_s3_bucket` is not supported on platform"

--- a/test/functional/ui_test.rb
+++ b/test/functional/ui_test.rb
@@ -32,19 +32,18 @@ describe "InSpec UI behavior" do
     describe "headline" do
       let(:feature) { "headline" }
       it "has correct output" do
-        run_result.exit_status.must_equal 0
         expected = <<-EOT
 
  ───────────────────────────────── \e[1m\e[37mBig News!\e[0m ───────────────────────────────── \n
         EOT
         show_spaces(run_result.stdout).must_equal show_spaces(expected)
+        run_result.exit_status.must_equal 0
       end
     end
 
     describe "table" do
       let(:feature) { "table" }
       it "has correct output" do
-        run_result.exit_status.must_equal 0
         expected = <<~EOT
           ┌──────────────────────┬──────────┬───────────┐
           │\e[1m\e[37m         Band         \e[0m│\e[1m\e[37m Coolness \e[0m│\e[1m\e[37m Nerd Cred \e[0m│
@@ -55,39 +54,40 @@ describe "InSpec UI behavior" do
           └──────────────────────┴──────────┴───────────┘
         EOT
         show_spaces(run_result.stdout).must_equal show_spaces(expected)
+        run_result.exit_status.must_equal 0
       end
     end
 
     describe "warning" do
       let(:feature) { "warning" }
       it "has correct output" do
-        run_result.exit_status.must_equal 0
         expected = <<~EOT
           \e[1m\e[33mWARNING:\e[0m Things will be OK in the end
         EOT
         show_spaces(run_result.stdout).must_equal show_spaces(expected)
+        run_result.exit_status.must_equal 0
       end
     end
 
     describe "error" do
       let(:feature) { "error" }
       it "has correct output" do
-        run_result.exit_status.must_equal 0
         expected = <<~EOT
           \e[1m\e[38;5;9mERROR:\e[0m Burned down, fell over, and then sank into the swamp.
         EOT
         show_spaces(run_result.stdout).must_equal show_spaces(expected)
+        run_result.exit_status.must_equal 0
       end
     end
 
     describe "list_item" do
       let(:feature) { "list_item" }
       it "has correct output" do
-        run_result.exit_status.must_equal 0
         expected = <<-EOT
  \e[1m\e[37m•\e[0m TODO: make more lists
         EOT
         show_spaces(run_result.stdout).must_equal show_spaces(expected)
+        run_result.exit_status.must_equal 0
       end
     end
   end
@@ -97,8 +97,9 @@ describe "InSpec UI behavior" do
     let(:post_opts) { "--no-color" }
     describe "everything" do
       let(:feature) { "everything" }
+
       it "has correct output" do
-        run_result.exit_status.must_equal 0
+        # TODO: trailing whitespace required in tests. Hidden via "--- \n"
         expected = <<~EOT
 
            --------------------------------- Big News! --------------------------------- \n
@@ -114,6 +115,7 @@ describe "InSpec UI behavior" do
            * TODO: make more lists
         EOT
         show_spaces(run_result.stdout).must_equal show_spaces(expected)
+        run_result.exit_status.must_equal 0
       end
     end
   end
@@ -122,45 +124,45 @@ describe "InSpec UI behavior" do
     describe "normal exit" do
       let(:feature) { "exitnormal" }
       it "has correct output" do
-        assert_exit_code 0, run_result
         run_result.stderr.must_equal ""
         run_result.stdout.must_equal "test exit normal\n"
+        assert_exit_code 0, run_result
       end
     end
 
     describe "usage exit" do
       let(:feature) { "exitusage" }
       it "has correct output" do
-        assert_exit_code 1, run_result
         run_result.stderr.must_equal "" # ie, we intentionally exit-1'd; not a crash
         run_result.stdout.must_equal "test exit usage_error\n"
+        assert_exit_code 1, run_result
       end
     end
 
     describe "plugin exit" do
       let(:feature) { "exitplugin" }
       it "has correct output" do
-        assert_exit_code 2, run_result
         run_result.stderr.must_equal ""
         run_result.stdout.must_equal "test exit plugin_error\n"
+        assert_exit_code 2, run_result
       end
     end
 
     describe "skipped exit" do
       let(:feature) { "exitskipped" }
       it "has correct output" do
-        assert_exit_code 101, run_result
         run_result.stderr.must_equal ""
         run_result.stdout.must_equal "test exit skipped_tests\n"
+        assert_exit_code 101, run_result
       end
     end
 
     describe "failed exit" do
       let(:feature) { "exitfailed" }
       it "has correct output" do
-        assert_exit_code 100, run_result
         run_result.stderr.must_equal ""
         run_result.stdout.must_equal "test exit failed_tests\n"
+        assert_exit_code 100, run_result
       end
     end
 
@@ -172,8 +174,8 @@ describe "InSpec UI behavior" do
       describe "the interactive flag" do
         let(:feature) { "interactive" }
         it "should report the interactive flag is on" do
-          assert_exit_code 0, run_result
           run_result.stdout.must_include "true"
+          assert_exit_code 0, run_result
         end
       end
 
@@ -188,8 +190,8 @@ describe "InSpec UI behavior" do
         describe "prompting" do
           let(:feature) { "prompt" }
           it "should launch apollo" do
-            assert_exit_code 0, run_result
             run_result.stdout.must_include "Apollo"
+            assert_exit_code 0, run_result
           end
         end
       end
@@ -201,16 +203,16 @@ describe "InSpec UI behavior" do
     describe "the interactive flag" do
       let(:feature) { "interactive" }
       it "should report the interactive flag is off" do
-        assert_exit_code 0, run_result
         run_result.stdout.must_include "false"
+        assert_exit_code 0, run_result
       end
     end
 
     describe "prompting" do
       let(:feature) { "prompt" }
       it "should crash with stacktrace" do
-        assert_exit_code 1, run_result
         run_result.stderr.must_include "Inspec::UserInteractionRequired"
+        assert_exit_code 1, run_result
       end
     end
   end

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -1,3 +1,5 @@
+require "inspec/resources"
+
 class MockLoader
   # collects emulation operating systems
   OPERATING_SYSTEMS = {
@@ -568,6 +570,7 @@ class MockLoader
   end
 
   def self.load_profile(name, opts = {})
+    require "inspec/profile"
     opts[:test_collector] = Inspec::RunnerMock.new
     opts[:backend] = Inspec::Backend.create(Inspec::Config.mock(opts))
     Inspec::Profile.for_target(profile_path(name), opts)

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -2,6 +2,7 @@ require "helper"
 require "stringio"
 
 require "inspec/config"
+require "plugins/inspec-compliance/lib/inspec-compliance/api"
 
 describe "Inspec::Config" do
 

--- a/test/unit/dependencies/lockfile_test.rb
+++ b/test/unit/dependencies/lockfile_test.rb
@@ -1,4 +1,5 @@
 require "helper"
+require "inspec/dependencies/lockfile" # TODO: move files or namespace properly
 
 describe Inspec::Lockfile do
   # Ruby 1.9: .to_yaml format is slightly different

--- a/test/unit/dsl/control_test.rb
+++ b/test/unit/dsl/control_test.rb
@@ -1,5 +1,6 @@
 require "helper"
 require "inspec/config"
+require "inspec/profile"
 require "inspec/runner_mock"
 require "fetchers/mock"
 

--- a/test/unit/fetchers/git_test.rb
+++ b/test/unit/fetchers/git_test.rb
@@ -1,4 +1,5 @@
 require "helper"
+require "inspec/fetcher"
 
 describe Fetchers::Git do
   let(:fetcher) { Fetchers::Git }

--- a/test/unit/fetchers/local_test.rb
+++ b/test/unit/fetchers/local_test.rb
@@ -1,4 +1,5 @@
 require "helper"
+require "inspec/fetcher"
 
 describe Fetchers::Local do
   let(:fetcher) { Fetchers::Local }

--- a/test/unit/fetchers/source_reader_test.rb
+++ b/test/unit/fetchers/source_reader_test.rb
@@ -1,4 +1,5 @@
 require "helper"
+require "inspec/source_reader"
 
 describe Inspec::SourceReader do
   let(:reg) { Inspec::SourceReader }

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -1,4 +1,5 @@
 require "helper"
+require "inspec/fetcher" # TODO: require fetchers/url directly
 
 describe Fetchers::Url do
   it "registers with the fetchers registry" do

--- a/test/unit/file_provider_test.rb
+++ b/test/unit/file_provider_test.rb
@@ -1,4 +1,5 @@
 require "helper"
+require "inspec/file_provider" # TODO: split
 
 describe Inspec::MockProvider do
   let(:subject) { Inspec::MockProvider.new(target) }

--- a/test/unit/plugin/v1/resource_test.rb
+++ b/test/unit/plugin/v1/resource_test.rb
@@ -1,4 +1,7 @@
 require "helper"
+require "inspec/resource"
+require "inspec/resources/os"
+# require 'inspec/plugin/v1/plugin_types/resource'
 
 describe Inspec::Plugins::Resource do
   let(:base) { Inspec::Plugins::Resource }
@@ -17,7 +20,8 @@ describe Inspec::Plugins::Resource do
   end
 
   def create(&block)
-    random_name = (0...50).map { (65 + rand(26)).chr }.join
+    # random_name = (0...50).map { (65 + rand(26)).chr }.join
+    random_name = "NotSoRandomName"
     Class.new(base) do
       name random_name
       instance_eval(&block)

--- a/test/unit/profiles/control_eval_context_test.rb
+++ b/test/unit/profiles/control_eval_context_test.rb
@@ -1,5 +1,6 @@
 require "helper"
 require "inspec/control_eval_context"
+require "inspec/profile_context"
 
 describe Inspec::ControlEvalContext do
   module FakeDSL

--- a/test/unit/profiles/profile_test.rb
+++ b/test/unit/profiles/profile_test.rb
@@ -3,6 +3,7 @@ require "inspec/profile_context"
 require "inspec/runner_mock"
 require "inspec/resource"
 require "inspec/resources/command"
+require "inspec/profile"
 
 describe Inspec::Profile do
   let(:logger) { Minitest::Mock.new }

--- a/test/unit/source_readers/flat_test.rb
+++ b/test/unit/source_readers/flat_test.rb
@@ -1,4 +1,6 @@
 require "helper"
+require "inspec/source_reader"
+require "source_readers/flat" # TODO: break circular
 
 describe SourceReaders::Flat do
   let(:reader) { SourceReaders::Flat }

--- a/test/unit/source_readers/inspec_test.rb
+++ b/test/unit/source_readers/inspec_test.rb
@@ -1,4 +1,6 @@
 require "helper"
+require "inspec/source_reader"
+require "source_readers/inspec" # TODO: break circular
 
 describe SourceReaders::InspecReader do
   let(:reader) { SourceReaders::InspecReader }

--- a/test/unit/ui_test.rb
+++ b/test/unit/ui_test.rb
@@ -3,6 +3,7 @@ Encoding.default_external = Encoding::UTF_8
 require "minitest/autorun"
 require "inspec/ui"
 require "inspec/base_cli"
+require "inspec/errors"
 require "stringio"
 
 # https://gist.github.com/chrisopedia/8754917


### PR DESCRIPTION
This attempts to shave off time from our tests by speeding up the implementation, mostly be rearranging when and how we load things. There's more to be done (I really want to remove the resource registration system!) but this should help us in the meantime.