### PR TITLE
Moved the osx? guard below minitest/autorun.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -156,10 +156,6 @@ class InspecTest < Minitest::Test
   # shared stuff here
 end
 
-class ParallelTest < InspecTest
-  parallelize_me!
-end
-
 module Minitest::Guard
   # TODO: push up to minitest
   def osx?(platform = RUBY_PLATFORM)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,13 +23,6 @@ if ENV["CI_ENABLE_COVERAGE"]
   end
 end
 
-module Minitest::Guard
-  # TODO: push up to minitest
-  def osx?(platform = RUBY_PLATFORM)
-    /darwin/ =~ platform
-  end
-end
-
 ##
 #
 # Do not add any other code from here until the end of this code
@@ -165,4 +158,11 @@ end
 
 class ParallelTest < InspecTest
   parallelize_me!
+end
+
+module Minitest::Guard
+  # TODO: push up to minitest
+  def osx?(platform = RUBY_PLATFORM)
+    /darwin/ =~ platform
+  end
 end


### PR DESCRIPTION
I didn't hit this because I use `minitest` to run my tests, not `m`.

Signed-off-by: Ryan Davis <zenspider@chef.io>