### PR TITLE
Add several tests to our artifact suite

### DIFF
--- a/.expeditor/artifact.habitat.yml
+++ b/.expeditor/artifact.habitat.yml
@@ -1,4 +1,9 @@
 ---
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 30
+
 steps:
 
 - label: ":linux: Validate Habitat Builds of Chef InSpec"
@@ -6,7 +11,8 @@ steps:
     - .expeditor/buildkite/artifact.habitat.test.sh
   expeditor:
     executor:
-      linux:
+      docker:
+        image: ruby:2.6
         privileged: true
 
 - label: ":windows: Validate Habitat Builds of Chef InSpec"

--- a/.expeditor/buildkite/artifact.habitat.install.sh
+++ b/.expeditor/buildkite/artifact.habitat.install.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -ueo pipefail
-
-hab origin key import < "$HAB_CI_KEY"
-hab pkg install -b "${project_root:?is undefined}/results/${pkg_artifact:?is undefined}"

--- a/.expeditor/buildkite/artifact.habitat.test.sh
+++ b/.expeditor/buildkite/artifact.habitat.test.sh
@@ -1,45 +1,56 @@
 #!/usr/bin/env bash
 
-set -ueo pipefail
+set -eo pipefail
 
 export HAB_ORIGIN='ci'
 export PLAN='inspec'
 export CHEF_LICENSE="accept-no-persist"
 export HAB_LICENSE="accept-no-persist"
+project_root="$(git rev-parse --show-toplevel)"
 
 echo "--- system details"
 uname -a
 
+echo "--- Installing Habitat"
+id -a
+curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash
+
+
 echo "--- Generating fake origin key"
 hab origin key generate $HAB_ORIGIN
-HAB_CI_KEY=$(realpath "$HOME"/.hab/cache/keys/"$HAB_ORIGIN"*.pub)
+HAB_CI_KEY=$(realpath /hab/cache/keys/"$HAB_ORIGIN"*.pub)
 export HAB_CI_KEY
+if [ -f "$HAB_CI_KEY" ]; then
+    hab origin key import < "$HAB_CI_KEY"
+else
+    echo "$HAB_CI_KEY not found"
+    ls "$HOME/.hab/cache/keys"
+    ls "$project_root/hab/cache/keys"
+    ls /hab
+    exit 1
+fi
+
 
 echo "--- Building $PLAN"
-project_root="$(git rev-parse --show-toplevel)"
 cd "$project_root"
-
 DO_CHECK=true hab pkg build .
 
 echo "--- Sourcing 'results/last_build.sh'"
 if [ -f ./results/last_build.env ]; then
+    cat ./results/last_build.env
     . ./results/last_build.env
     export pkg_artifact
     export project_root
 fi
 
 echo "+++ Installing ${pkg_ident:?is undefined}"
-
-# habitat sudo install
-HSI="$project_root"/.expeditor/buildkite/artifact.habitat.install.sh
-
-sudo -E "$HSI"
+hab pkg install -b "${project_root:?is undefined}/results/${pkg_artifact:?is undefined}"
 
 echo "+++ Testing $PLAN"
 
-PATH="/hab/bin:$PATH"
+PATH="$(hab pkg path ci/inspec)/bin:$PATH"
 export PATH
+echo "PATH is $PATH"
 
 pushd "$project_root/test/artifact"
-hab pkg exec core/ruby rake
-popd
+rake

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -122,6 +122,11 @@ merge_actions:
     ignore_labels:
      - "Omnibus: Skip Build"
      - "Expeditor: Skip All"
+ - trigger_pipeline:artifact/habitat:
+    only_if: built_in:bump_version
+    ignore_labels:
+     - "Habitat: Skip Build"
+     - "Expeditor: Skip All"
  - trigger_pipeline:omnibus/release:
     only_if: built_in:bump_version
     ignore_labels:

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ueo pipefail
+set -eo pipefail
 
 channel="${CHANNEL:-unstable}"
 product="${PRODUCT:-inspec}"
@@ -27,14 +27,13 @@ fi
 
 echo "--- Running verification for $channel $product $version"
 
-# Set GEM_HOME and GEM_PATH to verify our appbundle inspec shim is correctly
-# removing them from the environment while launching from our embedded ruby.
-export GEM_HOME=/SHOULD_NOT_EXIST
-export GEM_PATH=/SHOULD_NOT_EXIST
 export CHEF_LICENSE="accept-no-persist"
