### PR TITLE
Fix for postfix_conf when using a non-standard config location

### DIFF
--- a/lib/inspec/resources/postfix_conf.rb
+++ b/lib/inspec/resources/postfix_conf.rb
@@ -11,7 +11,7 @@ module Inspec::Resources
     def initialize(*opts)
       @params = {}
       if opts.length == 1
-        @raw_content = load_raw_content(opts)
+        @raw_content = load_raw_content(opts[0])
       else
         @raw_content = load_raw_content("/etc/postfix/main.cf")
       end
@@ -25,7 +25,7 @@ module Inspec::Resources
     private
 
     def resource_base_name
-      "POSTFIX_CONF"
+      "Postfix Config"
     end
   end
 end

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -160,6 +160,7 @@ class MockLoader
       "C:/fakepath/fakefile" => emptyfile.call,
       "/etc/cron.d/crondotd" => mockfile.call("crondotd"),
       "/etc/postfix/main.cf" => mockfile.call("main.cf"),
+      "/etc/postfix/other.cf" => mockfile.call("other.cf"),
     }
 
     # create all mock commands

--- a/test/unit/mock/files/other.cf
+++ b/test/unit/mock/files/other.cf
@@ -1,0 +1,4 @@
+# Test other configuration for Postfix
+
+test_parameter_other = value
+other_test_param_other = $value

--- a/test/unit/resources/postfix_conf_test.rb
+++ b/test/unit/resources/postfix_conf_test.rb
@@ -10,4 +10,11 @@ describe "Inspec::Resources::Postfix_Conf" do
     _(resource.params).must_equal result
     _(resource.value(%w{test_parameter})).must_equal "value"
   end
+
+  it "Test default parsing of other.cf on Centos 7" do
+    resource = MockLoader.new(:centos7).load_resource("postfix_conf", "/etc/postfix/other.cf")
+    result = { "test_parameter_other" => "value", "other_test_param_other" => "$value" }
+    _(resource.params).must_equal result
+    _(resource.value(%w{test_parameter_other})).must_equal "value"
+  end
 end


### PR DESCRIPTION
Pass the first argument of the opts array instead of the whole array which
confuses the SimpleConfig parser. Also added a test which verifies this fixes
the issue.

In addition, change the base_name to something that matches other resource base
names.

Signed-off-by: Lance Albertson <lance@osuosl.org>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
