### PR TITLE
replaced instances of `have_protocols` with `have_protocol` in docume…

### DIFF
--- a/docs/resources/iis_app.md.erb
+++ b/docs/resources/iis_app.md.erb
@@ -26,7 +26,7 @@ An `iis_app` resource block declares details about the named site:
     describe iis_app('application_path', 'site_name') do
       it { should exist }
       it { should have_application_pool('application_pool') }
-      it { should have_protocols('protocol') }
+      it { should have_protocol('protocol') }
       it { should have_site_name('site') }
       it { should have_physical_path('physical_path') }
       it { should have_path('application_path') }
@@ -45,7 +45,7 @@ For example:
     describe iis_app('/myapp', 'Default Web Site') do
       it { should exist }
       it { should have_application_pool('MyAppPool') }
-      it { should have_protocols('http') }
+      it { should have_protocol('http') }
       it { should have_site_name('Default Web Site') }
       it { should have_physical_path('C:\\inetpub\\wwwroot\\myapp') }
       it { should have_path('\\My Application') }

--- a/lib/inspec/resources/iis_app.rb
+++ b/lib/inspec/resources/iis_app.rb
@@ -10,7 +10,7 @@ module Inspec::Resources
       describe iis_app('/myapp', 'Default Web Site') do
         it { should exist }
         it { should have_application_pool('MyAppPool') }
-        it { should have_protocols('http') }
+        it { should have_protocol('http') }
         it { should have_site_name('Default Web Site') }
         it { should have_physical_path('C:\\inetpub\\wwwroot\\myapp') }
         it { should have_path('\\My Application') }

--- a/test/kitchen/policies/default/controls/iis_site_spec.rb
+++ b/test/kitchen/policies/default/controls/iis_site_spec.rb
@@ -33,7 +33,7 @@ end
 describe iis_app('/TestApp', 'Default Web Site') do
   it { should exist }
   it { should have_application_pool('DefaultAppPool') }
-  it { should have_protocols('http') }
+  it { should have_protocol('http') }
   it { should have_site_name('Default Web Site') }
   it { should have_physical_path('C:\\inetpub\\wwwroot\\Test') }
   it { should have_path('\\TestApp') }


### PR DESCRIPTION
Signed-off-by: Cameron Straka <strakacameron@hotmail.com>

Modified example and document instances of `have_protocols` to `have_protocol`
## Description
Docs were incorrectly referencing have_protocols in 4 places, creating error 'expected iis_app 'app_name' to respond to `has_protocols?`' when docs were followed

## Related Issue
No known related issues

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
