### PR TITLE
Telemetry: wire up the options and env switches

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -6,16 +6,16 @@ expeditor:
       retry:
         automatic:
           limit: 1
-      
+
 steps:
 
-- label: run-tests-ruby-2.4
-  command:
-    - /workdir/.expeditor/buildkite/verify.sh
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-stretch
+# - label: run-tests-ruby-2.4
+#   command:
+#     - /workdir/.expeditor/buildkite/verify.sh
+#   expeditor:
+#     executor:
+#       docker:
+#         image: ruby:2.4-stretch
 
 - label: run-tests-ruby-2.5
   command:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -9,14 +9,6 @@ expeditor:
 
 steps:
 
-# - label: run-tests-ruby-2.4
-#   command:
-#     - /workdir/.expeditor/buildkite/verify.sh
-#   expeditor:
-#     executor:
-#       docker:
-#         image: ruby:2.4-stretch
-
 - label: run-tests-ruby-2.5
   command:
     - /workdir/.expeditor/buildkite/verify.sh

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -9,6 +9,14 @@ expeditor:
 
 steps:
 
+- label: run-tests-ruby-2.4
+  command:
+    - /workdir/.expeditor/buildkite/verify.sh
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.4-stretch
+
 - label: run-tests-ruby-2.5
   command:
     - /workdir/.expeditor/buildkite/verify.sh

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "train-core", "~> 3.0"
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
+  spec.add_dependency "chef-core", "~> 0.0"
   spec.add_dependency "thor", "~> 0.20"
   spec.add_dependency "json-schema", "~> 2.8"
   spec.add_dependency "method_source", "~> 0.8"

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   # Implementation dependencies
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
+  spec.add_dependency "chef-core", "~> 0.0"
   spec.add_dependency "thor", "~> 0.20"
   spec.add_dependency "json-schema", "~> 2.8"
   spec.add_dependency "method_source", "~> 0.8"

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -230,7 +230,13 @@ module Inspec
     #
     def configure_telemeter(inspec_config)
       telemetry_config = {}
-      telemetry_config[:payload_dir] = "#{Inspec.config_dir}/telemetry}"
+      telemetry_config[:product] = {
+        name: "inspec",
+        version: Inspec::VERSION,
+        origin: "command-line",
+        install_context: "omnibus", # TODO - detect rubygems install, issue 4585
+      }
+      telemetry_config[:payload_dir] = "#{Inspec.config_dir}/telemetry"
       telemetry_config[:session_file] = ".inspec-telemetry-#{$$}"
       # telemetry_config[:installation_identifier_file] Documented but not generally available on InSpec clients.
       telemetry_config[:dev_mode] = ENV["INSPEC_TELEMETRY_DEV_MODE"] \
@@ -248,6 +254,7 @@ module Inspec
       if telemetry_config[:enabled]
         Inspec::Log.info("Enabling telemetry in #{telemetry_config[:dev_mode] ? "dev" : "prod"} mode")
         Inspec::Log.info("Will write telemetry data files to #{telemetry_config[:payload_dir]}")
+        FileUtils.mkdir_p(telemetry_config[:payload_dir])
       else
         Inspec::Log.info("Telemetry is disabled.")
       end

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -331,6 +331,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     log_device = suppress_log_output?(o) ? nil : $stdout
     o[:logger] = Logger.new(log_device)
     o[:logger].level = get_log_level(o[:log_level])
+    configure_telemeter(o)
 
     if o[:command].nil?
       runner = Inspec::Runner.new(o)

--- a/lib/inspec/utils/telemetry/collector.rb
+++ b/lib/inspec/utils/telemetry/collector.rb
@@ -1,3 +1,4 @@
+require "chef_core/telemeter"
 require "inspec/config"
 require "inspec/utils/telemetry/data_series"
 require "singleton"

--- a/lib/inspec/utils/telemetry/collector.rb
+++ b/lib/inspec/utils/telemetry/collector.rb
@@ -1,4 +1,3 @@
-require "chef_core/telemeter"
 require "inspec/config"
 require "inspec/utils/telemetry/data_series"
 require "singleton"


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

This (Draft) PR makes the CLI option --enable-telemetry and ENV variables work with `chef-core/telemeter` to setup the Telemeter. It also kicks off the old session upload if enabled, so we're off to the races.

The logic behind whether to enable the telemetry system is a bit fraught. It bears review.

All enable logic is currently hidden behind a feature flag env var.

We'll need to add a call to the configuration method, `base_cli/configure_telemeter()` in each subcommand. This PR just does `shell`.

There are no tests for this code at the moment.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
