### PR TITLE
Add faraday_middleware to gemspec

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sslshake",           "~> 1.2"
   spec.add_dependency "parallel",           "~> 1.9"
   spec.add_dependency "faraday",            ">= 0.9.0", "< 1.4"
+  spec.add_dependency "faraday_middleware", "~> 1.0"
   spec.add_dependency "tty-table",          "~> 0.10"
   spec.add_dependency "tty-prompt",         "~> 0.17"
   spec.add_dependency "tomlrb",             ">= 1.2", "< 2.1"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Adds faraday_middleware to the gemspec, which is required by the http resource. This appears to have been working by accident for a while; things that use inspec-core were not getting this recently.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #5390

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
