### PR TITLE
Improve testing for yum.repo in CentOS 8

### DIFF
--- a/lib/inspec/resources/yum.rb
+++ b/lib/inspec/resources/yum.rb
@@ -59,7 +59,7 @@ module Inspec::Resources
         # detect repo start
         in_repo = true if line =~ /^\s*Repo-id\s*:\s*(.*)\b/
         # detect repo end
-        if line == "\n" && in_repo
+        if (line == "\n" || line =~ /\s*Total packages:/) && in_repo
           in_repo = false
           @cache.push(repo)
           repo = {}

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -6,7 +6,7 @@ class MockLoader
     centos5: { name: "centos", family: "redhat", release: "5.11", arch: "x86_64" },
     centos6: { name: "centos", family: "redhat", release: "6.6", arch: "x86_64" },
     centos7: { name: "centos", family: "redhat", release: "7.1.1503", arch: "x86_64" },
-    centos8: { name: "centos", family: "redhat", release: "8.9.10", arch: "x86_64" },
+    centos8: { name: "centos", family: "redhat", release: "8.0.1905", arch: "x86_64" },
     cloudlinux: { name: "cloudlinux", family: "redhat", release: "7.4", arch: "x86_64" },
     coreos: { name: "coreos", family: "coreos", release: "1437.0.0", arch: "x86_64" },
     debian6: { name: "debian", family: "debian", release: "6", arch: "x86_64" },

--- a/test/unit/mock/cmd/yum-centos8-repolist-all
+++ b/test/unit/mock/cmd/yum-centos8-repolist-all
@@ -1,50 +1,66 @@
-Config time: 0.006
-Yum version: 3.4.3
-base                                                                                                                  | 3.6 kB  00:00:00
-epel/x86_64/metalink                                                                                                  |  26 kB  00:00:00
-epel                                                                                                                  | 4.3 kB  00:00:00
-extras                                                                                                                | 3.4 kB  00:00:00
-updates                                                                                                               | 3.4 kB  00:00:00
-(1/3): epel/x86_64/group_gz                                                                                           | 169 kB  00:00:00
-epel/x86_64/primary_db         FAILED
-https://ftp.fau.de/epel/7/x86_64/repodata/ccbc93c2ab37b82a6376c9562d2aec27b81112bc3c943e1871f7ed0318fe24b9-primary.sqlite.xz: [Errno 14] HTTPS Error 404 - Not Found
-Trying other mirror.
-(2/3): epel/x86_64/updateinfo                                                                                         | 349 kB  00:00:00
-(3/3): epel/x86_64/primary_db                                                                                         | 3.5 MB  00:00:04
-Loading mirror speeds from cached hostfile
- * base: ftp.hosteurope.de
- * epel: ftp-stud.hs-esslingen.de
- * extras: mirror.informatik.hs-fulda.de
- * updates: mirror.softaculous.com
-Setting up Package Sacks
-pkgsack time: 0.005
-Repo-id      : base/7/x86_64
-Repo-name    : CentOS-7 - Base
+Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync
+DNF version: 4.0.9
+cachedir: /var/cache/dnf
+repo: using cache for: AppStream
+not found other for: CentOS-8 - AppStream
+not found deltainfo for: CentOS-8 - AppStream
+not found updateinfo for: CentOS-8 - AppStream
+AppStream: using metadata from Fri 20 Sep 2019 10:23:13 PM UTC.
+repo: using cache for: BaseOS
+not found other for: CentOS-8 - Base
+not found modules for: CentOS-8 - Base
+not found deltainfo for: CentOS-8 - Base
+not found updateinfo for: CentOS-8 - Base
+BaseOS: using metadata from Fri 20 Sep 2019 10:05:43 PM UTC.
+repo: using cache for: extras
+not found other for: CentOS-8 - Extras
+not found modules for: CentOS-8 - Extras
+not found deltainfo for: CentOS-8 - Extras
+not found updateinfo for: CentOS-8 - Extras
+extras: using metadata from Sat 21 Sep 2019 01:57:03 PM UTC.
+Last metadata expiration check: 0:01:35 ago on Mon 07 Oct 2019 11:55:21 PM UTC.
+Completion plugin: Generating completion cache...
+
+Repo-id      : AppStream
+Repo-name    : CentOS-8 - AppStream
 Repo-status  : enabled
