### PR TITLE
Removed all metaprogramming from ControlEvalContext

### DIFF
--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -110,6 +110,11 @@ module Inspec
     end
 
     def add_resources(context)
+      # # TODO: write real unit tests for this and then make this change:
+      # dsl = context.to_resources_dsl
+      # self.class.include dsl
+      # Inspec::Rule.include dsl
+
       self.class.class_eval do
         include context.to_resources_dsl
       end

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -12,236 +12,188 @@ module Inspec
   # etc).
   #
   class ControlEvalContext
-    # Create the context for controls. This includes all components of the DSL,
-    # including matchers and resources.
-    #
-    # @param [ResourcesDSL] resources_dsl which has all resources to attach
-    # @return [RuleContext] the inner context of rules
-    def self.rule_context(resources_dsl, profile_id)
-      Class.new(Inspec::Rule) do
-        include RSpec::Core::DSL
-        with_resource_dsl resources_dsl
+    include Inspec::DSL
+    include Inspec::DSL::RequireOverride
 
-        # allow attributes to be accessed within control blocks
-        define_method :input do |input_name, options = {}|
-          if options.empty?
-            # Simply an access, no event here
-            Inspec::InputRegistry.find_or_register_input(input_name, profile_id).value
-          else
-            options[:priority] ||= 20
-            options[:provider] = :inline_control_code
-            evt = Inspec::Input.infer_event(options)
-            Inspec::InputRegistry.find_or_register_input(input_name, profile_id, event: evt).value
-          end
-        end
-
-        # Find the Input object, but don't collapse to a value.
-        # Will return nil on a miss.
-        define_method :input_object do |input_name|
-          Inspec::InputRegistry.find_or_register_input(input_name, profile_id)
-        end
-
-        define_method :attribute do |name, options = {}|
-          Inspec.deprecate(:attrs_dsl, "Input name: #{name}, Profile: #{profile_id}")
-          input(name, options)
-        end
-
-        # Support for Control DSL plugins.
-        # This is called when an unknown method is encountered
-        # within a control block.
-        def method_missing(method_name, *arguments, &block)
-          # Check to see if there is a control_dsl plugin activator hook with the method name
-          registry = Inspec::Plugin::V2::Registry.instance
-          hook = registry.find_activators(plugin_type: :control_dsl, activator_name: method_name).first
-          if hook
-            # OK, load the hook if it hasn't been already.  We'll then know a module,
-            # which we can then inject into the context
-            hook.activate
-
-            # Inject the module's methods into the context.
-            # implementation_class is the field name, but this is actually a module.
-            self.class.include(hook.implementation_class)
-            # Now that the module is loaded, it defined one or more methods
-            # (presumably the one we were looking for.)
-            # We still haven't called it, so do so now.
-            send(method_name, *arguments, &block)
-          else
-            begin
-              Inspec::DSL.method_missing_resource(inspec, method_name, *arguments)
-            rescue LoadError
-              super
-            end
-          end
-        end
-
-      end
+    class << self
+      attr_accessor :profile_context_owner
+      attr_accessor :profile_id
+      attr_accessor :resources_dsl
     end
 
     # Creates the heart of the control eval context:
     #
     # An instantiated object which has all resources registered to it
-    # and exposes them to the a test file.
+    # and exposes them to the test file.
     #
     # @param profile_context [Inspec::ProfileContext]
     # @param outer_dsl [OuterDSLClass]
     # @return [ProfileContextClass]
-    def self.create(profile_context, resources_dsl) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-      profile_context_owner = profile_context
-      profile_id = profile_context.profile_id
-      rule_class = rule_context(resources_dsl, profile_id)
-      Class.new do # rubocop:disable Metrics/BlockLength
-        include Inspec::DSL
-        include Inspec::DSL::RequireOverride
-        include resources_dsl
+    def self.create(profile_context, resources_dsl)
+      klass = Class.new self
+      klass.include resources_dsl
 
-        attr_accessor :skip_file
+      klass.profile_context_owner = profile_context
+      klass.profile_id            = profile_context.profile_id
+      klass.resources_dsl         = resources_dsl
 
