### PR TITLE
Allow Thor 1.x versions to be used

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "train-core", "~> 3.0"
   spec.add_dependency "chef-telemetry", "~> 1.0"
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
-  spec.add_dependency "thor", "~> 0.20"
+  spec.add_dependency "thor", ">= 0.20", "< 2.0"
   spec.add_dependency "json-schema", "~> 2.8"
   spec.add_dependency "method_source", "~> 0.8"
   spec.add_dependency "rubyzip", "~> 1.1"

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   # Implementation dependencies
   spec.add_dependency "chef-telemetry", "~> 1.0"
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
-  spec.add_dependency "thor", "~> 0.20"
+  spec.add_dependency "thor", ">= 0.20", "< 2.0"
   spec.add_dependency "json-schema", "~> 2.8"
   spec.add_dependency "method_source", "~> 0.8"
   spec.add_dependency "rubyzip", "~> 1.2", ">= 1.2.2"


### PR DESCRIPTION
Thor 1.0 drops support for Ruby 1.8 and 1.9. We should loosen this dep
to allow the 1.x series since bug fixes are occurring there now.

Signed-off-by: Tim Smith <tsmith@chef.io>