### PR TITLE
updates file resource doc to add example for sticky bit with leading …

### DIFF
--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -117,6 +117,14 @@ not
 
     { should cmp '644' }
 
+or:
+
+    { should cmp '01775' }
+
+not
+
+    { should cmp '1775' }
+
 Without the zero prefix for the octal value, Chef InSpec will interpret it as the _decimal_ value 644, which is octal 1024 or `-----w-r-T`, and any test for a file that is `-rw-r--r--` will fail.
 
 Note: see the [`be_more_permissive_than(mode)`](#be_more_permissive_than?(mode)) matcher for upper and lower bounds on file mode.

--- a/docs/resources/file.md.erb
+++ b/docs/resources/file.md.erb
@@ -117,7 +117,7 @@ not
 
     { should cmp '644' }
 
-or:
+or write:
 
     { should cmp '01775' }
 


### PR DESCRIPTION
…zero

Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
updates file resource doc md to add example for sticky bit with leading zero.  Updated with new PR with upstream merge for interim changes which were breaking windows testing on buildkite.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Clears up confusion on the file resource to show that tests which include sticky-bit position should also have a leading zero.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I have read the **CONTRIBUTING** document.
