### PR TITLE
Removing the osx? guard that has been pushed to minitest and released.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -170,10 +170,3 @@ end
 class InspecTest < Minitest::Test
   # shared stuff here
 end
-
-module Minitest::Guard
-  # TODO: push up to minitest
-  def osx?(platform = RUBY_PLATFORM)
-    /darwin/ =~ platform
-  end
-end


### PR DESCRIPTION
This is mostly to bump a release because our last one blew up.

Signed-off-by: Ryan Davis <zenspider@chef.io>