### PR TITLE
Remove maintainers task from require

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require "bundler"
 require "bundler/gem_helper"
 require "rake/testtask"
 require "train"
-require_relative "tasks/maintainers"
+# require_relative "tasks/maintainers" # TODO: bring back after we push faraday_middleware fix upstream
 require_relative "tasks/spdx"
 require "fileutils"
 

--- a/test/unit/resources/http_test.rb
+++ b/test/unit/resources/http_test.rb
@@ -1,6 +1,7 @@
 require "helper"
 require "inspec/resource"
 require "inspec/resources/http"
+Faraday::Error::ClientError = ::Faraday::ClientError # TODO/HACK push upstream to faraday_middleware
 require "faraday_middleware/response/follow_redirects"
 
 describe "Inspec::Resources::Http" do


### PR DESCRIPTION
```
[miah@awakening inspec]$ bundle exec rake
rake aborted!
NameError: uninitialized constant Faraday::Error::ClientError
Did you mean?  Faraday::ClientError
/home/miah/projects/github/.gems/inspec/ruby/2.6.0/gems/octokit-4.14.0/lib/octokit/middleware/follow_redirects.rb:14:in `<module:Middleware>'
/home/miah/projects/github/.gems/inspec/ruby/2.6.0/gems/octokit-4.14.0/lib/octokit/middleware/follow_redirects.rb:11:in `<module:Octokit>'
/home/miah/projects/github/.gems/inspec/ruby/2.6.0/gems/octokit-4.14.0/lib/octokit/middleware/follow_redirects.rb:9:in `<top (required)>'
/home/miah/projects/github/.gems/inspec/ruby/2.6.0/gems/octokit-4.14.0/lib/octokit/default.rb:1:in `require'
/home/miah/projects/github/.gems/inspec/ruby/2.6.0/gems/octokit-4.14.0/lib/octokit/default.rb:1:in `<top (required)>'
/home/miah/projects/github/.gems/inspec/ruby/2.6.0/gems/octokit-4.14.0/lib/octokit.rb:4:in `require'
/home/miah/projects/github/.gems/inspec/ruby/2.6.0/gems/octokit-4.14.0/lib/octokit.rb:4:in `<top (required)>'
/home/miah/projects/github/inspec/tasks/maintainers.rb:27:in `require'
/home/miah/projects/github/inspec/tasks/maintainers.rb:27:in `<top (required)>'
/home/miah/projects/github/inspec/Rakefile:7:in `require_relative'
/home/miah/projects/github/inspec/Rakefile:7:in `<top (required)>'
/home/miah/projects/github/.gems/inspec/ruby/2.6.0/gems/rake-13.0.0/exe/rake:27:in `<top (required)>'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/lib/bundler/cli/exec.rb:74:in `load'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/lib/bundler/cli/exec.rb:74:in `kernel_load'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/lib/bundler/cli/exec.rb:28:in `run'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/lib/bundler/cli.rb:463:in `exec'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/lib/bundler/cli.rb:27:in `dispatch'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/lib/bundler/cli.rb:18:in `start'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/exe/bundle:30:in `block in <top (required)>'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/home/miah/.gem/ruby/2.6.3/gems/bundler-2.0.1/exe/bundle:22:in `<top (required)>'
/home/miah/.gem/ruby/2.6.3/bin/bundle:23:in `load'
/home/miah/.gem/ruby/2.6.3/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)
```