### PR TITLE
Config final options to include additional items specific to plugins

### DIFF
--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -23,6 +23,8 @@ module Inspec
       shell_command
     }.freeze
 
+    @@valid_fields = %w{version cli_options credentials compliance reporter}
+
     extend Forwardable
 
     # Many parts of InSpec expect to treat the Config as a Hash
@@ -75,6 +77,11 @@ module Inspec
     # @return [Hash]
     def telemetry_options
       final_options.select { |key, _| key.include?("telemetry") }
+    end
+
+    # Use this to register valid configuration fields
+    def self.regsiter_valid_field(field)
+      @@valid_fields.push(field) unless field && (@@valid_fields.include? field)
     end
 
     #-----------------------------------------------------------------------#
@@ -284,10 +291,9 @@ module Inspec
         raise Inspec::ConfigError::Invalid, "Unsupported config file version '#{version}' - currently supported versions: 1.1"
       end
 
-      valid_fields = %w{version cli_options credentials compliance reporter}.sort
       @cfg_file_contents.keys.each do |seen_field|
-        unless valid_fields.include?(seen_field)
-          raise Inspec::ConfigError::Invalid, "Unrecognized top-level configuration field #{seen_field}.  Recognized fields: #{valid_fields.join(', ')}"
+        unless @@valid_fields.include?(seen_field)
+          raise Inspec::ConfigError::Invalid, "Unrecognized top-level configuration field #{seen_field}.  Recognized fields: #{@@valid_fields.join(', ')}"
         end
       end
     end
@@ -343,6 +349,8 @@ module Inspec
 
       # Highest precedence: merge in any options defined via the CLI
       options.merge!(@cli_opts)
+
+      options.merge!(@cfg_file_contents)
 
       options
     end

--- a/lib/inspec/plugin/v2/plugin_types/reporter.rb
+++ b/lib/inspec/plugin/v2/plugin_types/reporter.rb
@@ -1,0 +1,22 @@
+module Inspec::Plugin::V2::PluginType
+  class Reporter < Inspec::Plugin::V2::PluginBase
+    register_plugin_type(:reporter)
+
+    #====================================================================#
+    #                         Reporter plugin type API
+    #====================================================================#
+    # Implementation classes must implement these methods.
+
+    # Given a control and it's results, adds the necessary information to the report
+    # @param control
+    # @param results
+    def results(_control, _results)
+      raise NotImplementedError, "Plugin #{plugin_name} must implement the #results method"
+    end
+
+    # A finalizer method for closing report resources
+    def close
+      raise NotImplementedError, "Plugin #{plugin_name} must implement the #close method"
+    end
+  end
+end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -72,7 +72,7 @@ describe "Inspec::Config" do
     describe "when the file is a valid v1.1 file" do
       let(:fixture_name) { "basic" }
       it "should read the file successfully" do
-        expected = %w{create_lockfile reporter type}.sort
+        expected = %w{cli_options create_lockfile credentials reporter type version}.sort
         seen_fields.must_equal expected
       end
     end
@@ -80,7 +80,7 @@ describe "Inspec::Config" do
     describe "when the file is minimal" do
       let(:fixture_name) { "minimal" }
       it "should read the file successfully" do
-        expected = %w{reporter type}.sort
+        expected = %w{reporter type version}.sort
         seen_fields.must_equal expected
       end
     end
@@ -130,7 +130,7 @@ describe "Inspec::Config" do
     describe "when the exec command is used" do
       let(:command) { :exec }
       it "should have the correct defaults" do
-        expected = %w{color create_lockfile backend_cache reporter show_progress type}.sort
+        expected = %w{color create_lockfile backend_cache reporter show_progress type version}.sort
         seen_fields.must_equal expected
         final_options["reporter"].must_be_kind_of Hash
         final_options["reporter"].count.must_equal 1
@@ -145,7 +145,7 @@ describe "Inspec::Config" do
     describe "when the shell command is used" do
       let(:command) { :shell }
       it "should have the correct defaults" do
-        expected = %w{reporter type}.sort
+        expected = %w{reporter type version}.sort
         seen_fields.must_equal expected
         final_options["reporter"].must_be_kind_of Hash
         final_options["reporter"].count.must_equal 1
@@ -178,7 +178,7 @@ describe "Inspec::Config" do
       end
 
       it "should transparently round-trip the options" do
