### PR TITLE
Set trigger back on hab builds

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -22,7 +22,6 @@ pipelines:
      - HAB_NONINTERACTIVE: "true"
      - HAB_NOCOLORING: "true"
      - HAB_STUDIO_SECRET_HAB_NONINTERACTIVE: "true"
-    trigger: pull_request
  - omnibus/release
  - omnibus/adhoc:
     definition: .expeditor/release.omnibus.yml


### PR DESCRIPTION
Still doesn't do anything about subcmds failing. Those have to be
manually checked.

Signed-off-by: Ryan Davis <zenspider@chef.io>