### PR TITLE
Bump chefstyle to 1.5.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :omnibus do
 end
 
 group :test do
-  gem "chefstyle", "~> 1.2.1"
+  gem "chefstyle", "~> 1.5.7"
   gem "concurrent-ruby", "~> 1.0"
   gem "html-proofer", platforms: :ruby # do not attempt to run proofer on windows
   gem "json_schemer", ">= 0.2.1", "< 0.2.12"

--- a/examples/plugins/inspec-resource-lister/inspec-resource-lister.gemspec
+++ b/examples/plugins/inspec-resource-lister/inspec-resource-lister.gemspec
@@ -4,7 +4,7 @@
 
 # It is traditional in a gemspec to dynamically load the current version
 # from a file in the source tree.  The next three lines make that happen.
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-resource-lister/version"
 

--- a/inspec-bin/Gemfile
+++ b/inspec-bin/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-main_gemspec = File.expand_path("../inspec-bin.gemspec", __FILE__)
+main_gemspec = File.expand_path("inspec-bin.gemspec", __dir__)
 if File.exist?(main_gemspec)
   gemspec name: "inspec-bin"
 else

--- a/inspec-bin/Rakefile
+++ b/inspec-bin/Rakefile
@@ -3,7 +3,7 @@ Bundler::GemHelper.install_tasks name: "inspec-bin"
 desc "force install the inspec-bin gem"
 task "install:force" do
   sh "gem build -V inspec-bin.gemspec"
-  built_gem_path = Dir["inspec-bin-*.gem"].sort_by { |f| File.mtime(f) }.last
+  built_gem_path = Dir["inspec-bin-*.gem"].max_by { |f| File.mtime(f) }
   FileUtils.mkdir_p("pkg") unless Dir.exist?("pkg")
   FileUtils.mv(built_gem_path, "pkg")
   sh "gem install -f pkg/#{built_gem_path}"

--- a/inspec-bin/bin/inspec
+++ b/inspec-bin/bin/inspec
@@ -4,7 +4,7 @@
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "inspec/cli"

--- a/inspec-bin/inspec-bin.gemspec
+++ b/inspec-bin/inspec-bin.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-bin/version"
 

--- a/inspec-bin/inspec-core-bin.gemspec
+++ b/inspec-bin/inspec-core-bin.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-bin/version"
 

--- a/inspec-bin/lib/inspec-bin/version.rb
+++ b/inspec-bin/lib/inspec-bin/version.rb
@@ -1,5 +1,5 @@
 # This file managed by automation - do not edit manually
 module InspecBin
-  INSPECBIN_ROOT = File.expand_path("../..", __FILE__)
+  INSPECBIN_ROOT = File.expand_path("..", __dir__)
   VERSION = "4.24.22".freeze
 end

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec/version"
 

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec/version"
 

--- a/lib/bundles/inspec-supermarket/api.rb
+++ b/lib/bundles/inspec-supermarket/api.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "net/http"
-require "addressable/uri"
+require "net/http" unless defined?(Net::HTTP)
+require "addressable/uri" unless defined?(Addressable::URI)
 
 module Supermarket
   class API

--- a/lib/bundles/inspec-supermarket/target.rb
+++ b/lib/bundles/inspec-supermarket/target.rb
@@ -1,4 +1,4 @@
-require "uri"
+require "uri" unless defined?(URI)
 require "inspec/fetcher"
 require "inspec/fetcher/url"
 

--- a/lib/inspec/archive/tar.rb
+++ b/lib/inspec/archive/tar.rb
@@ -1,4 +1,4 @@
-require "rubygems/package"
+require "rubygems/package" unless defined?(Gem::Package)
 
 module Inspec::Archive
   class TarArchiveGenerator

--- a/lib/inspec/archive/zip.rb
+++ b/lib/inspec/archive/zip.rb
@@ -1,6 +1,6 @@
-require "rubygems"
-require "zip"
-require "pathname"
+require "rubygems" unless defined?(Gem)
+require "zip" unless defined?(Zip)
+require "pathname" unless defined?(Pathname)
 
 module Inspec::Archive
   class ZipArchiveGenerator

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -1,4 +1,4 @@
-require "thor"
+require "thor" unless defined?(Thor)
 require "inspec/log"
 require "inspec/ui"
 require "inspec/config"

--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -1,5 +1,5 @@
 require "inspec/fetcher"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 module Inspec
   class CachedFetcher

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -67,7 +67,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "A list of controls to include. Ignore all other tests."
   profile_options
   def json(target)
-    require "json"
+    require "json" unless defined?(JSON)
 
     o = config
     diagnose(o)

--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -1,11 +1,11 @@
 # Represents InSpec configuration.  Merges defaults, config file options,
 # and CLI arguments.
 
-require "pp"
-require "stringio"
-require "forwardable"
-require "thor"
-require "base64"
+require "pp" unless defined?(PP)
+require "stringio" unless defined?(StringIO)
+require "forwardable" unless defined?(Forwardable)
+require "thor" unless defined?(Thor)
+require "base64" unless defined?(Base64)
 require "inspec/plugin/v2/filter"
 
 module Inspec

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -1,4 +1,4 @@
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 module Inspec
   #

--- a/lib/inspec/env_printer.rb
+++ b/lib/inspec/env_printer.rb
@@ -1,6 +1,6 @@
 require "inspec/shell_detector"
-require "erb"
-require "shellwords"
+require "erb" unless defined?(Erb)
+require "shellwords" unless defined?(Shellwords)
 
 module Inspec
   class EnvPrinter

--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -1,6 +1,6 @@
-require "tmpdir"
-require "fileutils"
-require "mixlib/shellout"
+require "tmpdir" unless defined?(Dir.mktmpdir)
+require "fileutils" unless defined?(FileUtils)
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 require "inspec/log"
 
 module Inspec::Fetcher

--- a/lib/inspec/fetcher/local.rb
+++ b/lib/inspec/fetcher/local.rb
@@ -1,4 +1,4 @@
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 
 module Inspec::Fetcher
   class Local < Inspec.fetcher(1)

--- a/lib/inspec/fetcher/url.rb
+++ b/lib/inspec/fetcher/url.rb
@@ -1,7 +1,7 @@
-require "uri"
-require "openssl"
-require "tempfile"
-require "open-uri"
+require "uri" unless defined?(URI)
+require "openssl" unless defined?(OpenSSL)
+require "tempfile" unless defined?(Tempfile)
+require "open-uri" unless defined?(OpenURI)
 
 module Inspec::Fetcher
   class Url < Inspec.fetcher(1)

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -1,7 +1,7 @@
-require "rubygems/package"
-require "pathname"
-require "zlib"
-require "zip"
+require "rubygems/package" unless defined?(Gem::Package)
+require "pathname" unless defined?(Pathname)
+require "zlib" unless defined?(Zlib)
+require "zip" unless defined?(Zip)
 
 module Inspec
   class FileProvider

--- a/lib/inspec/input.rb
+++ b/lib/inspec/input.rb
@@ -14,14 +14,17 @@ module Inspec
   class Input
 
     class Error < Inspec::Error; end
+
     class ValidationError < Error
       attr_accessor :input_name
       attr_accessor :input_value
       attr_accessor :input_type
     end
+
     class TypeError < Error
       attr_accessor :input_type
     end
+
     class RequiredError < Error
       attr_accessor :input_name
     end

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -1,5 +1,5 @@
-require "forwardable"
-require "singleton"
+require "forwardable" unless defined?(Forwardable)
+require "singleton" unless defined?(Singleton)
 require "inspec/input"
 require "inspec/secrets"
 require "inspec/exceptions"
@@ -14,9 +14,11 @@ module Inspec
     extend Forwardable
 
     class Error < Inspec::Error; end
+
     class ProfileLookupError < Error
       attr_accessor :profile_name
     end
+
     class InputLookupError < Error
       attr_accessor :profile_name
       attr_accessor :input_name
@@ -199,7 +201,7 @@ module Inspec
           value = YAML.load(value)
         rescue Psych::SyntaxError => yaml_error
           # It could be that we just tried to run JSON through the YAML parser.
-          require "json"
+          require "json" unless defined?(JSON)
           begin
             value = JSON.parse(value)
           rescue JSON::ParserError => json_error

