### PR TITLE
fix(users): use proper os family in resource

### DIFF
--- a/lib/inspec/resources/users.rb
+++ b/lib/inspec/resources/users.rb
@@ -20,7 +20,7 @@ module Inspec::Resources
         WindowsUser.new(inspec)
       elsif ["darwin"].include?(os[:family])
         DarwinUser.new(inspec)
-      elsif ["freebsd"].include?(os[:family])
+      elsif ["bsd"].include?(os[:family])
         FreeBSDUser.new(inspec)
       elsif ["aix"].include?(os[:family])
         AixUser.new(inspec)


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <fzipitria@perceptyx.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
```
↺  The `user` resource is not supported on your OS yet.
```
When using inspec in FreeBSD, despite having the correct FreeBSDUser in the resource file.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5119 .
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-2428