### PR TITLE
Add windows as a supported platform for ssh_config

### DIFF
--- a/lib/inspec/resources/ssh_config.rb
+++ b/lib/inspec/resources/ssh_config.rb
@@ -20,7 +20,7 @@ module Inspec::Resources
     include FileReader
 
     def initialize(conf_path = nil, type = nil)
-      @conf_path = conf_path || "/etc/ssh/ssh_config"
+      @conf_path = conf_path || ssh_config_file("ssh_config")
       typename = (@conf_path.include?("sshd") ? "Server" : "Client")
       @type = type || "SSH #{typename} configuration #{conf_path}"
       read_content
@@ -76,6 +76,15 @@ module Inspec::Resources
       )
       @params = convert_hash(conf.params)
     end
+
+    def ssh_config_file(type)
+      if inspec.os.windows?
+        programdata = inspec.os_env("programdata").content
+        return "#{programdata}\\ssh\\#{type}"
+      end
+
+      "/etc/ssh/#{type}"
+    end
   end
 
   class SshdConfig < SshConfig
@@ -90,11 +99,22 @@ module Inspec::Resources
     EXAMPLE
 
     def initialize(path = nil)
-      super(path || "/etc/ssh/sshd_config")
+      super(path || ssh_config_file("sshd_config"))
     end
 
     def to_s
       "SSHD Configuration"
+    end
+
+    private
+
+    def ssh_config_file(type)
+      if inspec.os.windows?
+        programdata = inspec.os_env("programdata").content
+        return "#{programdata}\\ssh\\#{type}"
+      end
+
+      "/etc/ssh/#{type}"
     end
   end
 end

--- a/lib/inspec/resources/ssh_config.rb
+++ b/lib/inspec/resources/ssh_config.rb
@@ -7,6 +7,7 @@ module Inspec::Resources
   class SshConfig < Inspec.resource(1)
     name "ssh_config"
     supports platform: "unix"
+    supports platform: "windows"
     desc "Use the `ssh_config` InSpec audit resource to test OpenSSH client configuration data located at `/etc/ssh/ssh_config` on Linux and Unix platforms."
     example <<~EXAMPLE
       describe ssh_config do
@@ -80,6 +81,7 @@ module Inspec::Resources
   class SshdConfig < SshConfig
     name "sshd_config"
     supports platform: "unix"
+    supports platform: "windows"
     desc "Use the sshd_config InSpec audit resource to test configuration data for the Open SSH daemon located at /etc/ssh/sshd_config on Linux and UNIX platforms. sshd---the Open SSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command execution, and data exchanges."
     example <<~EXAMPLE
       describe sshd_config do


### PR DESCRIPTION
## Description
Openssh for windows is a thing, so allow the ssh_config and sshd_config
resources to be used on it.

## Related Issue
#4782

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.

Aha! Link: https://chef.aha.io/features/SH-401