### PR TITLE
Use default command timeout value if timeout is 0

### DIFF
--- a/lib/inspec/resources/command.rb
+++ b/lib/inspec/resources/command.rb
@@ -36,6 +36,7 @@ module Inspec::Resources
       # Can access this via Inspec::InspecCLI.commands["exec"].options[:command_timeout].default,
       # but that may not be loaded for kitchen-inspec and other pure gem consumers
       default_cli_timeout = 3600
+      cli_timeout = default_cli_timeout if cli_timeout == 0 # Under test-kitchen we get a 0 timeout, which can't be a resonable value
       if cli_timeout != default_cli_timeout
         @timeout = cli_timeout
       else


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
Addresses a circumstance in which the Config object is initialized with 0 values, which can happen under kitchen-inspec. This results in having a 0 command timeout, which breaks all `command` resources.

This fix uses the default of 3600 seconds if a zero is detected.

## Related Issue

Fixes #5454
Related to #5443

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
