### PR TITLE
Fixed apt resource incorrectly parsing deb files w/ quoted URIs.

### DIFF
--- a/lib/inspec/resources/apt.rb
+++ b/lib/inspec/resources/apt.rb
@@ -87,12 +87,14 @@ module Inspec::Resources
         active = raw_line == line
 
         # formats:
+        # deb               "http://archive.ubuntu.com/ubuntu/" wily main restricted ...
         # deb               http://archive.ubuntu.com/ubuntu/ wily main restricted ...
         # deb [trusted=yes] http://archive.ubuntu.com/ubuntu/ wily main restricted ...
 
         words = line.split
         words.delete 1 if words[1] && words[1].start_with?("[")
         type, url, distro, *components = words
+        url = url.delete('"') if url
 
         next if components.empty?
         next unless URI::HTTP === URI.parse(url)

--- a/test/unit/mock/cmd/etc-apt
+++ b/test/unit/mock/cmd/etc-apt
@@ -4,4 +4,5 @@ deb http://ppa.launchpad.net/ubuntu-wine/ppa/ubuntu wily main
 # newer versions of the distribution.
 
 deb http://archive.ubuntu.com/ubuntu/ wily main restricted
+deb "http://archive.ubuntu.com/ubuntu/" wily main restricted
 deb-src http://archive.ubuntu.com/ubuntu/ wily main restricted


### PR DESCRIPTION
Fixes #4559.

Signed-off-by: Ryan Davis <zenspider@chef.io>