### PR TITLE
Suppress gem docs when installing plugins

### DIFF
--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -328,7 +328,7 @@ module Inspec::Plugin::V2
 
       # OK, perform the installation.
       # Ignore deps here, because any needed deps should already be baked into new_plugin_dependency
-      request_set.install_into(gem_path, true, ignore_dependencies: true)
+      request_set.install_into(gem_path, true, ignore_dependencies: true, document: [])
 
       # Painful aspect of rubygems: the VendorSet request set type needs to be able to find a gemspec
       # file within the source of the gem (and not all gems include it in their source tree; they are

--- a/test/unit/plugin/v2/installer_test.rb
+++ b/test/unit/plugin/v2/installer_test.rb
@@ -151,7 +151,9 @@ class PluginInstallerInstallationTests < Minitest::Test
 
   def test_install_a_gem_from_local_file_creates_plugin_json
     gem_file = File.join(@plugin_fixture_pkg_path, "inspec-test-fixture-0.1.0.gem")
-    @installer.install("inspec-test-fixture", gem_file: gem_file)
+    stdout, stderr = capture_io do
+      @installer.install("inspec-test-fixture", gem_file: gem_file)
+    end
 
     # Should now be present in plugin.json
     plugin_json_path = File.join(ENV["INSPEC_CONFIG_DIR"], "plugins.json")
@@ -160,6 +162,12 @@ class PluginInstallerInstallationTests < Minitest::Test
 
     assert_equal 1, config_file.count, "plugins.json should have one entry"
     assert config_file.existing_entry?(:'inspec-test-fixture')
+
+    # Should not try to install docs
+    # Installing ri documentation for ...
+    # Parsing documentation for ...
+    refute_match /Installing ri documentation for/, stdout
+    refute_match /Installing rdoc documentation for/, stdout
   end
 
   def test_install_a_gem_from_rubygems_org

--- a/test/unit/plugin/v2/installer_test.rb
+++ b/test/unit/plugin/v2/installer_test.rb
@@ -151,7 +151,7 @@ class PluginInstallerInstallationTests < Minitest::Test
 
   def test_install_a_gem_from_local_file_creates_plugin_json
     gem_file = File.join(@plugin_fixture_pkg_path, "inspec-test-fixture-0.1.0.gem")
-    stdout, stderr = capture_io do
+    stdout, _stderr = capture_io do
       @installer.install("inspec-test-fixture", gem_file: gem_file)
     end
 
@@ -166,8 +166,8 @@ class PluginInstallerInstallationTests < Minitest::Test
     # Should not try to install docs
     # Installing ri documentation for ...
     # Parsing documentation for ...
-    refute_match /Installing ri documentation for/, stdout
-    refute_match /Installing rdoc documentation for/, stdout
+    refute_match(/Installing ri documentation for/, stdout)
+    refute_match(/Installing rdoc documentation for/, stdout)
   end
 
   def test_install_a_gem_from_rubygems_org


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
At some point in Ruby 2.6, rubygems started defaulting to generating `ri` docs by default when called via the internal API. This caused InSpec and Train plugins that relied on gems to generate documentation during installation. This was especially problematic for omnibus installs, as the docs would attempt to be installed under `/opt/inspec`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #3799 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
