### PR TITLE
Add: certificate content x509_certificate

### DIFF
--- a/docs/resources/x509_certificate.md.erb
+++ b/docs/resources/x509_certificate.md.erb
@@ -33,6 +33,22 @@ An `x509_certificate` resource block declares a certificate `key file` to be tes
       its('validity_in_days') { should be > 30 }
     end
 
+The `filepath` property can also be used.
+
+    describe x509_certificate(filepath: 'mycertificate.pem') do
+      its('validity_in_days') { should be > 30 }
+    end
+
+The resource also supports passing in the certificate content.
+
+    cert_content = file('certificate.pem').content
+
+    describe x509_certificate(content: cert_content) do
+      its('validity_in_days') { should be > 30 }
+    end
+
+If both `content` and `filepath` is given, the value passed in `content` is used.
+
 <br>
 
 ## Properties

--- a/lib/inspec/resources/x509_certificate.rb
+++ b/lib/inspec/resources/x509_certificate.rb
@@ -34,13 +34,15 @@ module Inspec::Resources
     include FileReader
 
     # @see https://tools.ietf.org/html/rfc5280#page-23
-    def initialize(filename)
-      @certpath = filename
+    def initialize(opts)
+      @opts = options(opts)
       @issuer = nil
       @parsed_subject = nil
       @parsed_issuer = nil
       @extensions = nil
-      @cert = OpenSSL::X509::Certificate.new read_file_content(@certpath)
+      @content = @opts[:content]
+      @content ||= read_file_content(@opts[:filepath])
+      @cert = OpenSSL::X509::Certificate.new @content
     end
 
     # Forward these methods directly to OpenSSL::X509::Certificate instance
@@ -137,7 +139,19 @@ module Inspec::Resources
     end
 
     def to_s
-      "x509_certificate #{@certpath}"
+      cert = @opts[:filepath]
+      cert ||= subject.CN
+      "x509_certificate #{cert}"
+    end
+
+    private
+
+    def options(opts)
+      if opts.is_a?(String)
+        { filepath: opts }
+      else
+        opts
+      end
     end
   end
 end

--- a/test/unit/resources/x509_certificate_test.rb
+++ b/test/unit/resources/x509_certificate_test.rb
@@ -10,6 +10,20 @@ describe "Inspec::Resources::X509Certificate" do
     )
   end
 
+  let(:resource_cert_with_content) do
+    load_resource(
+      "x509_certificate",
+      content: File.read("test/fixtures/files/test_certificate.rsa.crt.pem")
+    )
+  end
+
+  let(:resource_cert_with_filepath) do
+    load_resource(
+      "x509_certificate",
+      filepath: "test_certificate.rsa.crt.pem"
+    )
+  end
+
   # TODO: Regenerate certificate using `InSpec` not `Inspec`
   it "verify subject distingushed name" do
     _(resource_cert.send("subject_dn")).must_match "Inspec Test Certificate"
@@ -19,6 +33,10 @@ describe "Inspec::Resources::X509Certificate" do
   it "parses the certificate subject" do
     _(resource_cert.send("subject").CN).must_equal "Inspec Test Certificate"
     _(resource_cert.send("subject").emailAddress).must_equal "support@chef.io"
+    _(resource_cert_with_content.send("subject").CN).must_equal "Inspec Test Certificate"
+    _(resource_cert_with_content.send("subject").emailAddress).must_equal "support@chef.io"
+    _(resource_cert_with_filepath.send("subject").CN).must_equal "Inspec Test Certificate"
+    _(resource_cert_with_filepath.send("subject").emailAddress).must_equal "support@chef.io"
   end
 
   # TODO: Regenerate certificate using `InSpec` not `Inspec`


### PR DESCRIPTION
Support passing in certificate content to `x509_certificate` resource.

## Description
This change allows to read a certificate chain file having multiple certificates. The inspec `file` resource is used to read the combined pem, then split on the delimiter and pass the content to `x509_certificate` resource.


## Types of changes
- [x] New content (non-breaking change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] DCO signed