### PR TITLE
bump the habitat ruby dep for inspec to 2.7

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -15,7 +15,7 @@ $pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 $pkg_license=('Apache-2.0')
 
 $pkg_deps=@(
-  "chef/ruby-plus-devkit"
+  "chef/ruby27-plus-devkit"
 )
 $pkg_bin_dirs=@("bin"
                 "vendor/bin")


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Currently the ruby version for inspec is 2.6.5 where the currently chef client 2.7 this will put both clients on the same version of ruby.

## Related Issue
https://github.com/chef/effortless/issues/261

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
