### PR TITLE
Enable programmatic setting of plugin configuration

### DIFF
--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -128,10 +128,18 @@ module Inspec
     end
 
     #-----------------------------------------------------------------------#
-    #                      Fetching Plugin Data
+    #                      Handling Plugin Data
     #-----------------------------------------------------------------------#
     def fetch_plugin_config(plugin_name)
       Thor::CoreExt::HashWithIndifferentAccess.new(@plugin_cfg[plugin_name] || {})
+    end
+
+    def set_plugin_config(plugin_name, plugin_config)
+      @plugin_cfg[plugin_name] = plugin_config
+    end
+
+    def merge_plugin_config(plugin_name, additional_plugin_config)
+      @plugin_cfg[plugin_name].merge!(additional_plugin_config)
     end
 
     # clear the cached config

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -460,7 +460,7 @@ describe "Inspec::Config" do
   end
 
   # ========================================================================== #
-  #                        Fetching Plugin Config
+  #                        Handling Plugin Config
   # ========================================================================== #
   describe "when fetching plugin config" do
     let(:cfg) { Inspec::Config.new({}, cfg_io) }
@@ -490,6 +490,51 @@ describe "Inspec::Config" do
       end
     end
 
+  end
+
+  describe "when setting plugin config" do
+    let(:cfg) { Inspec::Config.new({}, cfg_io) }
+    let(:cfg_io) { StringIO.new(ConfigTestHelper.fixture(fixture_name)) }
+    let(:fixture_name) { "basic_1_2" }
+
+    let(:desired_settings) { { "test_key_01" => "test_value_02" } }
+
+    it "overwrites current configuration" do
+      cfg.set_plugin_config("inspec-test-plugin", desired_settings)
+      actual_settings = cfg.fetch_plugin_config("inspec-test-plugin")
+
+      assert_equal desired_settings, actual_settings
+    end
+  end
+
+  describe "when merging plugin config" do
+    let(:cfg) { Inspec::Config.new({}, cfg_io) }
+    let(:cfg_io) { StringIO.new(ConfigTestHelper.fixture(fixture_name)) }
+    let(:fixture_name) { "basic_1_2" }
+
+    let(:additional_settings) { { test_key_02: "test_value_02" } }
+    let(:override_settings) { { test_key_01: "test_value_02" } }
+
+    it "preserves current configuration" do
+      cfg.merge_plugin_config("inspec-test-plugin", additional_settings)
+      settings = cfg.fetch_plugin_config("inspec-test-plugin")
+
+      assert_equal "test_value_01", settings[:test_key_01]
+    end
+
+    it "includes additional configuration" do
+      cfg.merge_plugin_config("inspec-test-plugin", additional_settings)
+      settings = cfg.fetch_plugin_config("inspec-test-plugin")
+
+      assert_equal "test_value_02", settings[:test_key_02]
+    end
+
+    it "overwrites existing configuration" do
+      cfg.merge_plugin_config("inspec-test-plugin", override_settings)
+      settings = cfg.fetch_plugin_config("inspec-test-plugin")
+
+      assert_equal "test_value_02", settings[:test_key_01]
+    end
   end
 
   # ========================================================================== #


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Adds API methods to set and merge plugin configuration without the need of a config file.

## Related Issue

Implementation to my suggestion on  #5392 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I even added unit tests this time :)
