### PR TITLE
Rollback library eval context de-meta-programming

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,9 +35,10 @@ end
 
 group :integration do
   gem "berkshelf"
-  gem "chef", "< 15"
   gem "test-kitchen"
   gem "kitchen-vagrant"
+  gem "chef", "< 15"
+  gem "chef-zero", "< 15"
   gem "kitchen-inspec"
   gem "kitchen-ec2"
   gem "kitchen-dokken"

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem "minitest", "~> 5.5"
   gem "minitest-sprint", "~> 1.0"
   gem "rake", ">= 10"
-  gem "simplecov", "~> 0.10"
+  gem "simplecov", ["~> 0.10", "<=0.18.2"]
   gem "concurrent-ruby", "~> 1.0"
   gem "mocha", "~> 1.1"
   gem "ruby-progressbar", "~> 1.8"

--- a/lib/inspec/library_eval_context.rb
+++ b/lib/inspec/library_eval_context.rb
@@ -12,44 +12,42 @@ module Inspec
   # registry used by all dsl methods bound to the resource registry
   # passed into the #create constructor.
   #
+  #
   class LibraryEvalContext
-    # rubocop:disable Naming/ConstantName
-    Inspec = :nope! # see #initialize below
-    # rubocop:enable Naming/ConstantName
-
-    ##
-    # Include a custom `require` method that gets used when this
-    # context is used to eval source. See lib/inspec/dsl_shared.rb for
-    # more details.
-    include ::Inspec::DSL::RequireOverride
-
     def self.create(registry, require_loader)
-      Class.new(LibraryEvalContext).new(registry, require_loader)
-    end
+      c = Class.new(Inspec::Resource) do
+        define_singleton_method :__resource_registry do
+          registry
+        end
+      end
 
-    # Provide the local binding for this context which is
-    # necessary for calls to `require` to create all dependent
-    # objects in the correct context.
-    attr_accessor :__inspec_binding
+      c2 = Class.new do
+        define_singleton_method :resource do |version|
+          Inspec.validate_resource_dsl_version!(version)
+          c
+        end
+      end
 
-    def initialize(registry, require_loader)
-      @require_loader = require_loader
-      # rubocop:disable Style/RedundantSelf
-      self.__inspec_binding = self.instance_eval { binding }
-      # rubocop:enable Style/RedundantSelf
+      c3 = Class.new do
+        include Inspec::DSL::RequireOverride
+        def initialize(require_loader)
+          @require_loader = require_loader
+          @inspec_binding = nil
+        end
 
-      @res_klass = Class.new ::Inspec::Resource
-      @res_klass.__resource_registry = registry
+        def __inspec_binding
+          @inspec_binding
+        end
+      end
 
-      # NOTE: this *must* be a subclass of LibraryEvalContext to work
-      self.class.const_set :Inspec, self # BYPASS! See resource below
-    end
+      c3.const_set(:Inspec, c2)
+      res = c3.new(require_loader)
 
-    # Fake for Inspec.resource in lib/inspec/resource.rb that provides
-    # our own Resource subclass that has its own private __resource_registry
-    def resource(version)
-      ::Inspec.validate_resource_dsl_version!(version)
-      @res_klass
+      # Provide the local binding for this context which is necessary for
+      # calls to `require` to create all dependent objects in the correct
+      # context.
+      res.instance_variable_set("@inspec_binding", res.instance_eval("binding"))
+      res
     end
   end
 end


### PR DESCRIPTION
This broke creation of custom resources in resource packs,
and also made private resource registries too private.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

Fixes #4925

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
