### PR TITLE
Support 'clear_cache'

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -395,6 +395,20 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   end
   map %w{-v --version} => :version
 
+  desc "clear_cache", "clears the InSpec cache. Useful for debugging."
+  option :vendor_cache, type: :string,
+    desc: "Use the given path for caching dependencies. (default: ~/.inspec/cache)"
+  def clear_cache
+    o = config
+    configure_logger(o)
+    cache_path = o[:vendor_cache] || "~/.inspec/cache"
+    FileUtils.rm_r Dir.glob(File.expand_path(cache_path))
+
+    o[:logger] = Logger.new($stdout)
+    o[:logger].level = get_log_level(o[:log_level])
+    o[:logger].info "== InSpec cache cleared successfully =="
+  end
+
   private
 
   def run_command(opts)

--- a/lib/inspec/runner_rspec.rb
+++ b/lib/inspec/runner_rspec.rb
@@ -5,7 +5,7 @@ require "matchers/matchers"
 require "inspec/rspec_extensions"
 
 # There be dragons!! Or borgs, or something...
-# This file and all its contents cannot be unit-tested. both test-suits
+# This file and all its contents cannot be unit-tested. both test-suites
 # collide and disable all unit tests that have been added.
 
 module Inspec

--- a/test/functional/inspec_clear_cache_test.rb
+++ b/test/functional/inspec_clear_cache_test.rb
@@ -1,0 +1,27 @@
+require "functional/helper"
+require "securerandom"
+
+describe "inspec check" do
+  include FunctionalHelper
+
+  parallelize_me!
+
+  describe "inspec clear_cache" do
+    it "clears any existing cache" do
+      dirname = File.expand_path("~/.inspec/cache")
+      unless File.directory?(dirname)
+        FileUtils.mkdir_p(dirname)
+      end
+      newfile = "#{dirname}/#{SecureRandom.hex(10)}.txt"
+      File.write(newfile, SecureRandom.hex(100))
+
+      assert !Dir.glob(newfile).empty?
+
+      out = inspec("clear_cache")
+
+      assert_empty Dir.glob(newfile)
+      assert_exit_code 0, out
+      _(out.stdout).must_include "== InSpec cache cleared successfully ==\n"
+    end
+  end
+end

--- a/test/functional/inspec_clear_cache_test.rb
+++ b/test/functional/inspec_clear_cache_test.rb
@@ -8,7 +8,7 @@ describe "inspec check" do
 
   describe "inspec clear_cache" do
     it "clears any existing cache" do
-      dirname = File.expand_path("~/.inspec/cache")
+      dirname = File.expand_path("~/.inspec/#{SecureRandom.hex(10)}/alt-cache")
       unless File.directory?(dirname)
         FileUtils.mkdir_p(dirname)
       end
@@ -17,7 +17,7 @@ describe "inspec check" do
 
       assert !Dir.glob(newfile).empty?
 
-      out = inspec("clear_cache")
+      out = inspec("clear_cache --vendor-cache=#{dirname}")
 
       assert_empty Dir.glob(newfile)
       assert_exit_code 0, out


### PR DESCRIPTION
Helps with Customer Bug 236 (see there for repro)

Currently, when we run `inspec compliance upload my_profile` it is
cached locally in inspec when run. If we update the version in the core
code and run another upload, `inspec compliance upload my_profile` again
it will run the old cached version instead of running a new copy
from automate.

The current workaround is to specify the desired version with
`inspec exec compliance://my_profile/admin#0.1.1`.

The caching happens before we have forward sight into the profile's
contents and only the target name. So the text used to generate the
cache would be `compliance://my_profile/admin` which does not change
version to version.

A fix here could simply identify when we are doing a local `inspec exec
compliance://` (hitting local profiles does not generate a cache) and
skips the cache if there's no version specified. That would eliminate
the unexpected behavior. However, it is a breaking change for customers
as some current caching taking place would no longer take place.

Instead, we have included a `clear_cache` cli method for InSpec,
which should assist the core team and other developers in the future
when debugging edge case issues in InSpec.

Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>

< edited 2020-11-24 >