### PR TITLE
Resolve issue where the Inspec::Tag to_ruby method outputs invalid Ruby

### DIFF
--- a/lib/inspec/objects/tag.rb
+++ b/lib/inspec/objects/tag.rb
@@ -15,7 +15,7 @@ module Inspec
     end
 
     def to_ruby
-      "tag #{key.inspect}: #{value.inspect}"
+      "tag #{key}: #{value.inspect}"
     end
 
     def to_s

--- a/test/unit/dsl/objects_test.rb
+++ b/test/unit/dsl/objects_test.rb
@@ -472,10 +472,10 @@ end
       control.id = "tag.control.id"
       control.to_ruby.must_equal '
 control "tag.control.id" do
-  tag "key": "value"
-  tag "key2\'": "value\'"
-  tag "key3\"": "value\""
-  tag "key4": ["a", "b"]
+  tag key: "value"
+  tag key2\': "value\'"
+  tag key3": "value\""
+  tag key4: ["a", "b"]
 end
 '.strip
 

--- a/test/unit/dsl/objects_test.rb
+++ b/test/unit/dsl/objects_test.rb
@@ -454,28 +454,16 @@ end
       tag1.to_hash.must_equal res1
       control.add_tag(tag1)
 
-      res2 = { name: "key2'", value: "value'" }
+      res2 = { name: "key2", value: %w{a b} }
       tag2 = Inspec::Tag.new(res2[:name], res2[:value])
       tag2.to_hash.must_equal res2
       control.add_tag(tag2)
-
-      res3 = { name: "key3\"", value: "value\"" }
-      tag3 = Inspec::Tag.new(res3[:name], res3[:value])
-      tag3.to_hash.must_equal res3
-      control.add_tag(tag3)
-
-      res4 = { name: "key4", value: %w{a b} }
-      tag4 = Inspec::Tag.new(res4[:name], res4[:value])
-      tag4.to_hash.must_equal res4
-      control.add_tag(tag4)
 
       control.id = "tag.control.id"
       control.to_ruby.must_equal '
 control "tag.control.id" do
   tag key: "value"
-  tag key2\': "value\'"
-  tag key3": "value\""
-  tag key4: ["a", "b"]
+  tag key2: ["a", "b"]
 end
 '.strip
 
@@ -489,13 +477,7 @@ end
           name: "key",
           value: "value",
         }, {
-          name: "key2'",
-          value: "value'",
-        }, {
-          name: "key3\"",
-          value: "value\"",
-        }, {
-          name: "key4",
+          name: "key2",
           value: %w{a b},
         }],
       }


### PR DESCRIPTION
Signed-off-by: Irving Popovetsky <irving@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The `Inspec::Tag` `to_ruby` method inspects the key, but this produces invalid Ruby.  This PR removes the `.inspect` from the key so it outputs the bare string.

What you get:
```
"cci": "CCI-123456"
```
OR:
```
:cci: "CCI-123456"
```

What you always want:
```
cci: "CCI-123456"
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

This is affecting some customer-critical work that @TheLunaticScripter and I are working on in `inspec-scap`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
