### PR TITLE
remove inspec from pkg_deps/pkg_build_deps in template

### DIFF
--- a/lib/plugins/inspec-habitat/templates/habitat/plan.sh.erb
+++ b/lib/plugins/inspec-habitat/templates/habitat/plan.sh.erb
@@ -1,8 +1,6 @@
 pkg_name=<%= "inspec-profile-#{profile.name}" %>
 pkg_version=<%= profile.version %>
 pkg_origin=<%= habitat_origin %>
-pkg_deps=(chef/inspec)
-pkg_build_deps=(chef/inspec core/jq-static)
 pkg_svc_user=root
 <%= "pkg_license='#{profile.metadata.params[:license]}'" if profile.metadata.params[:license]%>
 pkg_scaffolding="chef/scaffolding-chef-inspec"


### PR DESCRIPTION
Signed-off-by: Josh Brand <jbrand@chef.io>

It's included as a dep in the scaffolding itself, and the multiple dependencies cause failures when building (ty @smacfarlane <3)

`jq` is also no longer needed, it was an artifact of legacy testing (per PR convo)

## Description
Fixes hab builds of profiles after running `inspec habitat setup`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
