### PR TITLE
Don't try to fool Thor's option type checker for --airgap on archive

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -173,7 +173,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "Generates a tar.gz archive."
   option :overwrite, type: :boolean, default: false,
     desc: "Overwrite existing archive."
-  option :airgap, type: :string, default: false, banner: "", # Actually a boolean, but this suppresses the creation of a --no-airgap...
+  option :airgap, type: :boolean, banner: "",
     desc: "Fallback to using local archives if fetching fails."
   option :ignore_errors, type: :boolean, default: false,
     desc: "Ignore profile warnings."


### PR DESCRIPTION
This silences a deprecation warning introduced with the fetcher fallback feature.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
