### PR TITLE
Get artifact/habitat starting tests on both Windows and Linux

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.install.sh
+++ b/.expeditor/buildkite/artifact.habitat.install.sh
@@ -3,4 +3,4 @@
 set -ueo pipefail
 
 hab origin key import < "$HAB_CI_KEY"
-hab pkg install --binlink "./results/${pkg_artifact:?is undefined}"
+hab pkg install -b "${project_root:?is undefined}/results/${pkg_artifact:?is undefined}"

--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -12,6 +12,15 @@ $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
 
 Write-Host "--- Installing the version of Habitat required"
+$hab_version = (hab --version)
+$hab_minor_version = $hab_version.split('.')[1]
+if ( -not $? -Or $hab_minor_version -lt 85 ) {
+    Write-Host "I'm being built with $hab_version. I need at least Hab 0.85.0, because I use the -IsPath option for setting/pushing paths in SetupEnvironment."
+throw "unable to build: required minimum version of Habitat not installed"
+} else {
+    Write-Host ":habicat: I think I have the version I need to build."
+}
+
 Install-Habitat --version 0.85.0.20190916
 
 Write-Host "--- Generating fake origin key"
@@ -21,14 +30,14 @@ Write-Host "--- Building $Plan"
 $project_root = "$(git rev-parse --show-toplevel)"
 Set-Location $project_root
 
-$env:DO_CHECK=$true; hab pkg build . -D
+$env:DO_CHECK=$true; hab pkg build .
 if (-not $?) { throw "unable to build" }
 
 . $project_root/results/last_build.ps1
 if (-not $?) { throw "unable to determine details about this build" }
 
 Write-Host "--- Installing $pkg_ident/$pkg_artifact"
-hab pkg install $project_root/results/$pkg_artifact
+hab pkg install -b $project_root/results/$pkg_artifact
 if (-not $?) { throw "unable to install this build" }
 
 Write-Host "+++ Testing $Plan"

--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -15,13 +15,11 @@ Write-Host "--- Installing the version of Habitat required"
 $hab_version = (hab --version)
 $hab_minor_version = $hab_version.split('.')[1]
 if ( -not $? -Or $hab_minor_version -lt 85 ) {
-    Write-Host "I'm being built with $hab_version. I need at least Hab 0.85.0, because I use the -IsPath option for setting/pushing paths in SetupEnvironment."
-throw "unable to build: required minimum version of Habitat not installed"
+    Install-Habitat --version 0.85.0.20190916
 } else {
     Write-Host ":habicat: I think I have the version I need to build."
 }
 
-Install-Habitat --version 0.85.0.20190916
 
 Write-Host "--- Generating fake origin key"
 hab origin key generate $env:HAB_ORIGIN
@@ -41,6 +39,8 @@ hab pkg install -b $project_root/results/$pkg_artifact
 if (-not $?) { throw "unable to install this build" }
 
 Write-Host "+++ Testing $Plan"
+
+$env:PATH = "C:\hab\bin;$env:PATH"
 Push-Location $project_root/test/artifact
 rake
 if (-not $?) { throw "rake failed" }

--- a/.expeditor/buildkite/artifact.habitat.test.sh
+++ b/.expeditor/buildkite/artifact.habitat.test.sh
@@ -25,6 +25,7 @@ echo "--- Sourcing 'results/last_build.sh'"
 if [ -f ./results/last_build.env ]; then
     . ./results/last_build.env
     export pkg_artifact
+    export project_root
 fi
 
 echo "+++ Installing ${pkg_ident:?is undefined}"
@@ -35,6 +36,10 @@ HSI="$project_root"/.expeditor/buildkite/artifact.habitat.install.sh
 sudo -E "$HSI"
 
 echo "+++ Testing $PLAN"
+
+PATH="/hab/bin:$PATH"
+export PATH
+
 pushd "$project_root/test/artifact"
-rake
+hab pkg exec core/ruby rake
 popd

--- a/test/artifact/inspec_detect_test.rb
+++ b/test/artifact/inspec_detect_test.rb
@@ -1,12 +1,24 @@
 require "minitest/autorun"
 
 class TestArtifactDetect < Minitest::Test
+  def test_inspec_exists_linux
+    skip if windows?
+    refute_match(/no inspec/, `/usr/bin/which inspec`)
+  end
+
+  def test_inspec_exists_windows
+    skip unless windows?
+    assert_match(/inspec.bat/, `Get-Command inspec`)
+  end
+
   def test_detect
+    exit = nil
     out, err = capture_subprocess_io do
-      assert system("inspec detect --no-color")
+      exit = system("inspec detect --no-color")
     end
 
-    assert_match %r{/Platform Details/}, out
-    assert_empty err
+    assert_empty err.sub(/#< CLIXML\n/, "")
+    assert_match(/Platform Details/, out)
+    assert exit
   end
 end


### PR DESCRIPTION
This updates our artifact test and habitat plans to validate our artifact.

The tests are currently failing (this is great!)

https://buildkite.com/chef/inspec-inspec-master-artifact-habitat/builds/60#268643f9-9e5c-4893-9a4b-b29770b338df

Its great because they are executing at all. Now we iterate on useful tests and fixing the issues we discover.