### PR TITLE
Add Chef patent URL to --help, tidy help output

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -164,6 +164,12 @@ module Inspec
         desc: "After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode."
     end
 
+    def self.help(*args)
+      super(*args)
+      puts "\nAbout #{Inspec::Dist::PRODUCT_NAME}:"
+      puts "  Patents: chef.io/patents\n\n"
+    end
+
     def self.format_platform_info(params: {}, indent: 0, color: 39)
       str = ""
       params.each do |item, info|

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -48,7 +48,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "Allow or disable user interaction"
 
   class_option :disable_core_plugins, type: :string, banner: "", # Actually a boolean, but this suppresses the creation of a --no-disable...
-    desc: "Disable loading all plugins that are shipped in the lib/plugins directory of InSpec. Useful in development."
+    desc: "Disable loading all plugins that are shipped in the lib/plugins directory of InSpec. Useful in development.",
+    hide: true
 
   class_option :disable_user_plugins, type: :string, banner: "",
     desc: "Disable loading all plugins that the user installed."
@@ -194,7 +195,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     pretty_handle_exception(e)
   end
 
-  desc "exec LOCATIONS", <<~EOT
+  desc "exec LOCATIONS", "Run all tests at LOCATIONS."
+  long_desc <<~EOT
     Run all test files at the specified LOCATIONS.
 
     Loads the given profile(s) and fetches their dependencies if needed. Then

--- a/test/functional/inspec_test.rb
+++ b/test/functional/inspec_test.rb
@@ -74,5 +74,17 @@ describe "command tests" do
         end
       end
     end
+
+    it "has an About section" do
+      outputs.each do |output|
+        _(output).must_include("About Chef InSpec")
+      end
+    end
+
+    it "mentions Chef's patents" do
+      outputs.each do |output|
+        _(output).must_include("Patents: chef.io/patents")
+      end
+    end
   end
 end

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -177,11 +177,9 @@ end
 #                                Plugin Disable Messaging
 #=========================================================================================#
 describe "disable plugin usage message integration" do
-  it "mentions the --disable-{user,core}-plugins options" do
+  it "mentions the --disable-user-plugins option" do
     outcome = inspec("help")
-    ["--disable-user-plugins", "--disable-core-plugins"].each do |option|
-      _(outcome.stdout).must_include(option)
-    end
+    _(outcome.stdout).must_include("--disable-user-plugins")
   end
 end
 


### PR DESCRIPTION
Fixes #5248

Mentions Chef's patents in help output.

@kekaichinose this looks like this:

![Screenshot 2020-09-18 at 10 14 18](https://user-images.githubusercontent.com/12136665/93581191-b8438780-f998-11ea-8537-9d7fad76aed6.png)

This might look neater if it went underneath an "About:" heading?

Signed-off-by: James Stocks <jstocks@chef.io>
