### PR TITLE
Add ENV var to skip live net tests in plugin installer unit tests

### DIFF
--- a/test/unit/plugin/v2/installer_test.rb
+++ b/test/unit/plugin/v2/installer_test.rb
@@ -9,9 +9,14 @@ Gem.done_installing_hooks.clear # Remove rdoc generation
 
 module InstallerTestHelpers
   RUN_SLOW = ENV["SLOW"]
+  RUN_LIVE_NET = ENV["LIVE_NET"]
 
   def skip_slow_tests
     skip "slow" unless RUN_SLOW
+  end
+
+  def skip_live_net_tests
+    skip "This test talks on the network" unless RUN_LIVE_NET
   end
 
   def reset_globals
@@ -34,7 +39,8 @@ module InstallerTestHelpers
   @@orig_home = Dir.home
 
   def setup
-    WebMock.disable_net_connect!(allow: %r{(api\.)?rubygems\.org/.*})
+    WebMock.disable_net_connect!(allow: %r{(api\.)?rubygems\.org/.*}) if RUN_LIVE_NET
+
     repo_path = File.expand_path(File.join( __FILE__, "..", "..", "..", "..", ".."))
     mock_path = File.join(repo_path, "test", "fixtures")
 
@@ -120,6 +126,8 @@ class PluginInstallerInstallationTests < Minitest::Test
   end
 
   def test_install_a_gem_from_local_file
+    skip_live_net_tests # This still accesses rubygems.org to check for deps
+
     gem_file = File.join(@plugin_fixture_pkg_path, "inspec-test-fixture-0.1.0.gem")
 
     assert_operator File, :exist?, gem_file
@@ -153,6 +161,8 @@ class PluginInstallerInstallationTests < Minitest::Test
   end
 
   def test_install_a_gem_from_local_file_creates_plugin_json
+    skip_live_net_tests # This still accesses rubygems.org to check for deps
+
     gem_file = File.join(@plugin_fixture_pkg_path, "inspec-test-fixture-0.1.0.gem")
     stdout, _stderr = capture_io do
       @installer.install("inspec-test-fixture", gem_file: gem_file)
@@ -175,6 +185,7 @@ class PluginInstallerInstallationTests < Minitest::Test
 
   def test_install_a_gem_from_rubygems_org
     skip_slow_tests
+    skip_live_net_tests
 
     capture_subprocess_io do
       @installer.install("inspec-test-fixture")
@@ -201,6 +212,7 @@ class PluginInstallerInstallationTests < Minitest::Test
 
   def test_handle_no_such_gem
     skip_slow_tests
+    skip_live_net_tests
 
     assert_raises(Inspec::Plugin::V2::InstallError) { @installer.install("inspec-test-fixture-nonesuch") }
   end
@@ -208,6 +220,7 @@ class PluginInstallerInstallationTests < Minitest::Test
   # Should be able to install a plugin while pinning the version
   def test_install_a_pinned_gem_from_rubygems_org
     skip_slow_tests
+    skip_live_net_tests
 
     capture_subprocess_io do
       @installer.install("inspec-test-fixture", version: "= 0.1.0")
@@ -226,6 +239,8 @@ class PluginInstallerInstallationTests < Minitest::Test
   end
 
   def test_install_a_gem_with_conflicting_depends_from_rubygems_org
+    skip_live_net_tests
+
     spec = Gem::Specification._all.find { |s| s.name == "rake" }
     spec.activate
 
@@ -237,6 +252,7 @@ class PluginInstallerInstallationTests < Minitest::Test
 
   def test_install_a_gem_with_invalid_depends_from_rubygems_org
     skip_slow_tests
+    skip_live_net_tests
 
     ex = assert_raises(Inspec::Plugin::V2::InstallError) do
       @installer.install("inspec-test-fixture", version: "= 0.1.2")
@@ -316,6 +332,7 @@ class PluginInstallerUpdaterTests < Minitest::Test
 
   def test_update_to_latest_version
     skip_slow_tests
+    skip_live_net_tests
 
     copy_in_config_dir("test-fixture-1-float")
     @installer.__reset_loader
@@ -339,6 +356,7 @@ class PluginInstallerUpdaterTests < Minitest::Test
 
   def test_update_to_specified_later_version
     skip_slow_tests
+    skip_live_net_tests
 
     copy_in_config_dir("test-fixture-1-float")
     @installer.__reset_loader
@@ -486,6 +504,8 @@ class PluginInstallerSearchTests < Minitest::Test
   end
 
   def test_search_for_plugin_by_exact_name
+    skip_live_net_tests
+
     results = @installer.search("inspec-test-fixture", exact: true)
     assert_kind_of Hash, results, "Results from searching should be a Hash"
     assert results.key?("inspec-test-fixture"), "Search results should have a key for the sought plugin"
@@ -496,11 +516,15 @@ class PluginInstallerSearchTests < Minitest::Test
   end
 
   def test_search_for_plugin_that_does_not_exist
+    skip_live_net_tests
+
     results = @installer.search("inspec-test-fixture-nonesuch", exact: true)
     assert_empty results
   end
 
   def test_search_for_plugin_by_wildard
+    skip_live_net_tests
+
     results = @installer.search("inspec-test-")
     assert_kind_of Hash, results, "Results from searching should be a Hash"
     assert results.key?("inspec-test-fixture"), "Search results should have a key for at least one plugin"
@@ -511,6 +535,7 @@ class PluginInstallerSearchTests < Minitest::Test
 
   def test_search_omits_inspec_gem_on_the_reject_list
     skip_slow_tests
+    skip_live_net_tests
 
     results = @installer.search("inspec-")
     assert results.key?("inspec-test-fixture")
@@ -528,6 +553,8 @@ class PluginInstallerSearchTests < Minitest::Test
   end
 
   def test_search_omits_train_gem_on_the_reject_list
+    skip_live_net_tests
+
     results = @installer.search("train-")
     assert results.key?("train-test-fixture")
 


### PR DESCRIPTION
## Description

The plugin installer unit tests that talk to rubygems.org are timing out on Windows. When run in isolation with webmock disabled, the test pass; however we use webmock extensively in some other unit tests (compliance and supermarket plugins, for example).

This change adds an ENV variable which controls skipping the tests which talk on the network.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #5334 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
