### PR TITLE
Detect install type via install path

### DIFF
--- a/lib/inspec/globals.rb
+++ b/lib/inspec/globals.rb
@@ -1,9 +1,15 @@
+require_relative "utils/install_context"
+
 module Inspec
+
+  extend Inspec::InstallContextHelpers
+
   def self.config_dir
     ENV["INSPEC_CONFIG_DIR"] ? ENV["INSPEC_CONFIG_DIR"] : File.join(Dir.home, ".inspec")
   end
 
   def self.src_root
-    File.expand_path(File.join(__FILE__, "..", "..", ".."))
+    @src_root ||= File.expand_path(File.join(__FILE__, "..", "..", ".."))
   end
+
 end

--- a/lib/inspec/globals.rb
+++ b/lib/inspec/globals.rb
@@ -9,7 +9,7 @@ module Inspec
   end
 
   def self.src_root
-    @src_root ||= File.expand_path(File.join(__FILE__, "..", "..", ".."))
+    @src_root ||= File.expand_path(File.join(__FILE__, "../../.."))
   end
 
 end

--- a/lib/inspec/utils/install_context.rb
+++ b/lib/inspec/utils/install_context.rb
@@ -54,13 +54,7 @@ module Inspec
     end
 
     def path_exist?(path)
-      # This exists for testing
-      if respond_to? :dummy_paths
-        dummy_paths.include? path
-      else
-        File.exist? path
-      end
+      File.exist? path
     end
-
   end
 end

--- a/lib/inspec/utils/install_context.rb
+++ b/lib/inspec/utils/install_context.rb
@@ -31,7 +31,7 @@ module Inspec
 
     def docker_install?
       # Our docker image is based on alpine. This could be easily fooled.
-      !!(rubygem_install? && File.exist?("/etc/alpine-release")) && File.exist?("/.dockerenv")
+      !!(rubygem_install? && path_exist?("/etc/alpine-release")) && path_exist?("/.dockerenv")
     end
 
     def habitat_install?
@@ -49,7 +49,16 @@ module Inspec
     def source_install?
       # These are a couple of examples of dirs removed during packaging
       %w{habitat test}.all? do |devdir|
-        Dir.exist?("#{src_root}/#{devdir}")
+        path_exist?("#{src_root}/#{devdir}")
+      end
+    end
+
+    def path_exist?(path)
+      # This exists for testing
+      if respond_to? :dummy_paths
+        dummy_paths.include? path
+      else
+        File.exist? path
       end
     end
 

--- a/lib/inspec/utils/install_context.rb
+++ b/lib/inspec/utils/install_context.rb
@@ -19,6 +19,8 @@ module Inspec
       "unknown"
     end
 
+    private
+
     def chef_workstation_install?
       !!(src_root.start_with?("/opt/chef-workstation") || src_root.start_with?("C:/opscode/chef-workstation"))
     end
@@ -29,7 +31,7 @@ module Inspec
 
     def docker_install?
       # Our docker image is based on alpine. This could be easily fooled.
-      !!(rubygem_install? && File.exist?("/etc/alpine-release"))
+      !!(rubygem_install? && File.exist?("/etc/alpine-release")) && File.exist?("/.dockerenv")
     end
 
     def habitat_install?

