### PR TITLE
Use powershell-native escape for package resource

### DIFF
--- a/lib/inspec/resources/package.rb
+++ b/lib/inspec/resources/package.rb
@@ -314,7 +314,7 @@ module Inspec::Resources
       # Find the package
       cmd = inspec.command <<-EOF.gsub(/^\s*/, "")
         Get-ItemProperty (@("#{search_paths.join('", "')}") | Where-Object { Test-Path $_ }) |
-        Where-Object { $_.DisplayName -match "^\s*#{package_name.shellescape}\.*" -or $_.PSChildName -match "^\s*#{package_name.shellescape}\.*" } |
+        Where-Object { $_.DisplayName -match "^\s*$([regex]::escape(#{package_name}))\.*" -or $_.PSChildName -match "^\s*$([regex]::escape(#{package_name}))\.*" } |
         Select-Object -Property DisplayName,DisplayVersion | ConvertTo-Json
       EOF
 


### PR DESCRIPTION
Fixes #5235

<!--- Provide a short summary of your changes in the Title above -->

## Description
The shellescape method does not escape properly for powershell regex. Using powershell's built-in regex escape method will ensure the string is properly escaped.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#5235 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
