### PR TITLE
Fix config reference in `compliance exec`

### DIFF
--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
@@ -72,10 +72,10 @@ module InspecPlugins
       desc "exec PROFILE", "executes a #{COMPLIANCE_PRODUCT_NAME} profile"
       exec_options
       def exec(*tests)
-        config = InspecPlugins::Compliance::Configuration.new
-        return unless loggedin(config)
+        compliance_config = InspecPlugins::Compliance::Configuration.new
+        return unless loggedin(compliance_config)
 
-        o = opts(:exec).dup
+        o = config # o is an Inspec::Config object, provided by a helper method from Inspec::BaseCLI
         diagnose(o)
         configure_logger(o)
 


### PR DESCRIPTION
Fixes #3891

When the `Inspec::Config` system was installed in March 2019, the method to fetch the configuration was renamed from `opts` to `config`. Core CLI commands got the update, but apparently the `compliance` CLI plugin did not get updated. I checked the other plugins, no other plugins are affected.

This was manually tested, due to the need to spin up an Automate instance - I used the instructions from [here](https://learn.chef.io/modules/try-chef-automate#/); interestingly, there are the remnants of some integration tests (which are a long way from working now) at https://github.com/inspec/inspec/blob/master/lib/plugins/inspec-compliance/test/integration/default/cli.rb . 

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

