### PR TITLE
Fixes #5373 : Add option to filter empty profiles from report

### DIFF
--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -146,7 +146,7 @@ This subcommand has additional options:
     Specify which transport to use, defaults to negotiate (WinRM).
 * ``--winrm-shell-type=WINRM_SHELL_TYPE``
     Specify which shell type to use (powershell,elevated or cmd), defaults to powershell (WinRM).
-    
+
 ## env
 
 Output shell-appropriate completion configuration
@@ -332,6 +332,8 @@ This subcommand has additional options:
     Whether to use disable sspi authentication, defaults to false (WinRM).
 * ``--winrm-transport=WINRM_TRANSPORT``
     Specify which transport to use, defaults to negotiate (WinRM).
+* ``--filter-empty-profiles``, ``--no-filter-empty-profiles``
+    Filter empty profiles (profiles without controls) from the report.
 
 ## help
 

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -164,6 +164,8 @@ module Inspec
         desc: "Use --no-diff to suppress 'diff' output of failed textual test results."
       option :sort_results_by, type: :string, default: "file", banner: "--sort-results-by=none|control|file|random",
         desc: "After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode."
+      option :filter_empty_profiles, type: :boolean, default: false,
+        desc: "Filter empty profiles (profiles without controls) from the report."
     end
 
     def self.help(*args)

--- a/lib/inspec/utils/run_data_filters.rb
+++ b/lib/inspec/utils/run_data_filters.rb
@@ -13,6 +13,7 @@ module Inspec
       def apply_run_data_filters_to_hash
         @config[:runtime_config] = Inspec::Config.cached || {}
         apply_report_resize_options
+        filter_empty_profiles
         redact_sensitive_inputs
         suppress_diff_output
         sort_controls
@@ -36,7 +37,15 @@ module Inspec
         end
       end
 
-      # Find any inputs with :sensitive = true and replace their values with "***"
+      # Filters profiles from report which don't have controls in it.
+      def filter_empty_profiles
+        runtime_config = @config[:runtime_config]
+        if runtime_config[:filter_empty_profiles] && @run_data[:profiles].count > 1
+          @run_data[:profiles].delete_if { |p| p[:controls].empty? }
+        end
+      end
+
+      # Find any inputs with :redact_sensitive_inputsitive = true and replace their values with "***"
       def redact_sensitive_inputs
         @run_data[:profiles]&.each do |p|
           p[:inputs]&.each do |i|

--- a/lib/inspec/utils/run_data_filters.rb
+++ b/lib/inspec/utils/run_data_filters.rb
@@ -45,7 +45,7 @@ module Inspec
         end
       end
 
-      # Find any inputs with :redact_sensitive_inputsitive = true and replace their values with "***"
+      # Find any inputs with :sensitive = true and replace their values with "***"
       def redact_sensitive_inputs
         @run_data[:profiles]&.each do |p|
           p[:inputs]&.each do |i|

--- a/test/fixtures/profiles/dependencies/resource-pack/README.md
+++ b/test/fixtures/profiles/dependencies/resource-pack/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec profile.

--- a/test/fixtures/profiles/dependencies/resource-pack/README.md
+++ b/test/fixtures/profiles/dependencies/resource-pack/README.md
@@ -1,3 +1,0 @@
-# Example InSpec Profile
-
-This example shows the implementation of an InSpec profile.

--- a/test/fixtures/profiles/dependencies/resource-pack/inspec.yml
+++ b/test/fixtures/profiles/dependencies/resource-pack/inspec.yml
@@ -1,0 +1,10 @@
+name: resource-pack
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  platform: os

--- a/test/fixtures/profiles/dependencies/resource-pack/libraries/example_config.rb
+++ b/test/fixtures/profiles/dependencies/resource-pack/libraries/example_config.rb
@@ -1,0 +1,15 @@
+class ExampleConfig < Inspec.resource(1)
+  name 'example_config'
+
+  desc "Example's resource description ..."
+
+  example "
+    describe example_config do
+      its('version') { should eq('1.0') }
+    end
+  "
+
+  def version
+    "1.0"
+  end
+end

