### PR TITLE
Fix freebsd osfamily user group tests

### DIFF
--- a/lib/inspec/resources/mount.rb
+++ b/lib/inspec/resources/mount.rb
@@ -61,7 +61,7 @@ module Inspec::Resources
       os = inspec.os
       if os.linux?
         LinuxMounts.new(inspec)
-      elsif ["freebsd"].include?(os[:family])
+      elsif os.bsd?
         BsdMounts.new(inspec)
       end
     end

--- a/lib/inspec/resources/users.rb
+++ b/lib/inspec/resources/users.rb
@@ -20,7 +20,7 @@ module Inspec::Resources
         WindowsUser.new(inspec)
       elsif ["darwin"].include?(os[:family])
         DarwinUser.new(inspec)
-      elsif ["freebsd"].include?(os[:family])
+      elsif ["bsd"].include?(os[:family])
         FreeBSDUser.new(inspec)
       elsif ["aix"].include?(os[:family])
         AixUser.new(inspec)

--- a/test/fixtures/cmd/id-fzipi
+++ b/test/fixtures/cmd/id-fzipi
@@ -1,0 +1,1 @@
+uid=1000(fzipi) gid=1000(fzipi) groups=1000(fzipi),0(wheel),1007(users)

--- a/test/fixtures/cmd/pw-usershow-fzipi-7
+++ b/test/fixtures/cmd/pw-usershow-fzipi-7
@@ -1,0 +1,1 @@
+fzipi:*:1000:1000:Felipe Zipitria,None,None,None:/home/fzipi:/usr/local/bin/bash

--- a/test/fixtures/cmd/pw-usershow-root-7
+++ b/test/fixtures/cmd/pw-usershow-root-7
@@ -1,1 +1,0 @@
-root:*:0:0:Charlie &:/root:/bin/csh

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -13,9 +13,9 @@ class MockLoader
     debian7: { name: "debian", family: "debian", release: "7", arch: "x86_64" },
     debian8: { name: "debian", family: "debian", release: "8", arch: "x86_64" },
     debian10: { name: "debian", family: "debian", release: "buster/sid", arch: "x86_64" },
-    freebsd10: { name: "freebsd", family: "freebsd", release: "10", arch: "amd64" },
-    freebsd11: { name: "freebsd", family: "freebsd", release: "11", arch: "amd64" },
-    freebsd12: { name: "freebsd", family: "freebsd", release: "12", arch: "amd64" },
+    freebsd10: { name: "freebsd", family: "bsd", release: "10", arch: "amd64" },
+    freebsd11: { name: "freebsd", family: "bsd", release: "11", arch: "amd64" },
+    freebsd12: { name: "freebsd", family: "bsd", release: "12", arch: "amd64" },
     macos10_10: { name: "mac_os_x", family: "darwin", release: "10.10.4", arch: nil },
     macos10_16: { name: "darwin", family: "darwin", release: "10.16", arch: nil },
     ubuntu1204: { name: "ubuntu", family: "debian", release: "12.04", arch: "x86_64" },
@@ -301,7 +301,8 @@ class MockLoader
       "id chartmann" => cmd.call("id-chartmann"),
       "dscl -q . -read /Users/chartmann NFSHomeDirectory PrimaryGroupID RecordName UniqueID UserShell" => cmd.call("dscl"),
       # user info for freebsd
-      "pw usershow root -7" => cmd.call("pw-usershow-root-7"),
+      "id fzipi" => cmd.call("id-fzipi"),
+      "pw usershow fzipi -7" => cmd.call("pw-usershow-fzipi-7"),
       # user info for windows (winrm 1.6.0, 1.6.1)
       "c603a7d32732390b1ed57ebd56fd176fecdb2035f005d33482de9adb1ddb4447" => cmd.call("adsiusers"),
       # group info for windows

--- a/test/kitchen/policies/default/controls/group_spec.rb
+++ b/test/kitchen/policies/default/controls/group_spec.rb
@@ -9,7 +9,7 @@ if os.linux?
     it { should_not exist }
     its('gid') { should eq nil }
   end
-elsif os[:family] == 'freebsd'
+elsif os.bsd?
   describe group('wheel') do
     it { should exist }
     its('gid') { should eq 0 }

--- a/test/kitchen/policies/default/controls/user_spec.rb
+++ b/test/kitchen/policies/default/controls/user_spec.rb
@@ -12,7 +12,7 @@ if ['centos', 'redhat', 'fedora', 'suse', 'debian', 'ubuntu'].include?(os[:famil
   # different groupset for centos 5
   userinfo[:groups] = ["root", "bin", "daemon", "sys", "adm", "disk", "wheel"] \
     if os[:release].to_i == 5
-elsif ['freebsd'].include?(os[:family])
+elsif ['freebsd'].include?(os[:name])
   userinfo = {
     username: 'root',
     groupname: 'wheel',

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -114,12 +114,12 @@ describe "Inspec::Resources::User" do
   end
 
   it "read user on freebsd" do
-    resource = MockLoader.new(:freebsd10).load_resource("user", "root")
+    resource = MockLoader.new(:freebsd11).load_resource("user", "fzipi")
     _(resource.exists?).must_equal true
-    _(resource.group).must_equal "root"
-    _(resource.groups).must_equal ["root"]
-    _(resource.home).must_equal "/root"
-    _(resource.shell).must_equal "/bin/csh"
+    _(resource.group).must_equal "fzipi"
+    _(resource.groups).must_equal %w{fzipi wheel users}
+    _(resource.home).must_equal "/home/fzipi"
+    _(resource.shell).must_equal "/usr/local/bin/bash"
     _(resource.mindays).must_be_nil
     _(resource.maxdays).must_be_nil
     _(resource.warndays).must_be_nil


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR fixes issues with os family naming. Family is always `bsd`, and if you want to match the name, `os[:name]` should be used.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#5119 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-2434