### PR TITLE
Ensure only_if is evaluated when control is run

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -26,7 +26,6 @@ module Inspec
 
       @resource_dsl = resource_dsl
       extend resource_dsl # TODO: remove! do it via method_missing
-
       # not changeable by the user:
       @__code = nil
       @__block = block
@@ -43,11 +42,11 @@ module Inspec
       return unless block_given?
 
       begin
-        instance_eval(&block)
 
-        # By applying waivers *after* the instance eval, we assure that
-        # waivers have higher precedence than only_if.
+        # This ensures we do not load and run control code that is waived.
         __apply_waivers
+
+        instance_eval(&block)
 
       rescue SystemStackError, StandardError => e
         # We've encountered an exception while trying to eval the code inside the


### PR DESCRIPTION
This is a small change that affects a few issues around expected
behavior and actual behavior. This is best illustrated with a few
examples.

Say within a control I have:

```ruby
control "01_test_control" do
  #... Some other code and describe blocks
  only_if { some_requirement_needed_to_proceed_like_an_unreliable_connection }
  describe(true) { it { should eq true } }
end
```

As I drafted this `only_if` I expect it to run.

Then, I am given a requirement to waive this control. I draft the
following waiver file:

```yaml
01_test_control:
  justification: At the moment we are not running this waiver.
  run: false
```

The control stops running with the following output and all is good:

```
 ↺  01_test_control No-op
     ↺  Skipped control due to waiver condition: At the moment we are
     not running this waiver.
```

Things change. Several months later I am asked to run that control. But
for documentation purposes we do keep it in waivers.yml as such:

```yaml
01_test_control:
  justification: At the moment we are not running this waiver.
  run: true
```

My __expectation__ is that the entire control block would evaluate at
this point, including my business logic within the only_if . This works
because if it does not run I’ll receive the different output of:

```
 ↺  01_test_control No-op
     ↺  Skipped control due to only_if condition.
```

However, that is not what happens in practice. `run: true` in waivers
will stop application of any only_ifs. I do not think this is expected
behavior. Feel free to use above code for reproduction cases.

**Why does this matter**

This also affects:

- https://github.com/inspec/inspec/issues/5068
- Customer issues around `skip_controls and waiver loading`
- https://github.com/inspec/inspec/issues/4959
- https://github.com/inspec/inspec/issues/5005
- https://github.com/inspec/inspec/issues/3760
- https://github.com/inspec/inspec/issues/4886
- https://github.com/inspec/inspec/issues/5133

This PR also prevents failures within `control` blocks from breaking when 
waived. It ensures that they remain skipped, which does not 
currently happen. ( NOTE: this applies only to failures, you can see 
that `puts 'hello'` or `sleep 20` will still evaluate and need a separate solution )

To reproduce:

```ruby
control "01_test_control" do
  fail
  describe(true) { it { should eq true } }
end
```

with:

```yaml
01_test_control:
  justification: At the moment we are not running this waiver.
  run: false
```

Running against master you get:

```
Profile: tests from testy.rb (tests from testy.rb)
Version: (not specified)
Target:  local://

  ×  01_test_control: testy.rb:1
     ×  Control Source Code Error testy.rb:1
```

Against this branch you get the expected behavior of:

```
Profile: tests from testy.rb (tests from testy.rb)
Version: (not specified)
Target:  local://

  ↺  01_test_control: No-op
     ↺  Skipped control due to waiver condition: At the moment we are
     not running this waiver.
```

Aha! Link: https://chef.aha.io/features/SH-2616