--- a/test/fixtures/profiles/dependencies/uses-resource-pack/README.md
+++ b/test/fixtures/profiles/dependencies/uses-resource-pack/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec profile.

--- a/test/fixtures/profiles/dependencies/uses-resource-pack/README.md
+++ b/test/fixtures/profiles/dependencies/uses-resource-pack/README.md
@@ -1,3 +1,0 @@
-# Example InSpec Profile
-
-This example shows the implementation of an InSpec profile.

--- a/test/fixtures/profiles/dependencies/uses-resource-pack/controls/example.rb
+++ b/test/fixtures/profiles/dependencies/uses-resource-pack/controls/example.rb
@@ -1,0 +1,18 @@
+# copyright: 2018, The Authors
+
+title "sample section"
+
+# you can also use plain tests
+describe file("/tmp") do
+  it { should be_directory }
+end
+
+# you add controls here
+control "tmp-1.0" do                        # A unique ID for this control
+  impact 0.7                                # The criticality, if this control fails.
+  title "Create /tmp directory"             # A human-readable title
+  desc "An optional description..."
+  describe file("/tmp") do                  # The actual test
+    it { should be_directory }
+  end
+end

--- a/test/fixtures/profiles/dependencies/uses-resource-pack/inspec.yml
+++ b/test/fixtures/profiles/dependencies/uses-resource-pack/inspec.yml
@@ -1,0 +1,13 @@
+name: uses-resource-pack
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  platform: os
+depends:
+  - name: resource-pack
+    path: ../resource-pack

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -421,6 +421,30 @@ describe "inspec exec with json formatter" do
     end
   end
 
+  describe "JSON reporter" do
+    describe "with --no-filter-empty-profiles option" do
+      let(:run_result) { run_inspec_process("exec #{profile_path}/dependencies/uses-resource-pack --no-filter-empty-profiles", json: true) }
+      let(:profiles) { @json["profiles"] }
+
+      it "does not filter the empty profiles(profiles without controls)" do
+        _(run_result.stderr).must_be_empty
+        _(profiles.count).must_equal 2
+        assert_exit_code(0, run_result)
+      end
+    end
+
+    describe "with --filter-empty-profiles option" do
+      let(:run_result) { run_inspec_process("exec #{profile_path}/dependencies/uses-resource-pack --filter-empty-profiles", json: true) }
+      let(:profiles) { @json["profiles"] }
+
+      it "does not filter the empty profiles(profiles without controls)" do
+        _(run_result.stderr).must_be_empty
+        _(profiles.count).must_equal 1
+        assert_exit_code(0, run_result)
+      end
+    end
+  end
+
   describe "JSON reporter using the --sort-results-by option" do
     let(:run_result) { run_inspec_process("exec #{profile_path}/sorted-results/sort-me-1 --sort-results-by #{sort_option}", json: true) }
     let(:control_order) { @json["profiles"][0]["controls"].map { |c| c["id"] }.join("") }

--- a/test/functional/inspec_exec_json_test.rb
+++ b/test/functional/inspec_exec_json_test.rb
@@ -429,7 +429,6 @@ describe "inspec exec with json formatter" do
       it "does not filter the empty profiles(profiles without controls)" do
         _(run_result.stderr).must_be_empty
         _(profiles.count).must_equal 2
-        assert_exit_code(0, run_result)
       end
     end
 
@@ -437,10 +436,9 @@ describe "inspec exec with json formatter" do
       let(:run_result) { run_inspec_process("exec #{profile_path}/dependencies/uses-resource-pack --filter-empty-profiles", json: true) }
       let(:profiles) { @json["profiles"] }
 
-      it "does not filter the empty profiles(profiles without controls)" do
+      it "does filter the empty profiles (profiles without controls)" do
         _(run_result.stderr).must_be_empty
         _(profiles.count).must_equal 1
-        assert_exit_code(0, run_result)
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added option `--filter-empty-profiles` to filter the profiles from report which does not have controls in it. 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fix #5373 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
