### PR TITLE
Fixed the formatting of `inspec exec -h` by not using long_desc.

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -208,9 +208,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     pretty_handle_exception(e)
   end
 
-  desc "exec LOCATIONS", "run all test files at the specified LOCATIONS."
-  # TODO: find a way for Thor not to butcher the formatting of this
-  long_desc <<~EOT
+  desc "exec LOCATIONS", <<~EOT
+    Run all test files at the specified LOCATIONS.
+
     Loads the given profile(s) and fetches their dependencies if needed. Then
     connects to the target and executes any controls contained in the profiles.
     One or more reporters are used to generate output.


### PR DESCRIPTION
long_desc does some really bad word wrapping stuff that totally breaks
our formatting of the output (like code blocks). So, don't use it. If
we like this, I will apply it to all of them.

Signed-off-by: Ryan Davis <zenspider@chef.io>