### PR TITLE
Truncate code_desc when truncating reports

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -136,7 +136,7 @@ module Inspec
         banner: "one two:/output/file/path",
         desc: "Enable one or more output reporters: cli, documentation, html, progress, json, json-min, json-rspec, junit, yaml"
       option :reporter_message_truncation, type: :string,
-        desc: "Number of characters to truncate failure messages in report data to (default: no truncation)"
+        desc: "Number of characters to truncate failure messages and code_desc in report data to (default: no truncation)"
       option :reporter_backtrace_inclusion, type: :boolean,
         desc: "Include a code backtrace in report data (default: true)"
       option :input, type: :array, banner: "name1=value1 name2=value2",

--- a/lib/inspec/utils/run_data_filters.rb
+++ b/lib/inspec/utils/run_data_filters.rb
@@ -18,7 +18,7 @@ module Inspec
         sort_controls
       end
 
-      # Apply options such as message truncation and removal of backtraces
+      # Apply options such as message and code_desc truncation, and removal of backtraces
       def apply_report_resize_options
         runtime_config = @config[:runtime_config]
 
@@ -30,7 +30,7 @@ module Inspec
           p[:controls].each do |c|
             c[:results]&.map! do |r|
               r.delete(:backtrace) unless include_backtrace
-              process_message_truncation(r)
+              process_truncation(r)
             end
           end
         end
@@ -93,9 +93,11 @@ module Inspec
 
       private
 
-      def process_message_truncation(result)
-        if result.key?(:message) && result[:message] != "" && @trunc > -1 && result[:message].length > @trunc
-          result[:message] = result[:message][0...@trunc] + "[Truncated to #{@trunc} characters]"
+      def process_truncation(result)
+        %i{code_desc message}.each do |field|
+          if result.key?(field) && result[field] != "" && @trunc > -1 && result[field].length > @trunc
+            result[field] = result[field][0...@trunc] + "[Truncated to #{@trunc} characters]"
+          end
         end
         result
       end

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -308,6 +308,10 @@ describe "inspec exec with json formatter" do
       _(control_with_message["results"].first["message"]).wont_be :nil?
       _(control_with_message["results"].first["message"]).must_equal "expected nil to match /some regex that is expected in the content/"
     end
+    it "reports full code_desc by default" do
+      _(control_with_message["results"].first["code_desc"]).wont_be :nil?
+      _(control_with_message["results"].first["code_desc"]).must_equal "File / content is expected to match /some regex that is expected in the content/"
+    end
   end
 
   describe "JSON reporter with reporter-message-truncation set to a number" do
@@ -319,6 +323,10 @@ describe "inspec exec with json formatter" do
       _(control_with_message["results"].first["message"]).wont_be :nil?
       _(control_with_message["results"].first["message"]).must_equal "expected nil to matc[Truncated to 20 characters]"
     end
+    it "reports a truncated code_desc" do
+      _(control_with_message["results"].first["code_desc"]).wont_be :nil?
+      _(control_with_message["results"].first["code_desc"]).must_equal "File / content is ex[Truncated to 20 characters]"
+    end
   end
 
   describe "JSON reporter with reporter-message-truncation set to a number and working message" do
@@ -328,6 +336,9 @@ describe "inspec exec with json formatter" do
     let(:control_with_message) { profile["controls"].find { |c| c["id"] == "Generates a message" } }
     it "does not report a truncated message" do
       assert !control_with_message["results"].first["message"].include?("Truncated")
+    end
+    it "does not report a truncated code_desc" do
+      assert !control_with_message["results"].first["code_desc"].include?("Truncated")
     end
   end
 
@@ -339,6 +350,10 @@ describe "inspec exec with json formatter" do
     it "reports full message" do
       _(control_with_message["results"].first["message"]).wont_be :nil?
       _(control_with_message["results"].first["message"]).must_equal "expected nil to match /some regex that is expected in the content/"
+    end
+    it "reports full code_desc" do
+      _(control_with_message["results"].first["code_desc"]).wont_be :nil?
+      _(control_with_message["results"].first["code_desc"]).must_equal "File / content is expected to match /some regex that is expected in the content/"
     end
   end
 


### PR DESCRIPTION
## Description

To limit report size, especially with JSON-based reporters which may be dealing with API POST size limits, the `--reporter-message-truncation` option was introduced to limit the size of the `message` field in JSON reports. However, for some controls, the `code_desc` field can also be huge. This change applies the same truncation to the code_desc field when the --reporter-message-truncation option is given.

The CLI usage message (which is also used for the web docs) is updated to reflect this.

Functional tests are included.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
