### PR TITLE
inputs: Accept bare input from the command line

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -63,7 +63,7 @@ That said, any profile that uses the DSL keyword `input()` (or the deprecated `a
 
 ### How can I set Inputs?
 
-As installed (without specialized plugins), Chef InSpec supports six ways of setting inputs:
+As installed (without specialized plugins), Chef InSpec supports several ways of setting inputs:
 
  * Inline in control code, using `input('input_name', value: 42)`.
  * In profile `inspec.yml` metadata files
@@ -80,7 +80,7 @@ In addition, Chef InSpec supports Input Plugins, which can provide optional inte
 
 Briefly:
 
-inline DSL < metadata < ( cli-inupt-file or kitchen-inspec or audit-cookbook ) < cli --input
+inline DSL < metadata < ( cli-input-file or kitchen-inspec or audit-cookbook ) < cli --input
 
 In addition, for inherited profiles:
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -46,11 +46,7 @@ Test Summary: 0 successful, 1 failure, 0 skipped
 
 That result clearly won't do. Let's override the input's default value. Create a file, `custom_amps.yml`:
 
-```yaml
-amplifier_max_volume: 11
-```
-
-We can now run that profile with `inspec exec rock_critic --input-file custom_amps.yaml`:
+We can now run that profile with `inspec exec rock_critic --input amplifier_max_volume=11`:
 
 ```
   11
@@ -71,7 +67,8 @@ As installed (without specialized plugins), Chef InSpec supports five ways of se
 
  * Inline in control code, using `input('input_name', value: 42)`.
  * In profile `inspec.yml` metadata files
- * Using the CLI option `--input-file somefile.yaml`
+ * Using the CLI option `--input name1=value1 name2=value2...` to read directly from the command line
+ * Using the CLI option `--input-file somefile.yaml` to read inputs from files
  * In kitchen-inspec, using the `verifier/inputs` settings
  * In the Audit Cookbook, using the `node[:audit][:inputs]`
 
@@ -83,7 +80,7 @@ In addition, Chef InSpec supports Input Plugins, which can provide optional inte
 
 Briefly:
 
-inline DSL < metadata < ( cli-input-file or kitchen-inspec or audit-cookbook )
+inline DSL < metadata < ( cli-inupt-file or kitchen-inspec or audit-cookbook ) < cli --input
 
 In addition, for inherited profiles:
 
@@ -122,7 +119,7 @@ As packaged, Chef InSpec uses the following priority values:
 | CLI `--input-file` option              | 40       |   No                |
 | inspec-kitchen `inputs:` section       | 40       |   No                |
 | audit cookbook `node[:audit][:inputs]` | 40       |   No                |
-
+| CLI `--input` option                   | 50       |   No                |
 
 ### What happened to "Attributes"?
 
@@ -246,9 +243,31 @@ an_input: a_value
 another_input: another_value
 ```
 
-CLI-set inputs have a priority of 40.
+CLI-input-file-set inputs have a priority of 40.
 
 As of Chef InSpec 4.3.2, this mechanism has the following limitations:
+
+  1. No [input options](#input-options-reference) may be set - only the name and value.
+  2. Because the CLI is outside the scope of any individual profile and the inputs don't take options, the inputs are clumsily copied into every profile, effectively making the CLI mechanism global.
+
+## Setting Input values using `--input`
+
+You may also provide inputs and values directly on the command line:
+
+```yaml
+inspec exec my_profile --input input_name=input_value
+```
+
+To set multiple inputs, say:
+```yaml
+inspec exec my_profile --input input_name1=input_value1 name2=value2
+```
+
+Don't repeat the `--input` flag; that will override the previous setting.
+
+CLI-set inputs have a priority of 50.
+
+As of Chef InSpec 4.12, this mechanism has the following limitations:
 
   1. No [input options](#input-options-reference) may be set - only the name and value.
   2. Because the CLI is outside the scope of any individual profile and the inputs don't take options, the inputs are clumsily copied into every profile, effectively making the CLI mechanism global.

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -44,7 +44,7 @@ When the above profile is executed by using `inspec exec rock_critic`, you would
 Test Summary: 0 successful, 1 failure, 0 skipped
 ```
 
-That result clearly won't do. Let's override the input's default value. Create a file, `custom_amps.yml`:
+That result clearly won't do. Let's override the input's default value.
 
 We can now run that profile with `inspec exec rock_critic --input amplifier_max_volume=11`:
 
@@ -63,7 +63,7 @@ That said, any profile that uses the DSL keyword `input()` (or the deprecated `a
 
 ### How can I set Inputs?
 
-As installed (without specialized plugins), Chef InSpec supports five ways of setting inputs:
+As installed (without specialized plugins), Chef InSpec supports six ways of setting inputs:
 
  * Inline in control code, using `input('input_name', value: 42)`.
  * In profile `inspec.yml` metadata files
@@ -263,7 +263,7 @@ To set multiple inputs, say:
 inspec exec my_profile --input input_name1=input_value1 name2=value2
 ```
 
-Don't repeat the `--input` flag; that will override the previous setting.
+Do not repeat the `--input` flag; that will override the previous setting.
 
 CLI-set inputs have a priority of 50.
 

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -133,6 +133,8 @@ module Inspec
       option :reporter, type: :array,
         banner: "one two:/output/file/path",
         desc: "Enable one or more output reporters: cli, documentation, html, progress, json, json-min, json-rspec, junit, yaml"
+      option :input, type: :array, banner: "name1=value1 name2=value2",
+        desc: "Specify one or more inputs directly on the command line, as --input NAME=VALUE"
       option :input_file, type: :array,
         desc: "Load one or more input files, a YAML file with values for the profile to use"
       option :attrs, type: :array,

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -158,7 +158,7 @@ module Inspec
         end
         input_name, input_value = pair.split("=")
         evt = Inspec::Input::Event.new(
-          value: input_value.sub(/,$/, ""), # Trim trailing comma if any
+          value: input_value.chomp(","), # Trim trailing comma if any
           provider: :cli,
           priority: 50
         )

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -137,7 +137,8 @@ module Inspec
         # Remaining args are possible sources of inputs
         cli_input_files: options[:runner_conf][:input_file], # From CLI --input-file
         profile_metadata: metadata,
-        runner_api: options[:runner_conf][:inputs] # This is the route the audit_cookbook and kitchen-inspec take
+        runner_api: options[:runner_conf][:inputs], # This is the route the audit_cookbook and kitchen-inspec take
+        cli_input_arg: options[:runner_conf][:input] # The --input name=value CLI option
       )
 
       @runner_context =

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -149,6 +149,56 @@ describe "inputs" do
     end
   end
 
+  describe "when using the --input inline raw input flag CLI option" do
+    let(:result) { run_inspec_process("exec #{inputs_profiles_path}/cli #{input_opt} #{control_opt}", json: true) }
+    let(:control_opt) { "" }
+
+    describe "when the --input is used once with one value" do
+      let(:input_opt) { "--input test_input_01=value_from_cli_01" }
+      let(:control_opt) { "--controls test_control_01" }
+      it("correctly reads the input") { result.must_have_all_controls_passing }
+    end
+
+    describe "when the --input is used once with two values" do
+      let(:input_opt) { "--input test_input_01=value_from_cli_01 test_input_02=value_from_cli_02" }
+      it("correctly reads the input") { result.must_have_all_controls_passing }
+    end
+
+    describe "when the --input is used once with two values and a comma" do
+      let(:input_opt) { "--input test_input_01=value_from_cli_01, test_input_02=value_from_cli_02" }
+      it("correctly reads the input") { result.must_have_all_controls_passing }
+    end
+
+    describe "when the --input is used twice with one value each" do
+      let(:input_opt) { "--input test_input_01=value_from_cli_01 --input test_input_02=value_from_cli_02" }
+      let(:control_opt) { "--controls test_control_02" }
+      # Expected, though unfortunate, behavior is to only notice the second input
+      it("correctly reads the input") { result.must_have_all_controls_passing }
+    end
+
+    describe "when the --input is used with no equal sign" do
+      let(:input_opt) { "--input value_from_cli_01" }
+      it "does not run and provides an error message" do
+        output = result.stdout
+        assert_includes "ERROR", output
+        assert_includes "An '=' is required", output
+        assert_includes "input_name_1=input_value_1", output
+        assert_equal 1, result.exit_status
+      end
+    end
+
+    describe "when the --input is used with a .yaml extension" do
+      let(:input_opt) { "--input myfile.yaml" }
+      it "does not run and provides an error message" do
+        output = result.stdout
+        assert_includes "ERROR", output
+        assert_includes "individual input values", output
+        assert_includes "Use --input-file", output
+        assert_equal 1, result.exit_status
+      end
+    end
+  end
+
   describe "when accessing inputs in a variety of scopes using the DSL" do
     it "is able to read the inputs using the input keyword" do
       cmd = "exec #{inputs_profiles_path}/scoping"

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -43,6 +43,13 @@ describe "inputs" do
       line = lines.detect { |l| l.include? "--attrs" }
       line.wont_be_nil
     end
+
+    it "includes the --input option" do
+      result = run_inspec_process("exec help", lock: true) # --no-create-lockfile option breaks usage help
+      lines = result.stdout.lines
+      line = lines.detect { |l| l.include? "--input" }
+      line.wont_be_nil
+    end
   end
 
   describe "when using a cli-specified file" do

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -46,9 +46,7 @@ describe "inputs" do
 
     it "includes the --input option" do
       result = run_inspec_process("exec help", lock: true) # --no-create-lockfile option breaks usage help
-      lines = result.stdout.lines
-      line = lines.detect { |l| l.include? "--input" }
-      line.wont_be_nil
+      assert_match(/--input\s/, result.stdout) # Careful not to match --input-file
     end
   end
 

--- a/test/unit/mock/profiles/inputs/cli/controls/cli.rb
+++ b/test/unit/mock/profiles/inputs/cli/controls/cli.rb
@@ -1,0 +1,10 @@
+control "test_control_01" do
+  describe input("test_input_01", value: "value_from_dsl") do
+    it { should cmp "value_from_cli_01"}
+  end
+end
+control "test_control_02" do
+  describe input("test_input_02", value: "value_from_dsl") do
+    it { should cmp "value_from_cli_02"}
+  end
+end

--- a/test/unit/mock/profiles/inputs/cli/inspec.yml
+++ b/test/unit/mock/profiles/inputs/cli/inspec.yml
@@ -1,0 +1,6 @@
+name: cli
+license: Apache-2.0
+summary: Profile to exercise setting inputs using the --input CLI option
+version: 0.1.0
+supports:
+  platform: os


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Implements a simple CLI option, `--input` , which takes name-value pairs on the CLI and accepts them as inputs. This is much less cumbersome than `--input-file`, which requires you to first write out a YAML file. For quick demos and such, this is a pain reliever and UX delight.

Example:

```
inspec exec my-profile --input some_input=some_value
```

This is not an "input plugin" but it is a "way of reading inputs". It could not be a plugin because we don't expose the CLI option facility in any pluggable fashion.

Things that are not perfect:
 * Repeated --input flags overwrite the previous flag, rather than adding a new input. Currently you can add multiple inputs using just one --input flag, but that is less intuitive.
 * This is now the 4th think in InputRegistry that is reading off the runner config to bind inputs - we're overdue for a refactor there (#4402)


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

This closes #3300 . 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
