### PR TITLE
Removed passgen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ group :test do
   gem "mocha", "~> 1.1"
   gem "ruby-progressbar", "~> 1.8"
   gem "webmock", "~> 3.0"
-  gem "passgen"
   gem "m"
   gem "pry", "~> 0.10"
   gem "pry-byebug"

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,6 @@
 require "bundler"
 require "bundler/gem_helper"
 require "rake/testtask"
-require "passgen"
 require "train"
 require_relative "tasks/maintainers"
 require_relative "tasks/spdx"
@@ -252,8 +251,9 @@ namespace :test do
       creds = connection.options
 
       # Determine the storage account name and the admin password
-      sa_name = (0...15).map { (65 + rand(26)).chr }.join.downcase
-      admin_password = Passgen.generate(length: 12, uppercase: true, lowercase: true, symbols: true, digits: true)
+      require "securerandom"
+      sa_name = ("a".."z").to_a.sample(15).join
+      admin_password = SecureRandom.alphanumeric 72
 
       # Use the first 4 characters of the storage account to create a suffix
       suffix = sa_name[0..3]


### PR DESCRIPTION
As reported in slack, passgen got yanked. It was only being used in our Rakefile and in a very basic way. I replaced it with SecureRandom.