### PR TITLE
Expand sys_info resource functionality

### DIFF
--- a/docs/resources/sys_info.md.erb
+++ b/docs/resources/sys_info.md.erb
@@ -51,6 +51,31 @@ The `hostname` matcher tests the host for which standard output is returned:
 
     its('hostname') { should eq 'value' }
 
+
+### fqdn
+
+The `fqdn` property tests the 'fully qualified domain name' of the system:
+
+    its('fqdn') { should eq 'value' }
+
+### domain
+
+The `domain` property tests the name of the DNS domain:
+
+    its('domain') { should eq 'value' }
+
+### ip-address
+
+The `ip-address` property tests all network addresses of the host:
+
+    its('ip-address') { should eq 'value' }
+
+### short
+
+The `short` property tests the host name cut at the first dot:
+
+    its('short') { should eq 'value' }
+
 ### manufacturer
 
 The `manufacturer` matcher tests the host for which standard output is returned:

--- a/docs/resources/sys_info.md.erb
+++ b/docs/resources/sys_info.md.erb
@@ -41,6 +41,24 @@ The following examples show how to use this Chef InSpec audit resource.
 
 <br>
 
+### Compare content to hostname
+
+    describe file('/path/to/some/file') do
+      its('content') { should match sys_info.hostname }
+    end
+
+<br>
+
+Options can be passed as arguments to hostname as well.
+
+    describe file('/path/to/some/file') do
+      its('content') { should match sys_info.hostname('full') }
+    end
+
+<br>
+
+Currently supported arguments to `hostname` on Linux platforms are 'full'|'f'|'fqdn'|'long', 'domain'|'d', 'ip_address'|'i', and 'short'|'s'. Mac currently supports 'full'|'f'|'fqdn'|'long' and 'short'|'s'
+
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -15,12 +15,12 @@ module Inspec::Resources
       end
 
       describe sys_info do
-        its('hostname') { should eq 'example.com' }
+        its('fqdn') { should eq 'user.example.com' }
       end
 
     EXAMPLE
 
-    %w{ alias domain fqdn ip-address short }.each do |opt|
+    %w{ domain fqdn ip-address short }.each do |opt|
       define_method(opt.to_sym) do
         hostname(opt)
       end
@@ -33,12 +33,10 @@ module Inspec::Resources
         opt = case opt
               when "f", "long", "fqdn", "full"
                 " -f"
-              when "a", "alias"
-                " -a"
               when "d", "domain"
                 " -d"
               when "i", "ip-address"
-                " -i"
+                " -I"
               when "s", "short"
                 " -s"
               else

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -13,13 +13,38 @@ module Inspec::Resources
       describe sys_info do
         its('hostname') { should eq 'example.com' }
       end
+
+      describe sys_info do
+        its('hostname') { should eq 'example.com' }
+      end
+
     EXAMPLE
 
+    %w{ alias domain fqdn ip-address short }.each do |opt|
+      define_method(opt.to_sym) do
+        hostname(opt)
+      end
+    end
+
     # returns the hostname of the local system
-    def hostname
+    def hostname(opt = nil)
       os = inspec.os
       if os.linux? || os.darwin?
-        inspec.command("hostname").stdout.chomp
+        opt = case opt
+              when "f", "long", "fqdn", "full"
+                " -f"
+              when "a", "alias"
+                " -a"
+              when "d", "domain"
+                " -d"
+              when "i", "ip-address"
+                " -i"
+              when "s", "short"
+                " -s"
+              else
+                nil
+              end
+        inspec.command("hostname#{opt}").stdout.chomp
       elsif os.windows?
         inspec.powershell("$env:computername").stdout.chomp
       else

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -20,7 +20,7 @@ module Inspec::Resources
 
     EXAMPLE
 
-    %w{ domain fqdn ip-address short }.each do |opt|
+    %w{ domain fqdn ip_address short }.each do |opt|
       define_method(opt.to_sym) do
         hostname(opt)
       end
@@ -35,7 +35,7 @@ module Inspec::Resources
                 " -f"
               when "d", "domain"
                 " -d"
-              when "i", "ip-address"
+              when "i", "ip_address"
                 " -I"
               when "s", "short"
                 " -s"
@@ -44,7 +44,11 @@ module Inspec::Resources
               end
         inspec.command("hostname#{opt}").stdout.chomp
       elsif os.windows?
-        inspec.powershell("$env:computername").stdout.chomp
+        if !opt.nil?
+          skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
+        else
+          inspec.powershell("$env:computername").stdout.chomp
+        end
       else
         skip_resource "The `sys_info.hostname` resource is not supported on your OS yet."
       end

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -30,41 +30,9 @@ module Inspec::Resources
     def hostname(opt = nil)
       os = inspec.os
       if os.linux?
