### PR TITLE
A more correct JUnit reporter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :test do
   gem "rake", ">= 10"
   gem "simplecov", ["~> 0.10", "<=0.18.2"]
   gem "concurrent-ruby", "~> 1.0"
+  gem "nokogiri", "~> 1.9"
   gem "mocha", "~> 1.1"
   gem "ruby-progressbar", "~> 1.8"
   gem "webmock", "~> 3.0"

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -39,19 +39,19 @@ inspec exec example_profile --reporter cli json:/tmp/output.json
 Output nothing to screen and write junit and html to a file.
 
 ```bash
-inspec exec example_profile --reporter junit:/tmp/junit.xml html:www/index.html
+inspec exec example_profile --reporter junit2:/tmp/junit.xml html:www/index.html
 ```
 
 Output json to screen and write to a file. Write junit to a file.
 
 ```bash
-inspec exec example_profile --reporter json junit:/tmp/junit.xml | tee out.json
+inspec exec example_profile --reporter json junit2:/tmp/junit.xml | tee out.json
 ```
 
 If you wish to pass the profiles directly after specifying the reporters you will need to use the end of options flag `--`.
 
 ```bash
-inspec exec --reporter json junit:/tmp/junit.xml -- profile1 profile2
+inspec exec --reporter json junit2:/tmp/junit.xml -- profile1 profile2
 ```
 
 If you are using the cli option `--config`, you can also set reporters.
@@ -108,9 +108,13 @@ This reporter includes all information about the profiles and test results in st
 
 This reporter is a very minimal text base report. It shows you which tests passed by name and has a small summary at the end.
 
-### junit
+### junit2
 
-This reporter outputs the standard junit spec in xml format.
+This reporter outputs the standard JUnit spec in XML format and is recommended for all new users of JUnit.
+
+#### junit
+
+This legacy reporter outputs nonstandard JUnit XML and is provided only for backwards compatibility.
 
 ### progress
 

--- a/lib/plugins/inspec-reporter-junit/README.md
+++ b/lib/plugins/inspec-reporter-junit/README.md
@@ -1,6 +1,6 @@
-# junit reporter
+# junit and junit2 reporters
 
-This is the implementation of the junit XML reporter.
+This is the implementation of the junit and junit2 XML reporter.
 
 ## To Install This Plugin
 
@@ -10,6 +10,10 @@ This plugin is included with inspec. There is no need to install it separately.
 
 This reporter generates an XML report in Apache Ant JUnit format.
 
+'junit' is the legacy Chef InSpec JUnit reporter. It generates nonstandard JUNit XML in several ways. New users are advised to use junit2.
+
+'junit2' is an updated reporter that attempts to match the JUnit "standard", such as it isn't, more closely. It validates against the schema published by [Windy Road](https://github.com/windyroad/JUnit-Schema).
+
 ## Implementation Note
 
-This reporter uses the REXML XML generator, but may use more advanced XML systems for testing. This is to keep packaging requirements for CHef InSpec lightweight and free of compiled dependencies.
+This reporter uses the REXML XML generator, but may use more advanced XML systems for testing. This is to keep packaging requirements for Chef InSpec lightweight and free of compiled dependencies.

--- a/lib/plugins/inspec-reporter-junit/lib/inspec-reporter-junit.rb
+++ b/lib/plugins/inspec-reporter-junit/lib/inspec-reporter-junit.rb
@@ -3,10 +3,19 @@ module InspecPlugins
   module JUnitReporter
     class Plugin < ::Inspec.plugin(2)
       plugin_name :'inspec-reporter-junit'
+
+      # Legacy JUnit reporter, which generates subtly incorrect XML.
       reporter :junit do
         require_relative "inspec-reporter-junit/reporter"
-        InspecPlugins::JUnitReporter::Reporter
+        InspecPlugins::JUnitReporter::ReporterV1
       end
+
+      # v2 reporter, which generates valid JUnit XML.
+      reporter :junit2 do
+        require_relative "inspec-reporter-junit/reporter"
+        InspecPlugins::JUnitReporter::ReporterV2
+      end
+
     end
   end
 end

