### PR TITLE
Rough draft on waiver input

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -137,6 +137,8 @@ module Inspec
         desc: "Specify one or more inputs directly on the command line, as --input NAME=VALUE"
       option :input_file, type: :array,
         desc: "Load one or more input files, a YAML file with values for the profile to use"
+      option :waiver_file, type: :array,
+        desc: "Load one or more waiver files."
       option :attrs, type: :array,
         desc: "Legacy name for --input-file - deprecated."
       option :create_lockfile, type: :boolean,

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -221,8 +221,8 @@ module Inspec
 
       path = determine_cfg_path(cli_opts)
 
-      cfg_io = File.open(path) if path
-      cfg_io || StringIO.new('{ "version": "1.1" }')
+      ver = KNOWN_VERSIONS.max
+      path ? File.open(path) : StringIO.new({ "version" => ver }.to_json)
     end
 
     def check_for_piped_config(cli_opts)

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -57,6 +57,12 @@ module Inspec
         RunnerRspec.new(@conf)
       end
 
+      if @conf[:waiver_file]
+        waivers = @conf.delete(:waiver_file)
+        @conf[:input_file] ||= []
+        @conf[:input_file].concat waivers
+      end
+
       # About reading inputs:
       #   @conf gets passed around a lot, eventually to
       # Inspec::InputRegistry.register_external_inputs.


### PR DESCRIPTION
long_desc does some really bad word wrapping stuff that totally breaks
our formatting of the output (like code blocks). So, don't use it. If
we like this, I will apply it to all of them.

Signed-off-by: Ryan Davis <zenspider@chef.io>