### PR TITLE
Optionally include controls source code in CLI reporter

### DIFF
--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -300,6 +300,8 @@ This subcommand has additional options:
     Enable one or more output reporters: cli, documentation, html, progress, json, json-min, json-rspec, junit, yaml
 * ``--reporter-backtrace-inclusion``, ``--no-reporter-backtrace-inclusion``
     Include a code backtrace in report data (default: true)
+* ``--reporter-include-source``
+    Include full source code of controls in the CLI report
 * ``--reporter-message-truncation=REPORTER_MESSAGE_TRUNCATION``
     Number of characters to truncate failure messages in report data to (default: no truncation)
 * ``--self-signed``, ``--no-self-signed``

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -171,6 +171,8 @@ module Inspec
       option :command_timeout, type: :numeric, default: 3600,
         desc: "Maximum seconds to allow commands to run during execution. Default 3600.",
         long_desc: "Maximum seconds to allow commands to run during execution. Default 3600. A timed out command is considered an error."
+      option :reporter_include_source, type: :boolean, default: false,
+        desc: "Include full source code of controls in the CLI report"
     end
 
     def self.help(*args)

--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -41,12 +41,14 @@ module Inspec::Reporters
     MULTI_TEST_CONTROL_SUMMARY_MAX_LEN = 60
 
     def render
+      @src_extent_map = {}
       run_data[:profiles].each do |profile|
         if profile[:status] == "skipped"
           platform = run_data[:platform]
           output("Skipping profile: '#{profile[:name]}' on unsupported platform: '#{platform[:name]}/#{platform[:release]}'.")
           next
         end
+        read_control_source(profile)
         @control_count = 0
         output("")
         print_profile_header(profile)
@@ -89,6 +91,7 @@ module Inspec::Reporters
         next if control.results.nil?
 
         output(format_control_header(control))
+        output(format_control_source(control)) if Inspec::Config.cached[:reporter_include_source]
         control.results.each do |result|
           output(format_result(control, result, :standard))
           @control_count += 1
@@ -125,6 +128,62 @@ module Inspec::Reporters
         indicator: impact,
         message: control.title_for_report
       )
+    end
+
+    def format_control_source(control)
+      src = @control_source[control.id]
+      message  = "Control Source from #{src[:path]}:#{src[:start]}..#{src[:end]}\n"
+      message += src[:content]
+      format_message(
+        color: "skipped",
+        indentation: 5,
+        message: message
+      )
+    end
+
+    def read_control_source(profile)
+      return unless Inspec::Config.cached[:reporter_include_source]
+
+      @control_source = {}
+      src_extent_map = {}
+
+      # First pass: build map of paths => ids => [start]
+      all_unique_controls.each do |control|
+        id = control[:id]
+        path = control[:source_location][:ref]
+        start = control[:source_location][:line]
+        next if path.nil? || start.nil?
+
+        src_extent_map[path] ||= []
+        src_extent_map[path] << { start: start, id: id }
+      end
+
+      # Now sort the controls by their starting line in their control file
+      src_extent_map.values.each do |extent_list|
+        extent_list.sort! { |a, b| a[:start] <=> b[:start] }
+      end
+
+      # Third pass: Read in files and split into lines
+      src_extent_map.keys.each do |path|
+        control_file_lines = File.read(path).lines # TODO error handling
+        last_line_in_file = control_file_lines.count
+        extent_list = src_extent_map[path]
+        extent_list.each_with_index do |extent, idx|
+          if idx == extent_list.count - 1 # Last entry
+            extent[:end] = last_line_in_file
+          else
+            extent[:end] = extent_list[idx + 1][:start] - 1
+          end
+
+          @control_source[extent[:id]] =
+            {
+              path: path,
+              start: extent[:start],
+              end: extent[:end],
+              content: control_file_lines.slice(extent[:start] - 1, extent[:end] - extent[:start] + 1).join(""),
+            }
+        end
+      end
     end
 
     def format_result(control, result, type)
@@ -310,6 +369,10 @@ module Inspec::Reporters
 
       def impact
         data[:impact]
+      end
+
+      def source_location
+        data[:source_location]
       end
 
       def anonymous?

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -1084,4 +1084,35 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
       end
     end
   end
+
+  describe "when using the --reporter-include-source option with the CLI reporter" do
+    let(:profile) { "#{profile_path}/sorted-results/sort-me-1" } # A profile with controls separated in multiple files
+    let(:run_result) { run_inspec_process("exec #{profile} --reporter-include-source") }
+    it "includes the control source code" do
+      _(run_result.stderr).must_be_empty
+
+      expected = %r{Control Source from .+test/fixtures/profiles/sorted-results/sort-me-1/controls/a-uvw.rb:1..6}
+      _(run_result.stdout).must_match expected
+      expected = <<EOT
+     control "w" do
+       describe "anything" do
+         it { should eq "anything" }
+       end
+     end
+EOT
+      _(run_result.stdout).must_include expected
+
+      expected = %r{Control Source from .+test/fixtures/profiles/sorted-results/sort-me-1/controls/c-rst.rb:1..6}
+      _(run_result.stdout).must_match expected
+      expected = <<EOT
+     control "r" do
+       describe "anything" do
+         it { should eq "anything" }
+       end
+     end
+EOT
+      _(run_result.stdout).must_include expected
+
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Adds a new CLI option, `--reporter-include-source` which includes the source code of the controls in the output of the CLI reporter.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Closes #5453

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
