### PR TITLE
Re-add `rake test:`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,6 +48,7 @@ GLOBS = [
 
 # run tests
 task default: ["test:lint", "test:default"]
+task test: ["test:lint", "test:default"]
 
 namespace :test do
 


### PR DESCRIPTION
Allow users to continue running `rake test`.