### PR TITLE
Add support for yocto linux in service resource

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -172,6 +172,8 @@ module Inspec::Resources
         end
       elsif os.solaris?
         Svcs.new(inspec)
+      elsif %w{yocto}.include?(platform)
+        Systemd.new(inspec, service_ctl)
       end
     end
 

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -31,6 +31,7 @@ class MockLoader
     aix: { name: "aix", family: "aix", release: "7.2", arch: "powerpc" },
     amazon: { name: "amazon", family: "redhat", release: "2015.03", arch: "x86_64" },
     amazon2: { name: "amazon", family: "redhat", release: "2", arch: "x86_64" },
+    yocto: { name: "yocto", family: "yocto", release: "0.0.1", arch: "aarch64" },
     undefined: { name: nil, family: nil, release: nil, arch: nil },
   }
 

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -417,6 +417,19 @@ describe "Inspec::Resources::Service" do
     _(resource.params).must_equal params
   end
 
+  # yocto
+  it "verify yocto service parsing" do
+    resource = MockLoader.new(:yocto).load_resource("service", "sshd")
+    params = Hashie::Mash.new({ "ActiveState" => "active", "Description" => "OpenSSH server daemon", "Id" => "sshd.service", "LoadState" => "loaded", "Names" => "sshd.service", "SubState" => "running", "UnitFileState" => "enabled" })
+    _(resource.type).must_equal "systemd"
+    _(resource.name).must_equal "sshd.service"
+    _(resource.description).must_equal "OpenSSH server daemon"
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+  end
+
   # unknown OS
   it "verify service handling on unsupported os" do
     resource = MockLoader.new(:undefined).load_resource("service", "dhcp")


### PR DESCRIPTION
Signed-off-by: Michael Lihs <michael.lihs@thoughtworks.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Adds support to the `service` resource for yocto-based linux distributions.

## Related Issue

https://github.com/inspec/inspec/issues/4842

requires https://github.com/inspec/train/pull/558 to be merged in the `train` library.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
