### PR TITLE
auditd_conf resource: expose conf path

### DIFF
--- a/lib/inspec/resources/auditd_conf.rb
+++ b/lib/inspec/resources/auditd_conf.rb
@@ -15,7 +15,7 @@ module Inspec::Resources
     EXAMPLE
 
     include FileReader
-    
+
     attr_reader :conf_path, :content
 
     def initialize(path = nil)

--- a/lib/inspec/resources/auditd_conf.rb
+++ b/lib/inspec/resources/auditd_conf.rb
@@ -15,6 +15,8 @@ module Inspec::Resources
     EXAMPLE
 
     include FileReader
+    
+    attr_reader :conf_path, :content
 
     def initialize(path = nil)
       @conf_path = path || "/etc/audit/auditd.conf"


### PR DESCRIPTION
The docs also say that conf_dir is accessible so this fixes that as well