### PR TITLE
Report faulty profiles instead of crashing

### DIFF
--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -446,9 +446,9 @@ The `run_data` object contains all data from the Chef InSpec run. Here is an ove
 |`run_data.profiles[0].depends[0].name`| name (assigned alias) of dependent profile|
 |`run_data.profiles[0].depends[0].path`| location of dependent profile if it was a local reference|
 |`run_data.profiles[0].depends[0].relative_path`| relative path within clone if it was a git reference|
-|`run_data.profiles[0].depends[0].skip_message`| Reason if status is "skipped"|
+|`run_data.profiles[0].depends[0].status_message`| Reason if status is "failed" or "skipped"|
 |`run_data.profiles[0].depends[0].supermarket`| String, "user/profilename" on Supermarket server if it was a Supermarket reference|
-|`run_data.profiles[0].depends[0].status`| String, one of "loaded" or "skipped"|
+|`run_data.profiles[0].depends[0].status`| String, one of "loaded", "failed" or "skipped"|
 |`run_data.profiles[0].depends[0].tag`| tag ref if it was a git reference|
 |`run_data.profiles[0].depends[0].version`| semver tag if it was a git reference|
 |`run_data.profiles[0].depends[0].url`| location of dependent profile if it was a URL reference|
@@ -466,14 +466,14 @@ The `run_data` object contains all data from the Chef InSpec run. Here is an ove
 |`run_data.profiles[0].name`| String, machine name of the profile|
 |`run_data.profiles[0].parent_profile`| String, name of the parent profile if this is a dependency|
 |`run_data.profiles[0].sha256`| String, checksum of the profile|
-|`run_data.profiles[0].skip_message`| String, message indicating why the profile was not loaded if status is "skipped"|
+|`run_data.profiles[0].status_message`| String, message indicating why the profile was not loaded if status is "failed" or "skipped"|
 |`run_data.profiles[0].summary`| String,  A one-line summary from the inspec.yml|
 |`run_data.profiles[0].supports`| Array of Support records indicating platform support|
 |`run_data.profiles[0].supports[0].platform_family`| Platform restriction by family|
 |`run_data.profiles[0].supports[0].platform_name`| Platform restriction by name|
 |`run_data.profiles[0].supports[0].platform`| Platform restriction by name|
 |`run_data.profiles[0].supports[0].release`| Platform restriction by release|
-|`run_data.profiles[0].status`| String, one of "loaded" or "skipped"|
+|`run_data.profiles[0].status`| String, one of "loaded", "failed" or "skipped"|
 |`run_data.statistics.controls.failed.total`| Integer, total count of failing controls|
 |`run_data.statistics.controls.passed.total`| Integer, total count of passing controls|
 |`run_data.statistics.controls.skipped.total`| Integer, total count of passing controls|

--- a/lib/inspec/exceptions.rb
+++ b/lib/inspec/exceptions.rb
@@ -4,6 +4,7 @@ module Inspec
   module Exceptions
     class InputsFileDoesNotExist < ArgumentError; end
     class InputsFileNotReadable < ArgumentError; end
+    class ProfileLoadFailed < StandardError; end
     class ResourceFailed < StandardError; end
     class ResourceSkipped < StandardError; end
     class SecretsBackendNotFound < ArgumentError; end

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -9,7 +9,12 @@ require "inspec/version"
 require "inspec/utils/spdx"
 
 module Inspec
-  # Extract metadata.rb information
+  # The Metadata class represents a profile's metadata.
+  # This includes the metadata stored in the profile's metadata.rb file, as well as inferred
+  # metadata like if this profile supports the current runtime and the intended target.
+  # This class does NOT represent the runtime state of a profile during execution.
+  # See lib/inspec/profile.rb for the runtime representation of a profile.
+  #
   # A Metadata object may be created and finalized with invalid data.
   # This allows the check CLI command to analyse the issues.
   # Use valid? to determine if the metadata is coherent.

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -265,7 +265,7 @@ module Inspec
           metadata.dependencies[i][:status] = "skipped"
           msg = "Skipping profile: '#{d.name}' on unsupported platform: '#{d.backend.platform.name}/#{d.backend.platform.release}'."
           metadata.dependencies[i][:status_message] = msg
