### PR TITLE
Automated chefstyle application for rubocop 0.72 compatibility

### DIFF
--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -295,19 +295,19 @@ module Inspec
     def validate_reporters!(reporters)
       return if reporters.nil?
       # TODO: move this into a reporter plugin type system
-      valid_types = [
-        "automate",
-        "cli",
-        "documentation",
-        "html",
-        "json",
-        "json-automate",
-        "json-min",
-        "json-rspec",
-        "junit",
-        "progress",
-        "yaml",
-      ]
+      valid_types = %w{
+        automate
+        cli
+        documentation
+        html
+        json
+        json-automate
+        json-min
+        json-rspec
+        junit
+        progress
+        yaml
+      }
 
       reporters.each do |reporter_name, reporter_config|
         raise NotImplementedError, "'#{reporter_name}' is not a valid reporter type." unless valid_types.include?(reporter_name)

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -461,9 +461,9 @@ module Inspec::Plugin::V2
 
       # Combine the Sets, so the resolver has one composite place to look
       Gem::Resolver.compose_sets(
-        installed_plugins_gem_set,     # The gems that are in the plugin gem path directory tree
+        installed_plugins_gem_set, # The gems that are in the plugin gem path directory tree
         InstalledVendorSet.new,
-        *extra_request_sets,           # Anything else our caller wanted to include
+        *extra_request_sets # Anything else our caller wanted to include
       )
     end
 

--- a/lib/inspec/plugin/v2/status.rb
+++ b/lib/inspec/plugin/v2/status.rb
@@ -14,7 +14,7 @@ module Inspec::Plugin::V2
     :loaded,                  # true, false False could mean not attempted or failed
     :load_exception,          # Exception class if it failed to load
     :name,                    # String name
-    :version,                 # three-digit version.  Core / bundled plugins use InSpec version here.
+    :version # three-digit version.  Core / bundled plugins use InSpec version here.
   ) do
     def initialize(*)
       super

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -127,7 +127,7 @@ module Inspec
         cli_input_files: options[:runner_conf][:input_file], # From CLI --input-file
         profile_metadata: metadata,
         # TODO: deprecation checks here
-        runner_api: options[:runner_conf][:attributes], # This is the route the audit_cookbook and kitchen-inspec take
+        runner_api: options[:runner_conf][:attributes] # This is the route the audit_cookbook and kitchen-inspec take
       )
 
       @runner_context =

--- a/lib/inspec/resources/apt.rb
+++ b/lib/inspec/resources/apt.rb
@@ -102,7 +102,7 @@ module Inspec::Resources
           components: parse_repo[4].chomp.split(" "),
           active: active,
         }
-        next unless ["deb", "deb-src"].include? repo[:type]
+        next unless %w{deb deb-src}.include? repo[:type]
 
         lines.push(repo)
       end

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/inspec-plugin_test.rb
@@ -233,10 +233,10 @@ class PluginManagerCliSearch < Minitest::Test
     result = run_inspec_process("plugin search --include-test-fixture inspec-")
     assert_equal 0, result.exit_status, "Search should exit 0"
     assert_includes result.stdout, "inspec-test-fixture", "Search result should contain the test gem"
-    [
-      "inspec-core",
-      "inspec-multi-server",
-    ].each do |plugin_name|
+    %w{
+      inspec-core
+      inspec-multi-server
+    }.each do |plugin_name|
       refute_includes result.stdout, plugin_name, "Search result should not contain excluded gems"
     end
   end
@@ -555,11 +555,11 @@ class PluginManagerCliInstall < Minitest::Test
     # are the names of real rubygems.  They are not InSpec/Train plugins, though,
     # and installing them would be a jam-up.
     # This is configured in 'etc/plugin-filter.json'.
-    [
-      "inspec-core",
-      "inspec-multi-server",
-      "train-tax-calculator",
-    ].each do |plugin_name|
+    %w{
+      inspec-core
+      inspec-multi-server
+      train-tax-calculator
+    }.each do |plugin_name|
       install_result = run_inspec_process_with_this_plugin("plugin install #{plugin_name}")
       assert_empty install_result.stderr
       assert_equal 2, install_result.exit_status, "Exit status should be 2"

--- a/test/unit/dsl/describe_test.rb
+++ b/test/unit/dsl/describe_test.rb
@@ -95,7 +95,7 @@ end
     end
 
     it "constructs a resource+argument block without a property call" do
