### PR TITLE
Habitat should not expand $PATH at buildtime

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.sh
+++ b/.expeditor/buildkite/artifact.habitat.test.sh
@@ -48,6 +48,9 @@ fi
 echo "+++ Installing ${pkg_ident:?is undefined}"
 hab pkg install -b "${project_root:?is undefined}/results/${pkg_artifact:?is undefined}"
 
+echo "--- Removing world readability from /usr/local/bundle"
+chmod go-w /usr/local/bundle
+
 echo "+++ Testing $PLAN"
 
 PATH="$(hab pkg path ci/inspec)/bin:$PATH"

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -70,7 +70,7 @@ wrap_inspec_bin() {
 set -e
 
 # Set binary path that allows InSpec to use non-Hab pkg binaries
-export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:$PATH"
+export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
 
 # Set Ruby paths defined from 'do_setup_environment()'
 export GEM_HOME="$GEM_HOME"


### PR DESCRIPTION
Habitat should have everything it needs at runtime as a habitat dependency and should prefer habitat dependency bins over native bins.

Signed-off-by: James Stocks <jstocks@chef.io>

Aha! Link: https://chef.aha.io/features/SH-2628