### PR TITLE
Pin json_schemer to maintain Ruby 2.4 support

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -44,18 +44,19 @@ pipelines:
  - integration/resources:
     description: Test core resources with test-kitchen.
     definition: .expeditor/integration.resources.yml
- - integration/libraries:
-    description: Integration with plugins, gems, resource packs.
-    definition: .expeditor/integration.libraries.yml
- - integration/profiles:
-    description: Integration with compliance-profiles, and dev-sec
-    definition: .expeditor/integration.profiles.yml
- - integration/cookbooks:
-    description: Integration with the audit cookbook
-    definition: .expeditor/integration.cookbooks.yml
- - integration/automate:
-    description: Integration with Chef Automate
-    definition: .expeditor/integration.automate.yml
+ # This breaks expeditor as it does not yet exist
+ # - integration/libraries:
+ #    description: Integration with plugins, gems, resource packs.
+ #    definition: .expeditor/integration.libraries.yml
+ # - integration/profiles:
+ #    description: Integration with compliance-profiles, and dev-sec
+ #    definition: .expeditor/integration.profiles.yml
+ # - integration/cookbooks:
+ #    description: Integration with the audit cookbook
+ #    definition: .expeditor/integration.cookbooks.yml
+ # - integration/automate:
+ #    description: Integration with Chef Automate
+ #    definition: .expeditor/integration.automate.yml
  - artifact/habitat:
     description: Execute tests against the habitat artifact
     definition: .expeditor/artifact.habitat.yml

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "chef-telemetry",     "~> 1.0"
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 2.0"
   spec.add_dependency "thor",               ">= 0.20", "< 2.0"
-  spec.add_dependency "json_schemer",       "~> 0.2.1"
+  spec.add_dependency "json_schemer",       ">= 0.2.1", "< 0.2.12"
   spec.add_dependency "method_source",      ">= 0.8", "< 2.0"
   spec.add_dependency "rubyzip",            "~> 1.2", ">= 1.2.2"
   spec.add_dependency "rspec",              "~> 3.9"


### PR DESCRIPTION
Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description

The July 12 release of `json_schemer` drops Ruby 2.4 support, which breaks our CI. This pins the dependency. This is currently breaking several other PRs so will try to get this across the line ASAP so others may rebase.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-2618