### PR TITLE
Don't ship the readme in the gem

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   # the gemfile and gemspec are necessary for appbundler so don't remove it
   spec.files =
-    Dir.glob("{{lib,etc}/**/*,README.md,LICENSE,Gemfile,inspec-core.gemspec}")
+    Dir.glob("{{lib,etc}/**/*,LICENSE,Gemfile,inspec-core.gemspec}")
       .grep_v(%r{(?<!inspec-init/templates/profiles/)(aws|azure|gcp)})
       .grep_v(%r{lib/plugins/.*/test/})
       .reject { |f| File.directory?(f) }


### PR DESCRIPTION
We're just deleting this from chef and workstation anyways. It's buried deep in the install directory and doesn't do anyone any good.

Signed-off-by: Tim Smith <tsmith@chef.io>