### PR TITLE
Add placeholder verify pipeline

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -19,6 +19,14 @@ pipelines:
       definition: .expeditor/release.omnibus.yml
       env:
         - ADHOC: true
+  - verify:
+      description: Pull Request validation tests
+      public: true
+      env:
+        - LANG: "C.UTF-8"
+        - SLOW: 1
+        - NO_AWS: 1
+        - MT_CPU: 5
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,0 +1,18 @@
+---
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 45
+      retry:
+        automatic:
+          limit: 1
+
+steps:
+
+ - label: Placeholder
+   command:
+     - exit 0
+   expeditor:
+      executor:
+        docker:
+          image: ruby:2.7


### PR DESCRIPTION
The pipeline won't exist until it merges onto the 3-stable branch.
This commit adds the pipeline with a placeholder step - the next PR will contain the real verification steps.

Signed-off-by: James Stocks <jstocks@chef.io>