### PR TITLE
Update Ruby to 2.6.5

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -9,4 +9,4 @@ override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to
 # grab the current train release from rubygems.org
 train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
 override "train", version: "v#{train_stable}"
-override "ruby", version: "2.6.3"
+override "ruby", version: "2.6.5"


### PR DESCRIPTION
This resolves multiple CVEs in ruby

https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/
https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-6-4-released/

Signed-off-by: Tim Smith <tsmith@chef.io>