### PR TITLE
Fix auditd resource processing of action and list

### DIFF
--- a/lib/inspec/resources/auditd.rb
+++ b/lib/inspec/resources/auditd.rb
@@ -187,8 +187,20 @@ module Inspec::Resources
       line.scan(/-S ([^ ]+)\s?/).flatten.first.split(",")
     end
 
+    # Processes the line and returns a pair of entries reflecting the 'action'
+    # and 'list' items.
+    #
+    # @return [Array[String,String]]
     def action_list_for(line)
-      line.scan(/-a ([^,]+),([^ ]+)\s?/).flatten
+      action_list = line.scan(/-a ([^,]+),([^ ]+)\s?/).flatten
+
+      # Actions and lists can be in either order
+      valid_actions = %w{never always}
+
+      [
+        (action_list & valid_actions).first,
+        (action_list - valid_actions).first,
+      ]
     end
 
     def key_for(line)

--- a/test/fixtures/cmd/auditctl
+++ b/test/fixtures/cmd/auditctl
@@ -2,7 +2,7 @@
 -a always,exit -F arch=b32 -S open,openat -F exit=-EPERM -F key=access
 -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=500 f24!=0 -F key=perm_mod
 -a always,exit -S all -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=-1 -F key=privileged
--a always,exit -S all -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=-1 -F key=privileged
+-a exit,always -S all -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=-1 -F key=privileged
 -w /etc/ssh/sshd_config -p rwxa -k CFG_sshd_config
 -w /etc/sudoers -p wa
 -w /etc/private-keys -p x


### PR DESCRIPTION
Per auditctl(8), the -a option can have either list,action or
action,list. This PR matches against valid actions for the action field
and passed the remainder off to the list field.

Closes #4664