### PR TITLE
Bump faraday dependencies

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mixlib-log",         "~> 3.0"
   spec.add_dependency "sslshake",           "~> 1.2"
   spec.add_dependency "parallel",           "~> 1.9"
-  spec.add_dependency "faraday",            ">= 0.9.0"
+  spec.add_dependency "faraday",            ">= 0.9.0", "< 1.1"
   spec.add_dependency "tty-table",          "~> 0.10"
   spec.add_dependency "tty-prompt",         "~> 0.17"
   spec.add_dependency "tomlrb",             "~> 1.2.0"

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "train", "~> 3.0"
 
   # Used for Azure profile until integrated into train
-  spec.add_dependency "faraday_middleware", "~> 0.12.2"
+  spec.add_dependency "faraday_middleware", ">= 0.12.2", "< 1.1"
 
   # Train plugins we ship with InSpec
   spec.add_dependency "train-habitat", "~> 0.1"


### PR DESCRIPTION
There are several outstanding issues about bumping faraday and
faraday_middleware. This gives us access to additional HTTP methods and
the versions we are pinned to are quite old.

Fixes #4234

This also helps us test out whether this bump passes our CI.

Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>
