### PR TITLE
Avoid pulling in the local context when building the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# We don't want/need anything from the local system, so ignore everything.
+*


### PR DESCRIPTION
This shaves 10.4 seconds spent pulling in the entire working directory, which just gets ignored since we do a gem install of inspec.

Signed-off-by: Tim Smith <tsmith@chef.io>