### PR TITLE
Update sslshake test for sslshake 1.13.1

### DIFF
--- a/test/unit/resources/ssl_test.rb
+++ b/test/unit/resources/ssl_test.rb
@@ -49,6 +49,6 @@ describe "Inspec::Resources::SSL" do
     resource = load_resource("ssl", host: "localhost")
     _(resource.protocols.uniq).must_equal ["ssl2", "ssl3", "tls1.0", "tls1.1", "tls1.2"]
     _(resource.ciphers.include?("TLS_RSA_WITH_AES_128_CBC_SHA256")).must_equal true
-    _([681, 993]).must_include(resource.ciphers.count)
+    _([681, 993, 1003]).must_include(resource.ciphers.count)
   end
 end


### PR DESCRIPTION
There are now 1003 ciphers.

Fixes newly occurring failures in CI (no issue ref).

Signed-off-by: James Stocks <jstocks@chef.io>