### PR TITLE
Permit plugin to be in path with git ref

### DIFF
--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -229,6 +229,7 @@ module InspecPlugins
         given = given.expand_path # Resolve any relative paths
         name_regex = /^(inspec|train)-/
         versioned_regex = /^(inspec|train)-[a-z0-9\-\_]+-\d+\.\d+\.\d+$/
+        sha_ref_regex = /^(inspec|train)-[a-z0-9\-\_]+-[0-9a-f]{5,40}$/
 
         # What are the last four things like?
         parts = [
@@ -257,14 +258,14 @@ module InspecPlugins
         # In that case, we'll have a version on the plugin name in part 0
         # /home/you/.gems/2.4.0/gems/inspec-something-3.45.1/lib/inspec-something.rb
         #   parts index:                     ^0^             ^1^      ^2^         ^3^
-        if parts[0] =~ versioned_regex && parts[1] == "lib" && parts[0].start_with?(parts[2]) && parts[3] == ".rb"
+        if (parts[0] =~ versioned_regex || parts[0] =~ sha_ref_regex) && parts[1] == "lib" && parts[0].start_with?(parts[2]) && parts[3] == ".rb"
           return given.to_s
         end
 
         # Case 4: Like case 3, but missing the .rb
         # /home/you/.gems/2.4.0/gems/inspec-something-3.45.1/lib/inspec-something
         #   parts index:                     ^0^             ^1^      ^2^         ^3^ (empty)
-        if parts[0] =~ versioned_regex && parts[1] == "lib" && parts[0].start_with?(parts[2]) && parts[3].empty?
+        if (parts[0] =~ versioned_regex || parts[0] =~ sha_ref_regex) && parts[1] == "lib" && parts[0].start_with?(parts[2]) && parts[3].empty?
           return given.to_s + ".rb"
         end
 


### PR DESCRIPTION
Fixes #3904

Signed-off-by: James Stocks <jstocks@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixes https://github.com/inspec/inspec/issues/3904 by allowing a plugin to be found in a folder that refers to a git SHA e.g. `/Users/jamesstocks/code/bundles/cool-project/ruby/2.4.0/bundler/gems/inspec-special-62e42ce9eca1`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#3904

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
