### PR TITLE
Config node_uuid with direct Inspec invocations

### DIFF
--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -172,7 +172,7 @@ This will be the node name which shows up in Automate.
 
 #### node_uuid
 
-This will be the node UUID which shows up in Automate. You will want to use a single static UUID per node for all your reports. If you are running Inspec outside of an audit cookbook or other environment where a chef_guid or node_uuid is already known to Inspec, you must specify a node_uuid in the Inspec config.
+This will be the node UUID which shows up in Chef Automate. Use a single static UUID per node for all your reports. You must specify a `node_uuid` in the Chef InSpec configuration file if running Chef InSpec outside of an audit cookbook or another environment where a `chef_guid` or `node_uuid` is already known to Chef InSpec.
 
 #### environment
 

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -131,6 +131,7 @@ The `automate` reporter type is a special reporter used with [Chef Automate](htt
 Example config:
 
 ```json
+
 {
     "reporter": {
         "automate" : {
@@ -171,7 +172,7 @@ This will be the node name which shows up in Automate.
 
 #### node_uuid
 
-This will be the node UUID which shows up in Automate. You will want to use a single static UUID per node for all your reports.
+This will be the node UUID which shows up in Automate. You will want to use a single static UUID per node for all your reports. If you are running Inspec outside of an audit cookbook or other environment where a chef_guid or node_uuid is already known to Inspec, you must specify a node_uuid in the Inspec config.
 
 #### environment
 


### PR DESCRIPTION
When using Inspec directly against an Automate system, `node_uuid` must be specified in the automate reporter specific config.

Signed-off-by: Sean Horn <sean_horn@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Doc that node_uuid is necessary for direct invocation of Inspec with automate reporter.