### PR TITLE
Fixed typo in umask example

### DIFF
--- a/docs/resources/login_defs.md.erb
+++ b/docs/resources/login_defs.md.erb
@@ -67,7 +67,7 @@ The `name` matcher tests the value of `name` as read from `login.defs` versus th
 
 ### Test umask setting
 
-    describe login_def do
+    describe login_defs do
       its('UMASK') { should eq '077' }
       its('PASS_MAX_DAYS') { should eq '90' }
     end


### PR DESCRIPTION
changed login_def to login_defs

<!--- Provide a short summary of your changes in the Title above -->

## Description
Example has a typo that breaks the test. 

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have read the **CONTRIBUTING** document.
