### PR TITLE
Replace input to_hash method, and add unit test for it

### DIFF
--- a/lib/inspec/input.rb
+++ b/lib/inspec/input.rb
@@ -319,6 +319,21 @@ module Inspec
     end
 
     #--------------------------------------------------------------------------#
+    #                               Marshalling
+    #--------------------------------------------------------------------------#
+
+    def to_hash
+      as_hash = { name: name, options: {} }
+      %i{description title identifier type required value}.each do |field|
+        val = send(field)
+        next if val.nil?
+
+        as_hash[:options][field] = val
+      end
+      as_hash
+    end
+
+    #--------------------------------------------------------------------------#
     #                           Value Type Coercion
     #--------------------------------------------------------------------------#
 

--- a/lib/inspec/input.rb
+++ b/lib/inspec/input.rb
@@ -318,6 +318,17 @@ module Inspec
       !current_value.is_a? NO_VALUE_SET
     end
 
+    def to_hash
+      as_hash = { name: name, options: {} }
+      %i{description title identifier type required value}.each do |field|
+        val = send(field)
+        next if val.nil?
+
+        as_hash[:options][field] = val
+      end
+      as_hash
+    end
+
     #--------------------------------------------------------------------------#
     #                           Value Type Coercion
     #--------------------------------------------------------------------------#

--- a/lib/inspec/input.rb
+++ b/lib/inspec/input.rb
@@ -319,21 +319,6 @@ module Inspec
     end
 
     #--------------------------------------------------------------------------#
-    #                               Marshalling
-    #--------------------------------------------------------------------------#
-
-    def to_hash
-      as_hash = { name: name, options: {} }
-      %i{description title identifier type required value}.each do |field|
-        val = send(field)
-        next if val.nil?
-
-        as_hash[:options][field] = val
-      end
-      as_hash
-    end
-
-    #--------------------------------------------------------------------------#
     #                           Value Type Coercion
     #--------------------------------------------------------------------------#
 

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -1,6 +1,6 @@
 require "forwardable"
 require "singleton"
-require "inspec/input"
+require "inspec/objects/input"
 require "inspec/secrets"
 require "inspec/exceptions"
 require "inspec/plugin/v2"

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -1,6 +1,6 @@
 require "forwardable"
 require "singleton"
-require "inspec/objects/input"
+require "inspec/input"
 require "inspec/secrets"
 require "inspec/exceptions"
 require "inspec/plugin/v2"

--- a/test/unit/inputs/input_test.rb
+++ b/test/unit/inputs/input_test.rb
@@ -25,6 +25,28 @@ describe Inspec::Input do
     end
   end
 
+  describe "marshalling" do
+    it "should be able to represent an Input as a Hash" do
+      input = Inspec::Input.new("test_input",
+        value: 12,
+        title: "Best input ever",
+        description: "important",
+        type: "Numeric",
+        required: true
+      )
+      _(input.to_hash).must_equal({
+        name: "test_input",
+        options: {
+        value: 12,
+        title: "Best input ever",
+        description: "important",
+        type: "Numeric",
+        required: true
+        }
+      })
+    end
+  end
+
   #==============================================================#
   #                   Setting Value - One Shot
   #            (see events_test.rb for overwrite support)

--- a/test/unit/inputs/input_test.rb
+++ b/test/unit/inputs/input_test.rb
@@ -36,11 +36,11 @@ describe Inspec::Input do
       _(input.to_hash).must_equal({
         name: "test_input",
         options: {
-        value: 12,
-        title: "Best input ever",
-        description: "important",
-        type: "Numeric",
-        required: true,
+          value: 12,
+          title: "Best input ever",
+          description: "important",
+          type: "Numeric",
+          required: true,
         },
       })
     end

--- a/test/unit/inputs/input_test.rb
+++ b/test/unit/inputs/input_test.rb
@@ -1,5 +1,5 @@
 require "helper"
-require "inspec/input"
+require "inspec/objects/input"
 
 describe Inspec::Input do
   let(:opts) { {} }
@@ -32,8 +32,7 @@ describe Inspec::Input do
         title: "Best input ever",
         description: "important",
         type: "Numeric",
-        required: true
-      )
+        required: true)
       _(input.to_hash).must_equal({
         name: "test_input",
         options: {
@@ -41,8 +40,8 @@ describe Inspec::Input do
         title: "Best input ever",
         description: "important",
         type: "Numeric",
-        required: true
-        }
+        required: true,
+        },
       })
     end
   end

--- a/test/unit/inputs/input_test.rb
+++ b/test/unit/inputs/input_test.rb
@@ -1,5 +1,5 @@
 require "helper"
-require "inspec/objects/input"
+require "inspec/input"
 
 describe Inspec::Input do
   let(:opts) { {} }


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description

This re-adds the `to_hash` method to the Input class, which allows Inputs to be marshalled for certain types of output, especially when the inputs are in inherited profiles.

Also included is a unit test to help exercise the method.

attn: @trevor-vaughan 

## Related Issue

Fixes #4504 
Supercedes #4502
Probably regressed on #4485

<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
