### PR TITLE
Add Windows 10 support and fix Omnibus tests to use embedded Ruby

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -31,3 +31,4 @@ builder-to-testers-map:
     - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
+    - windows-10-x86_64

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -21,17 +21,9 @@ Write-Output "--- Running verification for $channel $product $version"
 # reload Env:PATH to ensure it gets any changes that the install made (e.g. C:\opscode\inspec\bin\ )
 $Env:PATH = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
-Write-Host "--- Downloading Ruby + DevKit"
-aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.5-1-x64.exe c:/rubyinstaller-devkit-2.6.5-1-x64.exe
-
-Write-Host "--- Installing Ruby + DevKit"
-Start-Process c:\rubyinstaller-devkit-2.6.5-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
-
-Write-Host "--- Cleaning up installation"
-Remove-Item c:\rubyinstaller-devkit-2.6.5-1-x64.exe -Force
-
-$Env:Path += ";C:\ruby26\bin"
+$Env:Path = "C:\opscode\$product\bin;C:\opscode\$product\embedded\bin;$Env:PATH"
 Write-Host "+++ Testing $Plan"
 
-cd test/artifact
+Set-Location test/artifact
 rake
+If ($lastexitcode -ne 0) { Exit $lastexitcode }


### PR DESCRIPTION
## Description

NOTE: This PR conflicts with #4967 as it addresses the current issue installing Ruby during Omnibus testing in a different way.

In addition to adding Windows 10 support, this PR skips the install of Ruby during Windows Omnibus testers in favor of running the tests using the embedded Ruby similar to how Chef Infra Client performs its tests.

An adhoc build showing this working can be found here:

https://buildkite.com/chef/inspec-inspec-master-omnibus-adhoc/builds/120

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
