### PR TITLE
Disable rubocop on Code Climate.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -18,10 +18,5 @@ plugins:
       score_threshold: 30
   markdownlint:
     enabled: true
-  rubocop:
-    enabled: true
-    channel: rubocop-0-49
-    config:
-      file: .rubocop.yml
 exclude_patterns:
   - "www/source/javascripts/"


### PR DESCRIPTION
This is now managed by chefstyle which CodeClimate doesn't support. The code is linted before tests are started so style is already strictly enforced.