### PR TITLE
Update installer license text

### DIFF
--- a/omnibus/resources/inspec/msi/assets/LICENSE.rtf
+++ b/omnibus/resources/inspec/msi/assets/LICENSE.rtf
@@ -1,197 +1,128 @@
 {\rtf1\ansi\deff0{\fonttbl{\f0\fnil\fcharset0 Courier New;}}
 
-{\*\generator Msftedit 5.41.21.2500;}\viewkind4\uc1\pard\qc\lang1033\f0\fs20 Apache License\par
+{\*\generator Msftedit 5.41.21.2500;}\viewkind4\uc1\pard\qc\lang1033\f0\fs20 Software End User License Agreement\par
 
-Version 2.0, January 2004\par
+(Personal, Non-Commercial, Experimental)\par
 
-http://www.apache.org/licenses/\par
+May 14, 2019 - The most recent edition of this license is available at https://www.chef.io/end-user-license-agreement/\par
 
 \pard\par
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\par
+This Software End User License Agreement (this "Agreement"), is a binding agreement between Chef Software Inc. ("Chef") and You (as defined below).\par
 
 \par
 
-1. Definitions.\par
+IF YOU REPRESENT A CORPORATION, GOVERNMENTAL ORGANIZATION, OR OTHER LEGAL ENTITY, OR YOU INTEND TO USE THE SOFTWARE FOR COMMERCIAL PURPOSES, YOU MUST CONTACT CHEF DIRECTLY TO OBTAIN A COMMERCIAL LICENSE FOR THIS SOFTWARE. PLEASE VISIT https://www.chef.io/eula-inquiry/ TO INQUIRE.\par
 
 \par
 
-"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.\par
+LICENSOR PROVIDES THE SOFTWARE SOLELY ON THE TERMS AND CONDITIONS SET FORTH IN THIS AGREEMENT AND ON THE CONDITION THAT YOU ACCEPT THEM. BY CLICKING THE "ACCEPT" BUTTON YOU (A) ACCEPT THIS AGREEMENT AND AGREE TO BE LEGALLY BOUND BY ITS TERMS; AND (B) REPRESENT AND WARRANT THAT YOU HAVE THE LEGAL CAPACITY TO ENTER INTO A BINDING AGREEMENT. IF YOU DO NOT AGREE TO THE TERMS OF THIS AGREEMENT, YOU MUST NOT INSTALL OR USE THE SOFTWARE.\par
 
 \par
 
-"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.\par
+Definitions. For purposes of this Agreement, the following terms have the following meanings:\par
 
 \par
 
-"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.\par
+"Intellectual Property Rights" means patent, copyright, trademark, trade secret, database protection, or other intellectual property rights laws, and all similar or equivalent rights or forms of protection.\par
 
 \par
 
-"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.\par
+"Business" means any Person other than a natural person.\par
 
 \par
 
-"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation, source, and configuration files.\par
+"Commercial Purpose" means for the benefit of (i) any Business, or (ii) any undertaking intended, directly or indirectly, for profit.\par
 
 \par
 
-"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.\par
+"Experimental Use" means using the Software to learn, train, experiment with, or test viability of the Software. Experimental Use excludes pre-production and production environments as well as making the Software available to others, whether or not in exchange for any consideration.\par
 
 \par
 
-"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).\par
+"Person" means an individual, corporation, partnership, joint venture, limited liability company, governmental authority, non-profit organization, unincorporated organization, trust, association, or other entity.\par
 
 \par
 
-"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.\par
+"Software" means the software programs made available under this License.\par
 
 \par
 
-"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."\par
+"Term" has the meaning set forth in Section 6.\par
 
 \par
 
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.\par
+"Third Party" means any Person other than You or Chef.\par
 
 \par
 
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.\par
+"You" means the Person exercising permissions granted by this Agreement.\par
 
 \par
 
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license plies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.\par
+1. License Grant and Scope. Chef hereby grants to You a non-exclusive, non-transferable, limited license during the Term to use the Software solely as set forth in this Section 1 and subject to the terms of Section 3. Chef hereby grants You the non-exclusive, non-transferable, non-sublicensable, royalty free right to:\par
 
 \par
 
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:\par
+      * Download, copy, and install the Software on computers owned or leased, and controlled by, You. In addition to the foregoing, You may make copies of the Software for archival or backup purposes. All copies of the Software made by You must include all trademark, copyright, patent, and other Intellectual Property Rights notices contained in the original.\par
 
 \par
 
-      (a) You must give any other recipients of the Work or\par
-
-          Derivative Works a copy of this License; and\par
+      * Use and run the Software on such computers solely for Your personal, non-Commercial Purposes or Experimental Use.\par
 
 \par
 
-      (b) You must cause any modified files to carry prominent notices\par
-
-          stating that You changed the files; and\par
+2. Third-Party Materials. The Software includes software, content, data, or other materials, including related documentation, that are owned by Persons other than Chef and that are provided to You on license terms that are in addition to and/or different from those contained in this Agreement ("Third-Party Licenses"). A list of all materials included in the Software and provided under Third-Party Licenses can be found at https://www.chef.io/3rd-party-licenses/. You must comply with all Third-Party Licenses.\par
 
 \par
 
-      (c) You must retain, in the Source form of any Derivative Works\par
-
-          that You distribute, all copyright, patent, trademark, and\par
-
-          attribution notices from the Source form of the Work,\par
-
-          excluding those notices that do not pertain to any part of\par
-
-          the Derivative Works; and\par
+3. Use Restrictions. You must not, directly or indirectly: (a) modify, translate, adapt, or otherwise create derivative works or improvements, whether or not patentable, of the Software or any part thereof; (b) reverse engineer, disassemble, decompile, decode, or otherwise attempt to derive or gain access to the source code of the Software or any part thereof; (c) remove, delete, alter, or obscure any trademarks or any copyright, trademark, patent, or other intellectual property or proprietary rights notices provided on or with the Software, including any copy thereof; (d) rent, lease, lend, sell, sublicense, assign, distribute, publish, transfer, or otherwise make available the Software, or any features or functionality of the Software, to any Third Party for any reason; (e) use the Software in violation of any law, regulation, or rule; or (f) use the Software for purposes of competitive analysis of the Software, the development of a competing software product or service, or any other purpose that is to the Chef’s commercial disadvantage.\par
 
 \par
 
-      (d) If the Work includes a "NOTICE" text file as part of its\par
-
-          distribution, then any Derivative Works that You distribute\par
-
-          must include a readable copy of the attribution notices\par
-
-          contained within such NOTICE file, excluding those notices\par
-
-          that do not pertain to any part of the Derivative Works, in\par
-
-          at least one of the following places: within a NOTICE text\par
-
-          file distributed as part of the Derivative Works; within the\par
-
-          Source form or documentation, if provided along with the\par
-
-          Derivative Works; or, within a display generated by the\par
-
-          Derivative Works, if and wherever such third-party notices\par
-
-          normally appear. The contents of the NOTICE file are for\par
-
-          informational purposes only and do not modify the License.\par
-
-          You may add Your own attribution notices within Derivative\par
-
-          Works that You distribute, alongside or as an addendum to the\par
-
-          NOTICE text from the Work, provided that such additional\par
-
-          attribution notices cannot be construed as modifying the\par
-
-          License.\par
+4. Collection and Use of Information. You hereby consent to Chef receiving data and information directly from the Software for the sole purpose of obtaining information regarding Your use of the Software (e.g., when You install an update or upgrade), as well as any Software bugs, errors, and other similar technical support issues. Chef will only use such data and information ("Software Usage and Technical Support Data") for Chef’s own business purposes, including but not limited to the purposes of (i) gathering information about how You use the Software, which may be combined with information about how others use the Software, in order to help Chef better understand trends and Your needs in order to better consider new features, and (ii) improving the Software and Your use experience. Chef will use Software Usage and Technical Support Data solely in aggregate, anonymized form.\par
 
 \par
 
-You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.\par
+5. Intellectual Property Rights. You acknowledge that the Software is provided under license, and not sold, to You. Chef reserves all right, title, and interest in and to the Software and all Intellectual Property Rights in or to Software, except as expressly granted to You in this Agreement. Some portions of the Software may be separately available as source code from Chef under open source software licenses. Nothing in this Agreement affects any rights you may have separately under such licenses.\par
 
 \par
 
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.\par
+6. Term and Termination. This Agreement and the license granted hereunder shall remain in effect until terminated as set forth herein (the "Term").\par
 
 \par
 
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.\par
+      * You may terminate this Agreement by ceasing to use and destroying all copies of the Software.\par
 
 \par
 
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.\par
+      * Chef may terminate this Agreement for convenience.\par
+
+\par
+      * If You institute any litigation against Chef (including a cross-claim or counterclaim in a lawsuit) then the licenses granted to You under this Agreement shall terminate automatically as of the date such litigation is filed.\par
 
 \par
 
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.\par
+      * Upon termination of this Agreement, the license granted hereunder shall also terminate, and You shall cease using and destroy all copies of the Software.\par
 
 \par
 
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.\par
+7. Warranty Disclaimer. THE SOFTWARE IS PROVIDED TO YOU "AS IS" AND WITH ALL FAULTS AND DEFECTS WITHOUT WARRANTY OF ANY KIND. TO THE MAXIMUM EXTENT PERMITTED UNDER APPLICABLE LAW, CHEF, ON ITS OWN BEHALF AND ON BEHALF OF ITS AFFILIATES AND ITS AND THEIR RESPECTIVE LICENSORS EXPRESSLY DISCLAIMS ALL WARRANTIES, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, WITH RESPECT TO THE SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT, AND WARRANTIES THAT MAY ARISE OUT OF COURSE OF DEALING, COURSE OF PERFORMANCE, USAGE, OR TRADE PRACTICE. WITHOUT LIMITING THE FOREGOING, CHEF PROVIDES NO WARRANTY OR UNDERTAKING, AND MAKES NO REPRESENTATION OF ANY KIND THAT THE SOFTWARE WILL MEET YOUR REQUIREMENTS, ACHIEVE ANY INTENDED RESULTS, BE COMPATIBLE, OR WORK WITH ANY OTHER SOFTWARE, APPLICATIONS, SYSTEMS, OR SERVICES, OPERATE WITHOUT INTERRUPTION, MEET ANY PERFORMANCE OR RELIABILITY STANDARDS OR BE ERROR FREE, OR THAT ANY ERRORS OR DEFECTS CAN OR WILL BE CORRECTED. YOU MAY HAVE ADDITIONAL RIGHTS THAT VARY FROM STATE TO STATE.\par
 
 \par
 
-END OF TERMS AND CONDITIONS\par
+8. Limitation of Liability. TO THE FULLEST EXTENT PERMITTED UNDER APPLICABLE LAW: IN NO EVENT WILL CHEF OR ITS AFFILIATES, OR ANY OF ITS OR THEIR RESPECTIVE LICENSORS OR SERVICE PROVIDERS, BE LIABLE TO YOU FOR ANY CONSEQUENTIAL, INCIDENTAL, INDIRECT, EXEMPLARY, SPECIAL, OR PUNITIVE DAMAGES, WHETHER ARISING OUT OF OR IN CONNECTION WITH THIS AGREEMENT, BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, REGARDLESS OF WHETHER SUCH DAMAGES WERE FORESEEABLE AND WHETHER OR NOT CHEF WAS ADVISED OF THE POSSIBILITY OF SUCH YOU MAY HAVE ADDITIONAL RIGHTS THAT VARY FROM STATE TO STATE.\par
 
 \par
 
-APPENDIX: How to apply the Apache License to your work.\par
+9. Export Regulation. The Software may be subject to US export control laws, including the US Export Administration Act and its associated regulations. You shall not, directly or indirectly, export, re-export, or release the Software to, or make the Software accessible from, any jurisdiction or country to which export, re-export, or release is prohibited by law, rule, or regulation.\par
 
 \par
 
-To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.\par
-
-\par
-
-   Copyright [yyyy] [name of copyright owner]\par
-
-\par
-
-   Licensed under the Apache License, Version 2.0 (the "License");\par
-
-   you may not use this file except in compliance with the License.\par
-
-   You may obtain a copy of the License at\par
-
-\par
-
-       http://www.apache.org/licenses/LICENSE-2.0\par
-
-\par
-
-   Unless required by applicable law or agreed to in writing, software\par
-
-   distributed under the License is distributed on an "AS IS" BASIS,\par
-
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\par
-
-   implied. See the License for the specific language governing\par
-
-   permissions and limitations under the License.\par
+10. Miscellaneous. All matters arising out of or relating to this Agreement shall be governed by and construed in accordance with the internal laws of the State of Washington without giving effect to any conflict of law provision. Any legal action arising out of or relating to this Agreement will the subject to the exclusive jurisdiction of the state or federal courts located in King County. This Agreement constitutes the sole and entire agreement between You and Chef with respect to the subject matter contained herein, and supersedes all prior and contemporaneous understandings, agreements, representations, and warranties, both written and oral, with respect to such subject matter. If any provision of this Agreement is determined by a court of law to be unenforceable, this Agreement and the license granted herein will terminate automatically.\par
 
 \par
 
 }
 
