### PR TITLE
Stop building habitat for InSpec 3

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 $env:HAB_ORIGIN = 'ci'
 $env:CHEF_LICENSE = 'accept-no-persist'
 $env:HAB_LICENSE = 'accept-no-persist'
-$Plan = 'inspec'
+$Plan = 'inspec3'
 
 Write-Host "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'

--- a/.expeditor/buildkite/artifact.habitat.test.sh
+++ b/.expeditor/buildkite/artifact.habitat.test.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 export HAB_ORIGIN='ci'
-export PLAN='inspec'
+export PLAN='inspec3'
 export CHEF_LICENSE="accept-no-persist"
 export HAB_LICENSE="accept-no-persist"
 export project_root="$(git rev-parse --show-toplevel)"

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -12,7 +12,6 @@ docker_images:
         - GEM_SOURCE: http://artifactory.chef.co/omnibus-gems-local
 
 pipelines:
-  - habitat/build
   - omnibus/release
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml
@@ -68,10 +67,6 @@ merge_actions:
         - "Omnibus: Skip Build"
         - "Expeditor: Skip All"
       only_if: built_in:bump_version
-  - trigger_pipeline:habitat/build:
-      ignore_labels:
-        - "Habitat: Skip Build"
-        - "Expeditor: Skip All"
   - built_in:build_gem:
       only_if:
         - built_in:bump_version
@@ -83,7 +78,6 @@ subscriptions:
   - workload: artifact_published:current:inspec:{{version_constraint}}
     actions:
       - built_in:tag_docker_image
-      - built_in:promote_habitat_packages
   - workload: artifact_published:stable:inspec:{{version_constraint}}
     actions:
       - bash:.expeditor/update_dockerfile.sh
@@ -91,5 +85,4 @@ subscriptions:
       - built_in:publish_rubygems
       - built_in:create_github_release
       - built_in:tag_docker_image
-      - built_in:promote_habitat_packages
       - built_in:notify_chefio_slack_channels

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,4 +1,4 @@
-pkg_name=inspec
+pkg_name=inspec3
 pkg_origin=chef
 pkg_version=$(cat "$PLAN_CONTEXT/../VERSION")
 pkg_description="InSpec is an open-source testing framework for infrastructure


### PR DESCRIPTION
A habitat project can only track one major version at a time and `chef/inspec` is now InSpec 4.
The habitat config for this branch needs to build `chef/inspec3` instead, and we don't need to build/release it while no-one needs it.

Signed-off-by: James Stocks <jstocks@chef.io>