### PR TITLE
Add support for Windows to resource sys_info

### DIFF
--- a/docs/resources/sys_info.md.erb
+++ b/docs/resources/sys_info.md.erb
@@ -1,6 +1,6 @@
 ---
 title: About the sys_info Resource
-platform: os
+platform: Linux,Windows,Darwin(macOS)
 ---
 
 # sys_info
@@ -57,7 +57,8 @@ Options can be passed as arguments to hostname as well.
 
 <br>
 
-Currently supported arguments to `hostname` on Linux platforms are 'full'|'f'|'fqdn'|'long', 'domain'|'d', 'ip_address'|'i', and 'short'|'s'. Mac currently supports 'full'|'f'|'fqdn'|'long' and 'short'|'s'
+Currently supported arguments to `hostname` are 'full'|'f'|'fqdn'|'long', 'domain'|'d', 'ip_address'|'i', and 'short'|'s'. 
+Mac currently supports 'full'|'f'|'fqdn'|'long' and 'short'|'s'.
 
 ## Matchers
 
@@ -82,11 +83,11 @@ The `domain` property tests the name of the DNS domain:
 
     its('domain') { should eq 'value' }
 
-### ip-address
+### ip_address
 
 The `ip-address` property tests all network addresses of the host:
 
-    its('ip-address') { should eq 'value' }
+    its('ip_address') { should eq 'value' }
 
 ### short
 
@@ -105,3 +106,9 @@ The `manufacturer` matcher tests the host for which standard output is returned:
 The `model` matcher tests the host for which standard output is returned:
 
     its('model') { should eq 'Flux Capacitor' }
+
+### totalmemory_kb
+
+The `totalmemory_kb` matcher tests the totalmemory in size 'kb' for which standard output is returned:
+
+    its('totalmemory_kb') { should eq 8192000 }

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -9,7 +9,7 @@ module Inspec::Resources
     supports platform: "windows"
 
     desc "Use the sys_info resource to test for operating system properties."
-   example <<~EXAMPLE
+    example <<~EXAMPLE
       describe sys_info do
         its('hostname') { should eq 'hostname' }
       end
@@ -53,7 +53,7 @@ module Inspec::Resources
       @cache.info[:totalmemory_kb]
     end
 
-    def hostname 
+    def hostname
       @cache.info[:hostname]
     end
 
@@ -65,7 +65,7 @@ module Inspec::Resources
       "System Information"
     end
   end
-  
+
   class LinuxInfo < SysInfo
     attr_reader :inspec
     def initialize(inspec)
@@ -78,7 +78,7 @@ module Inspec::Resources
       ip = inspec.command("hostname -I").stdout.chomp
       short = inspec.command("hostname -s").stdout.chomp
       manufacturer = inspec.command("cat /sys/class/dmi/id/sys_vendor").stdout.chomp
