### PR TITLE
Run ps with an ulimited width on linux

### DIFF
--- a/lib/inspec/resources/processes.rb
+++ b/lib/inspec/resources/processes.rb
@@ -138,7 +138,7 @@ module Inspec::Resources
           command: 8,
         }
       else
-        command = "ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command"
+        command = "ps wwaxo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command"
         regex = /^(.+?)\s+(\d+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+(\w{3} \d{2}|\d{2}:\d{2}:\d{2})\s+([^ ]+)\s+([^ ]+)\s+(.*)$/
         field_map = {
           label: 1,

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -210,7 +210,7 @@ class MockLoader
       'find /sys/class/net/eth1/ -maxdepth 1 -type f -exec sh -c \'echo "[$(basename {})]"; cat {} || echo -n\' \;' => empty.call,
       "Get-Package -Name 'Not available' | ConvertTo-Json" => empty.call,
       "ps axo pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user,command" => cmd.call("ps-axo"),
-      "ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command" => cmd.call("ps-axoZ"),
+      "ps wwaxo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command" => cmd.call("ps-axoZ"),
       "ps -o pid,vsz,rss,tty,stat,time,ruser,args" => cmd.call("ps-busybox"),
       "env" => cmd.call("env"),
       "${Env:PATH}" => cmd.call("$env-PATH"),

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -228,6 +228,6 @@ describe "Inspec::Resources::Processes" do
   it "returns the correct command for non-busybox linux" do
     resource = MockLoader.new(:centos7).load_resource("processes")
     resource.expects(:busybox_ps?).returns(false)
-    _(resource.send(:ps_configuration_for_linux)[0]).must_equal "ps axo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command"
+    _(resource.send(:ps_configuration_for_linux)[0]).must_equal "ps wwaxo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command"
   end
 end


### PR DESCRIPTION
## Description

On some systems the output of ps may be truncated, which may prevent
profiles from working as intended.

Some implementations specifically mention that the output width is
undefined "(it may be 80, unlimited, determined by the TERM variable,
and so on)".

## Related Issue

This fixes #5226 with the fix mentioned there.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
