### PR TITLE
Expand docs and tests for only_if

### DIFF
--- a/docs/dsl_inspec.md
+++ b/docs/dsl_inspec.md
@@ -215,10 +215,10 @@ control 'windows-base-101' do
 end
 ```
 
-### Use `only_if` to exclude a specific test
+### Use `only_if` to exclude a specific control
 
-This shows how to allow skipping certain tests if conditions are not met, by using `only_if`.
-In this example the test will not be performed if `redis-cli` command does not exist. A optional
+This shows how to allow skipping certain controls if conditions are not met, by using `only_if`.
+In this example the control will not be performed if `redis-cli` command does not exist. A optional
 message can say why it was skipped.
 
 ```ruby
@@ -237,7 +237,7 @@ control 'nutcracker-connect-redis-001' do
 end
 ```
 
-Mixing this with other conditionals (like checking existence of the files etc.) can help to test different test paths using InSpec. This way you can skip certain tests which would 100% fail due to the way servers are prepared, but you know that the same test suites are reused later in different circumstances by different teams.
+Mixing this with other conditionals (like checking existence of the files etc.) can help to test different test paths using InSpec. This way you can skip certain controls which would 100% fail due to the way servers are prepared, but you know that the same control suites are reused later in different circumstances by different teams.
 
 Some notes about `only_if`:
 

--- a/docs/dsl_inspec.md
+++ b/docs/dsl_inspec.md
@@ -217,9 +217,8 @@ end
 
 ### Use `only_if` to exclude a specific control
 
-This shows how to allow skipping certain controls if conditions are not met, by using `only_if`.
-In this example the control will not be performed if `redis-cli` command does not exist. A optional
-message can say why it was skipped.
+This example shows how to allow skipping certain controls if conditions are not met by using `only_if`.
+In this example, the control will not be performed if the `redis-cli` command does not exist. A optional message can say why it was skipped.
 
 ```ruby
 control 'nutcracker-connect-redis-001' do
@@ -237,13 +236,14 @@ control 'nutcracker-connect-redis-001' do
 end
 ```
 
-Mixing this with other conditionals (like checking existence of the files etc.) can help to test different test paths using InSpec. This way you can skip certain controls which would 100% fail due to the way servers are prepared, but you know that the same control suites are reused later in different circumstances by different teams.
+Mixing this with other conditionals, such as checking existence of the files, can help to test different test paths using Chef InSpec. With this way, you can skip certain controls, which would 100% fail due to the way servers are prepared, but you know that the same control suites are reused later in different circumstances by different teams.
 
 Some notes about `only_if`:
 
- * `only_if` applies to the entire `control`. If the results of the `only_if` block evaluate to false, any CHef InSpec resources mentioned as part of a `describe` block will not be run. Additionally, the contents of the describe blocks will not be run. However, bare Ruby expressions and bare Chef InSpec resources (not assocated with a describe block) preceding the only_if statement will run.
+* `only_if` applies to the entire `control`. If the results of the `only_if` block evaluate to false, any Chef InSpec resources mentioned as part of a `describe` block will not be run. Additionally, the contents of the describe blocks will not be run. However, bare Ruby expressions and bare Chef InSpec resources (not assocated with a describe block) preceding the only_if statement will run
 
 To illustrate:
+
 ```ruby
 control "whatruns" do
   command("do_something") # This will ALWAYS run
@@ -255,16 +255,15 @@ control "whatruns" do
 end
 ```
 
- * Only one `only_if` is permitted per `control` block; if multiple `only_if` blocks are present, only the last one will be honored.
- * `only_if` may also be used outside a control block. In that case, it will be used to skip all controls in the current file.
- * To implement complex logic, use Ruby 'or' (`||`) and 'and' (`&&`) inside your `only_if` block:
+* Only one `only_if` is permitted per `control` block. If multiple `only_if` blocks are present, only the last `only_if` block will be honored
+* If used outside a control block, `only_if` skips all controls in the current file
+* To implement complex logic, use Ruby 'or' (`||`) and 'and' (`&&`) inside your `only_if` block:
 
 ```ruby
   only_if('ready for launch') do
     rocket_is_ready && weather_is_clear
   end
 ```
-
 
 ### Additional metadata for controls
 

--- a/docs/dsl_inspec.md
+++ b/docs/dsl_inspec.md
@@ -255,7 +255,6 @@ control "whatruns" do
 end
 ```
 
