### PR TITLE
Fix platform detection on hab

### DIFF
--- a/lib/inspec/resources/platform.rb
+++ b/lib/inspec/resources/platform.rb
@@ -19,23 +19,23 @@ module Inspec::Resources
     end
 
     def family
-      @platform.family
+      @platform[:family]
     end
 
     def release
-      @platform.release if @platform.respond_to?(:release)
+      @platform[:release]
     end
 
     def arch
-      @platform.arch if @platform.respond_to?(:arch)
+      @platform[:arch]
     end
 
     def families
-      @platform.family_hierarchy
+      @platform[:family_hierarchy]
     end
 
     def name
-      @platform.name
+      @platform[:name]
     end
 
     def [](key)

--- a/lib/inspec/resources/platform.rb
+++ b/lib/inspec/resources/platform.rb
@@ -23,7 +23,7 @@ module Inspec::Resources
     end
 
     def release
-      @platform.release
+      @platform.release if @platform.respond_to?(:release)
     end
 
     def arch


### PR DESCRIPTION
## Description

Fixes the `release` property of platform detection under linux on habitat.

This fixes the `inspec detect` and `inspec shell` commands under habitat in recent versions.

We do have existing tests that should cover this but they are notoriously unreliable. I'll see what I can do to improve that.

## Related Issue

Fixes #4933

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
