### PR TITLE
Fix backtrace occurs when using `cmp` to compare nil to an expectation

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -287,7 +287,7 @@ RSpec::Matchers.define :cmp do |first_expected| # rubocop:disable Metrics/BlockL
   end
 
   def format_actual(actual)
-    actual = "0%o" % actual if octal?(@expected)
+    actual = "0%o" % actual if octal?(@expected) && !actual.nil?
     "\n%s\n     got: %s\n\n(compared using `cmp` matcher)\n" % [format_expectation(false), actual]
   end
 

--- a/test/unit/matchers/matchers_test.rb
+++ b/test/unit/matchers/matchers_test.rb
@@ -55,6 +55,7 @@ describe "inspec matchers" do
       assert_cmp "happy", "happy"
       assert_cmp "HAPPY", "happy" # case insensitive
       refute_cmp "happy", "unhappy"
+      refute_cmp "happy", nil
     end
 
     it "String cmp String w/o ==" do
@@ -65,21 +66,25 @@ describe "inspec matchers" do
     it "String cmp String w/ versions " do
       assert_cmp "1.0", "1.0"
       refute_cmp "1.0.0", "1.0"
+      refute_cmp "1.0", nil
     end
 
     it "Regexp cmp String" do
       assert_cmp(/abc/, "xxx abc zzz")
       refute_cmp(/yyy/, "xxx abc zzz")
+      refute_cmp(/yyy/, nil)
     end
 
     it "Regexp cmp Int" do
       assert_cmp(/42/, 42)
       refute_cmp(/yyy/, 42)
+      refute_cmp(/yyy/, nil)
     end
 
     it "String (int) cmp Integer" do
       assert_cmp "42", 42
       refute_cmp "42", 420
+      refute_cmp "42", nil
     end
 
     it "String (bool) cmp Bool" do
@@ -89,45 +94,54 @@ describe "inspec matchers" do
       assert_cmp "false", false
       assert_cmp "FALSE", false
       refute_cmp "false", true
+      refute_cmp "false", nil
     end
 
     it "Int cmp String(int)" do
       assert_cmp 42, "42"
       refute_cmp 420, "42"
+      refute_cmp 420, nil
     end
 
     it "Int cmp String(!int)" do
       refute_cmp 42, :not_int
+      refute_cmp 42, nil
     end
 
     it "Float cmp Float" do
       assert_cmp 3.14159, 3.14159
       refute_cmp 3.14159, 42.0
+      refute_cmp 3.14159, nil
     end
 
     it "Float cmp String(float)" do
       assert_cmp 3.14159, "3.14159"
       refute_cmp 3.14159, "3.1415926"
+      refute_cmp 3.14159, nil
     end
 
     it "Float cmp String(!float)" do
       refute_cmp 3.14159, :not_float
+      refute_cmp 3.14159, nil
     end
 
     it "String cmp Symbol" do
       assert_cmp "abc", :abc
       assert_cmp "abc", :ABC
+      refute_cmp "abc", nil
     end
 
     it "String(oct) cmp Int" do
       assert_cmp "0777", 0777
       refute_cmp "0777", 0777 + 1
       refute_cmp "0999", 0 # bad octal regexp
+      refute_cmp "0777", nil
     end
 
     it "String(!oct) cmp Int" do
       obj = Object.new
       refute_cmp obj, 0x42
+      refute_cmp obj, nil
     end
 
     it "should test XXX" do


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
To reproduce issue used file resource in which provided the file path which does not exist
*  Added test case for nil compare
This line in the matchers.rb `actual = "0%o" % actual if octal?(@expected)` breaking the cmp matcher when actual output is nil (i.e. actual is nil)
irb
```
2.7.0 :004 > "0%o" % nil
Traceback (most recent call last):
        5: from /opt/chef-workstation/embedded/bin/irb:23:in `<main>'
        4: from /opt/chef-workstation/embedded/bin/irb:23:in `load'
        3: from /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        2: from (irb):4
        1: from (irb):4:in `%'
TypeError (can't convert nil into Integer)
``` 
Adding a nil check on that line fixes the issue.
Tested with following test 
```
control 'Ensure_fileX_has_correct_permissions' do
   describe file('/some/path/to/non-existing/file') do
      it { should exist }
      its('mode') { should cmp '0600' }
  end
end
```
inspec exec output before fix

```
     ×  Ensure_fileX_has_correct_permissions: File /some/path/to/non-existing/file (2 failed)
     ×  File /some/path/to/non-existing/file is expected to exist
     expected File /some/path/to/non-existing/file to exist
     ×  File /some/path/to/non-existing/file mode is expected to cmp == "0600"
     can't convert nil into Integer

```
inspec exec output after fix
```
×  Ensure_fileX_has_correct_permissions: File /some/path/to/non-existing/file (2 failed)
     ×  File /some/path/to/non-existing/file is expected to exist
     expected File /some/path/to/non-existing/file to exist
     ×  File /some/path/to/non-existing/file mode is expected to cmp == "0600"
     
     expected: 0600
          got: 
     
     (compared using `cmp` matcher)
```
Before fix build  https://buildkite.com/chef-oss/inspec-inspec-master-verify/builds/2814#3ddfb247-3c86-4b4f-ae50-9adf18308ebc/786-804

After fix build 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fix #5076 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