--- a/lib/plugins/inspec-reporter-junit/lib/inspec-reporter-junit/reporter.rb
+++ b/lib/plugins/inspec-reporter-junit/lib/inspec-reporter-junit/reporter.rb
@@ -12,8 +12,8 @@ module InspecPlugins::JUnitReporter
       testsuites = REXML::Element.new("testsuites")
       xml_output.add(testsuites)
 
-      run_data.profiles.each do |profile|
-        testsuites.add(build_profile_xml(profile))
+      run_data.profiles.each_with_index do |profile, idx|
+        testsuites.add(build_profile_xml(profile, idx))
       end
 
       formatter = REXML::Formatters::Pretty.new
@@ -22,7 +22,42 @@ module InspecPlugins::JUnitReporter
       output(formatter.write(xml_output.root, ""))
     end
 
-    def build_profile_xml(profile)
+    def count_profile_tests(profile)
+      profile.controls.reduce(0) do |acc, elem|
+        acc + elem.results.count
+      end
+    end
+
+    def count_profile_failed_tests(profile)
+      profile.controls.reduce(0) do |acc, elem|
+        acc + elem.results.reduce(0) do |fail_test_total, test_case|
+          test_case.status == "failed" ? fail_test_total + 1 : fail_test_total
+        end
+      end
+    end
+
+    def count_profile_skipped_tests(profile)
+      profile.controls.reduce(0) do |acc, elem|
+        acc + elem.results.reduce(0) do |skip_test_total, test_case|
+          test_case.status == "skipped" ? skip_test_total + 1 : skip_test_total
+        end
+      end
+    end
+
+    def count_profile_errored_tests(profile)
+      profile.controls.reduce(0) do |acc, elem|
+        acc + elem.results.reduce(0) do |err_test_total, test_case|
+          test_case.backtrace.nil? ? err_test_total : err_test_total + 1
+        end
+      end
+    end
+  end
+
+  # This is the "Legacy" JUnit reporter. It produces XML which is not
+  # correct according to the JUnit standard. It is retained for backwards
+  # compatibility.
+  class ReporterV1 < Reporter
+    def build_profile_xml(profile, _idx)
       profile_xml = REXML::Element.new("testsuite")
       profile_xml.add_attribute("name", profile.name)
       profile_xml.add_attribute("tests", count_profile_tests(profile))
@@ -55,19 +90,66 @@ module InspecPlugins::JUnitReporter
 
       result_xml
     end
+  end
 
-    def count_profile_tests(profile)
-      profile.controls.reduce(0) do |acc, elem|
-        acc + elem.results.count
-      end
-    end
+  # This is the "Corrected" JUnit reporter. It produces XML which is intended
+  # to be valid. It should be used whenever possible.
+  class ReporterV2 < Reporter
+    def build_profile_xml(profile, idx)
+      profile_xml = REXML::Element.new("testsuite")
+      profile_xml.add_attribute("name", profile.name)
+      profile_xml.add_attribute("tests", count_profile_tests(profile))
+      profile_xml.add_attribute("id", idx + 1)
 
-    def count_profile_failed_tests(profile)
-      profile.controls.reduce(0) do |acc, elem|
-        acc + elem.results.reduce(0) do |fail_test_total, test_case|
-          test_case.status == "failed" ? fail_test_total + 1 : fail_test_total
+      # junit2 counts failures and errors separately
+      errors = count_profile_errored_tests(profile)
+      profile_xml.add_attribute("errors", errors)
+      profile_xml.add_attribute("failures", count_profile_failed_tests(profile) - errors)
+      profile_xml.add_attribute("skipped", count_profile_skipped_tests(profile))
+
+      profile_xml.add_attribute("hostname", run_data.platform.target.nil? ? "" : run_data.platform.target.to_s)
+      # Author of the schema specified 8601, then went on to add
+      # a regex that requires no TZ
+      profile_xml.add_attribute("timestamp", Time.now.iso8601.slice(0, 19))
+
+      # These are empty but are just here to satisfy the schema
+      profile_xml.add_attribute("package", "")
+      profile_xml.add(REXML::Element.new("properties"))
+
+      profile_time = 0.0
+      profile.controls.each do |control|
+        control.results.each do |result|
+          profile_time += result.run_time
+          profile_xml.add(build_result_xml(profile.name, control, result))
         end
       end
