### PR TITLE
Fixed inspec lazy resource loader for rspec test dsl (eg before/after)

### DIFF
--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -10,6 +10,15 @@ module Inspec
   module DescribeDslLazyLoader
     # Support for Describe DSL plugins
     def method_missing(method_name, *arguments, &block)
+      # TODO: need a backend available at the describe level... class method somewhere?
+      # # see if it is a resource first
+      # begin
+      #   resource = Inspec::DSL.method_missing_resource(:where_is_backend?, method_name, *arguments)
+      #   return resource if resource
+      # rescue LoadError
+      #   # pass through
+      # end
+
       # Check to see if there is a describe_dsl plugin activator hook with the method name
       registry = Inspec::Plugin::V2::Registry.instance
       hook = registry.find_activators(plugin_type: :describe_dsl, activator_name: method_name).first
@@ -39,6 +48,14 @@ module Inspec
   module TestDslLazyLoader
     # Support for test DSL plugins
     def method_missing(method_name, *arguments, &block)
+      # see if it is a resource first
+      begin
+        resource = Inspec::DSL.method_missing_resource(inspec, method_name, *arguments)
+        return resource if resource
+      rescue LoadError
+        # pass through
+      end
+
       # Check to see if there is a test_dsl plugin activator hook with the method name
       registry = Inspec::Plugin::V2::Registry.instance
       hook = registry.find_activators(plugin_type: :test_dsl, activator_name: method_name).first


### PR DESCRIPTION
This does NOT fix lazy loading of resources at the describe block
level. I need to figure out where our backend/inspec/whatever is in
that context and it looks like we don't have one available.

Signed-off-by: Ryan Davis <zenspider@chef.io>