### PR TITLE
Make input() work in describe.one

### DIFF
--- a/lib/inspec/describe_base.rb
+++ b/lib/inspec/describe_base.rb
@@ -22,11 +22,6 @@ module Inspec
       @action.call("describe.one", @checks, nil)
     end
 
-    def __profile_id
-      # Excavate the profile ID. The action is a Method calling __add_check on a Rule whose profile ID we want
-      @action.receiver.instance_variable_get(:@__profile_id)
-    end
-
     def input(input_name, options = {})
       input_with_profile_id(__profile_id, input_name, options)
     end
@@ -42,5 +37,17 @@ module Inspec
     def describe(*args, &block)
       @checks.push(["describe", args, block])
     end
+
+    private
+
+    # While this is marked private, it gets consumed during an instance_eval,
+    # so it is fully visible. The double underscore is there to discourage
+    # use - this is a private API.
+    def __profile_id
+      # Excavate the profile ID. The action is a Method calling __add_check on
+      # a Rule whose profile ID we want
+      @action.receiver.instance_variable_get(:@__profile_id)
+    end
+
   end
 end

--- a/lib/inspec/describe_base.rb
+++ b/lib/inspec/describe_base.rb
@@ -17,6 +17,30 @@ module Inspec
       @action.call("describe.one", @checks, nil)
     end
 
+    def __profile_id
+      # Excavate the profile ID. The action is a Method calling __add_check on a Rule whose profile ID we want
+      @action.receiver.instance_variable_get(:@__profile_id)
+    end
+
+    def input(input_name, options = {})
+      profile_id = __profile_id
+
+      # TODO: DRY up - remainder of this code is identical to input() in rspec_extensions.rb
+      if options.empty?
+        # Simply an access, no event here
+        Inspec::InputRegistry.find_or_register_input(input_name, profile_id).value
+      else
+        options[:priority] = 20
+        options[:provider] = :inline_control_code
+        evt = Inspec::Input.infer_event(options)
+        Inspec::InputRegistry.find_or_register_input(input_name, profile_id, event: evt).value
+      end
+    end
+
+    def input_object(name)
+      Inspec::InputRegistry.find_or_register_input(name, __profile_id)
+    end
+
     def method_missing(method_name, *arguments)
       Inspec::DSL.method_missing_resource(inspec, method_name, *arguments)
     end

--- a/lib/inspec/describe_base.rb
+++ b/lib/inspec/describe_base.rb
@@ -1,5 +1,10 @@
+require "inspec/input_dsl_helpers"
+
 module Inspec
   class DescribeBase
+
+    include Inspec::InputDslHelpers
+
     def initialize(action)
       @action = action
       @checks = []
@@ -23,18 +28,7 @@ module Inspec
     end
 
     def input(input_name, options = {})
-      profile_id = __profile_id
-
-      # TODO: DRY up - remainder of this code is identical to input() in rspec_extensions.rb
-      if options.empty?
-        # Simply an access, no event here
-        Inspec::InputRegistry.find_or_register_input(input_name, profile_id).value
-      else
-        options[:priority] = 20
-        options[:provider] = :inline_control_code
-        evt = Inspec::Input.infer_event(options)
-        Inspec::InputRegistry.find_or_register_input(input_name, profile_id, event: evt).value
-      end
+      input_with_profile_id(__profile_id, input_name, options)
     end
 
     def input_object(name)

--- a/lib/inspec/input_dsl_helpers.rb
+++ b/lib/inspec/input_dsl_helpers.rb
@@ -1,0 +1,26 @@
+
+require "inspec/input_registry"
+
+module Inspec
+  # A mixin to provide implementations for the input() DSL methods
+  module InputDslHelpers
+
+    # Find or create an input, explicitly named by a profile ID and
+    #  input name. Evaluate the input and return the value.
+    # @param [String] Profile ID
+    # @param [String] Input Name
+    # @param [Hash] Input options - see input docs on website
+    # @returns [Object] Input value
+    def input_with_profile_id(profile_id, input_name, options)
+      if options.empty?
+        # Simply an access, no event here
+        Inspec::InputRegistry.find_or_register_input(input_name, profile_id).value
+      else
+        options[:priority] = 20
+        options[:provider] = :inline_control_code
+        evt = Inspec::Input.infer_event(options)
+        Inspec::InputRegistry.find_or_register_input(input_name, profile_id, event: evt).value
+      end
+    end
+  end
+end

--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -1,6 +1,7 @@
 require "inspec/input_registry"
 require "inspec/plugin/v2"
 require "rspec/core/example_group"
+require "inspec/input_dsl_helpers"
 
 # Any additions to RSpec::Core::ExampleGroup (the RSpec class behind describe blocks) should go here.
 
@@ -82,18 +83,12 @@ module Inspec
 end
 
 class RSpec::Core::ExampleGroup
+  include Inspec::InputDslHelpers
+
   # This DSL method allows us to access the values of inputs within InSpec tests
   def input(input_name, options = {})
     profile_id = self.class.metadata[:profile_id]
-    if options.empty?
-      # Simply an access, no event here
-      Inspec::InputRegistry.find_or_register_input(input_name, profile_id).value
-    else
-      options[:priority] = 20
-      options[:provider] = :inline_control_code
-      evt = Inspec::Input.infer_event(options)
-      Inspec::InputRegistry.find_or_register_input(input_name, profile_id, event: evt).value
-    end
+    input_with_profile_id(profile_id, input_name, options)
   end
   define_example_method :input
 

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -214,6 +214,14 @@ describe "inputs" do
 
       assert_json_controls_passing(result)
     end
+
+    it "is able to read the inputs in describe.one blocks" do
+      cmd = "exec #{inputs_profiles_path}/describe-one"
+
+      result = run_inspec_process(cmd, json: true)
+
+      assert_json_controls_passing(result)
+    end
   end
 
   describe "run profile with metadata inputs" do

--- a/test/unit/mock/profiles/inputs/describe-one/controls/describe-one.rb
+++ b/test/unit/mock/profiles/inputs/describe-one/controls/describe-one.rb
@@ -1,0 +1,19 @@
+control "control-01" do
+  # Sanity check that inputs in fact do work in control-level DSL as reported on #4523
+  value = input("input-inner-control", value: "test-value-01")
+
+  describe.one do
+    value = input("input-outer-test", value: "test-value-02")
+    describe "test-value-03" do
+      it { should cmp input("input-inner-test", value: "test-value-03") }
+    end
+  end
+
+  describe.one do
+    # Verify input_object DSL access works here
+    obj = input_object("input-outer-test")
+    describe obj.events.count do
+      it { should cmp 2 }
+    end
+  end
+end

--- a/test/unit/mock/profiles/inputs/describe-one/inspec.yml
+++ b/test/unit/mock/profiles/inputs/describe-one/inspec.yml
@@ -1,0 +1,6 @@
+name: describe-one
+license: Apache-2.0
+summary: A profile to verify that input DSL calls are available in describe.one blocks (refs github issue 4523)
+version: 0.1.0
+supports:
+  platform: os


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Adds the ability for `input()` (and its non-evaluating friend `input_object()`) to work inside a `describe.one` block. 

While this was reported as a regression, I don't believe this functionality was ever in place, either as `input()` or as `attribute()` - reproduction steps with a version welcome on #4523.

Reviewer notes:
This PR currently includes a simple functional test.
~~There is a small amount of code duplication which is noted in a TODO which could be factored out.~~

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #4523 
Fixes #3650 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