-          metadata.dependencies[i][:skip_message] = msg  # Repeat as skip_message for backward compatibility
+          metadata.dependencies[i][:skip_message] = msg # Repeat as skip_message for backward compatibility
           next
         elsif metadata.dependencies[i]
           # Currently wrapper profiles will load all dependencies, and then we

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -264,7 +264,8 @@ module Inspec
           # TODO: NO! this is a violation of encapsulation to an extreme
           metadata.dependencies[i][:status] = "skipped"
           msg = "Skipping profile: '#{d.name}' on unsupported platform: '#{d.backend.platform.name}/#{d.backend.platform.release}'."
-          metadata.dependencies[i][:skip_message] = msg
+          metadata.dependencies[i][:status_message] = msg
+          metadata.dependencies[i][:skip_message] = msg  # Repeat as skip_message for backward compatibility
           next
         elsif metadata.dependencies[i]
           # Currently wrapper profiles will load all dependencies, and then we
@@ -337,8 +338,9 @@ module Inspec
       if !supports_platform?
         res[:status] = "skipped"
         msg = "Skipping profile: '#{name}' on unsupported platform: '#{backend.platform.name}/#{backend.platform.release}'."
-        res[:skip_message] = msg
+        res[:status_message] = msg
       else
+        res[:status_message] = @status_message || ""
         res[:status] = failed? ? "failed" : "loaded"
       end
 
@@ -463,6 +465,10 @@ module Inspec
 
     def controls_count
       params[:controls].values.length
+    end
+
+    def set_status_message(msg)
+      @status_message = msg.to_s
     end
 
     # generates a archive of a folder profile

--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -72,6 +72,7 @@ module Inspec::Reporters
         "Profile" => format_profile_name(profile),
         "Version" => profile[:version] || "(not specified)",
       }
+      header["Failure Message"] = profile[:status_message] if profile[:status] == "failed"
       header["Target"] = run_data[:platform][:target] unless run_data[:platform][:target].nil?
       header["Target ID"] = @config["target_id"] unless @config["target_id"].nil?
 

--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -69,7 +69,7 @@ module Inspec::Reporters
         }.reject { |_k, v| v.nil? }
 
         # For backwards compatibility
-        res[:skip_message] = res[:status_message] if res[:status] == 'skipped'
+        res[:skip_message] = res[:status_message] if res[:status] == "skipped"
 
         res
       end

--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -45,8 +45,8 @@ module Inspec::Reporters
     end
 
     def profiles
-      run_data[:profiles].map { |p|
-        {
+      run_data[:profiles].map do |p|
+        res = {
           name:            p[:name],
           version:         p[:version],
           sha256:          p[:sha256],
@@ -64,10 +64,15 @@ module Inspec::Reporters
           groups:          profile_groups(p),
           controls:        profile_controls(p),
           status:          p[:status],
-          skip_message:    p[:skip_message],
+          status_message:  p[:status_message],
           waiver_data:     p[:waiver_data],
         }.reject { |_k, v| v.nil? }
-      }
+
+        # For backwards compatibility
+        res[:skip_message] = res[:status_message] if res[:status] == 'skipped'
+
+        res
+      end
     end
 
     def profile_groups(profile)

--- a/lib/inspec/run_data.rb
+++ b/lib/inspec/run_data.rb
@@ -47,7 +47,7 @@ module Inspec
     # core reporters have been migrated to plugins. It is probable that new data elements
     # and new Hash compatibility behavior will be added during the core reporter plugin
     # conversion process.
-    SCHEMA_VERSION = "0.1.0".freeze
+    SCHEMA_VERSION = "0.2.0".freeze
 
     def self.compatible_schema?(constraints)
       reqs = Gem::Requirement.create(constraints)

--- a/lib/inspec/run_data/profile.rb
+++ b/lib/inspec/run_data/profile.rb
@@ -15,7 +15,7 @@ module Inspec
       :summary,
       :supports,         # complex local
       :parent_profile,
-      :skip_message,
+      :status_message,
       :waiver_data,      # Undocumented but used in JSON reporter - should not be?
       :title,
       :version
@@ -40,7 +40,7 @@ module Inspec
           title
           version
           parent_profile
-          skip_message
+          status_message
           waiver_data
         }.each do |field|
           self[field] = raw_prof_data[field]
