### PR TITLE
Accept arrays in parse_config's method_missing

### DIFF
--- a/docs-chef-io/content/inspec/resources/parse_config.md
+++ b/docs-chef-io/content/inspec/resources/parse_config.md
@@ -53,6 +53,10 @@ where each test
 - May run a command to `stdout`, and then run the test against that output
 - May use options to define how configuration data is to be parsed
 
+## Examples
+
+This resource is based on the `parse_config_file` resource. As such please refer to the examples of the [`parse_config_file`](/inspec/resources/parse_config_file) resource.
+
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).

--- a/docs-chef-io/content/inspec/resources/parse_config.md
+++ b/docs-chef-io/content/inspec/resources/parse_config.md
@@ -53,13 +53,20 @@ where each test
 - May run a command to `stdout`, and then run the test against that output
 - May use options to define how configuration data is to be parsed
 
-## Examples
+## Options
 
-This resource is based on the `parse_config_file` resource. As such please refer to the examples of the [`parse_config_file`](/inspec/resources/parse_config_file) resource.
+This resource supports the following options for parsing configuration data. Use them in an `options` block stated outside of (and immediately before) the actual test:
 
-## Matchers
+    options = {
+        assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
+        multiple_values: true
+      }
 
-For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).
+    output = command('some-command').stdout
+
+    describe parse_config(output,  options) do
+      its('setting') { should eq 1 }
+    end
 
 ### assignment_regex
 
@@ -118,3 +125,12 @@ Use `standalone_comments: false`, to parse the following:
 
     'key = value # comment'
     params['key'] = 'value'
+
+
+## Examples
+
+This resource is based on the `parse_config_file` resource. As such please refer to the examples of the [`parse_config_file`](/inspec/resources/parse_config_file) resource.
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).

--- a/docs-chef-io/content/inspec/resources/parse_config.md
+++ b/docs-chef-io/content/inspec/resources/parse_config.md
@@ -55,7 +55,7 @@ where each test
 
 ## Options
 
-This resource supports the following options for parsing configuration data. Use them in an `options` block stated outside of (and immediately before) the actual test:
+This resource supports multiple options to parse configuration data. Use the options in an `options` block stated outside of (and immediately before) the actual test. For example:
 
     options = {
         assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
@@ -129,7 +129,7 @@ Use `standalone_comments: false`, to parse the following:
 
 ## Examples
 
-This resource is based on the `parse_config_file` resource. As such please refer to the examples of the [`parse_config_file`](/inspec/resources/parse_config_file) resource.
+This resource is based on the `parse_config_file` resource. See the [`parse_config_file`](/inspec/resources/parse_config_file) resource for examples.
 
 ## Matchers
 

--- a/docs-chef-io/content/inspec/resources/parse_config_file.md
+++ b/docs-chef-io/content/inspec/resources/parse_config_file.md
@@ -50,6 +50,13 @@ where each test
 - May run a command to `stdout`, and then run the test against that output
 - May use options to define how configuration data is to be parsed
 
+### Option names containing dots
+
+A possibly unexpected behaviour may occur when attempting to access option names containing dots with `its()`. A known behaviour, there are two ways to work around it:
+
+* Access the option by using the `params` attribute of the returned resource object
+* Since 4.23.9, `its` can be used by passing the option name in a single-element array (cf. examples)
+
 ## Options
 
 This resource supports the following options for parsing configuration data. Use them in an `options` block stated outside of (and immediately before) the actual test:
@@ -82,6 +89,12 @@ The following examples show how to use this Chef InSpec audit resource.
 
     describe parse_config_file('/path/to/yum.conf') do
      its('main') { should include('gpgcheck' => '1') }
+    end
+
+### Test a configuration setting containing dots
+
+    describe parse_config_file('/etc/sysctl.conf') do
+     its(['kernel.domainname']) { should eq 'example.com' }
     end
 
 ## Matchers

--- a/docs-chef-io/content/inspec/resources/parse_config_file.md
+++ b/docs-chef-io/content/inspec/resources/parse_config_file.md
@@ -69,38 +69,6 @@ This resource supports the following options for parsing configuration data. Use
       its('setting') { should eq 1 }
     end
 
-## Examples
-
-The following examples show how to use this Chef InSpec audit resource.
-
-### Test a configuration setting
-
-    describe parse_config_file('/path/to/file.conf') do
-     its('PARAM_X') { should eq 'Y' }
-    end
-
-### Use options, and then test a configuration setting
-
-    describe parse_config_file('/path/to/file.conf', { multiple_values: true }) do
-     its('PARAM_X') { should include 'Y' }
-    end
-
-### Test a file with an ini-like structure (such as a yum.conf)
-
-    describe parse_config_file('/path/to/yum.conf') do
-     its('main') { should include('gpgcheck' => '1') }
-    end
-
-### Test a configuration setting containing dots
-
-    describe parse_config_file('/etc/sysctl.conf') do
-     its(['kernel.domainname']) { should eq 'example.com' }
-    end
-
-## Matchers
-
-For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).
-
 ### assignment_regex
 
 Use `assignment_regex` to test a key value using a regular expression:
