### PR TITLE
Add --docker-url CLI option

### DIFF
--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -97,7 +97,7 @@ This subcommand has additional options:
 * ``--config=CONFIG``
     Read configuration from JSON file (`-` reads from stdin).
 * ``--docker-url``
-    Provides path to Docker API endpoint (Docker)
+    Provides path to Docker API endpoint (Docker).
 * ``--enable-password=ENABLE_PASSWORD``
     Password for enable mode on Cisco IOS devices.
 * ``--format=FORMAT``

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -96,6 +96,8 @@ This subcommand has additional options:
     Specifies the bastion user if applicable
 * ``--config=CONFIG``
     Read configuration from JSON file (`-` reads from stdin).
+* ``--docker-url``
+    Provides path to Docker API endpoint (Docker)
 * ``--enable-password=ENABLE_PASSWORD``
     Password for enable mode on Cisco IOS devices.
 * ``--format=FORMAT``
@@ -266,6 +268,8 @@ This subcommand has additional options:
     Write out a lockfile based on this execution (unless one already exists)
 * ``--distinct-exit``, ``--no-distinct-exit``
     Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.
+* ``--docker-url``
+    Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.
 * ``--enable-password=ENABLE_PASSWORD``
     Password for enable mode on Cisco IOS devices.
 * ``--filter-empty-profiles``, ``--no-filter-empty-profiles``
@@ -428,6 +432,8 @@ This subcommand has additional options:
     A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell
 * ``--distinct-exit``, ``--no-distinct-exit``
     Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures.
+* ``--docker-url``
+    Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.
 * ``--enable-password=ENABLE_PASSWORD``
     Password for enable mode on Cisco IOS devices.
 * ``--host=HOST``

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -120,6 +120,8 @@ module Inspec
         desc: "Provide a ID which will be included on reports"
       option :winrm_shell_type, type: :string, default: "powershell",
         desc: "Specify a shell type for winrm (eg. 'elevated' or 'powershell')"
+      option :docker_url, type: :string,
+        desc: "Provides path to Docker API endpoint (Docker)"
     end
 
     def self.profile_options


### PR DESCRIPTION
## Description

Adds a CLI option to specify the URI at which to connect to the Docker Engine. This is useful when connecting to Docker for Windows, for example.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Related to https://github.com/inspec/train/pull/674


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