--- a/lib/inspec/metadata.rb
+++ b/lib/inspec/metadata.rb
@@ -216,7 +216,7 @@ module Inspec
     end
 
     def self.from_yaml(ref, content, profile_id, logger = nil)
-      require "erb"
+      require "erb" unless defined?(Erb)
       res = Metadata.new(ref, logger)
       res.params = YAML.load(ERB.new(content).result)
       res.content = content

--- a/lib/inspec/plugin/v1/plugins.rb
+++ b/lib/inspec/plugin/v1/plugins.rb
@@ -1,4 +1,4 @@
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 module Inspec
   # Resource Plugins
@@ -36,7 +36,7 @@ module Inspec
         .flatten
 
       # load bundled plugins
-      bundled_dir = File.expand_path(File.dirname(__FILE__))
+      bundled_dir = __dir__
       @paths += Dir[File.join(bundled_dir, "..", "bundles", "inspec-*.rb")].flatten
 
       # map paths to names

--- a/lib/inspec/plugin/v2.rb
+++ b/lib/inspec/plugin/v2.rb
@@ -6,17 +6,22 @@ module Inspec
       class Exception < Inspec::Error; end
       class ConfigError < Inspec::Plugin::V2::Exception; end
       class LoadError < Inspec::Plugin::V2::Exception; end
+
       class GemActionError < Inspec::Plugin::V2::Exception
         attr_accessor :plugin_name
         attr_accessor :version
       end
+
       class InstallError < Inspec::Plugin::V2::GemActionError; end
+
       class PluginExcludedError < Inspec::Plugin::V2::InstallError
         attr_accessor :details
       end
+
       class UpdateError < Inspec::Plugin::V2::GemActionError
         attr_accessor :from_version, :to_version
       end
+
       class UnInstallError < Inspec::Plugin::V2::GemActionError; end
       class SearchError < Inspec::Plugin::V2::GemActionError; end
     end

--- a/lib/inspec/plugin/v2/config_file.rb
+++ b/lib/inspec/plugin/v2/config_file.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module Inspec::Plugin::V2
   # Represents the plugin config file on disk.

--- a/lib/inspec/plugin/v2/filter.rb
+++ b/lib/inspec/plugin/v2/filter.rb
@@ -1,5 +1,5 @@
-require "singleton"
-require "json"
+require "singleton" unless defined?(Singleton)
+require "json" unless defined?(JSON)
 require "inspec/globals"
 
 module Inspec::Plugin; end

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -1,12 +1,12 @@
 # This file is not required by default.
 
-require "singleton"
-require "forwardable"
-require "fileutils"
-require "uri"
+require "singleton" unless defined?(Singleton)
+require "forwardable" unless defined?(Forwardable)
+require "fileutils" unless defined?(FileUtils)
+require "uri" unless defined?(URI)
 
 # Gem extensions for doing unusual things - not loaded by Gem default
-require "rubygems/package"
+require "rubygems/package" unless defined?(Gem::Package)
 require "rubygems/name_tuple"
 require "rubygems/uninstaller"
 require "rubygems/remote_fetcher"

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -130,7 +130,7 @@ module Inspec::Plugin::V2
     end
 
     def self.plugin_gem_path
-      require "rbconfig"
+      require "rbconfig" unless defined?(RbConfig)
       ruby_abi_version = RbConfig::CONFIG["ruby_version"]
       # TODO: why are we installing under the api directory for plugins?
       base_dir = Inspec.config_dir

--- a/lib/inspec/plugin/v2/registry.rb
+++ b/lib/inspec/plugin/v2/registry.rb
@@ -1,5 +1,5 @@
-require "forwardable"
-require "singleton"
+require "forwardable" unless defined?(Forwardable)
+require "singleton" unless defined?(Singleton)
 require "train"
 
 require_relative "status"

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -1,8 +1,8 @@
 # Copyright 2015 Dominik Richter
 
-require "forwardable"
-require "openssl"
-require "pathname"
+require "forwardable" unless defined?(Forwardable)
+require "openssl" unless defined?(OpenSSL)
+require "pathname" unless defined?(Pathname)
 require "inspec/input_registry"
 require "inspec/cached_fetcher" # TODO: split or rename
 require "inspec/source_reader"

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -4,7 +4,7 @@ require "inspec/resource"
 require "inspec/library_eval_context"
 require "inspec/control_eval_context"
 require "inspec/require_loader"
-require "securerandom"
+require "securerandom" unless defined?(SecureRandom)
 require "inspec/input_registry"
 
 module Inspec

--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -1,5 +1,5 @@
-require "json"
-require "net/http"
+require "json" unless defined?(JSON)
+require "net/http" unless defined?(Net::HTTP)
 
 module Inspec::Reporters
   class Automate < JsonAutomate

--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module Inspec::Reporters
   # rubocop:disable Layout/AlignHash, Style/BlockDelimiters

--- a/lib/inspec/reporters/json_automate.rb
+++ b/lib/inspec/reporters/json_automate.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module Inspec::Reporters
   class JsonAutomate < Json

