### PR TITLE
Stores output of `inspec json` to archive and artifact

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -4,6 +4,7 @@ require "inspec/utils/deprecation/deprecator"
 require "inspec/dist"
 require "inspec/backend"
 require "inspec/dependencies/cache"
+require "inspec/utils/json_profile_summary"
 
 module Inspec # TODO: move this somewhere "better"?
   autoload :BaseCLI,       "inspec/base_cli"
@@ -77,24 +78,13 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     o[:vendor_cache] = Inspec::Cache.new(o[:vendor_cache])
 
     profile = Inspec::Profile.for_target(target, o)
-    info = profile.info
-    # add in inspec version
-    info[:generator] = {
-      name: "inspec",
-      version: Inspec::VERSION,
-    }
     dst = o[:output].to_s
-    if dst.empty?
-      puts JSON.dump(info)
-    else
-      if File.exist? dst
-        puts "----> updating #{dst}"
-      else
-        puts "----> creating #{dst}"
-      end
-      fdst = File.expand_path(dst)
-      File.write(fdst, JSON.dump(info))
-    end
+
+    # Write JSON
+    Inspec::Utils::JsonProfileSummary.produce_json(
+      info: profile.info,
+      write_path: dst
+    )
   rescue StandardError => e
     pretty_handle_exception(e)
   end

--- a/lib/inspec/utils/json_profile_summary.rb
+++ b/lib/inspec/utils/json_profile_summary.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Inspec
+  module Utils
+    #
+    # Inspec::Utils::JsonProfileSummary takes in certain information to identify a
+    # profile and then produces a JSON-formatted summary of that profile. It can
+    # return the results to STDOUT or a file. It is currently used in several
+    # places in the CLI such as `json`, `archive` and `artifact`.
+    #
+    #
+    module JsonProfileSummary
+      def self.produce_json(info:, write_path: "", suppress_output: false)
+        # add in inspec version
+        info[:generator] = {
+          name: "inspec",
+          version: Inspec::VERSION,
+        }
+        if write_path.empty?
+          puts JSON.dump(info)
+        else
+          unless suppress_output
+            if File.exist? write_path
+              Inspec::Log.info "----> updating #{write_path}"
+            else
+              Inspec::Log.info "----> creating #{write_path}"
+            end
+          end
+          full_write_path = File.expand_path(write_path)
+          File.write(full_write_path, JSON.dump(info))
+        end
+      end
+    end
+  end
+end

--- a/lib/plugins/inspec-artifact/test/functional/inspec_artifact_test.rb
+++ b/lib/plugins/inspec-artifact/test/functional/inspec_artifact_test.rb
@@ -44,6 +44,7 @@ class ArtifactCli < Minitest::Test
 
       assert_includes out.stdout.force_encoding(Encoding::UTF_8), "Installing to #{install_dir}"
       assert_includes Dir.entries(install_dir).join, "inspec.yml"
+      assert_includes Dir.entries(install_dir).join, "inspec.json"
       assert_exit_code 0, out
     end
   end

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -31,6 +31,17 @@ describe "inspec archive" do
     end
   end
 
+  it "archives an inspec.json file" do
+    prepare_examples("profile") do |dir|
+      out = inspec("archive " + dir + " --overwrite")
+
+      _(out.stderr).must_equal ""
+      t = Zlib::GzipReader.open(auto_dst)
+      _(Gem::Package::TarReader.new(t).entries.map(&:header).map(&:name)).must_include "inspec.json"
+      assert_exit_code 0, out
+    end
+  end
+
   it "auto-archives when no --output is given" do
     prepare_examples("profile") do |dir|
       out = inspec("archive " + dir + " --overwrite")

--- a/test/functional/inspec_json_profile_test.rb
+++ b/test/functional/inspec_json_profile_test.rb
@@ -110,7 +110,7 @@ describe "inspec json" do
     _(hm["name"]).must_equal "profile"
     _(hm["controls"].length).must_equal 4
 
-    _(out.stderr).must_equal ""
+    _(out.stderr).must_include "----> creating #{dst.path}"
 
     assert_exit_code 0, out
   end

--- a/test/functional/inspec_vendor_test.rb
+++ b/test/functional/inspec_vendor_test.rb
@@ -141,7 +141,7 @@ describe "example inheritance profile" do
       # out.stdout.scan(/Dependency does not exist in the cache/).length.must_equal 1
       _(out.stdout.scan(/Fetching URL:/).length).must_equal 0
 
-      _(out.stderr).must_equal ""
+      _(out.stderr).must_include "----> creating #{dst.path}"
 
       assert_exit_code 0, out
 

--- a/test/unit/json_profile_summary_test.rb
+++ b/test/unit/json_profile_summary_test.rb
@@ -1,0 +1,44 @@
+# copyright: 2020, Chef Software Inc.
+
+require "helper"
+require "inspec/utils/json_profile_summary"
+
+describe "JsoneProfileSummary" do
+  let(:profile_summary) { Inspec::Utils::JsonProfileSummary }
+  let(:info) { { test: "information" } }
+
+  describe "writes JSON to file" do
+    it "writes json to file" do
+      Dir.mktmpdir do |dir|
+        profile_summary.produce_json(
+          info: info,
+          write_path: "#{dir}/inspec-test.json"
+        )
+        assert File.file?("#{dir}/inspec-test.json")
+      end
+    end
+
+    it "suppresses loading output if requested" do
+      Dir.mktmpdir do |dir|
+        assert_output("") {
+          profile_summary.produce_json(
+            info: info,
+            write_path: "#{dir}/inspec-test.json",
+            suppress_output: true
+          )
+        }
+      end
+    end
+
+    it "returns JSON to STDOUT if no dst" do
+      assert_output(
+        "{\"test\":\"information\",\"generator\":{\"name\":\"inspec\",\""\
+        "version\":\"#{Inspec::VERSION}\"}}\n"
+      ) { profile_summary.produce_json(info: info) }
+    end
+
+    it "fails without arguments" do
+      assert_raises(ArgumentError) { profile_summary.produce_json }
+    end
+  end
+end


### PR DESCRIPTION
## Description

This was a feature request articulated in the issue below. 

The 30,000 foot version is that this PR takes the output of `inspec json` and stores it in the file `inspec.json` when running `inspec artifact` or `inspec archive`, within the actual archived file itself. It also includes a small refactoring to make the `inspec json` functionality portable throughout InSpec.

For more on the reasonings and benefits of this feature, see below.

## Related Issue

Fixes #4973 

If you are not familiar with `inspec artifact`, it appears to be a currently undocumented feature that is not recommended to be used. If you want to test it out or add to the discussion around artifact some useful info can be found here: https://github.com/inspec/inspec/issues/2821

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
