### PR TITLE
Add m1 support to MacOS build list

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -26,6 +26,8 @@ builder-to-testers-map:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
     - mac_os_x-11-x86_64
+  mac_os_x-11-arm64:
+    - mac_os_x-11-arm64
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,3 +4,6 @@
 train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
 override "train", version: "v#{train_stable}"
 override "ruby", version: "2.7.2"
+
+# Mac m1
+override "openssl", version: "1.1.1j" if mac_os_x? && arm?

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -6,4 +6,4 @@ override "train", version: "v#{train_stable}"
 override "ruby", version: "2.7.2"
 
 # Mac m1
-override "openssl", version: "1.1.1j" if mac_os_x? && arm?
+override "openssl", version: "1.1.1j" if mac_os_x?


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Adds m1 chip (ARM) support to our list of platforms for which we build packages.
As part of this, conditionally selects openssl version based on which platform we are building.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Closes #5429 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