+      profile_xml.add_attribute("time", "%.6f" % profile_time)
+
+      profile_xml.add(REXML::Element.new("system-out"))
+      profile_xml.add(REXML::Element.new("system-err"))
+
+      profile_xml
+    end
+
+    def build_result_xml(profile_name, control, result)
+      result_xml = REXML::Element.new("testcase")
+      result_xml.add_attribute("name", result.code_desc)
+      result_xml.add_attribute("classname", control.title.nil? ? "#{profile_name}.Anonymous" : "#{profile_name}.#{control.id}")
+
+      # <Nokogiri::XML::SyntaxError: 20:0: ERROR: Element 'testcase', attribute 'time': '4.9e-05' is not a valid value of the atomic type 'xs:decimal'.
+      # So, we format it.
+      result_xml.add_attribute("time", "%.6f" % result.run_time)
+
+      if result.status == "failed"
+        failure_element = REXML::Element.new("failure")
+        failure_element.add_attribute("message", result.message)
+        failure_element.add_attribute("type", result.resource_title&.to_s || "")
+        result_xml.add(failure_element)
+      elsif result.status == "skipped"
+        result_xml.add_element("skipped")
+      end
+
+      result_xml
     end
   end
 end

--- a/lib/plugins/inspec-reporter-junit/test/fixtures/schema/JUnit-162a883.xsd
+++ b/lib/plugins/inspec-reporter-junit/test/fixtures/schema/JUnit-162a883.xsd
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	 elementFormDefault="qualified"
+	 attributeFormDefault="unqualified">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+Copyright © 2011, Windy Road Technology Pty. Limited
+The Apache Ant JUnit XML Schema is distributed under the terms of the Apache License Version 2.0 http://www.apache.org/licenses/
+Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
+	</xs:annotation>
+	<xs:element name="testsuite" type="testsuite"/>
+	<xs:simpleType name="ISO8601_DATETIME_PATTERN">
+		<xs:restriction base="xs:dateTime">
+			<xs:pattern value="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="testsuites">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="testsuite" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="testsuite">
+								<xs:attribute name="package" type="xs:token" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Derived from testsuite/@name in the non-aggregated documents</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="id" type="xs:int" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="testsuite">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains the results of exexuting a testsuite</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="properties">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:attribute name="name" use="required">
+									<xs:simpleType>
+										<xs:restriction base="xs:token">
+											<xs:minLength value="1"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+								<xs:attribute name="value" type="xs:string" use="required"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:choice minOccurs="0">
+						<xs:element name="skipped" />
+						<xs:element name="error" minOccurs="0" maxOccurs="1">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="pre-string">
+										<xs:attribute name="message" type="xs:string">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The error message. e.g., if a java exception is thrown, the return value of getMessage()</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="type" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="failure">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="pre-string">
+										<xs:attribute name="message" type="xs:string">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The message specified in the assert</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="type" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The type of the assert.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+					</xs:choice>
+					<xs:attribute name="name" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Name of the test method</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="classname" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="time" type="xs:decimal" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="system-out">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="system-err">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="name" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="timestamp" type="ISO8601_DATETIME_PATTERN" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">when the test was executed. Timezone may not be specified.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="hostname" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="tests" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="failures" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="errors" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="skipped" type="xs:int" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of ignored or skipped tests in the suite.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="time" type="xs:decimal" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:simpleType name="pre-string">
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/test/functional/inspec_exec_junit_test.rb
+++ b/test/functional/inspec_exec_junit_test.rb
@@ -1,5 +1,5 @@
 require "functional/helper"
