### PR TITLE
Switch to builtin expeditor action for package cache purge

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -165,7 +165,7 @@ subscriptions:
     - built_in:promote_habitat_packages
     - bash:.expeditor/publish-release-notes.sh:
        post_commit: true
-    - bash:.expeditor/purge-cdn.sh:
+    - purge_packages_chef_io_fastly:{{target_channel}}/inspec/latest
        post_commit: true
     - bash:.expeditor/announce-release.sh:
        post_commit: true

--- a/.expeditor/purge-cdn.sh
+++ b/.expeditor/purge-cdn.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eou pipefail
-
-echo "Purging '${EXPEDITOR_CHANNEL}/${EXPEDITOR_PRODUCT_KEY}/latest' Surrogate Key group from Fastly"
-curl -X POST -H "Fastly-Key: $FASTLY_API_TOKEN" "https://api.fastly.com/service/1ga2Kt6KclvVvCeUYJ3MRp/purge/${EXPEDITOR_CHANNEL}/${EXPEDITOR_PRODUCT_KEY}/latest"


### PR DESCRIPTION
Using our own bash script doesn't seem to be supported anymore.

Signed-off-by: James Stocks <jstocks@chef.io>

Aha! Link: https://chef.aha.io/features/SH-2659