### PR TITLE
Revert conditional require of Thor

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -1,4 +1,4 @@
-require "thor" unless defined?(Thor)
+require "thor" # rubocop:disable Chef/Ruby/UnlessDefinedRequire
 require "inspec/log"
 require "inspec/ui"
 require "inspec/config"


### PR DESCRIPTION
## Description

Because inspec is sometimes included as a gem, this can cause problems when used in other CLI tools that use Thor. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #5387 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
