### PR TITLE
Bump rspec to 3.9 and fix broken tests.

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json-schema", "~> 2.8"
   spec.add_dependency "method_source", "~> 0.8"
   spec.add_dependency "rubyzip", "~> 1.1"
-  spec.add_dependency "rspec", ["~> 3.0", "< 3.9"] # TODO: Loosen - See https://github.com/inspec/inspec/issues/4575
+  spec.add_dependency "rspec", "~> 3.9"
   spec.add_dependency "rspec-its", "~> 1.2"
   spec.add_dependency "hashie", "~> 3.4"
   spec.add_dependency "mixlib-log"

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tty-table", "~> 0.10"
   spec.add_dependency "tty-prompt", "~> 0.17"
   # Used for Azure profile until integrated into train
-  spec.add_dependency "faraday_middleware", "~> 0.12.2"
+  spec.add_dependency "faraday_middleware", "~> 0.12"
   spec.add_dependency "tomlrb", "~> 1.2"
   spec.add_dependency "addressable", "~> 2.4"
   spec.add_dependency "parslet", "~> 1.5"

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json-schema", "~> 2.8"
   spec.add_dependency "method_source", "~> 0.8"
   spec.add_dependency "rubyzip", "~> 1.2", ">= 1.2.2"
-  spec.add_dependency "rspec", ["~> 3.0", "< 3.9"] # TODO: Loosen - See https://github.com/inspec/inspec/issues/4575
+  spec.add_dependency "rspec", "~> 3.9"
   spec.add_dependency "rspec-its", "~> 1.2"
   spec.add_dependency "pry", "~> 0"
   spec.add_dependency "hashie", "~> 3.4"

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -182,7 +182,7 @@ describe "inspec exec with json formatter" do
       _(result).wont_be :nil?
 
       _(result["status"]).must_equal "passed"
-      _(result["code_desc"]).must_equal "File / should be directory"
+      _(result["code_desc"]).must_equal "File / is expected to be directory"
       _(result["run_time"]).wont_be :nil?
       _(result["start_time"]).wont_be :nil?
 

--- a/test/functional/inspec_exec_jsonmin_test.rb
+++ b/test/functional/inspec_exec_jsonmin_test.rb
@@ -56,7 +56,7 @@ describe "inspec exec" do
     end
 
     it "has a code_desc" do
-      _(ex1["code_desc"]).must_equal "File / should be directory"
+      _(ex1["code_desc"]).must_equal "File / is expected to be directory"
       _(controls.find { |ex| !ex.key? "code_desc" }).must_be :nil?
     end
 

--- a/test/functional/inspec_exec_junit_test.rb
+++ b/test/functional/inspec_exec_junit_test.rb
@@ -56,7 +56,7 @@ describe "inspec exec with junit formatter" do
       end
 
       it 'has 2 elements named "File / should be directory"' do
-        _(REXML::XPath.match(suite, "//testcase[@name='File / should be directory']").length).must_equal 2
+        _(REXML::XPath.match(suite, "//testcase[@name='File / is expected to be directory']").length).must_equal 2
       end
 
       describe 'the testcase named "example_config Can\'t find file ..."' do

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -26,7 +26,7 @@ describe "inspec exec" do
   end
 
   before do
-    prof = "test/unit/mock/profiles"
+    prof = "test/fixtures/profiles"
     FileUtils.rm_f "#{prof}/aws-profile/inspec.lock"
     FileUtils.rm_f "#{prof}/simple-inheritance/inspec.lock"
     FileUtils.rm_f "#{prof}/simple-metadata/inspec.lock"
@@ -165,11 +165,11 @@ Test Summary: 0 successful, 0 failures, 0 skipped
 
     _(stdout).must_include "Target:  local://"
     _(stdout).must_include "working"
-    _(stdout).must_include "✔  should eq \"working\""
+    _(stdout).must_include "✔  is expected to eq \"working\""
     _(stdout).must_include "skippy\n"
     _(stdout).must_include "↺  This will be skipped intentionally"
     _(stdout).must_include "failing"
