### PR TITLE
Added --inspect option to inspect shell command.

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -327,10 +327,13 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell"
   option :distinct_exit, type: :boolean, default: true,
     desc: "Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures."
+  option :inspect, type: :boolean, default: false, desc: "Use verbose/debugging output for resources."
   def shell_func
     o = config
     diagnose(o)
     o[:debug_shell] = true
+
+    Inspec::ResourceBehaviors.toggle_inspect unless o[:inspect]
 
     log_device = suppress_log_output?(o) ? nil : $stdout
     o[:logger] = Logger.new(log_device)

--- a/lib/inspec/plugin/v1/plugin_types/resource.rb
+++ b/lib/inspec/plugin/v1/plugin_types/resource.rb
@@ -6,11 +6,15 @@ module Inspec
       @__resource_name__
     end
 
-    # Overwrite inspect to provide better output to RSpec results.
-    #
-    # @return [String] full name of the resource
-    def inspect
-      to_s
+    def self.toggle_inspect
+      has_inspect = instance_method(:inspect) rescue nil
+      unless has_inspect
+        define_method :inspect do
+          to_s
+        end
+      else
+        undef_method :inspect
+      end
     end
   end
 

--- a/lib/inspec/rspec_extensions.rb
+++ b/lib/inspec/rspec_extensions.rb
@@ -114,3 +114,15 @@ class RSpec::Core::ExampleGroup
   # So, we use prepend.
   prepend Inspec::TestDslLazyLoader
 end
+
+class ResourceInspector < RSpec::Support::ObjectFormatter::BaseInspector
+  def self.can_inspect?(object)
+    Inspec::Plugins::Resource === object
+  end
+
+  def inspect # do NOT use default inspect in rspec w/ resources
+    object.to_s
+  end
+end
+
+RSpec::Support::ObjectFormatter::INSPECTOR_CLASSES.unshift ResourceInspector

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -221,9 +221,7 @@ RSpec::Matchers.define :cmp do |first_expected| # rubocop:disable Metrics/BlockL
   end
 
   def octal?(value)
-    return false unless value.is_a?(String)
-
-    !(value =~ /\A0+[0-7]+\Z/).nil?
+    value.is_a?(String) && (value =~ /\A0+[0-7]+\Z/)
   end
 
   def boolean?(value)
@@ -288,25 +286,28 @@ RSpec::Matchers.define :cmp do |first_expected| # rubocop:disable Metrics/BlockL
     end
   end
 
+  def format_actual(actual)
+    actual = "0%o" % actual if octal?(@expected)
+    "\n%s\n     got: %s\n\n(compared using `cmp` matcher)\n" % [format_expectation(false), actual]
+  end
+
   def format_expectation(negate)
-    return "expected: " + @expected.inspect if @operation == :== && !negate
+    return "expected: %s" % [@expected] if @operation == :== && !negate
 
     negate_str = negate ? "not " : ""
-    "expected it #{negate_str}to be #{@operation} #{@expected.inspect}"
+    "expected it %sto be %s %p" % [negate_str, @operation, @expected]
   end
 
   failure_message do |actual|
-    actual = ("0" + actual.to_s(8)) if octal?(@expected)
-    "\n" + format_expectation(false) + "\n     got: #{actual.inspect}\n\n(compared using `cmp` matcher)\n"
+    format_actual actual
   end
 
   failure_message_when_negated do |actual|
-    actual = ("0" + actual.to_s(8)).inspect if octal?(@expected)
-    "\n" + format_expectation(true) + "\n     got: #{actual.inspect}\n\n(compared using `cmp` matcher)\n"
+    format_actual actual
   end
 
   description do
-    "cmp #{@operation} #{@expected.inspect}"
+    "cmp %s %p" % [@operation, @expected]
   end
 end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -383,8 +383,8 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
       _(stdout).must_include "×  7 is expected to cmp >= 9\n"
       _(stdout).must_include "×  7 is expected not to cmp == /^\\d$/\n"
       _(stdout).must_include "✔  7 is expected to cmp == \"7\""
-      _(stdout).must_include "expected: %p" % ["01147"]
-      _(stdout).must_include "got: %p" % [is_windows? ? "040755" : "0755"]
+      _(stdout).must_include "expected: %s" % ["01147"]
+      _(stdout).must_include "got: %s" % [is_windows? ? "040755" : "0755"]
     end
   end
 


### PR DESCRIPTION
* Removed Resource#inspect (calling to_s) to make debugging a happy experience.
* Added ResourceBehavior.toggle_inspect to add/remove a basic inspect.
* Added `--inspect` flag to `shell` command. Call toggle_inspect unless --inspect used.
* Cleaned up matchers.rb and removed most explicit calls to inspect.
* Added ResourceInspector to rspec's INSPECTOR_CLASSES.

Signed-off-by: Ryan Davis <zenspider@chef.io>