-        if !opt.nil?
-        opt = case opt
-              when "f", "long", "fqdn", "full"
-                " -f"
-              when "d", "domain"
-                " -d"
-              when "i", "ip_address"
-                " -I"
-              when "s", "short"
-                " -s"
-              else
-                "ERROR"
-              end
-        end
-        if opt == "ERROR"
-          skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
-        else
-          inspec.command("hostname#{opt}").stdout.chomp
-        end
+        linux_hostname(opt)
       elsif os.darwin?
-        if !opt.nil?
-        opt = case opt
-              when "f", "long", "fqdn", "full"
-                " -f"
-              when "s", "short"
-                " -s"
-              else
-                "ERROR"
-              end
-        end
-        if opt == "ERROR"
-          skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
-        else
-          inspec.command("hostname#{opt}").stdout.chomp
-        end
+        mac_hostname(opt)
       elsif os.windows?
         if !opt.nil?
           skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
@@ -73,6 +41,46 @@ module Inspec::Resources
         end
       else
         skip_resource "The `sys_info.hostname` resource is not supported on your OS yet."
+      end
+    end
+
+    def linux_hostname(opt = nil)
+      if !opt.nil?
+        opt = case opt
+            when "f", "long", "fqdn", "full"
+              " -f"
+            when "d", "domain"
+              " -d"
+            when "i", "ip_address"
+              " -I"
+            when "s", "short"
+              " -s"
+            else
+              "ERROR"
+            end
+      end
+      if opt == "ERROR"
+        skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
+      else
+        inspec.command("hostname#{opt}").stdout.chomp
+      end
+    end
+
+    def mac_hostname(opt = nil)
+      if !opt.nil?
+        opt = case opt
+            when "f", "long", "fqdn", "full"
+              " -f"
+            when "s", "short"
+              " -s"
+            else
+              "ERROR"
+            end
+      end
+      if opt == "ERROR"
+        skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
+      else
+        inspec.command("hostname#{opt}").stdout.chomp
       end
     end
 

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -29,7 +29,8 @@ module Inspec::Resources
     # returns the hostname of the local system
     def hostname(opt = nil)
       os = inspec.os
-      if os.linux? || os.darwin?
+      if os.linux?
+        if !opt.nil?
         opt = case opt
               when "f", "long", "fqdn", "full"
                 " -f"
@@ -40,9 +41,30 @@ module Inspec::Resources
               when "s", "short"
                 " -s"
               else
-                nil
+                "ERROR"
               end
-        inspec.command("hostname#{opt}").stdout.chomp
+        end
+        if opt == "ERROR"
+          skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
+        else
+          inspec.command("hostname#{opt}").stdout.chomp
+        end
+      elsif os.darwin?
+        if !opt.nil?
+        opt = case opt
+              when "f", "long", "fqdn", "full"
+                " -f"
+              when "s", "short"
+                " -s"
+              else
+                "ERROR"
+              end
+        end
+        if opt == "ERROR"
+          skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
+        else
+          inspec.command("hostname#{opt}").stdout.chomp
+        end
       elsif os.windows?
         if !opt.nil?
           skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -47,17 +47,17 @@ module Inspec::Resources
     def linux_hostname(opt = nil)
       if !opt.nil?
         opt = case opt
-            when "f", "long", "fqdn", "full"
-              " -f"
-            when "d", "domain"
-              " -d"
-            when "i", "ip_address"
-              " -I"
-            when "s", "short"
-              " -s"
-            else
-              "ERROR"
-            end
+              when "f", "long", "fqdn", "full"
+                " -f"
+              when "d", "domain"
+                " -d"
+              when "i", "ip_address"
+                " -I"
+              when "s", "short"
+                " -s"
+              else
+                "ERROR"
+              end
       end
       if opt == "ERROR"
         skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
@@ -69,13 +69,13 @@ module Inspec::Resources
     def mac_hostname(opt = nil)
       if !opt.nil?
         opt = case opt
-            when "f", "long", "fqdn", "full"
-              " -f"
-            when "s", "short"
-              " -s"
-            else
-              "ERROR"
-            end
+              when "f", "long", "fqdn", "full"
+                " -f"
+              when "s", "short"
+                " -s"
+              else
+                "ERROR"
+              end
       end
       if opt == "ERROR"
         skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."


### PR DESCRIPTION
Signed-off-by: Kerry Vance <vancelot@osuosl.org>
<!--- Provide a short summary of your changes in the Title above -->

## Description
Expand functionality of sys_info resource to allow different arguments to hostname function. Default behavior remains the same, so nothing should break. I was provisioning a server that used the full hostname in some files. The default behavior of 'hostname' didn't match the value used in the recipe. The value was dynamic not static, so could not be tested literally.
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
