### PR TITLE
Pin rspec to 3.9

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json_schemer",       ">= 0.2.1", "< 0.2.12"
   spec.add_dependency "method_source",      ">= 0.8", "< 2.0"
   spec.add_dependency "rubyzip",            "~> 1.2", ">= 1.2.2"
-  spec.add_dependency "rspec",              "~> 3.9"
+  spec.add_dependency "rspec",              "~> 3.9.0"
   spec.add_dependency "rspec-its",          "~> 1.2"
   spec.add_dependency "pry",                "~> 0.13"
   spec.add_dependency "hashie",             "~> 3.4"


### PR DESCRIPTION
Fixes #5296

rspec 3.10.0 introduces text changes to test outputs. Let's keep it pinned - we don't need to keep rspec current.

Signed-off-by: James Stocks <jstocks@chef.io>

Aha! Link: https://chef.aha.io/features/SH-472