### PR TITLE
Remove skips from windows testing in 'inputs' and 'archive' functional tests

### DIFF
--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -126,7 +126,6 @@ describe "inputs" do
 
       it "finds the values and does not issue any warnings" do
         output = run_result.stdout
-        skip_windows!
         refute_includes output, "DEPRECATION"
         structured_output = JSON.parse(output)
         assert_equal "passed", structured_output["profiles"][0]["controls"][0]["results"][0]["status"]
@@ -138,7 +137,6 @@ describe "inputs" do
       it "finds the values but issues a DEPRECATION warning" do
         run = run_result
         output = run.stdout
-        skip_windows!
 
         assert_empty run.stderr
         assert_includes output, "DEPRECATION"

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -36,7 +36,6 @@ describe "inspec archive" do
       out = inspec("archive " + dir + " --overwrite")
 
       _(out.stderr).must_equal ""
-      skip_windows!
       _(out.stdout).must_include "Generate archive " + auto_dst
       _(out.stdout).must_include "Finished archive generation."
       _(File.exist?(auto_dst)).must_equal true


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Simply removing the skips appears to work, though in my VM it may appear to hang on input - that may or may not happen in CI, so I'm opening a PR to find out.

UPDATE: seems to work fine in CI.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #4698
Fixes #4699

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
