### PR TITLE
Allow ‘=‘ character in CLI inputs

### DIFF
--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -165,7 +165,8 @@ module Inspec
             raise ArgumentError, "ERROR: An '=' is required when using --input. Usage: --input input_name1=input_value1 input2=value2"
           end
         end
-        input_name, input_value = pair.split("=")
+        pair = pair.match(/(.*?)=(.*)/)
+        input_name, input_value = pair[1], pair[2]
         input_value = parse_cli_input_value(input_name, input_value)
         evt = Inspec::Input::Event.new(
           value: input_value,

--- a/test/fixtures/profiles/inputs/with_various_values/controls/input_equals.rb
+++ b/test/fixtures/profiles/inputs/with_various_values/controls/input_equals.rb
@@ -1,0 +1,7 @@
+title 'With various values'
+
+control 'with equals sign' do
+  describe input(:my_input) do
+    it { should eq 'ab=cde' }
+  end
+end

--- a/test/fixtures/profiles/inputs/with_various_values/inspec.yml
+++ b/test/fixtures/profiles/inputs/with_various_values/inspec.yml
@@ -1,0 +1,8 @@
+name: profile
+title: InSpec Example Profile
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
+copyright_email: support@chef.io
+license: Apache-2.0
+summary: Demonstrates regressions for 5131
+version: 1.0.0

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -32,6 +32,18 @@ describe "inspec exec" do
     FileUtils.rm_f "#{prof}/simple-metadata/inspec.lock"
   end
 
+  it "handles '=' character on input" do
+    # This test handles a bug discovered at: https://github.com/inspec/inspec/issues/5131
+    inspec(
+      "exec " +
+      File.join(profile_path, "inputs", "with_various_values") +
+      " --no-create-lockfile" +
+      " --input my_input='ab=cde'"
+    )
+
+    _(stdout).must_include "0 failures"
+  end
+
   it "cleanly fails if mixing incompatible resource and transports" do
     # TODO: I do not know how to test this more directly. It should be possible.
     inspec "exec -t aws:// #{profile_path}/incompatible_resource_for_transport.rb"


### PR DESCRIPTION
Fixes #5131

Due to the use of `#split(‘=‘)` against inputs supplied via the CLI we had an edge case where inputs with `’=‘` in the value would cause a breakage.

This PR supplies a test for the regression and fixes the bug with a regex solution.

Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>

Aha! Link: https://chef.aha.io/features/SH-2552