### PR TITLE
grub_conf - handle no menuentry config

### DIFF
--- a/lib/inspec/resources/grub_conf.rb
+++ b/lib/inspec/resources/grub_conf.rb
@@ -29,7 +29,7 @@ module Inspec::Resources
       @content = read_file(@conf_path)
       @kernel = kernel || "default"
     rescue UnknownGrubConfig
-      skip_resource "The `grub_config` resource is not supported on your OS yet."
+      skip_resource "The `grub_conf` resource is not yet supported on the target OS #{inspec.os[:name]}."
     end
 
     def config_for_platform(path)
@@ -77,6 +77,7 @@ module Inspec::Resources
 
     def grub2_parse_kernel_lines(content, conf)
       menu_entries = extract_menu_entries(content)
+      return {} if menu_entries.empty?
 
       if @kernel == "default"
         default_menu_entry(menu_entries, conf["GRUB_DEFAULT"])


### PR DESCRIPTION
Fixes #5305

grub_conf assumes for grub2 that the config (default `/etc/default/grub`) contains `menuentry` lines. i.e. entries in the menu of kernels to boot.

A customer reports, and we can reproduce on the Vagrant `centos/8` image, that the default config for grub2 contains no such entries.

Signed-off-by: James Stocks <jstocks@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
