### PR TITLE
Add users.count attribute to AWS IAM Group resource

### DIFF
--- a/lib/resources/aws/aws_iam_group.rb
+++ b/lib/resources/aws/aws_iam_group.rb
@@ -13,7 +13,7 @@ class AwsIamGroup < Inspec.resource(1)
   supports platform: "aws"
 
   include AwsSingularResourceMixin
-  attr_reader :group_name, :users
+  attr_reader :group_name, :users, :users_count
 
   def to_s
     "IAM Group #{group_name}"
@@ -44,6 +44,7 @@ class AwsIamGroup < Inspec.resource(1)
       @exists = true
       @aws_group_struct = resp[:group]
       @users = resp[:users].map(&:user_name)
+      @users_count = resp[:users].map(&:user_name).length
     rescue Aws::IAM::Errors::NoSuchEntity
       @exists = false
     end


### PR DESCRIPTION
## Description
This PR suggest the addition of `users.count` attribute to the AWS IAM Group resource.

## Related Issue
No related issue.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I ran unit test on my workstation before opening this PR:

``` bundle exec rake test
Running RuboCop...
Inspecting 724 files
....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

724 files inspected, no offenses detected


Temporarily accepting Chef user license for the duration of testing...
The HashDiff constant used by this gem conflicts with another gem of a similar name.  As of version 1.0 the HashDiff constant will be completely removed and replaced by Hashdiff.  For more information see https://github.com/liufengyun/hashdiff/issues/45.
Run options: --seed 7883

# Running:

.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................S..S.....................................................................................................................................................................................................................................................................................................................................................................................................................................................S...............................................................................................................................................................................................................................................................................................................SS..........................................................................................................................S..................................................................................................................................................................................................................................................................................................S.SSS....................S................................................................................................................................................................................S.SS....S...................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................S..................................S..........SS........................................................................................

Fabulous run in 803.965917s, 3.2999 runs/s, 9.4457 assertions/s.

2653 runs, 7594 assertions, 0 failures, 0 errors, 19 skips

You have skipped tests. Run with --verbose for details.


Removing temporary Chef user license acceptance file that was placed for test duration.```
