### PR TITLE
Avoid ffi 1.14.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "inspec", path: "."
 # in it in order to package the executable. Hence the odd backwards dependency.
 gem "inspec-bin", path: "./inspec-bin"
 
-gem "ffi", ">= 1.9.14", "!= 1.13.0"
+gem "ffi", ">= 1.9.14", "!= 1.13.0", "!= 1.14.2"
 
 if Gem.ruby_version.to_s.start_with?("2.5")
   # 16.7.23 required ruby 2.6+


### PR DESCRIPTION
## Description

Avoids ffi 1.14.2, which in our build results in an error under Windows - see #5374 .

Verified by creating an adhoc omnibus build and installing; it resolved to 1.14.1 and worked correctly.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #5374

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
