### PR TITLE
Allows input and control to have the same name

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -332,7 +332,7 @@ module Inspec
       input_name = @__rule_id # TODO: control ID slugging
       registry = Inspec::InputRegistry.instance
       input = registry.inputs_by_profile.dig(__profile_id, input_name)
-      return unless input
+      return unless input && input.has_value? && input.value.is_a?(Hash)
 
       # An InSpec Input is a datastructure that tracks a profile parameter
       # over time. Its value can be set by many sources, and it keeps a

--- a/test/fixtures/profiles/waivers/namespace-clash/controls/namespace_clash.rb
+++ b/test/fixtures/profiles/waivers/namespace-clash/controls/namespace_clash.rb
@@ -1,0 +1,7 @@
+# This fixture tests for a regression found here: https://github.com/inspec/inspec/issues/4936
+control '01_my_control' do
+only_if { input('01_my_control', value: 'false') == 'false' }
+  describe true do
+    it { should eq true }
+  end
+end

--- a/test/fixtures/profiles/waivers/namespace-clash/inspec.yml
+++ b/test/fixtures/profiles/waivers/namespace-clash/inspec.yml
@@ -1,0 +1,5 @@
+name: namespace-clash
+summary: Verifies input and control namespace can safely clash
+version: 0.1.0
+supports:
+  platform: os

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -176,8 +176,8 @@ describe "inspec exec with json formatter" do
         "summary" => "Demonstrates the use of InSpec Compliance Profile",
         "version" => "1.0.0",
         "supports" => [{ "platform-family" => "unix" }, { "platform-family" => "windows" }],
-        "status" => "loaded",
         "attributes" => [],
+        "status" => "loaded",
       })
 
       _(groups.sort_by { |x| x["id"] }).must_equal([

--- a/test/functional/inspec_exec_junit_test.rb
+++ b/test/functional/inspec_exec_junit_test.rb
@@ -42,11 +42,11 @@ describe "inspec exec with junit formatter" do
     describe "the test suite" do
       let(:suite) { doc.elements.to_a("//testsuites/testsuite").first }
 
-      it "must have 6 testcase children" do
+      it "must have 4 testcase children" do
         _(suite.elements.to_a("//testcase").length).must_equal 4
       end
 
-      it "has the tests attribute with 5 total tests" do
+      it "has the tests attribute with 4 total tests" do
         _(suite.attribute("tests").value).must_equal "4"
       end
 


### PR DESCRIPTION
# Background

In https://github.com/inspec/inspec/issues/4936 the issue was reported that naming an input the same as a control caused an unexpected failure.

In that particular case, the naming was a result of a pre-waivers workaround which is no longer necessary, but ultimately a breakage of that name clash is an unexpected occurrance.

# The error

Due to how inputs are named and registered, `__apply_waivers` thinks that an object is a waiver that is not a waiver and tries to process it. On the micro level, it breaks when trying to pass a variable to a string as if it were a Hash.

# The fix

It is imperative that we preserve 100% of the current featureset, pass our tests, and fix this edge case along with new test coverage for the failure.

This PR updates the code to do a small ‘waiver check’ to stop the namespace clash from breaking the code.

Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>

## Related Issue

#4936 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
