### PR TITLE
Fix Expeditor Version Bump Script

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -6,5 +6,5 @@
 
 set -evx
 
-sed -i -r "s/VERSION = '.*'/VERSION = '$(cat VERSION)'/" lib/inspec/version.rb
-sed -i -r "s/VERSION = '.*'/VERSION = '$(cat VERSION)'/" inspec-bin/lib/inspec-bin/version.rb
+sed -i -r "s/VERSION = \".*\"/VERSION = \"$(cat VERSION)\"/" lib/inspec/version.rb
+sed -i -r "s/VERSION = \".*\"/VERSION = \"$(cat VERSION)\"/" inspec-bin/lib/inspec-bin/version.rb

--- a/inspec-bin/lib/inspec-bin/version.rb
+++ b/inspec-bin/lib/inspec-bin/version.rb
@@ -1,5 +1,5 @@
 # This file managed by automation - do not edit manually
 module InspecBin
   INSPECBIN_ROOT = File.expand_path("../..", __FILE__)
-  VERSION = "4.5.1".freeze
+  VERSION = "4.6.1".freeze
 end

--- a/lib/inspec/version.rb
+++ b/lib/inspec/version.rb
@@ -1,3 +1,3 @@
 module Inspec
-  VERSION = "4.5.1".freeze
+  VERSION = "4.6.1".freeze
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

The change to ChefStyle changed the string literal quotes from single quotes to double quotes. This broke the `update_version.sh` script used by Expeditor, so that `VERSION` was getting updated (to 4.5.1, 4.5.2, 4.5.3, etc) while lib/inspec/version.rb stayed at 4.5.1 . This kept the rubygem jammed at 4.5.1, so Artifactory kept overwriting it, and if we had released, it would have been a mislabelled gem artifact, containing 4.6.1 content but labeled as 4.5.1.

The update script was updated, using quote escaping as is used on chef/chef, and tested locally to verify it works.

As this is a release-blocking issue, and we need a release today for a critical issue, I will be expediting this PR.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
