### PR TITLE
Ensure Darwin is always detected in the install scripts

### DIFF
--- a/omnibus/package-scripts/inspec/postinst
+++ b/omnibus/package-scripts/inspec/postinst
@@ -17,7 +17,7 @@ error_exit()
 
 is_darwin()
 {
-  uname -v | grep "^Darwin" 2>&1 >/dev/null
+  uname -a | grep "^Darwin" 2>&1 >/dev/null
 }
 
 if is_darwin; then
@@ -41,6 +41,6 @@ done
 # be manually fixed.
 chown -Rh 0:0 $INSTALLER_DIR
 
-echo "Thank you for installing InSpec!"
+echo "Thank you for installing Chef InSpec!"
 
 exit 0

--- a/omnibus/package-scripts/inspec/postrm
+++ b/omnibus/package-scripts/inspec/postrm
@@ -6,7 +6,7 @@
 
 is_darwin()
 {
-  uname -v | grep "^Darwin" 2>&1 >/dev/null
+  uname -a | grep "^Darwin" 2>&1 >/dev/null
 }
 
 if is_darwin; then
@@ -32,6 +32,6 @@ elif [ "x$1" = "x0" ]; then
   cleanup_symlinks
 fi
 
-echo "InSpec has been uninstalled!"
+echo "Chef InSpec has been uninstalled!"
 
 exit 0


### PR DESCRIPTION
This is more reliable if the output changes

Signed-off-by: Tim Smith <tsmith@chef.io>