### PR TITLE
Update Ruby to 2.7.2

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -3,4 +3,4 @@
 # grab the current train release from rubygems.org
 train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
 override "train", version: "v#{train_stable}"
-override "ruby", version: "2.6.6"
+override "ruby", version: "2.7.2"


### PR DESCRIPTION
Now that Ruby 2.7.2 no longer throws deprecation warnings left and right
we should update InSpec to use the latest and greatest Ruby that we use
in Chef Infra Client and Workstation.

Signed-off-by: Tim Smith <tsmith@chef.io>

Aha! Link: https://chef.aha.io/features/SH-376