-      model =  inspec.command("cat /sys/class/dmi/id/product_name").stdout.chomp
+      model = inspec.command("cat /sys/class/dmi/id/product_name").stdout.chomp
       totalmemory_kb = inspec.command("awk '/MemTotal/ {print $2}' /proc/meminfo").stdout.chomp
 
       {

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -3,187 +3,140 @@ require "inspec/resources/powershell"
 
 module Inspec::Resources
   # this resource returns additional system informatio
-  class System < Inspec.resource(1)
+  class SysInfo < Inspec.resource(1)
     name "sys_info"
-    supports platform: "unix"
+    supports platform: "linux"
     supports platform: "windows"
 
-    desc "Use the user InSpec system resource to test for operating system properties."
-    example <<~EXAMPLE
+    desc "Use the sys_info resource to test for operating system properties."
+   example <<~EXAMPLE
       describe sys_info do
-        its('hostname') { should eq 'example.com' }
+        its('hostname') { should eq 'hostname' }
       end
 
       describe sys_info do
-        its('fqdn') { should eq 'user.example.com' }
+        its('fqdn') { should eq 'hostname.example.com' }
       end
 
     EXAMPLE
 
-    %w{ domain fqdn ip_address short }.each do |opt|
-      define_method(opt.to_sym) do
-        hostname(opt)
-      end
-    end
-    @cache = nil
-    
-    def win_cache
-      return {} if !inspec.os.windows?
-      cmd = inspec.command <<-EOF
-        Get-WmiObject Win32_ComputerSystem -Property * | ConvertTo-Json
-      EOF
-
-      return {} if cmd.stdout == ""
-      begin
-        sysinfo = JSON.parse(cmd.stdout)
-      rescue JSON::ParserError => each
-        raise Inspec::Exceptions::ResourceFailed,
-          "Failed to parse JSON from Powershell. " \
-          "Error: #{e}"
-      end
-      return sysinfo
-    end
-
-    # returns the hostname of the local system
-    def hostname(opt = nil)
+    def initialize
       os = inspec.os
+      @cache = nil
+
       if os.linux?
-        linux_hostname(opt)
-      elsif os.darwin?
-        mac_hostname(opt)
+        @cache = LinuxInfo.new(inspec)
       elsif os.windows?
-        opt = "s" if opt.nil?
-        windows_hostname(opt)
+        @cache = WindowsInfo.new(inspec)
       else
-        skip_resource "The `sys_info.hostname` resource is not supported on your OS yet."
-      end
-    end
-    
-    def windows_hostname(opt = nil)
-      if @cache.nil?
-        @cache = win_cache
-      end
-      if !opt.nil?
-        opt = case opt
-          when "f", "long", "fqdn", "full"
-            #https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-computersystem
-            return @cache["DNSHostName"] if (@cache["DomainRole"] == 2 || @cache["DomainRole"] == 0)
-            return "#{@cache["DNSHostName"]}.#{@cache["Domain"]}"
-          when "d", "domain"
-            return nil if (@cache["DomainRole"] == 2 || @cache["DomainRole"] == 0)
-            return @cache["Domain"]
-          when "i", "ip_address"
-            cmd = inspec.command("(Get-WmiObject Win32_NetWorkAdapterConfiguration | Where IPAddress -ne $null | select -Property ipaddress).IPAddress | ConvertTo-Json")
-            return {} if cmd.stdout == ""
-            begin
-              ip = JSON.parse(cmd.stdout)
-            rescue JSON::ParserError => each
-              raise Inspec::Exceptions::ResourceFailed,
-                "Failed to parse JSON from Powershell. " \
-                "Error: #{e}"
-            end
-            return ip
-          when "s", "short"
-            return @cache["DNSHostName"]
-          else "ERROR"
-        end
-      end
-      if opt == "ERROR"
-        skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
+        return skip_resource "The `sys_info` resource is not supported on your OS yet."
       end
     end
 
-    def linux_hostname(opt = nil)
-      if !opt.nil?
-        opt = case opt
-              when "f", "long", "fqdn", "full"
-                " -f"
-              when "d", "domain"
-                " -d"
-              when "i", "ip_address"
-                " -I"
-              when "s", "short"
-                " -s"
-              else
-                "ERROR"
-              end
-      end
-      if opt == "ERROR"
-        skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
-      else
-        inspec.command("hostname#{opt}").stdout.chomp
-      end
+    def domain
+      @cache.info[:domain]
     end
 
-    def mac_hostname(opt = nil)
-      if !opt.nil?
-        opt = case opt
-              when "f", "long", "fqdn", "full"
-                " -f"
-              when "s", "short"
-                " -s"
-              else
-                "ERROR"
-              end
-      end
-      if opt == "ERROR"
-        skip_resource "The `sys_info.hostname` resource is not supported with that option on your OS."
-      else
-        inspec.command("hostname#{opt}").stdout.chomp
-      end
+    def ip_address
+      @cache.info[:ip]
     end
 
-    # returns the Manufacturer of the local system
     def manufacturer
-      os = inspec.os
-      if os.darwin?
-        "Apple Inc."
-      elsif os.linux?
-        inspec.command("cat /sys/class/dmi/id/sys_vendor").stdout.chomp
-      elsif os.windows?
-        if @cache.nil?
-          @cache = win_cache
-        end
-        @cache["Manufacturer"]
-      else
-        skip_resource "The `sys_info.manufacturer` resource is not supported on your OS yet."
-      end
+      @cache.info[:manufacturer]
     end
 
-    # returns the ServerModel of the local system
     def model
-      os = inspec.os
-      if os.darwin?
-        inspec.command("sysctl -n hw.model").stdout.chomp
-      elsif os.linux?
-        inspec.command("cat /sys/class/dmi/id/product_name").stdout.chomp
-      elsif os.windows?
-        if @cache.nil?
-          @cache = win_cache
-        end
-        @cache["Model"]
-      else
-        skip_resource "The `sys_info.model` resource is not supported on your OS yet."
-      end
+      @cache.info[:model]
     end
-    
-    def totalmemory
-      os = inspec.os
-      if os.linux?
-        inspec.command("awk '/MemTotal/ {print $2}' /proc/meminfo").stdout.chomp
-      elsif os.windows?
-        if @cache.nil?
-          @cache = win_cache
-        end
-        #Calculation requried - Windows return bytes where linux returns kB
-        @cache["TotalPhysicalMemory"] / 1024 rescue nil
-      else
-        skip_resource "The `sys_info.totalmemory` resource is not supported on your OS yet."
-      end
+
+    def totalmemory_kb
+      @cache.info[:totalmemory_kb]
+    end
+
+    def hostname 
+      @cache.info[:hostname]
+    end
+
+    def fqdn
+      @cache.info[:fqdn]
     end
 
     def to_s
       "System Information"
+    end
+  end
+  
+  class LinuxInfo < SysInfo
+    attr_reader :inspec
+    def initialize(inspec)
+      @inspec = inspec
+    end
+
+    def info
+      fqdn = inspec.command("hostname -f").stdout.chomp
+      domain = inspec.command("hostname -d").stdout.chomp
+      ip = inspec.command("hostname -I").stdout.chomp
+      short = inspec.command("hostname -s").stdout.chomp
+      manufacturer = inspec.command("cat /sys/class/dmi/id/sys_vendor").stdout.chomp
+      model =  inspec.command("cat /sys/class/dmi/id/product_name").stdout.chomp
+      totalmemory_kb = inspec.command("awk '/MemTotal/ {print $2}' /proc/meminfo").stdout.chomp
+
+      {
+        fqdn: fqdn,
+        domain: domain,
+        ip: ip,
+        hostname: short,
+        manufacturer: manufacturer,
+        model: model,
+        totalmemory_kb: totalmemory_kb,
+      }
+    end
+  end
+
+  class WindowsInfo < SysInfo
+    attr_reader :inspec
+    def initialize(inspec)
+      @inspec = inspec
+    end
+
+    def info
+      cmd = inspec.command <<-EOF
+        Get-WmiObject Win32_ComputerSystem -Property * | convertto-json
+      EOF
+
+      cmd = {} if cmd.stdout == ""
+      begin
+        info = JSON.parse(cmd.stdout)
+      rescue JSON::ParserError => _e
+        return nil
+      end
+
+      ip_cmd = inspec.command("(Get-WmiObject Win32_NetWorkAdapterConfiguration | Where IPAddress -ne $null | select -Property ipaddress).IPAddress | ConvertTo-Json")
+      ip_cmd = {} if ip_cmd.stdout == ""
+      begin
+        ip_info = JSON.parse(ip_cmd.stdout)
+      rescue JSON::ParserError => _e
+        return nil
+      end
+
+      if (info["DomainRole"] == 2 || info["DomainRole"] == 0)
+        fqdn = info["DNSHostName"]
+        domain = nil
+      else
+        fqdn = "#{info["DNSHostName"]}.#{info["Domain"]}"
+        domain = info["Domain"]
+      end
+
+      memory = info["TotalPhysicalMemory"] / 1024 rescue nil
+      {
+        fqdn: fqdn,
+        domain: domain,
+        ip: ip_info,
+        hostname: info["DNSHostName"],
+        manufacturer: info["Manufacturer"],
+        model: info["Model"],
+        totalmemory_kb: memory,
+      }
     end
   end
 end

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -36,44 +36,42 @@ module Inspec::Resources
     end
 
     def domain
-      @cache[:domain]
+      @cache[:domain] || "The `sys_info.domain` resource is not supported on your OS yet."
     end
 
     def ip_address
-      @cache[:ip]
+      @cache[:ip] || "The `sys_info.ip_address` resource is not supported on your OS yet."
     end
 
     def manufacturer
-      @cache[:manufacturer]
+      @cache[:manufacturer] || "The `sys_info.manufacturer` resource is not supported on your OS yet."
     end
 
     def model
-      @cache[:model]
+      @cache[:model] || "The `sys_info.model` resource is not supported on your OS yet."
     end
 
     def totalmemory_kb
-      @cache[:totalmemory_kb]
+      @cache[:totalmemory_kb] || "The `sys_info.totalmemory_kb` resource is not supported on your OS yet."
     end
 
     def hostname(opt = nil)
       case opt
-        when nil
+        when nil, "s", "short"
           @cache[:hostname]
-        when "f","long","fqdn","full"
-          @cache[:fqdn]
-        when "d","domain"
+        when "f", "long", "fqdn", "full"
+          @cache[:fqdn] 
+        when "d", "domain"
           @cache[:domain]
         when "i", "ip_address"
           @cache[:ip_address]
-        when "s","short"
-          @cache[:hostname]
         else
           skip_resource "The sys_info.hostname resource is not supported with that option."
       end
     end
 
     def fqdn
-      @cache[:fqdn]
+      @cache[:fqdn] || "The `sys_info.fqdn` resource is not supported on your OS yet."
     end
 
     def to_s
@@ -94,7 +92,7 @@ module Inspec::Resources
       short = inspec.command("hostname -s").stdout.chomp
       manufacturer = inspec.command("cat /sys/class/dmi/id/sys_vendor").stdout.chomp
       model = inspec.command("cat /sys/class/dmi/id/product_name").stdout.chomp
-      totalmemory_kb = inspec.command("awk '/MemTotal/ {print $2}' /proc/meminfo").stdout.chomp
+      totalmemory_kb = inspec.command("awk '/MemTotal/ {print $2}' /proc/meminfo").stdout.chomp.to_i
 
       {
         fqdn: fqdn,
@@ -142,7 +140,7 @@ module Inspec::Resources
         domain = info["Domain"]
       end
 
-      memory = info["TotalPhysicalMemory"] / 1024 rescue nil
+      memory = info.fetch("TotalPhysicalMemory", 0) / 1024
       {
         fqdn: fqdn,
         domain: domain,
@@ -163,21 +161,15 @@ module Inspec::Resources
 
     def info
       fqdn = inspec.command("hostname -f").stdout.chomp
-      domain = "The `sys_info.domain` is not supported on your OS yet."
-      ip = "The `sys_info.ip_adress` is not supported on your OS yet."
       short = inspec.command("hostname -s").stdout.chomp
       manufacturer = "Apple Inc."
       model = inspec.command("sysctl -n hw.model").stdout.chomp
-      totalmemory_kb = "The `sys_info.totalmemory_kb` is not supported on your OS yet."
 
       {
         fqdn: fqdn,
-        domain: domain,
-        ip: ip,
         hostname: short,
         manufacturer: manufacturer,
         model: model,
-        totalmemory_kb: totalmemory_kb,
       }
     end
   end

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -55,8 +55,21 @@ module Inspec::Resources
       @cache[:totalmemory_kb]
     end
 
-    def hostname
-      @cache[:hostname]
+    def hostname(opt = nil)
+      case opt
+        when nil
+          @cache[:hostname]
+        when "f","long","fqdn","full"
+          @cache[:fqdn]
+        when "d","domain"
+          @cache[:domain]
+        when "i", "ip_address"
+          @cache[:ip_address]
+        when "s","short"
+          @cache[:hostname]
+        else
+          skip_resource "The sys_info.hostname resource is not supported with that option."
+      end
     end
 
     def fqdn
@@ -121,7 +134,7 @@ module Inspec::Resources
         return nil
       end
 
-      if (info["DomainRole"] == 2 || info["DomainRole"] == 0)
+      if info["DomainRole"] == 2 || info["DomainRole"] == 0
         fqdn = info["DNSHostName"]
         domain = nil
       else
@@ -167,5 +180,5 @@ module Inspec::Resources
         totalmemory_kb: totalmemory_kb,
       }
     end
-  end 
+  end
 end

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -25,40 +25,42 @@ module Inspec::Resources
       @cache = nil
 
       if os.linux?
-        @cache = LinuxInfo.new(inspec)
+        @cache = LinuxInfo.new(inspec).info
       elsif os.windows?
-        @cache = WindowsInfo.new(inspec)
+        @cache = WindowsInfo.new(inspec).info
+      elsif os.darwin?
+        @cache = DarwinInfo.new(inspec).info
       else
         return skip_resource "The `sys_info` resource is not supported on your OS yet."
       end
     end
 
     def domain
-      @cache.info[:domain]
+      @cache[:domain]
     end
 
     def ip_address
-      @cache.info[:ip]
+      @cache[:ip]
     end
 
     def manufacturer
-      @cache.info[:manufacturer]
+      @cache[:manufacturer]
     end
 
     def model
-      @cache.info[:model]
+      @cache[:model]
     end
 
     def totalmemory_kb
-      @cache.info[:totalmemory_kb]
+      @cache[:totalmemory_kb]
     end
 
     def hostname
-      @cache.info[:hostname]
+      @cache[:hostname]
     end
 
     def fqdn
-      @cache.info[:fqdn]
+      @cache[:fqdn]
     end
 
     def to_s
@@ -139,4 +141,31 @@ module Inspec::Resources
       }
     end
   end
+
+  class DarwinInfo < SysInfo
+    attr_reader :inspec
+    def initialize(inspec)
+      @inspec = inspec
+    end
+
+    def info
+      fqdn = inspec.command("hostname -f").stdout.chomp
+      domain = "The `sys_info.domain` is not supported on your OS yet."
+      ip = "The `sys_info.ip_adress` is not supported on your OS yet."
+      short = inspec.command("hostname -s").stdout.chomp
+      manufacturer = "Apple Inc."
+      model = inspec.command("sysctl -n hw.model").stdout.chomp
+      totalmemory_kb = "The `sys_info.totalmemory_kb` is not supported on your OS yet."
+
+      {
+        fqdn: fqdn,
+        domain: domain,
+        ip: ip,
+        hostname: short,
+        manufacturer: manufacturer,
+        model: model,
+        totalmemory_kb: totalmemory_kb,
+      }
+    end
+  end 
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The resource sys_info was designed to support Linux and Windows OS.
The latest changes for (hostname) didn´t include the Windows support.
On Windows (OS) it Always returns that hostname is not supported for the OS yet.

In regards to #4570 i tried to add some of the Features for Windows.
This pull - is just a first guess. Maybe its better to re-design the whole resource to support
some kind of "initialize" method and have all data directly available?

Since most of the Windows "sys_info" are stored in the Win32_ComputerSystem i decided to create a "Cache" that holds all Information, instead of running a single query for every Attribute.

In case the functionality is welcome please provide me some hints how it should look like to fit into inspec. I will take care of These changes.

If its okay for you - the documentation and test updates will follow as soon as we have an allignment ?

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#4570 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [x] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
