### PR TITLE
Properly report errors with bad tarball files.

### DIFF
--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -209,8 +209,10 @@ module Inspec
     def walk_tar(path, &callback)
       tar_file = Zlib::GzipReader.open(path)
       Gem::Package::TarReader.new(tar_file, &callback)
+    rescue => e
+      raise Inspec::Error, "Error opening/processing #{path}: #{e.message}"
     ensure
-      tar_file.close
+      tar_file.close if tar_file
     end
   end # class TarProvider
 


### PR DESCRIPTION
+ Raise a well-worded error with details and avoid an uncaught exception.
+ Fix error caused when the tar file is already invalid and we try to close it.

Fixes #3765.

Signed-off-by: Ryan Davis <zenspider@chef.io>