-        def initialize(backend, conf, dependencies, require_loader, skip_only_if_eval)
-          @backend = backend
-          @conf = conf
-          @dependencies = dependencies
-          @require_loader = require_loader
-          @skip_file_message = nil
-          @skip_file = false
-          @skip_only_if_eval = skip_only_if_eval
+      klass
+    end
+
+    attr_accessor :skip_file
+
+    def initialize(backend, conf, dependencies, require_loader, skip_only_if_eval)
+      @backend = backend
+      @conf = conf
+      @dependencies = dependencies
+      @require_loader = require_loader
+      @skip_file_message = nil
+      @skip_file = false
+      @skip_only_if_eval = skip_only_if_eval
+    end
+
+    def to_s
+      "Control Evaluation Context (#{profile_name})"
+    end
+
+    def profile_context_owner
+      self.class.profile_context_owner
+    end
+
+    def profile_id
+      self.class.profile_id
+    end
+
+    def resources_dsl
+      self.class.resources_dsl
+    end
+
+    def title(arg)
+      profile_context_owner.set_header(:title, arg)
+    end
+
+    def profile_name
+      profile_id
+    end
+
+    def control(id, opts = {}, &block)
+      opts[:skip_only_if_eval] = @skip_only_if_eval
+
+      register_control(Inspec::Rule.new(id, profile_id, resources_dsl, opts, &block))
+    end
+    alias rule control
+
+    # Describe allows users to write rspec-like bare describe
+    # blocks without declaring an inclosing control. Here, we
+    # generate a control for them automatically and then execute
+    # the describe block in the context of that control.
+    #
+    def describe(*args, &block)
+      loc = block_location(block, caller(1..1).first)
+      id = "(generated from #{loc} #{SecureRandom.hex})"
+
+      res = nil
+      rule = Inspec::Rule.new(id, profile_id, resources_dsl, {}) do
+        res = describe(*args, &block)
+      end
+      register_control(rule, &block)
+
+      res
+    end
+
+    def add_resource(name, new_res)
+      resources_dsl.module_exec do
+        define_method name.to_sym do |*args|
+          new_res.new(@backend, name.to_s, *args)
         end
+      end
+    end
 
-        define_method :title do |arg|
-          profile_context_owner.set_header(:title, arg)
-        end
+    def add_resources(context)
+      self.class.class_eval do
+        include context.to_resources_dsl
+      end
 
-        def to_s
-          "Control Evaluation Context (#{profile_name})"
-        end
+      # TODO: seriously consider getting rid of the NPM model
+      extend context.to_resources_dsl
+    end
 
-        define_method :profile_name do
-          profile_id
-        end
+    def add_subcontext(context)
+      profile_context_owner.add_subcontext(context)
+    end
 
-        define_method :control do |*args, &block|
-          id = args[0]
-          opts = args[1] || {}
-          opts[:skip_only_if_eval] = @skip_only_if_eval
-          register_control(rule_class.new(id, profile_id, opts, &block))
-        end
+    def register_control(control, &block)
+      if @skip_file
+        ::Inspec::Rule.set_skip_rule(control, true, @skip_file_message)
+      end
 
-        #
-        # Describe allows users to write rspec-like bare describe
-        # blocks without declaring an inclosing control. Here, we
-        # generate a control for them automatically and then execute
-        # the describe block in the context of that control.
-        #
-        define_method :describe do |*args, &block|
-          loc = block_location(block, caller(1..1).first)
-          id = "(generated from #{loc} #{SecureRandom.hex})"
+      unless profile_context_owner.profile_supports_platform?
+        platform = inspec.platform
+        msg = "Profile `#{profile_context_owner.profile_id}` is not supported on platform #{platform.name}/#{platform.release}."
+        ::Inspec::Rule.set_skip_rule(control, true, msg)
+      end
 
-          res = nil
-          rule = rule_class.new(id, profile_id, {}) do
-            res = describe(*args, &block)
-          end
-          register_control(rule, &block)
+      unless profile_context_owner.profile_supports_inspec_version?
+        msg = "Profile `#{profile_context_owner.profile_id}` is not supported on InSpec version (#{Inspec::VERSION})."
+        ::Inspec::Rule.set_skip_rule(control, true, msg)
+      end
 
-          res
-        end
+      profile_context_owner.register_rule(control, &block) unless control.nil?
+    end
 
-        define_method :add_resource do |name, new_res|
-          resources_dsl.module_exec do
-            define_method name.to_sym do |*args|
-              new_res.new(@backend, name.to_s, *args)
-            end
-          end
-        end
+    def input(input_name, options = {})
+      if options.empty?
+        # Simply an access, no event here
+        Inspec::InputRegistry.find_or_register_input(input_name, profile_id).value
+      else
+        options[:priority] ||= 20
+        options[:provider] = :inline_control_code
+        evt = Inspec::Input.infer_event(options)
+        Inspec::InputRegistry.find_or_register_input(input_name, profile_id, event: evt).value
+      end
+    end
 