--- a/lib/inspec/resources.rb
+++ b/lib/inspec/resources.rb
@@ -16,11 +16,11 @@ inspec_core_only = ENV["NO_AWS"] || !File.exist?(File.join(File.dirname(__FILE__
 # Do not attempt to load cloud resources if we are in inspec-core mode
 unless inspec_core_only
   require "resource_support/aws"
-  require "resources/azure/azure_backend.rb"
-  require "resources/azure/azure_generic_resource.rb"
-  require "resources/azure/azure_resource_group.rb"
-  require "resources/azure/azure_virtual_machine.rb"
-  require "resources/azure/azure_virtual_machine_data_disk.rb"
+  require "resources/azure/azure_backend"
+  require "resources/azure/azure_generic_resource"
+  require "resources/azure/azure_resource_group"
+  require "resources/azure/azure_virtual_machine"
+  require "resources/azure/azure_virtual_machine_data_disk"
 end
 
 require "inspec/resources/aide_conf"

--- a/lib/inspec/resources/apt.rb
+++ b/lib/inspec/resources/apt.rb
@@ -24,7 +24,7 @@ require "inspec/resources/command"
 # apt-get install software-properties-common
 # add-apt-repository ppa:ubuntu-wine/ppa
 
-require "uri"
+require "uri" unless defined?(URI)
 
 module Inspec::Resources
   class AptRepository < Inspec.resource(1)

--- a/lib/inspec/resources/auditd.rb
+++ b/lib/inspec/resources/auditd.rb
@@ -1,4 +1,4 @@
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 require "inspec/utils/filter_array"
 require "inspec/utils/filter"
 require "inspec/utils/parser"

--- a/lib/inspec/resources/csv.rb
+++ b/lib/inspec/resources/csv.rb
@@ -20,7 +20,7 @@ module Inspec::Resources
     #      { 'name' => 'row2', 'col1' => 'value3', 'col2' => 'value4' }
     #    ]
     def parse(content)
-      require "csv"
+      require "csv" unless defined?(CSV)
 
       # convert empty field to nil
       CSV::Converters[:blank_to_nil] = lambda do |field|

--- a/lib/inspec/resources/dh_params.rb
+++ b/lib/inspec/resources/dh_params.rb
@@ -1,4 +1,4 @@
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require "inspec/utils/file_reader"
 
 module Inspec::Resources

--- a/lib/inspec/resources/file.rb
+++ b/lib/inspec/resources/file.rb
@@ -1,6 +1,6 @@
 # copyright: 2015, Vulcano Security GmbH
 
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 require "inspec/utils/parser"
 
 module Inspec::Resources

--- a/lib/inspec/resources/http.rb
+++ b/lib/inspec/resources/http.rb
@@ -3,7 +3,7 @@
 # license: Apache v2
 
 require "inspec/resources/command"
-require "faraday"
+require "faraday" unless defined?(Faraday)
 require "faraday_middleware"
 require "hashie"
 

--- a/lib/inspec/resources/iis_website.rb
+++ b/lib/inspec/resources/iis_website.rb
@@ -1,2 +1,2 @@
 # This is just here to make the dynamic loader happy.
-require "inspec/resources/iis_website.rb"
+require "inspec/resources/iis_website"

--- a/lib/inspec/resources/interfaces.rb
+++ b/lib/inspec/resources/interfaces.rb
@@ -24,7 +24,7 @@ module Inspec::Resources
       .install_filter_methods_on_resource(self, :scan_interfaces)
 
     def ipv4_address
-      require "ipaddr"
+      require "ipaddr" unless defined?(IPAddr)
 
       # Loop over interface names
       # Select those that are up and have an ipv4 address

--- a/lib/inspec/resources/json.rb
+++ b/lib/inspec/resources/json.rb
@@ -66,7 +66,7 @@ module Inspec::Resources
     private
 
     def parse(content)
-      require "json"
+      require "json" unless defined?(JSON)
       JSON.parse(content)
     rescue => e
       raise Inspec::Exceptions::ResourceFailed, "Unable to parse JSON: #{e.message}"

--- a/lib/inspec/resources/key_rsa.rb
+++ b/lib/inspec/resources/key_rsa.rb
@@ -1,4 +1,4 @@
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require "hashie/mash"
 require "inspec/utils/file_reader"
 require "inspec/utils/pkey_reader"

--- a/lib/inspec/resources/mssql_session.rb
+++ b/lib/inspec/resources/mssql_session.rb
@@ -95,7 +95,7 @@ module Inspec::Resources
     end
 
     def parse_csv_result(cmd)
-      require "csv"
+      require "csv" unless defined?(CSV)
       table = CSV.parse(cmd.stdout, headers: true)
 
       # remove first row, since it will be a seperator line

--- a/lib/inspec/resources/mysql_session.rb
+++ b/lib/inspec/resources/mysql_session.rb
@@ -1,7 +1,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require "inspec/resources/command"
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 module Inspec::Resources
   class Lines

--- a/lib/inspec/resources/nginx.rb
+++ b/lib/inspec/resources/nginx.rb
@@ -1,4 +1,4 @@
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require "hashie/mash"
 require "inspec/resources/command"
 

--- a/lib/inspec/resources/nginx_conf.rb
+++ b/lib/inspec/resources/nginx_conf.rb
@@ -1,7 +1,7 @@
 require "inspec/utils/nginx_parser"
 require "inspec/utils/find_files"
 require "inspec/utils/file_reader"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 # STABILITY: Experimental
 # This resouce needs a proper interace to the underlying data, which is currently missing.

--- a/lib/inspec/resources/npm.rb
+++ b/lib/inspec/resources/npm.rb
@@ -1,5 +1,5 @@
 require "inspec/resources/command"
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 module Inspec::Resources
   class NpmPackage < Inspec.resource(1)

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -1,7 +1,7 @@
 require "inspec/resources/command"
 require "inspec/utils/database_helpers"
 require "hashie/mash"
-require "csv"
+require "csv" unless defined?(CSV)
 
 module Inspec::Resources
   # STABILITY: Experimental

--- a/lib/inspec/resources/port.rb
+++ b/lib/inspec/resources/port.rb
@@ -1,6 +1,6 @@
 require "inspec/utils/parser"
 require "inspec/utils/filter"
-require "ipaddr"
+require "ipaddr" unless defined?(IPAddr)
 
 # TODO: currently we return local ip only
 # TODO: improve handling of same port on multiple interfaces

--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -1,6 +1,6 @@
 # copyright: 2015, Vulcano Security GmbH
 
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 module Inspec::Resources
   class Lines

--- a/lib/inspec/resources/ppa.rb
+++ b/lib/inspec/resources/ppa.rb
@@ -1,2 +1,2 @@
 # This is just here to make the dynamic loader happy.
-require "inspec/resources/apt.rb"
+require "inspec/resources/apt"

--- a/lib/inspec/resources/processes.rb
+++ b/lib/inspec/resources/processes.rb
@@ -1,7 +1,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require "inspec/utils/filter"
-require "ostruct"
+require "ostruct" unless defined?(OpenStruct)
 require "inspec/resources/command"
 
 module Inspec::Resources

--- a/lib/inspec/resources/rabbitmq_conf.rb
+++ b/lib/inspec/resources/rabbitmq_conf.rb
@@ -1,2 +1,2 @@
 # This is just here to make the dynamic loader happy.
-require "inspec/resources/rabbitmq_config.rb"
+require "inspec/resources/rabbitmq_config"

--- a/lib/inspec/resources/registry_key.rb
+++ b/lib/inspec/resources/registry_key.rb
@@ -1,6 +1,6 @@
 # copyright: 2015, Vulcano Security GmbH
 
-require "json"
+require "json" unless defined?(JSON)
 require "inspec/resources/powershell"
 
 # Three constructor methods are available:

--- a/lib/inspec/resources/sshd_config.rb
+++ b/lib/inspec/resources/sshd_config.rb
@@ -1,2 +1,2 @@
 # This is just here to make the dynamic loader happy.
-require "inspec/resources/ssh_config.rb"
+require "inspec/resources/ssh_config"

--- a/lib/inspec/resources/ssl.rb
+++ b/lib/inspec/resources/ssl.rb
@@ -1,8 +1,8 @@
 # copyright: 2015, Chef Software Inc.
 
-require "sslshake"
+require "sslshake" unless defined?(SSLShake)
 require "inspec/utils/filter"
-require "uri"
+require "uri" unless defined?(URI)
 require "parallel"
 
 # Custom resource based on the InSpec resource DSL

--- a/lib/inspec/resources/toml.rb
+++ b/lib/inspec/resources/toml.rb
@@ -1,4 +1,4 @@
-require "tomlrb"
+require "tomlrb" unless defined?(Tomlrb)
 require "inspec/resources/json"
 
 module Inspec::Resources

--- a/lib/inspec/resources/vbscript.rb
+++ b/lib/inspec/resources/vbscript.rb
@@ -1,5 +1,5 @@
 require "inspec/resources/powershell"
-require "securerandom"
+require "securerandom" unless defined?(SecureRandom)
 
 module Inspec::Resources
   # This resource allows users to run vbscript on windows machines. We decided

--- a/lib/inspec/resources/windows_registry_key.rb
+++ b/lib/inspec/resources/windows_registry_key.rb
@@ -1,2 +1,2 @@
 # This is just here to make the dynamic loader happy.
-require "inspec/resources/registry_key.rb"
+require "inspec/resources/registry_key"

--- a/lib/inspec/resources/x509_certificate.rb
+++ b/lib/inspec/resources/x509_certificate.rb
@@ -1,4 +1,4 @@
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require "hashie/mash"
 require "inspec/utils/file_reader"
 

--- a/lib/inspec/resources/xml.rb
+++ b/lib/inspec/resources/xml.rb
@@ -13,7 +13,7 @@ module Inspec::Resources
     EXAMPLE
 
     def parse(content)
-      require "rexml/document"
+      require "rexml/document" unless defined?(REXML::Document)
       REXML::Document.new(content)
     rescue => e
       raise Inspec::Exceptions::ResourceFailed, "Unable to parse XML: #{e.message}"

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -1,7 +1,7 @@
 # copyright: 2015, Dominik Richter
 
-require "forwardable"
-require "uri"
+require "forwardable" unless defined?(Forwardable)
+require "uri" unless defined?(URI)
 require "inspec/backend"
 require "inspec/profile_context"
 require "inspec/profile"

--- a/lib/inspec/schema.rb
+++ b/lib/inspec/schema.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module Inspec
   class Schema

--- a/lib/inspec/schema/output_schema.rb
+++ b/lib/inspec/schema/output_schema.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 require "inspec/schema/primitives"
 require "inspec/schema/exec_json"
 require "inspec/schema/exec_json_min"

--- a/lib/inspec/schema/primitives.rb
+++ b/lib/inspec/schema/primitives.rb
@@ -1,4 +1,4 @@
-require "set"
+require "set" unless defined?(Set)
 
 # These elements are shared between more than one output type
 

--- a/lib/inspec/shell_detector.rb
+++ b/lib/inspec/shell_detector.rb
@@ -1,5 +1,5 @@
-require "etc"
-require "rbconfig"
+require "etc" unless defined?(Etc)
+require "rbconfig" unless defined?(RbConfig)
 
 module Inspec
   #

--- a/lib/inspec/utils/command_wrapper.rb
+++ b/lib/inspec/utils/command_wrapper.rb
@@ -1,4 +1,4 @@
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 class CommandWrapper
   UNIX_SHELLS = %w{sh bash zsh ksh}.freeze

--- a/lib/inspec/utils/deprecation/config_file.rb
+++ b/lib/inspec/utils/deprecation/config_file.rb
@@ -1,5 +1,5 @@
-require "stringio"
-require "json"
+require "stringio" unless defined?(StringIO)
+require "json" unless defined?(JSON)
 require "inspec/globals"
 require "inspec/config"
 

--- a/lib/inspec/utils/json_log.rb
+++ b/lib/inspec/utils/json_log.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 # a simple streaming json logger
 class Logger::JSONFormatter < Logger::Formatter

--- a/lib/inspec/utils/telemetry/collector.rb
+++ b/lib/inspec/utils/telemetry/collector.rb
@@ -1,6 +1,6 @@
 require "inspec/config"
 require "inspec/utils/telemetry/data_series"
-require "singleton"
+require "singleton" unless defined?(Singleton)
 
 module Inspec::Telemetry
   # A Singleton collection of data series objects.

--- a/lib/inspec/utils/telemetry/data_series.rb
+++ b/lib/inspec/utils/telemetry/data_series.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module Inspec; end
 

--- a/lib/plugins/inspec-artifact/lib/inspec-artifact/base.rb
+++ b/lib/plugins/inspec-artifact/lib/inspec-artifact/base.rb
@@ -1,8 +1,8 @@
-require "base64"
-require "openssl"
-require "pathname"
-require "set"
-require "tempfile"
+require "base64" unless defined?(Base64)
+require "openssl" unless defined?(OpenSSL)
+require "pathname" unless defined?(Pathname)
+require "set" unless defined?(Set)
+require "tempfile" unless defined?(Tempfile)
 require "yaml"
 require "inspec/dist"
 require "inspec/utils/json_profile_summary"

--- a/lib/plugins/inspec-artifact/test/functional/inspec_artifact_test.rb
+++ b/lib/plugins/inspec-artifact/test/functional/inspec_artifact_test.rb
@@ -1,6 +1,6 @@
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 require "plugins/shared/core_plugin_test_helper"
-require "securerandom"
+require "securerandom" unless defined?(SecureRandom)
 
 class ArtifactCli < Minitest::Test
   include CorePluginFunctionalHelper

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/api.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/api.rb
@@ -1,6 +1,6 @@
-require "net/http"
-require "uri"
-require "json"
+require "net/http" unless defined?(Net::HTTP)
+require "uri" unless defined?(URI)
+require "json" unless defined?(JSON)
 require "inspec/dist"
 
 require_relative "api/login"

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/http.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/http.rb
@@ -1,6 +1,6 @@
-require "net/http"
+require "net/http" unless defined?(Net::HTTP)
 require "net/http/post/multipart"
-require "uri"
+require "uri" unless defined?(URI)
 
 module InspecPlugins
   module Compliance

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/target.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/target.rb
@@ -1,4 +1,4 @@
-require "uri"
+require "uri" unless defined?(URI)
 require "inspec/fetcher"
 require "inspec/errors"
 require "inspec/dist"
@@ -85,7 +85,7 @@ module InspecPlugins
             # If version was specified, it will be the first and only result.
             # Note we are calling the sha256 as a string, not a symbol since
             # it was returned as json from the Compliance API.
-            profile_info = profile_result.sort_by { |x| Gem::Version.new(x["version"]) }[0]
+            profile_info = profile_result.min_by { |x| Gem::Version.new(x["version"]) }
             profile_checksum = profile_info.key?("sha256") ? profile_info["sha256"] : ""
           end
         end

--- a/lib/plugins/inspec-compliance/test/functional/inspec_compliance_test.rb
+++ b/lib/plugins/inspec-compliance/test/functional/inspec_compliance_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../../shared/core_plugin_test_helper.rb"
+require_relative "../../../shared/core_plugin_test_helper"
 
 class ComplianceCli < Minitest::Test
   include CorePluginFunctionalHelper

--- a/lib/plugins/inspec-compliance/test/unit/api/login_test.rb
+++ b/lib/plugins/inspec-compliance/test/unit/api/login_test.rb
@@ -1,7 +1,7 @@
 require "minitest/autorun"
 require "mocha/minitest"
 require "webmock/minitest"
-require_relative "../../../lib/inspec-compliance/api.rb"
+require_relative "../../../lib/inspec-compliance/api"
 
 describe InspecPlugins::Compliance::API do
   let(:automate_options) do

--- a/lib/plugins/inspec-compliance/test/unit/api_test.rb
+++ b/lib/plugins/inspec-compliance/test/unit/api_test.rb
@@ -1,7 +1,7 @@
 require "minitest/autorun"
 require "webmock/minitest"
 require "mocha/minitest"
-require_relative "../../lib/inspec-compliance/api.rb"
+require_relative "../../lib/inspec-compliance/api"
 
 describe InspecPlugins::Compliance::API do
   let(:profiles_response) do

--- a/lib/plugins/inspec-compliance/test/unit/target_test.rb
+++ b/lib/plugins/inspec-compliance/test/unit/target_test.rb
@@ -1,6 +1,6 @@
 require "minitest/autorun"
 require "mocha/minitest"
-require_relative "../../lib/inspec-compliance/api.rb"
+require_relative "../../lib/inspec-compliance/api"
 
 describe InspecPlugins::Compliance::Fetcher do
   let(:config) { { "server" => "myserver" } }

--- a/lib/plugins/inspec-habitat/lib/inspec-habitat/profile.rb
+++ b/lib/plugins/inspec-habitat/lib/inspec-habitat/profile.rb
@@ -1,7 +1,7 @@
 require "inspec/profile_vendor"
-require "mixlib/shellout"
-require "tomlrb"
-require "ostruct"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+require "tomlrb" unless defined?(Tomlrb)
+require "ostruct" unless defined?(OpenStruct)
 require "inspec/dist"
 
 module InspecPlugins

--- a/lib/plugins/inspec-habitat/test/functional/inspec_habitat_test.rb
+++ b/lib/plugins/inspec-habitat/test/functional/inspec_habitat_test.rb
@@ -1,5 +1,5 @@
-require_relative "../../../shared/core_plugin_test_helper.rb"
-require "fileutils"
+require_relative "../../../shared/core_plugin_test_helper"
+require "fileutils" unless defined?(FileUtils)
 
 class ProfileCli < Minitest::Test
   include CorePluginFunctionalHelper

--- a/lib/plugins/inspec-habitat/test/unit/profile_test.rb
+++ b/lib/plugins/inspec-habitat/test/unit/profile_test.rb
@@ -1,8 +1,8 @@
 require "mixlib/log"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 require "minitest/autorun"
 require "inspec/backend"
-require_relative "../../lib/inspec-habitat/profile.rb"
+require_relative "../../lib/inspec-habitat/profile"
 
 class InspecPlugins::Habitat::ProfileTest < Minitest::Test
   def setup
@@ -15,7 +15,7 @@ class InspecPlugins::Habitat::ProfileTest < Minitest::Test
 
     # Path from `__FILE__` needed to support running tests in `inspec/inspec`
     @test_profile_path = File.join(
-      File.expand_path(File.dirname(__FILE__)),
+      __dir__,
       "../",
       "support",
       "example_profile"

--- a/lib/plugins/inspec-init/lib/inspec-init/cli.rb
+++ b/lib/plugins/inspec-init/lib/inspec-init/cli.rb
@@ -1,4 +1,4 @@
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require_relative "renderer"
 
 module InspecPlugins

--- a/lib/plugins/inspec-init/lib/inspec-init/cli_profile.rb
+++ b/lib/plugins/inspec-init/lib/inspec-init/cli_profile.rb
@@ -1,4 +1,4 @@
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require_relative "renderer"
 
 module InspecPlugins

--- a/lib/plugins/inspec-init/lib/inspec-init/renderer.rb
+++ b/lib/plugins/inspec-init/lib/inspec-init/renderer.rb
@@ -1,5 +1,5 @@
-require "fileutils"
-require "erb"
+require "fileutils" unless defined?(FileUtils)
+require "erb" unless defined?(Erb)
 
 module InspecPlugins
   module Init

--- a/lib/plugins/inspec-init/test/functional/inspec_init_plugin_test.rb
+++ b/lib/plugins/inspec-init/test/functional/inspec_init_plugin_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../../shared/core_plugin_test_helper.rb"
+require_relative "../../../shared/core_plugin_test_helper"
 
 class InitPluginCli < Minitest::Test
   include CorePluginFunctionalHelper

--- a/lib/plugins/inspec-init/test/functional/inspec_init_profile_test.rb
+++ b/lib/plugins/inspec-init/test/functional/inspec_init_profile_test.rb
@@ -1,5 +1,5 @@
 require "yaml"
-require_relative "../../../shared/core_plugin_test_helper.rb"
+require_relative "../../../shared/core_plugin_test_helper"
 
 class InitCli < Minitest::Test
   include CorePluginFunctionalHelper

--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -1,4 +1,4 @@
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require "inspec/plugin/v2"
 require "inspec/plugin/v2/installer"
 require "inspec/dist"
@@ -505,8 +505,8 @@ module InspecPlugins
             plugin_name = status.name.to_s
             Inspec::Plugin::V2::Loader.list_installed_plugin_gems
               .select { |spec| spec.name == plugin_name }
-              .sort_by(&:version)
-              .last.version
+              .max_by(&:version)
+              .version
           end
         when :path
           "src"

--- a/lib/plugins/inspec-plugin-manager-cli/test/unit/cli_args_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/unit/cli_args_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../../shared/core_plugin_test_helper.rb"
+require_relative "../../../shared/core_plugin_test_helper"
 
 #-----------------------------------------------------------------------#
 # Thor option defs

--- a/lib/plugins/inspec-plugin-manager-cli/test/unit/plugin_def_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/unit/plugin_def_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../../shared/core_plugin_test_helper.rb"
+require_relative "../../../shared/core_plugin_test_helper"
 
 #-----------------------------------------------------------------------#
 # Plugin Definition

--- a/lib/plugins/inspec-reporter-html2/lib/inspec-reporter-html2/reporter.rb
+++ b/lib/plugins/inspec-reporter-html2/lib/inspec-reporter-html2/reporter.rb
@@ -1,4 +1,4 @@
-require "erb"
+require "erb" unless defined?(Erb)
 require "inspec/config"
 
 module InspecPlugins::Html2Reporter

--- a/lib/plugins/inspec-reporter-html2/test/functional/inspec_reporter_html2_test.rb
+++ b/lib/plugins/inspec-reporter-html2/test/functional/inspec_reporter_html2_test.rb
@@ -1,5 +1,5 @@
-require_relative "../../../shared/core_plugin_test_helper.rb"
-require "tempfile"
+require_relative "../../../shared/core_plugin_test_helper"
+require "tempfile" unless defined?(Tempfile)
 
 describe "inspec-reporter-html2" do
   include CorePluginFunctionalHelper

--- a/lib/plugins/inspec-reporter-html2/test/unit/plugin_def_test.rb
+++ b/lib/plugins/inspec-reporter-html2/test/unit/plugin_def_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../../shared/core_plugin_test_helper.rb"
+require_relative "../../../shared/core_plugin_test_helper"
 require_relative "../../lib/inspec-reporter-html2"
 require "inspec/plugin/v2"
 

--- a/lib/plugins/inspec-reporter-html2/test/unit/reporter_api_test.rb
+++ b/lib/plugins/inspec-reporter-html2/test/unit/reporter_api_test.rb
@@ -1,4 +1,4 @@
-require_relative "../../../shared/core_plugin_test_helper.rb"
+require_relative "../../../shared/core_plugin_test_helper"
 require_relative "../../lib/inspec-reporter-html2"
 require_relative "../../lib/inspec-reporter-html2/reporter"
 

--- a/lib/plugins/inspec-reporter-json-min/lib/inspec-reporter-json-min/reporter.rb
+++ b/lib/plugins/inspec-reporter-json-min/lib/inspec-reporter-json-min/reporter.rb
@@ -1,4 +1,4 @@
-require "json"
+require "json" unless defined?(JSON)
 
 module InspecPlugins::JsonMinReporter
   class Reporter < Inspec.plugin(2, :reporter)

--- a/lib/plugins/inspec-reporter-junit/lib/inspec-reporter-junit/reporter.rb
+++ b/lib/plugins/inspec-reporter-junit/lib/inspec-reporter-junit/reporter.rb
@@ -5,7 +5,7 @@ module InspecPlugins::JUnitReporter
     end
 
     def render
-      require "rexml/document"
+      require "rexml/document" unless defined?(REXML::Document)
       xml_output = REXML::Document.new
       xml_output.add(REXML::XMLDecl.new)
 

--- a/lib/plugins/shared/core_plugin_test_helper.rb
+++ b/lib/plugins/shared/core_plugin_test_helper.rb
@@ -3,14 +3,14 @@ require "minitest/autorun"
 require "minitest/pride"
 
 # Data formats commonly used in testing
-require "json"
-require "ostruct"
+require "json" unless defined?(JSON)
+require "ostruct" unless defined?(OpenStruct)
 
 # Utilities often needed
-require "fileutils"
-require "tmpdir"
-require "pathname"
-require "forwardable"
+require "fileutils" unless defined?(FileUtils)
+require "tmpdir" unless defined?(Dir.mktmpdir)
+require "pathname" unless defined?(Pathname)
+require "forwardable" unless defined?(Forwardable)
 
 require "functional/helper"
 require "inspec/plugin/v2"

--- a/lib/resources/aws/aws_billing_report.rb
+++ b/lib/resources/aws/aws_billing_report.rb
@@ -1,9 +1,7 @@
 require "resource_support/aws/aws_singular_resource_mixin"
 require "resource_support/aws/aws_backend_base"
 
-require "resource_support/aws/aws_singular_resource_mixin"
-require "resource_support/aws/aws_backend_base"
-require "aws-sdk-costandusagereportservice.rb"
+require "aws-sdk-costandusagereportservice"
 
 class AwsBillingReport < Inspec.resource(1)
   name "aws_billing_report"

--- a/lib/resources/aws/aws_ecs_cluster.rb
+++ b/lib/resources/aws/aws_ecs_cluster.rb
@@ -37,19 +37,18 @@ class AwsEcsCluster < Inspec.resource(1)
 
   def fetch_from_api
     backend = BackendFactory.create(inspec_runner)
-    begin
-      # Use default cluster if no cluster name is specified
-      params = cluster_name.nil? ? {} : { clusters: [cluster_name] }
-      clusters = backend.describe_clusters(params).clusters
 
-      # Cluster name is unique, we either get back one cluster, or none
-      if clusters.length == 1
-        @exists = true
-        unpack_describe_clusters_response(clusters.first)
-      else
-        @exists = false
-        populate_as_missing
-      end
+    # Use default cluster if no cluster name is specified
+    params = cluster_name.nil? ? {} : { clusters: [cluster_name] }
+    clusters = backend.describe_clusters(params).clusters
+
+    # Cluster name is unique, we either get back one cluster, or none
+    if clusters.length == 1
+      @exists = true
+      unpack_describe_clusters_response(clusters.first)
+    else
+      @exists = false
+      populate_as_missing
     end
   end
 

--- a/lib/resources/aws/aws_iam_policy.rb
+++ b/lib/resources/aws/aws_iam_policy.rb
@@ -2,9 +2,9 @@ require "resource_support/aws/aws_singular_resource_mixin"
 require "resource_support/aws/aws_backend_base"
 require "aws-sdk-iam"
 
-require "json"
-require "set"
-require "uri"
+require "json" unless defined?(JSON)
+require "set" unless defined?(Set)
+require "uri" unless defined?(URI)
 
 class AwsIamPolicy < Inspec.resource(1)
   name "aws_iam_policy"

--- a/lib/resources/aws/aws_security_group.rb
+++ b/lib/resources/aws/aws_security_group.rb
@@ -1,5 +1,5 @@
-require "set"
-require "ipaddr"
+require "set" unless defined?(Set)
+require "ipaddr" unless defined?(IPAddr)
 
 require "resource_support/aws/aws_singular_resource_mixin"
 require "resource_support/aws/aws_backend_base"

--- a/lib/resources/aws/aws_sqs_queue.rb
+++ b/lib/resources/aws/aws_sqs_queue.rb
@@ -2,7 +2,7 @@ require "resource_support/aws/aws_singular_resource_mixin"
 require "resource_support/aws/aws_backend_base"
 require "aws-sdk-sqs"
 
-require "uri"
+require "uri" unless defined?(URI)
 
 class AwsSqsQueue < Inspec.resource(1)
   name "aws_sqs_queue"

--- a/lib/resources/azure/azure_virtual_machine_data_disk.rb
+++ b/lib/resources/azure/azure_virtual_machine_data_disk.rb
@@ -1,5 +1,5 @@
 require "resources/azure/azure_backend"
-require "uri"
+require "uri" unless defined?(URI)
 
 module Inspec::Resources
   class AzureVirtualMachineDataDisk < AzureResourceBase

--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require_relative "../../../lib/inspec/version.rb"
+require_relative "../../../lib/inspec/version"
 
 name "inspec"
 friendly_name "InSpec"
@@ -37,7 +37,7 @@ build_version Inspec::VERSION
 build_iteration 1
 
 # Load dynamically updated overrides
-overrides_path = File.expand_path("../../../../omnibus_overrides.rb", __FILE__)
+overrides_path = File.expand_path("../../../omnibus_overrides.rb", __dir__)
 instance_eval(File.read(overrides_path), overrides_path)
 
 dependency "preparation"

--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require_relative "../../../lib/inspec/version.rb"
+require_relative "../../../lib/inspec/version"
 
 name "inspec"
 

--- a/test/fixtures/config_dirs/test-fixture-1-float/gems/2.4.0/gems/inspec-test-fixture-0.1.0/inspec-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/test-fixture-1-float/gems/2.4.0/gems/inspec-test-fixture-0.1.0/inspec-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-test-fixture/version"
 

--- a/test/fixtures/config_dirs/test-fixture-1-float/gems/2.5.0/gems/inspec-test-fixture-0.1.0/inspec-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/test-fixture-1-float/gems/2.5.0/gems/inspec-test-fixture-0.1.0/inspec-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-test-fixture/version"
 

--- a/test/fixtures/config_dirs/test-fixture-1-float/gems/2.6.0/gems/inspec-test-fixture-0.1.0/inspec-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/test-fixture-1-float/gems/2.6.0/gems/inspec-test-fixture-0.1.0/inspec-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-test-fixture/version"
 

--- a/test/fixtures/config_dirs/test-fixture-1-float/gems/2.7.0/gems/inspec-test-fixture-0.1.0/inspec-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/test-fixture-1-float/gems/2.7.0/gems/inspec-test-fixture-0.1.0/inspec-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-test-fixture/version"
 

--- a/test/fixtures/config_dirs/test-fixture-2-float/gems/2.4.0/gems/inspec-test-fixture-0.2.0/inspec-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/test-fixture-2-float/gems/2.4.0/gems/inspec-test-fixture-0.2.0/inspec-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-test-fixture/version"
 

--- a/test/fixtures/config_dirs/test-fixture-2-float/gems/2.5.0/gems/inspec-test-fixture-0.2.0/inspec-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/test-fixture-2-float/gems/2.5.0/gems/inspec-test-fixture-0.2.0/inspec-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-test-fixture/version"
 

--- a/test/fixtures/config_dirs/test-fixture-2-float/gems/2.6.0/gems/inspec-test-fixture-0.2.0/inspec-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/test-fixture-2-float/gems/2.6.0/gems/inspec-test-fixture-0.2.0/inspec-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-test-fixture/version"
 

--- a/test/fixtures/config_dirs/test-fixture-2-float/gems/2.7.0/gems/inspec-test-fixture-0.2.0/inspec-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/test-fixture-2-float/gems/2.7.0/gems/inspec-test-fixture-0.2.0/inspec-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-test-fixture/version"
 

--- a/test/fixtures/config_dirs/train-test-fixture/gems/2.4.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/train-test-fixture/gems/2.4.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|

--- a/test/fixtures/config_dirs/train-test-fixture/gems/2.5.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/train-test-fixture/gems/2.5.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|

--- a/test/fixtures/config_dirs/train-test-fixture/gems/2.6.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/train-test-fixture/gems/2.6.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|

--- a/test/fixtures/config_dirs/train-test-fixture/gems/2.7.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
+++ b/test/fixtures/config_dirs/train-test-fixture/gems/2.7.0/gems/train-test-fixture-0.1.0/train-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|

--- a/test/fixtures/plugins/inspec-dsl-test/lib/inspec-dsl-test.rb
+++ b/test/fixtures/plugins/inspec-dsl-test/lib/inspec-dsl-test.rb
@@ -1,4 +1,4 @@
-lib = File.expand_path("../../lib", __FILE__)
+lib = File.expand_path("../lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require_relative "inspec-dsl-test/version"

--- a/test/fixtures/plugins/inspec-test-fixture/inspec-test-fixture.gemspec
+++ b/test/fixtures/plugins/inspec-test-fixture/inspec-test-fixture.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-test-fixture/version"
 

--- a/test/fixtures/plugins/inspec-test-fixture/lib/inspec-test-fixture.rb
+++ b/test/fixtures/plugins/inspec-test-fixture/lib/inspec-test-fixture.rb
@@ -1,4 +1,4 @@
-lib = File.expand_path("../../lib", __FILE__)
+lib = File.expand_path("../lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require_relative "inspec-test-fixture/version"

--- a/test/functional/helper.rb
+++ b/test/functional/helper.rb
@@ -14,7 +14,7 @@ module FunctionalHelper
   extend Minitest::Guard
 
   let(:repo_path) do
-    path = File.expand_path("../../..", __FILE__)
+    path = File.expand_path("../..", __dir__)
     # fix for vagrant repo pathing
     path.gsub!("//vboxsvr", "C:") if is_windows?
     path

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -53,7 +53,7 @@ class MockLoader
   def backend
     return @backend if defined?(@backend)
 
-    scriptpath = ::File.expand_path "../..", __FILE__
+    scriptpath = ::File.expand_path "..", __dir__
 
     # create mock backend
     @backend = Inspec::Backend.create(Inspec::Config.mock)
@@ -604,7 +604,7 @@ class MockLoader
   end
 
   def self.home # "home" of the repo (not test!)... I really dislike this name
-    File.expand_path "../../..", __FILE__
+    File.expand_path "../..", __dir__
   end
 
   def self.profile_path(name)

--- a/test/unit/file_provider_test.rb
+++ b/test/unit/file_provider_test.rb
@@ -41,7 +41,7 @@ describe Inspec::DirProvider do
     end
 
     it "must not read files not covered" do
-      not_covered = File.expand_path("../../helper.rb", __FILE__)
+      not_covered = File.expand_path("../helper.rb", __dir__)
       _(File.file?(not_covered)).must_equal true
       _(subject.read(not_covered)).must_be_nil
     end
@@ -63,7 +63,7 @@ describe Inspec::DirProvider do
     end
 
     it "must not read files not covered" do
-      not_covered = File.expand_path("../../helper.rb", __FILE__)
+      not_covered = File.expand_path("../helper.rb", __dir__)
       _(File.file?(not_covered)).must_equal true
       _(subject.read(not_covered)).must_be_nil
     end

--- a/test/unit/reporters/base_test.rb
+++ b/test/unit/reporters/base_test.rb
@@ -2,7 +2,7 @@ require "helper"
 require "inspec/reporters"
 
 describe Inspec::Reporters::Base do
-  let(:path) { File.expand_path(File.dirname(__FILE__)) }
+  let(:path) { __dir__ }
   let(:report) do
     data = JSON.parse(File.read("test/fixtures//reporters/run_data.json"), symbolize_names: true)
     Inspec::Reporters::Base.new({ run_data: data })

--- a/test/unit/resources/aws_billing_report_test.rb
+++ b/test/unit/resources/aws_billing_report_test.rb
@@ -5,7 +5,6 @@ require "resources/aws/aws_billing_report"
 require "fixtures/files/aws_billing_backend"
 
 require "resource_support/aws"
-require "resources/aws/aws_billing_report"
 
 class EmptyAwsBillingReportTest < Minitest::Test
   def setup

--- a/test/unit/resources/aws_billing_reports_test.rb
+++ b/test/unit/resources/aws_billing_reports_test.rb
@@ -5,7 +5,6 @@ require "resources/aws/aws_billing_reports"
 require "fixtures/files/aws_billing_backend"
 
 require "resource_support/aws"
-require "resources/aws/aws_billing_reports"
 
 class ConstructorAwsBillingReportsTest < Minitest::Test
   def setup

--- a/test/unit/resources/aws_cloudtrail_trail_test.rb
+++ b/test/unit/resources/aws_cloudtrail_trail_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_cloudtrail_trail"
 
 require "resource_support/aws"
-require "resources/aws/aws_cloudtrail_trail"
 
 # MACTTSB = MockAwsCloudTrailTrailSingularBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_cloudtrail_trails_test.rb
+++ b/test/unit/resources/aws_cloudtrail_trails_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_cloudtrail_trails"
 
 require "resource_support/aws"
-require "resources/aws/aws_cloudtrail_trails"
 
 # MACTTPB = MockAwsCloudTrailTrailsPluralBackend
 # Abbreviation not used outside this file
@@ -73,6 +72,7 @@ class AwsCloudTrailTrailsProperties < Minitest::Test
     refute(basic.trail_arns.include?(nil))
   end
 end
+
 #=============================================================================#
 #                               Test Fixtures
 #=============================================================================#

--- a/test/unit/resources/aws_cloudwatch_alarm_test.rb
+++ b/test/unit/resources/aws_cloudwatch_alarm_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_cloudwatch_alarm"
 
 require "resource_support/aws"
-require "resources/aws/aws_cloudwatch_alarm"
 
 # MCWAB = MockCloudwatchAlarmBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_cloudwatch_log_metric_filter_test.rb
+++ b/test/unit/resources/aws_cloudwatch_log_metric_filter_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_cloudwatch_log_metric_filter"
 
 require "resource_support/aws"
-require "resources/aws/aws_cloudwatch_log_metric_filter"
 
 # CWLMF = CloudwatchLogMetricFilter
 # Abbreviation not used outside this file
@@ -76,6 +75,7 @@ class AwsCWLMFSearch < Minitest::Test
     assert lmf.exists?
   end
 end
+
 #=============================================================================#
 #                            Property Tests                                   #
 #=============================================================================#
@@ -105,6 +105,7 @@ class AwsMockCWLMFBackend
       []
     end
   end
+
   class Basic < AwsBackendBase
     def describe_metric_filters(criteria) # rubocop:disable Metrics/MethodLength
       everything = [

--- a/test/unit/resources/aws_config_delivery_channel_test.rb
+++ b/test/unit/resources/aws_config_delivery_channel_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_config_delivery_channel"
 
 require "resource_support/aws"
-require "resources/aws/aws_config_delivery_channel"
 
 # MDCSB = MockDeliveryChannelSingleBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_config_recorder_test.rb
+++ b/test/unit/resources/aws_config_recorder_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_config_recorder"
 
 require "resource_support/aws"
-require "resources/aws/aws_config_recorder"
 
 # MCRSB = MockConfigRecorderSingleBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_ebs_volume_test.rb
+++ b/test/unit/resources/aws_ebs_volume_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_ebs_volume"
 
 require "resource_support/aws"
-require "resources/aws/aws_ebs_volume"
 
 class TestEbs < Minitest::Test
   ID = "volume-id".freeze

--- a/test/unit/resources/aws_ebs_volumes_test.rb
+++ b/test/unit/resources/aws_ebs_volumes_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_ebs_volumes"
 
 require "resource_support/aws"
-require "resources/aws/aws_ebs_volumes"
 
 # MAEIPB = MockAwsEbsVolumesPluralBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_ec2_instance_test.rb
+++ b/test/unit/resources/aws_ec2_instance_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_ec2_instance"
 
 require "resource_support/aws"
-require "resources/aws/aws_ec2_instance"
 
 class TestEc2 < Minitest::Test
   ID = "instance-id".freeze

--- a/test/unit/resources/aws_ec2_instances_test.rb
+++ b/test/unit/resources/aws_ec2_instances_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_ec2_instances"
 
 require "resource_support/aws"
-require "resources/aws/aws_ec2_instances"
 
 # MAEIPB = MockAwsEC2InstancesPluralBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_ecs_cluster_test.rb
+++ b/test/unit/resources/aws_ecs_cluster_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_ecs_cluster"
 
 require "resource_support/aws"
-require "resources/aws/aws_ecs_cluster"
 
 # MAECSB = MockAwsEcsClusterSingularBackend
 # Abbreviation not used outside this file
@@ -128,6 +127,7 @@ class AwsEcsClusterProperties < Minitest::Test
   end
 
 end
+
 #=============================================================================#
 #                               Test Fixtures
 #=============================================================================#

--- a/test/unit/resources/aws_eks_cluster_test.rb
+++ b/test/unit/resources/aws_eks_cluster_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_eks_cluster"
 
 require "resource_support/aws"
-require "resources/aws/aws_eks_cluster"
 
 # MAEKSB = MockAwsEksClusterSingularBackend
 # Abbreviation not used outside this file
@@ -170,6 +169,7 @@ class AwsEksClusterProperties < Minitest::Test
   end
 
 end
+
 #=============================================================================#
 #                               Test Fixtures
 #=============================================================================#

--- a/test/unit/resources/aws_elb_test.rb
+++ b/test/unit/resources/aws_elb_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_elb"
 
 require "resource_support/aws"
-require "resources/aws/aws_elb"
 
 # MAESB = MockAwsElbSingularBackend
 # Abbreviation not used outside this file
@@ -139,6 +138,7 @@ class AwsElbProperties < Minitest::Test
   end
 
 end
+
 #=============================================================================#
 #                               Test Fixtures
 #=============================================================================#

--- a/test/unit/resources/aws_elbs_test.rb
+++ b/test/unit/resources/aws_elbs_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_elbs"
 
 require "resource_support/aws"
-require "resources/aws/aws_elbs"
 
 # MAEPB = MockAwsELBsPluralBackend
 # Abbreviation not used outside this file
@@ -196,6 +195,7 @@ class AwsElbsProperties < Minitest::Test
   end
 
 end
+
 #=============================================================================#
 #                               Test Fixtures
 #=============================================================================#

--- a/test/unit/resources/aws_flow_log_test.rb
+++ b/test/unit/resources/aws_flow_log_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_flow_log"
 
 require "resource_support/aws"
-require "resources/aws/aws_flow_log"
 
 class EmptyAwsFlowLog < Minitest::Test
   def setup

--- a/test/unit/resources/aws_iam_access_key_test.rb
+++ b/test/unit/resources/aws_iam_access_key_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_iam_access_key"
 
 require "resource_support/aws"
-require "resources/aws/aws_iam_access_key"
 
 class AwsIamAccessKeyConstructorTest < Minitest::Test
   def setup

--- a/test/unit/resources/aws_iam_access_keys_test.rb
+++ b/test/unit/resources/aws_iam_access_keys_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_iam_access_keys"
 
 require "resource_support/aws"
-require "resources/aws/aws_iam_access_keys"
 
 #==========================================================#
 #                 Constructor Tests                        #

--- a/test/unit/resources/aws_iam_group_test.rb
+++ b/test/unit/resources/aws_iam_group_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_iam_group"
 
 require "resource_support/aws"
-require "resources/aws/aws_iam_group"
 
 # MAIGSB = MockAwsIamGroupSingularBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_iam_groups_test.rb
+++ b/test/unit/resources/aws_iam_groups_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_iam_groups"
 
 require "resource_support/aws"
-require "resources/aws/aws_iam_groups"
 
 # MAIGPB = MockAwsIamGroupsPluralBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_iam_password_policy_test.rb
+++ b/test/unit/resources/aws_iam_password_policy_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_iam_password_policy"
 
 require "resource_support/aws"
-require "resources/aws/aws_iam_password_policy"
 
 class AwsIamPasswordPolicyTest < Minitest::Test
   def setup

--- a/test/unit/resources/aws_iam_policies_test.rb
+++ b/test/unit/resources/aws_iam_policies_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_iam_policies"
 
 require "resource_support/aws"
-require "resources/aws/aws_iam_policies"
 
 # MAIPPB = MockAwsIamPoliciesPluralBackend
 # Abbreviation not used outside this file
@@ -73,6 +72,7 @@ class AwsIamPoliciesProperties < Minitest::Test
     refute(basic.arns.include?(nil))
   end
 end
+
 #=============================================================================#
 #                               Test Fixtures
 #=============================================================================#

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_iam_policy"
 
 require "resource_support/aws"
-require "resources/aws/aws_iam_policy"
 
 # MAIPSB = MockAwsIamPolicySingularBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_iam_role_test.rb
+++ b/test/unit/resources/aws_iam_role_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_iam_role"
 
 require "resource_support/aws"
-require "resources/aws/aws_iam_role"
 
 # MIRB = MockIamRoleBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_iam_root_user"
 
 require "resource_support/aws"
-require "resources/aws/aws_iam_root_user"
 
 class AwsIamRootUserTest < Minitest::Test
   def setup

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_iam_user"
 
 require "resource_support/aws"
-require "resources/aws/aws_iam_user"
 
 # MAIUB = MockAwsIamUserBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_iam_users_test.rb
+++ b/test/unit/resources/aws_iam_users_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_iam_users"
 
 require "resource_support/aws"
-require "resources/aws/aws_iam_users"
 
 # Maiusb = Mock AwsIamUsers::BackendFactory
 # Abbreviation not used outside of this file

--- a/test/unit/resources/aws_kms_key_test.rb
+++ b/test/unit/resources/aws_kms_key_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_kms_key"
 
 require "resource_support/aws"
-require "resources/aws/aws_kms_key"
 
 # MAKKSB = MockAwsKmsKeyBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_kms_keys_test.rb
+++ b/test/unit/resources/aws_kms_keys_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_kms_keys"
 
 require "resource_support/aws"
-require "resources/aws/aws_kms_keys"
 
 # MAKKPB = MockAwsKmsKeysPluralBackend
 # Abbreviation not used outside this file
@@ -73,6 +72,7 @@ class AwsKmsKeysProperties < Minitest::Test
     refute(basic.key_arns.include?(nil))
   end
 end
+
 #=============================================================================#
 #                               Test Fixtures
 #=============================================================================#

--- a/test/unit/resources/aws_rds_instance_test.rb
+++ b/test/unit/resources/aws_rds_instance_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_rds_instance"
 
 require "resource_support/aws"
-require "resources/aws/aws_rds_instance"
 
 # MRDSIB = MockRDSInstanceBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_route_table_test.rb
+++ b/test/unit/resources/aws_route_table_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_route_table"
 
 require "resource_support/aws"
-require "resources/aws/aws_route_table"
 
 class EmptyAwsRouteTableTest < Minitest::Test
   def setup

--- a/test/unit/resources/aws_route_tables_test.rb
+++ b/test/unit/resources/aws_route_tables_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_route_tables"
 
 require "resource_support/aws"
-require "resources/aws/aws_route_tables"
 
 class EmptyAwsRouteTablesTest < Minitest::Test
   def setup

--- a/test/unit/resources/aws_s3_bucket_object_test.rb
+++ b/test/unit/resources/aws_s3_bucket_object_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_s3_bucket_object"
 
 require "resource_support/aws"
-require "resources/aws/aws_s3_bucket_object"
 
 # MSBOSB = MockS3BucketObjectSingleBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_s3_bucket_test.rb
+++ b/test/unit/resources/aws_s3_bucket_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_s3_bucket"
 
 require "resource_support/aws"
-require "resources/aws/aws_s3_bucket"
 
 # MSBSB = MockS3BucketSingleBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_s3_buckets_test.rb
+++ b/test/unit/resources/aws_s3_buckets_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_s3_buckets"
 
 require "resource_support/aws"
-require "resources/aws/aws_s3_buckets"
 
 # MSBB = MockS3BucketsBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_security_group_test.rb
+++ b/test/unit/resources/aws_security_group_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_security_group"
 
 require "resource_support/aws"
-require "resources/aws/aws_security_group"
 
 # MESGSB = MockEc2SecurityGroupSingleBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_security_groups_test.rb
+++ b/test/unit/resources/aws_security_groups_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_security_groups"
 
 require "resource_support/aws"
-require "resources/aws/aws_security_groups"
 
 # MESGB = MockSecurityGroupBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_sns_subscription_test.rb
+++ b/test/unit/resources/aws_sns_subscription_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_sns_subscription"
 
 require "resource_support/aws"
-require "resources/aws/aws_sns_subscription"
 
 # MASSSB = MockAwsSNSSubscriptionSingularBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_sns_topic_test.rb
+++ b/test/unit/resources/aws_sns_topic_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_sns_topic"
 
 require "resource_support/aws"
-require "resources/aws/aws_sns_topic"
 
 # MSNB = MockSnsBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_sns_topics_test.rb
+++ b/test/unit/resources/aws_sns_topics_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_sns_topics"
 
 require "resource_support/aws"
-require "resources/aws/aws_sns_topics"
 
 # MSTB = MockSnsTopicsBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_sqs_queue_test.rb
+++ b/test/unit/resources/aws_sqs_queue_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_sqs_queue"
 
 require "resource_support/aws"
-require "resources/aws/aws_sqs_queue"
 
 # MSQB = MockSQsBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_subnet_test.rb
+++ b/test/unit/resources/aws_subnet_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_subnet"
 
 require "resource_support/aws"
-require "resources/aws/aws_subnet"
 
 # MVSSB = MockVpcSubnetSingleBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_subnets_test.rb
+++ b/test/unit/resources/aws_subnets_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_subnets"
 
 require "resource_support/aws"
-require "resources/aws/aws_subnets"
 
 # MVSB = MockVpcSubnetsBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_vpc_test.rb
+++ b/test/unit/resources/aws_vpc_test.rb
@@ -3,7 +3,6 @@ require "inspec/resource"
 require "resources/aws/aws_vpc"
 
 require "resource_support/aws"
-require "resources/aws/aws_vpc"
 
 # MAVSB = MockAwsVpcSingularBackend
 # Abbreviation not used outside this file

--- a/test/unit/resources/aws_vpcs_test.rb
+++ b/test/unit/resources/aws_vpcs_test.rb
@@ -4,7 +4,6 @@ require "resources/aws/aws_vpcs"
 require "ipaddr"
 
 require "resource_support/aws"
-require "resources/aws/aws_vpcs"
 
 # MAVPB = MockAwsVpcsPluralBackend
 # Abbreviation not used outside this file
@@ -99,6 +98,7 @@ class AwsVpcsProperties < Minitest::Test
     assert_equal(1, @vpcs.dhcp_options_ids.count)
   end
 end
+
 #=============================================================================#
 #                               Test Fixtures
 #=============================================================================#

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -41,7 +41,7 @@ describe "Inspec::Resources::Package" do
   end
 
   # centos
-  describe "Rpm" do # rubocop:disable BlockLength
+  describe "Rpm" do # rubocop:disable Metrics/BlockLength
     let(:pkg) do
       {
         name: "curl",

--- a/test/unit/resources/yaml_test.rb
+++ b/test/unit/resources/yaml_test.rb
@@ -1,8 +1,6 @@
 require "helper"
 require "inspec/resource"
 require "inspec/resources/yaml"
-require "inspec/resource"
-require "inspec/resources/yaml"
 
 describe "Inspec::Resources::YAML" do
   describe "when loading a valid yaml" do


### PR DESCRIPTION
Bumps chefstyle to 1.5.7 from 1.2.1, and applies several changes:

 * conditionally `require` only if class not defined 
 * remove some duplicate requires
 * use min_by / max_by
 * replace `File.expand_path("../", __FILE__)` with `__DIR__` variant

Supercedes #5349 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
