### PR TITLE
waivers: functional test fixture and eval-time skipping

### DIFF
--- a/lib/inspec/formatters/base.rb
+++ b/lib/inspec/formatters/base.rb
@@ -158,6 +158,7 @@ module Inspec::Formatters
         start_time: example.execution_result.started_at.to_datetime.rfc3339.to_s,
         resource_title: example.metadata[:described_class] || example.metadata[:example_group][:description],
         expectation_message: format_expectation_message(example),
+        waiver_data: example.metadata[:waiver_data],
       }
 
       unless (pid = example.metadata[:profile_id]).nil?

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -42,7 +42,7 @@ module Inspec
       @__rule_id = id
       @__profile_id = profile_id
       @__checks = []
-      @__skip_rule = {}
+      @__skip_rule = {} # { result: true, message: "Why" }
       @__merge_count = 0
       @__merge_changes = []
       @__skip_only_if_eval = opts[:skip_only_if_eval]
@@ -206,6 +206,8 @@ module Inspec
       rule.instance_variable_get(:@__merge_changes)
     end
 
+    # If a rule is marked to be skipped, this
+    # creates a dummay array of "checks" with a skip outcome
     def self.prepare_checks(rule)
       skip_check = skip_status(rule)
       return checks(rule) unless skip_check[:result].eql?(true)

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -281,7 +281,7 @@ module Inspec
     # only_if mechanism)
     # Double underscore: not intended to be called as part of the DSL
     def __apply_waivers
-      input_name = "waiver_#{@__rule_id}" # TODO: control ID slugging
+      input_name = @__rule_id # TODO: control ID slugging
       registry = Inspec::InputRegistry.instance
       input = registry.inputs_by_profile[@__profile_id].dig(input_name)
       return unless input

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -312,8 +312,8 @@ module Inspec
           # It appears that yaml.rb automagically parses dates for us
           if expiry < Date.today # If the waiver expired, return - no skip applied
             __waiver_data["message"] = "Waiver expired on #{expiry}, evaluating control normally"
+            return
           end
-          return
         else
           ui = Inspec::UI.new
           ui.error("Unable to parse waiver expiration date '#{expiry}' for control #{@__rule_id}")

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -302,10 +302,10 @@ module Inspec
         if expiry.is_a?(Date)
           # It appears that yaml.rb automagically parses dates for us
           return if expiry < Date.today # If the waiver expired, return - no skip applied
-        elsif expiry.match(/never/i) # any other values?
-          # Do nothing, fall through
         else
-          raise Inspec::Exceptions::ResourceFailed, "Unable to parse waiver expiration date '#{expiry}' for control #{@__rule_id}"
+          ui = Inspec::UI.new
+          ui.error("Unable to parse waiver expiration date '#{expiry}' for control #{@__rule_id}")
+          ui.exit(:usage_error)
         end
       end
 

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -171,6 +171,7 @@ module Inspec
       metadata[:descriptions] = rule.descriptions
       metadata[:code] = rule.instance_variable_get(:@__code)
       metadata[:source_location] = rule.instance_variable_get(:@__source_location)