-    _(stdout).must_include "×  should eq \"as intended\""
+    _(stdout).must_include "×  is expected to eq \"as intended\""
     _(stdout).must_include "Test Summary: 1 successful, 1 failure, 1 skipped\n"
 
     _(stderr).must_equal ""
@@ -354,10 +354,10 @@ Version: (not specified)
 Target:  local://
 
   \xE2\x9C\x94  tmp-1.0: Create / directory
-     \xE2\x9C\x94  File / should be directory
+     \xE2\x9C\x94  File / is expected to be directory
 
   File /
-     \xE2\x9C\x94  should be directory
+     \xE2\x9C\x94  is expected to be directory
 
 Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
 Test Summary: 2 successful, 0 failures, 0 skipped\n"
@@ -377,12 +377,12 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
 
     it "should print all the results" do
       _(stdout).must_include "×  tmp-1.0: Create / directory (1 failed)"
-      _(stdout).must_include "×  should not be directory\n"
+      _(stdout).must_include "×  is expected not to be directory\n"
       _(stdout).must_include "×  undefined method `should_nota'"
-      _(stdout).must_include "×  should not be directory\n     expected `File /.directory?` to return false, got true"
-      _(stdout).must_include "×  7 should cmp >= 9\n"
-      _(stdout).must_include "×  7 should not cmp == /^\\d$/\n"
-      _(stdout).must_include "✔  7 should cmp == \"7\""
+      _(stdout).must_include "×  is expected not to be directory\n     expected `File /.directory?` to return false, got true"
+      _(stdout).must_include "×  7 is expected to cmp >= 9\n"
+      _(stdout).must_include "×  7 is expected not to cmp == /^\\d$/\n"
+      _(stdout).must_include "✔  7 is expected to cmp == \"7\""
       _(stdout).must_include "expected: %p" % ["01147"]
       _(stdout).must_include "got: %p" % [is_windows? ? "040755" : "0755"]
     end
@@ -395,7 +395,7 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
       _(stdout).must_include "×  tmp-1.0: Create / directory (1 failed)"
       _(stdout).must_include "×  cmp-1.0: Using the cmp matcher for numbers (2 failed)"
       _(stdout).must_include "×  undefined method `should_nota'"
-      _(stdout).must_include "×  should not be directory\n     expected `File /.directory?` to return false, got true"
+      _(stdout).must_include "×  is expected not to be directory\n     expected `File /.directory?` to return false, got true"
       _(stdout).must_include "✔  profiled-1: Create / directory (profile d)"
     end
   end
@@ -404,7 +404,7 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
     let(:out) { inspec("exec " + simple_inheritance) }
 
     it "should print the profile information and then the test results" do
-      _(stdout).must_include "  ×  tmp-1.0: Create / directory (1 failed)\n     ✔  File / should be directory\n     ×  File / should not be directory\n"
+      _(stdout).must_include "  ×  tmp-1.0: Create / directory (1 failed)\n     ✔  File / is expected to be directory\n     ×  File / is expected not to be directory\n"
     end
   end
 
@@ -567,10 +567,10 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
     it "hides sensitive output" do
       inspec("exec " + sensitive_profile + " --no-create-lockfile")
 
-      _(stdout).must_include '×  should eq "billy"'
+      _(stdout).must_include '×  is expected to eq "billy"'
       _(stdout).must_include 'expected: "billy"'
       _(stdout).must_include 'got: "bob"'
-      _(stdout).must_include '×  should eq "secret"'
+      _(stdout).must_include '×  is expected to eq "secret"'
       _(stdout).must_include "*** sensitive output suppressed ***"
       _(stdout).must_include "\nTest Summary: 2 successful, 2 failures, 0 skipped\n"
 


### PR DESCRIPTION
Tests are STILL brittle, but this at least lets us drop old rspec.

Signed-off-by: Ryan Davis <zenspider@chef.io>