### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "net/http"
-require "addressable/uri"
+require "net/http" unless defined?(Net::HTTP)
+require "addressable/uri" unless defined?(Addressable::URI)
 
 module Supermarket
   class API

--- a/lib/bundles/inspec-supermarket/target.rb
+++ b/lib/bundles/inspec-supermarket/target.rb
@@ -1,4 +1,4 @@
-require "uri"
+require "uri" unless defined?(URI)
 require "inspec/fetcher"
 require "inspec/fetcher/url"
 

--- a/lib/inspec/archive/zip.rb
+++ b/lib/inspec/archive/zip.rb
@@ -1,6 +1,6 @@
-require "rubygems"
+require "rubygems" unless defined?(Gem)
 require "zip"
-require "pathname"
+require "pathname" unless defined?(Pathname)
 
 module Inspec::Archive
   class ZipArchiveGenerator

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -1,4 +1,4 @@
-require "thor"
+require "thor" unless defined?(Thor)
 require "inspec/log"
 require "inspec/ui"
 require "inspec/config"

--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -1,5 +1,5 @@
 require "inspec/fetcher"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 module Inspec
   class CachedFetcher

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -66,7 +66,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "A list of controls to include. Ignore all other tests."
   profile_options
   def json(target)
-    require "json"
+    require "json" unless defined?(JSON)
 
     o = config
     diagnose(o)

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -1,10 +1,10 @@
 # Represents InSpec configuration.  Merges defaults, config file options,
 # and CLI arguments.
 
-require "pp"
-require "stringio"
-require "forwardable"
-require "thor"
+require "pp" unless defined?(PP)
+require "stringio" unless defined?(StringIO)
+require "forwardable" unless defined?(Forwardable)
+require "thor" unless defined?(Thor)
 require "base64"
 require "inspec/plugin/v2/filter"
 

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -1,4 +1,4 @@
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 module Inspec
   #

--- a/lib/inspec/dependencies/lockfile.rb
+++ b/lib/inspec/dependencies/lockfile.rb
@@ -1,4 +1,4 @@
-require "yaml"
+require "yaml" unless defined?(YAML)
 
 module Inspec
   class Lockfile

--- a/lib/inspec/env_printer.rb
+++ b/lib/inspec/env_printer.rb
@@ -1,6 +1,6 @@
 require "inspec/shell_detector"
-require "erb"
-require "shellwords"
+require "erb" unless defined?(Erb)
+require "shellwords" unless defined?(Shellwords)
 
 module Inspec
   class EnvPrinter

--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -1,6 +1,6 @@
-require "tmpdir"
-require "fileutils"
-require "mixlib/shellout"
+require "tmpdir" unless defined?(Dir.mktmpdir)
+require "fileutils" unless defined?(FileUtils)
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 require "inspec/log"
 
 module Inspec::Fetcher

--- a/lib/inspec/fetcher/local.rb
+++ b/lib/inspec/fetcher/local.rb
@@ -1,4 +1,4 @@
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 
 module Inspec::Fetcher
   class Local < Inspec.fetcher(1)

--- a/lib/inspec/fetcher/url.rb
+++ b/lib/inspec/fetcher/url.rb
@@ -1,6 +1,6 @@
-require "uri"
-require "openssl"
-require "tempfile"
+require "uri" unless defined?(URI)
+require "openssl" unless defined?(OpenSSL)
+require "tempfile" unless defined?(Tempfile)
 require "open-uri"
 
 module Inspec::Fetcher

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -1,5 +1,5 @@
 require "rubygems/package"
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require "zlib"
 require "zip"
 

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -1,5 +1,5 @@
-require "forwardable"
-require "singleton"
+require "forwardable" unless defined?(Forwardable)
+require "singleton" unless defined?(Singleton)
 require "inspec/input"
 require "inspec/secrets"
 require "inspec/exceptions"
@@ -189,12 +189,12 @@ module Inspec
         value = value.to_f
       when /^(\[|\{).*(\]|\})$/
         # Look for complex values and try to parse them.
-        require "yaml"
+        require "yaml" unless defined?(YAML)
         begin
           value = YAML.load(value)
         rescue Psych::SyntaxError => yaml_error
           # It could be that we just tried to run JSON through the YAML parser.
-          require "json"
+          require "json" unless defined?(JSON)
           begin
             value = JSON.parse(value)
           rescue JSON::ParserError => json_error

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -216,7 +216,7 @@ module Inspec
     end
 
     def self.from_yaml(ref, content, profile_id, logger = nil)
