### PR TITLE
Make fetchers fail consistently

### DIFF
--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -90,8 +90,8 @@ module Inspec::Fetcher
         # vendoring to something more complex, don't bother.
         FileUtils.rmdir(destination_path) if Dir.empty?(destination_path)
 
-        raise Inspec::FetcherFailure.new("Cannot find relative path '#{@relative_path}' " \
-                                         "within profile in git repo specified by '#{@remote_url}'")
+        raise Inspec::FetcherFailure, "Cannot find relative path '#{@relative_path}' " \
+                                      "within profile in git repo specified by '#{@remote_url}'"
       end
       FileUtils.cp_r("#{working_dir}/#{@relative_path}", destination_path)
     end
@@ -129,11 +129,11 @@ module Inspec::Fetcher
     def resolve_ref(ref_name)
       command_string = "git ls-remote \"#{@remote_url}\" \"#{ref_name}*\""
       cmd = shellout(command_string)
-      raise Inspec::FetcherFailure.new("Profile git dependency failed for #{@remote_url} - error running '#{command_string}': #{cmd.stderr}") unless cmd.exitstatus == 0
+      raise(Inspec::FetcherFailure, "Profile git dependency failed for #{@remote_url} - error running '#{command_string}': #{cmd.stderr}") unless cmd.exitstatus == 0
 
       ref = parse_ls_remote(cmd.stdout, ref_name)
       unless ref
-        raise Inspec::FetcherFailure.new("Profile git dependency failed - unable to resolve #{ref_name} to a specific git commit for #{@remote_url}")
+        raise Inspec::FetcherFailure, "Profile git dependency failed - unable to resolve #{ref_name} to a specific git commit for #{@remote_url}"
       end
 
       ref
@@ -191,7 +191,7 @@ module Inspec::Fetcher
       cmd.error!
       cmd.status
     rescue Errno::ENOENT
-      raise Inspec::FetcherFailure.new("Profile git dependency failed for #{@remote_url} - to use git sources, you must have git installed.")
+      raise Inspec::FetcherFailure, "Profile git dependency failed for #{@remote_url} - to use git sources, you must have git installed."
     end
 
     def shellout(cmd, opts = {})

--- a/lib/inspec/fetcher/local.rb
+++ b/lib/inspec/fetcher/local.rb
@@ -106,7 +106,7 @@ module Inspec::Fetcher
       if File.exist?(target)
         @archive_shasum = OpenSSL::Digest::SHA256.digest(File.read(target)).unpack("H*")[0]
       else
-        raise Inspec::FetcherFailure.new("Profile dependency local path '#{target}' does not exist")
+        raise Inspec::FetcherFailure, "Profile dependency local path '#{target}' does not exist"
       end
     end
 

--- a/lib/inspec/fetcher/local.rb
+++ b/lib/inspec/fetcher/local.rb
@@ -101,7 +101,13 @@ module Inspec::Fetcher
     end
 
     def perform_shasum(target)
-      @archive_shasum ||= OpenSSL::Digest::SHA256.digest(File.read(target)).unpack("H*")[0]
+      return @archive_shasum if @archive_shasum
+
+      if File.exist?(target)
+        @archive_shasum = OpenSSL::Digest::SHA256.digest(File.read(target)).unpack("H*")[0]
+      else
+        raise Inspec::FetcherFailure.new("Profile dependency local path '#{target}' does not exist")
+      end
     end
 
     def resolved_source

--- a/lib/inspec/fetcher/local.rb
+++ b/lib/inspec/fetcher/local.rb
@@ -102,12 +102,8 @@ module Inspec::Fetcher
 
     def perform_shasum(target)
       return @archive_shasum if @archive_shasum
-
-      if File.exist?(target)
-        @archive_shasum = OpenSSL::Digest::SHA256.digest(File.read(target)).unpack("H*")[0]
-      else
-        raise Inspec::FetcherFailure, "Profile dependency local path '#{target}' does not exist"
-      end
+      raise(Inspec::FetcherFailure, "Profile dependency local path '#{target}' does not exist") unless File.exist?(target)
+      @archive_shasum = OpenSSL::Digest::SHA256.digest(File.read(target)).unpack("H*")[0]
     end
 
     def resolved_source

--- a/lib/inspec/fetcher/local.rb
+++ b/lib/inspec/fetcher/local.rb
@@ -103,6 +103,7 @@ module Inspec::Fetcher
     def perform_shasum(target)
       return @archive_shasum if @archive_shasum
       raise(Inspec::FetcherFailure, "Profile dependency local path '#{target}' does not exist") unless File.exist?(target)
