### PR TITLE
add test for when run is not specified in waiver

### DIFF
--- a/docs-chef-io/content/inspec/waivers.md
+++ b/docs-chef-io/content/inspec/waivers.md
@@ -42,8 +42,8 @@ control_id:
 ```
 
 - `expiration_date` is optional. Absence means the waiver is permanent.
-- `run` is optional. If present and true, the control will run and be
-  reported, but failures in it won't make the overall run fail. If absent or false, the control will not be run. You may use any of yes, no, true or false.
+- `run` is optional. If absent or true, the control will run and be
+  reported, but failures in it won't make the overall run fail. If present and false, the control will not be run. You may use any of yes, no, true or false. To avoid confusion, it is good practice to explicitly specify whether the control should run.
 - `justification` can be any text you want and might include a reason
   as well as who signed off on the waiver.
 

--- a/test/fixtures/profiles/waivers/basic/controls/basic.rb
+++ b/test/fixtures/profiles/waivers/basic/controls/basic.rb
@@ -66,3 +66,7 @@ end
 control "17_waivered_expiry_in_future_string_not_ran" do
   describe(true) { it { should eq true } }
 end
+
+control "18_waivered_no_expiry_default_run" do
+  describe(true) { it { should eq false } }
+end

--- a/test/fixtures/profiles/waivers/basic/files/waivers.yaml
+++ b/test/fixtures/profiles/waivers/basic/files/waivers.yaml
@@ -68,4 +68,7 @@
 17_waivered_expiry_in_future_string_not_ran:
   expiration_date: "2077-06-01"
   justification: Lack of imagination
-  run: false  
+  run: false
+
+18_waivered_no_expiry_default_run:
+  justification: Too lazy to specify run, which defaults to true

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -48,6 +48,7 @@ describe "waivers" do
     in_past   = !!(control_id =~ /in_past/)
     in_future = !!(control_id =~ /in_future/)
     ran       = !!(control_id !~ /not_ran/)
+    default_run = !!(control_id =~ /default_run/)
     waiver_expired_in_past = /Waiver expired/ =~ act["message"]
 
     # higher logic
@@ -58,7 +59,7 @@ describe "waivers" do
     assert_instance_of Hash, act
 
     assert_stringy        act["justification"] # TODO: optional?
-    assert_equal ran,     act["run"]
+    assert_equal ran,     act["run"] unless default_run
     assert_equal waived,  act["skipped_due_to_waiver"]
     assert_stringy        act["message"] if     has_message
     # We supply a message indicating that the waiver has expired in all cases
@@ -100,6 +101,7 @@ describe "waivers" do
       "15_waivered_expiry_in_future_string_ran_passes"  => "passed",
       "16_waivered_expiry_in_future_string_ran_fails"   => "failed",
       "17_waivered_expiry_in_future_string_not_ran"     => "skipped",
+      "18_waivered_no_expiry_default_run"               => "failed",
     }.each do |control_id, expected|
       it "has all of the expected outcomes #{control_id}" do
         assert_test_outcome expected, control_id


### PR DESCRIPTION
The existing documentation explicitly claims that not specifying “run” in a waiver is equivalent to specifying “run: false.” It turns out to be the case that the claim is completely false. This commit includes a test for a new control 18_waivered_no_expiry_default_run that behaves exactly like the control 04_waivered_no_expiry_ran_fails. That is, not specifying run in a waiver is the same as specifying “run: true.”

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)
- [x] Hybrid! Additional test to demonstrate an error in documentation.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
