### PR TITLE
Fix issue Dir.home would break when HOME env absent

### DIFF
--- a/lib/inspec/globals.rb
+++ b/lib/inspec/globals.rb
@@ -1,11 +1,20 @@
 require_relative "utils/install_context"
 
+require 'etc' unless defined?(Etc)
+
 module Inspec
 
   extend Inspec::InstallContextHelpers
-
+  
   def self.config_dir
-    ENV["INSPEC_CONFIG_DIR"] ? ENV["INSPEC_CONFIG_DIR"] : File.join(Dir.home, ".inspec")
+    begin
+  	  home = Dir.home
+  	rescue ArgumentError, NoMethodError
+  	  # $HOME is not set in systemd service File.expand_path('~') will not work here
+  	  home = Etc.getpwuid(Process.uid).dir
+  	end
+
+    ENV["INSPEC_CONFIG_DIR"] ? ENV["INSPEC_CONFIG_DIR"] : File.join(home, ".inspec")
   end
 
   def self.src_root

--- a/lib/inspec/globals.rb
+++ b/lib/inspec/globals.rb
@@ -14,7 +14,7 @@ module Inspec
   def self.home_path
     Dir.home
   rescue ArgumentError, NoMethodError
-    # $HOME is not set in systemd service File.expand_path('~') will not work here
+    # If ENV['HOME'] is not set, Dir.home will fail due to expanding the ~. Fallback to Etc.
     require "etc" unless defined?(Etc)
     Etc.getpwuid.dir
   end

--- a/lib/inspec/globals.rb
+++ b/lib/inspec/globals.rb
@@ -1,24 +1,21 @@
 require_relative "utils/install_context"
 
-require 'etc' unless defined?(Etc)
-
 module Inspec
-
   extend Inspec::InstallContextHelpers
-  
-  def self.config_dir
-    begin
-  	  home = Dir.home
-  	rescue ArgumentError, NoMethodError
-  	  # $HOME is not set in systemd service File.expand_path('~') will not work here
-  	  home = Etc.getpwuid(Process.uid).dir
-  	end
 
-    ENV["INSPEC_CONFIG_DIR"] ? ENV["INSPEC_CONFIG_DIR"] : File.join(home, ".inspec")
+  def self.config_dir
+    ENV["INSPEC_CONFIG_DIR"] || File.join(home_path, ".inspec")
   end
 
   def self.src_root
     @src_root ||= File.expand_path(File.join(__FILE__, "../../.."))
   end
 
+  def self.home_path
+    Dir.home
+  rescue ArgumentError, NoMethodError
+    # $HOME is not set in systemd service File.expand_path('~') will not work here
+    require "etc" unless defined?(Etc)
+    Etc.getpwuid(Process.uid).dir
+  end
 end

--- a/lib/inspec/globals.rb
+++ b/lib/inspec/globals.rb
@@ -16,6 +16,6 @@ module Inspec
   rescue ArgumentError, NoMethodError
     # $HOME is not set in systemd service File.expand_path('~') will not work here
     require "etc" unless defined?(Etc)
-    Etc.getpwuid(Process.uid).dir
+    Etc.getpwuid.dir
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix the issue `Dir.home` would break when home directory lookup fail. when HOME even var is not set.
as `$HOME` is not set in systemd service `File.expand_path('~')` will not work here

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/inspec/inspec/issues/4803, https://github.com/chef/chef/issues/10565

Steps to reproduce
- `unset HOME`
- `ruby -e 'print Dir.home'`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>