-        define_method :add_resources do |context|
-          self.class.class_eval do
-            include context.to_resources_dsl
-          end
+    # Find the Input object, but don't collapse to a value.
+    # Will return nil on a miss.
+    def input_object(input_name)
+      Inspec::InputRegistry.find_or_register_input(input_name, profile_id)
+    end
 
-          rule_class.class_eval do
-            include context.to_resources_dsl
-          end
-        end
+    def attribute(name, options = {})
+      Inspec.deprecate(:attrs_dsl, "Input name: #{name}, Profile: #{profile_id}")
+      input(name, options)
+    end
 
-        define_method :add_subcontext do |context|
-          profile_context_owner.add_subcontext(context)
-        end
+    def skip_control(id)
+      profile_context_owner.unregister_rule(id)
+    end
+    alias skip_rule skip_control
 
-        define_method :register_control do |control, &block|
-          if @skip_file
-            ::Inspec::Rule.set_skip_rule(control, true, @skip_file_message)
-          end
+    def only_if(message = nil, &block)
+      return unless block
+      return if @skip_file == true
+      return if @skip_only_if_eval == true
 
-          unless profile_context_owner.profile_supports_platform?
-            platform = inspec.platform
-            msg = "Profile `#{profile_context_owner.profile_id}` is not supported on platform #{platform.name}/#{platform.release}."
-            ::Inspec::Rule.set_skip_rule(control, true, msg)
-          end
+      return if block.yield == true
 
-          unless profile_context_owner.profile_supports_inspec_version?
-            msg = "Profile `#{profile_context_owner.profile_id}` is not supported on InSpec version (#{Inspec::VERSION})."
-            ::Inspec::Rule.set_skip_rule(control, true, msg)
-          end
+      # Apply `set_skip_rule` for other rules in the same file
+      profile_context_owner.rules.values.each do |r|
+        sources_match = r.source_file == block.source_location[0]
+        Inspec::Rule.set_skip_rule(r, true, message) if sources_match
+      end
 
-          profile_context_owner.register_rule(control, &block) unless control.nil?
-        end
+      @skip_file_message = message
+      @skip_file = true
+    end
 
-        define_method :input do |input_name, options = {}|
-          if options.empty?
-            # Simply an access, no event here
-            Inspec::InputRegistry.find_or_register_input(input_name, profile_id).value
-          else
-            options[:priority] ||= 20
-            options[:provider] = :inline_control_code
-            evt = Inspec::Input.infer_event(options)
-            Inspec::InputRegistry.find_or_register_input(input_name, profile_id, event: evt).value
-          end
-        end
+    private
 
-        # Find the Input object, but don't collapse to a value.
-        # Will return nil on a miss.
-        define_method :input_object do |input_name|
-          Inspec::InputRegistry.find_or_register_input(input_name, profile_id)
-        end
-
-        define_method :attribute do |name, options = {}|
-          Inspec.deprecate(:attrs_dsl, "Input name: #{name}, Profile: #{profile_id}")
-          input(name, options)
-        end
-
-        define_method :skip_control do |id|
-          profile_context_owner.unregister_rule(id)
-        end
-
-        define_method :only_if do |message = nil, &block|
-          return unless block
-          return if @skip_file == true
-          return if @skip_only_if_eval == true
-
-          return if block.yield == true
-
-          # Apply `set_skip_rule` for other rules in the same file
-          profile_context_owner.rules.values.each do |r|
-            sources_match = r.source_file == block.source_location[0]
-            Inspec::Rule.set_skip_rule(r, true, message) if sources_match
-          end
-
-          @skip_file_message = message
-          @skip_file = true
-        end
-
-        alias_method :rule, :control
-        alias_method :skip_rule, :skip_control
-
-        private
-
-        def block_location(block, alternate_caller)
-          if block.nil?
-            alternate_caller[/^(.+:\d+):in .+$/, 1] || "unknown"
-          else
-            path, line = block.source_location
-            "#{File.basename(path)}:#{line}"
-          end
-        end
+    def block_location(block, alternate_caller)
+      if block.nil?
+        alternate_caller[/^(.+:\d+):in .+$/, 1] || "unknown"
+      else
+        path, line = block.source_location
+        "#{File.basename(path)}:#{line}"
       end
     end
   end

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -56,10 +56,14 @@ module Inspec
     end
 
     def control_eval_context
