### PR TITLE
Boolean, Numeric, and Structured CLI inputs

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -263,6 +263,19 @@ To set multiple inputs, say:
 inspec exec my_profile --input input_name1=input_value1 name2=value2
 ```
 
+If a CLI input value resembles a number, it will be converted to an Integer or Float. Scientific notation is not currently recognized.
+```yaml
+inspec exec my_profile --input integer_input=-11
+inspec exec my_profile --input float_input=11.0
+```
+
+You may set inputs with complex values, such as arrays and hashes using either YAML or JSON syntax. Just be sure to protect the string from the shell using single quotes.
+```yaml
+inspec exec my_profile --input array_input='[a,b,c]'
+inspec exec my_profile --input hash_input='{a: apples, b: bananas, c: cantelopes}'
+inspec exec my_profile --input json_input='{"a": "apples", "g": ["grape01", "grape02"] }'
+```
+
 Do not repeat the `--input` flag; that will override the previous setting.
 
 CLI-set inputs have a priority of 50.

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -265,15 +265,15 @@ inspec exec my_profile --input input_name1=input_value1 name2=value2
 
 If a CLI input value resembles a number, it will be converted to an Integer or Float. Scientific notation is not currently recognized.
 ```yaml
-inspec exec my_profile --input integer_input=-11
-inspec exec my_profile --input float_input=11.0
+inspec exec my_profile --input amplifier_volume=-11
+inspec exec my_profile --input water_depth=11.5
 ```
 
 You may set inputs with complex values, such as arrays and hashes using either YAML or JSON syntax. Just be sure to protect the string from the shell using single quotes.
 ```yaml
