### PR TITLE
RunData Filters; sensitive inputs; suppress diff; sorted output

### DIFF
--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -459,6 +459,7 @@ The `run_data` object contains all data from the Chef InSpec run. Here is an ove
 |`run_data.profiles[0].inputs`| Array of Input records describing inputs present in profile|
 |`run_data.profiles[0].inputs[0].name`| String name of Input|
 |`run_data.profiles[0].inputs[0].options.required`| Boolean, whether input was required.|
+|`run_data.profiles[0].inputs[0].options.sensitive`| Boolean, true if the value of the input has been replaced with "***" |
 |`run_data.profiles[0].inputs[0].options.type`| String, type constraint on input, if any|
 |`run_data.profiles[0].inputs[0].options.value`| Value of Input|
 |`run_data.profiles[0].license`| String, name of license for the profile|
@@ -480,6 +481,11 @@ The `run_data` object contains all data from the Chef InSpec run. Here is an ove
 |`run_data.statistics.controls.total`| Integer, total count of controls|
 |`run_data.statistics.duration`| Float, time in seconds for the execution of Resources.|
 |`run_data.version`| A String, such as "4.18.108" representing the Chef InSpec version.|
+
+#### RunData Structure ChangeLog
+
+v0.1.0 - Initial version
+v0.2.0 - added `run_data.profiles[0].inputs[0].options.sensitive`
 
 ## Implementing Input Plugins
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -199,6 +199,7 @@ inputs:
   value: 42
   required: true
   priority: 70
