### PR TITLE
Added ability to pass inputs to InSpec shell using input file and cli

### DIFF
--- a/docs-chef-io/content/inspec/shell.md
+++ b/docs-chef-io/content/inspec/shell.md
@@ -233,9 +233,9 @@ $ inspec shell --format json -c 'describe file("/Users/test") do it { should exi
 
 ## Running Chef InSpec Shell with inputs 
 
-Input option in shell subcommand would allow to more consistently and easily test and work with controls inside shell.
+The input options for the shell command allow you to provide values to profiles that are parameterized. This allows you to work more consistently with these profiles when switching between `shell` and `exec` when using profiles that have inputs. For more details on inputs, see the [inputs reference](/inspec/inputs/).
 
-This subcommand has following two options:
+The shell command has following two input options:
 * ``--input=name1=value1 name2=value2``
     Specify one or more inputs directly on the command line to shell, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.
 * ``--input-file=one two three``

--- a/docs-chef-io/content/inspec/shell.md
+++ b/docs-chef-io/content/inspec/shell.md
@@ -230,3 +230,43 @@ $ inspec shell --format json -c 'describe file("/Users/test") do it { should exi
   }
 }
 ```
+
+## Running Chef InSpec Shell with inputs 
+
+Input option in shell subcommand would allow to more consistently and easily test and work with controls inside shell.
+
+This subcommand has following two options:
+* ``--input=name1=value1 name2=value2``
+    Specify one or more inputs directly on the command line to shell, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.
+* ``--input-file=one two three``
+    Load one or more input files, a YAML file with values for the shell to use
+
+```bash
+$ inspec shell --input=input_name=input_value
+Welcome to the interactive InSpec Shell
+To find out how to use it, type: help
+
+inspec> control 'my_control' do
+inspec>   describe input('input_name') do
+inspec>     it { should cmp 'input_value' }
+inspec>   end
+inspec> end
+Profile: inspec-shell
+
+  ✔  my_control: input_value
+     ✔  input_value is expected to cmp == "input_value"
+
+Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
+Test Summary: 1 successful, 0 failures, 0 skipped
+inspec> exit
+```
+You may also provide inputs and values via YAML files on the command line to shell. The format can be seen below:
+
+```yaml
+input_name: input_value
+another_input: another_value
+```
+
+```bash
+$ inspec shell --input-file=<path>
+```

--- a/docs-chef-io/content/inspec/shell.md
+++ b/docs-chef-io/content/inspec/shell.md
@@ -231,15 +231,17 @@ $ inspec shell --format json -c 'describe file("/Users/test") do it { should exi
 }
 ```
 
-## Running Chef InSpec Shell with inputs 
+## Running Chef InSpec Shell With Inputs
 
-The input options for the shell command allow you to provide values to profiles that are parameterized. This allows you to work more consistently with these profiles when switching between `shell` and `exec` when using profiles that have inputs. For more details on inputs, see the [inputs reference](/inspec/inputs/).
+With InSpec [profiles that support inputs](inspec/inputs/#which-profiles-support-inputs),
+you can set inputs using the InSpec `shell` command. This allows you to work more consistently with
+InSpec profiles when switching between the `shell` and `exec` commands.
 
-The shell command has following two input options:
-* ``--input=name1=value1 name2=value2``
-    Specify one or more inputs directly on the command line to shell, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.
-* ``--input-file=one two three``
-    Load one or more input files, a YAML file with values for the shell to use
+For more details on inputs, see the [inputs reference](/inspec/inputs/).
+
+### Set Inputs with Command-line Options
+
+The `shell` command accepts one or more inputs in the command line as single-quoted YAML or JSON structures.
 
 ```bash
 $ inspec shell --input=input_name=input_value
@@ -260,7 +262,11 @@ Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
 Test Summary: 1 successful, 0 failures, 0 skipped
 inspec> exit
 ```
-You may also provide inputs and values via YAML files on the command line to shell. The format can be seen below:
+
+### Set Inputs with YAML File
+
+You can also save inputs and values to one or more YAML files and pass them to `shell` in the command line.
+For example:
 
 ```yaml
 input_name: input_value
@@ -268,5 +274,5 @@ another_input: another_value
 ```
 
 ```bash
-$ inspec shell --input-file=<path>
+inspec shell --input-file=<path>
 ```

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -328,7 +328,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :input_file, type: :array,
     desc: "Load one or more input files, a YAML file with values for the shell to use"
   option :input, type: :array, banner: "name1=value1 name2=value2",
-    desc: "Specify one or more inputs directly on the command line, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures."
+    desc: "Specify one or more inputs directly on the command line to the shell, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures."
   def shell_func
     o = config
     diagnose(o)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -325,6 +325,10 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       desc: "Maximum seconds to allow a command to run. Default 3600.",
       long_desc: "Maximum seconds to allow commands to run. Default 3600. A timed out command is considered an error."
   option :inspect, type: :boolean, default: false, desc: "Use verbose/debugging output for resources."
+  option :input_file, type: :array,
+    desc: "Load one or more input files, a YAML file with values for the shell to use"
+  option :input, type: :array, banner: "name1=value1 name2=value2",
+    desc: "Specify one or more inputs directly on the command line, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures."
   def shell_func
     o = config
     diagnose(o)

--- a/test/functional/inspec_shell_test.rb
+++ b/test/functional/inspec_shell_test.rb
@@ -2,6 +2,7 @@ require "functional/helper"
 
 describe "inspec shell tests" do
   include FunctionalHelper
+  let(:input_file_from_basic_input_profile) { File.join(profile_path, "inputs", "basic", "files", "flat.yaml") }
 
   parallelize_me!
 
@@ -9,6 +10,22 @@ describe "inspec shell tests" do
     def assert_shell_c(code, exit_status, json = false, stderr = "")
       json_suffix = " --reporter 'json'" if json
       command = "shell -c '#{code.tr("'", '\\\'')}'#{json_suffix}"