+
       @archive_shasum = OpenSSL::Digest::SHA256.digest(File.read(target)).unpack("H*")[0]
     end
 

--- a/lib/inspec/fetcher/url.rb
+++ b/lib/inspec/fetcher/url.rb
@@ -220,6 +220,9 @@ module Inspec::Fetcher
         opts[:http_basic_authentication]
 
       open(target, opts)
+
+    rescue Errno::ECONNREFUSED, OpenURI::HTTPError => e
+      raise Inspec::FetcherFailure.new("Profile URL dependency #{target} could not be fetched: #{e.message}")
     end
 
     def download_archive(path)

--- a/lib/inspec/fetcher/url.rb
+++ b/lib/inspec/fetcher/url.rb
@@ -273,7 +273,7 @@ module Inspec::Fetcher
         end
       end
       unless keys_missing_values.empty?
-        raise "Unable to fetch profile - the following HTTP headers have no value: " \
+        raise Inspec::FetcherFailure, "Unable to fetch profile - the following HTTP headers have no value: " \
           "#{keys_missing_values.join(", ")}"
       end
     end

--- a/lib/inspec/fetcher/url.rb
+++ b/lib/inspec/fetcher/url.rb
@@ -221,7 +221,7 @@ module Inspec::Fetcher
 
       open(target, opts)
 
-    rescue Errno::ECONNREFUSED, OpenURI::HTTPError => e
+    rescue SocketError, Errno::ECONNREFUSED, OpenURI::HTTPError => e
       raise Inspec::FetcherFailure.new("Profile URL dependency #{target} could not be fetched: #{e.message}")
     end
 

--- a/lib/inspec/fetcher/url.rb
+++ b/lib/inspec/fetcher/url.rb
@@ -222,7 +222,7 @@ module Inspec::Fetcher
       open(target, opts)
 
     rescue SocketError, Errno::ECONNREFUSED, OpenURI::HTTPError => e
-      raise Inspec::FetcherFailure.new("Profile URL dependency #{target} could not be fetched: #{e.message}")
+      raise Inspec::FetcherFailure, "Profile URL dependency #{target} could not be fetched: #{e.message}"
     end
 
     def download_archive(path)

--- a/test/fixtures/profiles/fetcher-failures/child/inspec.yml
+++ b/test/fixtures/profiles/fetcher-failures/child/inspec.yml
@@ -1,0 +1,6 @@
+name: child
+license: Apache-2.0
+summary: A basic profile used as the base profile for local dependencies.
+version: 0.1.0
+supports:
+  platform: os

--- a/test/fixtures/profiles/fetcher-failures/git-bad/inspec.yml
+++ b/test/fixtures/profiles/fetcher-failures/git-bad/inspec.yml
@@ -1,0 +1,9 @@
+name: git-bad
+license: Apache-2.0
+summary: A profile with a bad git dependency
+version: 0.1.0
+supports:
+  platform: os
+depends:
+  - name: nonesuch
+    git: http://localhost/no/such

--- a/test/fixtures/profiles/fetcher-failures/git-bad/inspec.yml
+++ b/test/fixtures/profiles/fetcher-failures/git-bad/inspec.yml
@@ -6,4 +6,4 @@ supports:
   platform: os
 depends:
   - name: nonesuch
-    git: http://localhost/no/such
+    git: http://localhost.invalid/no/such

--- a/test/fixtures/profiles/fetcher-failures/local-bad/inspec.yml
+++ b/test/fixtures/profiles/fetcher-failures/local-bad/inspec.yml
@@ -1,0 +1,9 @@
+name: local-bad
+license: Apache-2.0
+summary: A profile with a bad local dependency
+version: 0.1.0
+supports:
+  platform: os
+depends:
+  - name: nonesuch
+    path: ../nonesuch

--- a/test/fixtures/profiles/fetcher-failures/url-bad/inspec.yml
+++ b/test/fixtures/profiles/fetcher-failures/url-bad/inspec.yml
@@ -1,0 +1,9 @@
+name: url-bad
+license: Apache-2.0
+summary: A profile with a bad URL dependency
+version: 0.1.0
+supports:
+  platform: os
+depends:
+  - name: nonesuch
+    url: https://localhost/inspec/inspec-nonesuch/path/to/profile.tgz

--- a/test/fixtures/profiles/fetcher-failures/url-bad/inspec.yml
+++ b/test/fixtures/profiles/fetcher-failures/url-bad/inspec.yml
@@ -6,4 +6,4 @@ supports:
   platform: os
 depends:
   - name: nonesuch