-      require "erb"
+      require "erb" unless defined?(Erb)
       res = Metadata.new(ref, logger)
       res.params = YAML.load(ERB.new(content).result)
       res.content = content

--- a/lib/inspec/plugin/v1/plugins.rb
+++ b/lib/inspec/plugin/v1/plugins.rb
@@ -1,4 +1,4 @@
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 module Inspec
   # Resource Plugins

--- a/lib/inspec/plugin/v2/config_file.rb
+++ b/lib/inspec/plugin/v2/config_file.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module Inspec::Plugin::V2
   # Represents the plugin config file on disk.

--- a/lib/inspec/plugin/v2/filter.rb
+++ b/lib/inspec/plugin/v2/filter.rb
@@ -1,5 +1,5 @@
-require "singleton"
-require "json"
+require "singleton" unless defined?(Singleton)
+require "json" unless defined?(JSON)
 require "inspec/globals"
 
 module Inspec::Plugin; end

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -1,9 +1,9 @@
 # This file is not required by default.
 
-require "singleton"
-require "forwardable"
-require "fileutils"
-require "uri"
+require "singleton" unless defined?(Singleton)
+require "forwardable" unless defined?(Forwardable)
+require "fileutils" unless defined?(FileUtils)
+require "uri" unless defined?(URI)
 
 # Gem extensions for doing unusual things - not loaded by Gem default
 require "rubygems/package"

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -125,7 +125,7 @@ module Inspec::Plugin::V2
     end
 
     def self.plugin_gem_path
-      require "rbconfig"
+      require "rbconfig" unless defined?(RbConfig)
       ruby_abi_version = RbConfig::CONFIG["ruby_version"]
       # TODO: why are we installing under the api directory for plugins?
       base_dir = Inspec.config_dir

--- a/lib/inspec/plugin/v2/registry.rb
+++ b/lib/inspec/plugin/v2/registry.rb
@@ -1,5 +1,5 @@
-require "forwardable"
-require "singleton"
+require "forwardable" unless defined?(Forwardable)
+require "singleton" unless defined?(Singleton)
 require "train"
 
 require_relative "status"

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -1,8 +1,8 @@
 # Copyright 2015 Dominik Richter
 
-require "forwardable"
-require "openssl"
-require "pathname"
+require "forwardable" unless defined?(Forwardable)
+require "openssl" unless defined?(OpenSSL)
+require "pathname" unless defined?(Pathname)
 require "inspec/input_registry"
 require "inspec/cached_fetcher" # TODO: split or rename
 require "inspec/source_reader"

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -4,7 +4,7 @@ require "inspec/resource"
 require "inspec/library_eval_context"
 require "inspec/control_eval_context"
 require "inspec/require_loader"
-require "securerandom"
+require "securerandom" unless defined?(SecureRandom)
 require "inspec/input_registry"
 
 module Inspec

--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -1,5 +1,5 @@
-require "json"
-require "net/http"
+require "json" unless defined?(JSON)
+require "net/http" unless defined?(Net::HTTP)
 
 module Inspec::Reporters
   class Automate < JsonAutomate

--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module Inspec::Reporters
   # rubocop:disable Layout/AlignHash, Style/BlockDelimiters

--- a/lib/inspec/reporters/json_automate.rb
+++ b/lib/inspec/reporters/json_automate.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module Inspec::Reporters
   class JsonAutomate < Json

--- a/lib/inspec/reporters/yaml.rb
+++ b/lib/inspec/reporters/yaml.rb
@@ -1,4 +1,4 @@
-require "yaml"
+require "yaml" unless defined?(YAML)
 
 module Inspec::Reporters
   class Yaml < Base

--- a/lib/inspec/resources/apt.rb
+++ b/lib/inspec/resources/apt.rb
@@ -24,7 +24,7 @@ require "inspec/resources/command"
 # apt-get install software-properties-common
 # add-apt-repository ppa:ubuntu-wine/ppa
 
-require "uri"
+require "uri" unless defined?(URI)
 
 module Inspec::Resources
   class AptRepository < Inspec.resource(1)

--- a/lib/inspec/resources/auditd.rb
+++ b/lib/inspec/resources/auditd.rb
@@ -1,4 +1,4 @@
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 require "inspec/utils/filter_array"
 require "inspec/utils/filter"
 require "inspec/utils/parser"

