### PR TITLE
Re-Enable Omnibus Builds on MacOS 10.13

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -20,7 +20,7 @@ builder-to-testers-map:
     - el-7-x86_64
     - el-8-x86_64
     - amazon-2-x86_64
-  mac_os_x-10.14-x86_64:
+  mac_os_x-10.13-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
     - mac_os_x-11.0-x86_64


### PR DESCRIPTION
In order to unbreak the build, I'm going to temporarily re-enable builds on 10.13 (though we will only test on 10.14+). Our issue is that we have a DMG packing timeout under 10.14 that needs to be diagnosed.

Effectively reverts #5311, but leaves the doc changes intact.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
