### PR TITLE
Move windows bomb forward pre-emptively

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -147,8 +147,11 @@ class Minitest::Test
     skip msg
   end
 
+  # These tests are being worked on. There is an ongoing discussion whether the
+  # 'bomb' is helpful as it requires rebases of all active community PRs when
+  # we hit it. Context: https://github.com/inspec/inspec/pull/5063
   def skip_windows!
-    skip_until 2020, 9, 1, "These have never passed" if windows?
+    skip_until 2021, 1, 1, "These have never passed" if windows?
   end
 
   def unmock(&blk)


### PR DESCRIPTION
These tests are being worked on, and there has been internal discussion
about the value of this bomb. I am not taking a stance on that at this
point. However, when we do hit a bomb that requires all repo PRs (
including community ) to do a rebase after we do a fixing PR.

To prevent this while our team resource is somewhat limited I am going
to pre-emptively push this out.

Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