-Repo-revision: 1427842153
-Repo-updated : Tue Mar 31 22:50:46 2015
-Repo-pkgs    : 8652
-Repo-size    : 6.3 G
-Repo-mirrors : http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=stock
-Repo-baseurl : http://ftp.hosteurope.de/mirror/centos.org/7.1.1503/os/x86_64/ (9 more)
-Repo-expire  : 21600 second(s) (last: Sun Sep  6 10:20:46 2015)
+Repo-revision: 1569018193
+Repo-updated : Fri 20 Sep 2019 10:23:13 PM UTC
+Repo-pkgs    : 4,928
+Repo-size    : 7.1 G
+Repo-mirrors : http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream&infra=stock
+Repo-baseurl : http://mirror.web-ster.com/centos/8.0.1905/AppStream/x86_64/os/ (9 more)
+Repo-expire  : 172,800 second(s) (last: Mon 07 Oct 2019 11:55:14 PM UTC)
+Repo-filename: /etc/yum.repos.d/CentOS-AppStream.repo
+
+Repo-id      : BaseOS
+Repo-name    : CentOS-8 - Base
+Repo-status  : enabled
+Repo-revision: 1569017143
+Repo-updated : Fri 20 Sep 2019 10:05:43 PM UTC
+Repo-pkgs    : 2,713
+Repo-size    : 3.2 G
+Repo-mirrors : http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS&infra=stock
+Repo-baseurl : http://mirror.web-ster.com/centos/8.0.1905/BaseOS/x86_64/os/ (9 more)
+Repo-expire  : 172,800 second(s) (last: Mon 07 Oct 2019 11:55:16 PM UTC)
 Repo-filename: /etc/yum.repos.d/CentOS-Base.repo
 
-Repo-id      : base-debuginfo/x86_64
-Repo-name    : CentOS-7 - Debuginfo
+Repo-id      : base-debuginfo
+Repo-name    : CentOS-8 - Debuginfo
 Repo-status  : disabled
-Repo-baseurl : http://debuginfo.centos.org/7/x86_64/
-Repo-expire  : 21600 second(s) (last: Unknown)
+Repo-baseurl : http://debuginfo.centos.org/8/x86_64/
+Repo-expire  : 172,800 second(s) (last: unknown)
 Repo-filename: /etc/yum.repos.d/CentOS-Debuginfo.repo
 
-Repo-id      : extras/7/x86_64
-Repo-name    : CentOS-7 - Extras
+Repo-id      : extras
+Repo-name    : CentOS-8 - Extras
 Repo-status  : enabled
-Repo-revision: 1441314199
-Repo-updated : Thu Sep  3 21:03:33 2015
-Repo-pkgs    : 181
-Repo-size    : 742 M
-Repo-mirrors : http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=extras&infra=stock
-Repo-baseurl : http://mirror.informatik.hs-fulda.de/centos7.1.1503/extras/x86_64/ (9 more)
-Repo-expire  : 21600 second(s) (last: Sun Sep  6 10:20:48 2015)
-Repo-filename: /etc/yum.repos.d/CentOS-Base.repo
+Repo-revision: 1569074223
+Repo-updated : Sat 21 Sep 2019 01:57:03 PM UTC
+Repo-pkgs    : 3
+Repo-size    : 46 k
+Repo-mirrors : http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=extras&infra=stock
+Repo-baseurl : http://mirror.web-ster.com/centos/8.0.1905/extras/x86_64/os/ (9 more)
+Repo-expire  : 172,800 second(s) (last: Mon 07 Oct 2019 11:55:21 PM UTC)
+Repo-filename: /etc/yum.repos.d/CentOS-Extras.repo
+Total packages: 7,644

--- a/test/unit/resources/yum_test.rb
+++ b/test/unit/resources/yum_test.rb
@@ -15,7 +15,8 @@ describe "Inspec::Resources::YumRepo" do
     end
   end
 
