### PR TITLE
Change ffi pinning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "inspec", path: "."
 # in it in order to package the executable. Hence the odd backwards dependency.
 gem "inspec-bin", path: "./inspec-bin"
 
-gem "ffi", [">= 1.9.14", "< 1.13"] # 1.13 does not work on Windows: https://github.com/ffi/ffi/issues/784
+gem "ffi", ">= 1.9.14", "!= 1.13.0"
 
 group :omnibus do
   gem "rb-readline"

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,10 +1,10 @@
 source "https://rubygems.org"
 
-gem "ffi", [">= 1.9.14", "< 1.13"] # 1.13 does not work on Windows: https://github.com/ffi/ffi/issues/784
-
 gem "omnibus", git: "https://github.com/chef/omnibus", branch: "master"
 gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "master"
 gem "artifactory"
+
+gem "ffi", ">= 1.9.14", "!= 1.13.0"
 
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need


### PR DESCRIPTION
ffi 1.13.1 reverts the breaking change in 1.13.0
We can now use any version other than specifically 1.13.0.

Signed-off-by: James Stocks <jstocks@chef.io>