### PR TITLE
User windows fix

### DIFF
--- a/docs/resources/user.md.erb
+++ b/docs/resources/user.md.erb
@@ -34,13 +34,16 @@ A `user` resource block declares a user name, and then one (or more) matchers:
       its('mindays') { should eq 0 }
       its('maxdays') { should eq 90 }
       its('warndays') { should eq 8 }
+      its('passwordage') { should eq 355 }
+      its('maxbadpasswords') { should eq nil } // Only valid on Windows OS
+      its('badpasswordattempts') { should eq 0 }
     end
 
 where
 
 * `('root')` is the user to be tested
 * `it { should exist }` tests if the user exists
-* `gid`, `group`, `groups`, `home`, `maxdays`, `mindays`, `shell`, `uid`, and `warndays` are valid matchers for this resource
+* `gid`, `group`, `groups`, `home`, `maxdays`, `mindays`, `shell`, `uid`, `warndays`´, `passwordage`, `maxbadpasswords` and `badpasswordattempts` are valid matchers for this resource
 
 <br>
 
@@ -90,6 +93,7 @@ The `gid` matcher tests the group identifier:
     its('gid') { should eq 1234 }
 
 where `1234` represents the user identifier.
+The `gid` option is only available on Linux and will return `nil` for Windows os.
 
 ### group
 
@@ -98,6 +102,7 @@ The `group` matcher tests the group to which the user belongs:
     its('group') { should eq 'root' }
 
 where `root` represents the group.
+The `group` option is only available on Linux and will return `nil` for Windows os.
 
 ### groups
 
@@ -148,3 +153,29 @@ The `warndays` matcher tests the number of days a user is warned before a passwo
     its('warndays') { should eq 5 }
 
 where `5` represents the number of days a user is warned.
+
+### passwordage
+
+The `passwordage` matcher tests the number of days a user changed its password:
+
+    its('passwordage') { should_be <= 365 }
+
+where `365` represents the number of days since the last password change.
+
+### maxbadpasswords
+
+The `maxbadpasswords` matcher tests the count of max badpassword settings for a specific user.
+
+    its('maxbadpasswords') { should eq 7 }
+    
+where `7` is the count of maximum bad password attempts.
+
+### badpasswordattempts
+
+The `badpasswordattempts` matcher tests the count of bad password attempts for a user.
+
+    its('badpasswordattempts') { should eq 0 }
+   
+where `0` is the count of bad passwords for a user. 
+On Linux based operating systems it relies on `lastb` and for Windows it uses information stored for the user object.
+These settings will be resetted to `0` depending on your operating system configuration.

--- a/docs/resources/users.md.erb
+++ b/docs/resources/users.md.erb
@@ -31,7 +31,7 @@ A `users` resource block declares a user name, and then one (or more) matchers:
 
 where
 
-* `gid`, `group`, `groups`, `home`, `maxdays`, `mindays`, `shell`, `uid`, and `warndays` are valid matchers for this resource
+* `gid`, `group`, `groups`, `home`, `maxdays`, `mindays`, `shell`, `uid`, `warndays`, `passwordage`, `maxbadpasswords` and `badpasswordattempts` are valid matchers for this resource
 * `where(uid: 0).entries` represents a filter that runs the test only against matching users
 
 For example:
@@ -149,3 +149,29 @@ The `warndays` matcher tests the number of days a user is warned before a passwo
     its('warndays') { should eq 5 }
 
 where `5` represents the number of days a user is warned.
+
+### passwordage
+
+The `passwordage` matcher tests the number of days a user changed its password:
+
+    its('passwordage') { should_be <= 365 }
+
+where `365` represents the number of days since the last password change.
+
+### maxbadpasswords
+
+The `maxbadpasswords` matcher tests the count of max badpassword settings for a specific user.
+
+    its('maxbadpasswords') { should eq 7 }
+    
+where `7` is the count of maximum bad password attempts.
+
+### badpasswordattempts
+
+The `badpasswordattempts` matcher tests the count of bad password attempts for a user.
+
+    its('badpasswordattempts') { should eq 0 }
+   
+where `0` is the count of bad passwords for a user. 
+On Linux based operating systems it relies on `lastb` and for Windows it uses information stored for the user object.
+These settings will be resetted to `0` depending on your operating system configuration.

--- a/lib/inspec/resources/users.rb
+++ b/lib/inspec/resources/users.rb
@@ -118,7 +118,7 @@ module Inspec::Resources
   #   its('warndays') { should eq 5 }
   #   its('passwordage') { should be >= 0 }
   #   its('maxbadpasswords') { should eq nil } // not yet supported on linux
-  #   its('badpasswordattempts') { should eq 0 } 
+  #   its('badpasswordattempts') { should eq 0 }
   # end
   # describe user('Administrator') do
   #   it { should exist }
