### PR TITLE
Fix expeditor minor bump config, bump to 4.19

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -76,7 +76,7 @@ slack:
 github:
  delete_branch_on_merge: true
  minor_bump_labels:
-  - "Version: Bump Minor"
+  - "Expeditor: Bump Minor Version"
  version_tag_format: v{{version}}
  release_branch:
   - master:


### PR DESCRIPTION
The label configured to trigger a minor version bump does not match the actual label we have configured for the repo.

(the new features are https://github.com/inspec/inspec/pull/5017 and https://github.com/inspec/inspec/pull/5007 )

Signed-off-by: James Stocks <jstocks@chef.io>
