### PR TITLE
Use ruby:2-alpine base image for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM ruby:2-alpine
 LABEL maintainer="Chef Software, Inc. <docker@chef.io>"
 
 ARG EXPEDITOR_VERSION


### PR DESCRIPTION
The ruby:alpine image has been updated to Ruby 3.x which InSpec is not currently ready for. Changing this to ruby:2-alpine to force using the latest 2.x release until InSpec is ready for Ruby 3.x.

Signed-off-by: Lance Albertson <lance@osuosl.org>
