### PR TITLE
sum-coverage doesnt have -t

### DIFF
--- a/.expeditor/buildkite/coverage.sh
+++ b/.expeditor/buildkite/coverage.sh
@@ -49,7 +49,7 @@ bundle exec rake test
 EXIT_CODE=$?
 
 echo "+++ formatting and uploading test coverage"
-./test-reporter sum-coverage -t simplecov
+./test-reporter sum-coverage
 ./test-reporter after-build -t simplecov --exit-code "$EXIT_CODE"
 
 echo "--- uploading test-reporter.sha to s3"


### PR DESCRIPTION
Error: unknown shorthand flag: 't' in -t
Usage:
  cc-test-reporter sum-coverage [flags]

Flags:
  -o, --output string   output path (default "coverage/codeclimate.json")
  -p, --parts int       total number of parts to sum

Global Flags:
  -d, --debug   run in debug mode

Signed-off-by: Miah Johnson <miah@chia-pet.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