-      obj.qualifier = [["service", "avahi-daemon"]]
+      obj.qualifier = [%w{service avahi-daemon}]
       obj.qualifier.push(["info['properties']['UnitFileState']"])
       obj.add_test(nil, "eq", "enabled")
       obj.to_ruby.must_equal '

--- a/test/unit/dsl/objects_test.rb
+++ b/test/unit/dsl/objects_test.rb
@@ -144,7 +144,7 @@ end
     end
 
     it "constructs a resource+argument block without a property call" do
-      obj.qualifier = [["service", "avahi-daemon"]]
+      obj.qualifier = [%w{service avahi-daemon}]
       obj.qualifier.push(["info['properties']['UnitFileState']"])
       obj.expectation = "enabled"
       obj.matcher = "eq"

--- a/test/unit/plugin/v2/installer_test.rb
+++ b/test/unit/plugin/v2/installer_test.rb
@@ -248,11 +248,11 @@ class PluginInstallerInstallationTests < Minitest::Test
     # are the names of real rubygems.  They are not InSpec/Train plugins, though,
     # and installing them would be a jam-up.
     # This is configured in 'etc/plugin-filter.json'.
-    [
-      "inspec-core",
-      "inspec-multi-server",
-      "train-tax-calculator",
-    ].each do |plugin_name|
+    %w{
+      inspec-core
+      inspec-multi-server
+      train-tax-calculator
+    }.each do |plugin_name|
       ex = assert_raises(Inspec::Plugin::V2::InstallError) { @installer.install(plugin_name) }
       assert_includes(ex.message, "on the Plugin Exclusion List")
       assert_includes(ex.message, "Rationale:")
@@ -490,10 +490,10 @@ class PluginInstallerSearchTests < Minitest::Test
     # are the names of real rubygems.  They are not InSpec/Train plugins, though,
     # and installing them would be a jam-up.
     # This is configured in 'etc/plugin_filters.json'.
-    [
-      "inspec-core",
-      "inspec-multi-server",
-    ].each do |plugin_name|
+    %w{
+      inspec-core
+      inspec-multi-server
+    }.each do |plugin_name|
       refute results.key(plugin_name)
     end
   end

