### PR TITLE
WIP: Implement optional InSpecStyle in `inspec check`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "inspec", path: "."
 gem "inspec-bin", path: "./inspec-bin"
 
 gem "ffi", ">= 1.9.14", "!= 1.13.0"
+gem "inspecstyle"
 
 group :omnibus do
   gem "rb-readline"

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -160,6 +160,12 @@ module Inspec
         desc: "Suppress deprecation warnings. See install_dir/etc/deprecations.json for list of GROUPs or use 'all'."
     end
 
+    def self.check_options
+      profile_options
+      option :inspecstyle, type: :boolean,
+        desc: "Scan profile code for InSpecStyle compliance."
+    end
+
     def self.format_platform_info(params: {}, indent: 0, color: 39)
       str = ""
       params.each do |item, info|

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -164,6 +164,8 @@ module Inspec
       profile_options
       option :inspecstyle, type: :boolean,
         desc: "Scan profile code for InSpecStyle compliance."
+      option :inspecstyle_autocorrect, type: :boolean,
+        desc: "Scan profile code for InSpecStyle compliance and autocorrect where possible."
     end
 
     def self.format_platform_info(params: {}, indent: 0, color: 39)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -91,7 +91,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 
   desc "check PATH", "verify all tests at the specified PATH"
   option :format, type: :string
-  profile_options
+  check_options
   def check(path) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
     o = config
     diagnose(o)
@@ -134,6 +134,26 @@ class Inspec::InspecCLI < Inspec::BaseCLI
         errors = ui.red("#{result[:errors].length} errors", print: false)
         warnings = ui.yellow("#{result[:warnings].length} warnings", print: false)
         ui.plain_line("Summary:     #{errors}, #{warnings}")
+      end
+      
+      full_inspec_message = <<~EOF
+
+      InSpecStyle is currently in its opt-in phase for InSpec 4 and will be the
+      default for InSpec 5. It helps lint your deprecated InSpec code; gives you
+      tips on writing faster, flexible, more scalable InSpec code; and provides
+      utilities for InSpec autocorrection. It will be available in `check`, as
+      a standalone rubygem, and also as a linter for your favorite code editor!
+
+      Help us make InSpecStyle better! Learn more here:
+      https://github.com/inspec/inspec/issues/5112
+
+      EOF
+
+      # Return InSpecStyle Output
+      if result[:inspecstyle]
+        ui.bold("\nInSpecStyle Evaluation:\n")
+        ui.bold_cyan(full_inspec_message)
+        ui.cyan(result[:inspecstyle])
       end
     end
     ui.exit Inspec::UI::EXIT_USAGE_ERROR unless result[:summary][:valid]

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -135,7 +135,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
         warnings = ui.yellow("#{result[:warnings].length} warnings", print: false)
         ui.plain_line("Summary:     #{errors}, #{warnings}")
       end
-      
+
       full_inspec_message = <<~EOF
 
       InSpecStyle is currently in its opt-in phase for InSpec 4 and will be the

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -382,8 +382,9 @@ module Inspec
       # Capture InSpecStyle run
       runtime_config = Inspec::Config.cached.respond_to?(:final_options) ? Inspec::Config.cached.final_options : {}
 
+      autocorrect = runtime_config[:inspecstyle_autocorrect] ? "-a" : nil
 
-      if runtime_config[:inspecstyle]
+      if runtime_config[:inspecstyle] || runtime_config[:inspecstyle_autocorrect]
         inspecstyle_target = if File.directory?(@target)
                            File.join(@target, "**/controls/*.rb")
                          else
@@ -393,7 +394,14 @@ module Inspec
         output = capture_stdout do
           require 'rubocop'
           ::RuboCop::CLI.new.run(
-            [inspecstyle_target, "-r", "inspecstyle", "--only", "InSpecStyle"]
+            [
+              inspecstyle_target,
+              "-r",
+              "inspecstyle",
+              "--only",
+              "InSpecStyle",
+              autocorrect
+            ]
           )
         end
         result[:inspecstyle] = output

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -379,6 +379,22 @@ module Inspec
         warnings: [],
       }
 
