### PR TITLE
Remove thread requires as this is built in now

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -90,7 +90,6 @@ namespace :test do
   # rubocop:disable Style/BlockDelimiters,Layout/ExtraSpacing,Lint/AssignmentInCondition
 
   def n_threads_run(n_workers, jobs)
-    require "thread"
     queue = Queue.new
 
     jobs.each do |job|


### PR DESCRIPTION
This is already required out of the box. no need to require it again.

Signed-off-by: Tim Smith <tsmith@chef.io>
