### PR TITLE
oracledb_session fixes

### DIFF
--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -1,5 +1,4 @@
 require "inspec/resources/command"
-require "hashie/mash"
 require "inspec/utils/database_helpers"
 require "htmlentities"
 require "rexml/document"
@@ -21,8 +20,8 @@ module Inspec::Resources
       end
     EXAMPLE
 
-    attr_reader :user, :password, :host, :port, :service,
-                :db_role, :su_user, :bin
+    attr_reader :bin, :db_role, :host, :password, :port, :service,
+                :su_user, :user
 
     def initialize(opts = {})
       @user = opts[:user]
@@ -74,7 +73,7 @@ module Inspec::Resources
     # su, using a db_role
     def command_builder(format_options, query)
       verified_query = verify_query(query)
-      sql_prefix, sql_postfix = ""
+      sql_prefix, sql_postfix = "", ""
       if inspec.os.windows?
         sql_prefix = %{@'\n#{format_options}\n#{verified_query}\nEXIT\n'@ | }
       else

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -40,11 +40,7 @@ module Inspec::Resources
     end
 
     def query(q)
-      escaped_query = q.gsub(/\\/, '\\\\').gsub(/"/, '\\"')
-      # escape tables with $
-      escaped_query = escaped_query.gsub("$", '\\$')
 
-      p = nil
       # use sqlplus if sqlcl is not available
       if @sqlcl_bin && inspec.command(@sqlcl_bin).exist?
         bin = @sqlcl_bin
@@ -59,13 +55,6 @@ module Inspec::Resources
       command = command_builder(format_options, sql)
       cmd = inspec.command(command)
 
-      out = cmd.stdout + "\n" + cmd.stderr
-      if out.downcase =~ /^error/
-        # TODO: we need to throw an exception here
-        # change once https://github.com/chef/inspec/issues/1205 is in
-        warn "Could not execute the sql query #{out}"
-        DatabaseHelper::SQLQueryResult.new(cmd, Hashie::Mash.new({}))
-      end
       DatabaseHelper::SQLQueryResult.new(cmd, send(p, cmd.stdout))
     end
 

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -33,6 +33,7 @@ module Inspec::Resources
         Inspec.deprecate(:oracledb_session_pass_option, "The oracledb_session `pass` option is deprecated. Please use `password`.")
       end
 
+      @bin = "sqlplus"
       @host = opts[:host] || "localhost"
       @port = opts[:port] || "1521"
       @service = opts[:service]

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -41,11 +41,12 @@ module Inspec::Resources
       @db_role = opts[:as_db_role]
       @sqlcl_bin = opts[:sqlcl_bin] || nil
       @sqlplus_bin = opts[:sqlplus_bin] || "sqlplus"
+      skip_resource "Option 'as_os_user' not available in Windows" if inspec.os.windows? && su_user
+      fail_resource "Can't run Oracle checks without authentication" unless su_user && (user || password)
+      fail_resource "You must provide a service name for the session" unless service
     end
 
     def query(sql)
-      pre_flight_check
-
       # use sqlplus if sqlcl is not available
       if @sqlcl_bin && inspec.command(@sqlcl_bin).exist?
         @bin = @sqlcl_bin
@@ -68,12 +69,6 @@ module Inspec::Resources
     end
 
     private
-
-    def pre_flight_check
-      skip_resource "Option 'as_os_user' not available in Windows" if inspec.os.windows? && su_user
-      fail_resource "Can't run Oracle checks without authentication" unless su_user && (user || password)
-      fail_resource "You must provide a service name for the session" unless service
-    end
 
     # 3 commands
     # regular user password

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -69,9 +69,9 @@ module Inspec::Resources
     private
 
     def pre_flight_check
-      return skip_resource "Option 'as_os_user' not available in Windows" if inspec.os.windows? && su_user
-      return fail_resource "Can't run Oracle checks without authentication" unless su_user && (user || password)
-      return fail_resource "You must provide a service name for the session" unless service
+      skip_resource "Option 'as_os_user' not available in Windows" if inspec.os.windows? && su_user
+      fail_resource "Can't run Oracle checks without authentication" unless su_user && (user || password)
+      fail_resource "You must provide a service name for the session" unless service
     end
 
     # 3 commands

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -57,7 +57,6 @@ module Inspec::Resources
       end
 
       query = verify_query(escaped_query)
-      query += ";" unless query.end_with?(";")
       if @db_role.nil?
         command = %{#{bin} "#{@user}"/"#{@password}"@#{@host}:#{@port}/#{@service} <<EOC\n#{opts}\n#{query}\nEXIT\nEOC}
       elsif @su_user.nil?
@@ -89,8 +88,7 @@ module Inspec::Resources
       return fail_resource "You must provide a service name for the session" unless service
     end
     def verify_query(query)
-      # ensure we have a ; at the end
-      query + ";" unless query.strip.end_with?(";")
+      query += ";" unless query.strip.end_with?(";")
       query
     end
 

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -40,22 +40,23 @@ module Inspec::Resources
     end
 
     def query(sql)
+      pre_flight_check
 
       # use sqlplus if sqlcl is not available
       if @sqlcl_bin && inspec.command(@sqlcl_bin).exist?
-        bin = @sqlcl_bin
-        opts = "set sqlformat csv\nSET FEEDBACK OFF"
-        p = :parse_csv_result
+        @bin = @sqlcl_bin
+        format_options = "set sqlformat csv\nSET FEEDBACK OFF"
+        parser = :parse_csv_result
       else
-        bin = @sqlplus_bin
-        opts = "SET MARKUP HTML ON\nSET PAGESIZE 32000\nSET FEEDBACK OFF"
-        p = :parse_html_result
+        @bin = "#{@sqlplus_bin} -S"
+        format_options = "SET MARKUP HTML ON\nSET PAGESIZE 32000\nSET FEEDBACK OFF"
+        parser = :parse_html_result
       end
 
       command = command_builder(format_options, sql)
       cmd = inspec.command(command)
 
-      DatabaseHelper::SQLQueryResult.new(cmd, send(p, cmd.stdout))
+      DatabaseHelper::SQLQueryResult.new(cmd, send(parser, cmd.stdout))
     end
 
     def to_s

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -39,9 +39,7 @@ module Inspec::Resources
 
       @su_user = opts[:as_os_user]
       @db_role = opts[:as_db_role]
-
-      # we prefer sqlci although it is way slower than sqlplus, but it understands csv properly
-      @sqlcl_bin = "sql" unless opts.key?(:sqlplus_bin) # don't use it if user specified sqlplus_bin option
+      @sqlcl_bin = opts[:sqlcl_bin] || nil
       @sqlplus_bin = opts[:sqlplus_bin] || "sqlplus"
 
       return fail_resource "Can't run Oracle checks without authentication" if @su_user.nil? && (@user.nil? || @password.nil?)

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -56,9 +56,10 @@ module Inspec::Resources
       end
 
       command = command_builder(format_options, sql)
-      cmd = inspec.command(command)
+      inspec_cmd = inspec.command(command)
 
-      DatabaseHelper::SQLQueryResult.new(cmd, send(parser, cmd.stdout))
+      DatabaseHelper::SQLQueryResult.new(inspec_cmd, send(parser,
+                                                          inspec_cmd.stdout))
     end
 
     def to_s

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -39,7 +39,7 @@ module Inspec::Resources
       @sqlplus_bin = opts[:sqlplus_bin] || "sqlplus"
     end
 
-    def query(q)
+    def query(sql)
 
       # use sqlplus if sqlcl is not available
       if @sqlcl_bin && inspec.command(@sqlcl_bin).exist?

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -24,8 +24,6 @@ module Inspec::Resources
     attr_reader :user, :password, :host, :port, :service,
                 :db_role, :su_user, :bin
 
-
-    # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
     def initialize(opts = {})
       @user = opts[:user]
       @password = opts[:password] || opts[:pass]
@@ -47,7 +45,6 @@ module Inspec::Resources
     end
 
     def query(sql)
-      # use sqlplus if sqlcl is not available
       if @sqlcl_bin && inspec.command(@sqlcl_bin).exist?
         @bin = @sqlcl_bin
         format_options = "set sqlformat csv\nSET FEEDBACK OFF"
@@ -114,7 +111,7 @@ module Inspec::Resources
       results
     end
 
-    def parse_html_result(stdout) # rubocop:disable Metrics/AbcSize
+    def parse_html_result(stdout)
       result = stdout
       # make oracle html valid html by removing the p tag, it does not include a closing tag
       result = result.gsub("<p>", "").gsub("</p>", "").gsub("<br>", "")

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -21,7 +21,10 @@ module Inspec::Resources
       end
     EXAMPLE
 
-    attr_reader :user, :password, :host, :service, :as_os_user, :as_db_role
+    attr_reader :user, :password, :host, :port, :service,
+                :db_role, :su_user, :bin
+
+
     # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
     def initialize(opts = {})
       @user = opts[:user]

--- a/test/unit/resources/oracledb_session_test.rb
+++ b/test/unit/resources/oracledb_session_test.rb
@@ -3,6 +3,38 @@ require "inspec/resource"
 require "inspec/resources/oracledb_session"
 
 describe "Inspec::Resources::OracledbSession" do
+  it "Linux" do
+    resource = quick_resource(:oracledb_session, :linux, user: "USER", password: "password", host: "localhost", service: "ORCL", port: 1527, sqlplus_bin: "/bin/sqlplus") do |cmd|
+      cmd.strip!
+      case cmd
+      when "/bin/sqlplus -S \"USER\"/\"password\"@localhost:1527/ORCL <<'EOC'\nSET MARKUP HTML ON\nSET PAGESIZE 32000\nSET FEEDBACK OFF\nSELECT NAME AS VALUE FROM v$database;\nEXIT\nEOC" then
+        stdout_file "test/unit/mock/cmd/oracle-result"
+      else
+        raise cmd.inspect
+      end
+    end
+
+    query = resource.query("SELECT NAME AS VALUE FROM v$database;")
+    _(query.size).must_equal 1
+    _(query.row(0).column("value").value).must_equal "ORCL"
+  end
+
+  it "Windows" do
+    resource = quick_resource(:oracledb_session, :windows, user: "USER", password: "password", host: "localhost", service: "ORCL", port: 1527, sqlplus_bin: "C:/sqlplus.exe") do |cmd|
+      cmd.strip!
+      case cmd
+      when "@'\nSET MARKUP HTML ON\nSET PAGESIZE 32000\nSET FEEDBACK OFF\nSELECT NAME AS VALUE FROM v$database;\nEXIT\n'@ | C:/sqlplus.exe -S \"USER\"/\"password\"@localhost:1527/ORCL" then
+        stdout_file "test/unit/mock/cmd/oracle-result"
+      else
+        raise cmd.inspect
+      end
+    end
+
+    query = resource.query("SELECT NAME AS VALUE FROM v$database;")
+    _(query.size).must_equal 1
+    _(query.row(0).column("value").value).must_equal "ORCL"
+  end
+
   it "verify oracledb_session configuration" do
     resource = load_resource("oracledb_session", user: "SYSTEM", password: "supersecurepass", host: "localhost", service: "ORCL.localdomain")
     _(resource.user).must_equal "SYSTEM"

--- a/test/unit/resources/oracledb_session_test.rb
+++ b/test/unit/resources/oracledb_session_test.rb
@@ -3,7 +3,7 @@ require "inspec/resource"
 require "inspec/resources/oracledb_session"
 
 describe "Inspec::Resources::OracledbSession" do
-  it "Linux" do
+  it "sqlplus Linux" do
     resource = quick_resource(:oracledb_session, :linux, user: "USER", password: "password", host: "localhost", service: "ORCL", port: 1527, sqlplus_bin: "/bin/sqlplus") do |cmd|
       cmd.strip!
       case cmd
@@ -14,12 +14,13 @@ describe "Inspec::Resources::OracledbSession" do
       end
     end
 
+    _(resource.resource_skipped?).must_equal false
     query = resource.query("SELECT NAME AS VALUE FROM v$database;")
     _(query.size).must_equal 1
     _(query.row(0).column("value").value).must_equal "ORCL"
   end
 
-  it "Windows" do
+  it "sqlplus Windows" do
     resource = quick_resource(:oracledb_session, :windows, user: "USER", password: "password", host: "localhost", service: "ORCL", port: 1527, sqlplus_bin: "C:/sqlplus.exe") do |cmd|
       cmd.strip!
       case cmd
@@ -30,16 +31,42 @@ describe "Inspec::Resources::OracledbSession" do
       end
     end
 
+    _(resource.resource_skipped?).must_equal false
     query = resource.query("SELECT NAME AS VALUE FROM v$database;")
     _(query.size).must_equal 1
     _(query.row(0).column("value").value).must_equal "ORCL"
   end
 
+  it "skipped when sqlplus Windows as_os_user" do
+    resource = quick_resource(:oracledb_session, :windows, user: "USER", password: "password", host: "localhost", service: "ORCL", port: 1527, sqlplus_bin: "C:/sqlplus.exe", as_os_user: "Administrator")
+
+    _(resource.resource_skipped?).must_equal true
+    _(resource.resource_exception_message).must_equal "Option 'as_os_user' not available in Windows"
+  end
+
+  it "fails when no user, password, or su" do
+    resource = quick_resource(:oracledb_session, :windows, host: "localhost", service: "ORCL", port: 1527, sqlplus_bin: "C:/sqlplus.exe")
+
+    _(resource.resource_failed?).must_equal true
+    _(resource.resource_exception_message).must_equal "Can't run Oracle checks without authentication"
+  end
+
+  it "fails when no service name is provided" do
+    resource = quick_resource(:oracledb_session, :windows, user: "USER", password: "password", host: "localhost", port: 1527, sqlplus_bin: "C:/sqlplus.exe")
+
+    _(resource.resource_failed?).must_equal true
+    _(resource.resource_exception_message).must_equal "You must provide a service name for the session"
+  end
+
   it "verify oracledb_session configuration" do
-    resource = load_resource("oracledb_session", user: "SYSTEM", password: "supersecurepass", host: "localhost", service: "ORCL.localdomain")
-    _(resource.user).must_equal "SYSTEM"
-    _(resource.password).must_equal "supersecurepass"
+    resource = quick_resource(:oracledb_session, :linux, user: "USER", password: "password", host: "localhost", service: "ORCL", as_db_role: "dbrole", as_os_user: "osuser")
+    _(resource.user).must_equal "USER"
+    _(resource.password).must_equal "password"
     _(resource.host).must_equal "localhost"
-    _(resource.service).must_equal "ORCL.localdomain"
+    _(resource.port).must_equal "1521"
+    _(resource.service).must_equal "ORCL"
+    _(resource.db_role).must_equal "dbrole"
+    _(resource.su_user).must_equal "osuser"
+    _(resource.bin).must_equal "sqlplus"
   end
 end

--- a/test/unit/resources/oracledb_session_test.rb
+++ b/test/unit/resources/oracledb_session_test.rb
@@ -42,11 +42,4 @@ describe "Inspec::Resources::OracledbSession" do
     _(resource.host).must_equal "localhost"
     _(resource.service).must_equal "ORCL.localdomain"
   end
-
-  it "run a SQL query" do
-    resource = load_resource("oracledb_session", user: "SYSTEM", password: "supersecurepass", host: "127.0.0.1", service: "ORCL.localdomain", port: 1527)
-    query = resource.query("SELECT NAME AS VALUE FROM v$database;")
-    _(query.size).must_equal 1
-    _(query.row(0).column("value").value).must_equal "ORCL"
-  end
 end


### PR DESCRIPTION
- Fixes here documents on Windows. Windows uses a different format `@''@` and you need to pipe that to your app.
- Fixes here documents on UNIX. Bash will no longer interpolate SQL Queries into shell environment variables. You shouldn't need to use crazy escape techniques anymore! (This fix should apply to windows as well!)
- Added a bunch of tests for sqlplus, linux, and windows.
- Did _NOT_ test sqlcl / csv parsing. That will have to be separate work.

Fixes #4641 #3680 #3594 #3655 #3255