### PR TITLE
Fix mysql_session stdout, stderr and exit_status parameters

### DIFF
--- a/docs/resources/mysql_session.md.erb
+++ b/docs/resources/mysql_session.md.erb
@@ -24,14 +24,14 @@ This resource first became available in v1.0.0 of InSpec.
 A `mysql_session` resource block declares the username and password to use for the session, and then the command to be run:
 
     describe mysql_session('username', 'password').query('QUERY') do
-      its('stdout') { should match(/expected-result/) }
+      its('output') { should match(/expected-result/) }
     end
 
 where
 
 * `mysql_session` declares a username and password, connecting locally, with permission to run the query
 * `query('QUERY')` contains the query to be run
-* `its('stdout') { should eq(/expected-result/) }` compares the results of the query against the expected result in the test
+* `its('output') { should eq(/expected-result/) }` compares the results of the query against the expected result in the test
 
 <br>
 
@@ -44,7 +44,7 @@ The following examples show how to use this Chef InSpec audit resource.
     sql = mysql_session('my_user','password')
 
     describe sql.query('show databases like \'test\';') do
-      its('stdout') { should_not match(/test/) }
+      its('output') { should_not match(/test/) }
     end
 
 ### Alternate Connection: Different Host

--- a/www/content/inspec/resources/mysql_session.md
+++ b/www/content/inspec/resources/mysql_session.md
@@ -29,14 +29,14 @@ This resource first became available in v1.0.0 of InSpec.
 A `mysql_session` resource block declares the username and password to use for the session, and then the command to be run:
 
     describe mysql_session('username', 'password').query('QUERY') do
-      its('stdout') { should match(/expected-result/) }
+      its('output') { should match(/expected-result/) }
     end
 
 where
 
 - `mysql_session` declares a username and password, connecting locally, with permission to run the query
 - `query('QUERY')` contains the query to be run
-- `its('stdout') { should eq(/expected-result/) }` compares the results of the query against the expected result in the test
+- `its('output') { should eq(/expected-result/) }` compares the results of the query against the expected result in the test
 
 ## Examples
 
@@ -47,7 +47,7 @@ The following examples show how to use this Chef InSpec audit resource.
     sql = mysql_session('my_user','password')
 
     describe sql.query('show databases like \'test\';') do
-      its('stdout') { should_not match(/test/) }
+      its('output') { should_not match(/test/) }
     end
 
 ### Alternate Connection: Different Host


### PR DESCRIPTION
A feature introduced in #5124 changed how the mysql_session resource works to
where stdout, stderr, and exit_status no longer worked. The Lines class only
exposes output instead of stdout, stderr and exit_status.

As a work around, this adds backwards compatibilty for stdout, stderr and
exit_status parameters. In addition I updated the documentation to prefer output
over stdout/stderr.

This fixes #5218.

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description

I wasn't sure if we wanted to deprecate ``stdout``and ``stderr`` or not so please let me know if we do.

## Related Issue
- #5218 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
