### PR TITLE
Try to decode archive contents to UTF-8 to avoid encoding corruption.

### DIFF
--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -51,7 +51,7 @@ module Inspec
     def relative_provider
       RelativeFileProvider.new(self)
     end
-  end
+  end # class FileProvider
 
   class MockProvider < FileProvider
     attr_reader :files
@@ -89,7 +89,7 @@ module Inspec
 
       File.binread(file)
     end
-  end
+  end # class DirProvider
 
   class ZipProvider < FileProvider
     attr_reader :files
@@ -146,7 +146,7 @@ module Inspec
       end
       res
     end
-  end
+  end # class ZipProvider
 
   class TarProvider < FileProvider
     attr_reader :files
@@ -221,7 +221,7 @@ module Inspec
 
       res
     end
-  end
+  end # class TarProvider
 
   class RelativeFileProvider
     BLACKLIST_FILES = [
@@ -323,5 +323,5 @@ module Inspec
       b = File.dirname(new_pre + "b")
       get_prefix([a, b])
     end
-  end
+  end # class RelativeFileProvider
 end

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -214,6 +214,11 @@ module Inspec
           break
         end
       end
+
+      try = res.dup
+      try.force_encoding Encoding::UTF_8
+      res = try if try.valid_encoding?
+
       res
     end
   end

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -157,38 +157,45 @@ module Inspec
 
       here = Pathname.new(".")
 
-      walk_tar(@path) do |tar|
-        @files = tar.find_all { |e|
-          name = e.full_name
-          (e.file?                   && # duh
-           !name.empty?              && # for empty filenames?
-           name !~ %r{\.{2}(?:/|\z)} && # .. (to avoid attacks?)
-           !name.include?("PaxHeader/"))
-        }.map { |e| Pathname.new(e.full_name).relative_path_from(here).to_s }
+      walk_tar(@path) do |entries|
+        entries.each do |entry|
+          name = entry.full_name
+
+          # rubocop:disable Layout/MultilineOperationIndentation
+          # rubocop:disable Style/ParenthesesAroundCondition
+          next unless (entry.file? &&              # duh
+                       !name.empty? &&             # for empty filenames?
+                       name !~ %r{\.\.(?:/|\z)} && # .. (to avoid attacks?)
+                       !name.include?("PaxHeader/"))
+
+          path = Pathname.new(name).relative_path_from(here).to_s
+
+          @contents[path] = begin # not ||= in a tarball, last one wins
+                              res = entry.read
+                              try = res.dup
+                              try.force_encoding Encoding::UTF_8
+                              res = try if try.valid_encoding?
+                              res
+                            end
+        end
+
+        @files = @contents.keys
       end
     end
 
     def extract(destination_path = ".")
       FileUtils.mkdir_p(destination_path)
 
-      walk_tar(@path) do |files|
-        files.each do |file|
-          next unless @files.include?(file.full_name)
+      @contents.each do |path, body|
+        full_path = File.join(destination_path, path)
 
-          final_path = File.join(destination_path, file.full_name)
-
-          # This removes the top level directory (and any other files) to ensure
-          # extracted files do not conflict.
-          FileUtils.remove_entry(final_path) if File.exist?(final_path)
-
-          FileUtils.mkdir_p(File.dirname(final_path))
-          File.open(final_path, "wb") { |f| f.write(file.read) }
-        end
+        FileUtils.mkdir_p(File.dirname(full_path))
+        File.open(full_path, "wb") { |f| f.write(body) }
       end
     end
 
     def read(file)
-      @contents[file] ||= read_from_tar(file)
+      @contents[file]
     end
 
     private
@@ -198,27 +205,6 @@ module Inspec
       Gem::Package::TarReader.new(tar_file, &callback)
     ensure
       tar_file.close
-    end
-
-    def read_from_tar(file)
-      return nil unless @files.include?(file)
-
-      res = nil
-      # NB `TarReader` includes `Enumerable` beginning with Ruby 2.x
-      walk_tar(@path) do |tar|
-        tar.each do |entry|
-          next unless entry.file? && [file, "./#{file}"].include?(entry.full_name)
-
-          res = entry.read
-          break
-        end
-      end
-
-      try = res.dup
-      try.force_encoding Encoding::UTF_8
-      res = try if try.valid_encoding?
-
-      res
     end
   end # class TarProvider
 

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -68,7 +68,7 @@ module Inspec
     end
 
     def self.for_target(target, opts = {})
-      opts[:vendor_cache] = opts[:vendor_cache] || Cache.new
+      opts[:vendor_cache] ||= Cache.new
       fetcher = resolve_target(target, opts[:vendor_cache])
       for_fetcher(fetcher, opts)
     end

--- a/test/unit/file_provider_test.rb
+++ b/test/unit/file_provider_test.rb
@@ -187,16 +187,19 @@ describe Inspec::TarProvider do
     end
   end
 
+  Entry = Struct.new(:full_name) do
+    def file?; true; end
+
+    def read; ""; end
+  end
+
   describe "applied to a tar with an empty filename" do
     # Just a placeholder, it will be ignored anyway:
     let(:cls) do
       class MockTarProvider < Inspec::TarProvider
-        Entry = Struct.new(:full_name, :file?)
-
-        private
-
         def walk_tar(path, &callback)
-          yield([Entry.new("", true), Entry.new("tartar", true), Entry.new("", true)])
+          paths = ["", "tartar", ""]
+          yield paths.map { |s| Entry.new s }
         end
       end
       MockTarProvider
@@ -210,12 +213,9 @@ describe Inspec::TarProvider do
   describe "applied to a tar with paths above dir" do
     let(:cls) do
       class MockZipSlipTarProvider < Inspec::TarProvider
-        Entry = Struct.new(:full_name, :file?)
-
-        private
-
         def walk_tar(path, &callback)
-          yield([Entry.new("../haha", true), Entry.new("tartar", true), Entry.new("../../blah", true)])
+          paths = ["", "tartar", ""]
+          yield paths.map { |s| Entry.new s }
         end
       end
       MockZipSlipTarProvider


### PR DESCRIPTION
Fixes #4135.

Signed-off-by: Ryan Davis <zenspider@chef.io>