### PR TITLE
Fix Markdown markup for the aws_security_group resource

### DIFF
--- a/docs/resources/aws_security_group.md.erb
+++ b/docs/resources/aws_security_group.md.erb
@@ -28,7 +28,7 @@ This resource first became available in v2.0.16 of InSpec.
 
 ## Syntax
 
-Resource parameters: group_id, group_name, id, vpc_id
+Resource parameters: `group_id`, `group_name`, `id`, `vpc_id`
 
 An `aws_security_group` resource block uses resource parameters to search for and then test a Security Group. If no SGs match, no error is raised, but the `exists` matcher returns `false`, and all scalar properties are `nil`. List properties returned under these conditions are empty lists. If more than one SG matches (due to vague search parameters), an error is raised.
 
@@ -205,7 +205,7 @@ A String reflecting the name that was given to the SG at creation time.
 
 A list of the rules that the Security Group applies to incoming network traffic. This is a low-level property that is used by the [`allow_in`](#allow_in) and [`allow_in_only`](#allow_in_only) matchers; see them for detailed examples. `inbound_rules` is provided here for those wishing to use Ruby code to inspect the rules directly, instead of using higher-level matchers.
 
-Order is critical in these rules, as the sequentially first rule to match is applied to network traffic. By default, AWS includes a reject-all rule as the last inbound rule.  This implicit rule does not appear in the inbound_rules list.
+Order is critical in these rules, as the sequentially first rule to match is applied to network traffic. By default, AWS includes a reject-all rule as the last inbound rule.  This implicit rule does not appear in the `inbound_rules` list.
 
 If the Security Group could not be found (that is, `exists` is false), `inbound_rules` returns an empty list.
 
@@ -215,7 +215,7 @@ If the Security Group could not be found (that is, `exists` is false), `inbound_
 
 ### inbound\_rules\_count
 
-A Number totalling the number of individual rules defined - It is a sum of the combinations of port, protocol, ipv4 rules, ipv6 rules and security group rules.
+A Number totalling the number of individual rules defined - It is a sum of the combinations of port, protocol, IPv4 rules, IPv6 rules and security group rules.
 
     describe aws_security_group(group_name: linux_servers) do
       its('inbound_rules_count'){ should eq 10 }
@@ -235,7 +235,7 @@ If the Security Group could not be found (that is, `exists` is false), `outbound
 
 ### outbound\_rules\_count
 
-A Number totalling the number of individual rules defined - It is a sum of the combinations of port, protocol, ipv4 rules, ipv6 rules and security group rules.
+A Number totalling the number of individual rules defined - It is a sum of the combinations of port, protocol, IPv4 rules, IPv6 rules and security group rules.
 
     describe aws_security_group(group_name: linux_servers) do
       its('outbound_rules_count'){ should eq 2 }
@@ -274,60 +274,60 @@ The `allow` series of matchers enable you to perform queries about what network 
 
 `allow_in_only` and `allow_out_only` examines if exactly one rule exists (but see `position`, below), and if it matches the criteria (this is useful for ensuring no unexpected rules have been added). Additionally, `allow_in_only` and `allow_out_only` do _not_ perform inexact matching; you must specify exactly the port range or IP address(es) you wish to match.
 
-The matchers accept a key-value list of search criteria.  For a rule to match, it must match all provided criteria.
+The matchers accept a key-value list of search criteria.  For a rule to match, it must match all provided criteria:
 
-  * from_port - Determines if a rule exists whose port range begins at the specified number. The word 'from_' does *not* relate to inbound/outbound directionality; it relates to the port range ("counting _from_"). `from_port` is an exact criterion; so if the rule allows 1000-2000 and you specify a `from_port` of 1001, it does not match.
-  * ipv4_range - Specifies an IPv4 address or subnet as a CIDR, or a list of them, to be checked as a permissible origin (for `allow_in`) or destination (for `allow_out`) for traffic.  Each AWS Security Group rule may have multiple allowed source IP ranges.
-  * ipv6_range - Specifies an IPv6 address or subnet as a CIDR, or a list of them, to be checked as a permissible origin (for `allow_in`) or destination (for `allow_out`) for traffic.  Each AWS Security Group rule may have multiple allowed source IP ranges.
-  * port - Determines if a particular TCP/IP port is reachable. allow_in and allow_out examine whether the specified port is included in the port range of a rule, while allow_in. You may specify the port as a string (`'22'`) or as a number.
-  * position - A one-based index into the list of rules. If provided, this restricts the evaluation to the rule at that position. You may also use the special values `:first` and `:last`. `position` may also be used to enable `allow_in_only` and `allow_out_only` to work with multi-rule Security Groups.
-  * protocol - Specifies the IP protocol. 'tcp', 'udp', and 'icmp' are some typical values. The string "-1" or 'any' is used to indicate any protocol.
-  * to_port - Determines if a rule exists whose port range ends at the specified number. The word 'to_' does *not* relate to inbound/outbound directionality; it relates to the port range ("counting _to_"). `to_port` is an exact criterion; so if the rule allows 1000-2000 and you specify a `to_port` of 1999, it does not match.
-  * security_group - Specifies a security-group id, to be checked as permissible origin (for `allow_in`) or destination (for `allow_out`) for traffic. Each AWS Security Group rule may have multiple allowed source or destination security groups.
+  * `from_port` - Determines if a rule exists whose port range begins at the specified number. The word `from_` does *not* relate to inbound/outbound directionality; it relates to the port range ("counting \_from\_"). `from_port` is an exact criterion; so if the rule allows 1000-2000 and you specify a `from_port` of 1001, it does not match.
+  * `ipv4_range` - Specifies an IPv4 address or subnet as a CIDR, or a list of them, to be checked as a permissible origin (for `allow_in`) or destination (for `allow_out`) for traffic.  Each AWS Security Group rule may have multiple allowed source IP ranges.
+  * `ipv6_range` - Specifies an IPv6 address or subnet as a CIDR, or a list of them, to be checked as a permissible origin (for `allow_in`) or destination (for `allow_out`) for traffic.  Each AWS Security Group rule may have multiple allowed source IP ranges.
+  * `port` - Determines if a particular TCP/IP port is reachable. `allow_in` and `allow_out` examine whether the specified port is included in the port range of a rule, while `allow_in`. You may specify the port as a string (`'22'`) or as a number.
+  * `position` - A one-based index into the list of rules. If provided, this restricts the evaluation to the rule at that position. You may also use the special values `:first` and `:last`. `position` may also be used to enable `allow_in_only` and `allow_out_only` to work with multi-rule Security Groups.
+  * `protocol` - Specifies the IP protocol. `tcp`, `udp`, and `icmp` are some typical values. The string `"-1"` or `any` is used to indicate any protocol.
+  * `to_port` - Determines if a rule exists whose port range ends at the specified number. The word `to_` does *not* relate to inbound/outbound directionality; it relates to the port range ("counting \_to\_"). `to_port` is an exact criterion; so if the rule allows 1000-2000 and you specify a `to_port` of 1999, it does not match.
+  * `security_group` - Specifies a security-group id, to be checked as permissible origin (for `allow_in`) or destination (for `allow_out`) for traffic. Each AWS Security Group rule may have multiple allowed source or destination security groups.
 
-    describe aws_security_group(group_name: 'mixed-functionality-group') do
-      # Allow RDP from defined range
-      it { should allow_in(port: 3389, ipv4_range: '10.5.0.0/16') }
-      it { should allow_in(port: 3389, ipv6_range: '2001:db8::/122') }
+        describe aws_security_group(group_name: 'mixed-functionality-group') do
+          # Allow RDP from defined range
+          it { should allow_in(port: 3389, ipv4_range: '10.5.0.0/16') }
+          it { should allow_in(port: 3389, ipv6_range: '2001:db8::/122') }
 
-      # Allow SSH from two ranges
-      it { should allow_in(port: 22, ipv4_range: ['10.5.0.0/16', '10.2.3.0/24']) }
+          # Allow SSH from two ranges
+          it { should allow_in(port: 22, ipv4_range: ['10.5.0.0/16', '10.2.3.0/24']) }
 
-      # Check Bacula port range
-      it { should allow_in(from_port: 9101, to_port: 9103, ipv4_range: '10.6.7.0/24') }
+          # Check Bacula port range
+          it { should allow_in(from_port: 9101, to_port: 9103, ipv4_range: '10.6.7.0/24') }
 
-      # Assuming the AWS SG allows 9001-9003, use inexact matching to check 9002
-      it { should allow_in(port: 9002) }
+          # Assuming the AWS SG allows 9001-9003, use inexact matching to check 9002
+          it { should allow_in(port: 9002) }
 
-      # Assuming the AWS SG allows 10.2.1.0/24, use inexact matching to check 10.2.1.33/32
-      it { should allow_in(ipv4_range: '10.2.1.33/32') }
+          # Assuming the AWS SG allows 10.2.1.0/24, use inexact matching to check 10.2.1.33/32
+          it { should allow_in(ipv4_range: '10.2.1.33/32') }
 
-      # Ensure the 3rd outbound rule is TCP-based
-      it { should allow_in(protocol: 'tcp', position: 3') }
+          # Ensure the 3rd outbound rule is TCP-based
+          it { should allow_in(protocol: 'tcp', position: 3) }
 
-      # Do not allow unrestricted IPv4 access.
-      it { should_not allow_in(ipv4_range: '0.0.0.0/0') }
+          # Do not allow unrestricted IPv4 access.
+          it { should_not allow_in(ipv4_range: '0.0.0.0/0') }
 
-      # Allow unrestricted access from security-group.
-      it { should allow_in(security_group: 'sg-11112222') }
-    end
+          # Allow unrestricted access from security-group.
+          it { should allow_in(security_group: 'sg-11112222') }
+        end
 
-    # Suppose you have a Group that should allow SSH and RDP from
-    # the admin network, 10.5.0.0/16. The resource has 2 rules to
-    # allow this, and you want to ensure no others have been added.
-    describe aws_security_group(group_name: 'admin-group') do
-      # Allow RDP from a defined range and nothing else
-      # The SG must have this rule in position 1 and it must match this exactly
-      it { should allow_in_only(port: 3389, ipv4_range: '10.5.0.0/16', position: 1) }
+        # Suppose you have a Group that should allow SSH and RDP from
+        # the admin network, 10.5.0.0/16. The resource has 2 rules to
+        # allow this, and you want to ensure no others have been added.
+        describe aws_security_group(group_name: 'admin-group') do
+          # Allow RDP from a defined range and nothing else
+          # The SG must have this rule in position 1 and it must match this exactly
+          it { should allow_in_only(port: 3389, ipv4_range: '10.5.0.0/16', position: 1) }
 
-      # Specify position 2 for the SSH rule.  Without `position`,
-      # allow_in_only only allows one rule, total.
-      it { should allow_in_only(port: 22, ipv4_range: '10.5.0.0/16', position: 2) }
+          # Specify position 2 for the SSH rule.  Without `position`,
+          # allow_in_only only allows one rule, total.
+          it { should allow_in_only(port: 22, ipv4_range: '10.5.0.0/16', position: 2) }
 
-      # Because this is an _only matcher, this fails - _only matchers
-      # use exact IP matching.
-      it { should allow_in_only(port: 3389, ipv4_range: '10.5.1.34/32', position: 1) }
-    end
+          # Because this is an _only matcher, this fails - _only matchers
+          # use exact IP matching.
+          it { should allow_in_only(port: 3389, ipv4_range: '10.5.1.34/32', position: 1) }
+        end
 
 ### exists
 


### PR DESCRIPTION
## Description
The formatting of the [aws_security_group](https://www.inspec.io/docs/reference/resources/aws_security_group/) resource has several bugs. The "Matchers" section is particularly affected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
