### PR TITLE
Remove windows test skip timebomb

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -147,11 +147,10 @@ class Minitest::Test
     skip msg
   end
 
-  # These tests are being worked on. There is an ongoing discussion whether the
-  # 'bomb' is helpful as it requires rebases of all active community PRs when
-  # we hit it. Context: https://github.com/inspec/inspec/pull/5063
+  # These tests are being worked on. These are github issues for them.
+  # Related: https://github.com/inspec/inspec/pull/5063
   def skip_windows!
-    skip_until 2021, 1, 1, "These have never passed" if windows?
+    skip "These have never passed" if windows?
   end
 
   def unmock(&blk)


### PR DESCRIPTION
## Description

The "windows test skip timebomb" is a date hardcoded in the codebase, currently Jan 1 2021, after which the tests start throwing an exception in the CI system for any Windows tests that are still being skipped rather than implemented.

At this point, the majority of skipped windows tests were addressed on #5063, and the remainder are not currently on the roadmap. Given the disruptive nature of the "timebomb" (it affects all subsequently opened PRs) and the unlikelihood of it having its intended effect, let's remove it.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
