### PR TITLE
Add timeout option to command resource

### DIFF
--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -258,6 +258,8 @@ This subcommand has additional options:
     Specifies the bastion port if applicable
 * ``--bastion-user=BASTION_USER``
     Specifies the bastion user if applicable
+* ``--command-timeout=SECONDS``
+    Maximum seconds to allow a command to run. Default 3600.
 * ``--config=CONFIG``
     Read configuration from JSON file (`-` reads from stdin).
 * ``--controls=one two three``
@@ -422,6 +424,8 @@ This subcommand has additional options:
     Specifies the bastion user if applicable
 * ``-c``, ``--command=COMMAND``
     A single command string to run instead of launching the shell
+* ``--command-timeout=SECONDS``
+    Maximum seconds to allow a command to run. Default 3600.
 * ``--config=CONFIG``
     Read configuration from JSON file (`-` reads from stdin).
 * ``--depends=one two three``

--- a/docs-chef-io/content/inspec/resources/command.md
+++ b/docs-chef-io/content/inspec/resources/command.md
@@ -138,25 +138,27 @@ Wix includes several tools -- such as `candle` (preprocesses and compiles source
 
 ### Timing Out Long-Running Commands
 
-On target platforms that support the feature, the command resource takes an option `timeout:` which specifies how long the command may run in seconds before erroring out and failing the control.
+On target platforms that support the feature, the command resource takes an optional `timeout:` parameter which specifies how long the command may run in seconds before erroring out and failing the control.
 
-    describe command("find / -owner badguy", timeout: 300) do
-      its("stdout") { should be_empty }
-    end
+```ruby
+describe command("find / -owner badguy", timeout: 300) do
+  its("stdout") { should be_empty }
+end
+```
 
 This example would run the `find` command for up to 300 seconds, then give up and fail the control if it exceeded that time.
 On supported target platforms, the default timeout is 3600 seconds (one hour).
 
-Aside from setting the value on a per-resource basis, you may also use the `--command-timeout` CLI option to globally set a command timeout. If the CLI option is used, it takes precedence over any per-resource `timeout:` options.
+Aside from setting the value on a per-resource basis, you may also use the `--command-timeout` CLI option to globally set a command timeout. The CLI option takes precedence over any per-resource `timeout:` options.
 
 Currently supported target platforms include:
- * Local Unix-like OSes, including MacOS
+ * Local Unix-like OSes, including macOS
  * SSH targets
  * Windows targets via WinRM
 
 Any target platforms not listed are not supported at this time.
 
-On unsupported platforms, the timeout value is ignored, and the command will run indefinitely.
+On unsupported platforms, the timeout value is ignored and the command will run indefinitely.
 
 ### Redacting Sensitive Commands
 

--- a/docs-chef-io/content/inspec/resources/command.md
+++ b/docs-chef-io/content/inspec/resources/command.md
@@ -136,6 +136,28 @@ Wix includes several tools -- such as `candle` (preprocesses and compiles source
       end
     end
 
+### Timing Out Long-Running Commands
+
+On target platforms that support the feature, the command resource takes an option `timeout:` which specifies how long the command may run in seconds before erroring out and failing the control.
+
+    describe command("find / -owner badguy", timeout: 300) do
+      its("stdout") { should be_empty }
+    end
+
+This example would run the `find` command for up to 300 seconds, then give up and fail the control if it exceeded that time.
+On supported target platforms, the default timeout is 3600 seconds (one hour).
+
+Aside from setting the value on a per-resource basis, you may also use the `--command-timeout` CLI option to globally set a command timeout. If the CLI option is used, it takes precedence over any per-resource `timeout:` options.
+
+Currently supported target platforms include:
+ * Local Unix-like OSes, including MacOS
+ * SSH targets
+ * Windows targets via WinRM
+
+Any target platforms not listed are not supported at this time.
+
+On unsupported platforms, the timeout value is ignored, and the command will run indefinitely.
+
 ### Redacting Sensitive Commands
 
 By default the command that is ran is shown in the Chef InSpec output. This can be problematic if the command contains sensitive arguments such as a password. These sensitive parts can be redacted by passing in `redact_regex` and a regular expression to redact. Optionally, you can use 2 capture groups to fine tune what is redacted.

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -166,9 +166,9 @@ module Inspec
         desc: "After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode."
       option :filter_empty_profiles, type: :boolean, default: false,
         desc: "Filter empty profiles (profiles without controls) from the report."
-      option :command_timeout, type: :numeric, default: 60,
-        desc: "Maximum minutes to allow commands to run during execution. Default 60.",
-        long_desc: "Maximum minutes to allow commands to run during execution. Default 60. A timed out command is considered an error."
+      option :command_timeout, type: :numeric, default: 3600,
+        desc: "Maximum seconds to allow commands to run during execution. Default 3600.",
+        long_desc: "Maximum seconds to allow commands to run during execution. Default 3600. A timed out command is considered an error."
     end
 
     def self.help(*args)

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -166,6 +166,9 @@ module Inspec
         desc: "After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode."
       option :filter_empty_profiles, type: :boolean, default: false,
         desc: "Filter empty profiles (profiles without controls) from the report."
+      option :command_timeout, type: :numeric, default: 60,
+        desc: "Maximum minutes to allow commands to run during execution. Default 60.",
+        long_desc: "Maximum minutes to allow commands to run during execution. Default 60. A timed out command is considered an error."
     end
 
     def self.help(*args)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -321,9 +321,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell"
   option :distinct_exit, type: :boolean, default: true,
     desc: "Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures."
-  option :command_timeout, type: :numeric, default: 60,
-      desc: "Maximum minutes to allow a command to run. Default 60.",
-      long_desc: "Maximum minutes to allow commands to run. Default 60. A timed out command is considered an error."
+  option :command_timeout, type: :numeric, default: 3600,
+      desc: "Maximum seconds to allow a command to run. Default 3600.",
+      long_desc: "Maximum seconds to allow commands to run. Default 3600. A timed out command is considered an error."
   option :inspect, type: :boolean, default: false, desc: "Use verbose/debugging output for resources."
   def shell_func
     o = config

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -321,6 +321,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell"
   option :distinct_exit, type: :boolean, default: true,
     desc: "Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures."
+  option :command_timeout, type: :numeric, default: 60,
+      desc: "Maximum minutes to allow a command to run. Default 60.",
+      long_desc: "Maximum minutes to allow commands to run. Default 60. A timed out command is considered an error."
   option :inspect, type: :boolean, default: false, desc: "Use verbose/debugging output for resources."
   def shell_func
     o = config

--- a/lib/inspec/resources/command.rb
+++ b/lib/inspec/resources/command.rb
@@ -32,14 +32,7 @@ module Inspec::Resources
 
       @command = cmd
 
-      @timeout = options[:timeout]&.to_i || Inspec::Config.cached.final_options['command_timeout']&.to_i
-      if @timeout
-        # train uses seconds but inspec advertises minutes
-        @timeout = @timeout * 60
-      else
-        warn "InSpec config is missing value for command_timeout. Defaulting to 60m"
-        @timeout = 3600
-      end
+      @timeout = options[:timeout]&.to_i || Inspec::Config.cached.final_options['command_timeout']&.to_i || 3600
 
       if options[:redact_regex]
         unless options[:redact_regex].is_a?(Regexp)
@@ -53,11 +46,11 @@ module Inspec::Resources
     end
 
     def result
-      @result ||= begin 
+      @result ||= begin
         inspec.backend.run_command(@command, timeout: @timeout)
       rescue Train::CommandTimeoutReached
         raise Inspec::Exceptions::ResourceFailed,
-              "Command `#{@command}` timed out after #{@timeout / 60} minute(s)"
+              "Command `#{@command}` timed out after #{@timeout} seconds"
       end
     end
 

--- a/lib/inspec/resources/command.rb
+++ b/lib/inspec/resources/command.rb
@@ -32,6 +32,15 @@ module Inspec::Resources
 
       @command = cmd
 
+      @timeout = options[:timeout]&.to_i || Inspec::Config.cached.final_options['command_timeout']&.to_i
+      if @timeout
+        # train uses seconds but inspec advertises minutes
+        @timeout = @timeout * 60
+      else
+        warn "InSpec config is missing value for command_timeout. Defaulting to 60m"
+        @timeout = 3600
+      end
+
       if options[:redact_regex]
         unless options[:redact_regex].is_a?(Regexp)
           # Make sure command is replaced so sensitive output isn't shown
@@ -44,7 +53,12 @@ module Inspec::Resources
     end
 
     def result
-      @result ||= inspec.backend.run_command(@command)
+      @result ||= begin 
+        inspec.backend.run_command(@command, timeout: @timeout)
+      rescue Train::CommandTimeoutReached
+        raise Inspec::Exceptions::ResourceFailed,
+              "Command `#{@command}` timed out after #{@timeout / 60} minute(s)"
+      end
     end
 
     def stdout

--- a/lib/inspec/resources/command.rb
+++ b/lib/inspec/resources/command.rb
@@ -32,7 +32,15 @@ module Inspec::Resources
 
       @command = cmd
 
-      @timeout = options[:timeout]&.to_i || Inspec::Config.cached.final_options['command_timeout']&.to_i || 3600
+      cli_timeout = Inspec::Config.cached['command_timeout'].to_i
+      # Can access this via Inspec::InspecCLI.commands["exec"].options[:command_timeout].default,
+      # but that may not be loaded for kitchen-inspec and other pure gem consumers
+      default_cli_timeout = 3600
+      if cli_timeout != default_cli_timeout
+        @timeout = cli_timeout
+      else
+        @timeout = options[:timeout]&.to_i || default_cli_timeout
+      end
 
       if options[:redact_regex]
         unless options[:redact_regex].is_a?(Regexp)

--- a/lib/inspec/resources/command.rb
+++ b/lib/inspec/resources/command.rb
@@ -49,6 +49,9 @@ module Inspec::Resources
       @result ||= begin
         inspec.backend.run_command(@command, timeout: @timeout)
       rescue Train::CommandTimeoutReached
+        # Without a small sleep, the train connection gets broken
+        # We've already timed out, so a small sleep is not likely to be painful here.
+        sleep 0.1
         raise Inspec::Exceptions::ResourceFailed,
               "Command `#{@command}` timed out after #{@timeout} seconds"
       end

--- a/lib/inspec/resources/command.rb
+++ b/lib/inspec/resources/command.rb
@@ -32,7 +32,7 @@ module Inspec::Resources
 
       @command = cmd
 
-      cli_timeout = Inspec::Config.cached['command_timeout'].to_i
+      cli_timeout = Inspec::Config.cached["command_timeout"].to_i
       # Can access this via Inspec::InspecCLI.commands["exec"].options[:command_timeout].default,
       # but that may not be loaded for kitchen-inspec and other pure gem consumers
       default_cli_timeout = 3600
@@ -56,12 +56,12 @@ module Inspec::Resources
     def result
       @result ||= begin
         inspec.backend.run_command(@command, timeout: @timeout)
-      rescue Train::CommandTimeoutReached
-        # Without a small sleep, the train connection gets broken
-        # We've already timed out, so a small sleep is not likely to be painful here.
-        sleep 0.1
-        raise Inspec::Exceptions::ResourceFailed,
-              "Command `#{@command}` timed out after #{@timeout} seconds"
+                  rescue Train::CommandTimeoutReached
+                    # Without a small sleep, the train connection gets broken
+                    # We've already timed out, so a small sleep is not likely to be painful here.
+                    sleep 0.1
+                    raise Inspec::Exceptions::ResourceFailed,
+                          "Command `#{@command}` timed out after #{@timeout} seconds"
       end
     end
 

--- a/test/fixtures/profiles/timeouts/controls/inline-timeout.rb
+++ b/test/fixtures/profiles/timeouts/controls/inline-timeout.rb
@@ -1,0 +1,11 @@
+control "timeout-test-01" do
+  # Do something that will timeout, with inline timeout option
+  describe command("sleep 10; echo oops", timeout: 2) do
+    its("stdout") { should be_empty }
+  end
+
+  # Validate that the connection still works after a timeout
+  describe command("echo hello") do
+    its("exit_status") { should cmp 0 }
+  end
+end

--- a/test/fixtures/profiles/timeouts/inspec.yml
+++ b/test/fixtures/profiles/timeouts/inspec.yml
@@ -1,0 +1,10 @@
+name: sleepy
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: A profile that contains tests that take a long time to execute, to test the command timeout feature
+version: 0.1.0
+supports:
+  platform: os

--- a/test/unit/resources/json_test.rb
+++ b/test/unit/resources/json_test.rb
@@ -95,6 +95,7 @@ describe "Inspec::Resources::JSON" do
     # stdout:empty, stderr:empty
 
     def run_json_cmd(cmd)
+      Inspec::Config.cached["command_timeout"] = 3600 # Reset to default
       quick_resource("json", :linux, command: cmd)
     end
 


### PR DESCRIPTION
This PR is an adoption of work by @james-stocks on #5273.

Allow commands to have a timeout, set in seconds. This is considered an emergency mechanism to stop CI being halted indefinitely. If a test inherently needs to pass or fail based on a timeout, this should be scripted into the command string instead.

It can be set for a command resource, like:

```
  describe command('sleep 100', timeout: 10) do
    its('exit_status') { should cmp 0 }
  end
```

It can also be set as a new option `command-timeout`.
A timeout set on the command line takes precedence over an option set on the `command` resource.

If no timeout is set at all, a command will default to timing out after 1 hour.

Importantly, the timeout feature is only available on Train transports that implement a timeout in their `run_command_via_connection` option block. For now, that includes SSH, local Unix-like OSes, and WinRM. Platforms that do not support timeouts simply ignore the timeout and run forever.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
