### PR TITLE
Enforced bump. Fully allow this to build before merge.

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -162,7 +162,7 @@ subscriptions:
     # - built_in:rollover_changelog
     # - built_in:publish_rubygems
     # - built_in:create_github_release
-    # # - built_in:tag_docker_image No longer exists
+    # # - built_in:tag_docker_image No longer exists #
     # - built_in:promote_habitat_packages
     # - bash:.expeditor/publish-release-notes.sh:
     #    post_commit: true

--- a/lib/bundles/inspec-supermarket/cli.rb
+++ b/lib/bundles/inspec-supermarket/cli.rb
@@ -5,7 +5,7 @@ module Supermarket
   class SupermarketCLI < Inspec::BaseCLI
     namespace "supermarket"
 
-    # TODO: find another solution, once https://github.com/erikhuda/thor/issues/261 is fixed
+    # TODO: find another solution, once https://github.com/erikhuda/thor/issues/261 is fixed.
     def self.banner(command, _namespace = nil, _subcommand = false)
       "#{basename} #{subcommand_prefix} #{command.usage}"
     end


### PR DESCRIPTION
Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>

We will hopefully catch future expeditor changes to publish so that expeditor can catch them quickly. (with the only_if changes)

For now, this also includes a dummy /lib change to try and trigger full release. Will let this completely build, merge to master, then completely build, then try InSpec promote. If continued issues, will cycle again to releng and go to bed to start again tomorrow.