### PR TITLE
upstream is basic_auth_only not basic_auth

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -101,7 +101,7 @@ module Inspec
         desc: "Specify which transport to use, defaults to negotiate (WinRM)."
       option :winrm_disable_sspi, type: :boolean,
         desc: "Whether to use disable sspi authentication, defaults to false (WinRM)."
-      option :winrm_basic_auth, type: :boolean,
+      option :winrm_basic_auth_only, type: :boolean,
         desc: "Whether to use basic authentication, defaults to false (WinRM)."
       option :config, type: :string,
         desc: "Read configuration from JSON file (`-` reads from stdin)."


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The option in winrm is **basic_auth_only** not **basic_auth**. After the change i am able to authenticate with --winrm_basic_auth_only

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