@@ -158,3 +126,35 @@ Use `standalone_comments: false`, to parse the following:
 
     'key = value # comment'
     params['key'] = 'value'
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).
+
+## Examples
+
+The following examples show how to use this Chef InSpec audit resource.
+
+### Test a configuration setting
+
+    describe parse_config_file('/path/to/file.conf') do
+     its('PARAM_X') { should eq 'Y' }
+    end
+
+### Use options, and then test a configuration setting
+
+    describe parse_config_file('/path/to/file.conf', { multiple_values: true }) do
+     its('PARAM_X') { should include 'Y' }
+    end
+
+### Test a file with an ini-like structure (such as a yum.conf)
+
+    describe parse_config_file('/path/to/yum.conf') do
+     its('main') { should include('gpgcheck' => '1') }
+    end
+
+### Test a configuration setting containing dots
+
+    describe parse_config_file('/etc/sysctl.conf') do
+     its(['kernel.domainname']) { should eq 'example.com' }
+    end

--- a/docs-chef-io/content/inspec/resources/parse_config_file.md
+++ b/docs-chef-io/content/inspec/resources/parse_config_file.md
@@ -50,16 +50,16 @@ where each test
 - May run a command to `stdout`, and then run the test against that output
 - May use options to define how configuration data is to be parsed
 
-### Option names containing dots
+### Option Names Containing Periods
 
-A possibly unexpected behaviour may occur when attempting to access option names containing dots with `its()`. A known behaviour, there are two ways to work around it:
+A possible behavior may occur when attempting to access option names containing periods with `its()`. There are two ways to work around it:
 
 * Access the option by using the `params` attribute of the returned resource object
-* Since 4.23.9, `its` can be used by passing the option name in a single-element array (cf. examples)
+* Since 4.24.5, `its` can be used by passing the option name in a single-element array. See the `parse config file` examples.
 
 ## Options
 