--- a/lib/inspec/resources/dh_params.rb
+++ b/lib/inspec/resources/dh_params.rb
@@ -1,4 +1,4 @@
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require "inspec/utils/file_reader"
 
 module Inspec::Resources

--- a/lib/inspec/resources/file.rb
+++ b/lib/inspec/resources/file.rb
@@ -1,6 +1,6 @@
 # copyright: 2015, Vulcano Security GmbH
 
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 require "inspec/utils/parser"
 
 module Inspec::Resources

--- a/lib/inspec/resources/interfaces.rb
+++ b/lib/inspec/resources/interfaces.rb
@@ -24,7 +24,7 @@ module Inspec::Resources
       .install_filter_methods_on_resource(self, :scan_interfaces)
 
     def ipv4_address
-      require "ipaddr"
+      require "ipaddr" unless defined?(IPAddr)
 
       # Loop over interface names
       # Select those that are up and have an ipv4 address

--- a/lib/inspec/resources/json.rb
+++ b/lib/inspec/resources/json.rb
@@ -66,7 +66,7 @@ module Inspec::Resources
     private
 
     def parse(content)
-      require "json"
+      require "json" unless defined?(JSON)
       JSON.parse(content)
     rescue => e
       raise Inspec::Exceptions::ResourceFailed, "Unable to parse JSON: #{e.message}"

--- a/lib/inspec/resources/key_rsa.rb
+++ b/lib/inspec/resources/key_rsa.rb
@@ -1,4 +1,4 @@
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require "hashie/mash"
 require "inspec/utils/file_reader"
 require "inspec/utils/pkey_reader"

--- a/lib/inspec/resources/mysql_session.rb
+++ b/lib/inspec/resources/mysql_session.rb
@@ -1,7 +1,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require "inspec/resources/command"
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 module Inspec::Resources
   class Lines

--- a/lib/inspec/resources/nginx.rb
+++ b/lib/inspec/resources/nginx.rb
@@ -1,4 +1,4 @@
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require "hashie/mash"
 require "inspec/resources/command"
 

--- a/lib/inspec/resources/nginx_conf.rb
+++ b/lib/inspec/resources/nginx_conf.rb
@@ -1,7 +1,7 @@
 require "inspec/utils/nginx_parser"
 require "inspec/utils/find_files"
 require "inspec/utils/file_reader"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 # STABILITY: Experimental
 # This resouce needs a proper interace to the underlying data, which is currently missing.

--- a/lib/inspec/resources/npm.rb
+++ b/lib/inspec/resources/npm.rb
@@ -1,5 +1,5 @@
 require "inspec/resources/command"
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 module Inspec::Resources
   class NpmPackage < Inspec.resource(1)

--- a/lib/inspec/resources/port.rb
+++ b/lib/inspec/resources/port.rb
@@ -1,6 +1,6 @@
 require "inspec/utils/parser"
 require "inspec/utils/filter"
-require "ipaddr"
+require "ipaddr" unless defined?(IPAddr)
 
 # TODO: currently we return local ip only
 # TODO: improve handling of same port on multiple interfaces

--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -1,6 +1,6 @@
 # copyright: 2015, Vulcano Security GmbH
 
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 module Inspec::Resources
   class Lines

--- a/lib/inspec/resources/processes.rb
+++ b/lib/inspec/resources/processes.rb
@@ -1,7 +1,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require "inspec/utils/filter"
-require "ostruct"
+require "ostruct" unless defined?(OpenStruct)
 require "inspec/resources/command"
 
 module Inspec::Resources

--- a/lib/inspec/resources/registry_key.rb
+++ b/lib/inspec/resources/registry_key.rb
@@ -1,6 +1,6 @@
 # copyright: 2015, Vulcano Security GmbH
 
-require "json"
+require "json" unless defined?(JSON)
 require "inspec/resources/powershell"
 
 # Three constructor methods are available:

--- a/lib/inspec/resources/ssl.rb
+++ b/lib/inspec/resources/ssl.rb
@@ -1,8 +1,8 @@
 # copyright: 2015, Chef Software Inc.
 
-require "sslshake"
+require "sslshake" unless defined?(SSLShake)
 require "inspec/utils/filter"
-require "uri"
+require "uri" unless defined?(URI)
 require "parallel"
 
 # Custom resource based on the InSpec resource DSL

--- a/lib/inspec/resources/toml.rb
+++ b/lib/inspec/resources/toml.rb
@@ -1,4 +1,4 @@
-require "tomlrb"
+require "tomlrb" unless defined?(Tomlrb)
 require "inspec/resources/json"
 
 module Inspec::Resources

