### PR TITLE
Add support for alternate Gem source for plugin installation/search

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -47,6 +47,15 @@ $ inspec plugin install train-some-plugin
 
 For more details on what the `plugin` command can do, see the [online help](https://www.inspec.io/docs/reference/cli/#plugin), or run `inspec plugin help`.
 
+## How do I use a different Gem server?
+
+You can specify an alternate source by passing the base of your Gem repository to the `--source` parameter:
+
+```bash
+$ inspec plugin search --source https://my.private.server inspec-private
+$ inspec plugin install --source https://my.private.server inspec-private-plugin
+```
+
 ## How do I write a plugin?
 
 ### Chef InSpec Plugins

--- a/lib/plugins/inspec-plugin-manager-cli/test/unit/cli_args_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/unit/cli_args_test.rb
@@ -28,7 +28,7 @@ class PluginManagerCliOptions < Minitest::Test
 
   def test_search_args
     arg_config = cli_class.all_commands["search"].options
-    assert_equal 3, arg_config.count, "The search command should have 3 options"
+    assert_equal 4, arg_config.count, "The search command should have 4 options"
 
     assert_includes arg_config.keys, :all, "The search command should have an --all option"
     assert_equal :boolean, arg_config[:all].type, "The --all option should be boolean"
@@ -42,6 +42,12 @@ class PluginManagerCliOptions < Minitest::Test
     refute_nil arg_config[:exact].description, "The --exact option should have a description"
     refute arg_config[:exact].required, "The --exact option should not be required"
 
+    assert_includes arg_config.keys, :source, "The search command should have a --source option"
+    assert_equal :string, arg_config[:source].type, "The --source option should be a string"
+    assert_equal :s, arg_config[:source].aliases.first, "The --source option should be aliased as -s"
+    refute_nil arg_config[:source].description, "The --source option should have a description"
+    refute arg_config[:source].required, "The --source option should not be required"
+
     assert_includes arg_config.keys, :'include-test-fixture', "The search command should have an --include-test-fixture option"
     assert_equal :boolean, arg_config[:'include-test-fixture'].type, "The --include-test-fixture option should be boolean"
     refute arg_config[:'include-test-fixture'].required, "The --include-test-fixture option should not be required"
@@ -51,13 +57,19 @@ class PluginManagerCliOptions < Minitest::Test
 
   def test_install_args
     arg_config = cli_class.all_commands["install"].options
-    assert_equal 1, arg_config.count, "The install command should have 1 option"
+    assert_equal 2, arg_config.count, "The install command should have 2 options"
 
     assert_includes arg_config.keys, :version, "The install command should have a --version option"
     assert_equal :string, arg_config[:version].type, "The --version option should be a string"
     assert_equal :v, arg_config[:version].aliases.first, "The --version option should be aliased as -v"
     refute_nil arg_config[:version].description, "The --version option should have a description"
     refute arg_config[:version].required, "The --version option should not be required"
+
+    assert_includes arg_config.keys, :source, "The install command should have a --source option"
+    assert_equal :string, arg_config[:source].type, "The --source option should be a string"
+    assert_equal :s, arg_config[:source].aliases.first, "The --source option should be aliased as -s"
+    refute_nil arg_config[:source].description, "The --source option should have a description"
+    refute arg_config[:source].required, "The --source option should not be required"
 
     assert_equal 1, cli_class.instance_method(:install).arity, "The install command should take one argument"
   end


### PR DESCRIPTION
## Description
In enterprise environments there is often no access to rubygems.org but an internal server is proxying the requests or even replacing it completely. This PR implements the --source option for InSpec plugins to allow referencing those internals servers instead of rubygems.org. It is added both for `plugin install` and `plugin search`

## Related Issue
Related to #3297 for more air-gap capabilities

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
