### PR TITLE
Remove inspec-vault from the plugin exclusion list

### DIFF
--- a/etc/plugin_filters.json
+++ b/etc/plugin_filters.json
@@ -26,10 +26,6 @@
       "rationale": "This gem is currently only a placeholder, waiting to be built."
     },
     {
-      "plugin_name": "inspec-vault",
-      "rationale": "This gem is currently only a placeholder, waiting to be built."
-    },
-    {
       "plugin_name": "train-vault",
       "rationale": "This gem is currently only a placeholder, waiting to be built."
     },


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
This removes `inspec-vault` from the list of excluded plugins, allowing a user to install the rubygem.

As work is now started on inspec-vault, it will soon be installable. We need it to be installable for development, if not for use.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