--- a/lib/inspec/resources/vbscript.rb
+++ b/lib/inspec/resources/vbscript.rb
@@ -1,5 +1,5 @@
 require "inspec/resources/powershell"
-require "securerandom"
+require "securerandom" unless defined?(SecureRandom)
 
 module Inspec::Resources
   # This resource allows users to run vbscript on windows machines. We decided

--- a/lib/inspec/resources/x509_certificate.rb
+++ b/lib/inspec/resources/x509_certificate.rb
@@ -1,4 +1,4 @@
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require "hashie/mash"
 require "inspec/utils/file_reader"
 

--- a/lib/inspec/resources/xml.rb
+++ b/lib/inspec/resources/xml.rb
@@ -13,7 +13,7 @@ module Inspec::Resources
     EXAMPLE
 
     def parse(content)
-      require "rexml/document"
+      require "rexml/document" unless defined?(REXML::Document)
       REXML::Document.new(content)
     rescue => e
       raise Inspec::Exceptions::ResourceFailed, "Unable to parse XML: #{e.message}"

--- a/lib/inspec/resources/yaml.rb
+++ b/lib/inspec/resources/yaml.rb
@@ -1,4 +1,4 @@
-require "yaml"
+require "yaml" unless defined?(YAML)
 require "inspec/resources/json"
 
 # Parses a yaml document

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -1,7 +1,7 @@
 # copyright: 2015, Dominik Richter
 
-require "forwardable"
-require "uri"
+require "forwardable" unless defined?(Forwardable)
+require "uri" unless defined?(URI)
 require "inspec/backend"
 require "inspec/profile_context"
 require "inspec/profile"

--- a/lib/inspec/schema.rb
+++ b/lib/inspec/schema.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module Inspec
   class Schema

--- a/lib/inspec/schema/output_schema.rb
+++ b/lib/inspec/schema/output_schema.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 require "inspec/schema/primitives"
 require "inspec/schema/exec_json"
 require "inspec/schema/exec_json_min"

--- a/lib/inspec/schema/primitives.rb
+++ b/lib/inspec/schema/primitives.rb
@@ -1,4 +1,4 @@
-require "set"
+require "set" unless defined?(Set)
 
 # These elements are shared between more than one output type
 

--- a/lib/inspec/secrets/yaml.rb
+++ b/lib/inspec/secrets/yaml.rb
@@ -1,4 +1,4 @@
-require "yaml"
+require "yaml" unless defined?(YAML)
 
 module Secrets
   class YAML < Inspec.secrets(1)

--- a/lib/inspec/shell_detector.rb
+++ b/lib/inspec/shell_detector.rb
@@ -1,5 +1,5 @@
-require "etc"
-require "rbconfig"
+require "etc" unless defined?(Etc)
+require "rbconfig" unless defined?(RbConfig)
 
 module Inspec
   #

--- a/lib/inspec/utils/command_wrapper.rb
+++ b/lib/inspec/utils/command_wrapper.rb
@@ -1,4 +1,4 @@
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 class CommandWrapper
   UNIX_SHELLS = %w{sh bash zsh ksh}.freeze

--- a/lib/inspec/utils/deprecation/config_file.rb
+++ b/lib/inspec/utils/deprecation/config_file.rb
@@ -1,5 +1,5 @@
-require "stringio"
-require "json"
+require "stringio" unless defined?(StringIO)
+require "json" unless defined?(JSON)
 require "inspec/globals"
 require "inspec/config"
 

--- a/lib/inspec/utils/json_log.rb
+++ b/lib/inspec/utils/json_log.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 # a simple streaming json logger
 class Logger::JSONFormatter < Logger::Formatter

--- a/lib/inspec/utils/telemetry/collector.rb
+++ b/lib/inspec/utils/telemetry/collector.rb
@@ -1,6 +1,6 @@
 require "inspec/config"
 require "inspec/utils/telemetry/data_series"
-require "singleton"
+require "singleton" unless defined?(Singleton)
 
 module Inspec::Telemetry
   # A Singleton collection of data series objects.

--- a/lib/inspec/utils/telemetry/data_series.rb
+++ b/lib/inspec/utils/telemetry/data_series.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module Inspec; end
 

--- a/lib/plugins/inspec-artifact/lib/inspec-artifact/base.rb
+++ b/lib/plugins/inspec-artifact/lib/inspec-artifact/base.rb
@@ -1,9 +1,9 @@
 require "base64"
