### PR TITLE
Fix empty attributes array in json reporter

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -312,11 +312,11 @@ module Inspec
       end
 
       # add information about the required inputs
-      if res[:inputs].nil? || res[:inputs].empty?
+      if params[:inputs].nil? || params[:inputs].empty?
         # convert to array for backwards compatability
         res[:inputs] = []
       else
-        res[:inputs] = res[:inputs].values.map(&:to_hash)
+        res[:inputs] = params[:inputs].values.map(&:to_hash)
       end
       res[:sha256] = sha256
       res[:parent_profile] = parent_profile unless parent_profile.nil?


### PR DESCRIPTION
issue #4807: shallow copy of params missed inputs

## Description
using `dup` to shallow copy `params`, which means `inputs` is not copied into `res` yet and `res[:inputs] = []` branch always executes

## Related Issue
https://github.com/inspec/inspec/issues/4807

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
