### PR TITLE
Fix warnings coming from ruby -w

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -8,6 +8,8 @@ require "inspec/utils/deprecation/global_method"
 # Allow end of options during array type parsing
 # https://github.com/erikhuda/thor/issues/631
 class Thor::Arguments
+  alias old_parse_array parse_array
+
   def parse_array(_name)
     return shift if peek.is_a?(Array)
 

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -6,7 +6,6 @@ require "stringio"
 require "forwardable"
 require "thor"
 require "base64"
-require "inspec/base_cli"
 require "inspec/plugin/v2/filter"
 
 module Inspec
@@ -422,6 +421,7 @@ module Inspec
 
     def finalize_set_top_level_command(options)
       options[:type] = @command_name
+      require "inspec/base_cli"
       Inspec::BaseCLI.inspec_cli_command = @command_name # TODO: move to a more relevant location
     end
 

--- a/lib/inspec/resources/gem.rb
+++ b/lib/inspec/resources/gem.rb
@@ -1,4 +1,5 @@
-require "inspec/resources/command"
+# circular: require "inspec/resource"
+# but... already being included by inspec/resource.rb
 
 module Inspec::Resources
   class GemPackage < Inspec.resource(1)
@@ -37,6 +38,8 @@ module Inspec::Resources
 
     def info
       return @info if defined?(@info)
+
+      require "inspec/resources/command"
 
       cmd = inspec.command("#{@gem_binary} list --local -a -q \^#{@package_name}\$")
       return {} unless cmd.exit_status == 0

--- a/lib/inspec/resources/shadow.rb
+++ b/lib/inspec/resources/shadow.rb
@@ -52,12 +52,6 @@ module Inspec::Resources
       .register_column(:inactive_days, field: "inactive_days")
       .register_column(:expiry_dates, field: "expiry_date")
       .register_column(:reserved, field: "reserved")
-    # These are deprecated, but we need to "alias" them
-    filtertable
-      .register_custom_property(:user) { |table, value| table.resource.user(value) }
-      .register_custom_property(:password) { |table, value| table.resource.password(value) }
-      .register_custom_property(:last_change) { |table, value| table.resource.last_change(value) }
-      .register_custom_property(:expiry_date) { |table, value| table.resource.expiry_date(value) }
 
     filtertable.register_custom_property(:content) do |t, _|
       t.entries.map do |e|

--- a/lib/inspec/utils/parser.rb
+++ b/lib/inspec/utils/parser.rb
@@ -227,6 +227,8 @@ module XinetdParser
   def parse_xinetd(raw) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     return {} if raw.nil?
 
+    require "inspec/utils/simpleconfig"
+
     res = {}
     cur_group = nil
     simple_conf = []
@@ -273,5 +275,3 @@ module XinetdParser
     res
   end
 end
-
-require "inspec/utils/simpleconfig"


### PR DESCRIPTION
This first pass fixes all our circular requires and duplicate method
warnings that come from:

```
ruby -w -Ilib:test test/functional/helper.rb
```

Signed-off-by: Ryan Davis <zenspider@chef.io>