+project_root="$(pwd)"
+export project_root
 
-inspec version
+cd test/artifact
 
-inspec shell -c platform.family
+PATH=/opt/inspec/bin:/opt/inspec/embedded/bin:$PATH
+export PATH
 
-inspec plugin list
+rake

--- a/test/artifact/artifact_helper.rb
+++ b/test/artifact/artifact_helper.rb
@@ -1,7 +1,7 @@
 require "minitest/autorun"
 require "open3"
 
-TEST_CLI_OPTS="--chef-license=accept-no-persist"
+TEST_CLI_OPTS = "--chef-license=accept-no-persist".freeze
 
 class ArtifactTest < Minitest::Test
   make_my_diffs_pretty!
@@ -10,7 +10,7 @@ class ArtifactTest < Minitest::Test
     command = "inspec #{inspec_command} #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3({ "PATH" => ENV["PATH"] },
                                             command,
-                                            { :chdir => ENV["project_root"]})
+                                            { chdir: ENV["project_root"] })
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")
     assert stdout

--- a/test/artifact/artifact_helper.rb
+++ b/test/artifact/artifact_helper.rb
@@ -9,7 +9,8 @@ class ArtifactTest < Minitest::Test
   def assert_artifact(inspec_command)
     command = "inspec #{inspec_command} #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3({ "PATH" => ENV["PATH"] },
-                                            command)
+                                            command,
+                                            { :chdir => ENV["project_root"]})
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")
     assert stdout

--- a/test/artifact/artifact_helper.rb
+++ b/test/artifact/artifact_helper.rb
@@ -6,8 +6,8 @@ TEST_CLI_OPTS="--chef-license=accept-no-persist"
 class ArtifactTest < Minitest::Test
   make_my_diffs_pretty!
 
-  def assert_artifact(command)
-    command = "inspec #{command} #{TEST_CLI_OPTS}"
+  def assert_artifact(inspec_command)
+    command = "inspec #{inspec_command} #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3({ "PATH" => ENV["PATH"] },
                                             command)
 

--- a/test/artifact/artifact_helper.rb
+++ b/test/artifact/artifact_helper.rb
@@ -1,0 +1,4 @@
+require "minitest/autorun"
+require "open3"
+
+TEST_CLI_OPTS="--chef-license=accept-no-persist"

--- a/test/artifact/artifact_helper.rb
+++ b/test/artifact/artifact_helper.rb
@@ -2,3 +2,17 @@ require "minitest/autorun"
 require "open3"
 
 TEST_CLI_OPTS="--chef-license=accept-no-persist"
+
+class ArtifactTest < Minitest::Test
+  make_my_diffs_pretty!
+
+  def assert_artifact(command)
+    command = "inspec #{command} #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3({ "PATH" => ENV["PATH"] },
+                                            command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/artifact_installation_test.rb
+++ b/test/artifact/artifact_installation_test.rb
@@ -11,6 +11,7 @@ class TestArtifactInstallation < Minitest::Test
       stdout, stderr, status = Open3.capture3({ "PATH" => ENV["PATH"] },
                                               "/usr/bin/which inspec")
       refute_match(/no inspec/, stdout)
+      assert_includes(ENV["PATH"], "/bin")
     end
 
     assert_empty stderr

--- a/test/artifact/artifact_installation_test.rb
+++ b/test/artifact/artifact_installation_test.rb
@@ -1,0 +1,21 @@
+require_relative "artifact_helper"
+
+class TestArtifactInstallation < Minitest::Test
+  parallelize_me!
+
+  def test_inspec_exists_linux
+    skip if windows?
+    stdout, stderr, status = Open3.capture3("/usr/bin/which inspec")
+    refute_match(/no inspec/, stdout)
+    assert_empty stderr
+    assert status
+  end
+
+  def test_inspec_exists_windows
+    skip unless windows?
+    stdout, stderr, status = Open3.capture3("Get-Command inspec")
+    assert_match(/inspec.bat/, stdout)
+    assert_empty stderr
+    assert status
+  end
+end

--- a/test/artifact/artifact_installation_test.rb
+++ b/test/artifact/artifact_installation_test.rb
@@ -3,18 +3,16 @@ require_relative "artifact_helper"
 class TestArtifactInstallation < Minitest::Test
   parallelize_me!
 
