### PR TITLE
Tweak expeditor configuration for PR template and auto assignment

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -155,4 +155,11 @@ subscriptions:
     - built_in:notify_chefio_slack_channels
  - workload: pull_request_opened:{{agent_id}}:*
    actions:
-     - post_github_comment:.expeditor/templates/pull_request.mustache
+     - post_github_comment:.expeditor/templates/pull_request.mustache:
+         ignore_team_members:
+           - inspec/owners
+           - inspec/inspec-core-team
+     - built_in:github_auto_assign_author:
+         only_if_team_member:
+           - inspec/owners
+           - inspec/inspec-core-team


### PR DESCRIPTION
Allow expeditor to automatically assign PR's opened by the team.
Prevent expeditor from posting pull_request template on PR's opened by the team.

Signed-off-by: Miah Johnson <miah@chia-pet.org>