### PR TITLE
Update rake deps for security issue

### DIFF
--- a/examples/kitchen-ansible/Gemfile
+++ b/examples/kitchen-ansible/Gemfile
@@ -3,9 +3,9 @@ source "https://rubygems.org"
 gem "inspec", path: "../../."
 
 group :test do
-  gem "bundler", "~> 1.5"
+  gem "bundler", "~> 2.0"
   gem "minitest", "~> 5.5"
-  gem "rake", "~> 10"
+  gem "rake", ["~> 12.3", ">= 12.3.3"]
   gem "simplecov", "~> 0.10"
 end
 

--- a/examples/kitchen-chef/Gemfile
+++ b/examples/kitchen-chef/Gemfile
@@ -3,9 +3,9 @@ source "https://rubygems.org"
 gem "inspec", path: "../../."
 
 group :test do
-  gem "bundler", "~> 1.5"
+  gem "bundler", "~> 2.0"
   gem "minitest", "~> 5.5"
-  gem "rake", "~> 10"
+  gem "rake", ["~> 12.3", ">= 12.3.3"]
   gem "simplecov", "~> 0.10"
 end
 

--- a/examples/kitchen-puppet/Gemfile
+++ b/examples/kitchen-puppet/Gemfile
@@ -3,9 +3,9 @@ source "https://rubygems.org"
 gem "inspec", path: "../../."
 
 group :test do
-  gem "bundler", "~> 1.5"
+  gem "bundler", "~> 2.0"
   gem "minitest", "~> 5.5"
-  gem "rake", "~> 10"
+  gem "rake", ["~> 12.3", ">= 12.3.3"]
   gem "simplecov", "~> 0.10"
 end
 


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
CVE-2020-8130 is a security issue in Rake 12.3.2 and previous. This updates the Gemfile dep in the examples to be 12.3.3 and later.
