### PR TITLE
Automatically publish release notes and announce releases

### DIFF
--- a/.expeditor/announce-release.sh
+++ b/.expeditor/announce-release.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -exou pipefail
+
+# Download the release-notes for our specific build
+curl -o release-notes.md "https://packages.chef.io/release-notes/${EXPEDITOR_PRODUCT_KEY}/${EXPEDITOR_VERSION}.md"
+
+topic_title="Chef InSpec $EXPEDITOR_VERSION Released!"
+topic_body=$(cat <<EOH
+Hello InSpec friends!
+We are delighted to announce the availability of version $EXPEDITOR_VERSION of Chef InSpec. Changes include:
+$(cat release-notes.md)
+---
+## Get the Build
+
+You can download binaries directly from [downloads.chef.io](https://downloads.chef.io/$EXPEDITOR_PRODUCT_KEY/$EXPEDITOR_VERSION).
+EOH
+)
+
+# category 9 is "Chef Release Announcements": https://discourse.chef.io/c/chef-release
+
+curl -X POST https://discourse.chef.io/posts \
+  -H "Content-Type: multipart/form-data" \
+  -F "api_username=chef-ci" \
+  -F "api_key=$DISCOURSE_API_TOKEN" \
+  -F "category=9" \
+  -F "title=$topic_title" \
+  -F "raw=$topic_body"
+
+# Cleanup
+rm release-notes.md

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -102,4 +102,10 @@ subscriptions:
     - built_in:create_github_release
     - built_in:tag_docker_image
     - built_in:promote_habitat_packages
+    - bash:.expeditor/publish-release-notes.sh:
+         post_commit: true
+    - bash:.expeditor/purge-cdn.sh:
+         post_commit: true
+    - bash:.expeditor/announce-release.sh:
+         post_commit: true
     - built_in:notify_chefio_slack_channels

--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eou pipefail
+
+git clone https://github.com/inspec/inspec.wiki.git
+
+pushd ./inspec.wiki
+  # Publish release notes to S3
+  aws s3 cp Pending-Release-Notes.md "s3://chef-automate-artifacts/release-notes/${EXPEDITOR_PRODUCT_KEY}/${EXPEDITOR_VERSION}.md" --acl public-read --content-type "text/plain" --profile chef-cd
+  aws s3 cp Pending-Release-Notes.md "s3://chef-automate-artifacts/${EXPEDITOR_CHANNEL}/latest/${EXPEDITOR_PRODUCT_KEY}/release-notes.md" --acl public-read --content-type "text/plain" --profile chef-cd
+
+  # Reset "Pending Release Notes" wiki page
+  cat >./Pending-Release-Notes.md <<EOH
+## New Features
+-
+## Improvements
+-
+## Bug Fixes
+-
+## Backward Incompatibilities
+-
+EOH
+
+  # Push changes back up to GitHub
+  git add .
+  git commit -m "Release Notes for promoted build $EXPEDITOR_VERSION"
+  git push origin master
+popd
+
+rm -rf inspec.wiki

--- a/.expeditor/purge-cdn.sh
+++ b/.expeditor/purge-cdn.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eou pipefail
+
+echo "Purging '${EXPEDITOR_CHANNEL}/${EXPEDITOR_PRODUCT_KEY}/latest' Surrogate Key group from Fastly"
+curl -X POST -H "Fastly-Key: $FASTLY_API_TOKEN" "https://api.fastly.com/service/1ga2Kt6KclvVvCeUYJ3MRp/purge/${EXPEDITOR_CHANNEL}/${EXPEDITOR_PRODUCT_KEY}/latest"


### PR DESCRIPTION
This change updates InSpec begin using the streamlined release notes
process we are already using on Automate and Chef Workstation. More
details on this new process can be found on the following epic:
https://github.com/chef/release-engineering/issues/692

Signed-off-by: Seth Chisamore <schisamo@chef.io>