-    url: https://localhost/inspec/inspec-nonesuch/path/to/profile.tgz
+    url: https://localhost.invalid/inspec/inspec-nonesuch/path/to/profile.tgz

--- a/test/functional/fetchers_test.rb
+++ b/test/functional/fetchers_test.rb
@@ -22,5 +22,17 @@ describe "the fetchers" do
         assert_exit_code(1, run_result)
       end
     end
+
+    describe "when using the url fetcher on a bad dep" do
+      let(:path) { "#{fetcher_profiles}/url-bad" }
+      it "should throw an exception not a stacktrace" do
+        _(run_result.stdout).must_be_empty
+        _(run_result.stderr).wont_match looks_like_a_stacktrace
+        _(run_result.stderr).must_match(/Profile URL dependency .+ could not be fetched:/)
+        _(run_result.stderr).must_include "https://localhost/inspec/inspec-nonesuch/path/to/profile.tgz" # URL of the missing profile in message
+        assert_exit_code(1, run_result)
+      end
+    end
+
   end
 end

--- a/test/functional/fetchers_test.rb
+++ b/test/functional/fetchers_test.rb
@@ -1,0 +1,26 @@
+require "functional/helper"
+
+describe "the fetchers" do
+  parallelize_me!
+  include FunctionalHelper
+
+  let(:looks_like_a_stacktrace) { %r{lib/inspec/.+\.rb:\d+:in} }
+  let(:invocation) { "exec #{path} --no-create-lockfile" }
+  let(:run_result) { inspec(invocation) }
+
+  # Refs #4726
+  describe "when fetchers fetch a bad dependency" do
+    let(:fetcher_profiles) { "#{profile_path}/fetcher-failures" }
+
+    describe "when using the local fetcher on a bad dep" do
+      let(:path) { "#{fetcher_profiles}/local-bad" }
+      it "should throw an exception not a stacktrace" do
+        _(run_result.stdout).must_be_empty
+        _(run_result.stderr).wont_match looks_like_a_stacktrace
+        _(run_result.stderr).must_match(/Profile dependency local path .+ does not exist/)
+        _(run_result.stderr).must_include "fetcher-failures/nonesuch" # path of the missing profile in message
+        assert_exit_code(1, run_result)
+      end
+    end
+  end
+end

--- a/test/functional/fetchers_test.rb
+++ b/test/functional/fetchers_test.rb
@@ -12,36 +12,44 @@ describe "the fetchers" do
   describe "when fetchers fetch a bad dependency" do
     let(:fetcher_profiles) { "#{profile_path}/fetcher-failures" }
 
+    def assert_fetcher_failed_cleanly(run_result, error_regex, profile_location)
+      _(run_result.stdout).must_be_empty
+      _(run_result.stderr).wont_match looks_like_a_stacktrace
+      _(run_result.stderr).must_match(error_regex)
+      _(run_result.stderr).must_include profile_location
+      assert_exit_code(1, run_result)
+    end
+
     describe "when using the local fetcher on a bad dep" do
       let(:path) { "#{fetcher_profiles}/local-bad" }
       it "should throw an exception not a stacktrace" do
-        _(run_result.stdout).must_be_empty
-        _(run_result.stderr).wont_match looks_like_a_stacktrace
-        _(run_result.stderr).must_match(/Profile dependency local path .+ does not exist/)
-        _(run_result.stderr).must_include "fetcher-failures/nonesuch" # path of the missing profile in message
-        assert_exit_code(1, run_result)
+        assert_fetcher_failed_cleanly(
+          run_result,
+          /Profile dependency local path .+ does not exist/,
+          "fetcher-failures/nonesuch"
+        )
       end
     end
 
     describe "when using the url fetcher on a bad dep" do
       let(:path) { "#{fetcher_profiles}/url-bad" }
       it "should throw an exception not a stacktrace" do
-        _(run_result.stdout).must_be_empty
-        _(run_result.stderr).wont_match looks_like_a_stacktrace
-        _(run_result.stderr).must_match(/Profile URL dependency .+ could not be fetched:/)
-        _(run_result.stderr).must_include "https://localhost/inspec/inspec-nonesuch/path/to/profile.tgz" # URL of the missing profile in message
-        assert_exit_code(1, run_result)
+        assert_fetcher_failed_cleanly(
+          run_result,
+          /Profile URL dependency .+ could not be fetched:/,
+          "https://localhost/inspec/inspec-nonesuch/path/to/profile.tgz"
+        )
       end
     end
 
     describe "when using the url fetcher on a bad dep" do
       let(:path) { "#{fetcher_profiles}/git-bad" }
       it "should throw an exception not a stacktrace" do
