### PR TITLE
Revert aarch64 build targets

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -11,8 +11,6 @@ builder-to-testers-map:
     - debian-8-x86_64
     - debian-9-x86_64
     - debian-10-x86_64
-  debian-10-aarch64:
-    - debian-10-aarch64
   el-6-x86_64:
     - el-6-x86_64
   el-7-aarch64:
@@ -30,11 +28,6 @@ builder-to-testers-map:
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
-  sles-15-aarch64:
-    - sles-15-aarch64
-  ubuntu-18.04-aarch64:
-    - ubuntu-18.04-aarch64
-    - ubuntu-20.04-aarch64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64


### PR DESCRIPTION
These currently do not build - they need unf_ext 0.0.7.7 and InSpec needs 0.0.7.2

Signed-off-by: James Stocks <jstocks@chef.io>