### PR TITLE
CLI Option to silence deprecations

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -155,6 +155,9 @@ module Inspec
         desc: "Show progress while executing tests."
       option :distinct_exit, type: :boolean, default: true,
         desc: "Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures."
+      option :silence_deprecations, type: :array,
+        banner: "[all]|[GROUP GROUP...]",
+        desc: "Suppress deprecation warnings. See install_dir/etc/deprecations.json for list of GROUPs or use 'all'."
     end
 
     def self.format_platform_info(params: {}, indent: 0, color: 39)

--- a/test/functional/logging_test.rb
+++ b/test/functional/logging_test.rb
@@ -180,4 +180,30 @@ describe "Deprecation Facility Behavior" do
       end
     end
   end
+
+  describe "when desprecations are silenced via the CLI" do
+    let(:profile_name) { "typical" }
+    describe "when a specific deprecation is silenced" do
+      # Run two controls with two different deprecation groups, and silence one
+      let(:control_flag) { "--controls deprecate_warn_mode deprecate_fail_mode --silence-deprecations a_group_that_will_fail" }
+      it "silences the specified deprecation but not others" do
+        # stderr will still contain the warning deprecation
+        _(run_result.stderr).must_include "DEPRECATION: This should warn"
+        # control 0, result 1 will fail but not contain a deprecation warning
+        _(json_result[1]["status"]).must_equal "failed"
+        _(json_result[1]["message"]).wont_include "DEPRECATION"
+      end
+    end
+    describe "when all deprecations are silenced with 'all'" do
+      # Run two controls with two different deprecation groups, and silence all deprecations with the "all" param
+      let(:control_flag) { "--controls deprecate_warn_mode deprecate_fail_mode --silence-deprecations all" }
+      it "silences all deprecations explicitly" do
+        # stderr will not contain the warning deprecation
+        _(run_result.stderr).wont_include "DEPRECATION: This should warn"
+        # control 0, result 1 will fail but not contain a deprecation warning
+        _(json_result[1]["status"]).must_equal "failed"
+        _(json_result[1]["message"]).wont_include "DEPRECATION"
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Adds a CLI option to `exec`, `--silence-deprecations` which changes the action taken for specified deprecation groups from either `warn` or `fail_control` to `ignore`, effectively silencing them.

The user may name multiple deprecation groups separated by spaces, or in a feature I am sure will be used frequently, simply say `--silence-deprecations all` to suppress all such deprecations. 

Deprecations whose actions are `exit` cannot be suppressed, as they are intended to be the warning after functionality has *already* been removed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Closes #4228

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
