### PR TITLE
feat(sensitive): add sensitive output to mysql and postgres sessions

### DIFF
--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -47,7 +47,7 @@ module Inspec::Resources
 
     def query(query, db = [])
       psql_cmd = create_psql_cmd(query, db)
-      cmd = inspec.command(psql_cmd)
+      cmd = inspec.command(psql_cmd, redact_regex: /(PGPASSWORD=').+(' psql .*)/)
       out = cmd.stdout + "\n" + cmd.stderr
       if cmd.exit_status != 0 || out =~ /could not connect to .*/ || out.downcase =~ /^error:.*/
         Lines.new(out, "PostgreSQL query with errors: #{query}")

--- a/test/unit/resources/mysql_session_test.rb
+++ b/test/unit/resources/mysql_session_test.rb
@@ -1,6 +1,7 @@
 require "helper"
 require "inspec/resource"
 require "inspec/resources/mysql_session"
+require "inspec/resources/command"
 
 describe "Inspec::Resources::MysqlSession" do
   it "verify mysql_session escaped login details with single quotes correctly" do
@@ -16,5 +17,13 @@ describe "Inspec::Resources::MysqlSession" do
 
     _(resource.send(:create_mysql_cmd, "SELECT 1 FROM DUAL;"))
       .must_equal('mysql -h localhost -s -e "SELECT 1 FROM DUAL;"')
+  end
+  it "verify mysql_session redacts output" do
+    cmd = %q{mysql -uroot -p\'\%\"\'\"\&\^\*\&\(\)\'\*\% -h localhost -s -e "SELECT 1 FROM DUAL;"}
+    options = { redact_regex: /(mysql -u\w+ -p).+(\s-(h|S).*)/ }
+    resource = load_resource("command", cmd, options)
+
+    expected_to_s = %q{Command: `mysql -uroot -pREDACTED -h localhost -s -e "SELECT 1 FROM DUAL;"`}
+    _(resource.to_s).must_equal(expected_to_s)
   end
 end

--- a/test/unit/resources/postgres_session_test.rb
+++ b/test/unit/resources/postgres_session_test.rb
@@ -1,6 +1,7 @@
 require "helper"
 require "inspec/resource"
 require "inspec/resources/postgres_session"
+require "inspec/resources/command"
 
 describe "Inspec::Resources::PostgresSession" do
   it "verify postgres_session create_psql_cmd with a basic query" do
@@ -10,5 +11,13 @@ describe "Inspec::Resources::PostgresSession" do
   it "verify postgres_session escaped_query with a complex query" do
     resource = load_resource("postgres_session", "myuser", "mypass", "127.0.0.1")
     _(resource.send(:create_psql_cmd, "SELECT current_setting('client_min_messages')", ["testdb"])).must_equal "PGPASSWORD='mypass' psql -U myuser -d testdb -h 127.0.0.1 -A -t -c SELECT\\ current_setting\\(\\'client_min_messages\\'\\)"
+  end
+  it "verify postgres_session redacts output" do
+    cmd = %q{PGPASSWORD='mypass' psql -U myuser -d testdb -h 127.0.0.1 -A -t -c "SELECT current_setting('client_min_messages')"}
+    options = { redact_regex: /(PGPASSWORD=').+(' psql .*)/ }
+    resource = load_resource("command", cmd, options)
+
+    expected_to_s = %q{Command: `PGPASSWORD='REDACTED' psql -U myuser -d testdb -h 127.0.0.1 -A -t -c "SELECT current_setting('client_min_messages')"`}
+    _(resource.to_s).must_equal(expected_to_s)
   end
 end


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <fzipitria@perceptyx.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Sessions in postgres or mysql end in the `command` resource. While the resource supports using regex to prevent showing sensitive information, none of the resources for databases prevent showing sensitive information.

This PR adds an additional `sensitive` parameter, that uses a proper (I hope) regex to show `REDACTED` in the command output.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Related to #3185.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-2448