### PR TITLE
Rework and unify gemspecs.

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -15,36 +15,37 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.4"
 
-  spec.files = %w{README.md LICENSE} + Dir.glob("{bin,lib,etc}/**/*", File::FNM_DOTMATCH)
-    .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/ || f =~ %r{lib/plugins/.*/test/} }
+  # the gemfile and gemspec are necessary for appbundler so don't remove it
+  spec.files =
+    Dir.glob("{{lib,etc}/**/*,README.md,LICENSE,Gemfile,inspec-core.gemspec}")
+      .grep_v(%r{(?<!inspec-init/templates/profiles/)(aws|azure|gcp)})
+      .grep_v(%r{lib/plugins/.*/test/})
+      .reject { |f| File.directory?(f) }
 
   # Implementation dependencies
-  spec.add_dependency "chef-telemetry", "~> 1.0"
+  spec.add_dependency "chef-telemetry",     "~> 1.0"
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
-  spec.add_dependency "thor", ">= 0.20", "< 2.0"
-  spec.add_dependency "json-schema", "~> 2.8"
-  spec.add_dependency "method_source", "~> 0.8"
-  spec.add_dependency "rubyzip", "~> 1.2", ">= 1.2.2"
-  spec.add_dependency "rspec", "~> 3.9"
-  spec.add_dependency "rspec-its", "~> 1.2"
-  spec.add_dependency "pry", "~> 0"
-  spec.add_dependency "hashie", "~> 3.4"
-  spec.add_dependency "mixlib-log"
-  spec.add_dependency "sslshake", "~> 1.2"
-  spec.add_dependency "parallel", "~> 1.9"
-  spec.add_dependency "faraday", ">=0.9.0"
-  spec.add_dependency "tty-table", "~> 0.10"
-  spec.add_dependency "tty-prompt", "~> 0.17"
-  spec.add_dependency "tomlrb", "~> 1.2"
-  spec.add_dependency "addressable", "~> 2.4"
-  spec.add_dependency "parslet", "~> 1.5"
-  spec.add_dependency "semverse"
-  spec.add_dependency "htmlentities"
-  spec.add_dependency "multipart-post"
-  spec.add_dependency "term-ansicolor"
+  spec.add_dependency "thor",               ">= 0.20", "< 2.0"
+  spec.add_dependency "json-schema",        "~> 2.8"
+  spec.add_dependency "method_source",      "~> 0.8"
+  spec.add_dependency "rubyzip",            "~> 1.2", ">= 1.2.2"
+  spec.add_dependency "rspec",              "~> 3.9"
+  spec.add_dependency "rspec-its",          "~> 1.2"
+  spec.add_dependency "pry",                "~> 0"
+  spec.add_dependency "hashie",             "~> 3.4"
+  spec.add_dependency "mixlib-log",         "~> 3.0"
+  spec.add_dependency "sslshake",           "~> 1.2"
+  spec.add_dependency "parallel",           "~> 1.9"
+  spec.add_dependency "faraday",            ">= 0.9.0"
+  spec.add_dependency "tty-table",          "~> 0.10"
+  spec.add_dependency "tty-prompt",         "~> 0.17"
+  spec.add_dependency "tomlrb",             "~> 1.2"
+  spec.add_dependency "addressable",        "~> 2.4"
+  spec.add_dependency "parslet",            "~> 1.5"
+  spec.add_dependency "semverse",           "~> 3.0"
+  spec.add_dependency "htmlentities",       "~> 4.3" # TODO: remove when #4853 fixed
+  spec.add_dependency "multipart-post",     "~> 2.0"
+  spec.add_dependency "term-ansicolor",     "~> 1.7"
 
   spec.add_dependency "train-core", "~> 3.0"
-
-  # Used for Azure profile until integrated into train
-  spec.add_dependency "faraday_middleware", "~> 0.12.2"
 end

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -5,43 +5,46 @@ require "inspec/version"
 Gem::Specification.new do |spec|
   spec.name          = "inspec-core"
   spec.version       = Inspec::VERSION
