### PR TITLE
Remove unused build-essential dep in berksfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,5 @@
 source "https://supermarket.chef.io"
 
 cookbook "audit"
-cookbook "build-essential"
 cookbook "install_inspec", path: "./test/kitchen/cookbooks/install_inspec"
 cookbook "os_prepare", path: "./test/kitchen/cookbooks/os_prepare"


### PR DESCRIPTION
This is not used by the test cookbooks

Signed-off-by: Tim Smith <tsmith@chef.io>