### PR TITLE
Change "an Chef Inspec" to "a Chef Inspec".

### DIFF
--- a/docs/dsl_inspec.md
+++ b/docs/dsl_inspec.md
@@ -54,7 +54,7 @@ where
 * `tag` is optional meta-information with with key or key-value pairs
 * `ref` is a reference to an external document
 * `describe` is a block that contains at least one test. A `control` block must contain at least one `describe` block, but may contain as many as required
-* `sshd_config` is an Chef InSpec resource. For the full list of Chef InSpec resources, see Chef InSpec resource documentation
+* `sshd_config` is a Chef InSpec resource. For the full list of Chef InSpec resources, see Chef InSpec resource documentation
 * `its('Port')` is the matcher; `{ should eq '22' }` is the test. A `describe` block must contain at least one matcher, but may contain as many as required
 
 ## Advanced concepts
@@ -280,8 +280,8 @@ Core and custom resources are written as regular Ruby classes which inherit from
 
 ## Interactive Debugging with Pry
 
-Here's a sample Chef InSpec control that users Ruby variables to instantiate
-an Chef InSpec resource once and use the content in multiple tests.
+Here's a sample Chef InSpec control that uses Ruby variables to instantiate
+a Chef InSpec resource once and use the content in multiple tests.
 
 ```ruby
 control 'check-perl' do

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -128,7 +128,7 @@ A [resource](#resource) that is _not_ included with InSpec. It may be a resource
 
 ### describe block
 
-The _`describe`_ keyword is used with a _`describe block`_ to refer to an Chef InSpec resource. You use the `describe` keyword along with the name of a [resource](#resource) to enclose related [tests](#test) that apply to the resource. Multiple describe blocks are usually grouped together in a [control](#control), but you can also use them outside of a control.
+The _`describe`_ keyword is used with a _`describe block`_ to refer to a Chef InSpec resource. You use the `describe` keyword along with the name of a [resource](#resource) to enclose related [tests](#test) that apply to the resource. Multiple describe blocks are usually grouped together in a [control](#control), but you can also use them outside of a control.
 
 ```Ruby
 control 'Rule 1.1 - Color restrictions' do

--- a/docs/habitat.md
+++ b/docs/habitat.md
@@ -4,7 +4,7 @@ title: Chef InSpec Integration with Chef Habitat
 
 # Chef Habitat Integration
 
-Chef InSpec provides an easy method to create an executable Chef Habitat package for an Chef InSpec profile. When run via the Chef Habitat Supervisor, the package will run Chef InSpec with your profile and write out its findings to the supervisor log. This provides the ability to ship your compliance controls alongside your Chef Habitat-packaged application and continuously run InSpec, providing you *Continuous Compliance.*
+Chef InSpec provides an easy method to create an executable Chef Habitat package for a Chef InSpec profile. When run via the Chef Habitat Supervisor, the package will run Chef InSpec with your profile and write out its findings to the supervisor log. This provides the ability to ship your compliance controls alongside your Chef Habitat-packaged application and continuously run InSpec, providing you *Continuous Compliance.*
 
 ## What is Chef Habitat
 