@@ -132,8 +132,8 @@ module Inspec::Resources
   #   its('maxdays') { should eq 42 }
   #   its('warndays') { should eq nil }
   #   its('passwordage') { should eq 355 }
-  #   its('maxbadpasswords') { should eq 0 } 
-  #   its('badpasswordattempts') { should eq 0 } 
+  #   its('maxbadpasswords') { should eq 0 }
+  #   its('badpasswordattempts') { should eq 0 }
   # end
   #
   # The following  Serverspec  matchers are deprecated in favor for direct value access

--- a/lib/inspec/resources/users.rb
+++ b/lib/inspec/resources/users.rb
@@ -466,7 +466,7 @@ module Inspec::Resources
       cmd = inspec.command("echo $((($(date +%s) - $(date -d '#{params["Last password change"]}' '+%s'))/86400))")
       dayslastset = convert_to_i(cmd.stdout.chomp) if cmd.exit_status == 0
 
-      cmd = inspec.command("lastb -w -a | awk '{print $1}' | grep #{username} | wc -l")
+      cmd = inspec.command("lastb -w -a | grep #{username} | wc -l")
       badpasswordattempts = convert_to_i(cmd.stdout.chomp) if cmd.exit_status == 0
 
       {

--- a/lib/inspec/resources/users.rb
+++ b/lib/inspec/resources/users.rb
@@ -464,18 +464,10 @@ module Inspec::Resources
       ).params
 
       cmd = inspec.command("echo $((($(date +%s) - $(date -d '#{params["Last password change"]}' '+%s'))/86400))")
-      if cmd.exit_status != 0
-        dayslastset = nil
-      else
-        dayslastset = convert_to_i(cmd.stdout.chomp)
-      end
+      dayslastset = convert_to_i(cmd.stdout.chomp) if cmd.exit_status == 0
 
       cmd = inspec.command("lastb -w -a | awk '{print $1}' | grep #{username} | wc -l")
-      if cmd.exit_status != 0
-        badpasswordattempts = nil
-      else
-        badpasswordattempts = convert_to_i(cmd.stdout.chomp)
-      end
+      badpasswordattempts = convert_to_i(cmd.stdout.chomp) if cmd.exit_status == 0
 
       {
         mindays: convert_to_i(params["Minimum number of days between password change"]),

--- a/lib/inspec/resources/users.rb
+++ b/lib/inspec/resources/users.rb
@@ -573,6 +573,31 @@ module Inspec::Resources
       res[0] unless res.empty?
     end
 
+    def meta_info(username)
+      res = identity(username)
+      return if res.nil?
+      {
+        home: res[:home],
+        shell: res[:shell],
+        domain: res[:domain],
+        userflags: res[:userflags],
+      }
+    end
+
+    def credentials(username)
+      res = identity(username)
+      return if res.nil?
+      {
+        mindays: res[:mindays],
+        maxdays: res[:maxdays],
+        warndays: res[:warndays],
+        badpasswordattempts: res[:badpasswordattempts],
+        maxbadpasswords: res[:maxbadpasswords],
+        minpasswordlength: res[:minpasswordlength],
+        passwordage: res[:passwordage],
+      }
+    end
+
     def list_users
       collect_user_details.map { |user| user[:username] }
     end

--- a/lib/inspec/resources/users.rb
+++ b/lib/inspec/resources/users.rb
@@ -463,7 +463,7 @@ module Inspec::Resources
         group_re: nil,
         multiple_values: false
       ).params
-      
+
       dparse = Date.parse "#{params['Last password change']}"
       dayslastset = (Date.today - dparse).to_i
       cmd = inspec.command("lastb -w -a | grep #{username} | wc -l")

--- a/lib/inspec/resources/users.rb
+++ b/lib/inspec/resources/users.rb
@@ -3,6 +3,7 @@ require "inspec/utils/convert"
 require "inspec/utils/filter"
 require "inspec/utils/simpleconfig"
 require "inspec/resources/powershell"
+require "date"
 
 module Inspec::Resources
   # This file contains two resources, the `user` and `users` resource.
@@ -462,10 +463,9 @@ module Inspec::Resources
         group_re: nil,
         multiple_values: false
       ).params
-
-      cmd = inspec.command("echo $((($(date +%s) - $(date -d '#{params["Last password change"]}' '+%s'))/86400))")
-      dayslastset = convert_to_i(cmd.stdout.chomp) if cmd.exit_status == 0
-
+      
+      dparse = Date.parse "#{params['Last password change']}"
+      dayslastset = (Date.today - dparse).to_i
       cmd = inspec.command("lastb -w -a | grep #{username} | wc -l")
       badpasswordattempts = convert_to_i(cmd.stdout.chomp) if cmd.exit_status == 0
 

--- a/test/integration/default/controls/user_spec.rb
+++ b/test/integration/default/controls/user_spec.rb
@@ -91,6 +91,12 @@ if os.windows?
     # should return the SID of the user
     its('uid') { should_not eq nil}
     its('groups') { should include userinfo[:groups] }
