### PR TITLE
Improve programmatic plugin configuration

### DIFF
--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -135,10 +135,15 @@ module Inspec
     end
 
     def set_plugin_config(plugin_name, plugin_config)
+      plugin_name = plugin_name.to_s unless plugin_name.is_a? String
+
       @plugin_cfg[plugin_name] = plugin_config
     end
 
     def merge_plugin_config(plugin_name, additional_plugin_config)
+      plugin_name = plugin_name.to_s unless plugin_name.is_a? String
+
+      @plugin_cfg[plugin_name] = {} if @plugin_cfg[plugin_name].nil?
       @plugin_cfg[plugin_name].merge!(additional_plugin_config)
     end
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -535,6 +535,13 @@ describe "Inspec::Config" do
 
       assert_equal "test_value_02", settings[:test_key_01]
     end
+
+    it "handles handles empty configuration correctly" do
+      cfg.merge_plugin_config("inspec-missing-plugin", additional_settings)
+      settings = cfg.fetch_plugin_config("inspec-missing-plugin")
+
+      assert_equal "test_value_02", settings[:test_key_02]
+    end
   end
 
   # ========================================================================== #


### PR DESCRIPTION
## Description

- Fixed a bug on trying to use `merge_plugin_config` with unset plugin configuration (`nil` error) & added regression test
- Changed plugin keys on `merge_plugin_config` and `set_plugin_config` to `String`, matching current implementations

## Related Issue

none

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
