### PR TITLE
WIP: Trigger expeditor changes for 5204

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -103,6 +103,7 @@ merge_actions:
     ignore_labels:
      - "Expeditor: Skip All"
      - "Expeditor: Skip Version Bump"
+     - "Meaningless label"
     only_if_modified:
      - .expeditor/*
      - docs/*


### PR DESCRIPTION
If we understand things correctly, this PR should trigger the changes here: https://github.com/inspec/inspec/pull/5204

The flow *may* be repetitive, i.e. we may need to merge into `expeditor-development` every time we wish to trigger a change. If so, my vote on flow (which we should probably document once agreed) would be to house main expeditor tweaks/development on the original PR (5204) and merge those changes into this branch and development to see if they pass. 

If this works, this branch will stay to trigger builds on expeditor development in future. This makes it so we don't have to spam master during config dev.

Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>