--- a/lib/inspec/utils/install_context.rb
+++ b/lib/inspec/utils/install_context.rb
@@ -1,0 +1,55 @@
+module Inspec
+
+  # Hueristics to determine how InSpec was installed.
+  module InstallContextHelpers
+
+    def guess_install_context
+      # These all work by simple path recognition
+      return "chef-workstation" if chef_workstation_install?
+      return "omnibus" if omnibus_install?
+      return "chefdk" if chefdk_install?
+      return "habitat" if habitat_install?
+
+      # Order matters here - gem mode is easily mistaken for one of the above
+      return "docker" if docker_install?
+      return "rubygem" if rubygem_install?
+
+      return "source" if source_install?
+
+      "unknown"
+    end
+
+    def chef_workstation_install?
+      !!(src_root.start_with?("/opt/chef-workstation") || src_root.start_with?("C:/opscode/chef-workstation"))
+    end
+
+    def chefdk_install?
+      !!(src_root.start_with?("/opt/chef-dk") || src_root.start_with?("C:/opscode/chef-dk"))
+    end
+
+    def docker_install?
+      # Our docker image is based on alpine. This could be easily fooled.
+      !!(rubygem_install? && File.exist?("/etc/alpine-release"))
+    end
+
+    def habitat_install?
+      !!src_root.match(%r{hab/pkgs/chef/inspec/\d+\.\d+\.\d+/\d{14}})
+    end
+
+    def omnibus_install?
+      !!(src_root.start_with?("/opt/inspec") || src_root.start_with?("C:/opscode/inspec"))
+    end
+
+    def rubygem_install?
+      !!src_root.match(%r{gems/inspec-\d+\.\d+\.\d+})
+    end
+
+    def source_install?
+      # These are a couple of examples of dirs removed during packaging
+      %w{habitat test}.all? do |devdir|
+        Dir.exist?("#{src_root}/#{devdir}")
+      end
+    end
+
+  end
+end

--- a/lib/inspec/utils/install_context.rb
+++ b/lib/inspec/utils/install_context.rb
@@ -1,6 +1,6 @@
 module Inspec
 
-  # Hueristics to determine how InSpec was installed.
+  # Heuristics to determine how InSpec was installed.
   module InstallContextHelpers
 
     def guess_install_context

--- a/test/unit/utils/install_context_test.rb
+++ b/test/unit/utils/install_context_test.rb
@@ -22,6 +22,7 @@ describe Inspec::InstallContextHelpers do
     before do
       Inspec.expects(:src_root).at_least_once.returns("/somewhere/gems/inspec-4.18.39")
       File.expects(:exist?).at_least_once.with("/etc/alpine-release").returns(true)
+      File.expects(:exist?).at_least_once.with("/.dockerenv").returns(true)
     end
 
     it "should properly detect a Docker install" do

--- a/test/unit/utils/install_context_test.rb
+++ b/test/unit/utils/install_context_test.rb
@@ -8,11 +8,11 @@ def assert_install_contexts(test_obj, test_expected_to_be_true, also_rubygem)
   should_be_false -= [test_expected_to_be_true]
   should_be_false = should_be_false.map { |m| "#{m}_install?".tr("-", "_").to_sym }
   should_be_false -= [:rubygem_install?] if also_rubygem
-  should_be_false.each { |m| expect(test_obj.send(m)).must_equal false }
+  should_be_false.each { |m| _(test_obj.send(m)).must_equal false }
 
   should_be_true   = ["#{test_expected_to_be_true}_install?".tr("-", "_").to_sym]
   should_be_true  += [:rubygem_install?] if also_rubygem
-  should_be_true.each { |m| expect(test_obj.send(m)).must_equal true }
+  should_be_true.each { |m| _(test_obj.send(m)).must_equal true }
 
   expect(test_obj.guess_install_context).must_equal test_expected_to_be_true
 end

