### PR TITLE
Set test skip bomb date to end of 2020Q1

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -148,7 +148,7 @@ class Minitest::Test
   end
 
   def skip_windows!
-    skip_until 2019, 12, 31, "These have never passed" if windows?
+    skip_until 2020, 3, 31, "These have never passed" if windows?
   end
 
   def unmock(&blk)


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

This gets master green again by pushing back the arbitrary deadline for skipped tests, currently isolated to the Windows platform.

Keep in mind we have nice Github issues for each outstanding skipped test.
