### PR TITLE
Debian service detection for Buster

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -127,10 +127,14 @@ module Inspec::Resources
           Systemd.new(inspec, service_ctl)
         end
       elsif %w{debian}.include?(platform)
-        version = os[:release].to_i
+        if os[:release] == "buster/sid"
+          version = 10
+        else
+          version = os[:release].to_i
+        end
         if version > 7
           Systemd.new(inspec, service_ctl)
-        else
+        elsif version > 0
           SysV.new(inspec, service_ctl || "/usr/sbin/service")
         end
       elsif %w{redhat fedora centos oracle cloudlinux}.include?(platform)

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -13,6 +13,7 @@ class MockLoader
     debian6: { name: "debian", family: "debian", release: "6", arch: "x86_64" },
     debian7: { name: "debian", family: "debian", release: "7", arch: "x86_64" },
     debian8: { name: "debian", family: "debian", release: "8", arch: "x86_64" },
+    debian10: { name: "debian", family: "debian", release: "buster/sid", arch: "x86_64" },
     freebsd9: { name: "freebsd", family: "freebsd", release: "9", arch: "amd64" },
     freebsd10: { name: "freebsd", family: "freebsd", release: "10", arch: "amd64" },
     osx104: { name: "mac_os_x", family: "darwin", release: "10.10.4", arch: nil },

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -330,6 +330,19 @@ describe "Inspec::Resources::Service" do
     _(resource.params).must_equal params
   end
 
+  # debian 10 with systemd
+  it "verify debian 10 service parsing" do
+    resource = MockLoader.new(:debian10).load_resource("service", "sshd")
+    params = Hashie::Mash.new({ "ActiveState" => "active", "Description" => "OpenSSH server daemon", "Id" => "sshd.service", "LoadState" => "loaded", "Names" => "sshd.service", "SubState" => "running", "UnitFileState" => "enabled" })
+    _(resource.type).must_equal "systemd"
+    _(resource.name).must_equal "sshd.service"
+    _(resource.description).must_equal "OpenSSH server daemon"
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+  end
+
   # debian 8 with systemd but no service file
   it "gets the correct service info when the `.service` file is missing" do
     resource = MockLoader.new(:debian8).load_resource("service", "apache2")


### PR DESCRIPTION
## Description
Currently, /etc/debian_version for the Debian Buster/Sid release contains "buster/sid". This causes version to be set to 0 resulting in SysV being configured as the service provider incorrectly. This commit updates the debian detection logic to work for "buster/sid" as version 10 and makes sense that we have a non-0 version before setting the init system.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
