### PR TITLE
Fix yum repo matcher for rhel-8 / centos-8

### DIFF
--- a/lib/inspec/resources/yum.rb
+++ b/lib/inspec/resources/yum.rb
@@ -50,7 +50,7 @@ module Inspec::Resources
 
       # parse the repository data from yum
       # we cannot use -C, because this is not reliable and may lead to errors
-      @command_result = inspec.command("yum -v repolist all")
+      @command_result = inspec.command("yum -v repolist all; echo")
       @content = @command_result.stdout
       @cache = []
       repo = {}


### PR DESCRIPTION
Fix parsing for the final repo in yum repolist

## Description
The update yum / dnf tooling in rhel-8 / centos-8 omits the final empty line in "yum repolist" output.
This results in the final repository not being parsed.

CentOS 6 output:
```
Repo-id      : updates
Repo-name    : CentOS-6 - Updates
Repo-status  : enabled
Repo-revision: 1565879235
Repo-updated : Sun Aug 25 03:27:52 2019
Repo-pkgs    : 595
Repo-size    : 7.8 G
Repo-baseurl : https://foobar.tld/repo/
Repo-expire  : 21,600 second(s) (last: Wed Sep 25 11:18:39 2019)

repolist: 19,972
```

CentOS 8 output:
```
Repo-id      : sensu
Repo-name    : sensu monitoring
Repo-status  : enabled
Repo-revision: 1562883501
Repo-updated : Fri Jul 12 00:18:40 2019
Repo-pkgs    : 1
Repo-size    : 24 M
Repo-baseurl : http://repositories.sensuapp.org/yum/8/x86_64/
Repo-expire  : 21,600 second(s) (last: Wed Sep 25 11:18:39 2019)
Repo-excluded: 127

Repo-id      : updates
Repo-name    : CentOS-8 - Updates
Repo-status  : enabled
Repo-revision: 1565879235
Repo-updated : Sun Aug 25 03:27:52 2019
Repo-pkgs    : 595
Repo-size    : 7.8 G
Repo-baseurl : Repo-baseurl : https://foobar.tld/repo/
Repo-expire  : 21,600 second(s) (last: Wed Sep 25 11:18:39 2019)
```

In this case the 'updates' repo would not be parsed.

The easiest fix I could come up with was adding an additional echo.
I'm sure a cleaner fix is possible, but this was quick and easy.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the **CONTRIBUTING** document.