- * `only_if` results in a skipped result for the control and all tests in the control, and is the only supported way of skipping an InSpec control. Other methods relying on RSpec-specific features such as `before` and `skip` may not work in the future.
  * Only one `only_if` is permitted per `control` block; if multiple `only_if` blocks are present, only the last one will be honored.
  * `only_if` may also be used outside a control block. In that case, it will be used to skip all controls in the current file.
  * To implement complex logic, use Ruby 'or' (`||`) and 'and' (`&&`) inside your `only_if` block:

--- a/docs/dsl_inspec.md
+++ b/docs/dsl_inspec.md
@@ -241,26 +241,17 @@ Mixing this with other conditionals (like checking existence of the files etc.) 
 
 Some notes about `only_if`:
 
- * `only_if` applies to the entire `control`. If the results of the `only_if` block evaluate to false, the contents of the describe blocks will not be run. However, the describe block resources (`command('redis-cli SET test_inspec "HELLO"')` in the above example) that preceded the only_if WILL run. For this reason, `only_if` should usually come first in the control, prior to any `describe` blocks.
+ * `only_if` applies to the entire `control`. If the results of the `only_if` block evaluate to false, any CHef InSpec resources mentioned as part of a `describe` block will not be run. Additionally, the contents of the describe blocks will not be run. However, bare Ruby expressions and bare Chef InSpec resources (not assocated with a describe block) preceding the only_if statement will run.
 
+To illustrate:
 ```ruby
-control "don't do this" do
-  describe command("something-dangerous") do
-    # ...
+control "whatruns" do
+  command("do_something") # This will ALWAYS run
+  describe command("do_another_thing") do # This will not run
+    command("do_yet_another_thing") # This will not run
   end
-  # command("something-dangerous") already ran!!!
-  only_if { its_safe }
-end
-```
-
-Instead, do this:
-```ruby
-control "do this instead" do
-  only_if { its_safe }
-  # command("something-dangerous") won't run unless it is safe
-  describe command("something-dangerous") do
-    # ...
-  end
+  only_if { false }
+  command("do_something_else") # This will not run
 end
 ```
 

--- a/test/fixtures/profiles/only_if/skip-control/controls/skip-control.rb
+++ b/test/fixtures/profiles/only_if/skip-control/controls/skip-control.rb
@@ -37,14 +37,6 @@ control "control-skip-test-outer-error" do
   end
 end
 
-control "control-skip-test-outer-error-test-first" do
-  desc "This control should demo that preceding ruby expressions DO get evaluated"
-  describe 1/0 do # does error!
-    it { should cmp 1/0 }
-  end
-  only_if { false }
-end
-
 control "control-skip-test-outer-resource-test-first" do
   desc "This control should demo that preceding test resources DO NOT get evaluated"
   describe command("echo toldyaso") do # does exec

--- a/test/fixtures/profiles/only_if/skip-control/controls/skip-control.rb
+++ b/test/fixtures/profiles/only_if/skip-control/controls/skip-control.rb
@@ -1,0 +1,56 @@
+control "control-start" do
+  desc "This control should not get skipped"
+  describe "a string" do
+    it { should cmp "a string" }
+  end
+end
+
+control "control-skip-no-message" do
+  desc "This control should get skipped"
+  only_if { false }
+  describe "a string" do
+    it { should cmp "a string" }
+  end
+end
+
+control "control-skip-with-message" do
+  desc "This control should get skipped"
+  only_if("here is a message") { false }
+  describe "a string" do
+    it { should cmp "a string" }
+  end
+end
+
+control "control-skip-test-body" do
+  desc "This control should demo that the test body does not get evaluated"
+  only_if { false }
+  describe "infinity" do
+    it { should cmp 1/0 }
+  end
+end
+
+control "control-skip-test-outer-error" do
+  desc "This control should demo that following test resources do not get evaluated"
+  only_if { false }
+  describe 1/0 do # does not error!
+    it { should cmp 1/0 }
+  end
+end
+
+control "control-skip-test-outer-error-test-first" do
+  desc "This control should demo that preceding test resources DO get evaluated"
+  describe 1/0 do # does error!
+    it { should cmp 1/0 }
+  end
+  only_if { false }
+end
+
+control "multi-skip" do
+  desc "This control should get skipped"
+  only_if("here is the intended message") { false }
+  only_if("here is a different message") { false }
+  describe "a string" do
+    it { should cmp "a string" }
+  end
+end
+

