### PR TITLE
Skip controls deeply

### DIFF
--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -173,6 +173,9 @@ module Inspec
 
     def unregister_rule(id)
       @rules.delete(full_id(@profile_id, id))
+      @control_subcontexts.each do |c|
+        c.unregister_rule(id)
+      end
     end
 
     attr_reader :current_load

--- a/test/fixtures/profiles/dependencies/deep-skip-inner/controls/controls-inner.rb
+++ b/test/fixtures/profiles/dependencies/deep-skip-inner/controls/controls-inner.rb
@@ -1,0 +1,11 @@
+control "deep-skip-inner-01" do
+  describe file("/") do
+    it { should be_directory }
+  end
+end
+
+control "deep-skip-inner-skipme" do
+  describe file("/") do
+    it { should be_directory }
+  end
+end

--- a/test/fixtures/profiles/dependencies/deep-skip-inner/inspec.yml
+++ b/test/fixtures/profiles/dependencies/deep-skip-inner/inspec.yml
@@ -1,0 +1,10 @@
+name: deep-skip-inner
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: See issue 5300
+version: 0.1.0
+supports:
+  platform: os

--- a/test/fixtures/profiles/dependencies/deep-skip-mid/controls/controls-mid.rb
+++ b/test/fixtures/profiles/dependencies/deep-skip-mid/controls/controls-mid.rb
@@ -1,0 +1,10 @@
+control "deep-skip-mid-01" do
+  describe file("/") do
+    it { should be_directory }
+  end
+end
+
+include_controls("deep-skip-inner") do
+  # Issue 5300: this control should be skipped without this line
+  # skip_control "deep-skip-inner-skipme"
+end

--- a/test/fixtures/profiles/dependencies/deep-skip-mid/inspec.yml
+++ b/test/fixtures/profiles/dependencies/deep-skip-mid/inspec.yml
@@ -1,0 +1,13 @@
+name: deep-skip-mid
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: See issue 5300
+version: 0.1.0
+supports:
+  platform: os
+depends:
+  - name: deep-skip-inner
+    path: ../deep-skip-inner

--- a/test/fixtures/profiles/dependencies/deep-skip-outer/controls/controls-outer.rb
+++ b/test/fixtures/profiles/dependencies/deep-skip-outer/controls/controls-outer.rb
@@ -1,0 +1,9 @@
+control "deep-skip-outer-01" do
+  describe file("/") do
+    it { should be_directory }
+  end
+end
+
+include_controls("deep-skip-mid") do
+  skip_control "deep-skip-inner-skipme"
+end

--- a/test/fixtures/profiles/dependencies/deep-skip-outer/inspec.yml
+++ b/test/fixtures/profiles/dependencies/deep-skip-outer/inspec.yml
@@ -1,0 +1,13 @@
+name: deep-skip-outer
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: See issue 5300
+version: 0.1.0
+supports:
+  platform: os
+depends:
+  - name: deep-skip-mid
+    path: ../deep-skip-mid

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -457,4 +457,15 @@ describe "inspec exec with json formatter" do
       end
     end
   end
+
+  # Issue 5300
+  describe "deep skip control" do
+    let(:run_result) { run_inspec_process("exec #{profile_path}/dependencies/deep-skip-outer", json: true) }
+    let(:inner_profile_controls) { @json["profiles"][2]["controls"] }
+    it "skips a control two levels down" do
+      _(run_result.stderr).must_be_empty
+      # Should skip the second control labelled "skipme" because there is a skip_control in the outer profile
+      _(inner_profile_controls.count).must_equal 1
+    end
+  end
 end


### PR DESCRIPTION
When calling `include_controls` with a `skip_control` inside, and the profiles are nested more than one level deep, update the behavior to skip the control from the outer layer. This avoids having to skip the control from the middle layers of wrapping.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #5300 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