+  sensitive: true
 ```
 
 All [input options](#input-options-reference) are supported in metadata files.
@@ -328,6 +329,12 @@ Allowed in: DSL, Metadata
 Optional, `String`. Allows you to set an input in another profile from your profile.
 
 Allowed in: DSL, Metadata
+
+### Sensitive
+
+Optional, `true` or `false`. If `true`, the value of the input will be used normally during the `exec` run, but the value will be obscured as "***" in the "inputs" or "attributes" section of any [Reporter](https://www.inspec.io/docs/reference/reporters) that explicitly lists Inputs (the `json` reporter is one such reporter). Note that this will not obscure input values that are used as test results.
+
+Allowed in: Metadata
 
 ## Advanced Topics
 

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -158,6 +158,8 @@ module Inspec
       option :silence_deprecations, type: :array,
         banner: "[all]|[GROUP GROUP...]",
         desc: "Suppress deprecation warnings. See install_dir/etc/deprecations.json for list of GROUPs or use 'all'."
+      option :diff, type: :boolean, default: true,
+        desc: "Use --no-diff to suppress 'diff' output of failed textual test results."
     end
 
     def self.format_platform_info(params: {}, indent: 0, color: 39)

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -160,6 +160,8 @@ module Inspec
         desc: "Suppress deprecation warnings. See install_dir/etc/deprecations.json for list of GROUPs or use 'all'."
       option :diff, type: :boolean, default: true,
         desc: "Use --no-diff to suppress 'diff' output of failed textual test results."
+      option :sort_results_by, type: :string, default: "none", banner: "--sort-results-by=none|control|file|random",
+        desc: "After normal execution order, results are sorted by control ID, or by file, or randomly. None uses legacy unsorted mode."
     end
 
     def self.format_platform_info(params: {}, indent: 0, color: 39)

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -160,8 +160,8 @@ module Inspec
         desc: "Suppress deprecation warnings. See install_dir/etc/deprecations.json for list of GROUPs or use 'all'."
       option :diff, type: :boolean, default: true,
         desc: "Use --no-diff to suppress 'diff' output of failed textual test results."
-      option :sort_results_by, type: :string, default: "none", banner: "--sort-results-by=none|control|file|random",
-        desc: "After normal execution order, results are sorted by control ID, or by file, or randomly. None uses legacy unsorted mode."
+      option :sort_results_by, type: :string, default: "file", banner: "--sort-results-by=none|control|file|random",
+        desc: "After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode."
     end
 
     def self.format_platform_info(params: {}, indent: 0, color: 39)

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -405,6 +405,18 @@ module Inspec
       @plugin_cfg = data
     end
 
+    def validate_sort_results_by!(option_value)
+      expected = %w{
+        none
+        control
+        file
+        random
+      }
+      return if expected.include? option_value
+
+      raise Inspec::ConfigError::Invalid, "--sort-results-by must be one of #{expected.join(", ")}"
+    end
+
     #-----------------------------------------------------------------------#
     #                         Merging Options
     #-----------------------------------------------------------------------#
@@ -435,6 +447,7 @@ module Inspec
       finalize_parse_reporters(options)
       finalize_handle_sudo(options)
       finalize_compliance_login(options)
+      finalize_sort_results(options)
 
       Thor::CoreExt::HashWithIndifferentAccess.new(options)
     end
@@ -506,6 +519,12 @@ module Inspec
       if options.key?("compliance")
         require "plugins/inspec-compliance/lib/inspec-compliance/api"
         InspecPlugins::Compliance::API.login(options["compliance"])
+      end
+    end
+
+    def finalize_sort_results(options)
+      if options.key?("sort_results_by")
+        validate_sort_results_by!(options["sort_results_by"])
       end
     end
 

--- a/lib/inspec/input.rb
+++ b/lib/inspec/input.rb
@@ -171,7 +171,7 @@ module Inspec
     # are free to go higher.
     DEFAULT_PRIORITY_FOR_VALUE_SET = 60
 
-    attr_reader :description, :events, :identifier, :name, :required, :title, :type
+    attr_reader :description, :events, :identifier, :name, :required, :sensitive, :title, :type
 
     def initialize(name, options = {})
       @name = name
@@ -264,6 +264,7 @@ module Inspec
       @required = options[:required] if options.key?(:required)
       @identifier = options[:identifier] if options.key?(:identifier) # TODO: determine if this is ever used
       @type = options[:type] if options.key?(:type)
+      @sensitive = options[:sensitive] if options.key?(:sensitive)
     end
 
     def make_creation_event(options)
@@ -320,7 +321,7 @@ module Inspec
 
     def to_hash
       as_hash = { name: name, options: {} }
-      %i{description title identifier type required value}.each do |field|
+      %i{description title identifier type required value sensitive}.each do |field|
         val = send(field)
         next if val.nil?
 
@@ -334,7 +335,7 @@ module Inspec
     #--------------------------------------------------------------------------#
 
     def to_s
-      "Input #{name} with #{current_value}"
+      "Input #{name} with " + (sensitive ? "***" : "#{current_value}")
     end
 
     #--------------------------------------------------------------------------#

--- a/lib/inspec/input.rb
+++ b/lib/inspec/input.rb
@@ -335,7 +335,7 @@ module Inspec
     #--------------------------------------------------------------------------#
 
     def to_s
-      "Input #{name} with " + (sensitive ? "***" : "#{current_value}")
+      "Input #{name} with value " + (sensitive ? "*** (senstive)" : "#{current_value}")
     end
 
     #--------------------------------------------------------------------------#

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -316,6 +316,7 @@ module Inspec
         profile_name,
         type: input_options[:type],
         required: input_options[:required],
+        sensitive: input_options[:sensitive],
         event: evt
       )
     end

--- a/lib/inspec/plugin/v2/plugin_types/reporter.rb
+++ b/lib/inspec/plugin/v2/plugin_types/reporter.rb
@@ -1,18 +1,20 @@
 require_relative "../../../run_data"
+require_relative "../../../utils/run_data_filters"
 
 module Inspec::Plugin::V2::PluginType
   class Reporter < Inspec::Plugin::V2::PluginBase
     register_plugin_type(:reporter)
+    include Inspec::Utils::RunDataFilters
 
     attr_reader :run_data
 
     def initialize(config)
       @config = config
 
-      # Trim the run_data while still a Hash; if it is huge, this
+      # Filter the run_data while still a Hash; if it is huge, this
       # saves on conversion time
       @run_data = config[:run_data] || {}
-      apply_report_resize_options
+      apply_run_data_filters_to_hash
 
       unless Inspec::RunData.compatible_schema?(self.class.run_data_schema_constraints)
         # Best we can do is warn here, the InSpec run has finished
@@ -22,26 +24,6 @@ module Inspec::Plugin::V2::PluginType
       # Convert to RunData object for consumption by Reporter
       @run_data = Inspec::RunData.new(@run_data)
       @output = ""
-    end
-
-    # This is a temporary duplication of code from lib/inspec/reporters/base.rb
-    # To be DRY'd up once the core reporters become plugins...
-    # Apply options such as message truncation and removal of backtraces
-    def apply_report_resize_options
-      runtime_config = Inspec::Config.cached.respond_to?(:final_options) ? Inspec::Config.cached.final_options : {}
-
-      message_truncation = runtime_config[:reporter_message_truncation] || "ALL"
-      @trunc = message_truncation == "ALL" ? -1 : message_truncation.to_i
-      include_backtrace = runtime_config[:reporter_backtrace_inclusion].nil? ? true : runtime_config[:reporter_backtrace_inclusion]
-
-      @run_data[:profiles]&.each do |p|
-        p[:controls].each do |c|
-          c[:results]&.map! do |r|
-            r.delete(:backtrace) unless include_backtrace
-            process_message_truncation(r)
-          end
-        end
-      end
     end
 
     def output(str, newline = true)
@@ -60,15 +42,6 @@ module Inspec::Plugin::V2::PluginType
 
     def self.run_data_schema_constraints
       raise NotImplementedError, "#{self.class} must implement a `run_data_schema_constraints` class method to declare its compatibiltity with the RunData API."
-    end
-
-    private
-
-    def process_message_truncation(result)
-      if result.key?(:message) && result[:message] != "" && @trunc > -1 && result[:message].length > @trunc
-        result[:message] = result[:message][0...@trunc] + "[Truncated to #{@trunc} characters]"
-      end
-      result
     end
   end
 end

--- a/lib/inspec/reporters/base.rb
+++ b/lib/inspec/reporters/base.rb
@@ -1,30 +1,17 @@
+require_relative "../utils/run_data_filters"
+
 module Inspec::Reporters
   class Base
+    include Inspec::Utils::RunDataFilters
+
     attr_reader :run_data
 
     def initialize(config)
       @config = config
-      @run_data = config[:run_data]
-      apply_report_resize_options unless @run_data.nil?
+      @run_data = config[:run_data] || {}
+      apply_run_data_filters_to_hash
+
       @output = ""
-    end
-
-    # Apply options such as message truncation and removal of backtraces
-    def apply_report_resize_options
-      runtime_config = Inspec::Config.cached.respond_to?(:final_options) ? Inspec::Config.cached.final_options : {}
-
-      message_truncation = runtime_config[:reporter_message_truncation] || "ALL"
-      @trunc = message_truncation == "ALL" ? -1 : message_truncation.to_i
-      include_backtrace = runtime_config[:reporter_backtrace_inclusion].nil? ? true : runtime_config[:reporter_backtrace_inclusion]
-
-      @run_data[:profiles]&.each do |p|
-        p[:controls].each do |c|
-          c[:results]&.map! do |r|
-            r.delete(:backtrace) unless include_backtrace
-            process_message_truncation(r)
-          end
-        end
-      end
     end
 
     def output(str, newline = true)
@@ -39,15 +26,6 @@ module Inspec::Reporters
     # each reporter must implement #render
     def render
       raise NotImplementedError, "#{self.class} must implement a `#render` method to format its output."
