### PR TITLE
[ci] Add artifactory to omnibus/Gemfile

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus", branch: "master"
 gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "master"
+gem "artifactory"
 
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need


### PR DESCRIPTION
### Description

This change only affects CI. The artifactory gem is required for the publish part of the build stage.

### Related Issue

https://github.com/chef/omnibus-buildkite-plugin/issues/22