### PR TITLE
Refactor some of resources/service.rb

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -148,7 +148,7 @@ module Inspec::Resources
         SysV.new(inspec, service_ctl)
       elsif %w{mac_os_x}.include?(platform)
         LaunchCtl.new(inspec, service_ctl)
-      elsif os.windows?
+      elsif %w{windows}.include?(platform)
         WindowsSrv.new(inspec)
       elsif %w{freebsd}.include?(platform)
         BSDInit.new(inspec, service_ctl)
@@ -170,7 +170,7 @@ module Inspec::Resources
         else
           Systemd.new(inspec, service_ctl)
         end
-      elsif os.solaris?
+      elsif %w{solaris smartos omnios openindiana opensolaris nexentacore}.include?(platform)
         Svcs.new(inspec)
       end
     end

--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -112,21 +112,23 @@ module Inspec::Resources
       # Ubuntu < 15.04 : Upstart
       # Upstart runs with PID 1 as /sbin/init.
       # Systemd runs with PID 1 as /lib/systemd/systemd.
-      if %w{ubuntu}.include?(platform)
+
+      case platform
+      when "ubuntu"
         version = os[:release].to_f
         if version < 15.04
           Upstart.new(inspec, service_ctl)
         else
           Systemd.new(inspec, service_ctl)
         end
-      elsif %w{linuxmint}.include?(platform)
+      when "linuxmint"
         version = os[:release].to_f
         if version < 18
           Upstart.new(inspec, service_ctl)
         else
           Systemd.new(inspec, service_ctl)
         end
-      elsif %w{debian}.include?(platform)
+      when "debian"
         if os[:release] == "buster/sid"
           version = 10
         else
@@ -137,40 +139,40 @@ module Inspec::Resources
         elsif version > 0
           SysV.new(inspec, service_ctl || "/usr/sbin/service")
         end
-      elsif %w{redhat fedora centos oracle cloudlinux}.include?(platform)
+      when "redhat", "fedora", "centos", "oracle", "cloudlinux"
         version = os[:release].to_i
         if (%w{redhat centos oracle cloudlinux}.include?(platform) && version >= 7) || (platform == "fedora" && version >= 15)
           Systemd.new(inspec, service_ctl)
         else
           SysV.new(inspec, service_ctl || "/sbin/service")
         end
-      elsif %w{wrlinux}.include?(platform)
+      when "wrlinux"
         SysV.new(inspec, service_ctl)
-      elsif %w{mac_os_x}.include?(platform)
+      when "mac_os_x"
         LaunchCtl.new(inspec, service_ctl)
-      elsif %w{windows}.include?(platform)
+      when "windows"
         WindowsSrv.new(inspec)
-      elsif %w{freebsd}.include?(platform)
+      when "freebsd"
         BSDInit.new(inspec, service_ctl)
-      elsif %w{arch}.include?(platform)
+      when "arch"
         Systemd.new(inspec, service_ctl)
-      elsif %w{coreos}.include?(platform)
+      when "coreos"
         Systemd.new(inspec, service_ctl)
-      elsif %w{suse opensuse}.include?(platform)
+      when "suse", "opensuse"
         if os[:release].to_i >= 12
           Systemd.new(inspec, service_ctl)
         else
           SysV.new(inspec, service_ctl || "/sbin/service")
         end
-      elsif %w{aix}.include?(platform)
+      when "aix"
         SrcMstr.new(inspec)
-      elsif %w{amazon}.include?(platform)
+      when "amazon"
         if os[:release] =~ /^20\d\d/
           Upstart.new(inspec, service_ctl)
         else
           Systemd.new(inspec, service_ctl)
         end
-      elsif %w{solaris smartos omnios openindiana opensolaris nexentacore}.include?(platform)
+      when "solaris", "smartos", "omnios", "openindiana", "opensolaris", "nexentacore"
         Svcs.new(inspec)
       end
     end

--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -141,7 +141,11 @@ module Inspec::Resources
         end
       when "redhat", "fedora", "centos", "oracle", "cloudlinux"
         version = os[:release].to_i
-        if (%w{redhat centos oracle cloudlinux}.include?(platform) && version >= 7) || (platform == "fedora" && version >= 15)
+
+        systemd = ((platform != "fedora" && version >= 7) ||
+                   (platform == "fedora" && version >= 15))
+
+        if systemd
           Systemd.new(inspec, service_ctl)
         else
           SysV.new(inspec, service_ctl || "/sbin/service")


### PR DESCRIPTION
```
# Calculating -------------------------------------
#           include_eh    529.315k (± 3.2%) i/s -      2.675M in   5.058296s
#        include_or_eq    909.795k (± 1.5%) i/s -      4.568M in   5.022491s
#            case_when      9.043M (± 2.8%) i/s -     45.443M in   5.029499s
#
# Comparison:
#            case_when:  9042590.3 i/s
#        include_or_eq:   909795.2 i/s - 9.94x  slower
#           include_eh:   529315.0 i/s - 17.08x  slower
```
from:
```ruby
#!/usr/bin/env ruby -w

require "benchmark/ips"

def include_eh
  platform = "none of them"

  if %w{ubuntu}.include?(platform)
  elsif %w{linuxmint}.include?(platform)
  elsif %w{debian}.include?(platform)
  elsif %w{redhat fedora centos oracle cloudlinux}.include?(platform)
  elsif %w{wrlinux}.include?(platform)
  elsif %w{mac_os_x}.include?(platform)
  elsif %w{windows}.include?(platform)
  elsif %w{freebsd}.include?(platform)
  elsif %w{arch}.include?(platform)
  elsif %w{coreos}.include?(platform)
  elsif %w{suse opensuse}.include?(platform)
  elsif %w{aix}.include?(platform)
  elsif %w{amazon}.include?(platform)
  elsif %w{solaris}.include?(platform)
  elsif %w{yocto}.include?(platform)
  else
    true
  end
end

def include_or_eq
  platform = "none of them"

  if    platform == "ubuntu"
  elsif platform == "linuxmint"
  elsif platform == "debian"
  elsif %w{redhat fedora centos oracle cloudlinux}.include?(platform)
  elsif platform == "wrlinux"
  elsif platform == "mac_os_x"
  elsif platform == "windows"
  elsif platform == "freebsd"
  elsif platform == "arch"
  elsif platform == "coreos"
  elsif %w{suse opensuse}.include?(platform)
  elsif platform == "aix"
  elsif platform == "amazon"
  elsif platform == "solaris"
  elsif platform == "yocto"
  else
    true
  end
end

def case_when
  platform = "none of them"

  case platform
  when "ubuntu"
  when "linuxmint"
  when "debian"
  when "redhat", "fedora", "centos", "oracle", "cloudlinux"
  when "wrlinux"
  when "mac_os_x"
  when "windows"
  when "freebsd"
  when "arch"
  when "coreos"
  when "suse", "opensuse"
  when "aix"
  when "amazon"
  when "solaris"
  when "yocto"
  else
    true
  end
end

p include_eh
p include_or_eq
p case_when

Benchmark.ips do |x|
  # x.options

  x.report("include_eh") do |max|
    max.times do
      include_eh
    end
  end

  x.report("include_or_eq") do |max|
    max.times do
      include_or_eq
    end
  end

  x.report("case_when") do |max|
    max.times do
      case_when
    end
  end

  x.compare!
end
```