### PR TITLE
Return arrays for wmi properties

### DIFF
--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -191,6 +191,11 @@ class MockLoader
       mock.mock_command("", "", stderr, 1)
     }
 
+    # DEV NOTES: Most of the key=>value pairs below represent inspec commands=>responses to mock in testing.
+    #   "cf04ce5615167da0133540398aa9989bf48b3d15a615f08f97eafaeec6e5b2ba" => cmd.call("get-wmiobject"),
+    # In this ^^^ case, the key is the sha256sum of the script that is sent to the 'inspec.powershell' method in resources/wmi.rb
+    # And the content of 'get-wmiobject' can be found in this file: 'test/fixtures/cmd/get-wmiobject'. If you change the script
+    # that the inspec resource sends, you have to calculate the new sha256sum of it and update it here
     mock_cmds = {
       "" => empty.call,
       "sh -c 'find /no/such/mock -type f -maxdepth 1'" => empty.call,
@@ -375,7 +380,7 @@ class MockLoader
       # xinetd configuration
       "find /etc/xinetd.d -type f" => cmd.call("find-xinetd.d"),
       # wmi test
-      "2979ebeb80a475107d85411f109209a580ccf569071b3dc7acff030b8635c6b9" => cmd.call("get-wmiobject"),
+      "cf04ce5615167da0133540398aa9989bf48b3d15a615f08f97eafaeec6e5b2ba" => cmd.call("get-wmiobject"),
       # user info on hpux
       "logins -x -l root" => cmd.call("logins-x"),
       # packages on hpux

--- a/test/kitchen/policies/default/controls/wmi_spec.rb
+++ b/test/kitchen/policies/default/controls/wmi_spec.rb
@@ -26,7 +26,7 @@ describe wmi({
   namespace: 'root\\rsop\\computer',
   filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
 }) do
-   its('Setting') { should eq 1 }
+   its('Setting') { should eq [1] }
 end
 
 # new syntax
@@ -34,14 +34,14 @@ describe wmi({
   namespace: 'root\rsop\computer',
   query: "SELECT Setting FROM RSOP_SecuritySettingBoolean WHERE KeyName='LSAAnonymousNameLookup' AND Precedence=1"
 }) do
-  its('Setting') { should eq false }
+  its('Setting') { should cmp false }
 end
 
 describe wmi({
   namespace: 'root\cimv2',
   query: 'SELECT filesystem FROM win32_logicaldisk WHERE drivetype=3'
 }).params.values.join do
-  it { should eq 'NTFS' }
+  it { should cmp 'NTFS' }
 end
 
 # deprecated syntax
@@ -53,8 +53,8 @@ describe wmi('RSOP_SecuritySettingNumeric', {
   namespace: 'root\\rsop\\computer',
   filter: 'KeyName = \'MinimumPasswordAge\' And precedence=1'
 }) do
-   its('Setting') { should eq 1 }
-   its('setting') { should eq 1 }
+   its('Setting') { should cmp 1 }
+   its('setting') { should include 1 }
 end
 
 describe wmi('win32_service', {


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/inspec/inspec/issues/5313

## Types of changes:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [x] Breaking change (a content change which would break existing functionality or processes)

## Braking change:

Tests for the wmi resource that used the `eq` matcher without an array expected value, for example:
```ruby
describe wmi({:namespace=>"root\\cimv2", :query=>"SELECT installstate FROM win32_optionalfeature WHERE name = 'SMB1Protocol'"}) do
  its("installstate") { should eq 2 }
end
```

will need to upgrade to an expected array value, for example:
```ruby
  its("installstate") { should eq [2] }
```

or use the `cmp` matcher instead of `eq`
```ruby
  its("installstate") { should cmp 2 }
```

As a bonus, the resource is now compatible with a new `includes` matcher:
```ruby
  its("installstate") { should includes 2 }
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
