### PR TITLE
Fix escaping of Windows package names

### DIFF
--- a/lib/inspec/resources/package.rb
+++ b/lib/inspec/resources/package.rb
@@ -314,7 +314,7 @@ module Inspec::Resources
       # Find the package
       cmd = inspec.command <<-EOF.gsub(/^\s*/, "")
         Get-ItemProperty (@("#{search_paths.join('", "')}") | Where-Object { Test-Path $_ }) |
-        Where-Object { $_.DisplayName -match "^\s*#{package_name.shellescape}\.*" -or $_.PSChildName -match "^\s*#{package_name.shellescape}\.*" } |
+        Where-Object { $_.DisplayName -like "#{package_name}" -or $_.PSChildName -like "#{package_name}" } |
         Select-Object -Property DisplayName,DisplayVersion | ConvertTo-Json
       EOF
 

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -269,7 +269,7 @@ class MockLoader
       "rmsock f0000000000000001 tcpcb" => cmd.call("rmsock-f0001"),
       "rmsock f0000000000000002 tcpcb" => cmd.call("rmsock-f0002"),
       # packages on windows
-      "f7718ece69188bb19cd458e2aeab0a8d968f3d40ac2f4199e21cc976f8db5ef6" => cmd.call("get-item-property-package"),
+      "6785190b3df7291a7622b0b75b0217a9a78bd04690bc978df51ae17ec852a282" => cmd.call("get-item-property-package"),
       # service status upstart on ubuntu
       "initctl status ssh" => cmd.call("initctl-status-ssh"),
       # upstart version on ubuntu


### PR DESCRIPTION
This resolves #5235 and supersedes #5238.

Instead of using `-match` use `-like` when querying the Windows registry. This completely removes the problem of trying to clean the string for a regex and just let's Powershell do that with `-like`.

I confirmed this works with the use case of having a package name such as `Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29325` work as-is without any modification.

**NOTE: Someone with more PowerShell experience should let me know if this impacts backward compatibilty issues with older versions of Windows.**

Signed-off-by: Lance Albertson <lance@osuosl.org>
