### PR TITLE
use stdlib SecureRandom to generate a password

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ group :test do
   gem "mocha", "~> 1.1"
   gem "ruby-progressbar", "~> 1.8"
   gem "webmock", "~> 3.0"
-  gem "passgen"
   gem "m"
   gem "pry", "~> 0.10"
   gem "pry-byebug"

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,6 @@
 require "bundler"
 require "bundler/gem_helper"
 require "rake/testtask"
-require "passgen"
 require "train"
 require_relative "tasks/maintainers"
 require_relative "tasks/spdx"
@@ -252,8 +251,9 @@ namespace :test do
       creds = connection.options
 
       # Determine the storage account name and the admin password
+      require "securerandom"
       sa_name = (0...15).map { (65 + rand(26)).chr }.join.downcase
-      admin_password = Passgen.generate(length: 12, uppercase: true, lowercase: true, symbols: true, digits: true)
+      admin_password = SecureRandom.alphanumeric(72)
 
       # Use the first 4 characters of the storage account to create a suffix
       suffix = sa_name[0..3]


### PR DESCRIPTION
## Description

Replaces the now-yanked passgen gem with something available in the Ruby standard library. Why `.base64(23)`? Base64 with an input of 23 was reliably generating 32-character strings with uppercase, lowercase, numerics, and symbols.

From the docs on the Azure terraform provider:

> NOTE: admin_password must be between 6-72 characters long and must satisfy at least 3 of password complexity requirements from the following:
> 1. Contains an uppercase character
> 2. Contains a lowercase character
> 3. Contains a numeric digit
> 4. Contains a special character

So, this should suffice.

## Related Issue

No issue open at the moment. This should resolve the error:

```
Could not find gem 'passgen' in any of the gem sources listed in your Gemfile.
```

When `bundle install` is run on the project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~New content (non-breaking change)~
- ~Breaking change (a content change which would break existing functionality or processes)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
