### PR TITLE
Don't build packages for EOL Debian 8

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -7,8 +7,7 @@ fips-platforms:
   - el-*-x86_64
   - windows-*
 builder-to-testers-map:
-  debian-8-x86_64:
-    - debian-8-x86_64
+  debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
   el-6-x86_64:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -45,13 +45,6 @@ platforms:
     image: dokken/centos-7
     pid_one_command: /usr/lib/systemd/systemd
 
-- name: debian-8
-  driver:
-    image: dokken/debian-8
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update -y
-
 - name: debian-9
   driver:
     image: dokken/debian-9

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -25,8 +25,6 @@ platforms:
     run_list: yum-epel::default
   - name: centos-7
     run_list: yum-epel::default
-  - name: debian-8
-    run_list: apt::default
   - name: debian-9
     run_list: apt::default
   - name: ubuntu-16.04


### PR DESCRIPTION
Debian 8 is out of support and we shouldn't produce packages for it anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>