### PR TITLE
Update oracledb_session.rb

### DIFF
--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -48,7 +48,7 @@ module Inspec::Resources
         format_options = "set sqlformat csv\nSET FEEDBACK OFF"
       else
         @bin = "#{@sqlplus_bin} -S"
-        format_options = "SET MARKUP CSV ON\nSET PAGESIZE 32000\nSET FEEDBACK OFF"
+        format_options = "SET PAGESIZE 32000\nSET FEEDBACK OFF\nSET UNDERLINE OFF"
       end
 
       command = command_builder(format_options, sql)

--- a/test/unit/resources/oracledb_session_test.rb
+++ b/test/unit/resources/oracledb_session_test.rb
@@ -7,7 +7,7 @@ describe "Inspec::Resources::OracledbSession" do
     resource = quick_resource(:oracledb_session, :linux, user: "USER", password: "password", host: "localhost", service: "ORCL", port: 1527, sqlplus_bin: "/bin/sqlplus") do |cmd|
       cmd.strip!
       case cmd
-      when "/bin/sqlplus -S \"USER\"/\"password\"@localhost:1527/ORCL <<'EOC'\nSET MARKUP CSV ON\nSET PAGESIZE 32000\nSET FEEDBACK OFF\nSELECT NAME AS VALUE FROM v$database;\nEXIT\nEOC" then
+      when "/bin/sqlplus -S \"USER\"/\"password\"@localhost:1527/ORCL <<'EOC'\nSET PAGESIZE 32000\nSET FEEDBACK OFF\nSET UNDERLINE OFF\nSELECT NAME AS VALUE FROM v$database;\nEXIT\nEOC" then
         stdout_file "test/fixtures/cmd/oracle-result"
       else
         raise cmd.inspect
@@ -24,7 +24,7 @@ describe "Inspec::Resources::OracledbSession" do
     resource = quick_resource(:oracledb_session, :windows, user: "USER", password: "password", host: "localhost", service: "ORCL", port: 1527, sqlplus_bin: "C:/sqlplus.exe") do |cmd|
       cmd.strip!
       case cmd
-      when "@'\nSET MARKUP CSV ON\nSET PAGESIZE 32000\nSET FEEDBACK OFF\nSELECT NAME AS VALUE FROM v$database;\nEXIT\n'@ | C:/sqlplus.exe -S \"USER\"/\"password\"@localhost:1527/ORCL" then
+      when "@'\nSET PAGESIZE 32000\nSET FEEDBACK OFF\nSET UNDERLINE OFF\nSELECT NAME AS VALUE FROM v$database;\nEXIT\n'@ | C:/sqlplus.exe -S \"USER\"/\"password\"@localhost:1527/ORCL" then
         stdout_file "test/fixtures/cmd/oracle-result"
       else
         raise cmd.inspect


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
Running inspec from the database servers and using oracledb_session will fail, when the database server version is 12.1 or 11g. This is because the sqlplus version installed in the database servers will match with the database versions.

oracledb_session is using the following format options:
format_options = "SET MARKUP CSV ON\nSET PAGESIZE 32000\nSET FEEDBACK OFF"

Unfortunately "SET MARKUP CSV ON" was introduced in sqlplus version 12.2.0.1. So prior versions will miss it.
Reference:
https://docs.oracle.com/en/database/oracle/oracle-database/12.2/sqprn/index.html#SQPRN-GUID-98CEF1F8-FB5A-495F-8771-693546655613


The workaround provided by this PR is to replace the format options with a more generic set:
format_options = "SET PAGESIZE 32000\nSET FEEDBACK OFF\nSET UNDERLINE OFF"


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
[oracledb_session doesnt work with sqlplus 12.1 or lower. ](https://github.com/inspec/inspec/issues/5182)
 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [X] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