-    end
-
-    private
-
-    def process_message_truncation(result)
-      if result.key?(:message) && result[:message] != "" && @trunc > -1 && result[:message].length > @trunc
-        result[:message] = result[:message][0...@trunc] + "[Truncated to #{@trunc} characters]"
-      end
-      result
     end
   end
 end

--- a/lib/inspec/run_data/profile.rb
+++ b/lib/inspec/run_data/profile.rb
@@ -96,11 +96,12 @@ module Inspec
           # There are probably others
           :value,
           :type,
-          :required
+          :required,
+          :sensitive
         ) do
           include HashLikeStruct
           def initialize(raw_opts_data)
-            %i{value type required}.each { |f| self[f] = raw_opts_data[f] }
+            %i{value type required sensitive}.each { |f| self[f] = raw_opts_data[f] }
           end
         end
       end

--- a/lib/inspec/utils/run_data_filters.rb
+++ b/lib/inspec/utils/run_data_filters.rb
@@ -1,0 +1,46 @@
+module Inspec
+  module Utils
+    #   RunDataFilters is a mixin for core Reporters and plugin reporters.
+    # The methods operate on the run_data Hash (prior to any conversion to a
+    # full RunData object).
+    #   All methods here operate using the run_data accessor and modify
+    # its contents in place (if needed).
+    module RunDataFilters
+
+      # Long name, but we want to be clear this operates on the Hash
+      # This is the only method that client libraries need to call; any future
+      # feature growth should be handled internally here.
+      def apply_run_data_filters_to_hash
+        @config[:runtime_config] = Inspec::Config.cached || {}
+        apply_report_resize_options
+      end
+
+      # Apply options such as message truncation and removal of backtraces
+      def apply_report_resize_options
+        runtime_config = @config[:runtime_config]
+
+        message_truncation = runtime_config[:reporter_message_truncation] || "ALL"
+        @trunc = message_truncation == "ALL" ? -1 : message_truncation.to_i
+        include_backtrace = runtime_config[:reporter_backtrace_inclusion].nil? ? true : runtime_config[:reporter_backtrace_inclusion]
+
+        @run_data[:profiles]&.each do |p|
+          p[:controls].each do |c|
+            c[:results]&.map! do |r|
+              r.delete(:backtrace) unless include_backtrace
+              process_message_truncation(r)
+            end
+          end
+        end
+      end
+
+      private
+
+      def process_message_truncation(result)
+        if result.key?(:message) && result[:message] != "" && @trunc > -1 && result[:message].length > @trunc
+          result[:message] = result[:message][0...@trunc] + "[Truncated to #{@trunc} characters]"
+        end
+        result
+      end
+    end
+  end
+end

