### PR TITLE
   Fix broken unit test by adding require

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -6,6 +6,7 @@ require "inspec/describe"
 require "inspec/expect"
 require "inspec/resource"
 require "inspec/resources/os"
+require "inspec/input_registry"
 
 module Inspec
   class Rule


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Repairs a sporadic broken unit test caused by a missing `require` statement, which was exacerbated by a swallowed exception.

In detail: because InputRegistry (which relies on Singleton) was not being required, when we called `Inspec::InputRegistry.instance` that would be an undefined class method. Due to random load order of tests and process sharing, the problem only struck occasionally; when it did, it may exhibit as a "Control source code error" because it was located in a catch-anything exception handling block.

Anyway, now we require it explicitly.

## Related Issue

Fixes #4468 
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
