### PR TITLE
Updates README.md to clarify running InSpec local

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,8 @@ Note that installing from OS packages from [the download page](https://downloads
 That requires [bundler](http://bundler.io/):
 
 ```bash
-# From ./inspec-bin directory
 bundle install
-bundle exec bin/inspec help
+bundle exec inspec help
 ```
 
 To install it as a gem locally, run:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Note that installing from OS packages from [the download page](https://downloads
 That requires [bundler](http://bundler.io/):
 
 ```bash
+# From ./inspec-bin directory
 bundle install
 bundle exec bin/inspec help
 ```


### PR DESCRIPTION
## Description

When this part of the README was updated five years ago ( https://github.com/inspec/inspec/commit/b58a4b3f436eeabdb55e75cf9a1863fd19482758 ), the executable was to be found in `bin/inspec`. It has since been extracted to `inspec-bin/bin/inspec`. 

This current phrasing could cause some confusion as a user might actually run `bundle install` from their root and try to then run `bin/inspec`. 

This commit clarifies that you need to first `cd` down into `inspec-bin`

<!--- Provide a short summary of your changes in the Title above -->


<!--- Describe your changes in detail, what problems does it solve? -->
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
