### PR TITLE
Add deps on train 3 and train-winrm 0.2

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_dependency "train-core", "~> 2.0"
+  spec.add_dependency "train-core", "~> 3.0"
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
   spec.add_dependency "thor", "~> 0.20"
   spec.add_dependency "json-schema", "~> 2.8"

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -23,10 +23,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_dependency "train", "~> 2.0" # Inspec 4 must have train 2+
+  spec.add_dependency "train", "~> 3.0" # Inspec 4 must have train 2+; 3+ if we include train-winrm
   # Train plugins we ship with InSpec
   spec.add_dependency "train-habitat", "~> 0.1"
   spec.add_dependency "train-aws", "~> 0.1"
+  spec.add_dependency "train-winrm", "~> 0.2" # Requires train 3+
 
   # Implementation dependencies
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Updates dependencies on Train to be train 3, and adds train-winrm to the list of train plugins we include in the inspec gem.

This PR must be merged sequentially - train v3 does not yet exist - hence DO NOT MERGE flag.

 * This PR must be merged after https://github.com/inspec/train/pull/448
 * This PR must be merged after https://github.com/inspec/train-winrm/pull/9

Motivation for this change: WinRM support requires gem dependencies that involve native extensions (and thus compilers). By separating out the winrm support into a plugin, we can continue to include it in the usual inspec distribution (`inspec-bin` or `inspec` gems) while removing the need for compilers from the -core gems (`inspec-core-bin` and `inspec-core`).

Users of inspec should see no change in behavior.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