- 
+

--- a/omnibus/resources/inspec/pkg/license.html.erb
+++ b/omnibus/resources/inspec/pkg/license.html.erb
@@ -1,201 +1,243 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Software End User License Agreement
+(Personal, Non-Commercial, Experimental)
 
-   1. Definitions.
+May 14, 2019 - The most recent edition of this license is 
+available at https://www.chef.io/end-user-license-agreement/
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+This Software End User License Agreement (this “Agreement“), 
+is a binding agreement between Chef Software Inc. (“Chef“) 
+and You (as defined below).
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+IF YOU REPRESENT A CORPORATION, GOVERNMENTAL 
+ORGANIZATION, OR OTHER LEGAL ENTITY, OR YOU
+INTEND TO USE THE SOFTWARE FOR COMMERCIAL 
+PURPOSES, YOU MUST CONTACT CHEF DIRECTLY TO 
+OBTAIN A COMMERCIAL LICENSE FOR THIS 
+SOFTWARE. PLEASE VISIT 
+https://www.chef.io/eula-inquiry/ TO INQUIRE.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+LICENSOR PROVIDES THE SOFTWARE SOLELY ON THE 
+TERMS AND CONDITIONS SET FORTH IN THIS 
+AGREEMENT AND ON THE CONDITION THAT YOU 
+ACCEPT THEM. BY CLICKING THE “ACCEPT” BUTTON 
+YOU (A) ACCEPT THIS AGREEMENT AND AGREE 
+TO BE LEGALLY BOUND BY ITS TERMS; AND 
+(B) REPRESENT AND WARRANT THAT YOU HAVE THE 
+LEGAL CAPACITY TO ENTER INTO A BINDING 
+AGREEMENT. IF YOU DO NOT AGREE TO THE TERMS 
+OF THIS AGREEMENT, YOU MUST NOT INSTALL OR 
+USE THE SOFTWARE.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+Definitions. For purposes of this Agreement, the following 
+terms have the following meanings:
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+“Intellectual Property Rights” means patent, copyright, 
+trademark, trade secret, database protection, or other 
+intellectual property rights laws, and all similar or 
+equivalent rights or forms of protection.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+“Business” means any Person other than a natural person.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+“Commercial Purpose” means for the benefit of (i) any 
+Business, or (ii) any undertaking intended, directly 
+or indirectly, for profit.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+“Experimental Use” means using the Software to learn, 
+train, experiment with, or test viability of the 
+Software. Experimental Use excludes pre-production and 
+production environments as well as making the Software 
+available to others, whether or not in exchange for any 
+consideration.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+“Person” means an individual, corporation, partnership, 
+joint venture, limited liability company, governmental 
+authority, non-profit organization, unincorporated 
+organization, trust, association, or other entity.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+“Software” means the software programs made available 
+under this License.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+“Term” has the meaning set forth in Section 6.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+“Third Party” means any Person other than You or Chef.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+“You” means the Person exercising permissions granted by 
+this Agreement.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+ 1. License Grant and Scope. Chef hereby grants to You a 
+    non-exclusive, non-transferable, limited license 
+    during the Term to use the Software solely as set 
+    forth in this Section 1 and subject to the terms of 
+    Section 3. Chef hereby grants You the non-exclusive, 
+    non-transferable, non-sublicensable, royalty free 
+    right to:
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+   * Download, copy, and install the Software on computers 
+     owned or leased, and controlled by, You. In addition 
+     to the foregoing, You may make copies of the Software 
+     for archival or backup purposes. All copies of the 
+     Software made by You must include all trademark, 
+     copyright, patent, and other Intellectual Property 
+     Rights notices contained in the original.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+   * Use and run the Software on such computers solely 
+     for Your personal, non-Commercial Purposes or 
+     Experimental Use.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+ 2. Third-Party Materials. The Software includes software, 
+    content, data, or other materials, including related 
+    documentation, that are owned by Persons other than 
+    Chef and that are provided to You on license terms 
+    that are in addition to and/or different from those 
+    contained in this Agreement (“Third-Party Licenses“). 
+    A list of all materials included in the Software and 
+    provided under Third-Party Licenses can be found 
+    at https://www.chef.io/3rd-party-licenses/. You must 
+    comply with all Third-Party Licenses.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+ 3. Use Restrictions. You must not, directly or 
+    indirectly: (a) modify, translate, adapt, or otherwise 
+    create derivative works or improvements, whether or 
+    not patentable, of the Software or any part thereof; 
+    (b) reverse engineer, disassemble, decompile, decode, 
+    or otherwise attempt to derive or gain access to the 
+    source code of the Software or any part thereof; (c) 
+    remove, delete, alter, or obscure any trademarks or 
+    any copyright, trademark, patent, or other 
+    intellectual property or proprietary rights notices 
+    provided on or with the Software, including any copy 
+    thereof; (d) rent, lease, lend, sell, sublicense, 
+    assign, distribute, publish, transfer, or otherwise 
+    make available the Software, or any features or 
+    functionality of the Software, to any Third Party for 
+    any reason; (e) use the Software in violation of any 
+    law, regulation, or rule; or (f) use the Software for 
+    purposes of competitive analysis of the Software, the 
+    development of a competing software product or 
+    service, or any other purpose that is to the Chef’s 
+    commercial disadvantage.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+ 4. Collection and Use of Information. You hereby consent 
+    to Chef receiving data and information directly from 
+    the Software for the sole purpose of obtaining 
+    information regarding Your use of the Software 
+    (e.g., when You install an update or upgrade), as well 
+    as any Software bugs, errors, and other similar 
+    technical support issues. Chef will only use such data 
+    and information (“Software Usage and Technical Support 
+    Data”) for Chef’s own business purposes, including but 
+    not limited to the purposes of (i) gathering 
+    information about how You use the Software, which may 
+    be combined with information about how others use the 
+    Software, in order to help Chef better understand 
+    trends and Your needs in order to better consider new 
+    features, and (ii) improving the Software and Your use 
+    experience. Chef will use Software Usage and Technical 
+    Support Data solely in aggregate, anonymized form.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+ 5. Intellectual Property Rights. You acknowledge that the 
+    Software is provided under license, and not sold, to 
+    You. Chef reserves all right, title, and interest in 
+    and to the Software and all Intellectual Property 
+    Rights in or to Software, except as expressly granted 
+    to You in this Agreement. Some portions of the 
+    Software may be separately available as source code 
+    from Chef under open source software licenses. Nothing 
+    in this Agreement affects any rights you may have 
+    separately under such licenses.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+ 6. Term and Termination. This Agreement and the license 
+    granted hereunder shall remain in effect until 
+    terminated as set forth herein (the “Term“).
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+   * You may terminate this Agreement by ceasing to use 
+     and destroying all copies of the Software.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+   * Chef may terminate this Agreement for convenience.
 
