### PR TITLE
Add Ubuntu 20.04 x86_64 support

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -26,6 +26,7 @@ builder-to-testers-map:
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
+    - ubuntu-20.04-x86_64
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64


### PR DESCRIPTION
## Description

This PR simply adds the newly available Ubuntu 20.04 x86_64 tester to the Omnibus pipeline.

An adhoc build showing Ubuntu 20.04 successfully testing can be found here:

https://buildkite.com/chef/inspec-inspec-master-omnibus-adhoc/builds/121
Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