-  def test_inspec_exists_linux
-    skip if windows?
-    stdout, stderr, status = Open3.capture3("/usr/bin/which inspec")
-    refute_match(/no inspec/, stdout)
-    assert_empty stderr
-    assert status
-  end
+  def test_inspec_exists
+    if windows?
+      stdout, stderr, status = Open3.capture3("Get-Command inspec")
+      assert_match(/inspec.bat/, stdout)
+    else
+      stdout, stderr, status = Open3.capture3({ "PATH" => ENV["PATH"] },
+                                              "/usr/bin/which inspec")
+      refute_match(/no inspec/, stdout)
+    end
 
-  def test_inspec_exists_windows
-    skip unless windows?
-    stdout, stderr, status = Open3.capture3("Get-Command inspec")
-    assert_match(/inspec.bat/, stdout)
     assert_empty stderr
     assert status
   end

--- a/test/artifact/inspec_archive_test.rb
+++ b/test/artifact/inspec_archive_test.rb
@@ -1,0 +1,15 @@
+require_relative "artifact_helper"
+
+class TestInspecArchive < Minitest::Test
+  parallelize_me!
+
+  def test_archive
+    flunk
+    command = "/bin/inspec archive #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert_match(/Platform Details/, stdout)
+    assert status
+  end
+end

--- a/test/artifact/inspec_archive_test.rb
+++ b/test/artifact/inspec_archive_test.rb
@@ -2,7 +2,6 @@ require_relative "artifact_helper"
 
 class TestInspecArchive < ArtifactTest
   def test_archive
-    skip
-    assert_artifact(:archive)
+    assert_artifact("archive examples/profile")
   end
 end

--- a/test/artifact/inspec_archive_test.rb
+++ b/test/artifact/inspec_archive_test.rb
@@ -1,13 +1,8 @@
 require_relative "artifact_helper"
 
-class TestInspecArchive < Minitest::Test
+class TestInspecArchive < ArtifactTest
   def test_archive
     skip
-    command = "/bin/inspec archive #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert_match(/Platform Details/, stdout)
-    assert status
+    assert_artifact(:archive)
   end
 end

--- a/test/artifact/inspec_archive_test.rb
+++ b/test/artifact/inspec_archive_test.rb
@@ -1,10 +1,8 @@
 require_relative "artifact_helper"
 
 class TestInspecArchive < Minitest::Test
-  parallelize_me!
-
   def test_archive
-    flunk
+    skip
     command = "/bin/inspec archive #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 

--- a/test/artifact/inspec_check_test.rb
+++ b/test/artifact/inspec_check_test.rb
@@ -1,10 +1,8 @@
 require_relative "artifact_helper"
 
 class TestInspecCheck < Minitest::Test
-  parallelize_me!
-
   def test_check
-    flunk
+    skip
     command = "/bin/inspec check #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 

--- a/test/artifact/inspec_check_test.rb
+++ b/test/artifact/inspec_check_test.rb
@@ -3,7 +3,7 @@ require_relative "artifact_helper"
 class TestInspecCheck < Minitest::Test
   def test_check
     skip
-    command = "/bin/inspec check #{TEST_CLI_OPTS}"
+    command = "inspec check #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")

--- a/test/artifact/inspec_check_test.rb
+++ b/test/artifact/inspec_check_test.rb
@@ -1,0 +1,15 @@
+require_relative "artifact_helper"
+
+class TestInspecCheck < Minitest::Test
+  parallelize_me!
+
+  def test_check
+    flunk
+    command = "/bin/inspec check #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert_match(/Platform Details/, stdout)
+    assert status
+  end
+end

--- a/test/artifact/inspec_check_test.rb
+++ b/test/artifact/inspec_check_test.rb
@@ -2,7 +2,6 @@ require_relative "artifact_helper"
 
 class TestInspecCheck < ArtifactTest
   def test_check
-    skip
-    assert_artifact(:check)
+    assert_artifact("check examples/profile")
   end
 end

--- a/test/artifact/inspec_check_test.rb
+++ b/test/artifact/inspec_check_test.rb
@@ -1,13 +1,8 @@
 require_relative "artifact_helper"
 
-class TestInspecCheck < Minitest::Test
+class TestInspecCheck < ArtifactTest
   def test_check
     skip
-    command = "inspec check #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert_match(/Platform Details/, stdout)
-    assert status
+    assert_artifact(:check)
   end
 end

--- a/test/artifact/inspec_compliance_test.rb
+++ b/test/artifact/inspec_compliance_test.rb
@@ -1,12 +1,7 @@
 require_relative "artifact_helper"
 
