### PR TITLE
nginx_conf: Fix commented/empty file parsing

### DIFF
--- a/lib/inspec/resources/nginx_conf.rb
+++ b/lib/inspec/resources/nginx_conf.rb
@@ -63,6 +63,11 @@ module Inspec::Resources
     def parse_nginx(path)
       return nil if inspec.os.windows?
       content = read_content(path)
+
+      # Don't attempt to parse file if it contains only comments or is empty
+      # https://regexper.com/#%2F%5E%5Cs*%23%7C%5E%24%2F
+      return {} if content.split("\n").reject { |l| l =~ /^\s*#|^$/ } == []
+
       data = NginxConfig.parse(content)
       resolve_references(data, File.dirname(path))
     rescue StandardError => _

--- a/lib/inspec/resources/nginx_conf.rb
+++ b/lib/inspec/resources/nginx_conf.rb
@@ -66,7 +66,7 @@ module Inspec::Resources
 
       # Don't attempt to parse file if it contains only comments or is empty
       # https://regexper.com/#%2F%5E%5Cs*%23%7C%5E%24%2F
-      return {} if content.split("\n").reject { |l| l =~ /^\s*#|^$/ } == []
+      return {} if content.lines.reject { |l| l =~ /^\s*#|^$/ }.empty?
 
       data = NginxConfig.parse(content)
       resolve_references(data, File.dirname(path))

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -118,6 +118,8 @@ class MockLoader
       "/etc/nginx/nginx.conf" => mockfile.call("nginx.conf"),
       "/etc/nginx/proxy.conf" => mockfile.call("nginx_proxy.conf"),
       "/etc/nginx/conf/mime.types" => mockfile.call("nginx_mime.types"),
+      "/etc/nginx/conf.d/comments_only.conf" => mockfile.call("nginx_confd_comments_only.conf"),
+      "/etc/nginx/conf.d/empty.conf" => mockfile.call("nginx_confd_empty.conf"),
       "/etc/nginx/conf.d/foobar.conf" => mockfile.call("nginx_confd_foobar.conf"),
       "/etc/nginx/conf.d/multiple.conf" => mockfile.call("nginx_confd_multiple.conf"),
       "/etc/nginx/quotes.d/example.conf" => mockfile.call("nginx_quotesd_example.conf"),
@@ -156,7 +158,6 @@ class MockLoader
       "/fakepath/fakefile" => emptyfile.call,
       "C:/fakepath/fakefile" => emptyfile.call,
       "/etc/cron.d/crondotd" => mockfile.call("crondotd"),
-      "/missing_file" => emptyfile.call,
     }
 
     # create all mock commands

--- a/test/unit/mock/cmd/find-nginx-confd-multiple-conf
+++ b/test/unit/mock/cmd/find-nginx-confd-multiple-conf
@@ -1,2 +1,4 @@
+/etc/nginx/conf.d/comments_only.conf
+/etc/nginx/conf.d/empty.conf
 /etc/nginx/conf.d/foobar.conf
 /etc/nginx/conf.d/multiple.conf

--- a/test/unit/mock/files/nginx_confd_comments_only.conf
+++ b/test/unit/mock/files/nginx_confd_comments_only.conf
@@ -1,0 +1,33 @@
+# This file is empty save for comments
+
+#
+# HTTPS server configuration
+#
+
+#server {
+#    listen       443 ssl http2 default_server;
+#    listen       [::]:443 ssl;
+#    server_name  _;
+#    root         /usr/share/nginx/html;
+#
+#    ssl_certificate cert.pem;
+#    ssl_certificate_key cert.key;
+#    ssl_session_cache shared:SSL:1m;
+#    ssl_session_timeout  10m;
+#    ssl_ciphers HIGH:!aNULL:!MD5;
+#    ssl_prefer_server_ciphers on;
+#
+#    # Load configuration files for the default server block.
+#    include /etc/nginx/default.d/*.conf;
+#
+#    location / {
+#    }
+#
+#    error_page 404 /404.html;
+#        location = /40x.html {
+#    }
+#
+#    error_page 500 502 503 504 /50x.html;
+#        location = /50x.html {
+#    }
+#}

--- a/test/unit/resources/nginx_conf_test.rb
+++ b/test/unit/resources/nginx_conf_test.rb
@@ -10,7 +10,19 @@ describe "Inspec::Resources::NginxConf" do
   let(:nginx_conf) { MockLoader.new(:ubuntu1404).load_resource("nginx_conf") }
 
   it "doesnt fail with a missing file" do
-    nginx_conf = MockLoader.new(:ubuntu1404).load_resource("nginx_conf", "/missing_file")
+    # This path is not mocked because we cannot mock File.exist?
+    # ...As far as I know
+    nginx_conf = MockLoader.new(:ubuntu1404).load_resource("nginx_conf", "/this/path/does/not/exist")
+    _(nginx_conf.params).must_equal({})
+  end
+
+  it "does not fail with an empty file" do
+    nginx_conf = MockLoader.new(:ubuntu1404).load_resource("nginx_conf", "/etc/nginx/conf.d/empty.conf")
+    _(nginx_conf.params).must_equal({})
+  end
+
+  it "does not fail with a file that all lines are commented out" do
+    nginx_conf = MockLoader.new(:ubuntu1404).load_resource("nginx_conf", "/etc/nginx/conf.d/comments_only.conf")
     _(nginx_conf.params).must_equal({})
   end
 
@@ -26,6 +38,8 @@ describe "Inspec::Resources::NginxConf" do
       /etc/nginx/nginx.conf
       /etc/nginx/conf/mime.types
       /etc/nginx/proxy.conf
+      /etc/nginx/conf.d/comments_only.conf
+      /etc/nginx/conf.d/empty.conf
       /etc/nginx/conf.d/foobar.conf
       /etc/nginx/conf.d/multiple.conf
       /etc/nginx/quotes.d/example.conf


### PR DESCRIPTION
## Description

This fixes `nginx_conf.params` when:
  - Given an empty file
  - Given a file with only comments
  - Given a file that has an include for a file that:
    - Is empty
    - Has all lines commented out

## Related Issues

This fixes #4198 
This fixes #2790

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
