### PR TITLE
Allow for rspec 3.9 in the gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,10 @@ if Gem.ruby_version.to_s.start_with?("2.5")
   gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
 end
 
+# inspec tests depend text output that changed in the 3.10 release
+# but our runtime dep is still 3.9+
+gem "rspec", ">= 3.10"
+
 group :omnibus do
   gem "rb-readline"
   gem "appbundler"

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor",               ">= 0.20", "< 2.0"
   spec.add_dependency "method_source",      ">= 0.8", "< 2.0"
   spec.add_dependency "rubyzip",            ">= 1.2.2", "< 3.0"
-  spec.add_dependency "rspec",              "~> 3.10"
+  spec.add_dependency "rspec",              ">= 3.9", "< 3.11"
   spec.add_dependency "rspec-its",          "~> 1.2"
   spec.add_dependency "pry",                "~> 0.13"
   spec.add_dependency "hashie",             ">= 3.4", "< 5.0"


### PR DESCRIPTION
rspec 3.10 is causing issues with chef/chef tests due to changes in
rspec-mock that we're working to resolve. Right now we'd like to get the
latest inspec releases into chef/chef w/o the need for rspec 3.10. At
runtime inspec doesn't need 3.10, but it does need it for tests, so
let's make sure we bring it in via the gemfile, but allow the older 3.9
release at runtime.

Signed-off-by: Tim Smith <tsmith@chef.io>