-class TestInspecCompliance < Minitest::Test
+class TestInspecCompliance < ArtifactTest
   def test_compliance_version
-    command = "/bin/inspec compliance version #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+    assert_artifact("compliance help")
   end
 end

--- a/test/artifact/inspec_compliance_test.rb
+++ b/test/artifact/inspec_compliance_test.rb
@@ -1,8 +1,6 @@
 require_relative "artifact_helper"
 
 class TestInspecCompliance < Minitest::Test
-  parallelize_me!
-
   def test_compliance_version
     command = "/bin/inspec compliance version #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)

--- a/test/artifact/inspec_compliance_test.rb
+++ b/test/artifact/inspec_compliance_test.rb
@@ -1,0 +1,14 @@
+require_relative "artifact_helper"
+
+class TestInspecCompliance < Minitest::Test
+  parallelize_me!
+
+  def test_compliance_version
+    command = "/bin/inspec compliance version #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/inspec_compliance_test.rb
+++ b/test/artifact/inspec_compliance_test.rb
@@ -2,6 +2,6 @@ require_relative "artifact_helper"
 
 class TestInspecCompliance < ArtifactTest
   def test_compliance_version
-    assert_artifact("compliance help")
+    assert_artifact("compliance logout")
   end
 end

--- a/test/artifact/inspec_detect_test.rb
+++ b/test/artifact/inspec_detect_test.rb
@@ -1,8 +1,6 @@
 require_relative "artifact_helper"
 
 class TestInspecDetect < Minitest::Test
-  parallelize_me!
-
   def test_detect
     command = "/bin/inspec detect --no-color #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)

--- a/test/artifact/inspec_detect_test.rb
+++ b/test/artifact/inspec_detect_test.rb
@@ -2,7 +2,7 @@ require_relative "artifact_helper"
 
 class TestInspecDetect < Minitest::Test
   def test_detect
-    command = "/bin/inspec detect --no-color #{TEST_CLI_OPTS}"
+    command = "inspec detect --no-color #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")

--- a/test/artifact/inspec_detect_test.rb
+++ b/test/artifact/inspec_detect_test.rb
@@ -1,5 +1,4 @@
 require_relative "artifact_helper"
-require "open3"
 
 class TestInspecDetect < Minitest::Test
   parallelize_me!

--- a/test/artifact/inspec_detect_test.rb
+++ b/test/artifact/inspec_detect_test.rb
@@ -1,12 +1,7 @@
 require_relative "artifact_helper"
 
-class TestInspecDetect < Minitest::Test
+class TestInspecDetect < ArtifactTest
   def test_detect
-    command = "inspec detect --no-color #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert_match(/Platform Details/, stdout)
-    assert status
+    assert_artifact("detect --no-color")
   end
 end

--- a/test/artifact/inspec_detect_test.rb
+++ b/test/artifact/inspec_detect_test.rb
@@ -1,24 +1,15 @@
-require "minitest/autorun"
+require_relative "artifact_helper"
+require "open3"
 
-class TestArtifactDetect < Minitest::Test
-  def test_inspec_exists_linux
-    skip if windows?
-    refute_match(/no inspec/, `/usr/bin/which inspec`)
-  end
-
-  def test_inspec_exists_windows
-    skip unless windows?
-    assert_match(/inspec.bat/, `Get-Command inspec`)
-  end
+class TestInspecDetect < Minitest::Test
+  parallelize_me!
 
   def test_detect
-    exit = nil
-    out, err = capture_subprocess_io do
-      exit = system("inspec detect --no-color")
-    end
+    command = "/bin/inspec detect --no-color #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
 
