### PR TITLE
DRAFT: Inspec habitat ruby27

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -41,7 +41,7 @@ hab pkg install -b $project_root/results/$pkg_artifact
 Write-Host "--- Downloading Ruby + DevKit"
 $ruby_installer = "rubyinstaller-2.7.2-1-x86.exe"
 # aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.6-1-x64.exe c:/rubyinstaller-devkit-2.6.6-1-x64.exe
-Invoke-WebRequest -OutFile $ruby_installer -Uri "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.2-1/${ruby_installer}"
+Invoke-WebRequest -OutFile c:\$ruby_installer -Uri "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.2-1/${ruby_installer}"
 
 Write-Host "--- Installing Ruby + DevKit"
 Start-Process c:\$ruby_installer -ArgumentList '/verysilent /dir=C:\\ruby27' -Wait

--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -39,7 +39,7 @@ Write-Host "--- Installing $pkg_ident/$pkg_artifact"
 hab pkg install -b $project_root/results/$pkg_artifact
 
 Write-Host "--- Downloading Ruby + DevKit"
-$ruby_installer = "rubyinstaller-2.7.2-1-x86.exe"
+$ruby_installer = "rubyinstaller-2.7.2-1-x64.exe"
 # aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.6-1-x64.exe c:/rubyinstaller-devkit-2.6.6-1-x64.exe
 Invoke-WebRequest -OutFile c:\$ruby_installer -Uri "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.2-1/${ruby_installer}"
 

--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -39,15 +39,17 @@ Write-Host "--- Installing $pkg_ident/$pkg_artifact"
 hab pkg install -b $project_root/results/$pkg_artifact
 
 Write-Host "--- Downloading Ruby + DevKit"
-aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.6-1-x64.exe c:/rubyinstaller-devkit-2.6.6-1-x64.exe
+$ruby_installer = "rubyinstaller-2.7.2-1-x86.exe"
+# aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.6-1-x64.exe c:/rubyinstaller-devkit-2.6.6-1-x64.exe
+Invoke-WebRequest -OutFile $ruby_installer -Uri "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.2-1/${ruby_installer}"
 
 Write-Host "--- Installing Ruby + DevKit"
-Start-Process c:\rubyinstaller-devkit-2.6.6-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
+Start-Process c:\$ruby_installer -ArgumentList '/verysilent /dir=C:\\ruby27' -Wait
 
 Write-Host "--- Cleaning up installation"
-Remove-Item c:\rubyinstaller-devkit-2.6.6-1-x64.exe -Force
+Remove-Item c:\$ruby_installer -Force
 
-$Env:Path += ";C:\ruby26\bin;C:\hab\bin"
+$Env:Path += ";C:\ruby27\bin;C:\hab\bin"
 
 Write-Host "+++ Testing $Plan"
 

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -15,7 +15,7 @@ $pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 $pkg_license=('Apache-2.0')
 
 $pkg_deps=@(
-  "chef/ruby-plus-devkit"
+  "chef/ruby27-plus-devkit"
 )
 $pkg_bin_dirs=@("bin"
                 "vendor/bin")

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -10,7 +10,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/coreutils
   core/git
-  core/ruby26
+  core/ruby27
   core/bash
 )
 pkg_build_deps=(
@@ -80,7 +80,7 @@ export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
 
-exec $(pkg_path_for core/ruby26)/bin/ruby $real_bin \$@
+exec $(pkg_path_for core/ruby27)/bin/ruby $real_bin \$@
 EOF
   chmod -v 755 "$bin"
 }


### PR DESCRIPTION
Updates plans for Habitat packages to use the `ruby27` dependency.