### PR TITLE
group resource: Modified DarwinGroup to collect all users properly on macos

### DIFF
--- a/lib/inspec/resources/command.rb
+++ b/lib/inspec/resources/command.rb
@@ -1,6 +1,8 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require "inspec/resource"
+require "inspec/resources/platform"
+require "inspec/resources/os"
 
 module Inspec::Resources
   class Cmd < Inspec.resource(1)

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -33,6 +33,7 @@ module Inspec
     extend Forwardable
 
     attr_reader :backend, :rules
+    attr_accessor :target_profiles
 
     def attributes
       Inspec.deprecate(:rename_attributes_to_inputs, "Don't call runner.attributes, call runner.inputs")

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,13 @@ if ENV["CI_ENABLE_COVERAGE"]
   end
 end
 
+module Minitest::Guard
+  # TODO: push up to minitest
+  def osx?(platform = RUBY_PLATFORM)
+    /darwin/ =~ platform
+  end
+end
+
 ##
 #
 # Do not add any other code from here until the end of this code

--- a/test/unit/resources/group_test.rb
+++ b/test/unit/resources/group_test.rb
@@ -1,5 +1,4 @@
 require "helper"
-require "inspec/resource"
 require "inspec/resources/groups"
 
 describe "Inspec::Resources::Group" do
@@ -35,6 +34,28 @@ describe "Inspec::Resources::Group" do
     resource = MockLoader.new(:osx104).load_resource("group", "root")
     _(resource.exists?).must_equal true
     _(resource.gid).must_equal 0
+  end
+
+  def unmock(&blk)
+    require "fetchers/mock"
+    require "inspec/runner"
+
+    # TODO: there is WAY too much magic going on in here
+    runner = Inspec::Runner.new
+    runner.add_target("inspec.yml" => "name: inspec-shell")
+    profile = runner.target_profiles.first
+    ctx = profile.runner_context
+
+    ctx.load blk
+  end
+
+  if osx?
+    it "actually verifies group on mac" do
+      resource = unmock { group "staff" }
+      _(resource.exists?).must_equal true
+      _(resource.members).must_include "root"
+      _(resource.members).must_include ENV["LOGNAME"]
+    end
   end
 
   # freebsd


### PR DESCRIPTION
I noticed that my profile targeting group "staff" on OSX wasn't
returning ME. That seemed wrong. And it turns out it is wrong. We were
not collecting any users whose primary group was that group. (almost
all regular users are in group staff and they're all missing).

I ALSO found out that our MockLoader-based testing is piss-poor and,
through much pain and suffering, figured out how to test the group
resource directly.

Signed-off-by: Ryan Davis <zenspider@chef.io>