--- a/test/fixtures/profiles/only_if/skip-control/controls/skip-control.rb
+++ b/test/fixtures/profiles/only_if/skip-control/controls/skip-control.rb
@@ -38,9 +38,17 @@ control "control-skip-test-outer-error" do
 end
 
 control "control-skip-test-outer-error-test-first" do
-  desc "This control should demo that preceding test resources DO get evaluated"
+  desc "This control should demo that preceding ruby expressions DO get evaluated"
   describe 1/0 do # does error!
     it { should cmp 1/0 }
+  end
+  only_if { false }
+end
+
+control "control-skip-test-outer-resource-test-first" do
+  desc "This control should demo that preceding test resources DO NOT get evaluated"
+  describe command("echo toldyaso") do # does exec
+    its("stdout") { should include "toldya" }
   end
   only_if { false }
 end

--- a/test/fixtures/profiles/only_if/skip-control/inspec.yml
+++ b/test/fixtures/profiles/only_if/skip-control/inspec.yml
@@ -1,0 +1,6 @@
+name: skip-control
+license: Apache-2.0
+summary: A profile that skips controls using only_if
+version: 0.1.0
+supports:
+  platform: os

--- a/test/fixtures/profiles/only_if/skip-file/controls/normal.rb
+++ b/test/fixtures/profiles/only_if/skip-file/controls/normal.rb
@@ -1,0 +1,6 @@
+control "control-start-01" do
+  desc "This control should not get skipped"
+  describe "a string" do
+    it { should cmp "a string" }
+  end
+end

--- a/test/fixtures/profiles/only_if/skip-file/controls/skippy.rb
+++ b/test/fixtures/profiles/only_if/skip-file/controls/skippy.rb
@@ -1,0 +1,22 @@
+control "control-start-02" do
+  desc "This control should get skipped"
+  describe "a string" do
+    it { should cmp "a string" }
+  end
+end
+
+only_if("I wonder what this will do") { false }
+
+control "control-start-03" do
+  desc "This control should get skipped"
+  describe "a string" do
+    it { should cmp "a string" }
+  end
+end
+
+control "control-start-04" do
+  desc "This control should get skipped"
+  describe "a string" do
+    it { should cmp "a string" }
+  end
+end

--- a/test/fixtures/profiles/only_if/skip-file/inspec.yml
+++ b/test/fixtures/profiles/only_if/skip-file/inspec.yml
@@ -1,0 +1,6 @@
+name: skip-file
+license: Apache-2.0
+summary: A profile that tries to skip an entire file of controls using only_if
+version: 0.1.0
+supports:
+  platform: os

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -964,9 +964,12 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
         # 1/0 in resource declaration but it precedes the only_if
         _(@json.dig("profiles", 0, "controls", 5, "results", 0, "status")).must_equal "failed"
         _(@json.dig("profiles", 0, "controls", 5, "results", 0, "exception")).must_equal "RuntimeError"
-        # multiple only_ifs
+        # resource declaration but it precedes the only_if
         _(@json.dig("profiles", 0, "controls", 6, "results", 0, "status")).must_equal "skipped"
