### PR TITLE
Add ed25519 support to the habitat package

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -55,6 +55,10 @@ do_install() {
 
   wrap_inspec_bin
 
+  # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
+  # for omnibus we also install this as part of the package
+  gem install ed25519 bcrypt_pbkdf --no-document
+
   # Certain gems (timeliness) are getting installed with world writable files
   # This is removing write bits for group and other.
   find "$GEM_HOME" -xdev -perm -0002 -type f -print 2>/dev/null | xargs -I '{}' chmod go-w '{}'


### PR DESCRIPTION
net-ssh only has ed25519 support if the gem is installed. Because it has
native extensions we currently install it as part of the Omnibus package
via the Gemfile, and do not include it in the gemspec.

Without this using ssh keys with `inspec exec -t ssh://` errors with:

```
STDERR: /hab/pkgs/chef/inspec/4.23.16/20201102165953/lib/gems/net-ssh-6.1.0/lib/net/ssh/authentication/ed25519_loader.rb:21:in `raiseUnlessLoaded': OpenSSH keys only supported if ED25519 is available (NotImplementedError)
```