+      # Capture InSpecStyle run
+      runtime_config = Inspec::Config.cached.respond_to?(:final_options) ? Inspec::Config.cached.final_options : {}
+
+      if runtime_config[:inspecstyle]
+        inspecstyle_target = if File.directory?(@target)
+                           File.join(@target, "**/*.rb")
+                         else
+                           @target
+                         end
+
+        cmd = Mixlib::ShellOut.new(
+          "bundle exec rubocop #{inspecstyle_target} -r inspecstyle --only InSpecStyle"
+        ).run_command
+        result[:inspecstyle] = cmd.stdout
+      end
+
       entry = lambda { |file, line, column, control, msg|
         {
           file: file,

--- a/lib/inspec/ui.rb
+++ b/lib/inspec/ui.rb
@@ -75,6 +75,14 @@ module Inspec
       end
     end
 
+    # Allows bold and color
+    ANSI_CODES[:color].keys.each do |color|
+      define_method("bold_#{color}") do |str, opts = { print: true }|
+        result = color? ? (ANSI_CODES[:bold] + ANSI_CODES[:color][color] + str.to_s + ANSI_CODES[:reset]) : str.to_s
+        print_or_return(result, opts[:print])
+      end
+    end
+
     #=========================================================================#
     #                   High-Level formatting methods
     #=========================================================================#

--- a/test/fixtures/profiles/inspecstyle_violations/controls/host_spec.rb
+++ b/test/fixtures/profiles/inspecstyle_violations/controls/host_spec.rb
@@ -1,0 +1,13 @@
+# copyright: 2015, Chef Software, Inc
+
+title 'Host example.com lookup'
+
+control 'test01' do
+  impact 0.5
+  title 'Catchy title'
+  desc 'example.com should always exist.'
+  attribute('amplifier_max_volume', value: 10)
+  describe host('example.com') do
+    it { should be_resolvable }
+  end
+end

--- a/test/fixtures/profiles/inspecstyle_violations/inspec.yml
+++ b/test/fixtures/profiles/inspecstyle_violations/inspec.yml
@@ -1,0 +1,13 @@
+name: complete
+title: complete example profile
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
+copyright_email: support@chef.io
+license: Apache-2.0
+summary: Testing stub
+version: 1.0.0
+license: Apache-2.0
+supports:
+- os-family: linux
+- os-family: bsd
+- os-family: windows

--- a/test/functional/inspec_check_test.rb
+++ b/test/functional/inspec_check_test.rb
@@ -27,7 +27,7 @@ describe "inspec check" do
     it "outputs as normal" do
       out = inspec("check " + example_profile + " --inspecstyle")
       assert_exit_code 0, out
-      out.stdout.must_include("no offenses detected")
+      _(out.stdout).must_include("no offenses detected")
     end
   end
 
@@ -35,7 +35,7 @@ describe "inspec check" do
     it "shows standard violations" do
       out = inspec("check " + File.join(profile_path, "inspecstyle_violations") + " --inspecstyle")
       assert_exit_code 0, out
-      out.stdout.must_include("1 offense detected")
+      _(out.stdout).must_include("1 offense detected")
     end
   end
 

--- a/test/functional/inspec_check_test.rb
+++ b/test/functional/inspec_check_test.rb
@@ -23,6 +23,22 @@ describe "inspec check" do
     end
   end
 
+  describe "inspecstyle with no violations" do
+    it "outputs as normal" do
+      out = inspec("check " + example_profile + " --inspecstyle")
+      assert_exit_code 0, out
+      out.stdout.must_include("no offenses detected")
+    end
+  end
+
+  describe "inspecstyle with violations" do
+    it "shows standard violations" do
+      out = inspec("check " + File.join(profile_path, "inspecstyle_violations") + " --inspecstyle")
+      assert_exit_code 0, out
+      out.stdout.must_include("1 offense detected")
+    end
+  end
+
   describe "inspec check with skipping/failing a resource in FilterTable" do
     it "can check a profile containing resource exceptions" do
       out = inspec("check " + File.join(profile_path, "profile-with-resource-exceptions"))


### PR DESCRIPTION
With the `--inspecstyle` flag after `inspec check`, this will execute
a full run of the `inspecstyle` gem against the target file or
directory. As the aim is to have this default in InSpec 5.

It also includes additional information including how to get involved in
the discussion around future InSpecStyle rules; and that there are other
InSpecStyle tools available.

Aha! Link: https://chef.aha.io/features/SH-2629