### PR TITLE
Dist runner

### DIFF
--- a/lib/inspec/dist.rb
+++ b/lib/inspec/dist.rb
@@ -16,5 +16,21 @@ module Inspec
 
     # name of the compliance product
     COMPLIANCE_PRODUCT_NAME = "Chef Compliance"
+
+    # The suffix for workstation's eponymous folders, like /opt/workstation
+    # or C:/<LEGACY_CONF_DIR>/workstation
+    WORKSTATION_DIR_SUFFIX = "chef-workstation"
+
+    # The suffix for ChefDK's eponymous folders, like /opt/chef-dk
+    # or C:/<LEGACY_CONF_DIR>/chef-dk
+    CHEFDK_DIR_SUFFIX = "chef-dk"
+
+    # The suffix for Inspec's eponymous folders, like /opt/inspec
+    # or C:/<LEGACY_CONF_DIR>/inspec
+    INSPEC_DIR_SUFFIX = "inspec"
+
+    # The legacy conf folder: C:/opscode/chef*. Specifically the "opscode" part
+    # relevant *_DIR_SUFFIX is appended to it in code when needed
+    LEGACY_CONF_DIR = "opscode"
   end
 end

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -8,7 +8,6 @@ require "inspec/profile"
 require "inspec/metadata"
 require "inspec/config"
 require "inspec/dependencies/cache"
-require "inspec/dist"
 require "inspec/reporters"
 require "inspec/runner_rspec"
 # spec requirements
@@ -201,9 +200,9 @@ module Inspec
 
     def supports_profile?(profile)
       unless profile.supports_runtime?
-        raise "This profile requires #{Inspec::Dist::PRODUCT_NAME} version "\
+        raise "This profile requires product version "\
              "#{profile.metadata.inspec_requirement}. You are running "\
-             "#{Inspec::Dist::PRODUCT_NAME} v#{Inspec::VERSION}.\n"
+             "product v#{Inspec::VERSION}.\n"
       end
 
       true

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -200,7 +200,7 @@ module Inspec
 
     def supports_profile?(profile)
       unless profile.supports_runtime?
-        raise "This profile requires product version "\
+        raise "This profile requires the inspec-core gem version "\
              "#{profile.metadata.inspec_requirement}. You are running "\
              "product v#{Inspec::VERSION}.\n"
       end

--- a/lib/inspec/utils/install_context.rb
+++ b/lib/inspec/utils/install_context.rb
@@ -22,11 +22,11 @@ module Inspec
     private
 
     def chef_workstation_install?
-      !!(src_root.start_with?("/opt/chef-workstation") || src_root.start_with?("C:/opscode/chef-workstation"))
+      !!(src_root.start_with?("/opt/#{Inspec::Dist::WORKSTATION_DIR_SUFFIX}") || src_root.start_with?("C:/#{Inspec::Dist::LEGACY_CONF_DIR}/#{Inspec::Dist::WORKSTATION_DIR_SUFFIX}"))
     end
 
     def chefdk_install?
-      !!(src_root.start_with?("/opt/chef-dk") || src_root.start_with?("C:/opscode/chef-dk"))
+      !!(src_root.start_with?("/opt/#{Inspec::Dist::CHEFDK_DIR_SUFFIX}") || src_root.start_with?("C:/#{Inspec::Dist::LEGACY_CONF_DIR}/#{Inspec::Dist::CHEFDK_DIR_SUFFIX}"))
     end
 
     def docker_install?
@@ -39,7 +39,7 @@ module Inspec
     end
 
     def omnibus_install?
-      !!(src_root.start_with?("/opt/inspec") || src_root.start_with?("C:/opscode/inspec"))
+      !!(src_root.start_with?("/opt/#{Inspec::Dist::INSPEC_DIR_SUFFIX}") || src_root.start_with?("C:/#{Inspec::Dist::LEGACY_CONF_DIR}/#{Inspec::Dist::INSPEC_DIR_SUFFIX}"))
     end
 
     def rubygem_install?

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -316,7 +316,7 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     let(:out) { inspec("exec " + File.join(profile_path, "unsupported_inspec") + " --no-create-lockfile") }
 
     it "does not support this profile" do
-      _(stderr).must_equal "This profile requires Chef InSpec version >= 99.0.0. You are running Chef InSpec v#{Inspec::VERSION}.\n"
+      _(stderr).must_equal "This profile requires product version >= 99.0.0. You are running product v#{Inspec::VERSION}.\n"
 
       assert_exit_code 1, out
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This switches from dist constants to use generic terms in runner logs to keep the core gem distro-agnostic.

It also adds (in a separate commit) 3rd party distro support to the install_context helpers

## Related Issue
related issue from cinc: https://gitlab.com/cinc-project/distribution/auditor/-/issues/5
related issue from inspec core: https://github.com/inspec/inspec/issues/3637
related issue from inspec AWS https://github.com/inspec/inspec-aws/issues/166

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) I guess?
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