-        expected = %w{color array_value reporter string_key type}.sort
+        expected = %w{array_value color reporter string_key type version}.sort
         seen_fields.must_equal expected
         final_options[:color].must_equal true
         final_options["color"].must_equal true
@@ -203,7 +203,7 @@ describe "Inspec::Config" do
     describe "when the CLI opts are present in a 1.1 file" do
       let(:fixture_name) { :like_legacy }
       it "should read the options" do
-        expected = %w{color reporter target_id type}.sort
+        expected = %w{cli_options color reporter target_id type version}.sort
         seen_fields.must_equal expected
         final_options["color"].must_equal "true"  # Dubious - should this be String or TrueClass?
         final_options["target_id"].must_equal "mynode"
@@ -437,7 +437,7 @@ describe "Inspec::Config" do
       let(:cli_opts) { {} }
       it "the config file setting should prevail" do
         Inspec::Config::Defaults.stubs(:default_for_command).returns("target_id" => "value_from_default")
-        expected = %w{reporter target_id type}.sort
+        expected = %w{cli_options reporter target_id type version}.sort
         seen_fields.must_equal expected
         cfg.final_options["target_id"].must_equal "value_from_config_file"
         cfg.final_options[:target_id].must_equal "value_from_config_file"
@@ -449,7 +449,7 @@ describe "Inspec::Config" do
       let(:cfg_io) { nil }
       it "the CLI option should prevail" do
         Inspec::Config::Defaults.stubs(:default_for_command).returns("target_id" => "value_from_default")
-        expected = %w{reporter target_id type}.sort
+        expected = %w{reporter target_id type version}.sort
         seen_fields.must_equal expected
         cfg.final_options["target_id"].must_equal "value_from_cli_opts"
         cfg.final_options[:target_id].must_equal "value_from_cli_opts"
@@ -460,7 +460,7 @@ describe "Inspec::Config" do
       let(:file_fixture_name) { :override_check }
       let(:cli_opts) { { target_id: "value_from_cli_opts" } }
       it "the CLI option should prevail" do
-        expected = %w{reporter target_id type}.sort
+        expected = %w{cli_options reporter target_id type version}.sort
         seen_fields.must_equal expected
         cfg.final_options["target_id"].must_equal "value_from_cli_opts"
         cfg.final_options[:target_id].must_equal "value_from_cli_opts"
@@ -472,7 +472,7 @@ describe "Inspec::Config" do
       let(:command) { :shell } # shell default is [ :cli ]
       let(:file_fixture_name) { :override_check } # This fixture sets the cfg file contents to request a json reporter
       it "the config file setting should prevail" do
-        expected = %w{reporter target_id type}.sort
+        expected = %w{cli_options reporter target_id type version}.sort
         seen_fields.must_equal expected
         cfg.final_options["reporter"].must_be_kind_of Hash
         cfg.final_options["reporter"].keys.must_equal ["json"]


### PR DESCRIPTION
closes #4243 

## Description
Took the method described in the issue.   1) changed valid_fields to a class variable and provided a accessor method to append new values to it.   2) used this variable for config validation.  3) added cfg_file_contents to the final_options.  

## Test:
### Before change with key:value in configuration
Unrecognized top-level configuration field truth_services.  Recognized fields: cli_options, compliance, credentials, reporter, version

### After change with key:value in configuration, but Input plugin not registering valid field
  ↺  example: Example
     ↺  Input 'example_input' does not have a value. Skipping test.

### After change with key:value in configuration and Input plugin registering valid field 'truth_services'
  ✔  example: Example
     ✔  WORLD should eq "WORLD"


### Example Input plugin with registration
```ruby
# frozen_string_literal: true

require 'inspec/config'
  
module InspecPlugins
  module InspecTruthPlugin
    class Plugin < Inspec.plugin(2)
      
      # Metadata
      # Must match entry in plugins.json
      plugin_name :'inspec-truth_plugin'

      # Activation hooks
      input :local_file do
        require_relative 'local_file_input.rb'
        InspecPlugins::InspecTruthPlugin::LocalFileInput
      end
    end
  end
end

Inspec::Config.regsiter_valid_field('truth_services')
```

## Related Issue
#4243 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [ X ] I have read the **CONTRIBUTING** document.