-require "openssl"
-require "pathname"
-require "set"
-require "tempfile"
-require "yaml"
+require "openssl" unless defined?(OpenSSL)
+require "pathname" unless defined?(Pathname)
+require "set" unless defined?(Set)
+require "tempfile" unless defined?(Tempfile)
+require "yaml" unless defined?(YAML)
 require "inspec/dist"
 require "inspec/utils/json_profile_summary"
 

--- a/lib/plugins/inspec-artifact/test/functional/inspec_artifact_test.rb
+++ b/lib/plugins/inspec-artifact/test/functional/inspec_artifact_test.rb
@@ -1,6 +1,6 @@
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 require "plugins/shared/core_plugin_test_helper"
-require "securerandom"
+require "securerandom" unless defined?(SecureRandom)
 
 class ArtifactCli < Minitest::Test
   include CorePluginFunctionalHelper

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/api.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/api.rb
@@ -1,6 +1,6 @@
-require "net/http"
-require "uri"
-require "json"
+require "net/http" unless defined?(Net::HTTP)
+require "uri" unless defined?(URI)
+require "json" unless defined?(JSON)
 require "inspec/dist"
 
 require_relative "api/login"

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/http.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/http.rb
@@ -1,6 +1,6 @@
-require "net/http"
+require "net/http" unless defined?(Net::HTTP)
 require "net/http/post/multipart"
-require "uri"
+require "uri" unless defined?(URI)
 
 module InspecPlugins
   module Compliance

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/target.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/target.rb
@@ -1,4 +1,4 @@
-require "uri"
+require "uri" unless defined?(URI)
 require "inspec/fetcher"
 require "inspec/errors"
 require "inspec/dist"

--- a/lib/plugins/inspec-habitat/lib/inspec-habitat/profile.rb
+++ b/lib/plugins/inspec-habitat/lib/inspec-habitat/profile.rb
@@ -1,7 +1,7 @@
 require "inspec/profile_vendor"
-require "mixlib/shellout"
-require "tomlrb"
-require "ostruct"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+require "tomlrb" unless defined?(Tomlrb)
+require "ostruct" unless defined?(OpenStruct)
 require "inspec/dist"
 
 module InspecPlugins

--- a/lib/plugins/inspec-habitat/test/functional/inspec_habitat_test.rb
+++ b/lib/plugins/inspec-habitat/test/functional/inspec_habitat_test.rb
@@ -1,5 +1,5 @@
 require_relative "../../../shared/core_plugin_test_helper.rb"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 class ProfileCli < Minitest::Test
   include CorePluginFunctionalHelper

--- a/lib/plugins/inspec-habitat/test/unit/profile_test.rb
+++ b/lib/plugins/inspec-habitat/test/unit/profile_test.rb
@@ -1,5 +1,5 @@
 require "mixlib/log"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 require "minitest/autorun"
 require "inspec/backend"
 require_relative "../../lib/inspec-habitat/profile.rb"

--- a/lib/plugins/inspec-init/lib/inspec-init/cli.rb
+++ b/lib/plugins/inspec-init/lib/inspec-init/cli.rb
@@ -1,4 +1,4 @@
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require_relative "renderer"
 
 module InspecPlugins

--- a/lib/plugins/inspec-init/lib/inspec-init/cli_profile.rb
+++ b/lib/plugins/inspec-init/lib/inspec-init/cli_profile.rb
@@ -1,4 +1,4 @@
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require_relative "renderer"
 
 module InspecPlugins

--- a/lib/plugins/inspec-init/lib/inspec-init/renderer.rb
+++ b/lib/plugins/inspec-init/lib/inspec-init/renderer.rb
@@ -1,5 +1,5 @@
-require "fileutils"
-require "erb"
+require "fileutils" unless defined?(FileUtils)
+require "erb" unless defined?(Erb)
 
 module InspecPlugins
   module Init

--- a/lib/plugins/inspec-init/test/functional/inspec_init_profile_test.rb
+++ b/lib/plugins/inspec-init/test/functional/inspec_init_profile_test.rb
@@ -1,4 +1,4 @@
-require "yaml"
+require "yaml" unless defined?(YAML)
 require_relative "../../../shared/core_plugin_test_helper.rb"
 
 class InitCli < Minitest::Test

--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -1,4 +1,4 @@
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require "inspec/plugin/v2"
 require "inspec/plugin/v2/installer"
 require "inspec/dist"