-    assert_empty err.sub(/#< CLIXML\n/, "")
-    assert_match(/Platform Details/, out)
-    assert exit
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert_match(/Platform Details/, stdout)
+    assert status
   end
 end

--- a/test/artifact/inspec_env_test.rb
+++ b/test/artifact/inspec_env_test.rb
@@ -1,12 +1,7 @@
 require_relative "artifact_helper"
 
-class TestInspecEnv < Minitest::Test
+class TestInspecEnv < ArtifactTest
   def test_env
-    command = "inspec env #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+    assert_artifact(:env)
   end
 end

--- a/test/artifact/inspec_env_test.rb
+++ b/test/artifact/inspec_env_test.rb
@@ -1,5 +1,4 @@
 require_relative "artifact_helper"
-require "open3"
 
 class TestInspecEnv < Minitest::Test
   parallelize_me!

--- a/test/artifact/inspec_env_test.rb
+++ b/test/artifact/inspec_env_test.rb
@@ -2,6 +2,7 @@ require_relative "artifact_helper"
 
 class TestInspecEnv < ArtifactTest
   def test_env
-    assert_artifact(:env)
+    skip if windows?
+    assert_artifact("env bash")
   end
 end

--- a/test/artifact/inspec_env_test.rb
+++ b/test/artifact/inspec_env_test.rb
@@ -1,0 +1,14 @@
+require_relative "artifact_helper"
+require "open3"
+
+class TestInspecEnv < Minitest::Test
+  parallelize_me!
+  def test_env
+    command = "/bin/inspec env #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/inspec_env_test.rb
+++ b/test/artifact/inspec_env_test.rb
@@ -1,7 +1,6 @@
 require_relative "artifact_helper"
 
 class TestInspecEnv < Minitest::Test
-  parallelize_me!
   def test_env
     command = "/bin/inspec env #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)

--- a/test/artifact/inspec_env_test.rb
+++ b/test/artifact/inspec_env_test.rb
@@ -2,7 +2,7 @@ require_relative "artifact_helper"
 
 class TestInspecEnv < Minitest::Test
   def test_env
-    command = "/bin/inspec env #{TEST_CLI_OPTS}"
+    command = "inspec env #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")

--- a/test/artifact/inspec_exec_test.rb
+++ b/test/artifact/inspec_exec_test.rb
@@ -1,0 +1,15 @@
+require_relative "artifact_helper"
+
+class TestInspecExec < Minitest::Test
+  parallelize_me!
+
+  def test_exec
+    flunk
+    command = "/bin/inspec exec #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/inspec_exec_test.rb
+++ b/test/artifact/inspec_exec_test.rb
@@ -1,10 +1,8 @@
 require_relative "artifact_helper"
 
 class TestInspecExec < Minitest::Test
-  parallelize_me!
-
   def test_exec
-    flunk
+    skip
     command = "/bin/inspec exec #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 

--- a/test/artifact/inspec_exec_test.rb
+++ b/test/artifact/inspec_exec_test.rb
@@ -3,7 +3,7 @@ require_relative "artifact_helper"
 class TestInspecExec < Minitest::Test
   def test_exec
     skip
-    command = "/bin/inspec exec #{TEST_CLI_OPTS}"
+    command = "inspec exec #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")

--- a/test/artifact/inspec_exec_test.rb
+++ b/test/artifact/inspec_exec_test.rb
@@ -1,13 +1,8 @@
 require_relative "artifact_helper"
 
-class TestInspecExec < Minitest::Test
+class TestInspecExec < ArtifactTest
   def test_exec
     skip
-    command = "inspec exec #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+    assert_artifact(:exec)
   end
 end

--- a/test/artifact/inspec_exec_test.rb
+++ b/test/artifact/inspec_exec_test.rb
@@ -2,7 +2,6 @@ require_relative "artifact_helper"
 
 class TestInspecExec < ArtifactTest
   def test_exec
-    skip
-    assert_artifact(:exec)
+    assert_artifact("exec examples/meta-profile")
   end
 end

--- a/test/artifact/inspec_habitat_test.rb
+++ b/test/artifact/inspec_habitat_test.rb
@@ -1,10 +1,8 @@
 require_relative "artifact_helper"
 
 class TestInspecHabitat < Minitest::Test
-  parallelize_me!
-
   def test_habitat
-    flunk
+    skip
     command = "/bin/inspec habitat #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 

--- a/test/artifact/inspec_habitat_test.rb
+++ b/test/artifact/inspec_habitat_test.rb
@@ -1,0 +1,15 @@
+require_relative "artifact_helper"
+
+class TestInspecHabitat < Minitest::Test
+  parallelize_me!
+
+  def test_habitat
+    flunk
+    command = "/bin/inspec habitat #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/inspec_habitat_test.rb
+++ b/test/artifact/inspec_habitat_test.rb
@@ -2,7 +2,6 @@ require_relative "artifact_helper"
 
 class TestInspecHabitat < ArtifactTest
   def test_habitat
-    skip
-    assert_artifact(:habitat)
+    assert_artifact("habitat profile create examples/profile")
   end
 end

--- a/test/artifact/inspec_habitat_test.rb
+++ b/test/artifact/inspec_habitat_test.rb
@@ -1,13 +1,8 @@
 require_relative "artifact_helper"
 