@@ -51,11 +51,11 @@ module Inspec
     class Profile
       # Good candidate for keyword_init, but that is not in 2.4
       Dependency = Struct.new(
-        :name, :path, :status, :skip_message, :git, :url, :compliance, :supermarket, :branch, :tag, :commit, :version, :relative_path
+        :name, :path, :status, :status_message, :git, :url, :compliance, :supermarket, :branch, :tag, :commit, :version, :relative_path
       ) do
         include HashLikeStruct
         def initialize(raw_dep_data)
-          %i{name path status skip_message git url supermarket compliance branch tag commit version relative_path}.each { |f| self[f] = raw_dep_data[f] }
+          %i{name path status status_message git url supermarket compliance branch tag commit version relative_path}.each { |f| self[f] = raw_dep_data[f] }
         end
       end
 

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -115,8 +115,13 @@ module Inspec
           @test_collector.add_profile(requirement.profile)
         end
 
-        tests = profile.collect_tests
-        all_controls += tests unless tests.nil?
+        begin
+          tests = profile.collect_tests
+          all_controls += tests unless tests.nil?
+        rescue Inspec::Exceptions::ProfileLoadFailed => e
+          Inspec::Log.error "Failed to load profile #{profile.name}: #{e}"
+          next
+        end
       end
 
       all_controls.each do |rule|

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -120,6 +120,7 @@ module Inspec
           all_controls += tests unless tests.nil?
         rescue Inspec::Exceptions::ProfileLoadFailed => e
           Inspec::Log.error "Failed to load profile #{profile.name}: #{e}"
+          profile.set_status_message e.to_s
           next
         end
       end

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -90,9 +90,12 @@ module Inspec
       return @rspec_exit_code if @formatter.results.empty?
 
       stats = @formatter.results[:statistics][:controls]
+      load_failures = @formatter.results[:profiles]&.select { |p| p[:status] == "failed" }&.any?
       skipped = @formatter.results.dig(:profiles, 0, :status) == "skipped"
-      if stats[:failed][:total] == 0 && stats[:skipped][:total] == 0 && !skipped
+      if stats[:failed][:total] == 0 && stats[:skipped][:total] == 0 && !skipped && !load_failures
         0
+      elsif load_failures
+        @conf["distinct_exit"] ? 102 : 1
       elsif stats[:failed][:total] > 0
         @conf["distinct_exit"] ? 100 : 1
       elsif stats[:skipped][:total] > 0 || skipped

--- a/lib/inspec/schema.rb
+++ b/lib/inspec/schema.rb
@@ -147,6 +147,8 @@ module Inspec
         "license" => { "type" => "string", "optional" => true },
         "summary" => { "type" => "string", "optional" => true },
         "status" => { "type" => "string", "optional" => false },
