### PR TITLE
add resource sys_info.manufacturer and sys_info.model

### DIFF
--- a/docs/resources/sys_info.md.erb
+++ b/docs/resources/sys_info.md.erb
@@ -55,10 +55,10 @@ The `hostname` matcher tests the host for which standard output is returned:
 
 The `manufacturer` matcher tests the host for which standard output is returned:
 
-    its('manufacturer') { should eq 'value' }
+    its('manufacturer') { should eq 'ACME Corp.' }
 
 ### model
 
 The `model` matcher tests the host for which standard output is returned:
 
-    its('model') { should eq 'value' }
+    its('model') { should eq 'Flux Capacitor' }

--- a/docs/resources/sys_info.md.erb
+++ b/docs/resources/sys_info.md.erb
@@ -49,4 +49,16 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `hostname` matcher tests the host for which standard output is returned:
 
-    its('hostname') { should eq 'value' }
+its('hostname') { should eq 'value' }
+
+### manufacturer
+
+The `manufacturer` matcher tests the host for which standard output is returned:
+
+its('manufacturer') { should eq 'value' }
+
+### model
+
+The `model` matcher tests the host for which standard output is returned:
+
+    its('model') { should eq 'value' }

--- a/docs/resources/sys_info.md.erb
+++ b/docs/resources/sys_info.md.erb
@@ -49,13 +49,13 @@ For a full list of available matchers, please visit our [matchers page](https://
 
 The `hostname` matcher tests the host for which standard output is returned:
 
-its('hostname') { should eq 'value' }
+    its('hostname') { should eq 'value' }
 
 ### manufacturer
 
 The `manufacturer` matcher tests the host for which standard output is returned:
 
-its('manufacturer') { should eq 'value' }
+    its('manufacturer') { should eq 'value' }
 
 ### model
 

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -26,5 +26,29 @@ module Inspec::Resources
         skip_resource "The `sys_info.hostname` resource is not supported on your OS yet."
       end
     end
+
+    # returns the Manufacturer of the local system
+    def manufacturer
+      os = inspec.os
+      if os.linux? || os.darwin?
+        inspec.command("dmidecode | grep 'Vendor :'").split(": ").last.chomp
+      elsif os.windows?
+        inspec.powershell("Get-CimInstance -ClassName Win32_ComputerSystem | Select Manufacturer -ExpandProperty Manufacturer").stdout.chomp
+      else
+        skip_resource "The `sys_info.model` resource is not supported on your OS yet."
+      end
+    end
+
+    # returns the ServerModel of the local system
+    def model
+      os = inspec.os
+      if os.linux? || os.darwin?
+        inspec.command("dmidecode | grep 'Product Name: '").split(": ").last.chomp
+      elsif os.windows?
+        inspec.powershell("Get-CimInstance -ClassName Win32_ComputerSystem | Select Model -ExpandProperty Model").stdout.chomp
+      else
+        skip_resource "The `sys_info.model` resource is not supported on your OS yet."
+      end
+    end
   end
 end

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -45,7 +45,7 @@ module Inspec::Resources
     def model
       os = inspec.os
       if os.darwin?
-        inspec.command("system_profiler SPHardwareDataType | grep 'Model Identifier:'").split(": ").last.chomp
+        inspec.command("sysctl -n hw.model").stdout.chomp
       elsif os.linux?
         inspec.command("cat /sys/class/dmi/id/product_name").stdout.chomp
       elsif os.windows?

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -37,7 +37,7 @@ module Inspec::Resources
       elsif os.windows?
         inspec.powershell("Get-CimInstance -ClassName Win32_ComputerSystem | Select Manufacturer -ExpandProperty Manufacturer").stdout.chomp
       else
-        skip_resource "The `sys_info.model` resource is not supported on your OS yet."
+        skip_resource "The `sys_info.manufacturer` resource is not supported on your OS yet."
       end
     end
 

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -30,7 +30,9 @@ module Inspec::Resources
     # returns the Manufacturer of the local system
     def manufacturer
       os = inspec.os
-      if os.linux? || os.darwin?
+      if os.darwin?
+        'Apple Inc.'
+      elsif os.linux?
         inspec.command("dmidecode | grep 'Vendor :'").split(": ").last.chomp
       elsif os.windows?
         inspec.powershell("Get-CimInstance -ClassName Win32_ComputerSystem | Select Manufacturer -ExpandProperty Manufacturer").stdout.chomp

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -33,7 +33,7 @@ module Inspec::Resources
       if os.darwin?
         "Apple Inc."
       elsif os.linux?
-        inspec.command("dmidecode | grep 'Vendor :'").split(": ").last.chomp
+        inspec.command("cat /sys/class/dmi/id/sys_vendor").stdout.chomp
       elsif os.windows?
         inspec.powershell("Get-CimInstance -ClassName Win32_ComputerSystem | Select Manufacturer -ExpandProperty Manufacturer").stdout.chomp
       else
@@ -47,7 +47,7 @@ module Inspec::Resources
       if os.darwin?
         inspec.command("system_profiler SPHardwareDataType | grep 'Model Identifier:'").split(": ").last.chomp
       elsif os.linux?
-        inspec.command("dmidecode | grep 'Product Name: '").split(": ").last.chomp
+        inspec.command("cat /sys/class/dmi/id/product_name").stdout.chomp
       elsif os.windows?
         inspec.powershell("Get-CimInstance -ClassName Win32_ComputerSystem | Select Model -ExpandProperty Model").stdout.chomp
       else

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -31,7 +31,7 @@ module Inspec::Resources
     def manufacturer
       os = inspec.os
       if os.darwin?
-        'Apple Inc.'
+        "Apple Inc."
       elsif os.linux?
         inspec.command("dmidecode | grep 'Vendor :'").split(": ").last.chomp
       elsif os.windows?

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -42,7 +42,9 @@ module Inspec::Resources
     # returns the ServerModel of the local system
     def model
       os = inspec.os
-      if os.linux? || os.darwin?
+      if os.darwin?
+        inspec.command("system_profiler SPHardwareDataType | grep 'Model Identifier:'").split(": ").last.chomp
+      elsif os.linux?
         inspec.command("dmidecode | grep 'Product Name: '").split(": ").last.chomp
       elsif os.windows?
         inspec.powershell("Get-CimInstance -ClassName Win32_ComputerSystem | Select Model -ExpandProperty Model").stdout.chomp

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -370,11 +370,11 @@ class MockLoader
       # hostname windows
       "$env:computername" => cmd.call("$env-computername"),
       # Manufacturer linux
-      "dmidecode | grep 'Vendor: '" => cmd.call("manufacturer"),
+      "cat /sys/class/dmi/id/sys_vendor" => cmd.call("manufacturer"),
       # Manufacturer windows
       "Get-CimInstance -ClassName Win32_ComputerSystem | Select Manufacturer -ExpandProperty Manufacturer" => cmd.call("manufacturer"),
       # Model linux
-      "dmidecode | grep 'Product Name: '" => cmd.call("model"),
+      "cat /sys/class/dmi/id/product_name" => cmd.call("model"),
       # Model windows
       "Get-CimInstance -ClassName Win32_ComputerSystem | Select Model -ExpandProperty Model" => cmd.call("model"),
       # windows_hotfix windows

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -369,6 +369,14 @@ class MockLoader
       "hostname" => cmd.call("hostname"),
       # hostname windows
       "$env:computername" => cmd.call("$env-computername"),
+      # Manufacturer linux
+      "dmidecode | grep 'Vendor: '" => cmd.call("manufacturer"),
+      # Manufacturer windows
+      "Get-CimInstance -ClassName Win32_ComputerSystem | Select Manufacturer -ExpandProperty Manufacturer" => cmd.call("manufacturer"),
+      # Model linux
+      "dmidecode | grep 'Product Name: '" => cmd.call("model"),
+      # Model windows
+      "Get-CimInstance -ClassName Win32_ComputerSystem | Select Model -ExpandProperty Model" => cmd.call("model"),
       # windows_hotfix windows
       "get-hotfix -id KB4019215" => cmd.call("kb4019215"),
       # windows_hotfix windows doesn't exist

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -365,7 +365,7 @@ class MockLoader
       "netstat -an -f inet" => cmd.call("hpux-netstat-inet"),
       # ipv6 ports on hpux
       "netstat -an -f inet6" => cmd.call("hpux-netstat-inet6"),
-      # hostname linux
+      # hostname linux and darwin
       "hostname" => cmd.call("hostname"),
       # hostname windows
       "$env:computername" => cmd.call("$env-computername"),
@@ -375,6 +375,8 @@ class MockLoader
       "Get-CimInstance -ClassName Win32_ComputerSystem | Select Manufacturer -ExpandProperty Manufacturer" => cmd.call("manufacturer"),
       # Model linux
       "cat /sys/class/dmi/id/product_name" => cmd.call("model"),
+      # Model darwin
+      "sysctl -n hw.model" => cmd.call("model_darwin"),
       # Model windows
       "Get-CimInstance -ClassName Win32_ComputerSystem | Select Model -ExpandProperty Model" => cmd.call("model"),
       # windows_hotfix windows

--- a/test/unit/mock/cmd/manufacturer
+++ b/test/unit/mock/cmd/manufacturer
@@ -1,0 +1,1 @@
+ACME Corp.

--- a/test/unit/mock/cmd/model
+++ b/test/unit/mock/cmd/model
@@ -1,0 +1,1 @@
+Flux Capacitor

--- a/test/unit/mock/cmd/model_darwin
+++ b/test/unit/mock/cmd/model_darwin
@@ -1,0 +1,1 @@
+MacBookPro13,3

--- a/test/unit/resources/sys_info_test.rb
+++ b/test/unit/resources/sys_info_test.rb
@@ -3,13 +3,13 @@ require "inspec/resource"
 require "inspec/resources/sys_info"
 
 describe "Inspec::Resources::SysInfo" do
-  describe "sys_info" do
+  describe "sys_info.hostname" do
     it "check sys_info.hostname on Ubuntu" do
       resource = MockLoader.new(:ubuntu1504).load_resource("sys_info")
       _(resource.hostname).must_equal "example.com"
     end
 
-    it "check sys_info.hostname on Windows" do
+    it "check sys_info on Windows" do
       resource = MockLoader.new(:windows).load_resource("sys_info")
       _(resource.hostname).must_equal "WIN-CIV7VMLVHLD"
     end
@@ -17,6 +17,40 @@ describe "Inspec::Resources::SysInfo" do
     it "check sysinfo.hostname on freebsd" do
       resource = MockLoader.new(:freebsd10).load_resource("sys_info")
       _(resource.hostname).must_equal "The `sys_info.hostname` resource is not supported on your OS yet."
+    end
+  end
+
+  describe "sys_info.manufacturer" do
+    it "check sys_info.manufacturer on Ubuntu" do
+      resource = MockLoader.new(:ubuntu1504).load_resource("sys_info")
+      _(resource.manufacturer).must_equal "ACME Corp."
+    end
+
+    it "check sys_info.manufacturer on Windows" do
+      resource = MockLoader.new(:windows).load_resource("sys_info")
+      _(resource.manufacturer).must_equal "ACME Corp."
+    end
+
+    it "check sysinfo.hostname on freebsd" do
+      resource = MockLoader.new(:freebsd10).load_resource("sys_info")
+      _(resource.manufacturer).must_equal "The `sys_info.hostname` resource is not supported on your OS yet."
+    end
+  end
+
+  describe "sys_info.model" do
+    it "check sys_info.model on Ubuntu" do
+      resource = MockLoader.new(:ubuntu1504).load_resource("sys_info")
+      _(resource.model).must_equal "Flux Capacitor"
+    end
+
+    it "check sys_info.model on Windows" do
+      resource = MockLoader.new(:windows).load_resource("sys_info")
+      _(resource.model).must_equal "Flux Capacitor"
+    end
+
+    it "check sysinfo on freebsd" do
+      resource = MockLoader.new(:freebsd10).load_resource("sys_info")
+      _(resource.model).must_equal "The `sys_info.hostname` resource is not supported on your OS yet."
     end
   end
 end

--- a/test/unit/resources/sys_info_test.rb
+++ b/test/unit/resources/sys_info_test.rb
@@ -3,54 +3,26 @@ require "inspec/resource"
 require "inspec/resources/sys_info"
 
 describe "Inspec::Resources::SysInfo" do
-  describe "sys_info.hostname" do
-    it "check sys_info.hostname on Ubuntu" do
+  describe "sys_info" do
+    it "check sys_info on Ubuntu" do
       resource = MockLoader.new(:ubuntu1504).load_resource("sys_info")
       _(resource.hostname).must_equal "example.com"
+      _(resource.manufacturer).must_equal "ACME Corp."
+      _(resource.model).must_equal "Flux Capacitor"
     end
 
     it "check sys_info on Windows" do
       resource = MockLoader.new(:windows).load_resource("sys_info")
       _(resource.hostname).must_equal "WIN-CIV7VMLVHLD"
-    end
-
-    it "check sysinfo.hostname on freebsd" do
-      resource = MockLoader.new(:freebsd10).load_resource("sys_info")
-      _(resource.hostname).must_equal "The `sys_info.hostname` resource is not supported on your OS yet."
-    end
-  end
-
-  describe "sys_info.manufacturer" do
-    it "check sys_info.manufacturer on Ubuntu" do
-      resource = MockLoader.new(:ubuntu1504).load_resource("sys_info")
       _(resource.manufacturer).must_equal "ACME Corp."
-    end
-
-    it "check sys_info.manufacturer on Windows" do
-      resource = MockLoader.new(:windows).load_resource("sys_info")
-      _(resource.manufacturer).must_equal "ACME Corp."
-    end
-
-    it "check sysinfo.hostname on freebsd" do
-      resource = MockLoader.new(:freebsd10).load_resource("sys_info")
-      _(resource.manufacturer).must_equal "The `sys_info.hostname` resource is not supported on your OS yet."
-    end
-  end
-
-  describe "sys_info.model" do
-    it "check sys_info.model on Ubuntu" do
-      resource = MockLoader.new(:ubuntu1504).load_resource("sys_info")
-      _(resource.model).must_equal "Flux Capacitor"
-    end
-
-    it "check sys_info.model on Windows" do
-      resource = MockLoader.new(:windows).load_resource("sys_info")
       _(resource.model).must_equal "Flux Capacitor"
     end
 
     it "check sysinfo on freebsd" do
       resource = MockLoader.new(:freebsd10).load_resource("sys_info")
-      _(resource.model).must_equal "The `sys_info.hostname` resource is not supported on your OS yet."
+      _(resource.hostname).must_equal "The `sys_info.hostname` resource is not supported on your OS yet."
+      _(resource.manufacturer).must_equal "The `sys_info.manufacturer` resource is not supported on your OS yet."
+      _(resource.model).must_equal "The `sys_info.model` resource is not supported on your OS yet."
     end
   end
 end

--- a/test/unit/resources/sys_info_test.rb
+++ b/test/unit/resources/sys_info_test.rb
@@ -4,17 +4,17 @@ require "inspec/resources/sys_info"
 
 describe "Inspec::Resources::SysInfo" do
   describe "sys_info" do
-    it "check ssh config parsing for Ubuntu" do
+    it "check sys_info.hostname on Ubuntu" do
       resource = MockLoader.new(:ubuntu1504).load_resource("sys_info")
       _(resource.hostname).must_equal "example.com"
     end
 
-    it "check ssh config parsing for Ubuntu" do
+    it "check sys_info.hostname on Windows" do
       resource = MockLoader.new(:windows).load_resource("sys_info")
       _(resource.hostname).must_equal "WIN-CIV7VMLVHLD"
     end
 
-    it "check ssh config parsing for freebsd" do
+    it "check sysinfo.hostname on freebsd" do
       resource = MockLoader.new(:freebsd10).load_resource("sys_info")
       _(resource.hostname).must_equal "The `sys_info.hostname` resource is not supported on your OS yet."
     end

--- a/test/unit/resources/sys_info_test.rb
+++ b/test/unit/resources/sys_info_test.rb
@@ -11,6 +11,13 @@ describe "Inspec::Resources::SysInfo" do
       _(resource.model).must_equal "Flux Capacitor"
     end
 
+    it "check sys_info on OSX" do
+      resource = MockLoader.new(:osx104).load_resource("sys_info")
+      _(resource.hostname).must_equal "example.com"
+      _(resource.manufacturer).must_equal "Apple Inc."
+      _(resource.model).must_equal "MacBookPro13,3"
+    end
+
     it "check sys_info on Windows" do
       resource = MockLoader.new(:windows).load_resource("sys_info")
       _(resource.hostname).must_equal "WIN-CIV7VMLVHLD"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This adds resource sys_info.manufacturer and sys_info.model, which let's you make choices in you inspec tests based on the manufacturer and model of your tested system.

It also fixes a wrong test desription int he sys_info.hostname tests 2dc0bbe.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