-class TestInspecHabitat < Minitest::Test
+class TestInspecHabitat < ArtifactTest
   def test_habitat
     skip
-    command = "/bin/inspec habitat #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+    assert_artifact(:habitat)
   end
 end

--- a/test/artifact/inspec_help_test.rb
+++ b/test/artifact/inspec_help_test.rb
@@ -1,5 +1,4 @@
 require_relative "artifact_helper"
-require "open3"
 
 class TestInspecHelp < Minitest::Test
   parallelize_me!

--- a/test/artifact/inspec_help_test.rb
+++ b/test/artifact/inspec_help_test.rb
@@ -1,12 +1,7 @@
 require_relative "artifact_helper"
 
-class TestInspecHelp < Minitest::Test
+class TestInspecHelp < ArtifactTest
   def test_help
-    command = "inspec help #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+    assert_artifact(:help)
   end
 end

--- a/test/artifact/inspec_help_test.rb
+++ b/test/artifact/inspec_help_test.rb
@@ -1,0 +1,14 @@
+require_relative "artifact_helper"
+require "open3"
+
+class TestInspecHelp < Minitest::Test
+  parallelize_me!
+  def test_help
+    command = "/bin/inspec help #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/inspec_help_test.rb
+++ b/test/artifact/inspec_help_test.rb
@@ -1,7 +1,6 @@
 require_relative "artifact_helper"
 
 class TestInspecHelp < Minitest::Test
-  parallelize_me!
   def test_help
     command = "/bin/inspec help #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)

--- a/test/artifact/inspec_help_test.rb
+++ b/test/artifact/inspec_help_test.rb
@@ -2,7 +2,7 @@ require_relative "artifact_helper"
 
 class TestInspecHelp < Minitest::Test
   def test_help
-    command = "/bin/inspec help #{TEST_CLI_OPTS}"
+    command = "inspec help #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")

--- a/test/artifact/inspec_init_test.rb
+++ b/test/artifact/inspec_init_test.rb
@@ -1,0 +1,15 @@
+require_relative "artifact_helper"
+
+class TestInspecInit < Minitest::Test
+  parallelize_me!
+
+  def test_init
+    flunk
+    command = "/bin/inspec init #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/inspec_init_test.rb
+++ b/test/artifact/inspec_init_test.rb
@@ -1,13 +1,8 @@
 require_relative "artifact_helper"
 
-class TestInspecInit < Minitest::Test
+class TestInspecInit < ArtifactTest
   def test_init
     skip
-    command = "/bin/inspec init #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+    assert_artifact(:init)
   end
 end

--- a/test/artifact/inspec_init_test.rb
+++ b/test/artifact/inspec_init_test.rb
@@ -1,10 +1,8 @@
 require_relative "artifact_helper"
 
 class TestInspecInit < Minitest::Test
-  parallelize_me!
-
   def test_init
-    flunk
+    skip
     command = "/bin/inspec init #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 

--- a/test/artifact/inspec_init_test.rb
+++ b/test/artifact/inspec_init_test.rb
@@ -1,8 +1,11 @@
 require_relative "artifact_helper"
 
 class TestInspecInit < ArtifactTest
-  def test_init
-    skip
-    assert_artifact(:init)
+  def test_init_profile
+    assert_artifact("init profile inspec-profile")
+  end
+
+  def test_init_plugin
+    assert_artifact("init plugin inspec-plugin --no-prompt")
   end
 end

--- a/test/artifact/inspec_json_test.rb
+++ b/test/artifact/inspec_json_test.rb
@@ -1,5 +1,4 @@
 require_relative "artifact_helper"
-require "open3"
 
 class TestInspecJson < Minitest::Test
   parallelize_me!

--- a/test/artifact/inspec_json_test.rb
+++ b/test/artifact/inspec_json_test.rb
@@ -1,10 +1,8 @@
 require_relative "artifact_helper"
 
 class TestInspecJson < Minitest::Test
-  parallelize_me!
-
   def test_json
-    flunk
+    skip
     # Need a tempdir
     command = "/bin/inspec json #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)

--- a/test/artifact/inspec_json_test.rb
+++ b/test/artifact/inspec_json_test.rb
@@ -1,0 +1,17 @@
+require_relative "artifact_helper"
+require "open3"
+
+class TestInspecJson < Minitest::Test
+  parallelize_me!
+
+  def test_json
+    flunk
+    # Need a tempdir
+    command = "/bin/inspec json #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/inspec_json_test.rb
+++ b/test/artifact/inspec_json_test.rb
@@ -1,14 +1,9 @@
 require_relative "artifact_helper"
 
