### PR TITLE
Change expeditor timeout from 30 to 45.

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -2,7 +2,7 @@
 expeditor:
   defaults:
     buildkite:
-      timeout_in_minutes: 30
+      timeout_in_minutes: 45
       
 steps:
 


### PR DESCRIPTION
Master is red right now because of windows builds.

Signed-off-by: Ryan Davis <zenspider@chef.io>