+    its('mindays') { should eq 0 }
+    its('maxdays') { should eq 42 }
+    its('warndays') { should eq nil }
+    its('passwordage') { should_be > 5 }
+    its('maxbadpasswords') { should eq 0 }
+    its('badpasswordattempts') { should eq 0 }
   end
 
   # also support simple username for local users without domain
@@ -99,7 +105,13 @@ if os.windows?
     # should return the SID of the user
     its('uid') { should_not eq nil}
     its('groups') { should include userinfo[:groups] }
-  end
+    its('mindays') { should eq 0 }
+    its('maxdays') { should eq 42 }
+    its('warndays') { should eq nil }
+    its('passwordage') { should_be > 5 }
+    its('maxbadpasswords') { should eq 0 }
+    its('badpasswordattempts') { should eq 0 }
+    end
 else
   # test single `user` resource
   describe user(userinfo[:username]) do

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -16,6 +16,7 @@ describe "Inspec::Resources::User" do
     _(resource.mindays).must_equal 0
     _(resource.maxdays).must_equal 99999
     _(resource.warndays).must_equal 7
+    _(resource.badpasswordattempts).must_equal 0
   end
 
   # ubuntu 14.04 test with ldap user
@@ -126,6 +127,7 @@ describe "Inspec::Resources::User" do
     _(resource.maxdays).must_be_nil
     _(resource.warndays).must_be_nil
     _(resource.disabled?).must_equal false
+    _(resource.badpasswordattempts).must_equal 0
   end
 
   it "read guest user on Windows" do

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -120,7 +120,7 @@ describe "Inspec::Resources::User" do
     _(resource.exists?).must_equal true
     _(resource.group).must_be_nil
     _(resource.groups).must_equal %w{Administrators Users}
-    _(resource.home).must_be_nil
+    _(resource.home).wont_be_nil
     _(resource.shell).must_be_nil
     _(resource.mindays).wont_be_nil
     _(resource.maxdays).wont_be_nil
@@ -138,7 +138,7 @@ describe "Inspec::Resources::User" do
     _(resource.shell).must_be_nil
     _(resource.mindays).wont_be_nil
     _(resource.maxdays).wont_be_nil
-    _(resource.warndays).wont_be_nil
+    _(resource.warndays).must_be_nil
     _(resource.disabled?).must_equal true
   end
 

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -16,7 +16,6 @@ describe "Inspec::Resources::User" do
     _(resource.mindays).must_equal 0
     _(resource.maxdays).must_equal 99999
     _(resource.warndays).must_equal 7
-    _(resource.badpasswordattempts).must_equal 0
   end
 
   # ubuntu 14.04 test with ldap user
@@ -127,7 +126,6 @@ describe "Inspec::Resources::User" do
     _(resource.maxdays).must_be_nil
     _(resource.warndays).must_be_nil
     _(resource.disabled?).must_equal false
-    _(resource.badpasswordattempts).must_equal 0
   end
 
   it "read guest user on Windows" do

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -122,9 +122,9 @@ describe "Inspec::Resources::User" do
     _(resource.groups).must_equal %w{Administrators Users}
     _(resource.home).must_be_nil
     _(resource.shell).must_be_nil
-    _(resource.mindays).must_be_nil
-    _(resource.maxdays).must_be_nil
-    _(resource.warndays).must_be_nil
+    _(resource.mindays).wont_be_nil
+    _(resource.maxdays).wont_be_nil
+    _(resource.warndays).wont_be_nil
     _(resource.disabled?).must_equal false
   end
 
@@ -134,11 +134,11 @@ describe "Inspec::Resources::User" do
     _(resource.exists?).must_equal true
     _(resource.group).must_be_nil
     _(resource.groups).must_equal ["Users"]
-    _(resource.home).must_be_nil
+    _(resource.home).wont_be_nil
     _(resource.shell).must_be_nil
-    _(resource.mindays).must_be_nil
-    _(resource.maxdays).must_be_nil
-    _(resource.warndays).must_be_nil
+    _(resource.mindays).wont_be_nil
+    _(resource.maxdays).wont_be_nil
+    _(resource.warndays).wont_be_nil
     _(resource.disabled?).must_equal true
   end
 

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -124,7 +124,7 @@ describe "Inspec::Resources::User" do
     _(resource.shell).must_be_nil
     _(resource.mindays).wont_be_nil
     _(resource.maxdays).wont_be_nil
-    _(resource.warndays).wont_be_nil
+    _(resource.warndays).must_be_nil
     _(resource.disabled?).must_equal false
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

Provide expected attributes in user resource. Missing usage of cache for windows accounts
reflect windows attributes to be also available for linux.

## Description
It solves: #4432 and parts of #4174 
Expected behaviour on linux and windows should be equal.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
Fixes #4432
#4174 
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
