### PR TITLE
Drop EOL Ruby 2.4 from testing, Fix Ruby 2.5 Gem build

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -17,14 +17,6 @@ steps:
         docker:
           image: ruby:2.6
 
-  - label: run-tests-ruby-2.4
-    command:
-      - /workdir/.expeditor/buildkite/verify.sh
-    expeditor:
-      executor:
-        docker:
-          image: ruby:2.4
-
   - label: run-tests-ruby-2.5
     command:
       - /workdir/.expeditor/buildkite/verify.sh

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,11 @@ gem "inspec-bin", path: "./inspec-bin"
 
 gem "ffi", ">= 1.9.14", "!= 1.13.0"
 
+if Gem.ruby_version.to_s.start_with?("2.5")
+  # 16.7.23 required ruby 2.6+
+  gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
+end
+
 group :omnibus do
   gem "rb-readline"
   gem "appbundler"


### PR DESCRIPTION
## Description

Addresses two related issues affecting our CI tests and gem builds of InSpec.

Firstly, drops Ruby 2.4 from CI testing. Ruby 2.4 has been EOL since March 2020. Closes #5067 .

Secondly, `chef-utils` 16.7.23 introduces a requirement for Ruby 2.6, which breaks any gem build on Ruby 2.5. Based on that, I've added a conditional pin on the library for 2.5 builds. 

Ruby 2.5 goes EOL in the first half of 2021. 

PSA: remember, the easiest way to consume InSpec is through Chef Workstation or the InSpec Omnibus packages, which include a known-working Ruby. Choosing to use a gem-based install involves a lot more upkeep.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Closes #5067 
#5320 will be needed for followup
Addresses https://github.com/chef/chef/issues/10698


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
