### PR TITLE
Add no-op resource and switch Rule to use it for skipped resources.

### DIFF
--- a/lib/inspec/resources/noop.rb
+++ b/lib/inspec/resources/noop.rb
@@ -1,0 +1,9 @@
+module Inspec::Resources
+  class Noop < Inspec.resource(1)
+    name "noop"
+
+    def to_s
+      "No-op"
+    end
+  end
+end

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -227,9 +227,7 @@ module Inspec
         msg = "Skipped control due to #{skip_check[:type]} condition."
       end
 
-      # TODO: we use os as the carrier here, but should consider
-      # a separate resource to do skipping
-      resource = rule.os
+      resource = rule.noop
       resource.skip_resource(msg)
       [["describe", [resource], nil]]
     end


### PR DESCRIPTION
Avoids the situation of using `os` for non-os transports and blowing up.

Fixes #4541.

Signed-off-by: Ryan Davis <zenspider@chef.io>