### PR TITLE
Fix input hash processing on inheritance

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -316,7 +316,9 @@ module Inspec
         # convert to array for backwards compatability
         res[:inputs] = []
       else
-        res[:inputs] = res[:inputs].values.map(&:to_hash)
+        res[:inputs] = res[:inputs].values.map do |input|
+          input.respond_to?(:to_hash) ? input.to_hash : input
+        end
       end
       res[:sha256] = sha256
       res[:parent_profile] = parent_profile unless parent_profile.nil?


### PR DESCRIPTION
When attempting to use an inherited profile, I was getting an error
indicating that `to_hash` could not be performed on an Inspec::Input
object.

This patch only calls the to_hash method if it is available on the
corresponding object.

No differences have been found in the output or processing.

EDIT (@clintoncwolfe): Fixes #4504  