--- a/lib/inspec/utils/run_data_filters.rb
+++ b/lib/inspec/utils/run_data_filters.rb
@@ -68,6 +68,7 @@ module Inspec
       # Optionally sort controls within each profile in report
       def sort_controls
         sort_type = @config[:runtime_config][:sort_results_by]
+        return unless sort_type
         return if sort_type == "none"
 
         @run_data[:profiles]&.each do |p|

--- a/lib/inspec/utils/run_data_filters.rb
+++ b/lib/inspec/utils/run_data_filters.rb
@@ -13,6 +13,7 @@ module Inspec
       def apply_run_data_filters_to_hash
         @config[:runtime_config] = Inspec::Config.cached || {}
         apply_report_resize_options
+        redact_sensitive_inputs
       end
 
       # Apply options such as message truncation and removal of backtraces
@@ -29,6 +30,17 @@ module Inspec
               r.delete(:backtrace) unless include_backtrace
               process_message_truncation(r)
             end
+          end
+        end
+      end
+
+      # Find any inputs with :sensitive = true and replace their values with "***"
+      def redact_sensitive_inputs
+        @run_data[:profiles]&.each do |p|
+          p[:inputs]&.each do |i|
+            next unless i[:options][:sensitive]
+
+            i[:options][:value] = "***"
           end
         end
       end

--- a/test/fixtures/profiles/diff-output/controls/diff-output.rb
+++ b/test/fixtures/profiles/diff-output/controls/diff-output.rb
@@ -1,0 +1,30 @@
+control "no-diff" do
+  expected = 1 + 1
+  actual = 2
+  describe expected do
+    it { should eq actual }
+  end
+end
+
+control "text-diff" do
+  expected = <<~EOT
+I am the very
+model of a modern
+major general
+EOT
+  # No one expects this
+  actual = <<~EOT
+The Spanish Inquisition
+EOT
+  describe expected do
+    it { should eq actual }
+  end
+end
+
+control "array-diff" do
+  expected = [1,2,3,4]
+  actual = [5,6,7]
+  describe expected do
+    it { should eq actual }
+  end
+end

--- a/test/fixtures/profiles/diff-output/inspec.yml
+++ b/test/fixtures/profiles/diff-output/inspec.yml
@@ -1,0 +1,10 @@
+name: diff-output
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  platform: os

