### PR TITLE
Deprecate inspec/object/* classes

### DIFF
--- a/etc/deprecations.json
+++ b/etc/deprecations.json
@@ -116,6 +116,10 @@
     "wmi_non_hash_usage": {
       "action": "fail_control",
       "suffix": "This property was removed in InSpec 4.0."
+    },
+    "object_classes": {
+      "action": "warn",
+      "suffix": "These classes will be removed in InSpec 5.0."
     }
   }
 }

--- a/lib/inspec/objects/control.rb
+++ b/lib/inspec/objects/control.rb
@@ -1,3 +1,8 @@
+# This class is deprecated and will be removed in the next major release of InSpec.
+# Use the Inspec::Object classes from the inspec-objects rubygem instead.
+
+require "inspec/utils/deprecation"
+
 module Inspec
   class Control
     attr_accessor :id, :title, :descriptions, :impact, :tests, :tags, :refs, :only_if
@@ -6,6 +11,8 @@ module Inspec
       @tags = []
       @refs = []
       @descriptions = {}
+
+      Inspec.deprecate(:object_classes, "The Inspec::Control class is deprecated. Use the Inspec::Object::Control class from the inspec-objects Ruby library.")
     end
 
     def add_test(t)

--- a/lib/inspec/objects/describe.rb
+++ b/lib/inspec/objects/describe.rb
@@ -1,3 +1,8 @@
+# This class is deprecated and will be removed in the next major release of InSpec.
+# Use the Inspec::Object classes from the inspec-objects rubygem instead.
+
+require "inspec/utils/deprecation"
+
 module Inspec
   class Describe
     # Internal helper to structure test objects.
@@ -53,6 +58,8 @@ module Inspec
       @qualifier = []
       @tests = []
       @variables = []
+
+      Inspec.deprecate(:object_classes, "The Inspec::Describe class is deprecated. Use the Inspec::Object::Describe class from the inspec-objects Ruby library.")
     end
 
     def add_test(its, matcher, expectation, opts = {})

--- a/lib/inspec/objects/each_loop.rb
+++ b/lib/inspec/objects/each_loop.rb
@@ -1,3 +1,8 @@
+# This class is deprecated and will be removed in the next major release of InSpec.
+# Use the Inspec::Object classes from the inspec-objects rubygem instead.
+
+require "inspec/utils/deprecation"
+
 module Inspec
   class EachLoop < List
     attr_reader :variables
@@ -6,6 +11,8 @@ module Inspec
       super
       @tests = []
       @variables = []
+
+      Inspec.deprecate(:object_classes, "The Inspec::EachLoop class is deprecated. Use the Inspec::Object::EachLoop class from the inspec-objects Ruby library.")
     end
 
     def add_test(t = nil)

--- a/lib/inspec/objects/input.rb
+++ b/lib/inspec/objects/input.rb
@@ -1,3 +1,7 @@
+# This file is deprecated and will be removed in the next major release of InSpec.
+# The Inspec::Input class will remain but these methods will be removed.
+# Use the Inspec::Object::Input class from the inspec-objects rubygem instead.
+
 require "inspec/input"
 
 module Inspec

--- a/lib/inspec/objects/or_test.rb
+++ b/lib/inspec/objects/or_test.rb
@@ -1,9 +1,16 @@
+# This class is deprecated and will be removed in the next major release of InSpec.
+# Use the Inspec::Object classes from the inspec-objects rubygem instead.
+
+require "inspec/utils/deprecation"
+
 module Inspec
   class OrTest
     attr_reader :tests
     def initialize(tests)
       @tests = tests
       @negated = false
+
+      Inspec.deprecate(:object_classes, "The Inspec::OrTest class is deprecated. Use the Inspec::Object::OrTest class from the inspec-objects Ruby library.")
     end
 
     def skip

--- a/lib/inspec/objects/tag.rb
+++ b/lib/inspec/objects/tag.rb
@@ -1,3 +1,8 @@
+# This class is deprecated and will be removed in the next major release of InSpec.
+# Use the Inspec::Object classes from the inspec-objects rubygem instead.
+
+require "inspec/utils/deprecation"
+
 module Inspec
   class Tag
     attr_accessor :key, :value
@@ -5,6 +10,8 @@ module Inspec
     def initialize(key, value)
       @key = key
       @value = value
+
+      Inspec.deprecate(:object_classes, "The Inspec::Tag class is deprecated. Use the Inspec::Object::Tag class from the inspec-objects Ruby library.")
     end
 
     def to_hash

--- a/lib/inspec/objects/test.rb
+++ b/lib/inspec/objects/test.rb
@@ -1,3 +1,8 @@
+# This class is deprecated and will be removed in the next major release of InSpec.
+# Use the Inspec::Object classes from the inspec-objects rubygem instead.
+
+require "inspec/utils/deprecation"
+
 module Inspec
   class Test
     attr_accessor :qualifier, :matcher, :expectation, :skip, :negated, :variables, :only_if
@@ -7,6 +12,8 @@ module Inspec
       @qualifier = []
       @negated = false
       @variables = []
+
+      Inspec.deprecate(:object_classes, "The Inspec::Test class is deprecated. Use the Inspec::Object::Test class from the inspec-objects Ruby library.")
     end
 
     def negate!

--- a/lib/inspec/objects/value.rb
+++ b/lib/inspec/objects/value.rb
@@ -1,3 +1,8 @@
+# This class is deprecated and will be removed in the next major release of InSpec.
+# Use the Inspec::Object classes from the inspec-objects rubygem instead.
+
+require "inspec/utils/deprecation"
+
 module Inspec
   class Value
     include ::Inspec::RubyHelper
@@ -9,6 +14,8 @@ module Inspec
     def initialize(qualifiers = [])
       @qualifier = qualifiers
       @variable = nil
+
+      Inspec.deprecate(:object_classes, "The Inspec::Value class is deprecated. Use the Inspec::Object::Value class from the inspec-objects Ruby library.")
     end
 
     def to_ruby

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -105,7 +105,7 @@ def handle_deprecations(opts_in, &block)
     expectations[group_name] = expectations[:all_others]
   end
 
-  # Wire up Insepc.deprecator accordingly using mocha stubbing
+  # Wire up Inspec.deprecator accordingly using mocha stubbing
   expectations.each do |group_name, expectation|
     inst = Inspec::Deprecation::Deprecator.any_instance
     case expectation


### PR DESCRIPTION
The classes in inspec/object have been moved to the inspec-objects
library. They aren't used directly by Inspec and will be removed in the
next major release.

```
2.5.3 :001 > require 'inspec/objects'
 => true 
2.5.3 :002 > require 'inspec/objects'
 => false 
2.5.3 :003 > Inspec::Control.new
[2019-11-08T15:06:37-05:00] WARN: DEPRECATION: The Inspec::Control class is deprecated. Use the Inspec::Object::Control class from the inspec-objects Ruby library. These classes will be removed in InSpec 5.0.
 => #<Inspec::Control:0x00005598aff02240 @tests=[], @tags=[], @refs=[], @descriptions={}> 
```

closes https://github.com/inspec/inspec/issues/4679