+        "status_message" => { "type" => "string", "optional" => true },
+        # skip_message is deprecated, status_message should be used to store the reason for skipping
         "skip_message" => { "type" => "string", "optional" => true },
 
         "supports" => {

--- a/lib/inspec/schema/exec_json.rb
+++ b/lib/inspec/schema/exec_json.rb
@@ -83,7 +83,7 @@ module Inspec
         "required" => %w{name sha256 supports attributes groups controls},
         # Name is mandatory in inspec.yml.
         # supports, controls, groups, and attributes are always present, even if empty
-        # sha256, status, skip_message
+        # sha256, status, status_message
         "properties" => {
           # These are provided in inspec.yml
           "name" => Primitives::STRING,
@@ -100,10 +100,11 @@ module Inspec
           "description" => Primitives::STRING,
           "inspec_version" => Primitives::STRING,
 
-          # These are generated at runtime, and all except skip_message are guaranteed
+          # These are generated at runtime, and all except status_message and skip_message are guaranteed
           "sha256" => Primitives::STRING,
           "status" => Primitives::STRING,
-          "skip_message" => Primitives::STRING, # If skipped, why
+          "status_message" => Primitives::STRING, # If skipped or failed to load, why
+          "skip_message" => Primitives::STRING,   # Deprecated field storing reason for skipping. status_message should be used instead.
           "controls" => Primitives.array(CONTROL.ref),
           "groups" => Primitives.array(Primitives::CONTROL_GROUP.ref),
           "attributes" => Primitives.array(Primitives::INPUT),

--- a/lib/inspec/schema/primitives.rb
+++ b/lib/inspec/schema/primitives.rb
@@ -160,7 +160,7 @@ module Inspec
           "url" => URL,
           "branch" => STRING,
           "path" => STRING,
-          "skip_message" => STRING,
+          "status_message" => STRING,
           "status" => STRING,
           "git" => URL,
           "supermarket" => STRING,

--- a/lib/plugins/inspec-reporter-html2/templates/profile.html.erb
+++ b/lib/plugins/inspec-reporter-html2/templates/profile.html.erb
@@ -7,8 +7,8 @@
     <% if profile.summary %>
     <tr class="profile-summary"><th>Summary:</th><td><%= profile.summary %></td></tr>
     <% end %>
-    <% if profile.skip_message %>
-    <tr class="profile-skip-message"><th>Skip Message:</th><td><%= profile.skip_message %></td></tr>
+    <% if profile.status_message %>
+    <tr class="profile-status-message"><th>Status Message:</th><td><%= profile.status_message %></td></tr>
     <% end %>
   </table>
 

--- a/lib/plugins/inspec-reporter-html2/templates/profile.html.erb
+++ b/lib/plugins/inspec-reporter-html2/templates/profile.html.erb
@@ -7,7 +7,10 @@
     <% if profile.summary %>
     <tr class="profile-summary"><th>Summary:</th><td><%= profile.summary %></td></tr>
     <% end %>
-    <% if profile.status_message %>
+    <% if profile.status != "loaded" %>
+    <tr class="profile-status"><th>Status:</th><td><%= profile.status %></td></tr>
+    <% end %>
+    <% if profile.status_message && !profile.status_message.empty? %>
     <tr class="profile-status-message"><th>Status Message:</th><td><%= profile.status_message %></td></tr>
     <% end %>
   </table>

--- a/test/fixtures/profiles/basic_profile/README.md
+++ b/test/fixtures/profiles/basic_profile/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec profile.

--- a/test/fixtures/profiles/basic_profile/controls/example.rb
+++ b/test/fixtures/profiles/basic_profile/controls/example.rb
@@ -1,0 +1,8 @@
+control 'The letter a' do
+  impact 0.7
+  title 'The letter a'
+  desc 'It is very important that the letter a works correctly.'
+  describe 'a' do
+    it { should cmp 'a' }
+  end
+end

--- a/test/fixtures/profiles/basic_profile/inspec.yml
+++ b/test/fixtures/profiles/basic_profile/inspec.yml
@@ -1,0 +1,10 @@
+name: basic_profile
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: A simple profile with a control that always passes.
+version: 0.1.0
+supports:
+  platform: os

--- a/test/fixtures/profiles/incompatible_resource_for_transport.rb
+++ b/test/fixtures/profiles/incompatible_resource_for_transport.rb
@@ -1,3 +1,5 @@
-describe file('/foo') do
-  it { should exist }
+control '/foo must exit' do
+  describe file('/foo') do
+    it { should exist }
+  end
 end

--- a/test/fixtures/profiles/raise_outside_control/controls/raises.rb
+++ b/test/fixtures/profiles/raise_outside_control/controls/raises.rb
@@ -1,0 +1,11 @@
+# Ref https://github.com/inspec/inspec/issues/5107
+# Users may add code outside controls without exception handling.
+# While this is a user mistake, users may not know about it if we don't report it...
+
+raise StandardError, 'Something unforeseen...'
+
+control "Test Exception Example" do
+  describe file("/tmp") do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/fixtures/profiles/raise_outside_control/inspec.yml
+++ b/test/fixtures/profiles/raise_outside_control/inspec.yml
@@ -1,0 +1,8 @@
+name: raise_outside_control
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: This profile has code that raises outside of a control. This is a user mistake, but we need to handle it. 
+version: 0.1.0

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -100,6 +100,8 @@ describe "inspec exec with json formatter" do
     _(profile["depends"].count).must_equal 2
     profile["depends"].each do |d|
       _(d["status"]).must_equal "skipped"
+      _(d["status_message"]).must_include "Skipping profile: "
+      # For backwards compatibility, the skip reason is also given as skip_message
       _(d["skip_message"]).must_include "Skipping profile: "
     end
 
@@ -116,6 +118,7 @@ describe "inspec exec with json formatter" do
     _(profile["depends"].count).must_equal 2
     profile["depends"].each do |d|
       _(d["status"]).must_equal "loaded"
+      _(d.key?("status_message")).must_equal false
       _(d.key?("skip_message")).must_equal false
     end
 
@@ -131,6 +134,7 @@ describe "inspec exec with json formatter" do
     data = JSON.parse(out.stdout)
     profile = data["profiles"].first
     _(profile["status"]).must_equal "skipped"
+    _(profile["status_message"]).must_include "Skipping profile: 'skippy' on unsupported platform:"
     _(profile["skip_message"]).must_include "Skipping profile: 'skippy' on unsupported platform:"
 
     _(out.stderr).must_equal ""
@@ -202,6 +206,7 @@ describe "inspec exec with json formatter" do
         "supports" => [{ "platform-family" => "unix" }, { "platform-family" => "windows" }],
         "attributes" => [],
         "status" => "loaded",
+        "status_message"=>"",
       })
 
       _(groups.sort_by { |x| x["id"] }).must_equal([

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -159,8 +159,8 @@ describe "inspec exec with json formatter" do
 
     data = JSON.parse(out.stdout)
     _(data["profiles"].length).must_equal 2
-    good_profile_result = data["profiles"].select{ |p| p["name"] == "basic_profile" }.first
-    bad_profile_result = data["profiles"].select{ |p| p["name"] == "raise_outside_control" }.first
+    good_profile_result = data["profiles"].select { |p| p["name"] == "basic_profile" }.first
+    bad_profile_result = data["profiles"].select { |p| p["name"] == "raise_outside_control" }.first
     _(good_profile_result["status"]).must_equal "loaded"
     _(good_profile_result["controls"].first["results"].first["status"]).must_equal "passed"
     _(bad_profile_result["status"]).must_equal "failed"
@@ -206,7 +206,7 @@ describe "inspec exec with json formatter" do
         "supports" => [{ "platform-family" => "unix" }, { "platform-family" => "windows" }],
         "attributes" => [],
         "status" => "loaded",
-        "status_message"=>"",
+        "status_message" => "",
       })
 
       _(groups.sort_by { |x| x["id"] }).must_equal([

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -33,11 +33,12 @@ describe "inspec exec" do
   end
 
   it "cleanly fails if mixing incompatible resource and transports" do
-    # TODO: I do not know how to test this more directly. It should be possible.
+    # TODO: It should be possible to test this more directly.
     inspec "exec -t aws:// #{profile_path}/incompatible_resource_for_transport.rb"
 
-    _(stdout).must_be_empty
-    _(stderr).must_include "Unsupported resource/backend combination: file / aws. Exiting."
+    _(stderr).must_be_empty
+    _(stdout).must_include "Unsupported resource/backend combination: file / aws. Exiting."
+    assert_exit_code 100, out
   end
 
   it "can execute the profile" do
@@ -201,6 +202,15 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     _(stderr).must_equal ""
 
     assert_exit_code 100, out
+  end
+
+  it "reports whan a profile cannot be loaded" do
+    inspec("exec " + File.join(profile_path, "raise_outside_control") + " --no-create-lockfile")
+    _(stdout).must_include "Profile: InSpec Profile (raise_outside_control)"
+
+    _(stdout).must_include "ERROR: Failed to load profile raise_outside_control: Failed to load source for controls/raises.rb: Something unforeseen..."
+
+    assert_exit_code 102, out
   end
 
   it "can execute a simple file with the default formatter" do


### PR DESCRIPTION
Fixes #5107 

When InSpec cannot load a profile, it should log the failed profile instead of terminating InSpec entirely.

Aha! Link: https://chef.aha.io/features/SH-2553