### PR TITLE
Pre-load the gem resource to override the global gem method.

### DIFF
--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -110,3 +110,5 @@ end
 
 # Many resources use FilterTable.
 require "inspec/utils/filter"
+# conflicts with global `gem` method so we need to pre-load this.
+require "inspec/resources/gem"

--- a/lib/inspec/resources/gem.rb
+++ b/lib/inspec/resources/gem.rb
@@ -17,11 +17,12 @@ module Inspec::Resources
 
     def initialize(package_name, gem_binary = nil)
       @package_name = package_name
-      @gem_binary = case gem_binary
+      @gem_binary = case gem_binary # TODO: no. this is not right
                     when nil
                       "gem"
                     when :chef
                       if inspec.os.windows?
+                        # TODO: what about chef-dk or other installs?
                         'c:\opscode\chef\embedded\bin\gem.bat'
                       else
                         "/opt/chef/embedded/bin/gem"

--- a/lib/inspec/resources/gem.rb
+++ b/lib/inspec/resources/gem.rb
@@ -2,7 +2,7 @@ require "inspec/resources/command"
 
 module Inspec::Resources
   class GemPackage < Inspec.resource(1)
-    name "gem"
+    name "gem" # TODO: rename to "rubygem" and provide alias
     supports platform: "unix"
     supports platform: "windows"
     desc "Use the gem InSpec audit resource to test if a global gem package is installed."


### PR DESCRIPTION
This seems problematic to me in general. We should probably not
override global methods. Renaming this to rubygem and providing a
deprecated alias seems like the right thing to do.

Signed-off-by: Ryan Davis <zenspider@chef.io>