### PR TITLE
Fix service not working correctly on windows machines

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -104,6 +104,8 @@ module Inspec::Resources
       os = inspec.os
       platform = os[:name]
 
+      return WindowsSrv.new(inspec) if os.windows?
+
       # Ubuntu
       # @see: https://wiki.ubuntu.com/SystemdForUpstartUsers
       # Ubuntu 15.04 : Systemd
@@ -154,8 +156,6 @@ module Inspec::Resources
         SysV.new(inspec, service_ctl)
       when "mac_os_x"
         LaunchCtl.new(inspec, service_ctl)
-      when "windows"
-        WindowsSrv.new(inspec)
       when "freebsd"
         BSDInit.new(inspec, service_ctl)
       when "arch"


### PR DESCRIPTION
Signed-off-by: Albert Jubany Juàrez <ajubany@externos.itnow.es>

Fixes the service resource so it works on Windows machines.

## Description
The service resource when used on Windows machines it would appear as not supported platform. This was due to the change made some months ago of changing the original if/elsif/else structure to a switch statement. The elsif structure used the `os.windows?` to determine if it was a Windows host and the switch structure used a string comparation. Problem was that Windows machines have different names, rather than just "Windows". I changed it to a REGEX match.

## Related Issue
Fixes #4924

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
