### PR TITLE
Removes broken search button and icon

### DIFF
--- a/www/source/layouts/docs.slim
+++ b/www/source/layouts/docs.slim
@@ -6,9 +6,7 @@
       .columns.large-12.medium-12.z-20
         .flex.align.margin-both
           form.main-sidebar--search.shadow-dark action="/docs/search/" method="get"
-            input.st-default-search-input type="text" placeholder="Search documentation..." name="q"
-            button.search.shadow-dark.margin-left-xs action="/docs/search/" method="get"
-            i.fa.fa-search.t-white
+            input.st-default-search-input type="search" placeholder="Search documentation..." name="q"
     #particles-second
      canvas.particles-js-canvas-el /
 

--- a/www/source/stylesheets/_layout.scss
+++ b/www/source/stylesheets/_layout.scss
@@ -429,7 +429,7 @@ form.main-sidebar--search {
 
 //search input
 
-form.main-sidebar--search input[type="text"] {
+form.main-sidebar--search input[type="search"] {
 	font-family: $main-font;
 	font-weight: 400;
 	width: 100%;
@@ -442,30 +442,11 @@ form.main-sidebar--search input[type="text"] {
 	border-radius: 8px;
   background: $color_white;
   font-size: 1em;
-	color: $color_dark;
+  color: $color_dark;
+  margin: 0;
 
 	@include nav-small {
 		width:100%;
-	}
-}
-
-//Search button
-
-.search { // search icon
-	width: 45px;
-	height: 45px;
-	border: 1.5px solid $color_white;
-	border-radius: 8px;
-	background: rgba(255, 255, 255, 0);
-	cursor: pointer;
-	position: relative;
-	float: right;
-	outline: none;
-
-	i {
-		width: 20px;
-		margin-left: 8px;
-		height: auto;
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

The search button and search icon sat below the search bar. 
## Description
Remove search button and search icon.

The search button a) wasn't visible and b) didn't work. 
The search icon is generally unnecessary because users generally know what the point of the bar is. Even if they don't we have "search documentation" as the placeholder text.
Also changed the input type from "text" to "search", which is respected in HTML5 https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search

## Related Issues
#4752 
#4527 