-  spec.authors       = ["Dominik Richter"]
-  spec.email         = ["dominik.richter@gmail.com"]
-  spec.summary       = "Just InSpec"
-  spec.description   = "Core InSpec, local support only. See `inspec` for full support."
-  spec.homepage      = "https://github.com/chef/inspec"
+  spec.authors       = ["Chef InSpec Team"]
+  spec.email         = ["inspec@chef.io"]
+  spec.summary       = "Infrastructure and compliance testing. Core library."
+  spec.description   = "InSpec provides a framework for creating end-to-end infrastructure tests. You can use it for integration or even compliance testing. Create fully portable test profiles and use them in your workflow to ensure stability and security. Integrate InSpec in your change lifecycle for local testing, CI/CD, and deployment verification. This has local support only. See the `inspec` gem for full support."
+  spec.homepage      = "https://github.com/inspec/inspec"
   spec.license       = "Apache-2.0"
+  spec.require_paths = ["lib"]
+
+  spec.required_ruby_version = "~> 2.4"
 
   spec.files = %w{README.md LICENSE} + Dir.glob("{bin,lib,etc}/**/*", File::FNM_DOTMATCH)
     .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/ || f =~ %r{lib/plugins/.*/test/} }
 
-  spec.require_paths = ["lib"]
-
-  spec.required_ruby_version = ">= 2.4"
-
-  spec.add_dependency "train-core", "~> 3.0"
+  # Implementation dependencies
   spec.add_dependency "chef-telemetry", "~> 1.0"
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
   spec.add_dependency "thor", ">= 0.20", "< 2.0"
   spec.add_dependency "json-schema", "~> 2.8"
   spec.add_dependency "method_source", "~> 0.8"
-  spec.add_dependency "rubyzip", "~> 1.1"
+  spec.add_dependency "rubyzip", "~> 1.2", ">= 1.2.2"
   spec.add_dependency "rspec", "~> 3.9"
   spec.add_dependency "rspec-its", "~> 1.2"
+  spec.add_dependency "pry", "~> 0"
   spec.add_dependency "hashie", "~> 3.4"
   spec.add_dependency "mixlib-log"
-  spec.add_dependency "pry", "~> 0"
   spec.add_dependency "sslshake", "~> 1.2"
   spec.add_dependency "parallel", "~> 1.9"
   spec.add_dependency "faraday", ">=0.9.0"
-  spec.add_dependency "faraday_middleware", "~> 0.12.2"
+  spec.add_dependency "tty-table", "~> 0.10"
+  spec.add_dependency "tty-prompt", "~> 0.17"
   spec.add_dependency "tomlrb", "~> 1.2"
   spec.add_dependency "addressable", "~> 2.4"
   spec.add_dependency "parslet", "~> 1.5"
   spec.add_dependency "semverse"
   spec.add_dependency "htmlentities"
   spec.add_dependency "multipart-post"
-  spec.add_dependency "tty-table", "~> 0.10"
-  spec.add_dependency "tty-prompt", "~> 0.17"
   spec.add_dependency "term-ansicolor"
+
+  spec.add_dependency "train-core", "~> 3.0"
+
+  # Used for Azure profile until integrated into train
+  spec.add_dependency "faraday_middleware", "~> 0.12.2"
 end

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -15,38 +15,14 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.4"
 
-  # the gemfile and gemspec are necessary for appbundler so don't remove it
-  spec.files = %w{Gemfile inspec.gemspec README.md LICENSE} + Dir.glob(
-    "{bin,lib,etc}/**/*", File::FNM_DOTMATCH
-  ).reject { |f| File.directory?(f) }
+  # ONLY the aws/azure/gcp files. The rest will come in from inspec-core
+  # the gemspec is necessary for appbundler so don't remove it
+  spec.files =
+    Dir.glob("{{lib,etc}/**/*,inspec.gemspec}")
+      .grep(/aws|azure|gcp|gemspec/)
+      .reject { |f| File.directory?(f) }
 
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-    .reject { |f| File.directory?(f) || f =~ %r{lib/plugins/.*/test/} }
-
-  # Implementation dependencies
-  spec.add_dependency "chef-telemetry", "~> 1.0"
-  spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
-  spec.add_dependency "thor", ">= 0.20", "< 2.0"
-  spec.add_dependency "json-schema", "~> 2.8"
-  spec.add_dependency "method_source", "~> 0.8"
-  spec.add_dependency "rubyzip", "~> 1.2", ">= 1.2.2"
-  spec.add_dependency "rspec", "~> 3.9"
-  spec.add_dependency "rspec-its", "~> 1.2"
-  spec.add_dependency "pry", "~> 0"
-  spec.add_dependency "hashie", "~> 3.4"
-  spec.add_dependency "mixlib-log"
-  spec.add_dependency "sslshake", "~> 1.2"
-  spec.add_dependency "parallel", "~> 1.9"
-  spec.add_dependency "faraday", ">=0.9.0"
-  spec.add_dependency "tty-table", "~> 0.10"
-  spec.add_dependency "tty-prompt", "~> 0.17"
-  spec.add_dependency "tomlrb", "~> 1.2"
-  spec.add_dependency "addressable", "~> 2.4"
-  spec.add_dependency "parslet", "~> 1.5"
-  spec.add_dependency "semverse"
-  spec.add_dependency "htmlentities"
-  spec.add_dependency "multipart-post"
-  spec.add_dependency "term-ansicolor"
+  spec.add_dependency "inspec-core", "= #{Inspec::VERSION}"
 
   spec.add_dependency "train", "~> 3.0"
 