-class TestInspecJson < Minitest::Test
+class TestInspecJson < ArtifactTest
   def test_json
     skip
     # Need a tempdir
-    command = "/bin/inspec json #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+    assert_artifact(:json)
   end
 end

--- a/test/artifact/inspec_json_test.rb
+++ b/test/artifact/inspec_json_test.rb
@@ -2,8 +2,6 @@ require_relative "artifact_helper"
 
 class TestInspecJson < ArtifactTest
   def test_json
-    skip
-    # Need a tempdir
-    assert_artifact(:json)
+    assert_artifact("json examples/profile")
   end
 end

--- a/test/artifact/inspec_plugin_test.rb
+++ b/test/artifact/inspec_plugin_test.rb
@@ -3,7 +3,7 @@ require_relative "artifact_helper"
 class TestInspecPlugin < Minitest::Test
   def test_plugin
     skip
-    command = "/bin/inspec plugin #{TEST_CLI_OPTS}"
+    command = "inspec plugin #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")

--- a/test/artifact/inspec_plugin_test.rb
+++ b/test/artifact/inspec_plugin_test.rb
@@ -1,0 +1,15 @@
+require_relative "artifact_helper"
+
+class TestInspecPlugin < Minitest::Test
+  parallelize_me!
+
+  def test_plugin
+    flunk
+    command = "/bin/inspec plugin #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/inspec_plugin_test.rb
+++ b/test/artifact/inspec_plugin_test.rb
@@ -1,10 +1,8 @@
 require_relative "artifact_helper"
 
 class TestInspecPlugin < Minitest::Test
-  parallelize_me!
-
   def test_plugin
-    flunk
+    skip
     command = "/bin/inspec plugin #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 

--- a/test/artifact/inspec_plugin_test.rb
+++ b/test/artifact/inspec_plugin_test.rb
@@ -1,13 +1,7 @@
 require_relative "artifact_helper"
 
-class TestInspecPlugin < Minitest::Test
-  def test_plugin
-    skip
-    command = "inspec plugin #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+class TestInspecPlugin < ArtifactTest
+  def test_plugin_lsit
+    assert_artifact("plugin list")
   end
 end

--- a/test/artifact/inspec_shell_test.rb
+++ b/test/artifact/inspec_shell_test.rb
@@ -1,0 +1,14 @@
+require_relative "artifact_helper"
+require "open3"
+
+class TestInspecShell < Minitest::Test
+  parallelize_me!
+  def test_shell
+    command = "/bin/inspec shell -c 'os.family' #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/inspec_shell_test.rb
+++ b/test/artifact/inspec_shell_test.rb
@@ -1,10 +1,8 @@
 require_relative "artifact_helper"
-require "open3"
 
 class TestInspecShell < Minitest::Test
-  parallelize_me!
   def test_shell
-    command = "/bin/inspec shell -c 'os.family' #{TEST_CLI_OPTS}"
+    command = "inspec shell -c 'os.family' #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")

--- a/test/artifact/inspec_shell_test.rb
+++ b/test/artifact/inspec_shell_test.rb
@@ -1,12 +1,7 @@
 require_relative "artifact_helper"
 
-class TestInspecShell < Minitest::Test
+class TestInspecShell < ArtifactTest
   def test_shell
-    command = "inspec shell -c 'os.family' #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+    assert_artifact("shell -c 'os.family'")
   end
 end

--- a/test/artifact/inspec_supermarket_test.rb
+++ b/test/artifact/inspec_supermarket_test.rb
@@ -1,13 +1,7 @@
 require_relative "artifact_helper"
 
-class TestInspecSupermarket < Minitest::Test
+class TestInspecSupermarket < ArtifactTest
   def test_supermarket
-    skip
-    command = "inspec supermarket #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+    assert_artifact("supermarket profiles")
   end
 end

--- a/test/artifact/inspec_supermarket_test.rb
+++ b/test/artifact/inspec_supermarket_test.rb
@@ -1,10 +1,8 @@
 require_relative "artifact_helper"
 
 class TestInspecSupermarket < Minitest::Test
-  parallelize_me!
-
   def test_supermarket
-    flunk
+    skip
     command = "/bin/inspec supermarket #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 

