### PR TITLE
Fixes all notarization issues

### DIFF
--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -66,7 +66,7 @@ end
 
 package :pkg do
   identifier "com.getchef.pkg.inspec"
-  signing_identity "Developer ID Installer: Chef Software, Inc. (EU3VF8YLX2)"
+  signing_identity "Chef Software, Inc. (EU3VF8YLX2)"
 end
 compress :dmg
 

--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -52,4 +52,10 @@ build do
       appbundle "inspec", env: env
     end
   end
+
+  block "Delete test folder from problem gems" do
+    env["VISUAL"] = "echo"
+    gem_install_dir = shellout!("#{install_dir}/embedded/bin/gem open rubyzip", env: env).stdout.chomp
+    remove_directory "#{gem_install_dir}/test"
+  end
 end


### PR DESCRIPTION
## Description
This changes makes the neccessary changes to enable the pkg to pass apples notarization requirements.

1. Update omnibus and omnibus-software to versions that support deep signing
2. Drop 'Developer ID Installer:' from signing key. This lets sigining pick up the correct key for what is being signed.
3. Update inspec software definition to delete test dir from rubyzip gem because its fixtures contain zip files that the notarization service cannot inspect.

Signed-off-by: Jon Morrow <jmorrow@chef.io>

## Related Issue
https://github.com/chef/omnibus/pull/924
https://github.com/chef/omnibus-software/pull/1146

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