-      @control_eval_context ||= begin
-                                  ctx = Inspec::ControlEvalContext.create(self, to_resources_dsl)
-                                  ctx.new(@backend, @conf, dependencies, @require_loader, @skip_only_if_eval)
-                                end
+      @control_eval_context ||=
+        Inspec::ControlEvalContext.new(self,
+                                       to_resources_dsl,
+                                       @backend,
+                                       @conf,
+                                       dependencies,
+                                       @require_loader,
+                                       @skip_only_if_eval)
     end
 
     def reload_dsl

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -16,7 +16,6 @@ module Inspec
     attr_reader :__waiver_data
     attr_accessor :resource_dsl
     attr_reader :__profile_id
-    alias profile_id __profile_id
 
     def initialize(id, profile_id, resource_dsl, opts, &block)
       @impact = nil
@@ -176,23 +175,23 @@ module Inspec
     def input(input_name, options = {})
       if options.empty?
         # Simply an access, no event here
-        Inspec::InputRegistry.find_or_register_input(input_name, profile_id).value
+        Inspec::InputRegistry.find_or_register_input(input_name, __profile_id).value
       else
         options[:priority] ||= 20
         options[:provider] = :inline_control_code
         evt = Inspec::Input.infer_event(options)
-        Inspec::InputRegistry.find_or_register_input(input_name, profile_id, event: evt).value
+        Inspec::InputRegistry.find_or_register_input(input_name, __profile_id, event: evt).value
       end
     end
 
     # Find the Input object, but don't collapse to a value.
     # Will return nil on a miss.
     def input_object(input_name)
-      Inspec::InputRegistry.find_or_register_input(input_name, profile_id)
+      Inspec::InputRegistry.find_or_register_input(input_name, __profile_id)
     end
 
     def attribute(name, options = {})
-      Inspec.deprecate(:attrs_dsl, "Input name: #{name}, Profile: #{profile_id}")
+      Inspec.deprecate(:attrs_dsl, "Input name: #{name}, Profile: #{__profile_id}")
       input(name, options)
     end
 
@@ -332,7 +331,7 @@ module Inspec
     def __apply_waivers
       input_name = @__rule_id # TODO: control ID slugging
       registry = Inspec::InputRegistry.instance
-      input = registry.inputs_by_profile.dig(@__profile_id, input_name)
+      input = registry.inputs_by_profile.dig(__profile_id, input_name)
       return unless input
 
       # An InSpec Input is a datastructure that tracks a profile parameter

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -42,6 +42,10 @@ class MockLoader
     @platform = OPERATING_SYSTEMS[os]
   end
 
+  def self.connection
+    @connection ||= Train.create("local", command_runner: :generic).connection
+  end
+
   def backend
     return @backend if defined?(@backend)
 
@@ -52,7 +56,7 @@ class MockLoader
     mock = @backend.backend
 
     # create all mock files
-    local = Train.create("local", command_runner: :generic).connection
+    local = MockLoader.connection
 
     # set os emulation
     mock.mock_os(@platform)

--- a/test/unit/profiles/control_eval_context_test.rb
+++ b/test/unit/profiles/control_eval_context_test.rb
@@ -28,15 +28,10 @@ describe Inspec::ControlEvalContext do
   let(:backend) { mock }
   let(:profile_context) { Inspec::ProfileContext.new("test-profile", backend, {}) }
   let(:eval_context) do
-    c = Inspec::ControlEvalContext.create(profile_context, resource_dsl)
     # Options that are mocked below are:
     # backend, conf, dependencies, require_loader, and skip_only_if_eval
     # See: `lib/inspec/control_eval_context.rb` for more details
-    c.new(backend, {}, mock, mock, false)
-  end
-
-  it "accepts a context and a resource_dsl" do
-    Inspec::ControlEvalContext.create(profile_context, resource_dsl)
+    Inspec::ControlEvalContext.new(profile_context, resource_dsl, backend, {}, mock, mock, false)
   end
 
   it "provides rules with access to the given DSL" do

--- a/test/unit/profiles/profile_context_test.rb
+++ b/test/unit/profiles/profile_context_test.rb
@@ -49,8 +49,11 @@ module DescribeOneTest
   end
 end
 
+BACKEND = MockLoader.new.backend
+
 describe Inspec::ProfileContext do
-  let(:backend) { MockLoader.new.backend }
+
+  let(:backend) { BACKEND }
   let(:profile) { Inspec::ProfileContext.new(nil, backend, {}) }
 
   def get_checks(rule_index = 0)


### PR DESCRIPTION
+ Removed ControlEvalContext.rule_context entirely pushing into Rule
+ Gutted ControlEvalContext.create pushing into ControlEvalContext.
+ Added class ivar accessors for ControlEvalContext to bypass need for closures.
+ Converted all define_methods into defs.
+ Added resource_dsl to Rule#initialize

Signed-off-by: Ryan Davis <zenspider@chef.io>