### PR TITLE
Add to_s definitions to several resources

### DIFF
--- a/lib/inspec/resources/aide_conf.rb
+++ b/lib/inspec/resources/aide_conf.rb
@@ -48,6 +48,10 @@ module Inspec::Resources
 
     filter.install_filter_methods_on_resource(self, :params)
 
+    def to_s
+      "AIDE Config"
+    end
+
     private
 
     def read_content

--- a/lib/inspec/resources/etc_fstab.rb
+++ b/lib/inspec/resources/etc_fstab.rb
@@ -57,6 +57,10 @@ module Inspec::Resources
       where { mount_point == "/home" }.entries[0].mount_options
     end
 
+    def to_s
+      "File System Table File (fstab)"
+    end
+
     private
 
     def read_content

--- a/lib/inspec/resources/etc_hosts.rb
+++ b/lib/inspec/resources/etc_hosts.rb
@@ -37,6 +37,10 @@ module Inspec::Resources
       .register_column(:all_host_names, field: "all_host_names")
       .install_filter_methods_on_resource(self, :params)
 
+    def to_s
+      "Hosts File"
+    end
+
     private
 
     def default_hosts_file_path

--- a/lib/inspec/resources/firewalld.rb
+++ b/lib/inspec/resources/firewalld.rb
@@ -88,6 +88,10 @@ module Inspec::Resources
       firewalld_command("--zone=#{query_zone} --query-rich-rule='#{rule}'") == "yes"
     end
 
+    def to_s
+      "Firewall Rules"
+    end
+
     private
 
     def active_zones

--- a/lib/inspec/resources/postfix_conf.rb
+++ b/lib/inspec/resources/postfix_conf.rb
@@ -22,6 +22,10 @@ module Inspec::Resources
       SimpleConfig.new(content).params
     end
 
+    def to_s
+      "Postfix Mail Transfer Agent"
+    end
+
     private
 
     def resource_base_name

--- a/lib/inspec/resources/security_identifier.rb
+++ b/lib/inspec/resources/security_identifier.rb
@@ -47,6 +47,10 @@ module Inspec::Resources
       @sids.key?(@name)
     end
 
+    def to_s
+      "Security Identifier"
+    end
+
     private
 
     def fetch_sids

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -54,5 +54,9 @@ module Inspec::Resources
         skip_resource "The `sys_info.model` resource is not supported on your OS yet."
       end
     end
+
+    def to_s
+      "System Information"
+    end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Adds the method `to_s` with a simple fixed descriptive string to several resources that were missing the method. Without the method, RSpec attempts to generate a name for the example group, assembling the proposed name out of several elements including method names, which are Symbols. This results in a Conversion Error - see #4474 for repro.  However, if the Resource (which becomes an Example Group) implements `to_s`, that is called directly, and all goes well.

Note that I felt it was rather urgent to get this fix in, and keep it light; we might normally put in some features into the to_s method (like the path used, for etc_hosts - but that is not even stored as an ivar, and we'd need to set up some testing on that, etc).  I'm keeping it minimal here so we can get it working.


## 
Related Issue

Fixes #4474

<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
