### PR TITLE
Remove Windows skips from test/functional/inspec_exec_jsonmin_test.rb

### DIFF
--- a/test/functional/inspec_exec_jsonmin_test.rb
+++ b/test/functional/inspec_exec_jsonmin_test.rb
@@ -31,7 +31,6 @@ describe "inspec exec" do
 
     _(out.stderr).must_equal ""
 
-    skip_windows!
     assert_exit_code 0, out
   end
 

--- a/test/functional/inspec_exec_jsonmin_test.rb
+++ b/test/functional/inspec_exec_jsonmin_test.rb
@@ -65,11 +65,6 @@ describe "inspec exec" do
     let(:controls) { json["controls"] }
     let(:ex1) { controls.find { |x| x["id"] == "test01" } }
 
-    before do
-      # doesn't make sense on windows TODO: change the profile so it does?
-      skip if windows?
-    end
-
     it "must have 1 example" do
       _(json["controls"].length).must_equal 1
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
On my Windows laptop, test/functional/inspec_exec_jsonmin_test.rb passes when I remove the skips. This PR simply removes the skip statements.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #4705 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
