### PR TITLE
DO NOT MERGE YET: `let` blocks: Changes to speed up generated tests.

### DIFF
--- a/lib/inspec/objects/test.rb
+++ b/lib/inspec/objects/test.rb
@@ -82,7 +82,7 @@ module Inspec
               elsif xpect != ""
                 " " + expectation.inspect
               end
-      format("%s%sdescribe %p do\n  it { subject.%sshould%s %s%s }\nend",
+      format("%s%sdescribe %%q(%s) do\n  it { subject.%sshould%s %s%s }\nend",
         only_if_clause, vars, res, xtra, naughty, matcher, xpect)
     end
 

--- a/lib/inspec/objects/value.rb
+++ b/lib/inspec/objects/value.rb
@@ -12,8 +12,13 @@ module Inspec
     end
 
     def to_ruby
-      res = @variable.nil? ? "" : "#{@variable} = "
-      res + @qualifier.map { |x| ruby_qualifier(x) }.join(".")
+      val = @qualifier.map { |x| ruby_qualifier(x) }.join(".")
+
+      if @variable then
+        "let(:%s) { %s }" % [@variable, val]
+      else
+        val
+      end
     end
 
     def name_variable(cache = [])

--- a/lib/inspec/objects/value.rb
+++ b/lib/inspec/objects/value.rb
@@ -14,8 +14,12 @@ module Inspec
     def to_ruby
       val = @qualifier.map { |x| ruby_qualifier(x) }.join(".")
 
-      if @variable then
-        "let(:%s) { %s }" % [@variable, val]
+      if @variable
+        if @variable == :subject
+          "subject { %s }" % [val]
+        else
+          "let(:%s) { %s }" % [@variable, val]
+        end
       else
         val
       end

--- a/test/unit/dsl/objects_test.rb
+++ b/test/unit/dsl/objects_test.rb
@@ -10,7 +10,7 @@ describe "Objects" do
       obj.expectation = "2.4.2"
       _(obj.to_ruby).must_equal '
 subject { resource }
-describe "resource" do
+describe %q(resource) do
   it { subject.version.should cmp >= "2.4.2" }
 end
 '.strip
@@ -24,7 +24,7 @@ end
       obj.expectation = "2.4.2"
       _(obj.to_ruby).must_equal '
 subject { resource.version }
-describe "resource.version" do
+describe %q(resource.version) do
   it { subject.should cmp >= "2.4.2" }
 end
 '.strip
@@ -36,7 +36,7 @@ end
       obj.expectation = Regexp.new("^Desc.+$")
       _(obj.to_ruby).must_equal '
 subject { resource.to_s }
-describe "resource.to_s" do
+describe %q(resource.to_s) do
   it { subject.should cmp(/^Desc.+$/) }
 end
 '.strip
@@ -48,7 +48,7 @@ end
       obj.expectation = 3
       _(obj.to_ruby).must_equal '
 subject { resource.to_i }
-describe "resource.to_i" do
+describe %q(resource.to_i) do
   it { subject.should cmp > 3 }
 end
 '.strip
@@ -61,7 +61,7 @@ end
       obj.expectation = "mytest"
       _(obj.to_ruby).must_equal '
 subject { resource.name[2] }
-describe "resource.name[2]" do
+describe %q(resource.name[2]) do
   it { subject.should eq "mytest" }
 end
 '.strip
@@ -73,7 +73,7 @@ end
       obj.expectation = "mytest"
       _(obj.to_ruby).must_equal '
 subject { resource.hello("world") }
-describe "resource.hello(\"world\")" do
+describe %q(resource.hello("world")) do
   it { subject.should eq "mytest" }
 end
 '.strip
@@ -85,7 +85,7 @@ end
       obj.expectation = %w{mytest mytest2 mytest3}
       _(obj.to_ruby).must_equal '
 subject { resource.hello("world") }
-describe "resource.hello(\"world\")" do
+describe %q(resource.hello("world")) do
   it { subject.should be_in ["mytest", "mytest2", "mytest3"] }
 end
 '.strip
@@ -98,7 +98,7 @@ end
       obj.expectation = %w{mytest2 mytest3 mytest4}
       _(obj.to_ruby).must_equal '
 subject { resource.hello("world") }
-describe "resource.hello(\"world\")" do
+describe %q(resource.hello("world")) do
   it { subject.should_not be_in ["mytest2", "mytest3", "mytest4"] }
 end
 '.strip
@@ -110,7 +110,7 @@ end
       obj.expectation = %w{item1 item2 item3 item4 item5}
       _(obj.to_ruby).must_equal '
 subject { ["item1","item2","item3"] }
-describe "[\"item1\",\"item2\",\"item3\"]" do
+describe %q(["item1","item2","item3"]) do
   it { subject.should be_in ["item1", "item2", "item3", "item4", "item5"] }
 end
 '.strip
@@ -122,7 +122,7 @@ end
       obj.expectation = "0755"
       _(obj.to_ruby).must_equal '
 subject { resource }
-describe "resource" do
+describe %q(resource) do
   it { subject.mode.should cmp "0755" }
 end
 '.strip
@@ -135,7 +135,7 @@ end
 
       _(obj.to_ruby).must_equal '
 subject { command("ls /etc") }
-describe "command(\"ls /etc\")" do
+describe %q(command("ls /etc")) do
   it { subject.exit_status.should eq 0 }
 end
 '.strip
@@ -150,7 +150,7 @@ end
       # TODO: possibly put some logic into using subject
       _(obj.to_ruby).must_equal '
 subject { "aaa" }
-describe "\"aaa\"" do
+describe %q("aaa") do
   it { subject.should_not match(/^aa.*/) }
 end
 '.strip
@@ -163,7 +163,7 @@ end
       obj.matcher = "eq"
       _(obj.to_ruby).must_equal '
 subject { service("avahi-daemon").info[\'properties\'][\'UnitFileState\'] }
-describe "service(\"avahi-daemon\").info[\'properties\'][\'UnitFileState\']" do
+describe %q(service("avahi-daemon").info[\'properties\'][\'UnitFileState\']) do
   it { subject.should eq "enabled" }
 end
 '.strip
@@ -177,7 +177,7 @@ end
       _(obj.to_ruby).must_equal '
 only_if { package(\'ntp\').installed? }
 subject { resource }
-describe "resource" do
+describe %q(resource) do
   it { subject.version.should cmp >= "2.4.2" }
 end
 '.strip
@@ -197,7 +197,7 @@ end
       _(loop_obj.to_ruby).must_equal '
 port(25).addresses.each do |entry|
   subject { entry }
-  describe "entry" do
+  describe %q(entry) do
     it { subject.should_not match "0.0.0.0" }
   end
 end
@@ -217,7 +217,7 @@ end
       obj.negate!
       _(obj.to_ruby).must_equal '
 subject { passwd.where { user =~ /^(?!root|sync|shutdown|halt).*$/ } }
-describe "passwd.where { user =~ /^(?!root|sync|shutdown|halt).*$/ }" do
+describe %q(passwd.where { user =~ /^(?!root|sync|shutdown|halt).*$/ }) do
   it { subject.entries.should_not be_empty }
 end
 '.strip
@@ -244,11 +244,11 @@ end
       _(or_obj.to_ruby).must_equal '
 describe.one do
   subject { command("ls /etc") }
-  describe "command(\"ls /etc\")" do
+  describe %q(command("ls /etc")) do
     it { subject.exit_status.should eq 0 }
   end
   subject { command("ls /etc") }
-  describe "command(\"ls /etc\")" do
+  describe %q(command("ls /etc")) do
     it { subject.exit_status.should_not eq 100 }
   end
 end
@@ -262,11 +262,11 @@ end
       # TODO: yeah. the duplicated subject needs to be culled where possible, or numbered
       _(or_obj.to_ruby).must_equal '
 subject { command("ls /etc") }
-describe "command(\"ls /etc\")" do
+describe %q(command("ls /etc")) do
   it { subject.exit_status.should_not eq 0 }
 end
 subject { command("ls /etc") }
-describe "command(\"ls /etc\")" do
+describe %q(command("ls /etc")) do
   it { subject.exit_status.should eq 100 }
 end
 '.strip
@@ -288,11 +288,11 @@ end
 (1..5).each do |entry|
   describe.one do
     subject { command("ls /etc") }
-    describe "command(\"ls /etc\")" do
+    describe %q(command("ls /etc")) do
       it { subject.exit_status.should eq entity }
     end
     subject { command("ls /etc") }
-    describe "command(\"ls /etc\")" do
+    describe %q(command("ls /etc")) do
       it { subject.exit_status.should_not eq entity }
     end
   end
@@ -322,7 +322,7 @@ control "sample.control.id" do
   ref   "simple ref"
   ref   ({:ref=>"title", :url=>"my url"})
   subject { command("ls /etc") }
-  describe "command(\\"ls /etc\\")" do
+  describe %q(command("ls /etc")) do
     it { subject.exit_status.should eq 0 }
   end
 end
@@ -353,7 +353,7 @@ control "sample.control.id" do
   ref   ({:ref=>"title", :url=>"my url"})
   only_if { package(\'ntp\').installed? }
   subject { command("ls /etc") }
-  describe "command(\"ls /etc\")" do
+  describe %q(command("ls /etc")) do
     it { subject.exit_status.should eq 0 }
   end
 end
@@ -431,11 +431,11 @@ control "variable.control.id" do
   impact 1.0
   let(:a) { command("which grep") }
   subject { a }
-  describe "a" do
+  describe %q(a) do
     it { subject.exit_status.should eq 0 }
   end
   subject { a }
-  describe "a" do
+  describe %q(a) do
     it { subject.stdout.should contain "grep" }
   end
 end
@@ -468,7 +468,7 @@ control "variable.control.id" do
   impact 0.1
   let(:a) { passwd.where { user == "_chrony" }.uids.first }
   subject { user(entry.user) }
-  describe "user(entry.user)" do
+  describe %q(user(entry.user)) do
     it { subject.uid.should cmp a }
   end
 end

--- a/test/unit/dsl/objects_test.rb
+++ b/test/unit/dsl/objects_test.rb
@@ -9,7 +9,7 @@ describe "Objects" do
       obj.matcher = "cmp >="
       obj.expectation = "2.4.2"
       _(obj.to_ruby).must_equal '
-let(:subject) { resource }
+subject { resource }
 describe "resource" do
   it { subject.version.should cmp >= "2.4.2" }
 end
@@ -23,7 +23,7 @@ end
       obj.matcher = "cmp >="
       obj.expectation = "2.4.2"
       _(obj.to_ruby).must_equal '
-let(:subject) { resource.version }
+subject { resource.version }
 describe "resource.version" do
   it { subject.should cmp >= "2.4.2" }
 end
@@ -35,7 +35,7 @@ end
       obj.matcher = "cmp"
       obj.expectation = Regexp.new("^Desc.+$")
       _(obj.to_ruby).must_equal '
-let(:subject) { resource.to_s }
+subject { resource.to_s }
 describe "resource.to_s" do
   it { subject.should cmp(/^Desc.+$/) }
 end
@@ -47,7 +47,7 @@ end
       obj.matcher = "cmp >"
       obj.expectation = 3
       _(obj.to_ruby).must_equal '
-let(:subject) { resource.to_i }
+subject { resource.to_i }
 describe "resource.to_i" do
   it { subject.should cmp > 3 }
 end
@@ -60,7 +60,7 @@ end
       obj.matcher = "eq"
       obj.expectation = "mytest"
       _(obj.to_ruby).must_equal '
-let(:subject) { resource.name[2] }
+subject { resource.name[2] }
 describe "resource.name[2]" do
   it { subject.should eq "mytest" }
 end
@@ -72,7 +72,7 @@ end
       obj.matcher = "eq"
       obj.expectation = "mytest"
       _(obj.to_ruby).must_equal '
-let(:subject) { resource.hello("world") }
+subject { resource.hello("world") }
 describe "resource.hello(\"world\")" do
   it { subject.should eq "mytest" }
 end
@@ -84,7 +84,7 @@ end
       obj.matcher = "be_in"
       obj.expectation = %w{mytest mytest2 mytest3}
       _(obj.to_ruby).must_equal '
-let(:subject) { resource.hello("world") }
+subject { resource.hello("world") }
 describe "resource.hello(\"world\")" do
   it { subject.should be_in ["mytest", "mytest2", "mytest3"] }
 end
@@ -97,7 +97,7 @@ end
       obj.negate!
       obj.expectation = %w{mytest2 mytest3 mytest4}
       _(obj.to_ruby).must_equal '
-let(:subject) { resource.hello("world") }
+subject { resource.hello("world") }
 describe "resource.hello(\"world\")" do
   it { subject.should_not be_in ["mytest2", "mytest3", "mytest4"] }
 end
@@ -109,7 +109,7 @@ end
       obj.matcher = "be_in"
       obj.expectation = %w{item1 item2 item3 item4 item5}
       _(obj.to_ruby).must_equal '
-let(:subject) { ["item1","item2","item3"] }
+subject { ["item1","item2","item3"] }
 describe "[\"item1\",\"item2\",\"item3\"]" do
   it { subject.should be_in ["item1", "item2", "item3", "item4", "item5"] }
 end
@@ -121,7 +121,7 @@ end
       obj.matcher = "cmp"
       obj.expectation = "0755"
       _(obj.to_ruby).must_equal '
-let(:subject) { resource }
+subject { resource }
 describe "resource" do
   it { subject.mode.should cmp "0755" }
 end
@@ -134,7 +134,7 @@ end
       obj.expectation = 0
 
       _(obj.to_ruby).must_equal '
-let(:subject) { command("ls /etc") }
+subject { command("ls /etc") }
 describe "command(\"ls /etc\")" do
   it { subject.exit_status.should eq 0 }
 end
@@ -149,7 +149,7 @@ end
 
       # TODO: possibly put some logic into using subject
       _(obj.to_ruby).must_equal '
-let(:subject) { "aaa" }
+subject { "aaa" }
 describe "\"aaa\"" do
   it { subject.should_not match(/^aa.*/) }
 end
@@ -162,7 +162,7 @@ end
       obj.expectation = "enabled"
       obj.matcher = "eq"
       _(obj.to_ruby).must_equal '
-let(:subject) { service("avahi-daemon").info[\'properties\'][\'UnitFileState\'] }
+subject { service("avahi-daemon").info[\'properties\'][\'UnitFileState\'] }
 describe "service(\"avahi-daemon\").info[\'properties\'][\'UnitFileState\']" do
   it { subject.should eq "enabled" }
 end
@@ -176,7 +176,7 @@ end
       obj.only_if = "package('ntp').installed?"
       _(obj.to_ruby).must_equal '
 only_if { package(\'ntp\').installed? }
-let(:subject) { resource }
+subject { resource }
 describe "resource" do
   it { subject.version.should cmp >= "2.4.2" }
 end
@@ -196,7 +196,7 @@ end
       loop_obj.add_test(obj)
       _(loop_obj.to_ruby).must_equal '
 port(25).addresses.each do |entry|
-  let(:subject) { entry }
+  subject { entry }
   describe "entry" do
     it { subject.should_not match "0.0.0.0" }
   end
@@ -216,7 +216,7 @@ end
       obj.qualifier.push(["entries"])
       obj.negate!
       _(obj.to_ruby).must_equal '
-let(:subject) { passwd.where { user =~ /^(?!root|sync|shutdown|halt).*$/ } }
+subject { passwd.where { user =~ /^(?!root|sync|shutdown|halt).*$/ } }
 describe "passwd.where { user =~ /^(?!root|sync|shutdown|halt).*$/ }" do
   it { subject.entries.should_not be_empty }
 end
@@ -243,11 +243,11 @@ end
       or_obj = Inspec::OrTest.new([obj1, obj2])
       _(or_obj.to_ruby).must_equal '
 describe.one do
-  let(:subject) { command("ls /etc") }
+  subject { command("ls /etc") }
   describe "command(\"ls /etc\")" do
     it { subject.exit_status.should eq 0 }
   end
-  let(:subject) { command("ls /etc") }
+  subject { command("ls /etc") }
   describe "command(\"ls /etc\")" do
     it { subject.exit_status.should_not eq 100 }
   end
@@ -261,11 +261,11 @@ end
 
       # TODO: yeah. the duplicated subject needs to be culled where possible, or numbered
       _(or_obj.to_ruby).must_equal '
-let(:subject) { command("ls /etc") }
+subject { command("ls /etc") }
 describe "command(\"ls /etc\")" do
   it { subject.exit_status.should_not eq 0 }
 end
-let(:subject) { command("ls /etc") }
+subject { command("ls /etc") }
 describe "command(\"ls /etc\")" do
   it { subject.exit_status.should eq 100 }
 end
@@ -287,11 +287,11 @@ end
       _(res.to_ruby).must_equal '
 (1..5).each do |entry|
   describe.one do
-    let(:subject) { command("ls /etc") }
+    subject { command("ls /etc") }
     describe "command(\"ls /etc\")" do
       it { subject.exit_status.should eq entity }
     end
-    let(:subject) { command("ls /etc") }
+    subject { command("ls /etc") }
     describe "command(\"ls /etc\")" do
       it { subject.exit_status.should_not eq entity }
     end
@@ -321,7 +321,7 @@ control "sample.control.id" do
   impact 1.0
   ref   "simple ref"
   ref   ({:ref=>"title", :url=>"my url"})
-  let(:subject) { command("ls /etc") }
+  subject { command("ls /etc") }
   describe "command(\\"ls /etc\\")" do
     it { subject.exit_status.should eq 0 }
   end
@@ -352,7 +352,7 @@ control "sample.control.id" do
   ref   "simple ref"
   ref   ({:ref=>"title", :url=>"my url"})
   only_if { package(\'ntp\').installed? }
-  let(:subject) { command("ls /etc") }
+  subject { command("ls /etc") }
   describe "command(\"ls /etc\")" do
     it { subject.exit_status.should eq 0 }
   end
@@ -430,11 +430,11 @@ control "variable.control.id" do
   desc  "The most variable control the world has ever seen"
   impact 1.0
   let(:a) { command("which grep") }
-  let(:subject) { a }
+  subject { a }
   describe "a" do
     it { subject.exit_status.should eq 0 }
   end
-  let(:subject) { a }
+  subject { a }
   describe "a" do
     it { subject.stdout.should contain "grep" }
   end
@@ -467,7 +467,7 @@ end
 control "variable.control.id" do
   impact 0.1
   let(:a) { passwd.where { user == "_chrony" }.uids.first }
-  let(:subject) { user(entry.user) }
+  subject { user(entry.user) }
   describe "user(entry.user)" do
     it { subject.uid.should cmp a }
   end

--- a/test/unit/dsl/objects_test.rb
+++ b/test/unit/dsl/objects_test.rb
@@ -9,8 +9,9 @@ describe "Objects" do
       obj.matcher = "cmp >="
       obj.expectation = "2.4.2"
       _(obj.to_ruby).must_equal '
-describe resource do
-  its("version") { should cmp >= "2.4.2" }
+let(:subject) { resource }
+describe "resource" do
+  it { subject.version.should cmp >= "2.4.2" }
 end
 '.strip
     end
@@ -22,8 +23,9 @@ end
       obj.matcher = "cmp >="
       obj.expectation = "2.4.2"
       _(obj.to_ruby).must_equal '
-describe resource.version do
-  it { should cmp >= "2.4.2" }
+let(:subject) { resource.version }
+describe "resource.version" do
+  it { subject.should cmp >= "2.4.2" }
 end
 '.strip
     end
@@ -33,8 +35,9 @@ end
       obj.matcher = "cmp"
       obj.expectation = Regexp.new("^Desc.+$")
       _(obj.to_ruby).must_equal '
-describe resource.to_s do
-  it { should cmp(/^Desc.+$/) }
+let(:subject) { resource.to_s }
+describe "resource.to_s" do
+  it { subject.should cmp(/^Desc.+$/) }
 end
 '.strip
     end
@@ -44,8 +47,9 @@ end
       obj.matcher = "cmp >"
       obj.expectation = 3
       _(obj.to_ruby).must_equal '
-describe resource.to_i do
-  it { should cmp > 3 }
+let(:subject) { resource.to_i }
+describe "resource.to_i" do
+  it { subject.should cmp > 3 }
 end
 '.strip
     end
@@ -56,8 +60,9 @@ end
       obj.matcher = "eq"
       obj.expectation = "mytest"
       _(obj.to_ruby).must_equal '
-describe resource.name[2] do
-  it { should eq "mytest" }
+let(:subject) { resource.name[2] }
+describe "resource.name[2]" do
+  it { subject.should eq "mytest" }
 end
 '.strip
     end
@@ -67,8 +72,9 @@ end
       obj.matcher = "eq"
       obj.expectation = "mytest"
       _(obj.to_ruby).must_equal '
-describe resource.hello("world") do
-  it { should eq "mytest" }
+let(:subject) { resource.hello("world") }
+describe "resource.hello(\"world\")" do
+  it { subject.should eq "mytest" }
 end
 '.strip
     end
@@ -78,8 +84,9 @@ end
       obj.matcher = "be_in"
       obj.expectation = %w{mytest mytest2 mytest3}
       _(obj.to_ruby).must_equal '
-describe resource.hello("world") do
-  it { should be_in ["mytest", "mytest2", "mytest3"] }
+let(:subject) { resource.hello("world") }
+describe "resource.hello(\"world\")" do
+  it { subject.should be_in ["mytest", "mytest2", "mytest3"] }
 end
 '.strip
     end
@@ -90,8 +97,9 @@ end
       obj.negate!
       obj.expectation = %w{mytest2 mytest3 mytest4}
       _(obj.to_ruby).must_equal '
-describe resource.hello("world") do
-  it { should_not be_in ["mytest2", "mytest3", "mytest4"] }
+let(:subject) { resource.hello("world") }
+describe "resource.hello(\"world\")" do
+  it { subject.should_not be_in ["mytest2", "mytest3", "mytest4"] }
 end
 '.strip
     end
@@ -101,8 +109,9 @@ end
       obj.matcher = "be_in"
       obj.expectation = %w{item1 item2 item3 item4 item5}
       _(obj.to_ruby).must_equal '
-describe ["item1","item2","item3"] do
-  it { should be_in ["item1", "item2", "item3", "item4", "item5"] }
+let(:subject) { ["item1","item2","item3"] }
+describe "[\"item1\",\"item2\",\"item3\"]" do
+  it { subject.should be_in ["item1", "item2", "item3", "item4", "item5"] }
 end
 '.strip
     end
@@ -112,8 +121,9 @@ end
       obj.matcher = "cmp"
       obj.expectation = "0755"
       _(obj.to_ruby).must_equal '
-describe resource do
-  its("mode") { should cmp "0755" }
+let(:subject) { resource }
+describe "resource" do
+  it { subject.mode.should cmp "0755" }
 end
 '.strip
     end
@@ -124,8 +134,9 @@ end
       obj.expectation = 0
 
       _(obj.to_ruby).must_equal '
-describe command("ls /etc") do
-  its("exit_status") { should eq 0 }
+let(:subject) { command("ls /etc") }
+describe "command(\"ls /etc\")" do
+  it { subject.exit_status.should eq 0 }
 end
 '.strip
     end
@@ -136,9 +147,11 @@ end
       obj.negate!
       obj.expectation = Regexp.new("^aa.*")
 
+      # TODO: possibly put some logic into using subject
       _(obj.to_ruby).must_equal '
-describe "aaa" do
-  it { should_not match(/^aa.*/) }
+let(:subject) { "aaa" }
+describe "\"aaa\"" do
+  it { subject.should_not match(/^aa.*/) }
 end
 '.strip
     end
@@ -149,8 +162,9 @@ end
       obj.expectation = "enabled"
       obj.matcher = "eq"
       _(obj.to_ruby).must_equal '
-describe service("avahi-daemon").info[\'properties\'][\'UnitFileState\'] do
-  it { should eq "enabled" }
+let(:subject) { service("avahi-daemon").info[\'properties\'][\'UnitFileState\'] }
+describe "service(\"avahi-daemon\").info[\'properties\'][\'UnitFileState\']" do
+  it { subject.should eq "enabled" }
 end
 '.strip
     end
@@ -162,8 +176,9 @@ end
       obj.only_if = "package('ntp').installed?"
       _(obj.to_ruby).must_equal '
 only_if { package(\'ntp\').installed? }
-describe resource do
-  its("version") { should cmp >= "2.4.2" }
+let(:subject) { resource }
+describe "resource" do
+  it { subject.version.should cmp >= "2.4.2" }
 end
 '.strip
     end
@@ -181,8 +196,9 @@ end
       loop_obj.add_test(obj)
       _(loop_obj.to_ruby).must_equal '
 port(25).addresses.each do |entry|
-  describe entry do
-    it { should_not match "0.0.0.0" }
+  let(:subject) { entry }
+  describe "entry" do
+    it { subject.should_not match "0.0.0.0" }
   end
 end
 '.strip
@@ -200,8 +216,9 @@ end
       obj.qualifier.push(["entries"])
       obj.negate!
       _(obj.to_ruby).must_equal '
-describe passwd.where { user =~ /^(?!root|sync|shutdown|halt).*$/ } do
-  its("entries") { should_not be_empty }
+let(:subject) { passwd.where { user =~ /^(?!root|sync|shutdown|halt).*$/ } }
+describe "passwd.where { user =~ /^(?!root|sync|shutdown|halt).*$/ }" do
+  it { subject.entries.should_not be_empty }
 end
 '.strip
     end
@@ -226,11 +243,13 @@ end
       or_obj = Inspec::OrTest.new([obj1, obj2])
       _(or_obj.to_ruby).must_equal '
 describe.one do
-  describe command("ls /etc") do
-    its("exit_status") { should eq 0 }
+  let(:subject) { command("ls /etc") }
+  describe "command(\"ls /etc\")" do
+    it { subject.exit_status.should eq 0 }
   end
-  describe command("ls /etc") do
-    its("exit_status") { should_not eq 100 }
+  let(:subject) { command("ls /etc") }
+  describe "command(\"ls /etc\")" do
+    it { subject.exit_status.should_not eq 100 }
   end
 end
 '.strip
@@ -239,12 +258,16 @@ end
     it "negates a describe.one block, wow!" do
       or_obj = Inspec::OrTest.new([obj1, obj2])
       or_obj.negate!
+
+      # TODO: yeah. the duplicated subject needs to be culled where possible, or numbered
       _(or_obj.to_ruby).must_equal '
-describe command("ls /etc") do
-  its("exit_status") { should_not eq 0 }
+let(:subject) { command("ls /etc") }
+describe "command(\"ls /etc\")" do
+  it { subject.exit_status.should_not eq 0 }
 end
-describe command("ls /etc") do
-  its("exit_status") { should eq 100 }
+let(:subject) { command("ls /etc") }
+describe "command(\"ls /etc\")" do
+  it { subject.exit_status.should eq 100 }
 end
 '.strip
     end
@@ -264,11 +287,13 @@ end
       _(res.to_ruby).must_equal '
 (1..5).each do |entry|
   describe.one do
-    describe command("ls /etc") do
-      its("exit_status") { should eq entity }
+    let(:subject) { command("ls /etc") }
+    describe "command(\"ls /etc\")" do
+      it { subject.exit_status.should eq entity }
     end
-    describe command("ls /etc") do
-      its("exit_status") { should_not eq entity }
+    let(:subject) { command("ls /etc") }
+    describe "command(\"ls /etc\")" do
+      it { subject.exit_status.should_not eq entity }
     end
   end
 end
@@ -296,8 +321,9 @@ control "sample.control.id" do
   impact 1.0
   ref   "simple ref"
   ref   ({:ref=>"title", :url=>"my url"})
-  describe command("ls /etc") do
-    its("exit_status") { should eq 0 }
+  let(:subject) { command("ls /etc") }
+  describe "command(\\"ls /etc\\")" do
+    it { subject.exit_status.should eq 0 }
   end
 end
 '.strip
@@ -326,8 +352,9 @@ control "sample.control.id" do
   ref   "simple ref"
   ref   ({:ref=>"title", :url=>"my url"})
   only_if { package(\'ntp\').installed? }
-  describe command("ls /etc") do
-    its("exit_status") { should eq 0 }
+  let(:subject) { command("ls /etc") }
+  describe "command(\"ls /etc\")" do
+    it { subject.exit_status.should eq 0 }
   end
 end
 '.strip
@@ -396,17 +423,20 @@ end
       control.title = "Variable Control Important Title"
       control.descriptions[:default] = "The most variable control the world has ever seen"
       control.impact = 1.0
+      # TODO: doubled up on subject... probably skippable w/ some logic
       _(control.to_ruby).must_equal '
 control "variable.control.id" do
   title "Variable Control Important Title"
   desc  "The most variable control the world has ever seen"
   impact 1.0
-  a = command("which grep")
-  describe a do
-    its("exit_status") { should eq 0 }
+  let(:a) { command("which grep") }
+  let(:subject) { a }
+  describe "a" do
+    it { subject.exit_status.should eq 0 }
   end
-  describe a do
-    its("stdout") { should contain "grep" }
+  let(:subject) { a }
+  describe "a" do
+    it { subject.stdout.should contain "grep" }
   end
 end
 '.strip
@@ -436,9 +466,10 @@ end
       _(control.to_ruby).must_equal '
 control "variable.control.id" do
   impact 0.1
-  a = passwd.where { user == "_chrony" }.uids.first
-  describe user(entry.user) do
-    its("uid") { should cmp a }
+  let(:a) { passwd.where { user == "_chrony" }.uids.first }
+  let(:subject) { user(entry.user) }
+  describe "user(entry.user)" do
+    it { subject.uid.should cmp a }
   end
 end
 '.strip


### PR DESCRIPTION
CIS generated tests can have a lot of variables that are actually very
resource heavy. This converts all variables into their equivalent let
form, deferring all computation to actual use. This means that
"skipped" controls will have roughly zero impact.

I think there is still more to be done here and on that "skipped"
control concept. Its name is misleading at best yet still potentially
very costly.

Signed-off-by: Ryan Davis <zenspider@chef.io>