--- a/test/unit/resources/aws_elb_test.rb
+++ b/test/unit/resources/aws_elb_test.rb
@@ -154,10 +154,10 @@ module MAESB
       data = Aws::ElasticLoadBalancing::Types::DescribeAccessPointsOutput.new(
         load_balancer_descriptions: [
           Aws::ElasticLoadBalancing::Types::LoadBalancerDescription.new(
-            availability_zones: [
-              "us-east-1a",
-              "us-east-1c",
-            ],
+            availability_zones: %w{
+              us-east-1a
+              us-east-1c
+            },
             dns_name: "12345678.us-east-1.aws.amazon.com",
             load_balancer_name: "kang-the-alien",
             listener_descriptions: [
@@ -174,22 +174,22 @@ module MAESB
               Aws::ElasticLoadBalancing::Types::Instance.new(instance_id: "i-12345678"),
               Aws::ElasticLoadBalancing::Types::Instance.new(instance_id: "i-aaaabbbb"),
             ],
-            security_groups: [
-              "sg-12345678",
-              "sg-aaaabbbb",
-              "sg-99998888",
-            ],
-            subnets: [
-              "subnet-12345678",
-              "subnet-aaaabbbb",
-            ],
+            security_groups: %w{
+              sg-12345678
+              sg-aaaabbbb
+              sg-99998888
+            },
+            subnets: %w{
+              subnet-12345678
+              subnet-aaaabbbb
+            },
             vpc_id: "vpc-12345678"
           ),
           Aws::ElasticLoadBalancing::Types::LoadBalancerDescription.new(
-            availability_zones: [
-              "us-east-1b",
-              "us-east-1c",
-            ],
+            availability_zones: %w{
+              us-east-1b
+              us-east-1c
+            },
             dns_name: "12345678.us-east-2.aws.amazon.com",
             load_balancer_name: "kangaroo",
             listener_descriptions: [
@@ -205,21 +205,21 @@ module MAESB
             instances: [
               Aws::ElasticLoadBalancing::Types::Instance.new(instance_id: "i-87654321"),
             ],
-            security_groups: [
-              "sg-12345678",
-              "sg-99998888",
-            ],
-            subnets: [
-              "subnet-12345678",
-              "subnet-aaaabbbb",
-            ],
+            security_groups: %w{
+              sg-12345678
+              sg-99998888
+            },
+            subnets: %w{
+              subnet-12345678
+              subnet-aaaabbbb
+            },
             vpc_id: "vpc-12345678"
           ),
           Aws::ElasticLoadBalancing::Types::LoadBalancerDescription.new(
-            availability_zones: [
-              "us-east-1a",
-              "us-east-1e",
-            ],
+            availability_zones: %w{
+              us-east-1a
+              us-east-1e
+            },
             dns_name: "999999.us-east-1.aws.amazon.com",
             load_balancer_name: "gamma",
             listener_descriptions: [
@@ -234,15 +234,15 @@ module MAESB
             ],
             instances: [
             ],
-            security_groups: [
-              "sg-12345678",
-              "sg-99998888",
-              "sg-01010101",
-            ],
-            subnets: [
-              "subnet-ccccdddd",
-              "subnet-aaaabbbb",
-            ],
+            security_groups: %w{
+              sg-12345678
+              sg-99998888
+              sg-01010101
+            },
+            subnets: %w{
+              subnet-ccccdddd
+              subnet-aaaabbbb
+            },
             vpc_id: "vpc-87654321"
           )
         ]

--- a/test/unit/resources/aws_elbs_test.rb
+++ b/test/unit/resources/aws_elbs_test.rb
@@ -213,10 +213,10 @@ module MAEPB
       Aws::ElasticLoadBalancing::Types::DescribeAccessPointsOutput.new(
         load_balancer_descriptions: [
           Aws::ElasticLoadBalancing::Types::LoadBalancerDescription.new(
-            availability_zones: [
-              "us-east-1a",
-              "us-east-1c",
-            ],
+            availability_zones: %w{
+              us-east-1a
+              us-east-1c
+            },
             dns_name: "12345678.us-east-1.aws.amazon.com",
             load_balancer_name: "kang-the-alien",
             listener_descriptions: [
@@ -233,22 +233,22 @@ module MAEPB
               Aws::ElasticLoadBalancing::Types::Instance.new(instance_id: "i-12345678"),
               Aws::ElasticLoadBalancing::Types::Instance.new(instance_id: "i-aaaabbbb"),
             ],
-            security_groups: [
-              "sg-12345678",
-              "sg-aaaabbbb",
-              "sg-99998888",
-            ],
-            subnets: [
-              "subnet-12345678",
-              "subnet-aaaabbbb",
-            ],
+            security_groups: %w{
+              sg-12345678
+              sg-aaaabbbb
+              sg-99998888
+            },
+            subnets: %w{
+              subnet-12345678
+              subnet-aaaabbbb
+            },
             vpc_id: "vpc-12345678"
           ),
           Aws::ElasticLoadBalancing::Types::LoadBalancerDescription.new(
-            availability_zones: [
-              "us-east-1b",
-              "us-east-1c",
-            ],
+            availability_zones: %w{
+              us-east-1b
+              us-east-1c
+            },
             dns_name: "12345678.us-east-2.aws.amazon.com",
             load_balancer_name: "kangaroo",
             listener_descriptions: [
@@ -264,21 +264,21 @@ module MAEPB
             instances: [
               Aws::ElasticLoadBalancing::Types::Instance.new(instance_id: "i-87654321"),
             ],
-            security_groups: [
-              "sg-12345678",
-              "sg-99998888",
-            ],
-            subnets: [
-              "subnet-12345678",
-              "subnet-aaaabbbb",
-            ],
+            security_groups: %w{
+              sg-12345678
+              sg-99998888
+            },
+            subnets: %w{
+              subnet-12345678
+              subnet-aaaabbbb
+            },
             vpc_id: "vpc-12345678"
           ),
           Aws::ElasticLoadBalancing::Types::LoadBalancerDescription.new(
-            availability_zones: [
-              "us-east-1a",
-              "us-east-1e",
-            ],
+            availability_zones: %w{
+              us-east-1a
+              us-east-1e
+            },
             dns_name: "999999.us-east-1.aws.amazon.com",
             load_balancer_name: "gamma",
             listener_descriptions: [
@@ -293,15 +293,15 @@ module MAEPB
             ],
             instances: [
             ],
-            security_groups: [
-              "sg-12345678",
-              "sg-99998888",
-              "sg-01010101",
-            ],
-            subnets: [
-              "subnet-ccccdddd",
-              "subnet-aaaabbbb",
-            ],
+            security_groups: %w{
+              sg-12345678
+              sg-99998888
+              sg-01010101
+            },
+            subnets: %w{
+              subnet-ccccdddd
+              subnet-aaaabbbb
+            },
             vpc_id: "vpc-87654321"
           )
         ]

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -327,7 +327,7 @@ module MAIUB
           policy_names: []
         ),
         "leslie" => Aws::IAM::Types::ListUserPoliciesResponse.new(
-          policy_names: ["leslie-inline-01", "leslie-inline-02"]
+          policy_names: %w{leslie-inline-01 leslie-inline-02}
         ),
         "jared" => Aws::IAM::Types::ListUserPoliciesResponse.new(
           policy_names: ["jared-inline-01"]

--- a/test/unit/resources/aws_iam_users_test.rb
+++ b/test/unit/resources/aws_iam_users_test.rb
@@ -236,7 +236,7 @@ module Maiusb
           policy_names: []
         ),
         "bob" => Aws::IAM::Types::ListUserPoliciesResponse.new(
-          policy_names: ["bob-inline-01", "bob-inline-02"]
+          policy_names: %w{bob-inline-01 bob-inline-02}
         ),
         "carol" => Aws::IAM::Types::ListUserPoliciesResponse.new(
           policy_names: ["carol-inline-01"]

--- a/test/unit/resources/etc_group_test.rb
+++ b/test/unit/resources/etc_group_test.rb
@@ -22,7 +22,7 @@ describe "Inspec::Resources::EtcGroup" do
     www_filter = resource.where(name: "www-data")
     _(www_filter.gids).must_equal [33]
     _(www_filter.groups).must_equal ["www-data"]
-    _(www_filter.users).must_equal ["www-data", "root"]
+    _(www_filter.users).must_equal %w{www-data root}
   end
 
   it "verify group filter with wrong group" do
@@ -36,7 +36,7 @@ describe "Inspec::Resources::EtcGroup" do
     www_filter = resource.where(gid: 33)
     _(www_filter.gids).must_equal [33]
     _(www_filter.groups).must_equal ["www-data"]
-    _(www_filter.users).must_equal ["www-data", "root"]
+    _(www_filter.users).must_equal %w{www-data root}
   end
 
   it "verify group filter with wrong gid" do
@@ -50,7 +50,7 @@ describe "Inspec::Resources::EtcGroup" do
     www_filter = resource.where(users: "www-data,root")
     _(www_filter.gids).must_equal [33]
     _(www_filter.groups).must_equal ["www-data"]
-    _(www_filter.users).must_equal ["www-data", "root"]
+    _(www_filter.users).must_equal %w{www-data root}
   end
 
   it "verify group filter with no group members" do

--- a/test/unit/resources/groups_test.rb
+++ b/test/unit/resources/groups_test.rb
@@ -58,8 +58,8 @@ describe "groups resource on windows platform" do
 
     it "finds no group domains" do
       _(resource.domains.count).must_equal 4
-      _(resource.domains).must_equal ["WIN-CIV7VMLVHLD", "WIN-CIV7VMLVHLD",
-                                      "WIN-CIV7VMLVHLD", "WIN-CIV7VMLVHLD"]
+      _(resource.domains).must_equal %w{WIN-CIV7VMLVHLD WIN-CIV7VMLVHLD
+                                      WIN-CIV7VMLVHLD WIN-CIV7VMLVHLD}
     end
   end
 

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -54,7 +54,7 @@ describe "Inspec::Resources::Processes" do
   it "verify processes resource using where filters on linux os. String match regex" do
     resource = MockLoader.new(:centos6).load_resource("processes", ".+")
     _(resource.entries.length).must_equal 8
-    _(resource.where { pid < 11663 && cpu == "0.0" }.users).must_equal(["opscode-pgsql", "opscode", "root", "httpd"])
+    _(resource.where { pid < 11663 && cpu == "0.0" }.users).must_equal(%w{opscode-pgsql opscode root httpd})
     _(resource.where { user =~ /opscode-.*/ }.entries[0].to_h).must_equal({
       label: "system_u:system_r:init_t:s0",
       pid: 5127,


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

With rubocop 0.72 update, two rule changes introduced violations - on string literals in arrays, and trailing commas in arg lists. This PR applies `chefstyle -a` to fix the violations.

This is an entirely automated change - no files were hand edited.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Blocks #4254

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
