### PR TITLE
Bumps method_source dependency version

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
   spec.add_dependency "thor",               ">= 0.20", "< 2.0"
   spec.add_dependency "json_schemer",       "~> 0.2.1"
-  spec.add_dependency "method_source",      "~> 1.0"
+  spec.add_dependency "method_source",      ">= 0.8", "< 2.0"
   spec.add_dependency "rubyzip",            "~> 1.2", ">= 1.2.2"
   spec.add_dependency "rspec",              "~> 3.9"
   spec.add_dependency "rspec-its",          "~> 1.2"

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubyzip",            "~> 1.2", ">= 1.2.2"
   spec.add_dependency "rspec",              "~> 3.9"
   spec.add_dependency "rspec-its",          "~> 1.2"
-  spec.add_dependency "pry",                "~> 0"
+  spec.add_dependency "pry",                "~> 0.13"
   spec.add_dependency "hashie",             "~> 3.4"
   spec.add_dependency "mixlib-log",         "~> 3.0"
   spec.add_dependency "sslshake",           "~> 1.2"

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
   spec.add_dependency "thor",               ">= 0.20", "< 2.0"
   spec.add_dependency "json_schemer",       "~> 0.2.1"
-  spec.add_dependency "method_source",      "~> 0.8"
+  spec.add_dependency "method_source",      "~> 1.0"
   spec.add_dependency "rubyzip",            "~> 1.2", ">= 1.2.2"
   spec.add_dependency "rspec",              "~> 3.9"
   spec.add_dependency "rspec-its",          "~> 1.2"

--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -36,8 +36,13 @@ module Inspec
       end
 
       # configure pry shell prompt
-      Pry.config.prompt_name = "inspec"
-      Pry.prompt = [proc { "#{readline_ignore("\e[1m\e[32m")}#{Pry.config.prompt_name}> #{readline_ignore("\e[0m")}" }]
+      Pry::Prompt.add(
+        :inspec,
+        "inspec custom prompt"
+      ) do |_context, _nesting, _pry_instance, _sep|
+        "#{readline_ignore("\e[1m\e[32m")}inspec> #{readline_ignore("\e[0m")}"
+      end
+      Pry.config.prompt = Pry::Prompt[:inspec]
 
       # Add a help menu as the default intro
       Pry.hooks.add_hook(:before_session, "inspec_intro") do

--- a/lib/inspec/shell.rb
+++ b/lib/inspec/shell.rb
@@ -64,7 +64,7 @@ module Inspec
 
         pry.pager.open do |pager|
           pager.print pry.config.output_prefix
-          Pry::ColorPrinter.pp(value, pager, Pry::Terminal.width! - 1)
+          Pry::ColorPrinter.pp(value, pager, Pry::Output.new(pry).width - 1)
         end
       end
     end


### PR DESCRIPTION
The `method_source` dependency for inspec-core has not been bumped in
five years, and it is indirectly holding `pry` back elsewhere in the
ecosystem which is causing issues for ruby 2.7+ support.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue

This was brought to our attention by @tas50 , I do not have references for related issues but pertinent history can be found here:

* https://github.com/inspec/inspec/commit/f6509b7f8136d7cfea8270b3909f60d6bbe9a91f
* https://github.com/banister/method_source/commits/master

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
