### PR TITLE
Remove the pin on EOL Chef releases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,6 @@ group :integration do
   gem "berkshelf"
   gem "test-kitchen", ">= 2.8"
   gem "kitchen-vagrant", ">= 1.7"
-  gem "chef", "< 15"
-  gem "chef-zero", "< 15"
   gem "kitchen-inspec", ">= 2.0"
   gem "kitchen-dokken", ">= 2.11"
   gem "git"


### PR DESCRIPTION
Chef 14 is no longer supported and shouldn't be pinned here. These old deps bring in a bunch of old pins.

Signed-off-by: Tim Smith <tsmith@chef.io>