-require "rexml/document"
+require "nokogiri"
 
 describe "inspec exec with junit formatter" do
   include FunctionalHelper
@@ -9,11 +9,10 @@ describe "inspec exec with junit formatter" do
   it "can execute a simple file with the junit formatter" do
     out = inspec("exec " + example_control + " --reporter junit --no-create-lockfile")
 
-    # TODO: rexml is about as slow as you can go. Use nokogiri
-    doc = REXML::Document.new(out.stdout)
-    _(doc.has_elements?).must_equal true
-
     _(out.stderr).must_equal ""
+    doc = Nokogiri::XML(out.stdout)
+    _(doc.document?).must_equal true
+    _(doc.errors).must_be_empty
 
     skip_windows!
     assert_exit_code 0, out
@@ -22,45 +21,44 @@ describe "inspec exec with junit formatter" do
   it "can execute the profile with the junit formatter" do
     out = inspec("exec " + complete_profile + " --reporter junit --no-create-lockfile")
 
-    # TODO: _never_ use rexml. Anything else is guaranteed faster
-    doc = REXML::Document.new(out.stdout)
-    _(doc.has_elements?).must_equal true
-
     _(out.stderr).must_equal ""
+    doc = Nokogiri::XML(out.stdout)
+    _(doc.document?).must_equal true
+    _(doc.errors).must_be_empty
 
     assert_exit_code 0, out
   end
 
   describe "execute a profile with junit formatting" do
-    let(:doc) { REXML::Document.new(inspec("exec " + example_profile + " --reporter junit --no-create-lockfile").stdout) }
+    let(:doc) { Nokogiri::XML(inspec("exec " + example_profile + " --reporter junit --no-create-lockfile").stdout) }
 
     describe "the document" do
       it "has only one testsuite" do
-        _(doc.elements.to_a("//testsuite").length).must_equal 1
+        _(doc.xpath("//testsuite").length).must_equal 1
       end
     end
     describe "the test suite" do
-      let(:suite) { doc.elements.to_a("//testsuites/testsuite").first }
+      let(:suite) { doc.xpath("//testsuites/testsuite").first }
 
       it "must have 4 testcase children" do
-        _(suite.elements.to_a("//testcase").length).must_equal 4
+        _(suite.xpath("//testcase").length).must_equal 4
       end
 
       it "has the tests attribute with 4 total tests" do
-        _(suite.attribute("tests").value).must_equal "4"
+        _(suite.attr("tests")).must_equal "4"
       end
 
       it "has the failures attribute with 0 total tests" do
         skip_windows!
-        _(suite.attribute("failed").value).must_equal "0"
+        _(suite.attr("failed")).must_equal "0"
       end
 
-      it 'has 2 elements named "File / should be directory"' do
-        _(REXML::XPath.match(suite, "//testcase[@name='File / is expected to be directory']").length).must_equal 3
+      it 'has 3 elements named "File / should be directory"' do
+        _(suite.xpath("//testcase[@name='File / is expected to be directory']").length).must_equal 3
       end
 
       describe 'the testcase named "example_config Can\'t find file ..."' do
-        let(:example_yml_tests) { REXML::XPath.match(suite, "//testcase[@classname='profile.example-1.0' and @name='example_config']") }
+        let(:example_yml_tests) { suite.xpath("//testcase[@classname='profile.example-1.0' and @name='example_config']") }
         let(:first_example_test) { example_yml_tests.first }
 
         it "should be unique" do

--- a/test/functional/inspec_exec_junit_test.rb
+++ b/test/functional/inspec_exec_junit_test.rb
@@ -6,64 +6,115 @@ describe "inspec exec with junit formatter" do
 
   parallelize_me!
 
-  it "can execute a simple file with the junit formatter" do
-    out = inspec("exec " + example_control + " --reporter junit --no-create-lockfile")
+  describe "when running the legacy junit reporter" do
+    it "can execute a simple file with the junit formatter" do
+      out = inspec("exec " + example_control + " --reporter junit --no-create-lockfile")
 