--- a/test/fixtures/profiles/inputs/metadata-sensitive/controls/sensitive.rb
+++ b/test/fixtures/profiles/inputs/metadata-sensitive/controls/sensitive.rb
@@ -1,0 +1,24 @@
+# A normal input should work normally
+control "read-a-cleartext-input" do
+  describe input("cleartext_input") do
+    it { should eq "visible-in-clear" }
+  end
+end
+
+# A sensitive input should be able to be
+# read internally by InSpec but have its
+# value obscured in reporters input listings
+# (this does not affect the test message output)
+control "read-a-sensitve-input" do
+  describe input("sensitive_input") do
+    it { should eq "visible-in-secret" }
+  end
+end
+
+# An input with sensitive = false should work normally
+control "read-an-explicitly-nonsesnitve-input" do
+  describe input("explicitly_nonsensitive_input") do
+    it { should eq "visible-in-clear" }
+  end
+end
+

--- a/test/fixtures/profiles/inputs/metadata-sensitive/inspec.yml
+++ b/test/fixtures/profiles/inputs/metadata-sensitive/inspec.yml
@@ -1,0 +1,19 @@
+name: metadata-sensitive
+title: InSpec Profile
+license: Apache-2.0
+summary: A profile that tests the :sensitive flag on inputs
+version: 0.1.0
+supports:
+  platform: os
+
+inputs:
+  - name: cleartext_input
+    value: visible-in-clear
+
+  - name: sensitive_input
+    sensitive: true
+    value: visible-in-secret
+
+  - name: explicitly_nonsensitive_input
+    sensitive: false
+    value: visible-in-clear

--- a/test/fixtures/profiles/sorted-results/sort-me-1/controls/a-uvw.rb
+++ b/test/fixtures/profiles/sorted-results/sort-me-1/controls/a-uvw.rb
@@ -1,0 +1,18 @@
+control "w" do
+  describe "anything" do
+    it { should eq "anything" }
+  end
+end
+
+control "v" do
+  describe "anything" do
+    it { should eq "anything" }
+  end
+end
+
+control "u" do
+  describe "anything" do
+    it { should eq "anything" }
+  end
+end
+

--- a/test/fixtures/profiles/sorted-results/sort-me-1/controls/b-xyz.rb
+++ b/test/fixtures/profiles/sorted-results/sort-me-1/controls/b-xyz.rb
@@ -1,0 +1,18 @@
+control "z" do
+  describe "anything" do
+    it { should eq "anything" }
+  end
+end
+
+control "y" do
+  describe "anything" do
+    it { should eq "anything" }
+  end
+end
+
+control "x" do
+  describe "anything" do
+    it { should eq "anything" }
+  end
+end
+

--- a/test/fixtures/profiles/sorted-results/sort-me-1/controls/c-rst.rb
+++ b/test/fixtures/profiles/sorted-results/sort-me-1/controls/c-rst.rb
@@ -1,0 +1,18 @@
+control "t" do
+  describe "anything" do
+    it { should eq "anything" }
+  end
+end
+
+control "s" do
+  describe "anything" do
+    it { should eq "anything" }
+  end
+end
+
+control "r" do
+  describe "anything" do
+    it { should eq "anything" }
+  end
+end
+

--- a/test/fixtures/profiles/sorted-results/sort-me-1/inspec.yml
+++ b/test/fixtures/profiles/sorted-results/sort-me-1/inspec.yml
@@ -1,0 +1,6 @@
+name: sort-me-1
+license: Apache-2.0
+summary: A profile to test sorting of results
+version: 0.1.0
+supports:
+  platform: os

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -429,4 +429,17 @@ describe "inputs" do
       end
     end
   end
+
+  describe "when a profile is used with sensitive inputs" do
+    it "should access the values but hide them in the reporter data" do
+      result = run_inspec_process("exec #{inputs_profiles_path}/metadata-sensitive", json: true)
+      _(result.stderr).must_be_empty
+      assert_json_controls_passing(result)
+      # Inspect the JSON result to find the inputs hash and verify they are redacted as needed
+      inputs = @json["profiles"][0]["attributes"] # TODO rename to inputs, break automate
+      _(inputs[1]["options"]["value"]).wont_include "secret"
+      _(inputs[1]["options"]["value"]).must_include "***"
+      _(inputs[2]["options"]["value"]).wont_include "***" # Explicit sensitive = false
+    end
+  end
 end

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -384,4 +384,40 @@ describe "inspec exec with json formatter" do
     end
   end
 
