### PR TITLE
Remove the references to the core/cacerts so customers can specify it

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -10,7 +10,6 @@ $pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 $pkg_license=('Apache-2.0')
 
 $pkg_deps=@(
-  "core/cacerts"
   "chef/ruby-plus-devkit"
 )
 $pkg_bin_dirs=@("bin"
@@ -33,7 +32,6 @@ function Invoke-SetupEnvironment {
 
     Set-RuntimeEnv APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
     Set-RuntimeEnv FORCE_FFI_YAJL "ext"
-    Set-RuntimeEnv -IsPath SSL_CERT_FILE "$(Get-HabPackagePath cacerts)/ssl/cert.pem"
     Set-RuntimeEnv LANG "en_US.UTF-8"
     Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"
 }

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -9,7 +9,6 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_deps=(
   core/coreutils
-  core/cacerts
   core/git
   core/ruby
   core/bash
@@ -67,7 +66,6 @@ wrap_inspec_bin() {
   build_line "Adding wrapper $bin to $real_bin"
   cat <<EOF > "$bin"
 #!$(pkg_path_for core/bash)/bin/bash
-export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
 set -e
 
 # Set binary path that allows InSpec to use non-Hab pkg binaries


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

Currently the InSpec habitat packages are built with a dependency on the `core/cacerts` package. This sets the environment variable `SSL_CERT_DIR` to a specific version of the core/cacerts package. If a user wants to use inspec to communicate, via ssl, to an Automate, Github, or other server that does not have a cert chain that is in the `core/cacerts` package they will get an ssl error. The workaround for this is to then break immutability of the `core/cacerts` package by in the users consuming plan adding their custom certs to the specific version of `core/cacerts` that inspec is packaged with. Removing this will allow the user to set a custom cacerts package and set the `SSL_CERT_FILE` and `SSL_CERT_DIR` in their consuming plan. An example of this can be found in the [habitat scaffolding for InSpec](https://github.com/chef/effortless/blob/master/scaffolding-chef-inspec/lib/scaffolding.sh#L107).

## Related Issue
#4810 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [x] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
