### PR TITLE
Add ability to disable input caching for kitchen-inspec use

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -285,6 +285,20 @@ As of Chef InSpec 4.12, this mechanism has the following limitations:
   1. No [input options](#input-options-reference) may be set - only the name and value.
   2. Because the CLI is outside the scope of any individual profile and the inputs don't take options, the inputs are clumsily copied into every profile, effectively making the CLI mechanism global.
 
+## Setting Input values using Plugins
+
+Inputs can also be set by custom input plugins, which retrieve values from external sources like secret stores or databases. Please check Rubygems.Org for available InSpec input plugins.
+
+### Disabling Caching for Inputs
+
+Especially with plugins, it can be desirable to re-evaluate inputs every time and not cache them. By default, an existing input value is reused which can lead to problems if the retrieved values are expected to change. An example for this is using `kitchen-inspec` with input plugins to connect to a Vault server for password retrieval.
+
+To disable input caching, you can disable the cache from your Ruby code:
+
+```ruby
+Inspec::InputRegistry.instance.cache_inputs = false
+```
+
 ## Input Options Reference
 
 ### Name

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -29,6 +29,8 @@ module Inspec
     def_delegator :inputs_by_profile, :select
     def_delegator :profile_aliases, :key?, :profile_alias?
 
+    attr_accessor :cache_inputs
+
     def initialize
       # Keyed on String profile_name => Hash of String input_name => Input object
       @inputs_by_profile = {}
@@ -43,6 +45,9 @@ module Inspec
         activator.activate!
         activator.implementation_class.new
       end
+
+      # Activate caching for inputs by default
+      @cache_inputs = true
     end
 
     #-------------------------------------------------------------#
@@ -84,7 +89,7 @@ module Inspec
 
       # Find or create the input
       inputs_by_profile[profile_name] ||= {}
-      if inputs_by_profile[profile_name].key?(input_name)
+      if inputs_by_profile[profile_name].key?(input_name) && cache_inputs
         inputs_by_profile[profile_name][input_name].update(options)
       else
         inputs_by_profile[profile_name][input_name] = Inspec::Input.new(input_name, options)


### PR DESCRIPTION
## Description

When trying to test with input plugins from `kitchen-inspec` the [caching of past values for an input](https://github.com/inspec/inspec/blob/c5ee0ea5970376e48f5eabe4ecddd71c02c52809/lib/inspec/input_registry.rb#L87-L88) will cause problems.

With a `kitchen.yml` like ...

```yaml
verifier:
  load_plugins: true

suites:
  - name: one
    run_list:
      - recipe[test_cookbook]
    attributes:
      value: one
    control:
      - cache_check
  - name: two
    run_list:
      - recipe[test_cookbook]
    attributes:
      value: two
    control:
      - cache_check
```
... and using the `inspec-chef` plugin via ...

```ruby
control 'cache_check' do
  describe file('/tmp/') do
    let(:value) { input('node:///attributes/value') }

    its('content') { should cmp value }
  end
end
```

... only the first suite gets the correct attribute value "one" and every other suite gets "one" as well as the input name is identical.

This turned into a blocker for a project where a cookbook is supposed to install different MS SQL versions/editions controlled by data bags as central site configuration. Having one `kitchen converge` will access the cached values due to use of `Singleton` in `InputRegistry`. Making a separate `kitchen` call for each suite/platform combination would work.

I added a setting `cache_inputs` (default: `true`) to the `InputRegistry` which is accessible via API and added as separate condition.

For `kitchen-inspec` related changes, see [kitchen-inspec PR #258](https://github.com/inspec/kitchen-inspec/pull/258)

## Related Issue

No filed issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
