### PR TITLE
Add CLI target examples for Windows domain users

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,17 @@ Chef InSpec makes it easy to run your tests wherever you need. More options are 
 # run test locally
 inspec exec test.rb
 
-# run test on remote host on SSH
+# run test on remote host via SSH
 inspec exec test.rb -t ssh://user@hostname -i /path/to/key
 
 # run test on remote host using SSH agent private key authentication. Requires Chef InSpec 1.7.1
 inspec exec test.rb -t ssh://user@hostname
 
-# run test on remote windows host on WinRM
+# run test on remote windows host via WinRM
 inspec exec test.rb -t winrm://Administrator@windowshost --password 'your-password'
+
+# run test on remote windows host via WinRM as a domain user
+inspec exec test.rb -t winrm://windowshost --user 'UserName@domain' --password 'your-password'
 
 # run test on docker container
 inspec exec test.rb -t docker://container_id

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -39,6 +39,7 @@ path, `--ssl` to use SSL for transport layer encryption.
 $ inspec shell -t ssh://root@192.168.64.2:11022  # Login to remote machine using ssh as root.
 $ inspec shell -t ssh://user@hostname:1234 -i /path/to/user_key  # Login to hostname on port 1234 as user using given ssh key.
 $ inspec shell -t winrm://UserName:Password@windowsmachine:1234  # Login to windowsmachine over WinRM as UserName.
+$ inspec shell -t winrm://windowsmachine --user 'UserName@domain' --password 'Secret123!' # Login to windowsmachine as UserName@domain.org.
 $ inspec shell -t docker://container_id # Login to a Docker container.
 ```
 


### PR DESCRIPTION
This adds an example of using `-t winrm://` with a domain account. This is different because using two `@` (e.g. `winrm://user@domain@somehost`) is confusing and probably breaks the parser.

I'm not a fan of how it wraps...but also not sure how to solve it.

## Description
Current:
<img width="723" alt="Screen Shot 2019-06-25 at 15 36 47" src="https://user-images.githubusercontent.com/13783510/60138408-10241c00-975f-11e9-8eb1-17ddf6e0f28f.png">

New:
<img width="729" alt="Screen Shot 2019-06-25 at 15 28 55" src="https://user-images.githubusercontent.com/13783510/60138363-f08cf380-975e-11e9-8f05-a8428d97aeec.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