-    _(out.stderr).must_equal ""
-    doc = Nokogiri::XML(out.stdout)
-    _(doc.document?).must_equal true
-    _(doc.errors).must_be_empty
+      _(out.stderr).must_equal ""
+      doc = Nokogiri::XML(out.stdout)
+      _(doc.document?).must_equal true
+      _(doc.errors).must_be_empty
 
-    skip_windows!
-    assert_exit_code 0, out
-  end
-
-  it "can execute the profile with the junit formatter" do
-    out = inspec("exec " + complete_profile + " --reporter junit --no-create-lockfile")
-
-    _(out.stderr).must_equal ""
-    doc = Nokogiri::XML(out.stdout)
-    _(doc.document?).must_equal true
-    _(doc.errors).must_be_empty
-
-    assert_exit_code 0, out
-  end
-
-  describe "execute a profile with junit formatting" do
-    let(:doc) { Nokogiri::XML(inspec("exec " + example_profile + " --reporter junit --no-create-lockfile").stdout) }
-
-    describe "the document" do
-      it "has only one testsuite" do
-        _(doc.xpath("//testsuite").length).must_equal 1
-      end
+      skip_windows!
+      assert_exit_code 0, out
     end
-    describe "the test suite" do
-      let(:suite) { doc.xpath("//testsuites/testsuite").first }
 
-      it "must have 4 testcase children" do
-        _(suite.xpath("//testcase").length).must_equal 4
+    it "can execute the profile with the junit formatter" do
+      out = inspec("exec " + complete_profile + " --reporter junit --no-create-lockfile")
+
+      _(out.stderr).must_equal ""
+      doc = Nokogiri::XML(out.stdout)
+      _(doc.document?).must_equal true
+      _(doc.errors).must_be_empty
+
+      assert_exit_code 0, out
+    end
+
+    describe "execute a profile with junit formatting" do
+      let(:doc) { Nokogiri::XML(inspec("exec " + example_profile + " --reporter junit --no-create-lockfile").stdout) }
+
+      describe "the document" do
+        it "has only one testsuite" do
+          _(doc.xpath("//testsuite").length).must_equal 1
+        end
       end
+      describe "the test suite" do
+        let(:suite) { doc.xpath("//testsuites/testsuite").first }
 
-      it "has the tests attribute with 4 total tests" do
-        _(suite.attr("tests")).must_equal "4"
-      end
+        it "must have 4 testcase children" do
+          _(suite.xpath("//testcase").length).must_equal 4
+        end
 
-      it "has the failures attribute with 0 total tests" do
-        skip_windows!
-        _(suite.attr("failed")).must_equal "0"
-      end
+        it "has the tests attribute with 4 total tests" do
+          _(suite.attr("tests")).must_equal "4"
+        end
 
-      it 'has 3 elements named "File / should be directory"' do
-        _(suite.xpath("//testcase[@name='File / is expected to be directory']").length).must_equal 3
-      end
+        it "has the failures attribute with 0 total tests" do
+          skip_windows!
+          _(suite.attr("failed")).must_equal "0"
+        end
 
-      describe 'the testcase named "example_config Can\'t find file ..."' do
-        let(:example_yml_tests) { suite.xpath("//testcase[@classname='profile.tmp-1.0' and @name='File / is expected to be directory']") }
+        it 'has 3 elements named "File / should be directory"' do
+          _(suite.xpath("//testcase[@name='File / is expected to be directory']").length).must_equal 3
+        end
 
-        it "should be unique" do
-          _(example_yml_tests.length).must_equal 1
+        describe 'the testcase named "example_config Can\'t find file ..."' do
+          let(:example_yml_tests) { suite.xpath("//testcase[@classname='profile.tmp-1.0' and @name='File / is expected to be directory']") }
+
+          it "should be unique" do
+            _(example_yml_tests.length).must_equal 1
+          end
         end
       end
     end
