### PR TITLE
Fixed the rest of the minitest deprecations by removing FuncTestRunResult.

### DIFF
--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/helper.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/helper.rb
@@ -9,7 +9,7 @@ module PluginManagerHelpers
   let(:list_after_run) do
     Proc.new do |run_result, tmp_dir|
       # After installing/uninstalling/whatevering, run list with config in the same dir, and capture it.
-      run_result.payload.list_result = parse_plugin_list_lines(
+      @list_result = parse_plugin_list_lines(
         run_inspec_process("plugin list", env: { INSPEC_CONFIG_DIR: tmp_dir }).stdout
       )
     end

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
@@ -54,12 +54,12 @@ class PluginManagerCliInstall < Minitest::Test
       assert_includes success_message, "plugin installed via source path reference"
 
       # Check round-trip UX via list
-      itf_plugin = install_result.payload.list_result.detect { |p| p[:name] == fixture_info[:plugin_name] }
+      itf_plugin = @list_result.detect { |p| p[:name] == fixture_info[:plugin_name] }
       refute_nil itf_plugin, "plugin name should now appear in the output of inspec list"
       assert_equal "path", itf_plugin[:type], "list output should show that it is a path installation"
 
       # Check plugin statefile. Extra important in this case, since all should resolve to the same entry point.
-      plugin_data = install_result.payload.plugin_data
+      plugin_data = @plugin_data
       entry = plugin_data["plugins"].detect { |e| e["name"] == fixture_info[:plugin_name] }
       assert_equal fixture_info[:resolved_path], entry["installation_path"], "Regardless of input, the entry point should be correct."
 
@@ -164,7 +164,7 @@ class PluginManagerCliInstall < Minitest::Test
     refute_nil success_message, "Should find a success message at the end"
     assert_includes success_message, "installed from local .gem file"
 
-    itf_plugin = install_result.payload.list_result.detect { |p| p[:name] == "inspec-test-fixture" }
+    itf_plugin = @list_result.detect { |p| p[:name] == "inspec-test-fixture" }
     refute_nil itf_plugin, "plugin name should now appear in the output of inspec list"
     assert_equal "gem (user)", itf_plugin[:type]
     assert_equal "0.1.0", itf_plugin[:version]
@@ -195,7 +195,7 @@ class PluginManagerCliInstall < Minitest::Test
     assert_includes success_message, "0.2.0"
     assert_includes success_message, "installed from rubygems.org"
 
-    itf_plugin = install_result.payload.list_result.detect { |p| p[:name] == "inspec-test-fixture" }
+    itf_plugin = @list_result.detect { |p| p[:name] == "inspec-test-fixture" }
     refute_nil itf_plugin, "plugin name should now appear in the output of inspec list"
     assert_equal "gem (user)", itf_plugin[:type]
     assert_equal "0.2.0", itf_plugin[:version]
@@ -225,7 +225,7 @@ class PluginManagerCliInstall < Minitest::Test
     assert_includes success_message, "0.1.0"
     assert_includes success_message, "installed from rubygems.org"
 
-    itf_plugin = install_result.payload.list_result.detect { |p| p[:name] == "inspec-test-fixture" }
+    itf_plugin = @list_result.detect { |p| p[:name] == "inspec-test-fixture" }
     refute_nil itf_plugin, "plugin name should now appear in the output of inspec list"
     assert_equal "gem (user)", itf_plugin[:type]
     assert_equal "0.1.0", itf_plugin[:version]
@@ -317,7 +317,7 @@ class PluginManagerCliInstall < Minitest::Test
     assert_includes success_message, "0.1.0"
     assert_includes success_message, "installed from rubygems.org"
 
-    ttf_plugin = install_result.payload.list_result.detect { |p| p[:name] == "train-test-fixture" }
+    ttf_plugin = @list_result.detect { |p| p[:name] == "train-test-fixture" }
     refute_nil ttf_plugin, "plugin name should now appear in the output of inspec list"
     assert_equal "gem (user)", ttf_plugin[:type]
     assert_equal "0.1.0", ttf_plugin[:version]

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/uninstall_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/uninstall_test.rb
@@ -20,7 +20,7 @@ class PluginManagerCliUninstall < Minitest::Test
     assert_includes success_message, "0.1.0"
     assert_includes success_message, "has been uninstalled"
 
-    itf_plugins = uninstall_result.payload.list_result.select { |p| p[:name] == "inspec-test-fixture" }
+    itf_plugins = @list_result.select { |p| p[:name] == "inspec-test-fixture" }
     assert_empty itf_plugins, "inspec-test-fixture should not appear in the output of inspec list"
 
     assert_empty uninstall_result.stderr
@@ -42,7 +42,7 @@ class PluginManagerCliUninstall < Minitest::Test
     assert_includes success_message, "path-based plugin install"
     assert_includes success_message, "has been uninstalled"
 
-    itf_plugins = uninstall_result.payload.list_result.select { |p| p[:name] == "inspec-meaning-of-life" }
+    itf_plugins = @list_result.select { |p| p[:name] == "inspec-meaning-of-life" }
     assert_empty itf_plugins, "inspec-meaning-of-life should not appear in the output of inspec list"
 
     assert_empty uninstall_result.stderr

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/update_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/update_test.rb
@@ -22,7 +22,7 @@ class PluginManagerCliUpdate < Minitest::Test
     assert_includes success_message, "0.2.0"
     assert_includes success_message, "updated from rubygems.org"
 
-    itf_plugin = update_result.payload.list_result.detect { |p| p[:name] == "inspec-test-fixture" }
+    itf_plugin = @list_result.detect { |p| p[:name] == "inspec-test-fixture" }
     refute_nil itf_plugin, "plugin name should now appear in the output of inspec list"
     assert_equal "gem (user)", itf_plugin[:type]
     assert_equal "0.2.0", itf_plugin[:version]

--- a/lib/plugins/shared/core_plugin_test_helper.rb
+++ b/lib/plugins/shared/core_plugin_test_helper.rb
@@ -65,7 +65,7 @@ module CorePluginFunctionalHelper
     elsif opts.key?(:env)
       prefix = opts[:env].to_a.map { |assignment| "#{assignment[0]}=#{assignment[1]}" }.join(" ")
     end
-    Inspec::FuncTestRunResult.new(TRAIN_CONNECTION.run_command("#{prefix} #{exec_inspec} #{command_line}"))
+    TRAIN_CONNECTION.run_command("#{prefix} #{exec_inspec} #{command_line}")
   end
 
   # This helper does some fancy footwork to make InSpec think a plugin
@@ -76,8 +76,7 @@ module CorePluginFunctionalHelper
   #       Modify plugin_statefile_data as needed; it will be written to a plugins.json
   #       in tmp_dir_path.  You may also copy in other things to the tmp_dir_path. Your PWD
   #       will be in the tmp_dir, and it will exist and be empty.
-  #    :post_run: Proc(FuncTestRunResult, tmp_dir_path) - optional result capture block.
-  #       run_result will be populated, but you can add more to the ostruct .payload
+  #    :post_run: Proc(CommandResult, tmp_dir_path) - optional result capture block.
   #       Your PWD will be the tmp_dir, and it will still exist (for a moment!)
   def run_inspec_process_with_this_plugin(command_line, opts = {})
     plugin_path = __find_plugin_path_from_caller
@@ -101,7 +100,7 @@ module CorePluginFunctionalHelper
 
       # Read the resulting plugins.json into memory, if any
       if File.exist?(plugin_file_path)
-        run_result.payload.plugin_data = JSON.parse(File.read(plugin_file_path))
+        @plugin_data = JSON.parse(File.read(plugin_file_path))
       end
 
       opts[:post_run]&.call(run_result, tmp_dir)

--- a/test/functional/filter_table_test.rb
+++ b/test/functional/filter_table_test.rb
@@ -11,7 +11,7 @@ describe "filtertable functional tests" do
   end
 
   def failed_control_test_outcomes(run_result)
-    failed_controls = run_result.payload.json["profiles"][0]["controls"].select { |ctl| ctl["results"][0]["status"] == "failed" }
+    failed_controls = @json["profiles"][0]["controls"].select { |ctl| ctl["results"][0]["status"] == "failed" }
 
     # Re-package any failed controls into a hash mapping control_id => message
     # We will later test against this, as it provides more informative test output
@@ -37,7 +37,7 @@ describe "filtertable functional tests" do
       _(outcome_hash.keys).must_include(expected_control)
     end
 
-    _(run_result.stderr_ignore_deprecations).must_equal "" # TODO: we have a cli_option_json_config triggering somewhere
+    _(stderr_ignore_deprecations(run_result)).must_equal "" # TODO: we have a cli_option_json_config triggering somewhere
     assert_exit_code 100, run_result
   end
 

--- a/test/functional/git_fetcher_test.rb
+++ b/test/functional/git_fetcher_test.rb
@@ -38,12 +38,12 @@ describe "running profiles with git-based dependencies" do
   def assert_relative_fetch_works(profile_name, expected_profiles, expected_controls)
     run_result = run_inspec_process("exec #{git_profiles}/#{profile_name}", json: true)
     assert_empty run_result.stderr
-    run_result.must_have_all_controls_passing
+    assert_json_controls_passing(run_result)
 
     # Should know about the top-level profile and the child profile
-    assert_equal expected_profiles, (run_result.payload.json["profiles"].map { |p| p["name"] })
+    assert_equal expected_profiles, (@json["profiles"].map { |p| p["name"] })
 
-    controls = run_result.payload.json["profiles"].map { |p| p["controls"] }.flatten.map { |c| c["id"] }.uniq
+    controls = @json["profiles"].map { |p| p["controls"] }.flatten.map { |c| c["id"] }.uniq
     # Should have controls from the top-level and included child profile
     expected_controls.each { |control| assert_includes controls, control }
 
@@ -58,7 +58,7 @@ describe "running profiles with git-based dependencies" do
     it "should work on a local checkout" do
       run_result = run_inspec_process("exec #{git_profiles}/basic-local", json: true)
       assert_empty run_result.stderr
-      run_result.must_have_all_controls_passing
+      assert_json_controls_passing(run_result)
     end
   end
   # describe "running a profile with a basic remote dependency"

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -156,24 +156,24 @@ describe "inputs" do
     describe "when the --input is used once with one value" do
       let(:input_opt) { "--input test_input_01=value_from_cli_01" }
       let(:control_opt) { "--controls test_control_01" }
-      it("correctly reads the input") { result.must_have_all_controls_passing }
+      it("correctly reads the input") { assert_json_controls_passing(result) }
     end
 
     describe "when the --input is used once with two values" do
       let(:input_opt) { "--input test_input_01=value_from_cli_01 test_input_02=value_from_cli_02" }
-      it("correctly reads the input") { result.must_have_all_controls_passing }
+      it("correctly reads the input") { assert_json_controls_passing(result) }
     end
 
     describe "when the --input is used once with two values and a comma" do
       let(:input_opt) { "--input test_input_01=value_from_cli_01, test_input_02=value_from_cli_02" }
-      it("correctly reads the input") { result.must_have_all_controls_passing }
+      it("correctly reads the input") { assert_json_controls_passing(result) }
     end
 
     describe "when the --input is used twice with one value each" do
       let(:input_opt) { "--input test_input_01=value_from_cli_01 --input test_input_02=value_from_cli_02" }
       let(:control_opt) { "--controls test_control_02" }
       # Expected, though unfortunate, behavior is to only notice the second input
-      it("correctly reads the input") { result.must_have_all_controls_passing }
+      it("correctly reads the input") { assert_json_controls_passing(result) }
     end
 
     describe "when the --input is used with no equal sign" do
@@ -205,14 +205,14 @@ describe "inputs" do
 
       result = run_inspec_process(cmd, json: true)
 
-      result.must_have_all_controls_passing
+      assert_json_controls_passing(result)
     end
     it "is able to read the inputs using the legacy attribute keyword" do
       cmd = "exec #{inputs_profiles_path}/legacy-attributes-dsl"
 
       result = run_inspec_process(cmd, json: true)
 
-      result.must_have_all_controls_passing
+      assert_json_controls_passing(result)
     end
   end
 
@@ -223,7 +223,7 @@ describe "inputs" do
 
       result = run_inspec_process(cmd, json: true)
 
-      result.must_have_all_controls_passing
+      assert_json_controls_passing(result)
       _(result.stderr).must_be_empty
     end
 
@@ -232,7 +232,7 @@ describe "inputs" do
 
       result = run_inspec_process(cmd, json: true)
 
-      result.must_have_all_controls_passing
+      assert_json_controls_passing(result)
       # Will eventually issue deprecation warning
     end
 
@@ -272,7 +272,7 @@ describe "inputs" do
 
         result = run_inspec_process(cmd, json: true)
 
-        result.must_have_all_controls_passing
+        assert_json_controls_passing(result)
       end
     end
   end
@@ -285,7 +285,7 @@ describe "inputs" do
 
       _(result.stderr).must_include "WARN: Input 'undeclared_01'"
       _(result.stderr).must_include "does not have a value"
-      result.must_have_all_controls_passing
+      assert_json_controls_passing(result)
     end
   end
 end

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -736,7 +736,7 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
 
   describe "when specifying a config file" do
     let(:run_result) { run_inspec_process("exec " + File.join(profile_path, "simple-metadata") + " " + cli_args, json: true, env: env) }
-    let(:seen_target_id) { run_result.payload.json["platform"]["target_id"] }
+    let(:seen_target_id) { @json["platform"]["target_id"] }
     let(:stderr) { run_result.stderr }
     let(:env) { {} }
 
@@ -769,7 +769,7 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
           result = run_inspec_process( "exec " + File.join(profile_path, "simple-metadata") + " " + cli_args + " ", opts )
 
           _(result.stderr).must_be_empty
-          _(result.payload.json["platform"]["target_id"]).must_equal "from-config-file"
+          _(@json["platform"]["target_id"]).must_equal "from-config-file"
         end
 
         it "detect should exit 0" do
@@ -842,7 +842,7 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
       JSON.parse(json).select { |k, v| %w{name release}.include? k }
     end
     let(:run_result) { run_inspec_process("exec " + File.join(profile_path, "simple-metadata") + " " + cli_args, json: true) }
-    let(:seen_platform) { run_result.payload.json["platform"].select { |k, v| %w{name release target_id}.include? k } }
+    let(:seen_platform) { run_result; @json["platform"].select { |k, v| %w{name release target_id}.include? k } }
     let(:stderr) { run_result.stderr }
 
     describe "when neither target nor backend is specified" do

--- a/test/functional/logging_test.rb
+++ b/test/functional/logging_test.rb
@@ -11,7 +11,7 @@ describe "Deprecation Facility Behavior" do
   let(:run_result) { run_inspec_process(invocation, json: true) }
 
   # Expect one control, 3 results
-  let(:json_result) { run_result.payload.json["profiles"][0]["controls"][0]["results"] }
+  let(:json_result) { run_result; @json["profiles"][0]["controls"][0]["results"] }
 
   describe "when the deprecation is in a custom resource and the deprecate DSL method is used" do
     describe "when the action is to fail the control" do

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -7,7 +7,7 @@ describe "waivers" do
 
   let(:waivers_profiles_path) { "#{profile_path}/waivers" }
   let(:run_result)            { run_inspec_process(cmd, json: true) }
-  let(:controls_by_id)        { run_result.payload.json.dig("profiles", 0, "controls").map { |c| [c["id"], c] }.to_h }
+  let(:controls_by_id)        { run_result; @json.dig("profiles", 0, "controls").map { |c| [c["id"], c] }.to_h }
   let(:cmd)                   { "exec #{waivers_profiles_path}/#{profile_name} --input-file #{waivers_profiles_path}/#{profile_name}/files/#{waiver_file}" }
 
   def assert_test_outcome(expected, control_id)
@@ -92,8 +92,8 @@ describe "waivers" do
     let(:profile_name) { "waiver-wrapper" }
     let(:waiver_file) { "waivers.yaml" }
     it "should set the data in the child but be empty in the wrapper" do
-      json = run_result.payload.json
-      child_profile = json["profiles"].detect { |p| p["name"] == "waiver-child" }
+      run_result
+      child_profile = @json["profiles"].detect { |p| p["name"] == "waiver-child" }
       child_waiver_data = child_profile.dig("controls", 0, "waiver_data")
       assert_instance_of Hash, child_waiver_data
       refute_empty child_waiver_data
@@ -105,7 +105,7 @@ describe "waivers" do
       }
       assert_equal expected_child_waiver_data, child_waiver_data
 
-      wrapper_profile = json["profiles"].detect { |p| p["name"] == "waiver-wrapper" }
+      wrapper_profile = @json["profiles"].detect { |p| p["name"] == "waiver-wrapper" }
       wrapper_waiver_data = wrapper_profile.dig("controls", 0, "waiver_data")
       assert_instance_of Hash, wrapper_waiver_data
       assert_empty wrapper_waiver_data


### PR DESCRIPTION
Folded the json & other payloads into plain ivars on the test.
Found and removed some unused code while I was there.

Fixes #4533.

Signed-off-by: Ryan Davis <zenspider@chef.io>