-   END OF TERMS AND CONDITIONS
+   * If You institute any litigation against Chef 
+     (including a cross-claim or counterclaim in a 
+     lawsuit) then the licenses granted to You under this 
+     Agreement shall terminate automatically as of the 
+     date such litigation is filed.
 
-   APPENDIX: How to apply the Apache License to your work.
+   * Upon termination of this Agreement, the license 
+     granted hereunder shall also terminate, and You 
+     shall cease using and destroy all copies of the 
+     Software.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+ 7. Warranty Disclaimer. THE SOFTWARE IS 
+    PROVIDED TO YOU “AS IS” AND WITH ALL 
+    FAULTS AND DEFECTS WITHOUT WARRANTY OF 
+    ANY KIND. TO THE MAXIMUM EXTENT 
+    PERMITTED UNDER APPLICABLE LAW, CHEF, 
+    ON ITS OWN BEHALF AND ON BEHALF OF ITS 
+    AFFILIATES AND ITS AND THEIR RESPECTIVE 
+    LICENSORS EXPRESSLY DISCLAIMS ALL 
+    WARRANTIES, WHETHER EXPRESS, IMPLIED, 
+    STATUTORY, OR OTHERWISE, WITH RESPECT 
+    TO THE SOFTWARE, INCLUDING ALL IMPLIED 
+    WARRANTIES OF MERCHANTABILITY, FITNESS 
+    FOR A PARTICULAR PURPOSE, TITLE, AND 
+    NON-INFRINGEMENT, AND WARRANTIES THAT 
+    MAY ARISE OUT OF COURSE OF DEALING, 
+    COURSE OF PERFORMANCE, USAGE, OR TRADE 
+    PRACTICE. WITHOUT LIMITING THE 
+    FOREGOING, CHEF PROVIDES NO WARRANTY OR 
+    UNDERTAKING, AND MAKES NO REPRESENTATION 
+    OF ANY KIND THAT THE SOFTWARE WILL MEET 
+    YOUR REQUIREMENTS, ACHIEVE ANY INTENDED 
+    RESULTS, BE COMPATIBLE, OR WORK WITH ANY 
+    OTHER SOFTWARE, APPLICATIONS, SYSTEMS, 
+    OR SERVICES, OPERATE WITHOUT 
+    INTERRUPTION, MEET ANY PERFORMANCE OR 
+    RELIABILITY STANDARDS OR BE ERROR FREE, 
+    OR THAT ANY ERRORS OR DEFECTS CAN OR 
+    WILL BE CORRECTED. YOU MAY HAVE 
+    ADDITIONAL RIGHTS THAT VARY FROM STATE 
+    TO STATE.
 
