### PR TITLE
fix(osfamily): use corresponding family or name for bsd/freebsd

### DIFF
--- a/test/kitchen/policies/default/controls/group_spec.rb
+++ b/test/kitchen/policies/default/controls/group_spec.rb
@@ -9,7 +9,7 @@ if os.linux?
     it { should_not exist }
     its('gid') { should eq nil }
   end
-elsif os[:family] == 'freebsd'
+elsif os.bsd?
   describe group('wheel') do
     it { should exist }
     its('gid') { should eq 0 }

--- a/test/kitchen/policies/default/controls/user_spec.rb
+++ b/test/kitchen/policies/default/controls/user_spec.rb
@@ -12,7 +12,7 @@ if ['centos', 'redhat', 'fedora', 'suse', 'debian', 'ubuntu'].include?(os[:famil
   # different groupset for centos 5
   userinfo[:groups] = ["root", "bin", "daemon", "sys", "adm", "disk", "wheel"] \
     if os[:release].to_i == 5
-elsif ['freebsd'].include?(os[:family])
+elsif ['freebsd'].include?(os[:name])
   userinfo = {
     username: 'root',
     groupname: 'wheel',


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <fzipitria@perceptyx.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Use proper family/name in tests also for bsd/freebsd.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Correct tests from #5120 and #5121.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-2430