### PR TITLE
Use first value of repeated settings in ssh_config and sshd_config

### DIFF
--- a/lib/inspec/resources/ssh_config.rb
+++ b/lib/inspec/resources/ssh_config.rb
@@ -39,7 +39,7 @@ module Inspec::Resources
     def convert_hash(hash)
       new_hash = {}
       hash.each do |k, v|
-        new_hash[k.downcase] = v
+        new_hash[k.downcase] ||= v
       end
       new_hash
     end

--- a/test/fixtures/files/ssh_config
+++ b/test/fixtures/files/ssh_config
@@ -4,3 +4,6 @@ Host *
     SendEnv LANG LC_*
     HashKnownHosts yes
     GSSAPIAuthentication no
+    HostBasedAuthentication yes
+    HostbasedAuthentication no
+    HostbasedAuthentication no

--- a/test/unit/resources/ssh_conf_test.rb
+++ b/test/unit/resources/ssh_conf_test.rb
@@ -18,6 +18,11 @@ describe "Inspec::Resources::SshConfig" do
       _(resource.gssapiauthentication).must_equal "no"
       _(resource.GSSAPIAuthentication).must_equal "no"
     end
+
+    it "uses the first value encountered" do
+      resource = load_resource("ssh_config")
+      _(resource.HostBasedAuthentication).must_equal "yes"
+    end
   end
 
   describe "sshd_config" do


### PR DESCRIPTION

## Description

Alters the `ssh_config` and `sshd_config` resources to use the value from the first entry specified (rather than the last) when a setting is repeated, in accordance with the spec.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #5410 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
