### PR TITLE
Typo in class name (obvious fix)

### DIFF
--- a/lib/inspec/resources/auditd.rb
+++ b/lib/inspec/resources/auditd.rb
@@ -45,7 +45,7 @@ module Inspec::Resources
       @params = []
 
       if @content =~ /^LIST_RULES:/
-        raise Inspec::Exceptions::RsourceFailed,
+        raise Inspec::Exceptions::ResourceFailed,
           "The version of audit is outdated." \
           "The `auditd` resource supports versions of audit >= 2.3."
       end


### PR DESCRIPTION
Fixes typo resulting in bug (reported in Slack) when auditd version is too old.

## Description
Missing the `e` in `Inspec::Exceptions::ResourceFailed` such that `Inspec::Exceptions::RsourceFailed` was not found

## Related Issue
N/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.