### PR TITLE
Add plugin config settings to Config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,6 +1,6 @@
 # The Chef InSpec Configuration File
 
-This documents the Chef InSpec configuration file format introduced in version 3.5 of InSpec.
+This documents the Chef InSpec configuration file format introduced in version 3.5 of InSpec and extended in later versions.
 
 ## Config File Location
 
@@ -83,3 +83,30 @@ Credential sets are intended to work hand-in-hand with the underlying credential
 ### reporter
 
 You may also set output (reporter) options in the config file.  See the [Reporters Page](https://www.inspec.io/docs/reference/reporters/) for details.
+
+## Version 1.2
+
+Version 1.2 adds a top-level field, "plugins".
+
+### plugins
+
+Use the `plugins` top-level configuration field to provide configuration settings to plugins that you use with Chef InSpec. Refer to the documentation of the plugin you are using for details regarding which settings are available.
+
+To use this new feature, add a new top-level key in your config file named  `plugins`. Then create a sub-key named for each plugin you wish to configure. Each plugin will have a key-value are that it may use as it sees fit - Chef Inspec does not specify the structure. Here is an example, using contrived plugins:
+
+```
+{
+  "version":"1.2",
+  "plugins": {
+    "inspec-training-wheels": {
+      "diameter": "4 inches"
+    },
+    "inspec-input-secrets": {
+      "security-tokens: [
+        "123456789".
+        "abcdef252875"
+      ]
+    }
+  }
+}
+```

--- a/docs/config.md
+++ b/docs/config.md
@@ -90,7 +90,7 @@ Version 1.2 adds a top-level field, "plugins".
 
 ### plugins
 
-Use the `plugins` top-level configuration field to provide configuration settings to plugins that you use with Chef InSpec. Refer to the documentation of the plugin you are using for details regarding which settings are available.
+Use the `plugins` top-level configuration field to provide configuration settings to plugins that you use with Chef InSpec. Refer to the documentation of the plugin you are using for details regarding what settings are available.
 
 To use this new feature, add a new top-level key in your config file named  `plugins`. Then create a sub-key named for each plugin you wish to configure. Each plugin will have a key-value are that it may use as it sees fit - Chef Inspec does not specify the structure. Here is an example, using contrived plugins:
 

--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -68,6 +68,12 @@ Putting this all together, here is a plugins.json file from the Chef InSpec test
 }
 ```
 
+### Plugin Runtime Configuration
+
+You can read runtime configuration data from your user using `Inspec::Config.cached.fetch_plugin_config("your-plugin-name")`, which will return a hash with indifferent access representing the user's config file `plugins` section pertaining to your plugin. See [the config file](https://www.inspec.io/docs/reference/config/) for more information.
+
+Do not store or read configuration information from plugins.json.
+
 ## Plugin Parts
 
 ### A Typical Plugin File Layout

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -7,9 +7,12 @@ require "forwardable"
 require "thor"
 require "base64"
 require "inspec/base_cli"
+require "inspec/plugin/v2/filter"
 
 module Inspec
   class Config
+    include Inspec::Plugin::V2::FilterPredicates
+
     # These are options that apply to any transport
     GENERIC_CREDENTIALS = %w{
       backend
@@ -365,7 +368,7 @@ module Inspec
 
       data.each do |plugin_name, plugin_settings|
         # Enforce that every key is a valid inspec or train plugin name
-        unless plugin_name.match(/^(inspec|train)-/) # TODO - replace with FilterPredicate calls once #4387 merges
+        unless valid_plugin_name?(plugin_name)
           raise Inspec::ConfigError::Invalid, "Plugin settings should ne named after the the InSpec or Train plugin. Valid names must begin with inspec- or train-, not '#{plugin_name}' "
         end
 

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -53,6 +53,7 @@ module Inspec
     def initialize(cli_opts = {}, cfg_io = nil, command_name = nil)
       @command_name = command_name || (ARGV.empty? ? nil : ARGV[0].to_sym)
       @defaults = Defaults.for_command(@command_name)
+      @plugin_cfg = {}
 
       @cli_opts = cli_opts.dup
       cfg_io = resolve_cfg_io(@cli_opts, cfg_io)
@@ -60,7 +61,6 @@ module Inspec
 
       @merged_options = merge_options
       @final_options = finalize_options
-      @plugin_cfg = {}
       self.class.cached = self
     end
 
@@ -123,6 +123,13 @@ module Inspec
         creds[option.to_sym] = value
         creds
       end
+    end
+
+    #-----------------------------------------------------------------------#
+    #                      Fetching Plugin Data
+    #-----------------------------------------------------------------------#
+    def fetch_plugin_config(plugin_name)
+      Thor::CoreExt::HashWithIndifferentAccess.new(@plugin_cfg[plugin_name] || {})
     end
 
     private
@@ -367,6 +374,8 @@ module Inspec
           raise Inspec::ConfigError::Invalid, "The plugin settings for '#{plugin_name}' in your config file should be a Hash (key-value list)."
         end
       end
+
+      @plugin_cfg = data
     end
 
     #-----------------------------------------------------------------------#

--- a/lib/inspec/plugin/v2/filter.rb
+++ b/lib/inspec/plugin/v2/filter.rb
@@ -2,6 +2,8 @@ require "singleton"
 require "json"
 require "inspec/globals"
 
+module Inspec::Plugin; end
+
 module Inspec::Plugin::V2
   Exclusion = Struct.new(:plugin_name, :rationale)
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -125,6 +125,33 @@ describe "Inspec::Config" do
         ex.message.must_include "compliance"
       end
     end
+
+    describe "when a 1.2 file has an array for the plugins list" do
+      let(:fixture_name) { "bad_1_2_array" }
+      it "should complain about the array" do
+        ex = proc { cfg }.must_raise(Inspec::ConfigError::Invalid)
+        ex.message.must_include "'plugin' field"
+        ex.message.must_include "must be a hash"
+      end
+    end
+
+    describe "when a 1.2 file has an invalid name for a plugin" do
+      let(:fixture_name) { "bad_1_2_bad_name" }
+      it "should complain about the bad plugin name" do
+        ex = proc { cfg }.must_raise(Inspec::ConfigError::Invalid)
+        ex.message.must_include "names must begin with"
+        ex.message.must_include "inspec- or train-"
+      end
+    end
+
+    describe "when a 1.2 file has a bad value for a setting tree" do
+      let(:fixture_name) { "bad_1_2_bad_value" }
+      it "should complain about the bad plugin value" do
+        ex = proc { cfg }.must_raise(Inspec::ConfigError::Invalid)
+        ex.message.must_include "should be a Hash"
+        ex.message.must_include "inspec-test-bad-settings"
+      end
+    end
   end
 
   # ========================================================================== #
@@ -639,6 +666,35 @@ module ConfigTestHelper
           }
         }
       EOJ7
+    when :bad_1_2_array
+      <<~EOJ8
+        {
+          "version": "1.2",
+          "plugins": [
+            "inspec-test-plugin1",
+            "inspec-test-plugin2"
+          ]
+        }
+      EOJ8
+    when :bad_1_2_bad_name
+      <<~EOJ9
+        {
+          "version": "1.2",
+          "plugins": {
+            "spectacles-banana-peeler": {
+            }
+          }
+        }
+      EOJ9
+    when :bad_1_2_bad_value
+      <<~EOJ10
+        {
+          "version": "1.2",
+          "plugins": {
+            "inspec-test-bad-settings": 42
+          }
+        }
+      EOJ10
     end
   end
   module_function :fixture

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -77,6 +77,14 @@ describe "Inspec::Config" do
       end
     end
 
+    describe "when the file is a valid v1.2 file" do
+      let(:fixture_name) { "basic_1_2" }
+      it "should read the file successfully" do
+        expected = %w{create_lockfile reporter type}.sort # No new top-level key - API only
+        seen_fields.must_equal expected
+      end
+    end
+
     describe "when the file is minimal" do
       let(:fixture_name) { "minimal" }
       it "should read the file successfully" do
@@ -603,6 +611,34 @@ module ConfigTestHelper
           }
         }
       EOJ6
+    when :basic_1_2
+      <<~EOJ7
+        {
+          "version": "1.2",
+          "cli_options": {
+            "create_lockfile": "false"
+          },
+          "reporter": {
+            "automate" : {
+              "url": "http://some.where",
+              "token" : "YOUR_A2_ADMIN_TOKEN"
+            }
+          },
+          "credentials": {
+            "ssh": {
+              "set1": {
+                "host": "some.host",
+                "user": "some_user"
+              }
+            }
+          },
+          "plugins": {
+            "inspec-test-plugin": {
+              "test_key_01":"test_value_01"
+            }
+          }
+        }
+      EOJ7
     end
   end
   module_function :fixture

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -472,9 +472,8 @@ describe "Inspec::Config" do
 
       it "returns an empty hash with indifferent access" do
         settings = cfg.fetch_plugin_config("inspec-test-not-present")
-        refute_nil settings
-        assert settings.empty?
         assert_kind_of Thor::CoreExt::HashWithIndifferentAccess, settings
+        assert_empty settings
       end
     end
 
@@ -486,8 +485,8 @@ describe "Inspec::Config" do
         refute_nil settings
         refute settings.empty?
         assert_kind_of Thor::CoreExt::HashWithIndifferentAccess, settings
-        assert_equal settings[:test_key_01], "test_value_01"
-        assert_equal settings["test_key_01"], "test_value_01"
+        assert_equal "test_value_01", settings[:test_key_01]
+        assert_equal "test_value_01", settings["test_key_01"]
       end
     end
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -3,6 +3,7 @@ require "stringio"
 
 require "inspec/config"
 require "plugins/inspec-compliance/lib/inspec-compliance/api"
+require "thor" # For Thor::CoreExt::HashWithIndifferentAccess
 
 describe "Inspec::Config" do
 
@@ -456,6 +457,40 @@ describe "Inspec::Config" do
         creds[:user].must_equal "bob"
       end
     end
+  end
+
+  # ========================================================================== #
+  #                        Fetching Plugin Config
+  # ========================================================================== #
+  describe "when fetching plugin config" do
+    let(:cfg) { Inspec::Config.new({}, cfg_io) }
+    let(:cfg_io) { StringIO.new(ConfigTestHelper.fixture(fixture_name)) }
+    let(:fixture_name) { "basic_1_2" }
+
+    describe "when fetching a plugin config that is absent" do
+      let(:fixture_name) { "basic_1_2" }
+
+      it "returns an empty hash with indifferent access" do
+        settings = cfg.fetch_plugin_config("inspec-test-not-present")
+        refute_nil settings
+        assert settings.empty?
+        assert_kind_of Thor::CoreExt::HashWithIndifferentAccess, settings
+      end
+    end
+
+    describe "when fetching a plugin config that is present" do
+      let(:fixture_name) { "basic_1_2" }
+
+      it "returns the settings as a hash with indifferent access" do
+        settings = cfg.fetch_plugin_config("inspec-test-plugin")
+        refute_nil settings
+        refute settings.empty?
+        assert_kind_of Thor::CoreExt::HashWithIndifferentAccess, settings
+        assert_equal settings[:test_key_01], "test_value_01"
+        assert_equal settings["test_key_01"], "test_value_01"
+      end
+    end
+
   end
 
   # ========================================================================== #


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This PR is an adoption-in-spirit of #4244 . It increments our config format version to 1.2, adds a `plugins` section to the config file, and adds validation for it along with tests and docs.

This is needed for upcoming work on input plugins, which require configuration prior to being used.

Adding this new version of the config schema revealed a need for refactoring to make the validation properly schema-based - it's not intolerable now, but will be in another version or two. #4405

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #4243 

~~There is one area that uses a regex where a predicate defined on #4387 would be better; if that merges soon this should be updated to use the predicates instead.~~ (done)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
