### PR TITLE
Explicitly require the compliance fetcher

### DIFF
--- a/lib/inspec/fetcher.rb
+++ b/lib/inspec/fetcher.rb
@@ -43,3 +43,4 @@ end
 require "inspec/fetcher/local"
 require "inspec/fetcher/url"
 require "inspec/fetcher/git"
+require "plugins/inspec-compliance/lib/inspec-compliance/api"


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

Fixes a regression introduced in 4.18.55 in which profiles stored on Automate server we unable to be fetched.

This was not detected because we do not have automated testing against an automate server.  That is on the roadmap for end-to-end testing.

## Related Issue

Fixes #4935 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