+      metadata[:waiver_data] = rule.__waiver_data
     end
   end
 end

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -1,0 +1,73 @@
+require "functional/helper"
+
+describe "waivers" do
+  include FunctionalHelper
+  let(:waivers_profiles_path) { "#{profile_path}/waivers" }
+
+  def assert_test_outcome(expected, result_json)
+    assert_equal expected, result_json["status"]
+  end
+
+  def assert_waiver_annotation(result_json)
+    # TODO - test JSON for waiver annotation
+  end
+
+  def refute_waiver_annotation(result_json)
+    # TODO - test JSON for waiver annotation
+    # Don't suppose we get this for free by defining assert_waiver_annotation ...
+  end
+
+  describe "a fully pre-slugged control file" do
+    it "has all of the expected outcomes" do
+      cmd = "exec #{waivers_profiles_path}/basic --input-file #{waivers_profiles_path}/basic/files/waivers.yaml"
+      run_result = run_inspec_process(cmd,json: true)
+      controls_by_id = run_result.payload.json["profiles"][0]["controls"].map {|c| [c["id"], c] }.to_h
+
+      [
+        "01_not_waivered_passes",
+        "03_waivered_no_expiry_not_skipped_passes", # this had a waiver but still passed - no annotation?
+        "06_waivered_expiry_in_past_not_skipped_passes", # a stale waiver
+        "08_waivered_expiry_in_past_skipped", # another stale waiver
+        "09_waivered_expiry_in_future_not_skipped_passes", # unneeded waiver
+      ].each do |control_id|
+        result = controls_by_id[control_id]["results"][0]
+        assert_test_outcome "passed", result
+        refute_waiver_annotation result
+      end
+
+      [
+        "02_not_waivered_fails",
+        "07_waivered_expiry_in_past_not_skipped_fails", # Should this give a special waiver expired message?
+      ].each do |control_id|
+        result = controls_by_id[control_id]["results"][0]
+        assert_test_outcome "failed", result
+        refute_waiver_annotation result
+      end
+
+      # Each of these should have been forced to skip by the waiver system
+      [
+        "05_waivered_no_expiry_skipped",
+        "11_waivered_expiry_in_future_skipped"
+      ].each do |control_id|
+        result = controls_by_id[control_id]["results"][0]
+        assert_test_outcome "skipped", result
+        assert_waiver_annotation result
+      end
+
+      # Each of these should have had a failure, but had a waiver annotation
+      # added to the output.
+      [
+        "04_waivered_no_expiry_not_skipped_fails",
+        "10_waivered_expiry_in_future_not_skipped_fails"
+      ].each do |control_id|
+        result = controls_by_id[control_id]["results"][0]
+        assert_test_outcome "failed", result
+        assert_waiver_annotation result
+      end
+
+    end
+  end
+
+  # describe "an inherited profile"
+  # describe "a profile whose control ids require transformation"
+end

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -79,4 +79,26 @@ describe "waivers" do
       assert_equal 1, result.exit_status
     end
   end
+
+  describe "waivers and only_if" do
+    let(:profile_name) { "only_if" }
+
+    describe "when an only_if is used with no waiver" do
+      let(:waiver_file) { "empty.yaml" }
+      it "skips the control with an only_if message" do
+        msg = controls_by_id.dig("01_only_if", "results", 0, "skip_message")
+        assert_includes msg, "due to only_if"
+        refute_includes msg, "waiver"
+      end
+    end
+
+    describe "when both a skipping waiver and an only_if are present" do
+      let(:waiver_file) { "waiver.yaml" }
+      it "skips the control with a waiver message" do
+        msg = controls_by_id.dig("01_only_if", "results", 0, "skip_message")
+        refute_includes msg, "due to only_if"
+        assert_includes msg, "waiver"
+      end
+    end
+  end
 end

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -2,27 +2,26 @@ require "functional/helper"
 
 describe "waivers" do
   include FunctionalHelper
+  let(:cmd) { "exec #{waivers_profiles_path}/basic --input-file #{waivers_profiles_path}/basic/files/waivers.yaml" }
+  let(:run_result) { run_inspec_process(cmd, json: true) }
   let(:waivers_profiles_path) { "#{profile_path}/waivers" }
+  let(:controls_by_id) { run_result.payload.json.dig("profiles", 0, "controls").map { |c| [c["id"], c] }.to_h }
 
-  def assert_test_outcome(expected, result_json)
-    assert_equal expected, result_json["status"]
+  def assert_test_outcome(expected, control_id)
+    assert_equal expected, controls_by_id.dig(control_id, "results", 0, "status")
   end
 
-  def assert_waiver_annotation(result_json)
+  def assert_waiver_annotation(control_id)
     # TODO - test JSON for waiver annotation
   end
 
-  def refute_waiver_annotation(result_json)
+  def refute_waiver_annotation(control_id)
     # TODO - test JSON for waiver annotation
     # Don't suppose we get this for free by defining assert_waiver_annotation ...
   end
 
   describe "a fully pre-slugged control file" do
     it "has all of the expected outcomes" do
-      cmd = "exec #{waivers_profiles_path}/basic --input-file #{waivers_profiles_path}/basic/files/waivers.yaml"
-      run_result = run_inspec_process(cmd, json: true)
-      controls_by_id = run_result.payload.json["profiles"][0]["controls"].map { |c| [c["id"], c] }.to_h
-
       [
         "01_not_waivered_passes",
         "03_waivered_no_expiry_not_skipped_passes", # this had a waiver but still passed - no annotation?
@@ -30,18 +29,16 @@ describe "waivers" do
         "08_waivered_expiry_in_past_skipped", # another stale waiver
         "09_waivered_expiry_in_future_not_skipped_passes", # unneeded waiver
       ].each do |control_id|