-        _(run_result.stdout).must_be_empty
-        _(run_result.stderr).wont_match looks_like_a_stacktrace
-        _(run_result.stderr).must_match(/Profile git dependency failed for .+ Connection refused/)
-        _(run_result.stderr).must_include "http://localhost/no/such" # URL of the missing profile in message
-        assert_exit_code(1, run_result)
+        assert_fetcher_failed_cleanly(
+          run_result,
+          /Profile git dependency failed for .+ Connection refused/,
+          "http://localhost/no/such"
+        )
       end
     end
 

--- a/test/functional/fetchers_test.rb
+++ b/test/functional/fetchers_test.rb
@@ -34,5 +34,16 @@ describe "the fetchers" do
       end
     end
 
+    describe "when using the url fetcher on a bad dep" do
+      let(:path) { "#{fetcher_profiles}/git-bad" }
+      it "should throw an exception not a stacktrace" do
+        _(run_result.stdout).must_be_empty
+        _(run_result.stderr).wont_match looks_like_a_stacktrace
+        _(run_result.stderr).must_match(/Profile git dependency failed for .+ Connection refused/)
+        _(run_result.stderr).must_include "http://localhost/no/such" # URL of the missing profile in message
+        assert_exit_code(1, run_result)
+      end
+    end
+
   end
 end

--- a/test/functional/fetchers_test.rb
+++ b/test/functional/fetchers_test.rb
@@ -22,7 +22,7 @@ describe "the fetchers" do
 
     describe "when using the local fetcher on a bad dep" do
       let(:path) { "#{fetcher_profiles}/local-bad" }
-      it "should throw an exception not a stacktrace" do
+      it "should throw an exception not a stacktrace with a local fetcher" do
         assert_fetcher_failed_cleanly(
           run_result,
           /Profile dependency local path .+ does not exist/,
@@ -33,22 +33,22 @@ describe "the fetchers" do
 
     describe "when using the url fetcher on a bad dep" do
       let(:path) { "#{fetcher_profiles}/url-bad" }
-      it "should throw an exception not a stacktrace" do
+      it "should throw an exception not a stacktrace with a url fetcher" do
         assert_fetcher_failed_cleanly(
           run_result,
           /Profile URL dependency .+ could not be fetched:/,
-          "https://localhost/inspec/inspec-nonesuch/path/to/profile.tgz"
+          "https://localhost.invalid/inspec/inspec-nonesuch/path/to/profile.tgz"
         )
       end
     end
 
-    describe "when using the url fetcher on a bad dep" do
+    describe "when using the git fetcher on a bad dep" do
       let(:path) { "#{fetcher_profiles}/git-bad" }
-      it "should throw an exception not a stacktrace" do
+      it "should throw an exception not a stacktrace with a git fetcher" do
         assert_fetcher_failed_cleanly(
           run_result,
-          /Profile git dependency failed for .+ Connection refused/,
-          "http://localhost/no/such"
+          /Profile git dependency failed for .+ Could not resolve host.+/,
+          "http://localhost.invalid/no/such"
         )
       end
     end

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -284,7 +284,7 @@ describe Inspec::Fetcher::Url do
             }
 
             Inspec::Fetcher::Url.new("fake_url", config).send(:http_opts)
-          }.must_raise RuntimeError
+          }.must_raise Inspec::FetcherFailure
         end
       end
 
@@ -300,7 +300,7 @@ describe Inspec::Fetcher::Url do
             }
 
             Inspec::Fetcher::Url.new("fake_url", config).send(:http_opts)
-          }.must_raise RuntimeError
+          }.must_raise Inspec::FetcherFailure
         end
       end
     end
@@ -339,7 +339,7 @@ describe Inspec::Fetcher::Url do
             }
 
             Inspec::Fetcher::Url.new("fake_url", config).send(:http_opts)
-          }.must_raise RuntimeError
+          }.must_raise Inspec::FetcherFailure
         end
       end
 
@@ -356,7 +356,7 @@ describe Inspec::Fetcher::Url do
             }
 
             Inspec::Fetcher::Url.new("fake_url", config).send(:http_opts)
-          }.must_raise RuntimeError
+          }.must_raise Inspec::FetcherFailure
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

 * Modifies the `local`, `url`, and `git` fetchers to throw an `Inspec::FetcherFailure` exception if the fetch operation fails. 
 * Since `inspec` intercepts errors in that inheritance tree, the UX changes to no longer stacktrace - instead issuing the human-friendly one-line exception message.
 * The `compliance` fetcher was found to already be using this facility.

Simple test fixtures (profiles with bad dependencies) are included. Functional tests are included.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #4726

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
