### PR TITLE
Remove Gemfile.local support to use Dependabot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,3 @@ end
 group :deploy do
   gem "inquirer"
 end
-
-# add these additional dependencies into Gemfile.local
-eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")


### PR DESCRIPTION
If you remove this then Dependabot can manage deps, which helps keep us
up to data without manual work.

Signed-off-by: Tim Smith <tsmith@chef.io>