### PR TITLE
Ensure truncate message only returns on truncated values

### DIFF
--- a/lib/inspec/plugin/v2/plugin_types/reporter.rb
+++ b/lib/inspec/plugin/v2/plugin_types/reporter.rb
@@ -31,17 +31,14 @@ module Inspec::Plugin::V2::PluginType
       runtime_config = Inspec::Config.cached.respond_to?(:final_options) ? Inspec::Config.cached.final_options : {}
 
       message_truncation = runtime_config[:reporter_message_truncation] || "ALL"
-      trunc = message_truncation == "ALL" ? -1 : message_truncation.to_i
+      @trunc = message_truncation == "ALL" ? -1 : message_truncation.to_i
       include_backtrace = runtime_config[:reporter_backtrace_inclusion].nil? ? true : runtime_config[:reporter_backtrace_inclusion]
 
       @run_data[:profiles]&.each do |p|
         p[:controls].each do |c|
           c[:results]&.map! do |r|
             r.delete(:backtrace) unless include_backtrace
-            if r.key?(:message) && r[:message] != "" && trunc > -1
-              r[:message] = r[:message][0...trunc] + "[Truncated to #{trunc} characters]"
-            end
-            r
+            process_message_truncation(r)
           end
         end
       end
@@ -63,6 +60,15 @@ module Inspec::Plugin::V2::PluginType
 
     def self.run_data_schema_constraints
       raise NotImplementedError, "#{self.class} must implement a `run_data_schema_constraints` class method to declare its compatibiltity with the RunData API."
+    end
+
+    private
+
+    def process_message_truncation(result)
+      if result.key?(:message) && result[:message] != "" && @trunc > -1 && result[:message].length > @trunc
+        result[:message] = result[:message][0...@trunc] + "[Truncated to #{@trunc} characters]"
+      end
+      result
     end
   end
 end

--- a/lib/inspec/reporters/base.rb
+++ b/lib/inspec/reporters/base.rb
@@ -14,17 +14,14 @@ module Inspec::Reporters
       runtime_config = Inspec::Config.cached.respond_to?(:final_options) ? Inspec::Config.cached.final_options : {}
 
       message_truncation = runtime_config[:reporter_message_truncation] || "ALL"
-      trunc = message_truncation == "ALL" ? -1 : message_truncation.to_i
+      @trunc = message_truncation == "ALL" ? -1 : message_truncation.to_i
       include_backtrace = runtime_config[:reporter_backtrace_inclusion].nil? ? true : runtime_config[:reporter_backtrace_inclusion]
 
       @run_data[:profiles]&.each do |p|
         p[:controls].each do |c|
           c[:results]&.map! do |r|
             r.delete(:backtrace) unless include_backtrace
-            if r.key?(:message) && r[:message] != "" && trunc > -1
-              r[:message] = r[:message][0...trunc] + "[Truncated to #{trunc} characters]"
-            end
-            r
+            process_message_truncation(r)
           end
         end
       end
@@ -42,6 +39,15 @@ module Inspec::Reporters
     # each reporter must implement #render
     def render
       raise NotImplementedError, "#{self.class} must implement a `#render` method to format its output."
+    end
+
+    private
+
+    def process_message_truncation(result)
+      if result.key?(:message) && result[:message] != "" && @trunc > -1 && result[:message].length > @trunc
+        result[:message] = result[:message][0...@trunc] + "[Truncated to #{@trunc} characters]"
+      end
+      result
     end
   end
 end

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -299,6 +299,16 @@ describe "inspec exec with json formatter" do
     end
   end
 
+  describe "JSON reporter with reporter-message-truncation set to a number and working message" do
+    let(:raw) { inspec("exec " + failure_control + " --reporter json --reporter-message-truncation=10000 --no-create-lockfile").stdout }
+    let(:json) { JSON.load(raw) }
+    let(:profile) { json["profiles"][0] }
+    let(:control_with_message) { profile["controls"].find { |c| c["id"] == "Generates a message" } }
+    it "does not report a truncated message" do
+      assert !control_with_message["results"].first["message"].include?("Truncated")
+    end
+  end
+
   describe "JSON reporter with reporter-message-truncation set to ALL" do
     let(:raw) { inspec("exec " + failure_control + " --reporter json --reporter-message-truncation=ALL --no-create-lockfile").stdout }
     let(:json) { JSON.load(raw) }


### PR DESCRIPTION
At the moment we return the "Truncate" text whenever the setting is
utilized. This PR ensures that we only advise truncation when it's been
executed.

Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>

## Related Issue

Fixes #5162 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-2702