### PR TITLE
Add command-timeout option

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -162,6 +162,9 @@ module Inspec
         desc: "Use --no-diff to suppress 'diff' output of failed textual test results."
       option :sort_results_by, type: :string, default: "file", banner: "--sort-results-by=none|control|file|random",
         desc: "After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode."
+      option :command_timeout, type: :numeric, default: 60,
+        desc: "Maximum minutes to allow commands to run during execution. Default 60.",
+        long_desc: "Maximum minutes to allow commands to run during execution. Default 60. A timed out command is considered an error."
     end
 
     def self.help(*args)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -321,6 +321,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell"
   option :distinct_exit, type: :boolean, default: true,
     desc: "Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures."
+  option :command_timeout, type: :numeric, default: 60,
+      desc: "Maximum minutes to allow a command to run. Default 60.",
+      long_desc: "Maximum minutes to allow commands to run. Default 60. A timed out command is considered an error."
   option :inspect, type: :boolean, default: false, desc: "Use verbose/debugging output for resources."
   def shell_func
     o = config

--- a/lib/inspec/resources/command.rb
+++ b/lib/inspec/resources/command.rb
@@ -32,6 +32,15 @@ module Inspec::Resources
 
       @command = cmd
 
+      @timeout = options[:timeout]&.to_i || Inspec::Config.cached.final_options['command_timeout']&.to_i
+      if @timeout
+        # train uses seconds but inspec advertises minutes
+        @timeout = @timeout * 60
+      else
+        warn "InSpec config is missing value for command_timeout. Defaulting to 60m"
+        @timeout = 3600
+      end
+
       if options[:redact_regex]
         unless options[:redact_regex].is_a?(Regexp)
           # Make sure command is replaced so sensitive output isn't shown
@@ -44,7 +53,12 @@ module Inspec::Resources
     end
 
     def result
-      @result ||= inspec.backend.run_command(@command)
+      @result ||= begin 
+        inspec.backend.run_command(@command, timeout: @timeout)
+      rescue Train::CommandTimeoutReached
+        raise Inspec::Exceptions::ResourceFailed,
+              "Command `#{@command}` timed out after #{@timeout / 60} minute(s)"
+      end
     end
 
     def stdout


### PR DESCRIPTION
TODO: 

- [ ] Add docs
- [ ] test one of our Automate profiles

Allow commands to have a timeout, set in minutes. This is considered an emergency mechanism to stop CI being halted indefinitely. If a test inherently needs to pass or fail based on a timeout, this should be scripted into the command string instead.

It can be set for a command resource, like:

```
  describe command('sleep 100', timeout: 1) do
    its('exit_status') { should cmp 0 }
  end
```

It can also be set as a new option `command-timeout`.
A timeout set on a `command` resource takes precedence over the `command-timeout` option.

If no timeout is set at all, a command will default to timing out after 1 hour

Signed-off-by: James Stocks <jstocks@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