--- a/lib/plugins/inspec-reporter-html2/lib/inspec-reporter-html2/reporter.rb
+++ b/lib/plugins/inspec-reporter-html2/lib/inspec-reporter-html2/reporter.rb
@@ -1,4 +1,4 @@
-require "erb"
+require "erb" unless defined?(Erb)
 require "inspec/config"
 
 module InspecPlugins::Html2Reporter

--- a/lib/plugins/inspec-reporter-html2/test/functional/inspec_reporter_html2_test.rb
+++ b/lib/plugins/inspec-reporter-html2/test/functional/inspec_reporter_html2_test.rb
@@ -1,5 +1,5 @@
 require_relative "../../../shared/core_plugin_test_helper.rb"
-require "tempfile"
+require "tempfile" unless defined?(Tempfile)
 
 describe "inspec-reporter-html2" do
   include CorePluginFunctionalHelper

--- a/lib/plugins/inspec-reporter-json-min/lib/inspec-reporter-json-min/reporter.rb
+++ b/lib/plugins/inspec-reporter-json-min/lib/inspec-reporter-json-min/reporter.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module InspecPlugins::JsonMinReporter
   class Reporter < Inspec.plugin(2, :reporter)

--- a/lib/plugins/inspec-reporter-junit/lib/inspec-reporter-junit/reporter.rb
+++ b/lib/plugins/inspec-reporter-junit/lib/inspec-reporter-junit/reporter.rb
@@ -5,7 +5,7 @@ module InspecPlugins::JUnitReporter
     end
 
     def render
-      require "rexml/document"
+      require "rexml/document" unless defined?(REXML::Document)
       xml_output = REXML::Document.new
       xml_output.add(REXML::XMLDecl.new)
 

--- a/lib/plugins/shared/core_plugin_test_helper.rb
+++ b/lib/plugins/shared/core_plugin_test_helper.rb
@@ -3,14 +3,14 @@ require "minitest/autorun"
 require "minitest/pride"
 
 # Data formats commonly used in testing
-require "json"
-require "ostruct"
+require "json" unless defined?(JSON)
+require "ostruct" unless defined?(OpenStruct)
 
 # Utilities often needed
-require "fileutils"
-require "tmpdir"
-require "pathname"
-require "forwardable"
+require "fileutils" unless defined?(FileUtils)
+require "tmpdir" unless defined?(Dir.mktmpdir)
+require "pathname" unless defined?(Pathname)
+require "forwardable" unless defined?(Forwardable)
 
 require "functional/helper"
 require "inspec/plugin/v2"

--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -2,9 +2,9 @@ require "resource_support/aws/aws_singular_resource_mixin"
 require "resource_support/aws/aws_backend_base"
 require "aws-sdk-iam"
 
-require "json"
-require "set"
-require "uri"
+require "json" unless defined?(JSON)
+require "set" unless defined?(Set)
+require "uri" unless defined?(URI)
 
 class AwsIamPolicy < Inspec.resource(1)
   name "aws_iam_policy"

--- a/lib/resources/aws/aws_security_group.rb
+++ b/lib/resources/aws/aws_security_group.rb
@@ -1,5 +1,5 @@
-require "set"
-require "ipaddr"
+require "set" unless defined?(Set)
+require "ipaddr" unless defined?(IPAddr)
 
 require "resource_support/aws/aws_singular_resource_mixin"
 require "resource_support/aws/aws_backend_base"

--- a/lib/resources/aws/aws_sqs_queue.rb
+++ b/lib/resources/aws/aws_sqs_queue.rb
@@ -2,7 +2,7 @@ require "resource_support/aws/aws_singular_resource_mixin"
 require "resource_support/aws/aws_backend_base"
 require "aws-sdk-sqs"
 
-require "uri"
+require "uri" unless defined?(URI)
 
 class AwsSqsQueue < Inspec.resource(1)
   name "aws_sqs_queue"

--- a/lib/resources/azure/azure_virtual_machine_data_disk.rb
+++ b/lib/resources/azure/azure_virtual_machine_data_disk.rb
@@ -1,5 +1,5 @@
 require "resources/azure/azure_backend"
-require "uri"
+require "uri" unless defined?(URI)
 
 module Inspec::Resources
   class AzureVirtualMachineDataDisk < AzureResourceBase


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs of InSpec.

Signed-off-by: Tim Smith <tsmith@chef.io>