### PR TITLE
Pin back parslet to avoid conflict with toml in chef infra

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tty-prompt",         "~> 0.17"
   spec.add_dependency "tomlrb",             ">= 1.2", "< 2.1"
   spec.add_dependency "addressable",        "~> 2.4"
-  spec.add_dependency "parslet",            ">= 1.5", "< 3.0"
+  spec.add_dependency "parslet",            ">= 1.5", "< 2.0" # Pinned < 2.0, see #5389
   spec.add_dependency "semverse",           "~> 3.0"
   spec.add_dependency "multipart-post",     "~> 2.0"
 


### PR DESCRIPTION
## Description

toml 0.2.0 and parslet 2.x do not get along; this causes problems in Chef Infra. Pin back to < 2 for now.

## Related Issue

Fixes #5389

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