@@ -55,6 +31,6 @@ Gem::Specification.new do |spec|
 
   # Train plugins we ship with InSpec
   spec.add_dependency "train-habitat", "~> 0.1"
-  spec.add_dependency "train-aws", "~> 0.1"
-  spec.add_dependency "train-winrm", "~> 0.2"
+  spec.add_dependency "train-aws",     "~> 0.1"
+  spec.add_dependency "train-winrm",   "~> 0.2"
 end

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -11,6 +11,9 @@ Gem::Specification.new do |spec|
   spec.description   = "InSpec provides a framework for creating end-to-end infrastructure tests. You can use it for integration or even compliance testing. Create fully portable test profiles and use them in your workflow to ensure stability and security. Integrate InSpec in your change lifecycle for local testing, CI/CD, and deployment verification."
   spec.homepage      = "https://github.com/inspec/inspec"
   spec.license       = "Apache-2.0"
+  spec.require_paths = ["lib"]
+
+  spec.required_ruby_version = "~> 2.4"
 
   # the gemfile and gemspec are necessary for appbundler so don't remove it
   spec.files = %w{Gemfile inspec.gemspec README.md LICENSE} + Dir.glob(
@@ -19,15 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
     .reject { |f| File.directory?(f) || f =~ %r{lib/plugins/.*/test/} }
-  spec.require_paths = ["lib"]
-
-  spec.required_ruby_version = ">= 2.4"
-
-  spec.add_dependency "train", "~> 3.0"
-  # Train plugins we ship with InSpec
-  spec.add_dependency "train-habitat", "~> 0.1"
-  spec.add_dependency "train-aws", "~> 0.1"
-  spec.add_dependency "train-winrm", "~> 0.2"
 
   # Implementation dependencies
   spec.add_dependency "chef-telemetry", "~> 1.0"
@@ -46,8 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", ">=0.9.0"
   spec.add_dependency "tty-table", "~> 0.10"
   spec.add_dependency "tty-prompt", "~> 0.17"
-  # Used for Azure profile until integrated into train
-  spec.add_dependency "faraday_middleware", "~> 0.12"
   spec.add_dependency "tomlrb", "~> 1.2"
   spec.add_dependency "addressable", "~> 2.4"
   spec.add_dependency "parslet", "~> 1.5"
@@ -55,4 +47,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency "htmlentities"
   spec.add_dependency "multipart-post"
   spec.add_dependency "term-ansicolor"
+
+  spec.add_dependency "train", "~> 3.0"
+
+  # Used for Azure profile until integrated into train
+  spec.add_dependency "faraday_middleware", "~> 0.12.2"
+
+  # Train plugins we ship with InSpec
+  spec.add_dependency "train-habitat", "~> 0.1"
+  spec.add_dependency "train-aws", "~> 0.1"
+  spec.add_dependency "train-winrm", "~> 0.2"
 end


### PR DESCRIPTION
First step is to get them agreeing on dependencies.

There's still some oddities between train vs train-core and
dependencies for AWS and the like, but this brings them in line so
diffing between them is MUCH better.

Next is to gut inspec and push everything over to inspec-core.

Signed-off-by: Ryan Davis <zenspider@chef.io>