-        _(@json.dig("profiles", 0, "controls", 6, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition: here is a different message"
+        _(@json.dig("profiles", 0, "controls", 6, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition."
+        # multiple only_ifs
+        _(@json.dig("profiles", 0, "controls", 7, "results", 0, "status")).must_equal "skipped"
+        _(@json.dig("profiles", 0, "controls", 7, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition: here is a different message"
       end
     end
     describe "when running a profile with an only_if at the top-level" do

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -943,4 +943,43 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
     end
 
   end
+
+  describe "when evaluating profiles with only_if" do
+    let(:run_result) { run_inspec_process("exec #{profile}", json: true) }
+    describe "when running a profile with a variety of skips" do
+      let(:profile) { "#{profile_path}/only_if/skip-control" }
+      it "should correctly skip in individual controls" do
+        run_result
+        _(@json.dig("profiles", 0, "controls", 0, "results", 0, "status")).must_equal "passed"
+        _(@json.dig("profiles", 0, "controls", 1, "results", 0, "status")).must_equal "skipped"
+        _(@json.dig("profiles", 0, "controls", 1, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition."
+        _(@json.dig("profiles", 0, "controls", 2, "results", 0, "status")).must_equal "skipped"
+        _(@json.dig("profiles", 0, "controls", 2, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition: here is a message"
+        # 1/0 in test body
+        _(@json.dig("profiles", 0, "controls", 3, "results", 0, "status")).must_equal "skipped"
+        _(@json.dig("profiles", 0, "controls", 3, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition."
+        # 1/0 in resource declaration but it follows the only_if
+        _(@json.dig("profiles", 0, "controls", 4, "results", 0, "status")).must_equal "skipped"
+        _(@json.dig("profiles", 0, "controls", 4, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition."
+        # 1/0 in resource declaration but it precedes the only_if
+        _(@json.dig("profiles", 0, "controls", 5, "results", 0, "status")).must_equal "failed"
+        _(@json.dig("profiles", 0, "controls", 5, "results", 0, "exception")).must_equal "RuntimeError"
+        # multiple only_ifs
+        _(@json.dig("profiles", 0, "controls", 6, "results", 0, "status")).must_equal "skipped"
+        _(@json.dig("profiles", 0, "controls", 6, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition: here is a different message"
+      end
+    end
+    describe "when running a profile with an only_if at the top-level" do
+      let(:profile) { "#{profile_path}/only_if/skip-file" }
+      it "should correctly skip entire files" do
+        run_result
+        # first control is in a separate file
+        _(@json.dig("profiles", 0, "controls", 0, "results", 0, "status")).must_equal "passed"
+        # Latter three are in the same file
+        _(@json.dig("profiles", 0, "controls", 1, "results", 0, "status")).must_equal "skipped"
+        _(@json.dig("profiles", 0, "controls", 2, "results", 0, "status")).must_equal "skipped"
+        _(@json.dig("profiles", 0, "controls", 3, "results", 0, "status")).must_equal "skipped"
+      end
+    end
+  end
 end

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -961,15 +961,12 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
         # 1/0 in resource declaration but it follows the only_if
         _(@json.dig("profiles", 0, "controls", 4, "results", 0, "status")).must_equal "skipped"
         _(@json.dig("profiles", 0, "controls", 4, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition."
-        # 1/0 in resource declaration but it precedes the only_if
-        _(@json.dig("profiles", 0, "controls", 5, "results", 0, "status")).must_equal "failed"
-        _(@json.dig("profiles", 0, "controls", 5, "results", 0, "exception")).must_equal "RuntimeError"
         # resource declaration but it precedes the only_if
-        _(@json.dig("profiles", 0, "controls", 6, "results", 0, "status")).must_equal "skipped"
-        _(@json.dig("profiles", 0, "controls", 6, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition."
+        _(@json.dig("profiles", 0, "controls", 5, "results", 0, "status")).must_equal "skipped"
+        _(@json.dig("profiles", 0, "controls", 5, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition."
         # multiple only_ifs
-        _(@json.dig("profiles", 0, "controls", 7, "results", 0, "status")).must_equal "skipped"
-        _(@json.dig("profiles", 0, "controls", 7, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition: here is a different message"
+        _(@json.dig("profiles", 0, "controls", 6, "results", 0, "status")).must_equal "skipped"
+        _(@json.dig("profiles", 0, "controls", 6, "results", 0, "skip_message")).must_equal "Skipped control due to only_if condition: here is a different message"
       end
     end
     describe "when running a profile with an only_if at the top-level" do


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

#760 is currently the third-most 👍 issue in the repo, and is a simple docs request. Turns out not so simple; the behavior of `only_if` is poorly defined, because we have no tests on it.

I added tests and test fixtures.  I added more detailed docs. 

I changed the heading of the doc section to include the word `only_if`. This improves the eye-catching ability and likely search results, but also breaks links.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Closes #760

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
