### PR TITLE
Don't reload plugins if load_all is called repeatedly

### DIFF
--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -50,6 +50,11 @@ module Inspec::Plugin::V2
       # we want to allow "sidecar loading", in which case a plugin may add an entry to the registry.
       registry.plugin_names.dup.each do |plugin_name|
         plugin_details = registry[plugin_name]
+
+        # Under some conditions (kitchen-inspec with multiple test suites, for example), this may be
+        # called multple times. Don't reload anything.
+        next if plugin_details.loaded
+
         # We want to capture literally any possible exception here, since we are storing them.
         # rubocop: disable Lint/RescueException
         begin


### PR DESCRIPTION
## Description
This fixes a subtle issue in `kitchen-inspec`. Under kitchen-inspec, if there are multiple platforms or suites, the kitchen plugin will load inspec plugins prior to each instance running the verification step.  Because we use `load` to evaluate the plugin files, and load is not idempotent, so each time we 
load a plugin, the Activators are defined anew. This results in multiple copies of the Activators, as well as slow performance. When we go to load activators we expect them to be unique, resulting in an error like inspec/kitchen-inspec#262.

This change simply uses an existing tracking field to skip reloading a plugin if it has already been loaded.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes inspec/kitchen-inspec#262

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
