### PR TITLE
Ensure that we populate information about waiver expiration regardless of `run: true/false`

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -343,14 +343,8 @@ module Inspec
       __waiver_data["skipped_due_to_waiver"] = false
       __waiver_data["message"] = ""
 
-      # Waivers should have a hash value with keys possibly including "run" and
-      # expiration_date. We only care here if it has a "run" key and it
-      # is false-like, since all non-skipped waiver operations are handled
-      # during reporting phase.
-      return unless __waiver_data.key?("run") && !__waiver_data["run"]
-
-      # OK, the intent is to skip. Does it have an expiration date, and
-      # if so, is it in the future?
+      # Does it have an expiration date, and if so, is it in the future?
+      # This sets a waiver message before checking `run: true`
       expiry = __waiver_data["expiration_date"]
       if expiry
         # YAML will automagically give us a Date or a Time.
@@ -369,6 +363,12 @@ module Inspec
           ui.exit(:usage_error)
         end
       end
+
+      # Waivers should have a hash value with keys possibly including "run" and
+      # expiration_date. We only care here if it has a "run" key and it
+      # is false-like, since all non-skipped waiver operations are handled
+      # during reporting phase.
+      return unless __waiver_data.key?("run") && !__waiver_data["run"]
 
       # OK, apply a skip.
       @__skip_rule[:result] = true

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -48,6 +48,7 @@ describe "waivers" do
     in_past   = !!(control_id =~ /in_past/)
     in_future = !!(control_id =~ /in_future/)
     ran       = !!(control_id !~ /not_ran/)
+    waiver_expired_in_past = /Waiver expired/ =~ act["message"]
 
     # higher logic
     waived      = (!expiry && !ran) || (expiry && !ran && in_future)
@@ -60,7 +61,8 @@ describe "waivers" do
     assert_equal ran,     act["run"]
     assert_equal waived,  act["skipped_due_to_waiver"]
     assert_stringy        act["message"] if     has_message
-    assert_equal "",      act["message"] unless has_message
+    # We supply a message indicating that the waiver has expired in all cases
+    assert_equal "",      act["message"] unless has_message || waiver_expired_in_past
   end
 
   def refute_waiver_annotation(control_id)


### PR DESCRIPTION
Fixes #5260 

Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-365