### PR TITLE
Correct filesystem resource docs for windows example

### DIFF
--- a/docs/resources/filesystem.md.erb
+++ b/docs/resources/filesystem.md.erb
@@ -67,7 +67,9 @@ The following examples show how to use this Chef InSpec audit resource.
 
 ### Test if the C:\ partition is NTFS
 
-    describe filesystem('c:\') do
+Note that Windows filesystems (drives) are referred to without any slashes:
+
+    describe filesystem('c:') do
       its('type') { should cmp 'NTFS' }
     end
 


### PR DESCRIPTION
This came in via Community Slack; thanks to Kasey Linden for reporting and diagnosing the issue.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The example for the `filesystem` resource had an example for Windows that incorrectly included a `\` in the path. This was not only the wrong path to access the filesystem, it was also a syntax error since it escaped the closing quote.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
