### PR TITLE
Dropping chef-core from dependencies.

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "train-core", "~> 3.0"
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
-  spec.add_dependency "chef-core", "~> 0.0"
   spec.add_dependency "thor", "~> 0.20"
   spec.add_dependency "json-schema", "~> 2.8"
   spec.add_dependency "method_source", "~> 0.8"

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
 
   # Implementation dependencies
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
-  spec.add_dependency "chef-core", "~> 0.0"
   spec.add_dependency "thor", "~> 0.20"
   spec.add_dependency "json-schema", "~> 2.8"
   spec.add_dependency "method_source", "~> 0.8"


### PR DESCRIPTION
We'll be moving some code from chef-core to chef-telemetry and adding
that dependency in the next sprint.

Fixes #4716.
Fixes #4719.

Signed-off-by: Ryan Davis <zenspider@chef.io>