### PR TITLE
Remove the dependency on json_schemer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,19 +25,20 @@ end
 
 group :test do
   gem "chefstyle", "~> 1.2.1"
-  gem "minitest", "~> 5.5"
-  gem "minitest-sprint", "~> 1.0"
-  gem "rake", ">= 10"
-  gem "simplecov", ["~> 0.10", "<=0.18.2"]
   gem "concurrent-ruby", "~> 1.0"
-  gem "nokogiri", "~> 1.9"
-  gem "mocha", "~> 1.1"
-  gem "ruby-progressbar", "~> 1.8"
-  gem "webmock", "~> 3.0"
-  gem "m"
-  gem "pry", "~> 0.10"
-  gem "pry-byebug"
   gem "html-proofer", platforms: :ruby # do not attempt to run proofer on windows
+  gem "json_schemer", ">= 0.2.1", "< 0.2.12"
+  gem "m"
+  gem "minitest-sprint", "~> 1.0"
+  gem "minitest", "~> 5.5"
+  gem "mocha", "~> 1.1"
+  gem "nokogiri", "~> 1.9"
+  gem "pry-byebug"
+  gem "pry", "~> 0.10"
+  gem "rake", ">= 10"
+  gem "ruby-progressbar", "~> 1.8"
+  gem "simplecov", ["~> 0.10", "<=0.18.2"]
+  gem "webmock", "~> 3.0"
 end
 
 group :integration do

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "chef-telemetry",     "~> 1.0"
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 3.0"
   spec.add_dependency "thor",               ">= 0.20", "< 2.0"
-  spec.add_dependency "json_schemer",       ">= 0.2.1", "< 0.2.12"
   spec.add_dependency "method_source",      ">= 0.8", "< 2.0"
   spec.add_dependency "rubyzip",            "~> 1.2", ">= 1.2.2"
   spec.add_dependency "rspec",              "~> 3.9.0"


### PR DESCRIPTION
It looks like we're only using this in 3 test files and it conflicts with new RuboCop releases, which is blocking us from shipping that new release in Chef Infra Client and Workstation

Signed-off-by: Tim Smith <tsmith@chef.io>