--- a/test/unit/utils/install_context_test.rb
+++ b/test/unit/utils/install_context_test.rb
@@ -1,0 +1,86 @@
+require "helper"
+require "inspec/globals"
+require "inspec/utils/install_context"
+
+def check_install_contexts(test_expected_to_be_true, also_rubygem)
+  should_be_false = %w{chef-workstation chefdk docker
+                     habitat omnibus rubygem source}
+  should_be_false -= [test_expected_to_be_true]
+  should_be_false = should_be_false.map { |m| "#{m}_install?".tr("-", "_").to_sym }
+  should_be_false -= [:rubygem_install?] if also_rubygem
+  should_be_false.each { |m| expect(Inspec.method(m).call).must_equal false }
+
+  should_be_true   = ["#{test_expected_to_be_true}_install?".tr("-", "_").to_sym]
+  should_be_true  += [:rubygem_install?] if also_rubygem
+  should_be_true.each { |m| expect(Inspec.method(m).call).must_equal true }
+
+  expect(Inspec.guess_install_context).must_equal test_expected_to_be_true
+end
+
+describe Inspec::InstallContextHelpers do
+  describe "when it looks like a Docker installation" do
+    before do
+      Inspec.expects(:src_root).at_least_once.returns("/somewhere/gems/inspec-4.18.39")
+      File.expects(:exist?).at_least_once.with("/etc/alpine-release").returns(true)
+    end
+
+    it "should properly detect a Docker install" do
+      check_install_contexts("docker", true)
+    end
+  end
+
+  describe "when it looks like a Habitat installation" do
+    before do
+      Inspec.expects(:src_root).at_least_once.returns("/hab/pkgs/chef/inspec/4.18.61/20200121194907/lib/gems/inspec-4.18.61")
+    end
+
+    it "should properly detect a habitat install" do
+      check_install_contexts("habitat", true)
+    end
+  end
+
+  describe "when it looks like a gem installation" do
+    before do
+      Inspec.expects(:src_root).at_least_once.returns("/Users/alice/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/inspec-4.18.61")
+    end
+
+    it "should properly detect a rubygem install" do
+      check_install_contexts("rubygem", true)
+    end
+  end
+
+  describe "when it looks like a source installation" do
+    before do
+      fake_root = "/Users/alice/src/inspec"
+      Inspec.expects(:src_root).at_least_once.returns(fake_root)
+      Dir.expects(:exist?).with("#{fake_root}/habitat").at_least_once.returns(true)
+      Dir.expects(:exist?).with("#{fake_root}/test").at_least_once.returns(true)
+    end
+
+    it "should properly detect a source install" do
+      check_install_contexts("source", false)
+    end
+  end
+
+  {
+    "Windows" => "C:/opscode",
+    "Unix-like" => "/opt",
+  }.each do |os_name, inst_dir|
+    describe "when on #{os_name} machines" do
+      {
+        "chef-workstation" => "chef-workstation",
+        "chefdk" => "chef-dk",
+        "omnibus" => "inspec",
+      }.each do |inst_mode, inst_subdir|
+        describe "when it looks like a #{inst_mode} installation" do
+          before do
+            Inspec.expects(:src_root).at_least_once.returns("#{inst_dir}/#{inst_subdir}/embedded/lib/ruby/gems/2.6.0/gems/inspec-4.18.39")
+          end
+          it "should properly detect a #{os_name} #{inst_mode} install" do
+            check_install_contexts(inst_mode, true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/utils/install_context_test.rb
+++ b/test/unit/utils/install_context_test.rb
@@ -24,6 +24,14 @@ class InstallContextTester
     @src_root = src_root
     @dummy_paths = dummy_paths
   end
+
+  def path_exist?(path)
+    if dummy_paths.empty?
+      File.exist? path
+    else
+      dummy_paths.include? path
+    end
+  end
 end
 
 describe Inspec::InstallContextHelpers do

--- a/test/unit/utils/install_context_test.rb
+++ b/test/unit/utils/install_context_test.rb
@@ -2,64 +2,65 @@ require "helper"
 require "inspec/globals"
 require "inspec/utils/install_context"
 
-def assert_install_contexts(test_expected_to_be_true, also_rubygem)
+def assert_install_contexts(test_obj, test_expected_to_be_true, also_rubygem)
   should_be_false = %w{chef-workstation chefdk docker
                      habitat omnibus rubygem source}
   should_be_false -= [test_expected_to_be_true]
   should_be_false = should_be_false.map { |m| "#{m}_install?".tr("-", "_").to_sym }
   should_be_false -= [:rubygem_install?] if also_rubygem
-  should_be_false.each { |m| expect(Inspec.send(m)).must_equal false }
+  should_be_false.each { |m| expect(test_obj.send(m)).must_equal false }
 
   should_be_true   = ["#{test_expected_to_be_true}_install?".tr("-", "_").to_sym]
   should_be_true  += [:rubygem_install?] if also_rubygem
-  should_be_true.each { |m| expect(Inspec.send(m)).must_equal true }
+  should_be_true.each { |m| expect(test_obj.send(m)).must_equal true }
 
-  expect(Inspec.guess_install_context).must_equal test_expected_to_be_true
+  expect(test_obj.guess_install_context).must_equal test_expected_to_be_true
+end
+
+class InstallContextTester
+  include Inspec::InstallContextHelpers
+  attr_accessor :src_root, :dummy_paths
+  def initialize(src_root: "", dummy_paths: [])
+    @src_root = src_root
+    @dummy_paths = dummy_paths
+  end
 end
 
 describe Inspec::InstallContextHelpers do
-  describe "when it looks like a Docker installation" do
-    before do
-      Inspec.expects(:src_root).at_least_once.returns("/somewhere/gems/inspec-4.18.39")
-      File.expects(:exist?).at_least_once.with("/etc/alpine-release").returns(true)
-      File.expects(:exist?).at_least_once.with("/.dockerenv").returns(true)
-    end
 
+  parallelize_me!
+
+  describe "when it looks like a Docker installation" do
     it "should properly detect a Docker install" do
-      assert_install_contexts("docker", true)
+      test_obj = InstallContextTester.new(
+        src_root: "/somewhere/gems/inspec-4.18.39", dummy_paths: [ "/etc/alpine-release", "/.dockerenv" ]
+      )
+      assert_install_contexts(test_obj, "docker", true)
     end
   end
 
   describe "when it looks like a Habitat installation" do
-    before do
-      Inspec.expects(:src_root).at_least_once.returns("/hab/pkgs/chef/inspec/4.18.61/20200121194907/lib/gems/inspec-4.18.61")
-    end
-
     it "should properly detect a habitat install" do
-      assert_install_contexts("habitat", true)
+      test_obj = InstallContextTester.new(src_root: "/hab/pkgs/chef/inspec/4.18.61/20200121194907/lib/gems/inspec-4.18.61")
+      assert_install_contexts(test_obj, "habitat", true)
     end
   end
 
   describe "when it looks like a gem installation" do
-    before do
-      Inspec.expects(:src_root).at_least_once.returns("/Users/alice/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/inspec-4.18.61")
-    end
-
     it "should properly detect a rubygem install" do
-      assert_install_contexts("rubygem", true)
+      test_obj = InstallContextTester.new(src_root: "/Users/alice/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/inspec-4.18.61")
+      assert_install_contexts(test_obj, "rubygem", true)
     end
   end
 
   describe "when it looks like a source installation" do
-    before do
-      fake_root = "/Users/alice/src/inspec"
-      Inspec.expects(:src_root).at_least_once.returns(fake_root)
-      Dir.expects(:exist?).with("#{fake_root}/habitat").at_least_once.returns(true)
-      Dir.expects(:exist?).with("#{fake_root}/test").at_least_once.returns(true)
-    end
-
     it "should properly detect a source install" do
-      assert_install_contexts("source", false)
+      fake_root = "/Users/alice/src/inspec"
+      test_obj = InstallContextTester.new(
+        src_root: fake_root,
+        dummy_paths: [ "#{fake_root}/habitat", "#{fake_root}/test" ]
+      )
+      assert_install_contexts(test_obj, "source", false)
     end
   end
 
@@ -74,11 +75,9 @@ describe Inspec::InstallContextHelpers do
         "omnibus" => "inspec",
       }.each do |inst_mode, inst_subdir|
         describe "when it looks like a #{inst_mode} installation" do