+      # On darwin this value is:
+      # shell -c 'describe file(\"/Users/nickschwaderer/Documents/inspec/inspec/test/functional/inspec_shell_test.rb\") do it { should exist } end' --reporter 'json'"
+      # appears to break in windows.
+      out = inspec(command)
+
+      actual = out.stderr.gsub(/\e\[(\d+)(;\d+)*m/, "") # strip ANSI color codes
+      _(actual).must_equal stderr
+
+      assert_exit_code exit_status, out
+
+      out
+    end
+
+    def assert_shell_c_with_inputs(code, input_cmd, input, exit_status, json = false, stderr= "")
+      json_suffix = " --reporter 'json'" if json
+      command = "shell -c '#{code.tr("'", '\\\'')}'#{input_cmd} #{input}#{json_suffix}"
       # On darwin this value is:
       # shell -c 'describe file(\"/Users/nickschwaderer/Documents/inspec/inspec/test/functional/inspec_shell_test.rb\") do it { should exist } end' --reporter 'json'"
       # appears to break in windows.
@@ -177,6 +194,20 @@ describe "inspec shell tests" do
       out = assert_shell_c("control \"test\" do describe file(\"#{__FILE__}\") do it { should exist } end; describe file(\"foo/bar/baz\") do it { should exist } end end", 100)
       _(out.stdout).must_include "0 successful"
       _(out.stdout).must_include "1 failure"
+    end
+
+    it "loads input from external input file" do
+      skip_windows! # Breakage confirmed
+      out = assert_shell_c_with_inputs("describe input(\"a_quoted_string\") do it { should cmp \"Should not have quotes\" } end", " --input-file", input_file_from_basic_input_profile, 0)
+      _(out.stdout).must_include "1 successful"
+      _(out.stdout).must_include "0 failures"
+    end
+
+    it "loads input from input cli" do
+      skip_windows! # Breakage confirmed
+      out = assert_shell_c_with_inputs("describe input(\"test_input_01\") do it { should cmp \"value_from_cli_01\" } end", " --input", "test_input_01='value_from_cli_01'", 0)
+      _(out.stdout).must_include "1 successful"
+      _(out.stdout).must_include "0 failures"
     end
   end
 

--- a/test/functional/inspec_shell_test.rb
+++ b/test/functional/inspec_shell_test.rb
@@ -23,7 +23,7 @@ describe "inspec shell tests" do
       out
     end
 
-    def assert_shell_c_with_inputs(code, input_cmd, input, exit_status, json = false, stderr= "")
+    def assert_shell_c_with_inputs(code, input_cmd, input, exit_status, json = false, stderr = "")
       json_suffix = " --reporter 'json'" if json
       command = "shell -c '#{code.tr("'", '\\\'')}'#{input_cmd} #{input}#{json_suffix}"
       # On darwin this value is:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added ability to pass inputs to InSpec shell using input file and cli
`inspec shell --depends <path> --input-file=<path> -t <target>`
`inspec shell --depends <path> --input a=[1,2,3] -t <target>`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fix #4989 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