+  describe "JSON reporter using the --sort-results-by option" do
+    let(:run_result) { run_inspec_process("exec #{profile_path}/sorted-results/sort-me-1 --sort-results-by #{sort_option}", json: true) }
+    let(:control_order) { @json["profiles"][0]["controls"].map { |c| c["id"] }.join("") }
+
+    describe "when sending it a bad value for the option" do
+      let(:sort_option) { "garbage" }
+      it "should exit with a usage message" do
+        _(run_result.stderr).must_include "--sort-results-by must be one of none, control, file, random"
+        assert_exit_code(1, run_result)
+      end
+    end
+
+    describe "when using --sort-results-by file" do
+      let(:sort_option) { "file" }
+      it "should sort by file" do
+        _(run_result.stderr).must_be_empty
+        _(control_order).must_equal "wvuzyxtsr"
+      end
+    end
+
+    describe "when using --sort-results-by control" do
+      let(:sort_option) { "control" }
+      it "should sort by contol" do
+        _(run_result.stderr).must_be_empty
+        _(control_order).must_equal "rstuvwxyz"
+      end
+    end
+
+    describe "when using --sort-results-by random" do
+      let(:sort_option) { "random" }
+      it "should sort randomly" do
+        _(run_result.stderr).must_be_empty
+        _(control_order).wont_equal "wvuzyxtsr"
+      end
+    end
+  end
 end

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -356,4 +356,32 @@ describe "inspec exec with json formatter" do
       _(failed_result["backtrace"]).must_be :nil?
     end
   end
+
+  describe "JSON reporter using the --diff/--no-diff options" do
+    describe "JSON reporter with --diff option" do
+      let(:run_result) { run_inspec_process("exec #{profile_path}/diff-output --diff", json: true) }
+      let(:controls) { @json["profiles"][0]["controls"] }
+      it "runs normally with --diff" do
+        _(run_result.stderr).must_be_empty
+        _(controls[1]["results"][0]["message"]).must_include "got:"
+        _(controls[1]["results"][0]["message"]).must_include "Diff:"
+        _(controls[2]["results"][0]["message"]).must_include "got:"
+        assert_exit_code(100, run_result)
+      end
+    end
+
+    describe "JSON reporter with --no-diff option" do
+      let(:run_result) { run_inspec_process("exec #{profile_path}/diff-output --no-diff", json: true) }
+      let(:controls) { @json["profiles"][0]["controls"] }
+      it "suppresses the diff" do
+        _(run_result.stderr).must_be_empty
+        _(controls[1]["results"][0]["message"]).must_include "got:"
+        _(controls[1]["results"][0]["message"]).wont_include "Diff:"
+        _(controls[1]["results"][0]["message"]).wont_include "vegetable"
+        _(controls[2]["results"][0]["message"]).must_include "got:" # non-textual tests don't do diffs
+        assert_exit_code(100, run_result)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Formalizes the idea of filtering the Run Data before sending it to the reporters. Then implements 3 simple requested features using the concept. These are 4 clean commits, so if there are objections to any one feature, it can be rejected cleanly. Best to walk the commits on review, as otherwise this may seem nonsensical.

 * Refactors the message limiting features (truncation and backtrace squelch) into a mixin class, so that both core reporters and plugin reporters benefit without duplicating code.
 * Implements a mechanism to mark inputs as sensitive, replacing their values with "***"
 * Implements a CLI option to suppress Diff output for textual tests
 * Implements a CLI option to control order of controls in output (not execution order)

#4972 is also easily addressable using this technique (at least for plugin-based reporters; the RSpec html reporter is a lost cause, here), but I am unable to reproduce the issue. If that changes I may add a filter to intercept ugly internals in the test messaging.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Closes #4229, sensitive inputs
Closes #1535, suppress diff
Closes #4997 and Closes #3797 output ordering of controls

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-2472