-          before do
-            Inspec.expects(:src_root).at_least_once.returns("#{inst_dir}/#{inst_subdir}/embedded/lib/ruby/gems/2.6.0/gems/inspec-4.18.39")
-          end
           it "should properly detect a #{os_name} #{inst_mode} install" do
-            assert_install_contexts(inst_mode, true)
+            test_obj = InstallContextTester.new(src_root: "#{inst_dir}/#{inst_subdir}/embedded/lib/ruby/gems/2.6.0/gems/inspec-4.18.39")
+            assert_install_contexts(test_obj, inst_mode, true)
           end
         end
       end

--- a/test/unit/utils/install_context_test.rb
+++ b/test/unit/utils/install_context_test.rb
@@ -8,11 +8,11 @@ def assert_install_contexts(test_obj, test_expected_to_be_true, also_rubygem)
   should_be_false -= [test_expected_to_be_true]
   should_be_false = should_be_false.map { |m| "#{m}_install?".tr("-", "_").to_sym }
   should_be_false -= [:rubygem_install?] if also_rubygem
-  should_be_false.each { |m| _(test_obj.send(m)).must_equal false }
+  should_be_false.each { |m| _(test_obj).wont_be(m) }
 
   should_be_true   = ["#{test_expected_to_be_true}_install?".tr("-", "_").to_sym]
   should_be_true  += [:rubygem_install?] if also_rubygem
