### PR TITLE
Nginx Resource: Add parsing support for wildcard, dot prefix, and regex

### DIFF
--- a/lib/inspec/utils/nginx_parser.rb
+++ b/lib/inspec/utils/nginx_parser.rb
@@ -25,8 +25,12 @@ class NginxParser < Parslet::Parser
     str('"') >> (str('"').absent? >> any).repeat.as(:identifier) >> str('"') >> space.repeat
   end
 
+  rule(:regex_identifier) do
+    (str("~") >> match('\S').repeat).as(:identifier) >> space >> space.repeat
+  end
+
   rule(:identifier) do
-    standard_identifier | quoted_identifier
+    standard_identifier | quoted_identifier | regex_identifier
   end
 
   rule(:standard_value) do

--- a/lib/inspec/utils/nginx_parser.rb
+++ b/lib/inspec/utils/nginx_parser.rb
@@ -18,19 +18,15 @@ class NginxParser < Parslet::Parser
   end
 
   rule(:standard_identifier) do
-    (match("[a-zA-Z]") >> match('\S').repeat).as(:identifier) >> space >> space.repeat
+    (match("[a-zA-Z~*.]") >> match('\S').repeat).as(:identifier) >> space >> space.repeat
   end
 
   rule(:quoted_identifier) do
     str('"') >> (str('"').absent? >> any).repeat.as(:identifier) >> str('"') >> space.repeat
   end
 
-  rule(:regex_identifier) do
-    (str("~") >> match('\S').repeat).as(:identifier) >> space >> space.repeat
-  end
-
   rule(:identifier) do
-    standard_identifier | quoted_identifier | regex_identifier
+    standard_identifier | quoted_identifier
   end
 
   rule(:standard_value) do

--- a/test/unit/utils/nginx_parser_test.rb
+++ b/test/unit/utils/nginx_parser_test.rb
@@ -89,6 +89,15 @@ describe NginxParser do
   it "parses regex identifiers for assignments" do
     _(parsestr(%{~^\/opcache-api 1;})).must_equal "[{:assignment=>{:identifier=>\"~^/opcache-api\"@0, :args=>[{:value=>\"1\"@15}]}}]"
   end
+
+  it "parses wildcard identifiers for assignments" do
+    _(parsestr(%{*.example.org qa;})).must_equal "[{:assignment=>{:identifier=>\"*.example.org\"@0, :args=>[{:value=>\"qa\"@14}]}}]"
+  end
+
+  it "parses dot-prefixed identifiers for assignments" do
+    _(parsestr(%{.example.com test;})).must_equal "[{:assignment=>{:identifier=>\".example.com\"@0, :args=>[{:value=>\"test\"@13}]}}]"
+  end
+
 end
 
 describe NginxTransform do

--- a/test/unit/utils/nginx_parser_test.rb
+++ b/test/unit/utils/nginx_parser_test.rb
@@ -85,6 +85,10 @@ describe NginxParser do
   it "parses quoted identifiers for assignments" do
     _(parsestr(%{"~^\/opcache-api" 1;})).must_equal "[{:assignment=>{:identifier=>\"~^/opcache-api\"@1, :args=>[{:value=>\"1\"@17}]}}]"
   end
+
+  it "parses regex identifiers for assignments" do
+    _(parsestr(%{~^\/opcache-api 1;})).must_equal "[{:assignment=>{:identifier=>\"~^/opcache-api\"@0, :args=>[{:value=>\"1\"@15}]}}]"
+  end
 end
 
 describe NginxTransform do


### PR DESCRIPTION
My changes updates the nginx config parser to support wildcard, dot, and regex(~) prefixed keys. It fixes the issues #3611 has reported, but it does not support rows without a key/value pair.

Parses correctly
```
http {
    map $http_host $site_name {
        default test;
        ~^www\..*$  production;
        ~^stage\..*$  staging;
        ~^test\..*$  test;
        ~^qa\..*$  qa;
        .example.com test;
        *.example.org qa;
    }
}
```
Output 
```
{"http"=>
  [{"map"=>
     [{"_"=>["$http_host", "$site_name"],
       "default"=>[["test"]],
       "~^www\\..*$"=>[["production"]],
       "~^stage\\..*$"=>[["staging"]],
       "~^test\\..*$"=>[["test"]],
       "~^qa\\..*$"=>[["qa"]],
       ".example.com"=>[["test"]],
       "*.example.org"=>[["qa"]]}]}]}
```

Doesn't parse correctly.
```
http {
    map $http_host $site_name {
        hostnames;
        default test;
        ~^www\..*$  production;
        ~^stage\..*$  staging;
        ~^test\..*$  test;
        ~^qa\..*$  qa;
        .example.com test;
        *.example.org qa;
    }
}
```
Output
```
{"http"=>
  [{"map"=>
     [{"_"=>["$http_host", "$site_name"],
       "hostnames;"=>[["default", "test"]],
       "~^www\\..*$"=>[["production"]],
       "~^stage\\..*$"=>[["staging"]],
       "~^test\\..*$"=>[["test"]],
       "~^qa\\..*$"=>[["qa"]],
       ".example.com"=>[["test"]],
       "*.example.org"=>[["qa"]]}]}]}
```

Signed-off-by: Landy Chan Landychan92@gmail.com



## Related Issue
#3611

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
