### PR TITLE
Make codeclimate ignore inspec profiles

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -26,3 +26,5 @@ plugins:
     enabled: true
 exclude_patterns:
   - "www/source/javascripts/"
+  - "examples/"
+  - "test/unit/mock/profiles/"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -6,7 +6,7 @@ expeditor:
       retry:
         automatic:
           limit: 1
-      
+
 steps:
 
 - label: run-tests-ruby-2.4
@@ -32,6 +32,14 @@ steps:
     executor:
       docker:
         image: ruby:2.6-stretch
+
+- label:  run-tests-ruby-2.7-preview
+  command:
+    - /workdir/.expeditor/buildkite/verify.sh
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.7-rc-buster
 
 - label: isolated-tests-ruby-2.6
   command:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -6,7 +6,7 @@ expeditor:
       retry:
         automatic:
           limit: 1
-
+      
 steps:
 
 - label: run-tests-ruby-2.4
@@ -32,14 +32,6 @@ steps:
     executor:
       docker:
         image: ruby:2.6-stretch
-
-- label:  run-tests-ruby-2.7-preview
-  command:
-    - /workdir/.expeditor/buildkite/verify.sh
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.7-rc-buster
 
 - label: isolated-tests-ruby-2.6
   command:


### PR DESCRIPTION
We include some inspec profiles; cc should ignore them.