### PR TITLE
Fixes for tests under ruby 2.7

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -43,7 +43,7 @@ steps:
 
   - label: run-tests-ruby-2.7
     command:
-      - /workdir/.expeditor/buildkite/verify.sh || true
+      - /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/helper.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/helper.rb
@@ -59,4 +59,18 @@ module PluginManagerHelpers
   def teardown
     clear_empty_config_dir
   end
+
+  # This function exists because under Ruby 2.7 the rubygems gem issues deprecation warnings
+  def assert_empty_ignoring_27_warnings(stderr)
+    if Gem.ruby_version.segments[0, 2].join(".") == "2.7" # Assuming the deprecations are fixed in 2.8 and later
+      # /usr/local/lib/ruby/site_ruby/2.7.0/rubygems.rb:475: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
+      # /usr/local/lib/ruby/2.7.0/fileutils.rb:206: warning: The called method `mkdir_p' is defined here
+      # /usr/local/lib/ruby/site_ruby/2.7.0/rubygems/package.rb:509: warning: Using the last argument as keyword parameters is deprecated
+      # /usr/local/lib/ruby/site_ruby/2.7.0/rubygems/package.rb:489: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
+      # /usr/local/lib/ruby/2.7.0/fileutils.rb:180: warning: The called method `mkdir' is defined here"
+      stderr = stderr.split("\n").reject { |line| line =~ /(rubygems|fileutils).+warning.+(deprecated|defined)/ }
+    end
+
+    assert_empty stderr
+  end
 end

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
@@ -169,7 +169,7 @@ class PluginManagerCliInstall < Minitest::Test
     assert_equal "gem (user)", itf_plugin[:type]
     assert_equal "0.1.0", itf_plugin[:version]
 
-    assert_empty install_result.stderr
+    assert_empty_ignoring_27_warnings install_result.stderr
     assert_exit_code 0, install_result
   end
 
@@ -200,7 +200,7 @@ class PluginManagerCliInstall < Minitest::Test
     assert_equal "gem (user)", itf_plugin[:type]
     assert_equal "0.2.0", itf_plugin[:version]
 
-    assert_empty install_result.stderr
+    assert_empty_ignoring_27_warnings install_result.stderr
     assert_exit_code 0, install_result
   end
 
@@ -230,7 +230,7 @@ class PluginManagerCliInstall < Minitest::Test
     assert_equal "gem (user)", itf_plugin[:type]
     assert_equal "0.1.0", itf_plugin[:version]
 
-    assert_empty install_result.stderr
+    assert_empty_ignoring_27_warnings install_result.stderr
 
     assert_exit_code 0, install_result
   end
@@ -322,7 +322,7 @@ class PluginManagerCliInstall < Minitest::Test
     assert_equal "gem (user)", ttf_plugin[:type]
     assert_equal "0.1.0", ttf_plugin[:version]
 
-    assert_empty install_result.stderr
+    assert_empty_ignoring_27_warnings install_result.stderr
     assert_exit_code 0, install_result
   end
 

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/update_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/update_test.rb
@@ -27,7 +27,7 @@ class PluginManagerCliUpdate < Minitest::Test
     assert_equal "gem (user)", itf_plugin[:type]
     assert_equal "0.2.0", itf_plugin[:version]
 
-    assert_empty update_result.stderr
+    assert_empty_ignoring_27_warnings update_result.stderr
     assert_exit_code 0, update_result
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

1. Enable the tests under ruby 2.7 by removing the `||true` buildkite failsafe.
2. Found that 5 tests were failing due to deprecation warnings from fileutils and rubygems during plugin testing. Added a custom assertion to filter stderr.
3. ~~The final failing test is in train. I've opened [train#582](https://github.com/inspec/train/pull/582) to fix that, but this PR won't be clean until that is merged.~~

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