--- a/test/artifact/inspec_supermarket_test.rb
+++ b/test/artifact/inspec_supermarket_test.rb
@@ -3,7 +3,7 @@ require_relative "artifact_helper"
 class TestInspecSupermarket < Minitest::Test
   def test_supermarket
     skip
-    command = "/bin/inspec supermarket #{TEST_CLI_OPTS}"
+    command = "inspec supermarket #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")

--- a/test/artifact/inspec_supermarket_test.rb
+++ b/test/artifact/inspec_supermarket_test.rb
@@ -1,0 +1,15 @@
+require_relative "artifact_helper"
+
+class TestInspecSupermarket < Minitest::Test
+  parallelize_me!
+
+  def test_supermarket
+    flunk
+    command = "/bin/inspec supermarket #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/inspec_vendor_test.rb
+++ b/test/artifact/inspec_vendor_test.rb
@@ -1,10 +1,8 @@
 require_relative "artifact_helper"
 
 class TestInspecVendor < Minitest::Test
-  parallelize_me!
-
   def test_vendor
-    flunk
+    skip
     command = "/bin/inspec vendor #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 

--- a/test/artifact/inspec_vendor_test.rb
+++ b/test/artifact/inspec_vendor_test.rb
@@ -1,13 +1,8 @@
 require_relative "artifact_helper"
 
-class TestInspecVendor < Minitest::Test
+class TestInspecVendor < ArtifactTest
   def test_vendor
     skip
-    command = "inspec vendor #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+    assert_artifact(:vendor)
   end
 end

--- a/test/artifact/inspec_vendor_test.rb
+++ b/test/artifact/inspec_vendor_test.rb
@@ -2,7 +2,6 @@ require_relative "artifact_helper"
 
 class TestInspecVendor < ArtifactTest
   def test_vendor
-    skip
-    assert_artifact(:vendor)
+    assert_artifact("vendor examples/profile --overwrite")
   end
 end

--- a/test/artifact/inspec_vendor_test.rb
+++ b/test/artifact/inspec_vendor_test.rb
@@ -3,7 +3,7 @@ require_relative "artifact_helper"
 class TestInspecVendor < Minitest::Test
   def test_vendor
     skip
-    command = "/bin/inspec vendor #{TEST_CLI_OPTS}"
+    command = "inspec vendor #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")

--- a/test/artifact/inspec_vendor_test.rb
+++ b/test/artifact/inspec_vendor_test.rb
@@ -1,0 +1,15 @@
+require_relative "artifact_helper"
+
+class TestInspecVendor < Minitest::Test
+  parallelize_me!
+
+  def test_vendor
+    flunk
+    command = "/bin/inspec vendor #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end

--- a/test/artifact/inspec_version_test.rb
+++ b/test/artifact/inspec_version_test.rb
@@ -2,7 +2,6 @@ require_relative "artifact_helper"
 require "open3"
 
 class TestInspecVersion < Minitest::Test
-  parallelize_me!
   def test_version
     command = "/bin/inspec version #{TEST_CLI_OPTS}"
     stdout, stderr, status = Open3.capture3(command)

--- a/test/artifact/inspec_version_test.rb
+++ b/test/artifact/inspec_version_test.rb
@@ -1,13 +1,8 @@
 require_relative "artifact_helper"
 require "open3"
 
-class TestInspecVersion < Minitest::Test
+class TestInspecVersion < ArtifactTest
   def test_version
-    command = "/bin/inspec version #{TEST_CLI_OPTS}"
-    stdout, stderr, status = Open3.capture3(command)
-
-    assert_empty stderr.sub(/#< CLIXML\n/, "")
-    assert stdout
-    assert status
+    assert_artifact(:version)
   end
 end

--- a/test/artifact/inspec_version_test.rb
+++ b/test/artifact/inspec_version_test.rb
@@ -1,0 +1,14 @@
+require_relative "artifact_helper"
+require "open3"
+
+class TestInspecVersion < Minitest::Test
+  parallelize_me!
+  def test_version
+    command = "/bin/inspec version #{TEST_CLI_OPTS}"
+    stdout, stderr, status = Open3.capture3(command)
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "")
+    assert stdout
+    assert status
+  end
+end


### PR DESCRIPTION
To clarify what these are for.

When we build InSpec, we want to test the final built artifact. This is a simple set of tests to smoke test from the outside. We cover all the subcommands just to make sure we didn't miss anything in our prior tests.