-  should_be_true.each { |m| _(test_obj.send(m)).must_equal true }
+  should_be_true.each { |m| _(test_obj).must_be(m) }
 
   expect(test_obj.guess_install_context).must_equal test_expected_to_be_true
 end

--- a/test/unit/utils/install_context_test.rb
+++ b/test/unit/utils/install_context_test.rb
@@ -2,17 +2,17 @@ require "helper"
 require "inspec/globals"
 require "inspec/utils/install_context"
 
-def check_install_contexts(test_expected_to_be_true, also_rubygem)
+def assert_install_contexts(test_expected_to_be_true, also_rubygem)
   should_be_false = %w{chef-workstation chefdk docker
                      habitat omnibus rubygem source}
   should_be_false -= [test_expected_to_be_true]
   should_be_false = should_be_false.map { |m| "#{m}_install?".tr("-", "_").to_sym }
   should_be_false -= [:rubygem_install?] if also_rubygem
-  should_be_false.each { |m| expect(Inspec.method(m).call).must_equal false }
+  should_be_false.each { |m| expect(Inspec.send(m)).must_equal false }
 
   should_be_true   = ["#{test_expected_to_be_true}_install?".tr("-", "_").to_sym]
   should_be_true  += [:rubygem_install?] if also_rubygem
-  should_be_true.each { |m| expect(Inspec.method(m).call).must_equal true }
+  should_be_true.each { |m| expect(Inspec.send(m)).must_equal true }
 
   expect(Inspec.guess_install_context).must_equal test_expected_to_be_true
 end
@@ -25,7 +25,7 @@ describe Inspec::InstallContextHelpers do
     end
 
     it "should properly detect a Docker install" do
-      check_install_contexts("docker", true)
+      assert_install_contexts("docker", true)
     end
   end
 
@@ -35,7 +35,7 @@ describe Inspec::InstallContextHelpers do
     end
 
     it "should properly detect a habitat install" do
-      check_install_contexts("habitat", true)
+      assert_install_contexts("habitat", true)
     end
   end
 
@@ -45,7 +45,7 @@ describe Inspec::InstallContextHelpers do
     end
 
     it "should properly detect a rubygem install" do
-      check_install_contexts("rubygem", true)
+      assert_install_contexts("rubygem", true)
     end
   end
 
@@ -58,7 +58,7 @@ describe Inspec::InstallContextHelpers do
     end
 
     it "should properly detect a source install" do
-      check_install_contexts("source", false)
+      assert_install_contexts("source", false)
     end
   end
 
@@ -77,7 +77,7 @@ describe Inspec::InstallContextHelpers do
             Inspec.expects(:src_root).at_least_once.returns("#{inst_dir}/#{inst_subdir}/embedded/lib/ruby/gems/2.6.0/gems/inspec-4.18.39")
           end
           it "should properly detect a #{os_name} #{inst_mode} install" do
-            check_install_contexts(inst_mode, true)
+            assert_install_contexts(inst_mode, true)
           end
         end
       end


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Provides several new predicates and one classification method that guess at how InSpec was installed. Possible values include "chef-workstation", "chefdk", "docker", "habitat", "omnibus", "rubygem", and "source".

A unit test file is provided. This would be very impractical to test functionally, but I got the values in the test file (and in the implementation) by manually running each of the different scenarios. That said, I'm sure this could be easily fooled.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Closes #4585

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