-This resource supports the following options for parsing configuration data. Use them in an `options` block stated outside of (and immediately before) the actual test:
+This resource supports multiple options to parse configuration data. Use the options in an `options` block stated outside of (and immediately before) the actual test. For example:
 
     options = {
         assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/,
@@ -135,25 +135,27 @@ For a full list of available matchers, please visit our [matchers page](/inspec/
 
 The following examples show how to use this Chef InSpec audit resource.
 
-### Test a configuration setting
+### Test A Configuration Setting
 
     describe parse_config_file('/path/to/file.conf') do
      its('PARAM_X') { should eq 'Y' }
     end
 
-### Use options, and then test a configuration setting
+### Use Options And Then Test A Configuration Setting
 
     describe parse_config_file('/path/to/file.conf', { multiple_values: true }) do
      its('PARAM_X') { should include 'Y' }
     end
 
-### Test a file with an ini-like structure (such as a yum.conf)
+### Test A File With An INI File Structure
+
+`yum.conf` is one example of an INI file structure type.
 
     describe parse_config_file('/path/to/yum.conf') do
      its('main') { should include('gpgcheck' => '1') }
     end
 
-### Test a configuration setting containing dots
+### Test A Configuration Setting Containing Periods
 
     describe parse_config_file('/etc/sysctl.conf') do
      its(['kernel.domainname']) { should eq 'example.com' }

--- a/lib/inspec/resources/json.rb
+++ b/lib/inspec/resources/json.rb
@@ -48,7 +48,7 @@ module Inspec::Resources
     # @return [Object] the value stored at this position
     def method_missing(*keys)
       # catch bahavior of rspec its implementation
-      # @see https://github.com/rspec/rspec-its/blob/master/lib/rspec/its.rb#L110
+      # @see https://github.com/rspec/rspec-its/blob/v1.2.0/lib/rspec/its.rb#L110
       keys.shift if keys.is_a?(Array) && keys[0] == :[]
       value(keys)
     end

--- a/lib/inspec/resources/parse_config.rb
+++ b/lib/inspec/resources/parse_config.rb
@@ -57,7 +57,7 @@ module Inspec::Resources
 
     def method_missing(*name)
       # catch bahavior of rspec its implementation
-      # @see https://github.com/rspec/rspec-its/blob/master/lib/rspec/its.rb#L110
+      # @see https://github.com/rspec/rspec-its/blob/v1.2.0/lib/rspec/its.rb#L110
       name.shift if name.is_a?(Array) && name[0] == :[]
       read_params[name[0].to_s]
     end

--- a/lib/inspec/resources/parse_config.rb
+++ b/lib/inspec/resources/parse_config.rb
@@ -55,8 +55,11 @@ module Inspec::Resources
       read_params unless @content.nil?
     end
 
-    def method_missing(name)
-      read_params[name.to_s]
+    def method_missing(*name)
+      # catch bahavior of rspec its implementation
+      # @see https://github.com/rspec/rspec-its/blob/master/lib/rspec/its.rb#L110
+      name.shift if name.is_a?(Array) && name[0] == :[]
+      read_params[name[0].to_s]
     end
 
     def params(*opts)

--- a/lib/inspec/resources/wmi.rb
+++ b/lib/inspec/resources/wmi.rb
@@ -39,7 +39,7 @@ module Inspec::Resources
     # returns nil, if not existant or value
     def method_missing(*keys)
       # catch behavior of rspec its implementation
-      # @see https://github.com/rspec/rspec-its/blob/master/lib/rspec/its.rb#L110
+      # @see https://github.com/rspec/rspec-its/blob/v1.2.0/lib/rspec/its.rb#L110
       keys.shift if keys.is_a?(Array) && keys[0] == :[]
 
       # map all symbols to strings

--- a/test/unit/resources/parse_config_test.rb
+++ b/test/unit/resources/parse_config_test.rb
@@ -24,4 +24,13 @@ describe "Inspec::Resources::ParseConfig" do
     _(resource.params).must_equal result
     _(resource.send("kernel.domainname")).must_equal "example.com"
   end
+
+  it "parse_config resource accepts arrays due to rspec's its behavior" do
+    options = {
+      assignment_regex: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/,
+    }
+    params = [:[], "kernel.domainname"]
+    resource = MockLoader.new(:centos6).load_resource("parse_config", "kernel.domainname = example.com", options)
+    _(resource.send(*params)).must_equal "example.com"
+  end
 end


### PR DESCRIPTION
## Description
A single-element array allows Rspec's its behaviour to be worked around
and allow options containing dots to be tested using its.

This is already implemented by resources such as `json` and those based
on it (e.g. xml).

N.b. I feel like I'm missing something with regards to the documentation as I see it is in two directories. Is there some automagic tool I forgot to run?
Note as well that in the documentation I mention version `4.23.9` as the future version including this change, so feel free to correct it as needed.

## Related Issue
Related to issue inspec#875.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
