### PR TITLE
Add resource stubs so the resource loader will find all resources

### DIFF
--- a/lib/inspec/resources/bsd_service.rb
+++ b/lib/inspec/resources/bsd_service.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/service"

--- a/lib/inspec/resources/etc_hosts_allow.rb
+++ b/lib/inspec/resources/etc_hosts_allow.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/etc_hosts_allow_deny"

--- a/lib/inspec/resources/etc_hosts_deny.rb
+++ b/lib/inspec/resources/etc_hosts_deny.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/etc_hosts_allow_deny"

--- a/lib/inspec/resources/iis_website.rb
+++ b/lib/inspec/resources/iis_website.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/iis_website.rb"

--- a/lib/inspec/resources/launchd_service.rb
+++ b/lib/inspec/resources/launchd_service.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/service"

--- a/lib/inspec/resources/linux_kernel_parameter.rb
+++ b/lib/inspec/resources/linux_kernel_parameter.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/kernel_parameter"

--- a/lib/inspec/resources/parse_config_file.rb
+++ b/lib/inspec/resources/parse_config_file.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/parse_config"

--- a/lib/inspec/resources/ppa.rb
+++ b/lib/inspec/resources/ppa.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/apt.rb"

--- a/lib/inspec/resources/rabbitmq_conf.rb
+++ b/lib/inspec/resources/rabbitmq_conf.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/rabbitmq_config.rb"

--- a/lib/inspec/resources/runit_service.rb
+++ b/lib/inspec/resources/runit_service.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/service"

--- a/lib/inspec/resources/systemd_service.rb
+++ b/lib/inspec/resources/systemd_service.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/service"

--- a/lib/inspec/resources/sysv_service.rb
+++ b/lib/inspec/resources/sysv_service.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/service"

--- a/lib/inspec/resources/upstart_service.rb
+++ b/lib/inspec/resources/upstart_service.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/service"

--- a/lib/inspec/resources/windows_registry_key.rb
+++ b/lib/inspec/resources/windows_registry_key.rb
@@ -1,0 +1,2 @@
+# This is just here to make the dynamic loader happy.
+require "inspec/resources/registry_key.rb"


### PR DESCRIPTION
## Description

#4365 introduced dynamic resource loading, which makes InSpec much faster, but it relies on there being a 1:1 relationship between resource files and resources, which is not quite true. Most notably, most service resources are combined in the `service.rb` file, which defines `runit_service`, `systemd_service`, etc. Because these individual files did not exist, the loader failed to find them, and #4521 happens.

This PR makes the simple approach of adding a stub file for each service that requires service.rb.

While in DRAFT, am currently looking for other resources that do the same thing.

<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #4521
There was manual testing done on this, before and after, using the control code listed on #4529 .

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
