### PR TITLE
Wire up backend to rspec metadata, allowing for example groups to use resources

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -23,11 +23,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_dependency "train", "~> 3.0" # Inspec 4 must have train 2+; 3+ if we include train-winrm
+  spec.add_dependency "train", "~> 3.0"
   # Train plugins we ship with InSpec
   spec.add_dependency "train-habitat", "~> 0.1"
   spec.add_dependency "train-aws", "~> 0.1"
-  spec.add_dependency "train-winrm", "~> 0.2" # Requires train 3+
+  spec.add_dependency "train-winrm", "~> 0.2"
 
   # Implementation dependencies
   spec.add_dependency "chef-telemetry", "~> 1.0"

--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -11,14 +11,13 @@ module Inspec
   module DescribeDslLazyLoader
     # Support for Describe DSL plugins
     def method_missing(method_name, *arguments, &block)
-      # TODO: need a backend available at the describe level... class method somewhere?
-      # # see if it is a resource first
-      # begin
-      #   resource = Inspec::DSL.method_missing_resource(:where_is_backend?, method_name, *arguments)
-      #   return resource if resource
-      # rescue LoadError
-      #   # pass through
-      # end
+      begin
+        backend = metadata[:backend] # populated via Inspec::Runner#add_resource
+        resource = Inspec::DSL.method_missing_resource(backend, method_name, *arguments)
+        return resource if resource
+      rescue LoadError
+        # pass through
+      end
 
       # Check to see if there is a describe_dsl plugin activator hook with the method name
       registry = Inspec::Plugin::V2::Registry.instance

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -307,6 +307,8 @@ module Inspec
     def add_resource(method_name, arg, opts, block)
       case method_name
       when "describe"
+        opts = { backend: @test_collector.backend }.merge opts
+
         @test_collector.example_group(*arg, opts, &block)
       when "expect"
         block.example_group


### PR DESCRIPTION
Fixes #628.

Signed-off-by: Ryan Davis <zenspider@chef.io>