### PR TITLE
Remove clean-static-libs from omnibus build

### DIFF
--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -51,8 +51,6 @@ dependency "shebang-cleanup"
 # Ensure our SSL cert files are accessible to ruby.
 dependency "openssl-customization"
 # Remove all .dll.a and .a files needed for static linkage.
-dependency "clean-static-libs"
-
 dependency "ruby-cleanup"
 
 package :rpm do


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
On https://github.com/chef/omnibus-software/pull/1058 , the clean-static-libs omnibus software config was removed from omnibus-software, which broke our build. The functionality was moved to ruby-cleanup, which we already rely on. This PR just removes the unneeded and broken dep.

Skipping tests and approval to get straight to CD.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