-   Copyright <%= Time.new.year %> Chef Software Inc.
+ 8. Limitation of Liability. TO THE FULLEST 
+    EXTENT PERMITTED UNDER APPLICABLE LAW: 
+    IN NO EVENT WILL CHEF OR ITS AFFILIATES, 
+    OR ANY OF ITS OR THEIR RESPECTIVE 
+    LICENSORS OR SERVICE PROVIDERS, BE 
+    LIABLE TO YOU FOR ANY CONSEQUENTIAL, 
+    INCIDENTAL, INDIRECT, EXEMPLARY, SPECIAL, 
+    OR PUNITIVE DAMAGES, WHETHER ARISING OUT 
+    OF OR IN CONNECTION WITH THIS AGREEMENT, 
+    BREACH OF CONTRACT, TORT 
+    (INCLUDING NEGLIGENCE), OR OTHERWISE, 
+    REGARDLESS OF WHETHER SUCH DAMAGES WERE 
+    FORESEEABLE AND WHETHER OR NOT CHEF WAS 
+    ADVISED OF THE POSSIBILITY OF SUCH YOU MAY 
+    HAVE ADDITIONAL RIGHTS THAT VARY FROM 
+    STATE TO STATE.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+ 9. Export Regulation. The Software may be subject to US 
+    export control laws, including the US Export 
+    Administration Act and its associated regulations. 
+    You shall not, directly or indirectly, export, 
+    re-export, or release the Software to, or make the 
+    Software accessible from, any jurisdiction or country 
+    to which export, re-export, or release is prohibited 
+    by law, rule, or regulation.
 
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+10. Miscellaneous. All matters arising out of or relating 
+    to this Agreement shall be governed by and construed 
+    in accordance with the internal laws of the State of 
+    Washington without giving effect to any conflict of 
+    law provision. Any legal action arising out of or 
+    relating to this Agreement will the subject to the 
+    exclusive jurisdiction of the state or federal courts 
+    located in King County. This Agreement constitutes the 
+    sole and entire agreement between You and Chef with 
+    respect to the subject matter contained herein, and 
+    supersedes all prior and contemporaneous 
+    understandings, agreements, representations, and 
+    warranties, both written and oral, with respect 
+    to such subject matter. If any provision of this 
+    Agreement is determined by a court of law to be 
+    unenforceable, this Agreement and the license granted 
+    herein will terminate automatically.


### PR DESCRIPTION
Copied the correct license text over from chef/chef

Fixes 5066

Kicked off an adhoc build to test the installers from this branch: https://buildkite.com/chef/inspec-inspec-master-omnibus-adhoc/builds/140#eb343d2c-9fea-42da-adba-222c6bf0831a

Signed-off-by: James Stocks <jstocks@chef.io>

Aha! Link: https://chef.aha.io/features/SH-2160