### PR TITLE
Fix link to image in compliance plugin README

### DIFF
--- a/lib/plugins/inspec-compliance/README.md
+++ b/lib/plugins/inspec-compliance/README.md
@@ -71,7 +71,7 @@ $ inspec compliance login https://automate.compliance.test --insecure --user 'ad
 
 You will need an access token for authentication. You can retrieve one via:
 
-![Chef Compliance Token](images/cc-token.png)
+![Chef Compliance Token](lib/inspec-compliance/images/cc-token.png)
 
 You can choose the access token (`--token`) or the refresh token (`--refresh_token`)
 


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

## Description

The link to the image in the compliance plugin's README was broken. The image is showing an old version of Automate and should likely be updated, but at least now it is being displayed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
