### PR TITLE
Add quotation around -name option for apt resource to work properly with zsh

### DIFF
--- a/lib/inspec/resources/apt.rb
+++ b/lib/inspec/resources/apt.rb
@@ -78,7 +78,7 @@ module Inspec::Resources
       return @repo_cache if defined?(@repo_cache)
 
       # load all lists
-      cmd = inspec.command("find /etc/apt/ -name \*.list -exec sh -c 'cat {} || echo -n' \\;")
+      cmd = inspec.command("find /etc/apt/ -name \"*.list\" -exec sh -c 'cat {} || echo -n' \\;")
 
       # @see https://help.ubuntu.com/community/Repositories/CommandLine#Explanation_of_the_Repository_Format
       @repo_cache = cmd.stdout.lines.map do |raw_line|

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -344,7 +344,7 @@ class MockLoader
       "host -t AAAA example.com" => cmd.call("host-AAAA-example.com"),
       "ping -W 1 -c 1 example.com" => cmd.call("ping-example.com"),
       # apt
-      "find /etc/apt/ -name *.list -exec sh -c 'cat {} || echo -n' \\;" => cmd.call("etc-apt"),
+      "find /etc/apt/ -name \"*.list\" -exec sh -c 'cat {} || echo -n' \\;" => cmd.call("etc-apt"),
       # iptables
       "/usr/sbin/iptables  -S" => cmd.call("iptables-s"),
       %{sh -c 'type "/usr/sbin/iptables"'} => empty.call,


### PR DESCRIPTION
## Description
As of current implementation of `apt` resource, the shell command to fetch all package repository from `*.list` files fails on zsh because the value for `-name` option doesn't work on zsh.

```
% find /etc/apt/ -name *.list -exec sh -c 'cat {} || echo -n' \;
zsh: no matches found: *.list
```

By enclosing the value `*.list` with double quote, it works perfectly.

```
% find /etc/apt/ -name "*.list" -exec sh -c 'cat {} || echo -n' \;
deb http://deb.debian.org/debian buster main
deb-src http://deb.debian.org/debian buster main
deb http://security.debian.org/debian-security buster/updates main
deb-src http://security.debian.org/debian-security buster/updates main
deb http://deb.debian.org/debian buster-updates main
deb-src http://deb.debian.org/debian buster-updates main
deb http://deb.debian.org/debian buster-backports main
deb-src http://deb.debian.org/debian buster-backports main
deb [arch=amd64] https://download.docker.com/linux/debian buster stable
deb http://packages.cloud.google.com/apt cloud-sdk-buster main
deb http://packages.cloud.google.com/apt google-cloud-packages-archive-keyring-buster main
deb [arch=amd64] https://apt.releases.hashicorp.com buster main
deb http://packages.cloud.google.com/apt google-compute-engine-buster-stable main
```

## Related Issue
Fixes #5436
https://github.com/ymotongpoo/setup/issues/3

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
