### PR TITLE
Allow for waiver time as well as date

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -353,9 +353,12 @@ module Inspec
       # if so, is it in the future?
       expiry = __waiver_data["expiration_date"]
       if expiry
-        # YAML will automagically give us a Date or a Time
-        if [Date, Time].include?(expiry.class)
+        # YAML will automagically give us a Date or a Time.
+        # If transcoding YAML between languages (e.g. Go) the date might have also ended up as a String.
+        # A string that does not represent a valid time results in the date 0000-01-01.
+        if [Date, Time].include?(expiry.class) || (expiry.is_a?(String) && Time.new(expiry).year != 0)
           expiry = expiry.to_time if expiry.is_a? Date
+          expiry = Time.new(expiry) if expiry.is_a? String
           if expiry < Time.now # If the waiver expired, return - no skip applied
             __waiver_data["message"] = "Waiver expired on #{expiry}, evaluating control normally"
             return

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -353,9 +353,10 @@ module Inspec
       # if so, is it in the future?
       expiry = __waiver_data["expiration_date"]
       if expiry
-        if expiry.is_a?(Date)
-          # It appears that yaml.rb automagically parses dates for us
-          if expiry < Date.today # If the waiver expired, return - no skip applied
+        # YAML will automagically give us a Date or a Time
+        if [Date, Time].include?(expiry.class)
+          expiry = expiry.to_time if expiry.is_a? Date
+          if expiry < Time.now # If the waiver expired, return - no skip applied
             __waiver_data["message"] = "Waiver expired on #{expiry}, evaluating control normally"
             return
           end

--- a/test/fixtures/profiles/waivers/basic/controls/basic.rb
+++ b/test/fixtures/profiles/waivers/basic/controls/basic.rb
@@ -53,3 +53,16 @@ end
 control "14_waivered_expiry_in_future_z_not_ran" do
   describe(true) { it { should eq true } }
 end
+
+# If transcoding YAML between languages, a date might end up as an explicit string in YAML
+control "15_waivered_expiry_in_future_string_ran_passes" do
+  describe(true) { it { should eq true } }
+end
+
+control "16_waivered_expiry_in_future_string_ran_fails" do
+  describe(true) { it { should eq false } }
+end
+
+control "17_waivered_expiry_in_future_string_not_ran" do
+  describe(true) { it { should eq true } }
+end

--- a/test/fixtures/profiles/waivers/basic/controls/basic.rb
+++ b/test/fixtures/profiles/waivers/basic/controls/basic.rb
@@ -41,3 +41,15 @@ end
 control "11_waivered_expiry_in_future_not_ran" do
   describe(true) { it { should eq true } }
 end
+
+control "12_waivered_expiry_in_future_z_ran_passes" do
+  describe(true) { it { should eq true } }
+end
+
+control "13_waivered_expiry_in_future_z_ran_fails" do
+  describe(true) { it { should eq false } }
+end
+
+control "14_waivered_expiry_in_future_z_not_ran" do
+  describe(true) { it { should eq true } }
+end

--- a/test/fixtures/profiles/waivers/basic/files/waivers.yaml
+++ b/test/fixtures/profiles/waivers/basic/files/waivers.yaml
@@ -53,4 +53,19 @@
 14_waivered_expiry_in_future_z_not_ran:
   expiration_date: 2077-11-10T00:00:00Z
   justification: Lack of imagination
+  run: false
+
+15_waivered_expiry_in_future_string_ran_passes:
+  expiration_date: "2077-06-01"
+  justification: Handwaving
+  run: true
+
+16_waivered_expiry_in_future_string_ran_fails:
+  expiration_date: "2077-06-01"
+  justification: Didn't feel like it
+  run: true
+
+17_waivered_expiry_in_future_string_not_ran:
+  expiration_date: "2077-06-01"
+  justification: Lack of imagination
   run: false  

--- a/test/fixtures/profiles/waivers/basic/files/waivers.yaml
+++ b/test/fixtures/profiles/waivers/basic/files/waivers.yaml
@@ -39,3 +39,18 @@
   expiration_date: 2077-06-01
   justification: Lack of imagination
   run: false
+
+12_waivered_expiry_in_future_z_ran_passes:
+  expiration_date: 2077-11-10T00:00:00Z
+  justification: Handwaving
+  run: true
+
+13_waivered_expiry_in_future_z_ran_fails:
+  expiration_date: 2077-11-10T00:00:00Z
+  justification: Didn't feel like it
+  run: true
+
+14_waivered_expiry_in_future_z_not_ran:
+  expiration_date: 2077-11-10T00:00:00Z
+  justification: Lack of imagination
+  run: false  

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -95,6 +95,9 @@ describe "waivers" do
       "12_waivered_expiry_in_future_z_ran_passes"       => "passed",
       "13_waivered_expiry_in_future_z_ran_fails"        => "failed",
       "14_waivered_expiry_in_future_z_not_ran"          => "skipped",
+      "15_waivered_expiry_in_future_string_ran_passes"  => "passed",
+      "16_waivered_expiry_in_future_string_ran_fails"   => "failed",
+      "17_waivered_expiry_in_future_string_not_ran"     => "skipped",
     }.each do |control_id, expected|
       it "has all of the expected outcomes #{control_id}" do
         assert_test_outcome expected, control_id

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -92,6 +92,9 @@ describe "waivers" do
       "09_waivered_expiry_in_future_ran_passes"         => "passed",
       "10_waivered_expiry_in_future_ran_fails"          => "failed",
       "11_waivered_expiry_in_future_not_ran"            => "skipped",
+      "12_waivered_expiry_in_future_z_ran_passes"       => "passed",
+      "13_waivered_expiry_in_future_z_ran_fails"        => "failed",
+      "14_waivered_expiry_in_future_z_not_ran"          => "skipped",
     }.each do |control_id, expected|
       it "has all of the expected outcomes #{control_id}" do
         assert_test_outcome expected, control_id


### PR DESCRIPTION
Fixes #5037

The YAML parser may parse a waiver timestamp as a Time rather than a Date. Even when the user doesn't care about time, they may be using a tool that outputs YAML with trailing zeroes for hour, minutes, seconds etc.

TODO: confirm with @kekaichinose if allowing for time accuracy is desirable. We could also keep working with dates only and warn the user if they specify non-zero time values that will be ignored.

Signed-off-by: James Stocks <jstocks@chef.io>