### PR TITLE
Upgrade the habitat Ruby dependency to 2.6

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -10,7 +10,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/coreutils
   core/git
-  core/ruby
+  core/ruby26
   core/bash
 )
 pkg_build_deps=(
@@ -76,7 +76,7 @@ export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
 
-exec $(pkg_path_for core/ruby)/bin/ruby $real_bin \$@
+exec $(pkg_path_for core/ruby26)/bin/ruby $real_bin \$@
 EOF
   chmod -v 755 "$bin"
 }


### PR DESCRIPTION
We're using ruby 2.6.6 for omnibus via `omnibus_overrides.rb`, but the
core/ruby package is actually Ruby 2.5.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>

Aha! Link: https://chef.aha.io/features/SH-400