### PR TITLE
Un-deprecate the be_running matcher on service resource

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -104,7 +104,6 @@ end
 # Deprecated: You should not use this matcher anymore
 RSpec::Matchers.define :be_running do
   match do |service|
-    Inspec.deprecate(:serverspec_compatibility, "The service `be_running?` matcher is deprecated.")
     service.running? == true
   end
 


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

A close reading of what is going on here made it clear to me that there is a lot of unnecessary grief happening. The matcher is already restricted to the `service` resource (I had initially misunderstood and was under the impression it was a universal matcher); and I cannot speak to any long-term goal regarding maintaining or discarding serverspec compatibility.

Anyway, this message confuses a lot of people, and it should only have been in place when a clear alternative was offered. Let's withdraw the deprecation message and live a more peaceful life.

Thanks to @jerryaldrichiii 	to pointing that conclusion out several weeks ago.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Closes #4059

See also #4291

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
