### PR TITLE
inspec check: warn if inspec_version is not supported by current inspec

### DIFF
--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -89,7 +89,7 @@ module Inspec
       end
 
       unless supports_runtime?
-        errors.push("The current inspec version #{Inspec::VERSION} cannot satisfy profile inspec_version constraint #{params[:inspec_version]}")
+        warnings.push("The current inspec version #{Inspec::VERSION} cannot satisfy profile inspec_version constraint #{params[:inspec_version]}")
       end
 
       %w{title summary maintainer copyright license}.each do |field|

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -88,6 +88,10 @@ module Inspec
         errors.push("Version needs to be in SemVer format")
       end
 
+      unless supports_runtime?
+        errors.push("The current inspec version #{Inspec::VERSION} cannot satisfy profile inspec_version constraint #{params[:inspec_version]}")
+      end
+
       %w{title summary maintainer copyright license}.each do |field|
         next unless params[field.to_sym].nil?
 

--- a/test/functional/inspec_check_test.rb
+++ b/test/functional/inspec_check_test.rb
@@ -106,4 +106,13 @@ describe "inspec check" do
       assert_exit_code 1, out
     end
   end
+
+  describe "inspec check with unsatisfied runtime version constraint" do
+    it "should enforce runtime version constraint" do
+      out = inspec("check #{profile_path}/unsupported_inspec")
+      out.stdout.must_include "The current inspec version #{Inspec::VERSION}"
+      out.stdout.must_include ">= 99.0.0"
+      assert_exit_code 1, out
+    end
+  end
 end

--- a/test/unit/profiles/metadata_test.rb
+++ b/test/unit/profiles/metadata_test.rb
@@ -242,5 +242,10 @@ EOF
       m = version_meta("> " + next_version)
       m.supports_runtime?.must_equal false
     end
+
+    it "is included in valid?" do
+      m = version_meta("> #{next_version}")
+      refute m.valid?
+    end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Profiles state the range of InSpec engines they support by using the `inspec_version` metadata field in their `inspec.yml`, using full semver comparision operators. While `inspec exec` has enforced this constraint, `inspec check` has ignored the setting.

This change makes `inspec check` issue an "warn" level output event if the profile being examined is not one that the checking `inspec` would not be able to satisfy.

Note: the `inspec check` run completes normally - this change does not cause the check to abort. It simply adds a warn output (a common occurence).

## Related Issue
Closes #3585

<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
