### PR TITLE
Supports Scientific Linux in service resource

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -141,7 +141,7 @@ module Inspec::Resources
         elsif version > 0
           SysV.new(inspec, service_ctl || "/usr/sbin/service")
         end
-      when "redhat", "fedora", "centos", "oracle", "cloudlinux"
+      when "redhat", "fedora", "centos", "oracle", "cloudlinux", "scientific"
         version = os[:release].to_i
 
         systemd = ((platform != "fedora" && version >= 7) ||


### PR DESCRIPTION
Currently when using Scientific Linux the user will be prompted with the
unsupported OS error message. As it is based on RHEL, it should be able
to be supported inn the same way.

Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-2701