### PR TITLE
Remove macOS 10.13 from the build matrix

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -20,8 +20,7 @@ builder-to-testers-map:
     - el-7-x86_64
     - el-8-x86_64
     - amazon-2-x86_64
-  mac_os_x-10.13-x86_64:
-    - mac_os_x-10.13-x86_64
+  mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
     - mac_os_x-11.0-x86_64

--- a/README.md
+++ b/README.md
@@ -305,19 +305,19 @@ Remote Targets
 | Platform                     | Versions                                         | Architectures |
 | ---------------------------- | ------------------------------------------------ | ------------- |
 | AIX                          | 6.1, 7.1, 7.2                                    | ppc64         |
-| CentOS                       | 5, 6, 7                                          | i386, x86_64  |
-| Debian                       | 7, 8, 9                                          | i386, x86_64  |
+| CentOS                       | 6, 7, 8                                          | i386, x86_64  |
+| Debian                       | 9, 10                                            | i386, x86_64  |
 | FreeBSD                      | 9, 10, 11                                        | i386, amd64   |
-| Mac OS X                     | 10.9, 10.10, 10.11, 10.12, 10.13, 10.14          | x86_64        |
-| Oracle Enterprise Linux      | 5, 6, 7                                          | i386, x86_64  |
-| Red Hat Enterprise Linux     | 5, 6, 7                                          | i386, x86_64  |
+| macOS                        | 10.14, 10.15, 11.0                               | x86_64        |
+| Oracle Enterprise Linux      | 6, 7, 8                                          | i386, x86_64  |
+| Red Hat Enterprise Linux     | 6, 7, 8                                          | i386, x86_64  |
 | Solaris                      | 10, 11                                           | sparc, x86    |
-| Windows\*                    | 8, 8.1, 10, 2012, 2012R2, 2016                   | x86, x86_64   |
+| Windows\*                    | 8, 8.1, 10, 2012, 2012R2, 2016, 2019             | x86, x86_64   |
 | Ubuntu Linux                 |                                                  | x86, x86_64   |
-| SUSE Linux Enterprise Server | 11, 12                                           | x86_64        |
-| Scientific Linux             | 5.x, 6.x and 7.x                                 | i386, x86_64  |
+| SUSE Linux Enterprise Server | 12, 15                                           | x86_64        |
+| Scientific Linux             | 6, 7                                             | i386, x86_64  |
 | Fedora                       |                                                  | x86_64        |
-| OpenSUSE                     | 13, 42                                           | x86_64        |
+| OpenSUSE                     | 15                                               | x86_64        |
 | OmniOS                       |                                                  | x86_64        |
 | Gentoo Linux                 |                                                  | x86_64        |
 | Arch Linux                   |                                                  | x86_64        |
@@ -329,9 +329,10 @@ In addition, runtime support is provided for:
 
 | Platform | Versions | Arch   |
 | -------- | -------- | ------ |
-| Debian   | 8, 9     | x86_64 |
-| RHEL     | 6, 7     | x86_64 |
-| Ubuntu   | 12.04+   | x86_64 |
+| macOS    | 10.14+   | x86_64 |
+| Debian   | 9, 10    | x86_64 |
+| RHEL     | 6, 7, 8  | x86_64 |
+| Ubuntu   | 16.04+   | x86_64 |
 | Windows  | 8+       | x86_64 |
 | Windows  | 2012+    | x86_64 |
 


### PR DESCRIPTION
We support N-2 builds and now that Big Sur is out we can remove 10.13. I also cleaned up the supported platforms in the readme a bit.

Signed-off-by: Tim Smith <tsmith@chef.io>