-        result = controls_by_id[control_id]["results"][0]
-        assert_test_outcome "passed", result
-        refute_waiver_annotation result
+        assert_test_outcome "passed", control_id
+        refute_waiver_annotation control_id
       end
 
       [
         "02_not_waivered_fails",
         "07_waivered_expiry_in_past_not_skipped_fails", # Should this give a special waiver expired message?
       ].each do |control_id|
-        result = controls_by_id[control_id]["results"][0]
-        assert_test_outcome "failed", result
-        refute_waiver_annotation result
+        assert_test_outcome "failed", control_id
+        refute_waiver_annotation control_id
       end
 
       # Each of these should have been forced to skip by the waiver system
@@ -49,9 +46,8 @@ describe "waivers" do
         05_waivered_no_expiry_skipped
         11_waivered_expiry_in_future_skipped
       }.each do |control_id|
-        result = controls_by_id[control_id]["results"][0]
-        assert_test_outcome "skipped", result
-        assert_waiver_annotation result
+        assert_test_outcome "skipped", control_id
+        assert_waiver_annotation control_id
       end
 
       # Each of these should have had a failure, but had a waiver annotation
@@ -60,11 +56,9 @@ describe "waivers" do
         04_waivered_no_expiry_not_skipped_fails
         10_waivered_expiry_in_future_not_skipped_fails
       }.each do |control_id|
-        result = controls_by_id[control_id]["results"][0]
-        assert_test_outcome "failed", result
-        assert_waiver_annotation result
+        assert_test_outcome "failed", control_id
+        assert_waiver_annotation control_id
       end
-
     end
   end
 

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -8,7 +8,7 @@ describe "waivers" do
   let(:cmd) { "exec #{waivers_profiles_path}/#{profile_name} --input-file #{waivers_profiles_path}/#{profile_name}/files/#{waiver_file}" }
 
   def assert_test_outcome(expected, control_id)
-    assert_equal expected, controls_by_id.dig(control_id, "results", 0, "status")
+    assert_equal "#{control_id}_#{expected}", "#{control_id}_#{controls_by_id.dig(control_id, "results", 0, "status")}"
   end
 
   def assert_waiver_annotation(control_id)

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -75,7 +75,7 @@ describe "waivers" do
       result = run_result
       assert_includes "ERROR", result.stdout # the error level
       assert_includes "01_small", result.stdout # the offending control ID
-      assert_includes "never", result.stdout  # The bad value
+      assert_includes "never", result.stdout # The bad value
       assert_equal 1, result.exit_status
     end
   end

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -20,8 +20,8 @@ describe "waivers" do
   describe "a fully pre-slugged control file" do
     it "has all of the expected outcomes" do
       cmd = "exec #{waivers_profiles_path}/basic --input-file #{waivers_profiles_path}/basic/files/waivers.yaml"
