### PR TITLE
Update omnibus builds to Ruby 2.6.6

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -39,13 +39,13 @@ Write-Host "--- Installing $pkg_ident/$pkg_artifact"
 hab pkg install -b $project_root/results/$pkg_artifact
 
 Write-Host "--- Downloading Ruby + DevKit"
-aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.5-1-x64.exe c:/rubyinstaller-devkit-2.6.5-1-x64.exe
+aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.6-1-x64.exe c:/rubyinstaller-devkit-2.6.6-1-x64.exe
 
 Write-Host "--- Installing Ruby + DevKit"
-Start-Process c:\rubyinstaller-devkit-2.6.5-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
+Start-Process c:\rubyinstaller-devkit-2.6.6-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
 
 Write-Host "--- Cleaning up installation"
-Remove-Item c:\rubyinstaller-devkit-2.6.5-1-x64.exe -Force
+Remove-Item c:\rubyinstaller-devkit-2.6.6-1-x64.exe -Force
 
 $Env:Path += ";C:\ruby26\bin;C:\hab\bin"
 

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -3,4 +3,4 @@
 # grab the current train release from rubygems.org
 train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
 override "train", version: "v#{train_stable}"
-override "ruby", version: "2.6.5"
+override "ruby", version: "2.6.6"


### PR DESCRIPTION
2.6.5 has 2 CVEs in it:

    CVE-2020-10663: Unsafe Object Creation Vulnerability in JSON (Additional fix)
    CVE-2020-10933: Heap exposure vulnerability in the socket library

Signed-off-by: Tim Smith <tsmith@chef.io>