### PR TITLE
Use forked copy of pry-stack_explorer to avoid ruby 2.7 warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,10 @@ gem "inspec-bin", path: "./inspec-bin"
 
 gem "ffi", ">= 1.9.14"
 
+# pry-stack_explorer 0.4.9.3 emits warnings under 2.7 under inspec shell
+# https://github.com/pry/pry-stack_explorer/issues/43
+gem "pry-stack_explorer", git: "https://github.com/chef/pry-stack_explorer.git"
+
 group :omnibus do
   gem "rb-readline"
   gem "appbundler"


### PR DESCRIPTION
Makes a small modification to the Gemfile to cause the omnibus distribution of InSpec to use a patched version of pry-stack_explorer.

This is a temporary measure until a new, fixed gem is properly released. A PR has been created upstream. Until it is accepted and a new gem is released, the fix will not be present in gem-based distributions of Chef InSpec.

https://buildkite.com/chef/inspec-inspec-master-omnibus-adhoc/builds/133 is an adhoc omnibus build on the branch.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue

Partial fix for #5042 
https://github.com/chef/chef-workstation/pull/1225 similar PR in Chef Workstation to use fork in CW distribution

<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
