### PR TITLE
Ensure that resources are always initialized in all cases

### DIFF
--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -81,6 +81,7 @@ module Inspec
           @resource_skipped = false
           @resource_failed = false
           @supports = Inspec::Resource.supports[name]
+          @resource_exception_message = nil
 
           # attach the backend to this instance
           @__backend_runner__ = backend
@@ -95,13 +96,10 @@ module Inspec
             skip_resource(e.message)
           rescue Inspec::Exceptions::ResourceFailed => e
             fail_resource(e.message)
+          rescue NotImplementedError => e
+            fail_resource(e.message) unless @resource_failed
           rescue NoMethodError => e
-            # The new platform resources have methods generated on the fly
-            # for inspec check to work we need to skip these train errors
-            test_backend = defined?(Train::Transports::Mock::Connection) && backend.backend.class == Train::Transports::Mock::Connection
-            raise unless test_backend && e.receiver.class == Train::Transports::Mock::Connection
-
-            skip_resource(e.message)
+            skip_resource(e.message) unless @resource_failed
           end
         end
 

--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -86,12 +86,7 @@ module Inspec
           @__backend_runner__ = backend
           @__resource_name__ = name
 
-          # check resource supports
-          supported = true
-          supported = check_supports unless @supports.nil?
-          test_backend = defined?(Train::Transports::Mock::Connection) && backend.backend.class == Train::Transports::Mock::Connection
-          # do not return if we are supported, or for tests
-          return unless supported || test_backend
+          check_supports unless @supports.nil? # this has side effects
 
           # call the resource initializer
           begin
@@ -103,6 +98,7 @@ module Inspec
           rescue NoMethodError => e
             # The new platform resources have methods generated on the fly
             # for inspec check to work we need to skip these train errors
+            test_backend = defined?(Train::Transports::Mock::Connection) && backend.backend.class == Train::Transports::Mock::Connection
             raise unless test_backend && e.receiver.class == Train::Transports::Mock::Connection
 
             skip_resource(e.message)


### PR DESCRIPTION
It does NOT do what you think it does. It does NOT prevent an object
from coming back. All it does is have an uninitialized (or partially
initialized) object come back, which isn't helpful.

Signed-off-by: Ryan Davis <zenspider@chef.io>