### PR TITLE
Bug fix for loading hashmap inputs consistently

### DIFF
--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -256,7 +256,7 @@ module Inspec
 
         data.inputs.each do |input_name, input_value|
           evt = Inspec::Input::Event.new(
-            value: input_value&.class.eql?(Hash) ? Thor::CoreExt::HashWithIndifferentAccess.new(input_value) : input_value,
+            value: input_value.is_a?(Hash) ? Thor::CoreExt::HashWithIndifferentAccess.new(input_value) : input_value,
             provider: :cli_files,
             priority: 40,
             file: path
@@ -307,7 +307,7 @@ module Inspec
     def handle_raw_input_from_metadata(input_orig, profile_name)
       input_options = input_orig.dup
       input_name = input_options.delete(:name)
-      input_options[:value] = Thor::CoreExt::HashWithIndifferentAccess.new(input_options[:value]) if input_options[:value]&.class.eql?(Hash)
+      input_options[:value] = Thor::CoreExt::HashWithIndifferentAccess.new(input_options[:value]) if input_options[:value].is_a?(Hash)
       input_options[:provider] = :profile_metadata
       input_options[:file] = File.join(profile_name, "inspec.yml")
       input_options[:priority] ||= 30

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -225,7 +225,7 @@ module Inspec
       input_hash.each do |input_name, input_value|
         loc = Inspec::Input::Event.probe_stack # TODO: likely modify this to look for a kitchen.yml, if that is realistic
         evt = Inspec::Input::Event.new(
-          value: input_value,
+          value: input_value.is_a?(Hash) ? Thor::CoreExt::HashWithIndifferentAccess.new(input_value) : input_value,
           provider: :runner_api, # TODO: suss out if audit cookbook or kitchen-inspec or something unknown
           priority: 40,
           file: loc.path,

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -82,6 +82,7 @@ module Inspec
     def find_or_register_input(input_name, profile_name, options = {})
       input_name = input_name.to_s
       profile_name = profile_name.to_s
+      options[:event].value = Thor::CoreExt::HashWithIndifferentAccess.new(options[:event].value) if options[:event]&.value.is_a?(Hash)
 
       if profile_alias?(profile_name) && !profile_aliases[profile_name].nil?
         alias_name = profile_name
@@ -225,7 +226,7 @@ module Inspec
       input_hash.each do |input_name, input_value|
         loc = Inspec::Input::Event.probe_stack # TODO: likely modify this to look for a kitchen.yml, if that is realistic
         evt = Inspec::Input::Event.new(
-          value: input_value.is_a?(Hash) ? Thor::CoreExt::HashWithIndifferentAccess.new(input_value) : input_value,
+          value: input_value,
           provider: :runner_api, # TODO: suss out if audit cookbook or kitchen-inspec or something unknown
           priority: 40,
           file: loc.path,
@@ -256,7 +257,7 @@ module Inspec
 
         data.inputs.each do |input_name, input_value|
           evt = Inspec::Input::Event.new(
-            value: input_value.is_a?(Hash) ? Thor::CoreExt::HashWithIndifferentAccess.new(input_value) : input_value,
+            value: input_value,
             provider: :cli_files,
             priority: 40,
             file: path
@@ -307,7 +308,6 @@ module Inspec
     def handle_raw_input_from_metadata(input_orig, profile_name)
       input_options = input_orig.dup
       input_name = input_options.delete(:name)
-      input_options[:value] = Thor::CoreExt::HashWithIndifferentAccess.new(input_options[:value]) if input_options[:value].is_a?(Hash)
       input_options[:provider] = :profile_metadata
       input_options[:file] = File.join(profile_name, "inspec.yml")
       input_options[:priority] ||= 30

--- a/lib/inspec/input_registry.rb
+++ b/lib/inspec/input_registry.rb
@@ -256,7 +256,7 @@ module Inspec
 
         data.inputs.each do |input_name, input_value|
           evt = Inspec::Input::Event.new(
-            value: input_value,
+            value: input_value&.class.eql?(Hash) ? Thor::CoreExt::HashWithIndifferentAccess.new(input_value) : input_value,
             provider: :cli_files,
             priority: 40,
             file: path
@@ -307,6 +307,7 @@ module Inspec
     def handle_raw_input_from_metadata(input_orig, profile_name)
       input_options = input_orig.dup
       input_name = input_options.delete(:name)
+      input_options[:value] = Thor::CoreExt::HashWithIndifferentAccess.new(input_options[:value]) if input_options[:value]&.class.eql?(Hash)
       input_options[:provider] = :profile_metadata
       input_options[:file] = File.join(profile_name, "inspec.yml")
       input_options[:priority] ||= 30

--- a/test/fixtures/profiles/inputs/hashmap/controls/hashmap_input.rb
+++ b/test/fixtures/profiles/inputs/hashmap/controls/hashmap_input.rb
@@ -1,8 +1,6 @@
 # copyright: 218, The Authors
 title "Verifying loading of hashmap inputs using metadata and external file"
 
-# controls to test metadata file hash traversing
-
 control "hashmap-metadata" do
   title "Verifying loading of hashmap inputs using metadata file"
 
@@ -15,8 +13,6 @@ control "hashmap-metadata" do
     its([:metadata_nested_key_sym]) { should eq 'metadata_nested_value_sym' }
   end
 end
-
-# controls to test external attribute file hash traversing
 
 control "hashmap-external-file" do
   title "Verifying loading of hashmap inputs using external file"

--- a/test/fixtures/profiles/inputs/hashmap/controls/hashmap_input.rb
+++ b/test/fixtures/profiles/inputs/hashmap/controls/hashmap_input.rb
@@ -1,44 +1,32 @@
-# copyright: 218, The Authors
+# copyright: 2021, Chef Software, Inc.
 title "Verifying loading of hashmap inputs using metadata and external file"
 
 control "hashmap-metadata" do
   title "Verifying loading of hashmap inputs using metadata file"
 
-  describe input("metadata_basic_key") do
-    it { should cmp "metadata_basic_value" }
-  end
-
-  describe input("metadata_nested_key") do
-    its(["metadata_nested_key_str"]) { should eq "metadata_nested_value_str" }
-    its([:metadata_nested_key_sym]) { should eq "metadata_nested_value_sym" }
+  describe input("metadata_hash") do
+    its(["metadata_hash_key_str"]) { should eq "metadata_hash_value_str" }
+    its([:metadata_hash_key_sym]) { should eq "metadata_hash_value_sym" }
   end
 end
 
 control "hashmap-external-file" do
   title "Verifying loading of hashmap inputs using external file"
 
-  describe input("external_attribute_basic_key") do
-    it { should cmp "external_attribute_basic_value" }
-  end
-
-  describe input("external_attribute_nested_key") do
-    its(["external_attribute_nested_key_str"]) { should eq "external_attribute_nested_value_str" }
-    its([:external_attribute_nested_key_sym]) { should eq "external_attribute_nested_value_sym" }
+  describe input("external_input_hash") do
+    its(["external_input_hash_key_str"]) { should eq "external_input_hash_value_str" }
+    its([:external_input_hash_key_sym]) { should eq "external_input_hash_value_sym" }
   end
 end
 
 control "hashmap-profile-DSL" do
   title "Verifying loading of hashmap inputs using profile DSL"
 
-  describe input("dsl_basic_key", value: "dsl_basic_value") do
-    it { should cmp "dsl_basic_value" }
+  describe input("dsl_hash_string", value: { "dsl_hash_string_key": "dsl_hash_string_value" } ) do
+    its(["dsl_hash_string_key"]) { should eq "dsl_hash_string_value" }
   end
 
-  describe input("dsl_hash_string", value: { "dsl_nested_key_str": "dsl_nested_value_str" } ) do
-    its(["dsl_nested_key_str"]) { should eq "dsl_nested_value_str" }
-  end
-
-  describe input("dsl_hash_symbol", value: { dsl_nested_key_sym: :dsl_nested_value_sym } ) do
-    its([:dsl_nested_key_sym]) { should eq :dsl_nested_value_sym }
+  describe input("dsl_hash_symbol", value: { dsl_hash_symbol_key: :dsl_hash_symbol_value } ) do
+    its([:dsl_hash_symbol_key]) { should eq :dsl_hash_symbol_value }
   end
 end

--- a/test/fixtures/profiles/inputs/hashmap/controls/hashmap_input.rb
+++ b/test/fixtures/profiles/inputs/hashmap/controls/hashmap_input.rb
@@ -1,0 +1,32 @@
+# copyright: 218, The Authors
+title "Verifying loading of hashmap inputs using metadata and external file"
+
+# controls to test metadata file hash traversing
+
+control "hashmap-metadata" do
+  title "Verifying loading of hashmap inputs using metadata file"
+
+  describe input('metadata_basic_key') do
+    it { should cmp 'metadata_basic_value' }
+  end
+
+  describe input('metadata_nested_key') do
+    its(['metadata_nested_key_str']) { should eq 'metadata_nested_value_str' }
+    its([:metadata_nested_key_sym]) { should eq 'metadata_nested_value_sym' }
+  end
+end
+
+# controls to test external attribute file hash traversing
+
+control "hashmap-external-file" do
+  title "Verifying loading of hashmap inputs using external file"
+
+  describe input('external_attribute_basic_key') do
+    it { should cmp 'external_attribute_basic_value' }
+  end
+
+  describe input('external_attribute_nested_key') do
+    its(['external_attribute_nested_key_str']) { should eq 'external_attribute_nested_value_str' }
+    its([:external_attribute_nested_key_sym]) { should eq 'external_attribute_nested_value_sym' }
+  end
+end

--- a/test/fixtures/profiles/inputs/hashmap/controls/hashmap_input.rb
+++ b/test/fixtures/profiles/inputs/hashmap/controls/hashmap_input.rb
@@ -4,25 +4,41 @@ title "Verifying loading of hashmap inputs using metadata and external file"
 control "hashmap-metadata" do
   title "Verifying loading of hashmap inputs using metadata file"
 
-  describe input('metadata_basic_key') do
-    it { should cmp 'metadata_basic_value' }
+  describe input("metadata_basic_key") do
+    it { should cmp "metadata_basic_value" }
   end
 
-  describe input('metadata_nested_key') do
-    its(['metadata_nested_key_str']) { should eq 'metadata_nested_value_str' }
-    its([:metadata_nested_key_sym]) { should eq 'metadata_nested_value_sym' }
+  describe input("metadata_nested_key") do
+    its(["metadata_nested_key_str"]) { should eq "metadata_nested_value_str" }
+    its([:metadata_nested_key_sym]) { should eq "metadata_nested_value_sym" }
   end
 end
 
 control "hashmap-external-file" do
   title "Verifying loading of hashmap inputs using external file"
 
-  describe input('external_attribute_basic_key') do
-    it { should cmp 'external_attribute_basic_value' }
+  describe input("external_attribute_basic_key") do
+    it { should cmp "external_attribute_basic_value" }
   end
 
-  describe input('external_attribute_nested_key') do
-    its(['external_attribute_nested_key_str']) { should eq 'external_attribute_nested_value_str' }
-    its([:external_attribute_nested_key_sym]) { should eq 'external_attribute_nested_value_sym' }
+  describe input("external_attribute_nested_key") do
+    its(["external_attribute_nested_key_str"]) { should eq "external_attribute_nested_value_str" }
+    its([:external_attribute_nested_key_sym]) { should eq "external_attribute_nested_value_sym" }
+  end
+end
+
+control "hashmap-profile-DSL" do
+  title "Verifying loading of hashmap inputs using profile DSL"
+
+  describe input("dsl_basic_key", value: "dsl_basic_value") do
+    it { should cmp "dsl_basic_value" }
+  end
+
+  describe input("dsl_hash_string", value: { "dsl_nested_key_str": "dsl_nested_value_str" } ) do
+    its(["dsl_nested_key_str"]) { should eq "dsl_nested_value_str" }
+  end
+
+  describe input("dsl_hash_symbol", value: { dsl_nested_key_sym: :dsl_nested_value_sym } ) do
+    its([:dsl_nested_key_sym]) { should eq :dsl_nested_value_sym }
   end
 end

--- a/test/fixtures/profiles/inputs/hashmap/external_attributes.yml
+++ b/test/fixtures/profiles/inputs/hashmap/external_attributes.yml
@@ -1,4 +1,0 @@
-external_attribute_basic_key: external_attribute_basic_value
-external_attribute_nested_key: 
-  external_attribute_nested_key_str: external_attribute_nested_value_str
-  external_attribute_nested_key_sym: external_attribute_nested_value_sym

--- a/test/fixtures/profiles/inputs/hashmap/external_attributes.yml
+++ b/test/fixtures/profiles/inputs/hashmap/external_attributes.yml
@@ -1,0 +1,4 @@
+external_attribute_basic_key: external_attribute_basic_value
+external_attribute_nested_key: 
+  external_attribute_nested_key_str: external_attribute_nested_value_str
+  external_attribute_nested_key_sym: external_attribute_nested_value_sym

--- a/test/fixtures/profiles/inputs/hashmap/files/inputs.yml
+++ b/test/fixtures/profiles/inputs/hashmap/files/inputs.yml
@@ -1,0 +1,3 @@
+external_input_hash: 
+  external_input_hash_key_str: external_input_hash_value_str
+  external_input_hash_key_sym: external_input_hash_value_sym

--- a/test/fixtures/profiles/inputs/hashmap/inspec.yml
+++ b/test/fixtures/profiles/inputs/hashmap/inspec.yml
@@ -4,7 +4,7 @@ maintainer: The Authors
 copyright: The Authors
 copyright_email: you@example.com
 license: Apache-2.0
-summary: A profile that checks the hash inputs using metadata file and external file.
+summary: A profile that checks loading of hashmap inputs using metadata file and external file.
 version: 0.1.0
 supports:
   platform: os

--- a/test/fixtures/profiles/inputs/hashmap/inspec.yml
+++ b/test/fixtures/profiles/inputs/hashmap/inspec.yml
@@ -1,17 +1,14 @@
 name: hashmap
-title: InSpec Profile
-maintainer: The Authors
-copyright: The Authors
-copyright_email: you@example.com
+title: InSpec Profile to verify hashmap inputs
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
 license: Apache-2.0
-summary: A profile that checks loading of hashmap inputs using metadata file and external file.
+summary: A profile that checks loading of hashmap inputs
 version: 0.1.0
 supports:
   platform: os
 inputs:
-- name: metadata_basic_key
-  value: metadata_basic_value
-- name: metadata_nested_key
+- name: metadata_hash
   value:
-    metadata_nested_key_str: metadata_nested_value_str
-    metadata_nested_key_sym: metadata_nested_value_sym
+    metadata_hash_key_str: metadata_hash_value_str
+    metadata_hash_key_sym: metadata_hash_value_sym

--- a/test/fixtures/profiles/inputs/hashmap/inspec.yml
+++ b/test/fixtures/profiles/inputs/hashmap/inspec.yml
@@ -1,0 +1,17 @@
+name: hashmap
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: A profile that checks the hash inputs using metadata file and external file.
+version: 0.1.0
+supports:
+  platform: os
+inputs:
+- name: metadata_basic_key
+  value: metadata_basic_value
+- name: metadata_nested_key
+  value:
+    metadata_nested_key_str: metadata_nested_value_str
+    metadata_nested_key_sym: metadata_nested_value_sym

--- a/test/fixtures/profiles/inputs/via-runner/controls/via-runner.rb
+++ b/test/fixtures/profiles/inputs/via-runner/controls/via-runner.rb
@@ -2,4 +2,12 @@ control "test_control_01" do
   describe input("test_input_01", value: "value_from_dsl") do
     it { should cmp "value_from_api" }
   end
+
+  describe input("test_input_hash_string", value: { "string_key": "string_value_dsl" }) do
+    its(['string_key']) { should eq 'string_value' }
+  end
+
+  describe input("test_input_hash_symbol", value: { symbol_key: :symbol_value_dsl }) do
+    its([:symbol_key]) { should eq :symbol_value }
+  end
 end

--- a/test/fixtures/profiles/inputs/via-runner/controls/via-runner.rb
+++ b/test/fixtures/profiles/inputs/via-runner/controls/via-runner.rb
@@ -4,7 +4,7 @@ control "test_control_01" do
   end
 
   describe input("test_input_hash_string", value: { "string_key": "string_value_dsl" }) do
-    its(['string_key']) { should eq 'string_value' }
+    its(["string_key"]) { should eq "string_value" }
   end
 
   describe input("test_input_hash_symbol", value: { symbol_key: :symbol_value_dsl }) do

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -445,7 +445,7 @@ describe "inputs" do
   end
 
   describe "when a profile is executed with external inputs and inputs defined in metadata file" do
-    it "should access the values successfully from in both input ways" do
+    it "should access the values successfully from both input ways" do
       result = run_inspec_process("exec #{inputs_profiles_path}/hashmap --input-file #{external_attributes_file_path}", json: true)
       _(result.stderr).must_be_empty
       assert_json_controls_passing(result)

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -6,7 +6,7 @@ require "tempfile"
 describe "inputs" do
   include FunctionalHelper
   let(:inputs_profiles_path) { File.join(profile_path, "inputs") }
-  let(:external_attributes_file_path) { "#{inputs_profiles_path}/hashmap/external_attributes.yml" }
+  let(:external_attributes_file_path) { "#{inputs_profiles_path}/hashmap/files/inputs.yml" }
 
   parallelize_me!
 

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -124,12 +124,23 @@ describe "inputs" do
 
     describe "when using the current :inputs key" do
       let(:runner_options) { common_options.merge({ inputs: { test_input_01: "value_from_api" } }) }
-
       it "finds the values and does not issue any warnings" do
         output = run_result.stdout
         refute_includes output, "DEPRECATION"
         structured_output = JSON.parse(output)
         assert_equal "passed", structured_output["profiles"][0]["controls"][0]["results"][0]["status"]
+      end
+    end
+
+    describe "when using the current :inputs key with both string and symbol key in hashes" do
+      let(:runner_options) { common_options.merge({ inputs: { test_input_01: "value_from_api", test_input_hash_string: { "string_key": "string_value" }, test_input_hash_symbol: { symbol_key: :symbol_value } } }) }
+
+      it "finds the values and runs successfully" do
+        output = run_result.stdout
+        structured_output = JSON.parse(output)
+        assert_equal "passed", structured_output["profiles"][0]["controls"][0]["results"][0]["status"]
+        assert_equal "passed", structured_output["profiles"][0]["controls"][0]["results"][1]["status"]
+        assert_equal "passed", structured_output["profiles"][0]["controls"][0]["results"][2]["status"]
       end
     end
 

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -455,8 +455,8 @@ describe "inputs" do
     end
   end
 
-  describe "when a profile is executed with external inputs and inputs defined in metadata file" do
-    it "should access the values successfully from both input ways" do
+  describe "when a profile is executed with inputs through external file, metadata file and profile DSL" do
+    it "should access the values successfully from all input ways" do
       result = run_inspec_process("exec #{inputs_profiles_path}/hashmap --input-file #{external_attributes_file_path}", json: true)
       _(result.stderr).must_be_empty
       assert_json_controls_passing(result)

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -6,6 +6,7 @@ require "tempfile"
 describe "inputs" do
   include FunctionalHelper
   let(:inputs_profiles_path) { File.join(profile_path, "inputs") }
+  let(:external_attributes_file_path) { "#{inputs_profiles_path}/hashmap/external_attributes.yml" }
 
   parallelize_me!
 
@@ -440,6 +441,14 @@ describe "inputs" do
       _(inputs[1]["options"]["value"]).wont_include "secret"
       _(inputs[1]["options"]["value"]).must_include "***"
       _(inputs[2]["options"]["value"]).wont_include "***" # Explicit sensitive = false
+    end
+  end
+
+  describe "when a profile is executed with external inputs and inputs defined in metadata file" do
+    it "should access the values successfully from in both input ways" do
+      result = run_inspec_process("exec #{inputs_profiles_path}/hashmap --input-file #{external_attributes_file_path}", json: true)
+      _(result.stderr).must_be_empty
+      assert_json_controls_passing(result)
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
**Issues:** 
1. The inputs loaded from external file and metadata file were read in two different formats by InSpec, one hash with `symbol` keys and another hash with `string` as keys
2. Hash inputs loaded using runner API and profile DSL also, returns success only in one of the formats.

**Impact of solution:**

This approach will solve reading inputs irrespective of their formats, which enables using hashes inside InSpec controls in any way preferred.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #4057 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