-      run_result = run_inspec_process(cmd,json: true)
-      controls_by_id = run_result.payload.json["profiles"][0]["controls"].map {|c| [c["id"], c] }.to_h
+      run_result = run_inspec_process(cmd, json: true)
+      controls_by_id = run_result.payload.json["profiles"][0]["controls"].map { |c| [c["id"], c] }.to_h
 
       [
         "01_not_waivered_passes",
@@ -45,10 +45,10 @@ describe "waivers" do
       end
 
       # Each of these should have been forced to skip by the waiver system
-      [
-        "05_waivered_no_expiry_skipped",
-        "11_waivered_expiry_in_future_skipped"
-      ].each do |control_id|
+      %w{
+        05_waivered_no_expiry_skipped
+        11_waivered_expiry_in_future_skipped
+      }.each do |control_id|
         result = controls_by_id[control_id]["results"][0]
         assert_test_outcome "skipped", result
         assert_waiver_annotation result
@@ -56,10 +56,10 @@ describe "waivers" do
 
       # Each of these should have had a failure, but had a waiver annotation
       # added to the output.
-      [
-        "04_waivered_no_expiry_not_skipped_fails",
-        "10_waivered_expiry_in_future_not_skipped_fails"
-      ].each do |control_id|
+      %w{
+        04_waivered_no_expiry_not_skipped_fails
+        10_waivered_expiry_in_future_not_skipped_fails
+      }.each do |control_id|
         result = controls_by_id[control_id]["results"][0]
         assert_test_outcome "failed", result
         assert_waiver_annotation result

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -2,10 +2,10 @@ require "functional/helper"
 
 describe "waivers" do
   include FunctionalHelper
-  let(:cmd) { "exec #{waivers_profiles_path}/basic --input-file #{waivers_profiles_path}/basic/files/waivers.yaml" }
-  let(:run_result) { run_inspec_process(cmd, json: true) }
   let(:waivers_profiles_path) { "#{profile_path}/waivers" }
+  let(:run_result) { run_inspec_process(cmd, json: true) }
   let(:controls_by_id) { run_result.payload.json.dig("profiles", 0, "controls").map { |c| [c["id"], c] }.to_h }
+  let(:cmd) { "exec #{waivers_profiles_path}/#{profile_name} --input-file #{waivers_profiles_path}/#{profile_name}/files/#{waiver_file}" }
 
   def assert_test_outcome(expected, control_id)
     assert_equal expected, controls_by_id.dig(control_id, "results", 0, "status")
@@ -21,6 +21,9 @@ describe "waivers" do
   end
 
   describe "a fully pre-slugged control file" do
+    let(:profile_name) { "basic" }
+    let(:waiver_file) { "waivers.yaml" }
+
     it "has all of the expected outcomes" do
       [
         "01_not_waivered_passes",
@@ -64,4 +67,16 @@ describe "waivers" do
 
   # describe "an inherited profile"
   # describe "a profile whose control ids require transformation"
+
+  describe "a waiver file with invalid dates" do
+    let(:profile_name) { "short" }
+    let(:waiver_file) { "bad-date.yaml" }
+    it "gracefully errors" do
+      result = run_result
+      assert_includes "ERROR", result.stdout # the error level
+      assert_includes "01_small", result.stdout # the offending control ID
+      assert_includes "never", result.stdout  # The bad value
+      assert_equal 1, result.exit_status
+    end
+  end
 end

--- a/test/unit/mock/profiles/waivers/basic/controls/basic.rb
+++ b/test/unit/mock/profiles/waivers/basic/controls/basic.rb
@@ -1,0 +1,43 @@
+control "01_not_waivered_passes" do
+  describe(true) { it { should eq true } }
+end
+
+control "02_not_waivered_fails" do
+  describe(true) { it { should eq false } }
+end
+
+control "03_waivered_no_expiry_not_skipped_passes" do
+  describe(true) { it { should eq true } }
+end
+
+control "04_waivered_no_expiry_not_skipped_fails" do
+  describe(true) { it { should eq false } }
+end
+
+control "05_waivered_no_expiry_skipped" do
+  describe(true) { it { should eq true } }
+end
+
+control "06_waivered_expiry_in_past_not_skipped_passes" do
+  describe(true) { it { should eq true } }
+end
+
+control "07_waivered_expiry_in_past_not_skipped_fails" do
+  describe(true) { it { should eq false } }
+end
+
+control "08_waivered_expiry_in_past_skipped" do
+  describe(true) { it { should eq true } }
+end
+
+control "09_waivered_expiry_in_future_not_skipped_passes" do
+  describe(true) { it { should eq true } }
+end
+
+control "10_waivered_expiry_in_future_not_skipped_fails" do
+  describe(true) { it { should eq false } }
+end
+
+control "11_waivered_expiry_in_future_skipped" do
+  describe(true) { it { should eq true } }
+end

--- a/test/unit/mock/profiles/waivers/basic/files/waivers.yaml
+++ b/test/unit/mock/profiles/waivers/basic/files/waivers.yaml
@@ -28,17 +28,17 @@ waiver_08_waivered_expiry_in_past_skipped:
   justification: Contrariness
   skip: yes
 
-waiver_06_waivered_expiry_in_future_not_skipped_passes:
+waiver_09_waivered_expiry_in_future_not_skipped_passes:
   expiration_date: 2077-06-01
   justification: Handwaving
   skip: no
 
-waiver_07_waivered_expiry_in_future_not_skipped_fails:
+waiver_10_waivered_expiry_in_future_not_skipped_fails:
   expiration_date: 2077-06-01
   justification: Didn't feel like it
   skip: no
 
-waiver_08_waivered_expiry_in_future_skipped:
+waiver_11_waivered_expiry_in_future_skipped:
   expiration_date: 2077-06-01
   justification: Lack of imagination
   skip: yes

--- a/test/unit/mock/profiles/waivers/basic/files/waivers.yaml
+++ b/test/unit/mock/profiles/waivers/basic/files/waivers.yaml
@@ -1,41 +1,41 @@
-waiver_03_waivered_no_expiry_not_skipped_passes:
+03_waivered_no_expiry_not_skipped_passes:
   justification: Sound reasoning
   skip: no
 
-waiver_04_waivered_no_expiry_not_skipped_fails:
+04_waivered_no_expiry_not_skipped_fails:
   justification: Unassailable thinking
   skip: no
 
-waiver_05_waivered_no_expiry_skipped:
+05_waivered_no_expiry_skipped:
   justification: Sheer cleverness
   skip: yes
 
-waiver_06_waivered_expiry_in_past_not_skipped_passes:
+06_waivered_expiry_in_past_not_skipped_passes:
   expiration_date: 1977-06-01
   justification: Necessity
   skip: no
 
-waiver_07_waivered_expiry_in_past_not_skipped_fails:
+07_waivered_expiry_in_past_not_skipped_fails:
   expiration_date: 1977-06-01
   justification: Whimsy
   skip: no
 
-waiver_08_waivered_expiry_in_past_skipped:
+08_waivered_expiry_in_past_skipped:
   expiration_date: 1977-06-01
   justification: Contrariness
   skip: yes
 
-waiver_09_waivered_expiry_in_future_not_skipped_passes:
+09_waivered_expiry_in_future_not_skipped_passes:
   expiration_date: 2077-06-01
   justification: Handwaving
   skip: no
 
-waiver_10_waivered_expiry_in_future_not_skipped_fails:
+10_waivered_expiry_in_future_not_skipped_fails:
   expiration_date: 2077-06-01
   justification: Didn't feel like it
   skip: no
 
-waiver_11_waivered_expiry_in_future_skipped:
+11_waivered_expiry_in_future_skipped:
   expiration_date: 2077-06-01
   justification: Lack of imagination
   skip: yes

--- a/test/unit/mock/profiles/waivers/basic/files/waivers.yaml
+++ b/test/unit/mock/profiles/waivers/basic/files/waivers.yaml
@@ -1,0 +1,44 @@
+waiver_03_waivered_no_expiry_not_skipped_passes:
+  expiration_date: never
+  justification: Sound reasoning
+  skip: no
+
+waiver_04_waivered_no_expiry_not_skipped_fails:
+  expiration_date: never
+  justification: Unassailable thinking
+  skip: no
+
+waiver_05_waivered_no_expiry_skipped:
+  expiration_date: never
+  justification: Sheer cleverness
+  skip: yes
+
+waiver_06_waivered_expiry_in_past_not_skipped_passes:
+  expiration_date: 1977-06-01
+  justification: Necessity
+  skip: no
+
+waiver_07_waivered_expiry_in_past_not_skipped_fails:
+  expiration_date: 1977-06-01
+  justification: Whimsy
+  skip: no
+
+waiver_08_waivered_expiry_in_past_skipped:
+  expiration_date: 1977-06-01
+  justification: Contrariness
+  skip: yes
+
+waiver_06_waivered_expiry_in_future_not_skipped_passes:
+  expiration_date: 2077-06-01
+  justification: Handwaving
+  skip: no
+
+waiver_07_waivered_expiry_in_future_not_skipped_fails:
+  expiration_date: 2077-06-01
+  justification: Didn't feel like it
+  skip: no
+
+waiver_08_waivered_expiry_in_future_skipped:
+  expiration_date: 2077-06-01
+  justification: Lack of imagination
+  skip: yes

--- a/test/unit/mock/profiles/waivers/basic/files/waivers.yaml
+++ b/test/unit/mock/profiles/waivers/basic/files/waivers.yaml
@@ -1,15 +1,12 @@
 waiver_03_waivered_no_expiry_not_skipped_passes:
-  expiration_date: never
   justification: Sound reasoning
   skip: no
 
 waiver_04_waivered_no_expiry_not_skipped_fails:
-  expiration_date: never
   justification: Unassailable thinking
   skip: no
 
 waiver_05_waivered_no_expiry_skipped:
-  expiration_date: never
   justification: Sheer cleverness
   skip: yes
 

--- a/test/unit/mock/profiles/waivers/basic/inspec.yml
+++ b/test/unit/mock/profiles/waivers/basic/inspec.yml
@@ -1,0 +1,6 @@
+name: basic
+license: Apache-2.0
+summary: A profile that demonstrates basic usage of the waiver system
+version: 0.1.0
+supports:
+  platform: os

--- a/test/unit/mock/profiles/waivers/only_if/controls/only_if_controls.rb
+++ b/test/unit/mock/profiles/waivers/only_if/controls/only_if_controls.rb
@@ -1,0 +1,9 @@
+
+# This fixture will cause a "skip due to only if" if waivers are
+# not working correctly (should be waivered)
+control "01_only_if" do
+  only_if("test_message_from_dsl") { false }
+  describe true do
+    it { should eq true }
+  end
+end

--- a/test/unit/mock/profiles/waivers/only_if/files/waiver.yaml
+++ b/test/unit/mock/profiles/waivers/only_if/files/waiver.yaml
@@ -1,0 +1,3 @@
+01_only_if:
+  skip: true
+  justification: test_message_from_waiver

--- a/test/unit/mock/profiles/waivers/only_if/inspec.yml
+++ b/test/unit/mock/profiles/waivers/only_if/inspec.yml
@@ -1,0 +1,5 @@
+name: only_if
+summary: Verifies waiver/only_if precedence
+version: 0.1.0
+supports:
+  platform: os

--- a/test/unit/mock/profiles/waivers/small/controls/small.rb
+++ b/test/unit/mock/profiles/waivers/small/controls/small.rb
@@ -1,0 +1,5 @@
+control "01_small" do
+  describe true do
+    it { should eq true }
+  end
+end

--- a/test/unit/mock/profiles/waivers/small/files/bad-date.yaml
+++ b/test/unit/mock/profiles/waivers/small/files/bad-date.yaml
@@ -1,0 +1,4 @@
+waiver_01_small:
+  expiration_date: never
+  skip: true
+  justification: Callous disregard

--- a/test/unit/mock/profiles/waivers/small/files/bad-date.yaml
+++ b/test/unit/mock/profiles/waivers/small/files/bad-date.yaml
@@ -1,4 +1,4 @@
-waiver_01_small:
+01_small:
   expiration_date: never
   skip: true
   justification: Callous disregard

--- a/test/unit/mock/profiles/waivers/small/inspec.yml
+++ b/test/unit/mock/profiles/waivers/small/inspec.yml
@@ -1,0 +1,5 @@
+name: small
+summary: Test profile for running bad waiver files through InSpec
+version: 0.1.0
+supports:
+  platform: os


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

This is an implementation of #3845/#4414, which uses inputs to act as if `only_if` had been defined for a control. The waiver rules are applied, and the control is conditionally skipped using the only_if facility.

This PR includes a test fixture profile, which has a control and corresponding Input rotating through 11 cases of the various ways waivers may be used.

There is also a passing functional test.  It really does test that the controls are skipped when waivered; however there are several no-op assertions in the functional test file that are just placeholders for  Part 3.

There is an input file included. I made up the field names - they can certainly be adjusted as can the values.

There are placeholders in the functional test file for assertion methods for detecting3845 waiver annotations in the JSON report.

I went with a functional test after staring at the unit tests for the profile and control_eval_context unit tests. That's where the internal unit tests belong, but that is really opaque code. I was able to get a functional test up and running, and start tracing things that way much more easily. Happy to circle back later on that.

## Review Notes

Several things to discuss:

* ~~The waiver rules are currently applied BEFORE evaulating the contents of the control. I believe that means that any real `only_if` block in the profile source will have higher precedence.~~ UPDATE: the waiver rules now apply after the only_if.

* the ability to "slug" the control IDs (replacing spaces, etc) is not implemented here but needs to be implemented somewhere - not sure if here is the right place. @zenspider?

* ~~As implemented, some of the waiver logic (such as expiration date comparision) might need to be re-created in step 3 #4417. We may want to look into how to avoid that.~~ UPDATE: all logic happens here in step 2 now, and it records information in the run_data for step 3 to display, hopefully with only presentation (not business) logic.

## Related Issue

#3845 , #4414 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
