### PR TITLE
Deprecate platforms for 3-stable branch

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -18,8 +18,7 @@ builder-to-testers-map:
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
-  ubuntu-14.04-x86_64:
-    - ubuntu-14.04-x86_64
+  ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
   windows-2012r2-x86_64:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -15,8 +15,6 @@ builder-to-testers-map:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
     - mac_os_x-10.14-x86_64
-  sles-11-x86_64:
-    - sles-11-x86_64
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64


### PR DESCRIPTION
As of March 31st 2019, SLES 11 is no longer generally supported. Per our
support process we will no longer officially support SLES 11.

As of April 30th 2019, Ubuntu 14.04 is no longer generally supported. Per our
support process we will no longer officially support Ubuntu 14.04.

See https://docs.chef.io/platforms.html#platform-end-of-life-policy