### PR TITLE
Updating automate reporter example config to valid json

### DIFF
--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -131,14 +131,16 @@ The `automate` reporter type is a special reporter used with [Chef Automate](htt
 Example config:
 
 ```json
-"reporter": {
-    "automate" : {
-        "stdout" : false,
-        "url" : "https://YOUR_A2_URL/data-collector/v0/",
-        "token" : "YOUR_A2_ADMIN_TOKEN",
-        "insecure" : true,
-        "node_name" : "inspec_test_node",
-        "environment" : "prod"
+{
+    "reporter": {
+        "automate" : {
+            "stdout" : false,
+            "url" : "https://YOUR_A2_URL/data-collector/v0/",
+            "token" : "YOUR_A2_ADMIN_TOKEN",
+            "insecure" : true,
+            "node_name" : "inspec_test_node",
+            "environment" : "prod"
+        }
     }
 }
 ```


### PR DESCRIPTION
## Background
The example config located at: https://www.inspec.io/docs/reference/reporters/ for the Automate Report has invalid JSON.

## The Error 
If someone copy/pastes this code and updates it accordingly with their automate information they will receive a parse error

```
Error: Parse error on line 1:
"reporter": {	"automate": {	
----------^
Expecting 'EOF', '}', ',', ']', got ':'
```

## The Fix
Update the documentation to provide validate JSON:

```
{
	"reporter": {
		"automate": {
			"stdout": false,
			"url": "https://YOUR_A2_URL/data-collector/v0/",
			"token": "YOUR_A2_ADMIN_TOKEN",
			"insecure": true,
			"node_name": "inspec_test_node",
			"environment": "prod"
		}
	}
}
```

## Related Issue
https://github.com/inspec/inspec/issues/5006

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
