### PR TITLE
Fixes parsing of apt config files with arch specifier.

### DIFF
--- a/lib/inspec/resources/apt.rb
+++ b/lib/inspec/resources/apt.rb
@@ -92,7 +92,7 @@ module Inspec::Resources
         # deb [trusted=yes] http://archive.ubuntu.com/ubuntu/ wily main restricted ...
 
         words = line.split
-        words.delete 1 if words[1] && words[1].start_with?("[")
+        words.delete_at 1 if words[1] && words[1].start_with?("[")
         type, url, distro, *components = words
         url = url.delete('"') if url
 

--- a/test/fixtures/cmd/etc-apt
+++ b/test/fixtures/cmd/etc-apt
@@ -5,4 +5,5 @@ deb http://ppa.launchpad.net/ubuntu-wine/ppa/ubuntu wily main
 
 deb http://archive.ubuntu.com/ubuntu/ wily main restricted
 deb "http://archive.ubuntu.com/ubuntu/" wily main restricted
+deb [arch=amd64] "http://archive.ubuntu.com/ubuntu/" wily main restricted
 deb-src http://archive.ubuntu.com/ubuntu/ wily main restricted


### PR DESCRIPTION
Fixes #4683.

Signed-off-by: Ryan Davis <zenspider@chef.io>