### PR TITLE
Fixed file resource raising UndefinedMethod on source_path

### DIFF
--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -87,7 +87,15 @@ module Inspec
           @__backend_runner__ = backend
           @__resource_name__ = name
 
-          check_supports unless @supports.nil? # this has side effects
+          # check resource supports
+          supported = @supports ? check_supports : true # check_supports has side effects!
+          test_backend = defined?(Train::Transports::Mock::Connection) && backend.backend.class == Train::Transports::Mock::Connection
+          # raise unless we are supported or in test
+          unless supported || test_backend
+            msg = "Unsupported resource/backend combination: %s / %s. Exiting." %
+              [name, backend.platform.name]
+            raise ArgumentError, msg
+          end
 
           # call the resource initializer
           begin

--- a/lib/inspec/resources/platform.rb
+++ b/lib/inspec/resources/platform.rb
@@ -67,19 +67,22 @@ module Inspec::Resources
       return true if supports.nil? || supports.empty?
 
       status = true
-      supports.each do |s|
-        s.each do |k, v|
-          if %i{os_family os-family platform_family platform-family}.include?(k)
-            status = in_family?(v)
-          elsif %i{os platform}.include?(k)
-            status = platform?(v)
-          elsif %i{os_name os-name platform_name platform-name}.include?(k)
-            status = name == v
-          elsif k == :release
-            status = check_release(v)
-          else
-            status = false
-          end
+      supports.each do |support|
+        support.each do |k, v|
+          status =
+            case k
+            when :os_family, :"os-family", :platform_family, :"platform-family" then
+              in_family?(v)
+            when :os, :platform then
+              platform?(v)
+            when :os_name, :"os-name", :platform_name, :"platform-name" then
+              name == v
+            when :release then
+              check_release(v)
+            else
+              false
+            end
+
           break if status == false
         end
         return true if status == true

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -297,10 +297,9 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     let(:out) { inspec("exec " + File.join(profile_path, "aws-profile")) }
     it "exits with an error" do
       skip if ENV["NO_AWS"]
-
-      stdout.must_include "Resource `aws_iam_users` is not supported on platform"
-      stdout.must_include "Resource `aws_iam_access_keys` is not supported on platform"
-      stdout.must_include "Resource `aws_s3_bucket` is not supported on platform"
+      stdout.must_include "Unsupported resource/backend combination: aws_iam_users"
+      stdout.must_include "Unsupported resource/backend combination: aws_iam_access_keys"
+      stdout.must_include "Unsupported resource/backend combination: aws_s3_bucket"
       stdout.must_include "3 failures"
 
       assert_exit_code 100, out

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -27,9 +27,8 @@ describe "inspec exec" do
     # TODO: I do not know how to test this more directly. It should be possible.
     inspec "exec -t aws:// #{profile_path}/incompatible_resource_for_transport.rb"
 
-    stdout.must_include "Bad File on TrainPlugins::Aws::Connection"
-    stdout.must_include "Resource `file` is not supported on platform aws/train-aws"
-    stderr.must_equal ""
+    stdout.must_be_empty
+    stderr.must_include "Unsupported resource/backend combination: file / aws. Exiting."
   end
 
   it "can execute the profile" do


### PR DESCRIPTION
This is a first pass at fixing the failure found by @scottvidmar where
file resource was raising undefined_method on nil. The problem was
that the initialize method for file was not being called at all
because Resource#initialize was returning early without reporting
anything.

This fix causes a failure in test/functional/inspec_exec_test.rb where
it is testing a similar scenario but for some reason the unsupported
resources get reported. We need to figure that part out, but in the
meantime this will at least report an error at the root cause rather
than down the road.

Fixes #4208

Paired with @miah 

Signed-off-by: Ryan Davis <zenspider@chef.io>