### PR TITLE
Add SHA512 password example to `shadow` resource

### DIFF
--- a/docs/resources/shadow.md.erb
+++ b/docs/resources/shadow.md.erb
@@ -89,7 +89,7 @@ Use `where` to match any of the supported [filter criteria](#filter_criteria). `
 
 Use `where` with [expect syntax](https://www.inspec.io/docs/reference/profiles/#should-vs-expect-syntax) to show all users (that aren't disabled or locked) without SHA512 hashed passwords.
 
-    # Find users with password entries `*`, `!`, or don't begin with `$6$`
+    # Users with password fields that are not *, !, or don't begin with $6$
     bad_users = inspec.shadow.where { password !~ /^[*!]$|^\$6\$.*/ }.users
 
     describe 'Password hashes in /etc/shadow' do

--- a/docs/resources/shadow.md.erb
+++ b/docs/resources/shadow.md.erb
@@ -87,6 +87,18 @@ Use `where` to match any of the supported [filter criteria](#filter_criteria). `
       its('users') { should be_empty }
     end
 
+Use `where` with [expect syntax](https://www.inspec.io/docs/reference/profiles/#should-vs-expect-syntax) to show all users (that aren't disabled or locked) without SHA512 hashed passwords.
+
+    # Find users with password entries `*`, `!`, or don't begin with `$6$`
+    bad_users = inspec.shadow.where { password !~ /^[*!]$|^\$6\$.*/ }.users
+
+    describe 'Password hashes in /etc/shadow' do
+      it 'should only contain SHA512 hashes' do
+        message = "Users without SHA512 hashes: #{bad_users.join(', ')}"
+        expect(bad_users).to be_empty, failure_message
+      end
+    end
+
 <br>
 
 ## Properties

--- a/docs/resources/shadow.md.erb
+++ b/docs/resources/shadow.md.erb
@@ -95,7 +95,7 @@ Use `where` with [expect syntax](https://www.inspec.io/docs/reference/profiles/#
     describe 'Password hashes in /etc/shadow' do
       it 'should only contain SHA512 hashes' do
         message = "Users without SHA512 hashes: #{bad_users.join(', ')}"
-        expect(bad_users).to be_empty, failure_message
+        expect(bad_users).to be_empty, message
       end
     end
 


### PR DESCRIPTION
## Description

This adds an example that checks for SHA512 password hashes in `/etc/shadow`.

Many thanks to @kclinden, @sam1el, and @zenspider for helping make this possible.

Screenshot:

<img width="728" alt="Screen Shot 2019-07-17 at 20 04 36" src="https://user-images.githubusercontent.com/13783510/61426174-56881900-a8ce-11e9-9a8e-0f949176c419.png">

Failing output:
```
Password hashes in /etc/shadow
     ×  should only contain SHA512 hashes
     Users without SHA512 hashes: bad_user, really_bad_user
```

Passing output:
```
Password hashes in /etc/shadow
     ✔  should only contain SHA512 hashes
```

## Related Issue

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:

- [X] I have read the **CONTRIBUTING** document.
