### PR TITLE
Require ruby 2.5+ / allow ruby 3

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.4"
+  spec.required_ruby_version = ">= 2.5"
 
   # the gemfile and gemspec are necessary for appbundler so don't remove it
   spec.files =

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.4"
+  spec.required_ruby_version = ">= 2.5"
 
   # ONLY the aws/azure/gcp files. The rest will come in from inspec-core
   # the gemspec is necessary for appbundler so don't remove it


### PR DESCRIPTION
The currently ruby requirement is going to break things when we pull
Ruby 3 into Chef Infra Client next year.

Signed-off-by: Tim Smith <tsmith@chef.io>