### PR TITLE
Build packages on Debian

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -7,6 +7,10 @@ fips-platforms:
   - el-*-x86_64
   - windows-*
 builder-to-testers-map:
+  debian-8-x86_64:
+    - debian-8-x86_64
+    - debian-9-x86_64
+    - debian-10-x86_64
   el-6-x86_64:
     - el-6-x86_64
   el-7-x86_64:


### PR DESCRIPTION
We build our other products on Debian. Why not?

Signed-off-by: Tim Smith <tsmith@chef.io>