+  end
+
+  describe "when running the v2 junit reporter" do
+    let(:schema) { Nokogiri::XML::Schema(File.read("#{repo_path}/lib/plugins/inspec-reporter-junit/test/fixtures/schema/JUnit-162a883.xsd")) }
+    let(:run_result) { run_inspec_process("exec #{profile_name} --reporter junit2") }
+    let(:doc) { Nokogiri::XML(run_result.stdout) }
+
+    describe "when running a basic profile" do
+      let(:profile_name) { complete_profile }
+      it "can execute the profile with the junit formatter and produce validate JUnit XML" do
+
+        _(run_result.stderr).must_equal ""
+        _(doc.document?).must_equal true
+        _(doc.errors).must_be_empty            # syntax errors
+        _(schema.validate(doc)).must_be_empty  # XML validation errors
+
+        assert_exit_code 0, run_result
+
+        suite = doc.xpath("//testsuite").first
+        _(suite.attr("hostname")).must_equal "local://" # We put the target in hostname now
+        _(doc.xpath("//testsuite[@failed]")).must_be_empty # we are no longer populating the incorrect "failed" attribute
+      end
+    end
+
+    describe "when run on a profile with skips" do
+      let(:profile_name) { "#{profile_path}/skippy-controls" }
+      it "reports skips separately" do
+        _(run_result.stderr).must_equal ""
+        _(schema.validate(doc)).must_be_empty
+        suite = doc.xpath("//testsuite").first
+        _(suite.attr("skipped")).must_equal "2"
+        testcase = doc.xpath("//testcase").first
+        _(testcase.xpath("//skipped")).wont_be_empty
+      end
+    end
+
+    describe "when run on a profile with errors" do
+      let(:profile_name) { "#{profile_path}/exception-in-control" }
+      it "reports failures and errors separately" do
+        # InSpec CLI will report this as 4 failures. JUnit standard would
+        # see it as 4 errors, no failures.
+        _(run_result.stderr).must_equal ""
+        _(schema.validate(doc)).must_be_empty
+        suite = doc.xpath("//testsuite").first
+        _(suite.attr("failures")).must_equal "0"
+        _(suite.attr("errors")).must_equal "4"
+      end
+    end
+
   end
 end

--- a/test/functional/inspec_exec_junit_test.rb
+++ b/test/functional/inspec_exec_junit_test.rb
@@ -58,21 +58,10 @@ describe "inspec exec with junit formatter" do
       end
 
       describe 'the testcase named "example_config Can\'t find file ..."' do
-        let(:example_yml_tests) { suite.xpath("//testcase[@classname='profile.example-1.0' and @name='example_config']") }
-        let(:first_example_test) { example_yml_tests.first }
+        let(:example_yml_tests) { suite.xpath("//testcase[@classname='profile.tmp-1.0' and @name='File / is expected to be directory']") }
 
         it "should be unique" do
-          skip
           _(example_yml_tests.length).must_equal 1
-        end
-
-        it "should be skipped" do
-          skip
-          if is_windows?
-            _(first_example_test.elements.to_a("//skipped").length).must_equal 2
-          else
-            _(first_example_test.elements.to_a("//skipped").length).must_equal 1
-          end
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

NOTE: this PR is a branch off of cw/reporter-plugin-junit, and assumes #5084 will merge first.

Adds a new reporter, junit2, which tries really hard to be correct according to a schema I found on the internet. JUnit has no official schema, but the original reporter is pretty wild.

The original reporter with its quirks is still available as `junit`. We could rename it `junit0` and make the new one `junit`. That would break things.

For you plugin fans out there, this one is a reporter plugin that provides two reporters in one plugin, and uses class inheritance internally. Will we see more of that? FORESHADOWING....

Also:

 * Introduces a *testing* dependency on nokogiri. #5045 is going to do that too.
 * Replaces REXML tests for JUnit with nokogiri tests, closing #4770. We still use REXML to generate XML within the reporter, but unless we want to ship nokogiri, we must continue to do so. (We can't ship nokogiri, because it is compiled, and can't go in inspec-core).
 * Updates a few tests for JUnit that had bit rot.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #3006
Closes #4770

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-2272