### PR TITLE
fix Gemfile for inspec-core-bin gem

### DIFF
--- a/inspec-bin/Gemfile
+++ b/inspec-bin/Gemfile
@@ -1,2 +1,7 @@
 source "https://rubygems.org"
-gemspec name: "inspec-bin"
+main_gemspec = File.expand_path("../inspec-bin.gemspec", __FILE__)
+if File.exist?(main_gemspec)
+  gemspec name: "inspec-bin"
+else
+  gemspec name: "inspec-core-bin"
+end


### PR DESCRIPTION
* in order to appbundle inspec-core-bin we need a Gemfile.

* the previous gemfile refers to inspec-bin and that gets packaged and
shipped with the inspec-core-bin Gemfile and that does not work when
appbundler tries to use it.

* hacking up appbundler to be more complicated than it is, is probably
a poor idea since it is already a big pile of magic.

* so what would be good to do in order to preserve the DRY'ness of
having both inspec-bin and inspec-core-bin share binaries, would be to
have the Gemfile be usable by both gems when they are ultimately
consumed.

* because the inspec-core-bin gem only has the inspec-core-bin.gemspec
what we can do is test to see which gemspec we have and then behave
accordingly.

still a bit hacky, but better than the other alternatives we considered.
