### PR TITLE
Enable profile-bundled plugins

### DIFF
--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -30,6 +30,12 @@ The normal distribution and installation method is via gems, handled by the `ins
 
 For more on the `plugin` CLI command, run `inspec plugin help`.
 
+### Plugins can be bundled with a profile
+
+If plugin code is tightly coupled to one profile only, you can bundle it into the profile by placing it into the `libraries/` directory.
+
+The plugin name must be prefixed with "profile" to handle loading properly.
+
 ### Plugins may also be found by path to a source tree
 
 For local development or site-specific installations, you can also 'install' a plugin by path using `inspec plugin`, or edit `~/.inspec/plugins.json` directly to add a plugin.

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -49,6 +49,9 @@ module Inspec::Plugin::V2
       # Be careful not to actually iterate directly over the registry here;
       # we want to allow "sidecar loading", in which case a plugin may add an entry to the registry.
       registry.plugin_names.dup.each do |plugin_name|
+        # Skip plugins bundled with profiles, which get loaded automatically
+        next if registry.profile_bundled_plugin?(plugin_name)
+
         plugin_details = registry[plugin_name]
         # We want to capture literally any possible exception here, since we are storing them.
         # rubocop: disable Lint/RescueException

--- a/lib/inspec/plugin/v2/registry.rb
+++ b/lib/inspec/plugin/v2/registry.rb
@@ -50,6 +50,12 @@ module Inspec::Plugin::V2
       known_plugin?(name.to_sym) && registry[name.to_sym].installation_type == :path
     end
 
+    def profile_bundled_plugin?(name)
+      return unless known_plugin?(name.to_sym)
+
+      registry[name.to_sym].installation_type == :profile_bundled || name.start_with?("profile")
+    end
+
     def find_status_by_class(klass)
       registry.values.detect { |status| status.plugin_class == klass }
     end


### PR DESCRIPTION
## Description

_PR for discussion about this topic, following an example implementation_

In some bigger profiles, we encounter the need to add profile specific DSL methods as the controls themselves are handled by non-programmers. As these specifics are only valid in this one profile, we would like to bundle a plugin in the `libraries` path instead of spamming Gem files in 1:1 relations.

So far, this seems to trigger some test-related code in [`loader.rb`](https://github.com/inspec/inspec/blob/7888738cc096e92a9822cb8a8a17c21d1dc2968e/lib/inspec/plugin/v2/loader.rb#L64-L68) and result in a crash:

```
-----> Verifying <two-amazon2>...
[2020-08-14T14:38:52+00:00] ERROR: Could not load plugin profile-bundled: cannot load such file -- inline.rb
[2020-08-14T14:38:52+00:00] ERROR: Errors were encountered while loading plugins...
[2020-08-14T14:38:52+00:00] ERROR: Plugin name: profile-bundled
[2020-08-14T14:38:52+00:00] ERROR: Error: cannot load such file -- inline.rb
[2020-08-14T14:38:52+00:00] ERROR: Run again with --debug for a stacktrace.
```

The circumstances are pretty special: the run must be from within kitchen (`kitchen verify`) with more than one instance under test. The second instance under test then throws the error (maybe related to Singleton usage in Registry?).

My proposition is to skip the code in question for "profile-bundled" plugins to enable this sort of extension. My implementation is only looking for a name prefix so far, but maybe a way to set a plugin installation method to `:profile_bundled` would be cleaner. 

## Related Issue

No filed issue yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