@@ -14,7 +14,7 @@ To learn more about Chef Habitat and try our demos and tutorials, visit [https:/
 
 ## Using the Chef Habitat Integration
 
-After creating a Chef Habitat package for an Chef InSpec profile (see CLI commands below) and uploading the package to a Chef Habitat Depot or manually distributing to a host, start the Chef Habitat Supervisor with your package:
+After creating a Chef Habitat package for a Chef InSpec profile (see CLI commands below) and uploading the package to a Chef Habitat Depot or manually distributing to a host, start the Chef Habitat Supervisor with your package:
 
 ```bash
 hab start effortless/audit-baseline
@@ -70,7 +70,7 @@ Chef InSpec will write a JSON file in the `${svc_var_path}/inspec_results` direc
 
 ### inspec habitat profile create
 
-Create a Chef Habitat package for an Chef InSpec profile. Chef InSpec will validate the profile, fetch and vendor any dependencies (if necessary), and build the Chef Habitat package with a dependency on the latest InSpec. The resulting package will be saved to the current working directory.
+Create a Chef Habitat package for a Chef InSpec profile. Chef InSpec will validate the profile, fetch and vendor any dependencies (if necessary), and build the Chef Habitat package with a dependency on the latest InSpec. The resulting package will be saved to the current working directory.
 
 The package can then be manually uploaded to a Chef Habitat Depot or manually distributed to a host and installed via `hab pkg install`.
 
@@ -154,7 +154,7 @@ inspec habitat profile setup ~/profiles/frontend1
 
 ### inspec habitat profile upload
 
-Create and then upload a Chef Habitat package for an Chef InSpec profile. Like the `inspec habitat profile create` command, Chef InSpec will validate the profile, fetch and vendor any dependencies (if necessary), and build the Chef Habitat package with a dependency on the latest InSpec. However, instead of saving the package locally to the workstation, Chef InSpec will upload it to the depot defined in the `HAB_DEPOT` environment variable. If `HAB_DEPOT` is not defined, the package will be uploaded to the public Chef Habitat depot at [https://app.habitat.sh](https://app.habitat.sh).
+Create and then upload a Chef Habitat package for a Chef InSpec profile. Like the `inspec habitat profile create` command, Chef InSpec will validate the profile, fetch and vendor any dependencies (if necessary), and build the Chef Habitat package with a dependency on the latest InSpec. However, instead of saving the package locally to the workstation, Chef InSpec will upload it to the depot defined in the `HAB_DEPOT` environment variable. If `HAB_DEPOT` is not defined, the package will be uploaded to the public Chef Habitat depot at [https://app.habitat.sh](https://app.habitat.sh).
 
 #### Syntax
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -51,7 +51,7 @@ For more details on what the `plugin` command can do, see the [online help](http
 
 ### Chef InSpec Plugins
 
-For details on how to author an Chef InSpec Plugin, see the [developer documentation](https://github.com/inspec/inspec/blob/master/docs/dev/plugins.md)
+For details on how to author a Chef InSpec Plugin, see the [developer documentation](https://github.com/inspec/inspec/blob/master/docs/dev/plugins.md)
 
 ### Train Plugins
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -158,7 +158,7 @@ supports:
 
 # Profile Dependencies
 
-An Chef InSpec profile can bring in the controls and custom resources from another Chef InSpec profile. Additionally, when inheriting the controls of another profile, a profile can skip or even modify those included controls.
+A Chef InSpec profile can bring in the controls and custom resources from another Chef InSpec profile. Additionally, when inheriting the controls of another profile, a profile can skip or even modify those included controls.
 
 For hands-on examples, check out [Create a custom Chef InSpec profile](https://learn.chef.io/modules/create-a-custom-profile#/) on Learn Chef Rally.
 
@@ -340,7 +340,7 @@ Our documentation regarding [Inputs](https://www.inspec.io/docs/reference/inputs
 
 # Profile files
 
-An Chef InSpec profile may contain additional files that can be accessed during tests. A profile file enables you to separate the logic of your tests from the data your tests check for, for example, the list of ports you require to be open.
+A Chef InSpec profile may contain additional files that can be accessed during tests. A profile file enables you to separate the logic of your tests from the data your tests check for, for example, the list of ports you require to be open.
 
 To access these files, they must be stored in the `files` directory at the root of a profile. They are accessed by their name relative to this folder with `inspec.profile.file(...)`.
 

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -6,7 +6,7 @@ title: Chef InSpec Reporters
 
 Introduced in Chef InSpec 1.51.6
 
-A `reporter` is a facility for formatting and delivering the results of an Chef InSpec auditing run.
+A `reporter` is a facility for formatting and delivering the results of a Chef InSpec auditing run.
 
 Chef InSpec allows you to output your test results to one or more reporters. Configure the reporter(s) using either the `--reporter` option or as part of the general config file using the `--config` (or `--json-config`, prior to v3.6) option. While you can configure multiple reporters to write to different files, only one reporter can output to the screen(stdout).
 

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -46,7 +46,7 @@ $ inspec shell -t docker://container_id # Login to a Docker container.
 ## Resource Packs
 
 Use resource packs to share custom resources with other Chef InSpec users.
-A resource pack is an Chef InSpec profile that contains only custom resources and no other controls or tests.
+A resource pack is a Chef InSpec profile that contains only custom resources and no other controls or tests.
 
 For example, the profile in [`examples/profile`](https://github.com/chef/inspec/tree/master/examples/profile)in the Chef InSpec git repo defines a [`example_config` resource](https://github.com/chef/inspec/blob/master/examples/profile/controls/example.rb). To use these resources within the Chef InSpec shell, you will need to download and specify them as a dependency.
 


### PR DESCRIPTION
Documentation only changes

Change "an Chef Inspec" to "a Chef Inspec".

Change "that users Ruby variables" to "that uses Ruby variables".

Obvious fix.

Signed-off-by: Ken Crouch <kcrouch@chef.io>

Changed a few typos in the documentation

## Description
Improves documentation

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
