### PR TITLE
No longer need to include rubygems or bundler software dep

### DIFF
--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -19,8 +19,6 @@ require_relative "../../../lib/inspec/version.rb"
 name "inspec"
 
 dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 
 license :project_license
 

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,8 +4,6 @@
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
-override :rubygems, version: "3.0.3"
-override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to prevent double bundle
 # grab the current train release from rubygems.org
 train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
 override "train", version: "v#{train_stable}"

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,9 +1,5 @@
 # THIS IS NOW HAND MANAGED, JUST EDIT THE THING
-# .travis.yml and appveyor.yml consume this,
-# try to keep it machine-parsable.
-#
-# NOTE: You MUST update omnibus-software when adding new versions of
-# software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
+
 # grab the current train release from rubygems.org
 train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
 override "train", version: "v#{train_stable}"


### PR DESCRIPTION
## Description
Recent versions of Ruby have included Rubygems and Bundler, which they
did not always do. We also recently fixed some issues in Appbundler so
these software dependencies are no longer needed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
