### PR TITLE
WIP: Add ssl client parameters to the http resource

### DIFF
--- a/lib/inspec/resources/http.rb
+++ b/lib/inspec/resources/http.rb
@@ -115,6 +115,18 @@ module Inspec::Resources
         def ssl_verify?
           opts.fetch(:ssl_verify, true)
         end
+        
+        def ssl_client_cert?
+          opts.fetch(:ssl_client_cert, nil)
+        end
+        
+        def ssl_client_key?
+          opts.fetch(:ssl_client_key, nil)
+        end
+        
+        def ssl_client_cacert?
+          opts.fetch(:ssl_client_cacert, nil)
+        end
 
         def max_redirects
           opts.fetch(:max_redirects, 0)
@@ -242,6 +254,9 @@ module Inspec::Resources
           cmd << "--data #{Shellwords.shellescape(request_body)}" unless request_body.nil?
           cmd << "--location" if max_redirects > 0
           cmd << "--max-redirs #{max_redirects}" if max_redirects > 0
+          cmd << "--cacert #{ssl_client_cacert}" unless ssl_client_cacert.nil?
+          cmd << "--key #{ssl_client_key}" unless ssl_client_key.nil?
+          cmd << "--cert #{ssl_client_cert}" unless ssl_client_cert.nil?
 
           request_headers.each do |k, v|
             cmd << "-H '#{k}: #{v}'"

--- a/lib/inspec/resources/http.rb
+++ b/lib/inspec/resources/http.rb
@@ -116,15 +116,15 @@ module Inspec::Resources
           opts.fetch(:ssl_verify, true)
         end
 
-        def ssl_client_cert?
+        def ssl_client_cert
           opts.fetch(:ssl_client_cert, nil)
         end
 
-        def ssl_client_key?
+        def ssl_client_key
           opts.fetch(:ssl_client_key, nil)
         end
 
-        def ssl_client_cacert?
+        def ssl_client_cacert
           opts.fetch(:ssl_client_cacert, nil)
         end
 

--- a/lib/inspec/resources/http.rb
+++ b/lib/inspec/resources/http.rb
@@ -115,15 +115,15 @@ module Inspec::Resources
         def ssl_verify?
           opts.fetch(:ssl_verify, true)
         end
-        
+
         def ssl_client_cert?
           opts.fetch(:ssl_client_cert, nil)
         end
-        
+
         def ssl_client_key?
           opts.fetch(:ssl_client_key, nil)
         end
-        
+
         def ssl_client_cacert?
           opts.fetch(:ssl_client_cacert, nil)
         end


### PR DESCRIPTION
## Description
The http resource can now be used on endpoints requiring a TL client certificate.

## Related Issue
https://github.com/inspec/inspec/issues/5206

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
