### PR TITLE
Fix google_project_alert_policy Examples in the docs

### DIFF
--- a/docs-chef-io/content/inspec/resources/google_project_alert_policy.md
+++ b/docs-chef-io/content/inspec/resources/google_project_alert_policy.md
@@ -32,15 +32,15 @@ end
 
 ### Test that a GCP alert policy is enabled
 
-describe google_project_alert_policy(policy: 'spaterson', name: '9271751234503117449') do
-  it { should be_enabled }
-end
+    describe google_project_alert_policy(policy: 'spaterson', name: '9271751234503117449') do
+      it { should be_enabled }
+    end
 
 ### Test that a GCP compute alert policy display name is correct
 
-describe google_project_alert_policy(policy: 'spaterson-project', name: '9271751234503117449') do
-  its('display_name') { should eq 'policy name' }
-end
+    describe google_project_alert_policy(policy: 'spaterson-project', name: '9271751234503117449') do
+      its('display_name') { should eq 'policy name' }
+    end
 
 ## Properties
 

--- a/docs-chef-io/content/inspec/resources/google_project_alert_policy.md
+++ b/docs-chef-io/content/inspec/resources/google_project_alert_policy.md
@@ -19,8 +19,8 @@ A `google_project_alert_policy` is used to test a Google AlertPolicy resource
 
 ```ruby
 describe.one do
-  google_project_alert_policies(project: 'chef-gcp-inspec').policy_names do |policy_name|
-    describe google_project_alert_policy(project: 'chef-gcp-inspec', name: policy_name) do
+  google_project_alert_policies(project: 'chef-gcp-inspec').policy_names.each do |policy_name|
+    describe google_project_alert_policy(project: 'chef-gcp-inspec', name: policy_name.split('/').last) do
       it { should exist }
       its('display_name') { should cmp 'Display'}
       its('combiner') { should cmp 'OR'}

--- a/docs-chef-io/content/inspec/resources/google_project_alert_policy.md
+++ b/docs-chef-io/content/inspec/resources/google_project_alert_policy.md
@@ -32,15 +32,15 @@ end
 
 ### Test that a GCP alert policy is enabled
 
-    describe google_project_alert_policy(policy: 'spaterson', name: '9271751234503117449') do
-      it { should be_enabled }
-    end
+describe google_project_alert_policy(policy: 'spaterson', name: '9271751234503117449') do
+  it { should be_enabled }
+end
 
 ### Test that a GCP compute alert policy display name is correct
 
-    describe google_project_alert_policy(policy: 'spaterson-project', name: '9271751234503117449') do
-      its('display_name') { should eq 'policy name' }
-    end
+describe google_project_alert_policy(policy: 'spaterson-project', name: '9271751234503117449') do
+  its('display_name') { should eq 'policy name' }
+end
 
 ## Properties
 


### PR DESCRIPTION
Signed-off-by: Ryo Takashima <lio114514@gmail.com>

Fix google_project_alert_policy Examples in the docs

## Description

- The loop is not executed because `.each` does not exist
- [ALERT_POLICY_ID] is correct for the argument of `name:`


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
