### PR TITLE
Remove htmlentities dependency

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "addressable",        "~> 2.4"
   spec.add_dependency "parslet",            "~> 1.5"
   spec.add_dependency "semverse",           "~> 3.0"
-  spec.add_dependency "htmlentities",       "~> 4.3" # TODO: remove when #4853 fixed
   spec.add_dependency "multipart-post",     "~> 2.0"
 
   spec.add_dependency "train-core", "~> 3.0"


### PR DESCRIPTION
#4853 has been closed and I can find this being used anywhere in the codebase.

Signed-off-by: Tim Smith <tsmith@chef.io>