### PR TITLE
Fixed multiline error described in issue #3921

### DIFF
--- a/lib/inspec/resources/filesystem.rb
+++ b/lib/inspec/resources/filesystem.rb
@@ -100,7 +100,7 @@ module Inspec::Resources
         raise Inspec::Exceptions::ResourceFailed,
           "Unable to get available space for partition #{partition}"
       end
-      value = cmd.stdout.split(/\n/)[1].strip.split(" ")
+      value = cmd.stdout.gsub(/\n\s+/, " ").split(/\n/)[1].strip.split(" ")
       {
         name: partition,
         size_kb: value[2].to_i,


### PR DESCRIPTION
Signed-off-by: Albert Jubany Juàrez <ajubanyjuarez@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Addresses the bug that happens on RedHat 5 and 6 that if a filesystem has a long name, it puts a newline right after the filesystem name, and InSpec's describe filesystem doesn't manage it.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #3921

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
