### PR TITLE
Set the umask on travis in before_install so that file resource permission matcher can be tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 - "gem update --system '3.0'"
 - gem --version
 - bundle --version
+- umask 0022
 env:
   - SLOW=1 NO_AWS=1
   - CI_ENABLE_COVERAGE=true SLOW=1

--- a/test/unit/resources/file_test.rb
+++ b/test/unit/resources/file_test.rb
@@ -84,12 +84,17 @@ describe Inspec::Resources::FileResource do
   let(:file) { stub(unix_mode_mask: 000, mode: 644) }
 
   it "more_permissive_than?" do
-    skip_until 2019, 6, 21, "Breaks on travis-ci because file has 664, not 644"
     resource = MockLoader.new(:ubuntu1404).load_resource("file", "/fakepath/fakefile")
 
-    _(resource).wont_be :more_permissive_than?, "755"
-    _(resource).wont_be :more_permissive_than?, "644"
-    _(resource).must_be :more_permissive_than?, "640"
+    # TODO: this is NOT a valid way to test. Please use _actual_ mock files
+    # so we aren't beholden to the CI umask and other trivialities.
+    path = "test/unit/mock/files/emptyfile"
+    File.chmod 0644, path
+    perms = "perms = %03o" % [File.stat(path).mode]
+
+    _(resource).wont_be :more_permissive_than?, "755", perms
+    _(resource).wont_be :more_permissive_than?, "644", perms
+    _(resource).must_be :more_permissive_than?, "640", perms
 
     proc { resource.send(:more_permissive_than?, "0888") }.must_raise(ArgumentError)
   end


### PR DESCRIPTION
This removes one of our timebomb skips, fixes it by manually setting the file's mode before testing, and provides better feedback in case of an actual failure.

META: this was beyond frustrating. Uninformative failure messages, changing umasks, and I suspect filesystem caching (such that changing the umask doesn't actually have an effect). Multiply that with a 10 minute feedback loop and this was not a productive cycle for what is a fairly trivial problem.