-inspec exec my_profile --input array_input='[a,b,c]'
-inspec exec my_profile --input hash_input='{a: apples, b: bananas, c: cantelopes}'
-inspec exec my_profile --input json_input='{"a": "apples", "g": ["grape01", "grape02"] }'
+inspec exec my_profile --input alphabet='[a,b,c]'
+inspec exec my_profile --input fruits='{a: apples, b: bananas, c: cantelopes}'
+inspec exec my_profile --input json_fruit='{"a": "apples", "g": ["grape01", "grape02"] }'
 ```
 
 Do not repeat the `--input` flag; that will override the previous setting.

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -136,7 +136,7 @@ module Inspec
         banner: "one two:/output/file/path",
         desc: "Enable one or more output reporters: cli, documentation, html, progress, json, json-min, json-rspec, junit, yaml"
       option :input, type: :array, banner: "name1=value1 name2=value2",
-        desc: "Specify one or more inputs directly on the command line, as --input NAME=VALUE"
+        desc: "Specify one or more inputs directly on the command line, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures."
       option :input_file, type: :array,
         desc: "Load one or more input files, a YAML file with values for the profile to use"
       option :waiver_file, type: :array,

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -180,8 +180,8 @@ module Inspec
     def parse_cli_input_value(input_name, given_value)
       value = given_value.chomp(",") # Trim trailing comma if any
       case value
-      when /^true|false$/
-        value = value == "true"
+      when /^true|false$/i
+        value = !!(value =~ /true/i)
       when /^-?\d+$/
         value = value.to_i
       when /^-?\d+\.\d+$/
@@ -197,7 +197,7 @@ module Inspec
           begin
             value = JSON.parse(value)
           rescue JSON::ParserError => json_error
-            msg = "ERROR: Unparseable value '#{value}' for --input #{input_name}.\n"
+            msg = "Unparseable value '#{value}' for --input #{input_name}.\n"
             msg += "When treated as YAML, error: #{yaml_error.message}\n"
             msg += "When treated as JSON, error: #{json_error.message}"
             Inspec::Log.warn msg

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -204,7 +204,6 @@ module Inspec
       value
     end
 
-
     def bind_inputs_from_runner_api(profile_name, input_hash)
       # TODO: move this into a core plugin
 

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -179,11 +179,14 @@ module Inspec
     # Remove trailing commas, resolve type.
     def parse_cli_input_value(input_name, given_value)
       value = given_value.chomp(",") # Trim trailing comma if any
-      if value =~ /^-?\d+$/
+      case value
+      when /^true|false$/
+        value = value == "true"
+      when /^-?\d+$/
         value = value.to_i
-      elsif value =~ /^-?\d+\.\d+$/
+      when /^-?\d+\.\d+$/
         value = value.to_f
-      elsif value =~ /^(\[|\{).*(\]|\})$/
+      when /^(\[|\{).*(\]|\})$/
         # Look for complex values and try to parse them.
         require "yaml"
         begin

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -200,7 +200,7 @@ module Inspec
             msg = "ERROR: Unparseable value '#{value}' for --input #{input_name}.\n"
             msg += "When treated as YAML, error: #{yaml_error.message}\n"
             msg += "When treated as JSON, error: #{json_error.message}"
-            raise ArgumentError, msg
+            Inspec::Log.warn msg
           end
         end
       end

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -166,7 +166,7 @@ module Inspec
           end
         end
         input_name, input_value = pair.split("=")
-        input_value = clean_up_cli_input_value(input_name, input_value)
+        input_value = parse_cli_input_value(input_name, input_value)
         evt = Inspec::Input::Event.new(
           value: input_value,
           provider: :cli,
@@ -177,7 +177,7 @@ module Inspec
     end
 
     # Remove trailing commas, resolve type.
-    def clean_up_cli_input_value(input_name, given_value)
+    def parse_cli_input_value(input_name, given_value)
       value = given_value.chomp(",") # Trim trailing comma if any
       if value =~ /^-?\d+$/
         value = value.to_i

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -166,14 +166,27 @@ module Inspec
           end
         end
         input_name, input_value = pair.split("=")
+        input_value = clean_up_cli_input_value(input_value)
         evt = Inspec::Input::Event.new(
-          value: input_value.chomp(","), # Trim trailing comma if any
+          value: input_value,
           provider: :cli,
           priority: 50
         )
         find_or_register_input(input_name, profile_name, event: evt)
       end
     end
+
+    # Remove trailing commas, resolve type.
+    def clean_up_cli_input_value(given_value)
+      value = given_value.chomp(",") # Trim trailing comma if any
+      if value =~ /^-?\d+$/
+        value = value.to_i
+      elsif value =~ /^-?\d+\.\d+$/
+        value = value.to_f
+      end
+      value
+    end
+
 
     def bind_inputs_from_runner_api(profile_name, input_hash)
       # TODO: move this into a core plugin

--- a/test/fixtures/profiles/inputs/cli/controls/cli.rb
+++ b/test/fixtures/profiles/inputs/cli/controls/cli.rb
@@ -26,3 +26,47 @@ control "test_control_numeric_float" do
     it { should eq -11.0 } # Note eq not cmp
   end
 end
+
+control "test_control_yaml_array" do
+  describe input("test_input_06", value: "value_from_dsl") do
+    it { should eq [ "a", "b", "c" ] }
+  end
+end
+
+control "test_control_yaml_hash" do
+  describe input("test_input_07", value: "value_from_dsl") do
+    # Parser keeps tripping up on this when inlined
+    expected = { "a" => "apples", "b" => "bananas", "c" => "cantelopes" }
+    it { should eq expected }
+  end
+end
+
+control "test_control_yaml_deep" do
+  describe input("test_input_09", value: "value_from_dsl") do
+    # Parser keeps tripping up on this when inlined
+    expected = { "a" => "apples", "g" => ["grape01", "grape02"] }
+    it { should eq expected }
+  end
+end
+
+control "test_control_json_array" do
+  describe input("test_input_10", value: "value_from_dsl") do
+    it { should eq [ "a", "b", "c" ] }
+  end
+end
+
+control "test_control_json_hash" do
+  describe input("test_input_11", value: "value_from_dsl") do
+    # Parser keeps tripping up on this when inlined
+    expected = { "a" => "apples", "b" => "bananas", "c" => "cantelopes" }
+    it { should eq expected }
+  end
+end
+
+control "test_control_json_deep" do
+  describe input("test_input_12", value: "value_from_dsl") do
+    # Parser keeps tripping up on this when inlined
+    expected = { "a" => "apples", "g" => ["grape01", "grape02"] }
+    it { should eq expected }
+  end
+end

--- a/test/fixtures/profiles/inputs/cli/controls/cli.rb
+++ b/test/fixtures/profiles/inputs/cli/controls/cli.rb
@@ -8,3 +8,21 @@ control "test_control_02" do
     it { should cmp "value_from_cli_02"}
   end
 end
+
+control "test_control_numeric_implicit" do
+  describe input("test_input_03", value: "value_from_dsl") do
+    it { should eq 11 } # Note eq not cmp
+  end
+end
+
+control "test_control_numeric_type" do
+  describe input("test_input_04", value: "value_from_dsl") do
+    it { should eq 11 } # Note eq not cmp
+  end
+end
+
+control "test_control_numeric_float" do
+  describe input("test_input_05", value: "value_from_dsl") do
+    it { should eq -11.0 } # Note eq not cmp
+  end
+end

--- a/test/fixtures/profiles/inputs/cli/controls/cli.rb
+++ b/test/fixtures/profiles/inputs/cli/controls/cli.rb
@@ -70,3 +70,21 @@ control "test_control_json_deep" do
     it { should eq expected }
   end
 end
+
+control "test_control_bool_true" do
+  describe input("test_input_13", value: "value_from_dsl") do
+    it { should be_a TrueClass }
+  end
+end
+
+control "test_control_bool_false" do
+  describe input("test_input_14", value: "value_from_dsl") do
+    it { should be_a FalseClass }
+  end
+end
+
+control "test_control_bool_string" do
+  describe input("test_input_15", value: "value_from_dsl") do
+    it { should eq "TRUE" }
+  end
+end

--- a/test/fixtures/profiles/inputs/cli/controls/cli.rb
+++ b/test/fixtures/profiles/inputs/cli/controls/cli.rb
@@ -83,8 +83,8 @@ control "test_control_bool_false" do
   end
 end
 
-control "test_control_bool_string" do
+control "test_control_bool_true_caps" do
   describe input("test_input_15", value: "value_from_dsl") do
-    it { should eq "TRUE" }
+    it { should be_a TrueClass }
   end
 end

--- a/test/fixtures/profiles/inputs/cli/controls/cli.rb
+++ b/test/fixtures/profiles/inputs/cli/controls/cli.rb
@@ -11,19 +11,19 @@ end
 
 control "test_control_numeric_implicit" do
   describe input("test_input_03", value: "value_from_dsl") do
-    it { should eq 11 } # Note eq not cmp
+    it { should be_a Integer }
   end
 end
 
 control "test_control_numeric_type" do
   describe input("test_input_04", value: "value_from_dsl") do
-    it { should eq 11 } # Note eq not cmp
+    it { should be_a Integer }
   end
 end
 
 control "test_control_numeric_float" do
   describe input("test_input_05", value: "value_from_dsl") do
-    it { should eq -11.0 } # Note eq not cmp
+    it { should be_a Float }
   end
 end
 

--- a/test/fixtures/profiles/inputs/cli/inspec.yml
+++ b/test/fixtures/profiles/inputs/cli/inspec.yml
@@ -4,3 +4,7 @@ summary: Profile to exercise setting inputs using the --input CLI option
 version: 0.1.0
 supports:
   platform: os
+
+inputs:
+  - name: test_input_04
+    type: numeric

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -240,24 +240,31 @@ describe "inputs" do
       end
 
       # JSON mode
-      describe "when the --input is a JSON array" do
-        let(:input_opt) { %q{--input test_input_10='["a","b","c"]'} }
-        let(:control_opt) { "--controls test_control_json_array" }
-        it("correctly reads the input as a json array") { assert_json_controls_passing(result) }
+      # These three were tested manually on 2020-05-05 on win2016 and passed
+      # Under CI however, we have multiple layers of quoting and dequoting
+      # and it breaks badly. https://github.com/inspec/inspec/issues/5015
+      unless windows?
+        describe "when the --input is a JSON array" do
+          let(:input_opt) { %q{--input test_input_10='["a","b","c"]'} }
+          let(:control_opt) { "--controls test_control_json_array" }
+          it("correctly reads the input as a json array") {
+            assert_empty result.stderr
+            assert_json_controls_passing(result)
+          }
+        end
+        describe "when the --input is a JSON hash" do
+          # Note: this produces a String-keyed Hash
+          let(:input_opt) { %q{--input test_input_11='{"a": "apples", "b": "bananas", "c": "cantelopes"}'} }
+          let(:control_opt) { "--controls test_control_json_hash" }
+          it("correctly reads the input as a json hash") { assert_json_controls_passing(result) }
+        end
+        describe "when the --input is a JSON deep structure" do
+          # Note: this produces a String-keyed Hash
+          let(:input_opt) { %q{--input test_input_12='{"a": "apples", "g": ["grape01", "grape02"] }'} }
+          let(:control_opt) { "--controls test_control_json_deep" }
+          it("correctly reads the input as a json struct") { assert_json_controls_passing(result) }
+        end
       end
-      describe "when the --input is a JSON hash" do
-        # Note: this produces a String-keyed Hash
-        let(:input_opt) { %q{--input test_input_11='{"a": "apples", "b": "bananas", "c": "cantelopes"}'} }
-        let(:control_opt) { "--controls test_control_json_hash" }
-        it("correctly reads the input as a json hash") { assert_json_controls_passing(result) }
-      end
-      describe "when the --input is a JSON deep structure" do
-        # Note: this produces a String-keyed Hash
-        let(:input_opt) { %q{--input test_input_12='{"a": "apples", "g": ["grape01", "grape02"] }'} }
-        let(:control_opt) { "--controls test_control_json_deep" }
-        it("correctly reads the input as a json struct") { assert_json_controls_passing(result) }
-      end
-
     end
 
     describe "when the --input is used twice with one value each" do

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -158,19 +158,40 @@ describe "inputs" do
 
     describe "when the --input is used once with two values" do
       let(:input_opt) { "--input test_input_01=value_from_cli_01 test_input_02=value_from_cli_02" }
-      it("correctly reads the input") { assert_json_controls_passing(result) }
+      let(:control_opt) { "--controls test_control_01 test_control_02" }
+      it("correctly reads both inputs") { assert_json_controls_passing(result) }
     end
 
     describe "when the --input is used once with two values and a comma" do
       let(:input_opt) { "--input test_input_01=value_from_cli_01, test_input_02=value_from_cli_02" }
-      it("correctly reads the input") { assert_json_controls_passing(result) }
+      let(:control_opt) { "--controls test_control_01 test_control_02" }
+      it("correctly reads both inputs ignoring the comma") { assert_json_controls_passing(result) }
+    end
+
+    # See https://github.com/inspec/inspec/issues/4977
+    describe "when the --input is used with a numeric value" do
+      describe "when the --input is used with an integer value" do
+        let(:input_opt) { "--input test_input_03=11" }
+        let(:control_opt) { "--controls test_control_numeric_implicit" }
+        it("correctly reads the input as numeric") { assert_json_controls_passing(result) }
+      end
+      describe "when the --input is used with a integer value and is declared as a numeric type in metadata" do
+        let(:input_opt) { "--input test_input_04=11" }
+        let(:control_opt) { "--controls test_control_numeric_type" }
+        it("correctly reads the input as numeric") { assert_json_controls_passing(result) }
+      end
+      describe "when the --input is used with a float value" do
+        let(:input_opt) { "--input test_input_05=-11.0" }
+        let(:control_opt) { "--controls test_control_numeric_float" }
+        it("correctly reads the input as numeric") { assert_json_controls_passing(result) }
+      end
     end
 
     describe "when the --input is used twice with one value each" do
       let(:input_opt) { "--input test_input_01=value_from_cli_01 --input test_input_02=value_from_cli_02" }
       let(:control_opt) { "--controls test_control_02" }
       # Expected, though unfortunate, behavior is to only notice the second input
-      it("correctly reads the input") { assert_json_controls_passing(result) }
+      it("correctly reads the second input") { assert_json_controls_passing(result) }
     end
 
     describe "when the --input is used with no equal sign" do

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -195,7 +195,7 @@ describe "inputs" do
         it "does not run and provides a YAML error message" do
           output = result.stdout
           assert_includes "ERROR", output
-          # assert_includes "", output # TODO - find YAML parser error message
+          assert_includes "treated as YAML", output
           assert_includes "test_input_08", output
           assert_equal 1, result.exit_status
         end

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -187,6 +187,25 @@ describe "inputs" do
       end
     end
 
+    # See https://github.com/inspec/inspec/issues/4799
+    describe "when the --input is used with a boolean value" do
+      describe "when the --input is passed true" do
+        let(:input_opt) { "--input test_input_13=true" }
+        let(:control_opt) { "--controls test_control_bool_true" }
+        it("correctly reads the input as TrueClass") { assert_json_controls_passing(result) }
+      end
+      describe "when the --input is passed false" do
+        let(:input_opt) { "--input test_input_14=false" }
+        let(:control_opt) { "--controls test_control_bool_false" }
+        it("correctly reads the input as FalseClass") { assert_json_controls_passing(result) }
+      end
+      describe "when the --input is passed TRUE" do
+        let(:input_opt) { "--input test_input_15=TRUE" }
+        let(:control_opt) { "--controls test_control_bool_string" }
+        it("correctly reads the input as a string") { assert_json_controls_passing(result) }
+      end
+    end
+
     describe "when the --input is a complex structure" do
 
       # Garbage

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -216,7 +216,7 @@ describe "inputs" do
           assert_includes output, "WARN"
           assert_includes output, "treated as YAML"
           assert_includes output, "test_input_08"
-          assert_equal 100, result.exit_status
+          assert_exit_code(100, result)
         end
       end
 

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -187,6 +187,60 @@ describe "inputs" do
       end
     end
 
+    describe "when the --input is a complex structure" do
+
+      # Garbage
+      describe "when the --input is malformed YAML " do
+        let(:input_opt) { "--input test_input_08='[a, b, }]'" }
+        it "does not run and provides a YAML error message" do
+          output = result.stdout
+          assert_includes "ERROR", output
+          # assert_includes "", output # TODO - find YAML parser error message
+          assert_includes "test_input_08", output
+          assert_equal 1, result.exit_status
+        end
+      end
+
+      # YAML
+      describe "when the --input is a YAML array" do
+        let(:input_opt) { "--input test_input_06='[a,b,c]'" }
+        let(:control_opt) { "--controls test_control_yaml_array" }
+        it("correctly reads the input as a yaml array") { assert_json_controls_passing(result) }
+      end
+      describe "when the --input is a YAML hash" do
+        # Note: this produces a String-keyed Hash
+        let(:input_opt) { "--input test_input_07='{a: apples, b: bananas, c: cantelopes}'" }
+        let(:control_opt) { "--controls test_control_yaml_hash" }
+        it("correctly reads the input as a yaml hash") { assert_json_controls_passing(result) }
+      end
+      describe "when the --input is a YAML deep structure" do
+        # Note: this produces a String-keyed Hash
+        let(:input_opt) { "--input test_input_09='{a: apples, g: [grape01, grape02] }'" }
+        let(:control_opt) { "--controls test_control_yaml_deep" }
+        it("correctly reads the input as a yaml struct") { assert_json_controls_passing(result) }
+      end
+
+      # JSON mode
+      describe "when the --input is a JSON array" do
+        let(:input_opt) { %q{--input test_input_10='["a","b","c"]'} }
+        let(:control_opt) { "--controls test_control_json_array" }
+        it("correctly reads the input as a json array") { assert_json_controls_passing(result) }
+      end
+      describe "when the --input is a JSON hash" do
+        # Note: this produces a String-keyed Hash
+        let(:input_opt) { %q{--input test_input_11='{"a": "apples", "b": "bananas", "c": "cantelopes"}'} }
+        let(:control_opt) { "--controls test_control_json_hash" }
+        it("correctly reads the input as a json hash") { assert_json_controls_passing(result) }
+      end
+      describe "when the --input is a JSON deep structure" do
+        # Note: this produces a String-keyed Hash
+        let(:input_opt) { %q{--input test_input_12='{"a": "apples", "g": ["grape01", "grape02"] }'} }
+        let(:control_opt) { "--controls test_control_json_deep" }
+        it("correctly reads the input as a json struct") { assert_json_controls_passing(result) }
+      end
+
+    end
+
     describe "when the --input is used twice with one value each" do
       let(:input_opt) { "--input test_input_01=value_from_cli_01 --input test_input_02=value_from_cli_02" }
       let(:control_opt) { "--controls test_control_02" }

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -211,12 +211,12 @@ describe "inputs" do
       # Garbage
       describe "when the --input is malformed YAML " do
         let(:input_opt) { "--input test_input_08='[a, b, }]'" }
-        it "does not run and provides a YAML error message" do
-          output = result.stdout
-          assert_includes "ERROR", output
-          assert_includes "treated as YAML", output
-          assert_includes "test_input_08", output
-          assert_equal 1, result.exit_status
+        it "runs with failed tests and provides a YAML warning message" do
+          output = result.stderr
+          assert_includes output, "WARN"
+          assert_includes output, "treated as YAML"
+          assert_includes output, "test_input_08"
+          assert_equal 100, result.exit_status
         end
       end
 

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -201,8 +201,8 @@ describe "inputs" do
       end
       describe "when the --input is passed TRUE" do
         let(:input_opt) { "--input test_input_15=TRUE" }
-        let(:control_opt) { "--controls test_control_bool_string" }
-        it("correctly reads the input as a string") { assert_json_controls_passing(result) }
+        let(:control_opt) { "--controls test_control_bool_true_caps" }
+        it("correctly reads the input as a TrueClass even when capitalized") { assert_json_controls_passing(result) }
       end
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Parses the value passed in from the `--input` CLI flag and makes some guesses as to what it could be. Maybe boolean? Maybe numeric? Maybe YAML? Maybe JSON?

Most of the time, it will fall through to being a string. There is a chance we could now wrongly throw errors on strings that begin and end with [] or {} and fail to parse as JSON or YAML, but that seems pretty edge-casey.

Tests and docs included.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #4799 boolean case
Fixes #4977 numeric case
Fixes #4963 arrays, hashes and deeper things.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-2196