### PR TITLE
Add MacOS 11 Tester

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -24,6 +24,7 @@ builder-to-testers-map:
     - mac_os_x-10.13-x86_64
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
+    - mac_os_x-11.0-x86_64
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64


### PR DESCRIPTION
## Description

This PR just adds the new MacOS 11 "Big Sur" Omnibus Tester.

An adhoc build demonstrating the MacOS 11 Tester can be found here:

https://buildkite.com/chef/inspec-inspec-master-omnibus-adhoc/builds/156

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
