### PR TITLE
Use Expeditor's built in Bash helper to post release announcement

### DIFF
--- a/.expeditor/announce-release.sh
+++ b/.expeditor/announce-release.sh
@@ -17,15 +17,8 @@ You can download binaries directly from [downloads.chef.io](https://downloads.ch
 EOH
 )
 
-# category 9 is "Chef Release Announcements": https://discourse.chef.io/c/chef-release
-
-curl -X POST https://discourse.chef.io/posts \
-  -H "Content-Type: multipart/form-data" \
-  -F "api_username=chef-ci" \
-  -F "api_key=$DISCOURSE_API_TOKEN" \
-  -F "category=9" \
-  -F "title=$topic_title" \
-  -F "raw=$topic_body"
+# Use Expeditor's built in Bash helper to post our message: https://git.io/JvxPm
+post_discourse_release_announcement "$topic_title" "$topic_body"
 
 # Cleanup
 rm release-notes.md


### PR DESCRIPTION
The Discourse API has recently changed its authentication method and the underlying issue was fixed in Expeditor's `post_discourse_release_announcement` helper function: https://github.com/chef/expeditor/pull/1240

Signed-off-by: Seth Chisamore <schisamo@chef.io>