-  def assert_repositories(resource)
+  it "get repository details centos7" do
+    resource = centos7
     _(resource.repositories).must_equal [{
       "id" => "base/7/x86_64",
       "name" => "CentOS-7 - Base",
@@ -71,14 +72,6 @@ describe "Inspec::Resources::YumRepo" do
     _(extras.to_s).must_equal "YumRepo base-debuginfo/x86_64"
   end
 
-  it "get repository details centos7" do
-    assert_repositories centos7
-  end
-
-  it "get repository details centos8" do
-    assert_repositories centos8
-  end
-
   it "provides methods for retrieving per-repo information" do
     resource = centos7
     repo = resource.repo("base/7/x86_64")
@@ -90,5 +83,86 @@ describe "Inspec::Resources::YumRepo" do
     _(repo.size).must_equal "6.3 G"
     _(repo.status).must_equal "enabled"
     _(repo.updated).must_equal "Tue Mar 31 22:50:46 2015"
+  end
+  it "get repository details centos8" do
+    resource = centos8
+    _(resource.repositories).must_equal [{
+      "id" => "AppStream",
+      "name" => "CentOS-8 - AppStream",
+      "status" => "enabled",
+      "revision" => "1569018193",
+      "updated" => "Fri 20 Sep 2019 10:23:13 PM UTC",
+      "pkgs" => "4,928",
+      "size" => "7.1 G",
+      "mirrors" => "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream&infra=stock",
+      "baseurl" => "http://mirror.web-ster.com/centos/8.0.1905/AppStream/x86_64/os/ (9 more)",
+      "expire" => "172,800 second(s) (last: Mon 07 Oct 2019 11:55:14 PM UTC)",
+      "filename" => "/etc/yum.repos.d/CentOS-AppStream.repo",
+    }, {
+      "id" => "BaseOS",
+      "name" => "CentOS-8 - Base",
+      "status" => "enabled",
+      "revision" => "1569017143",
+      "updated" => "Fri 20 Sep 2019 10:05:43 PM UTC",
+      "pkgs" => "2,713",
+      "size" => "3.2 G",
+      "mirrors" => "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS&infra=stock",
+      "baseurl" => "http://mirror.web-ster.com/centos/8.0.1905/BaseOS/x86_64/os/ (9 more)",
+      "expire" => "172,800 second(s) (last: Mon 07 Oct 2019 11:55:16 PM UTC)",
+      "filename" => "/etc/yum.repos.d/CentOS-Base.repo",
+    }, {
+      "id" => "base-debuginfo",
+      "name" => "CentOS-8 - Debuginfo",
+      "status" => "disabled",
+      "baseurl" => "http://debuginfo.centos.org/8/x86_64/",
+      "expire" => "172,800 second(s) (last: unknown)",
+      "filename" => "/etc/yum.repos.d/CentOS-Debuginfo.repo",
+    }, {
+      "id" => "extras",
+      "name" => "CentOS-8 - Extras",
+      "status" => "enabled",
+      "revision" => "1569074223",
+      "updated" => "Sat 21 Sep 2019 01:57:03 PM UTC",
+      "pkgs" => "3",
+      "size" => "46 k",
+      "mirrors" => "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=extras&infra=stock",
+      "baseurl" => "http://mirror.web-ster.com/centos/8.0.1905/extras/x86_64/os/ (9 more)",
+      "expire" => "172,800 second(s) (last: Mon 07 Oct 2019 11:55:21 PM UTC)",
+      "filename" => "/etc/yum.repos.d/CentOS-Extras.repo",
+    }]
+    _(resource.repos.length).must_equal 4
+    # get repository details
+    _(resource.repos).must_equal %w{AppStream BaseOS base-debuginfo extras}
+    # test its syntax repo
+    _(resource.extras.exist?).must_equal true
+    _(resource.extras.enabled?).must_equal true
+    # test enabled extra repo
+    extras = resource.repo("extras")
+    _(extras.exist?).must_equal true
+    _(extras.enabled?).must_equal true
+    _(extras.baseurl).must_include "web-ster"
+    # test enabled extra repo with short name
+    extras = resource.repo("extras")
+    _(extras.exist?).must_equal true
+    _(extras.enabled?).must_equal true
+    _(extras.baseurl).must_include "web-ster"
+    # test disabled extra-source repo
+    extras = resource.repo("base-debuginfo")
+    _(extras.exist?).must_equal true
+    _(extras.enabled?).must_equal false
+    _(extras.to_s).must_equal "YumRepo base-debuginfo"
+  end
+
+  it "provides methods for retrieving per-repo information on >= el8" do
+    resource = centos8
+    repo = resource.repo("BaseOS")
+    _(repo.baseurl).must_equal "http://mirror.web-ster.com/centos/8.0.1905/BaseOS/x86_64/os/ (9 more)"
+    _(repo.expire).must_equal "172,800 second(s) (last: Mon 07 Oct 2019 11:55:16 PM UTC)"
+    _(repo.filename).must_equal "/etc/yum.repos.d/CentOS-Base.repo"
+    _(repo.mirrors).must_equal "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS&infra=stock"
+    _(repo.pkgs).must_equal "2,713"
+    _(repo.size).must_equal "3.2 G"
+    _(repo.status).must_equal "enabled"
+    _(repo.updated).must_equal "Fri 20 Sep 2019 10:05:43 PM UTC"
   end
 end


### PR DESCRIPTION
The output for ``yum -v repolist all`` changes slightly in CentOS 8 and breaks
the current regex for parsing the output. There are two specific changes that
are breaking this.

1. EL8 is no longer trailing the repo name with release version and arch (i.e.
   base instead of base/7/x86)
2. EL8 no longer adds a trailing newline on the last repo and instead has a line
   with ``Total packages:``. This means the repo listed last will never show up.

This change updates the regex to account for both pre-CentOS 8 and CentOS 8 and
beyond.

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
