### PR TITLE
fix error in passwd example

### DIFF
--- a/docs/resources/passwd.md.erb
+++ b/docs/resources/passwd.md.erb
@@ -39,7 +39,7 @@ A `passwd` resource block declares one (or more) users and associated user infor
       its('users') { should_not include 'forbidden_user' }
     end
 
-    describe passwd.uid(filter) do
+    describe passwd.uids(filter) do
       its('users') { should cmp 'root' }
       its('count') { should eq 1 }
     end


### PR DESCRIPTION
## Description
Fixes a spelling error in the passwd example. If you try to run the example provided you will get an error message:

NoMethodError: undefined method `uid' for /etc/passwd:#<Class:0x00000000058e7a60>
from (pry):61:in `load_with_context'

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
