### PR TITLE
Add method_missing to nginx_conf

### DIFF
--- a/docs-chef-io/content/inspec/resources/nginx_conf.md
+++ b/docs-chef-io/content/inspec/resources/nginx_conf.md
@@ -47,7 +47,7 @@ Parameters can be accessed either via `params` or via the `its` syntax:
       its('pid') { should cmp 'logs/nginx.pid' }
     end
 
-The `its` syntax allows for a more descriptive block and is available in the `nginx_conf`, `nginx_conf.http.entries` and `nginx_conf.http.servers` resources.
+The `its` syntax allows for a more descriptive block and is available in the `nginx_conf`, `nginx_conf.http.entries`, and `nginx_conf.http.servers` resources.
 
 ## Examples
 
@@ -68,7 +68,7 @@ The following examples show how to use this Chef InSpec audit resource.
       it { should cmp 5 }
     end
 
-    # Or, using its
+    # Or when using `its` syntax
     describe nginx_conf do
       its('worker_processes') { should cmp 5 }
     end

--- a/docs-chef-io/content/inspec/resources/nginx_conf.md
+++ b/docs-chef-io/content/inspec/resources/nginx_conf.md
@@ -41,6 +41,14 @@ where
 - `params['pid']` selects the `pid` entry from the global NGINX configuration
 - `{ should cmp 'logs/nginx.pid' }` tests if the PID is set to `logs/nginx.pid` (via `cmp` matcher)
 
+Parameters can be accessed either via `params` or via the `its` syntax:
+
+    describe nginx_conf do
+      its('pid') { should cmp 'logs/nginx.pid' }
+    end
+
+The `its` syntax allows for a more descriptive block and is available in the `nginx_conf`, `nginx_conf.http.entries` and `nginx_conf.http.servers` resources.
+
 ## Examples
 
 The following examples show how to use this Chef InSpec audit resource.
@@ -58,6 +66,11 @@ The following examples show how to use this Chef InSpec audit resource.
 
     describe nginx_conf.params['worker_processes'].flatten do
       it { should cmp 5 }
+    end
+
+    # Or, using its
+    describe nginx_conf do
+      its('worker_processes') { should cmp 5 }
     end
 
 ## Matchers

--- a/docs-chef-io/content/inspec/resources/nginx_conf.md
+++ b/docs-chef-io/content/inspec/resources/nginx_conf.md
@@ -30,7 +30,7 @@ This resource first became available in v1.37.6 of InSpec.
 
 An `nginx_conf` resource block declares the client NGINX configuration data to be tested:
 
-    describe nginx_conf.params['pid'] do
+    describe nginx_conf.params['pid'].flatten do
       it { should cmp 'logs/nginx.pid' }
     end
 

--- a/lib/inspec/resources/nginx_conf.rb
+++ b/lib/inspec/resources/nginx_conf.rb
@@ -63,6 +63,12 @@ module Inspec::Resources
       nil
     end
 
+    def respond_to_missing?(name, include_all = false)
+      return super if name.to_s.match?(/^to_/)
+
+      true
+    end
+
     private
 
     def read_content(path)
@@ -190,6 +196,12 @@ module Inspec::Resources
       (@params[name.to_s] || []).flatten
     end
 
+    def respond_to_missing?(name, include_all = false)
+      return super if name.to_s.match?(/^to_/)
+
+      true
+    end
+
     private
 
     def server_table
@@ -226,6 +238,12 @@ module Inspec::Resources
       return super if name.to_s.match?(/^to_/)
 
       (@params[name.to_s] || []).flatten
+    end
+
+    def respond_to_missing?(name, include_all = false)
+      return super if name.to_s.match?(/^to_/)
+
+      true
     end
 
     private

--- a/lib/inspec/resources/nginx_conf.rb
+++ b/lib/inspec/resources/nginx_conf.rb
@@ -54,6 +54,15 @@ module Inspec::Resources
       "nginx_conf #{@conf_path}"
     end
 
+    def method_missing(name)
+      return super if name.to_s.match?(/^to_/)
+
+      v = params[name.to_s]
+      return v.flatten unless v.nil?
+
+      nil
+    end
+
     private
 
     def read_content(path)
@@ -175,6 +184,12 @@ module Inspec::Resources
     end
     alias inspect to_s
 
+    def method_missing(name)
+      return super if name.to_s.match?(/^to_/)
+
+      (@params[name.to_s] || []).flatten
+    end
+
     private
 
     def server_table
@@ -206,6 +221,12 @@ module Inspec::Resources
       @parent.parent.to_s + ", server #{server}"
     end
     alias inspect to_s
+
+    def method_missing(name)
+      return super if name.to_s.match?(/^to_/)
+
+      (@params[name.to_s] || []).flatten
+    end
 
     private
 


### PR DESCRIPTION
## Description
Add `method_missing` methods to greatly simplify the use of the resource. At present one needs to access the parameters directly from `params` and then flatten the result, which makes this resource particularly hard to use.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-385