### PR TITLE
Remove 'integration' group from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,15 +41,6 @@ group :test do
   gem "webmock", "~> 3.0"
 end
 
-group :integration do
-  gem "berkshelf"
-  gem "test-kitchen", ">= 2.8"
-  gem "kitchen-vagrant", ">= 1.7"
-  gem "kitchen-inspec", ">= 2.0"
-  gem "kitchen-dokken", ">= 2.11"
-  gem "git"
-end
-
 group :deploy do
   gem "inquirer"
 end


### PR DESCRIPTION

## Description

Removes the currently unused integration section from the Gemfile, which sets up support for Test Kitchen and includes support for Chef - and importantly, gem support for chef-zero, which requires Ruby 2.6. 

Fixes the broken Ruby 2.5 verify tests on master.

Fixes #5333 

Affects #5204 - which will now need to include the integration section conditionally.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
