### PR TITLE
Remove default of 3600 seconds for command timeout

### DIFF
--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -261,7 +261,7 @@ This subcommand has additional options:
 * ``--bastion-user=BASTION_USER``
     Specifies the bastion user if applicable
 * ``--command-timeout=SECONDS``
-    Maximum seconds to allow a command to run. Default 3600.
+    Maximum seconds to allow a command to run.
 * ``--config=CONFIG``
     Read configuration from JSON file (`-` reads from stdin).
 * ``--controls=one two three``
@@ -431,7 +431,7 @@ This subcommand has additional options:
 * ``-c``, ``--command=COMMAND``
     A single command string to run instead of launching the shell
 * ``--command-timeout=SECONDS``
-    Maximum seconds to allow a command to run. Default 3600.
+    Maximum seconds to allow a command to run.
 * ``--config=CONFIG``
     Read configuration from JSON file (`-` reads from stdin).
 * ``--depends=one two three``

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -168,9 +168,9 @@ module Inspec
         desc: "After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode."
       option :filter_empty_profiles, type: :boolean, default: false,
         desc: "Filter empty profiles (profiles without controls) from the report."
-      option :command_timeout, type: :numeric, default: 3600,
-        desc: "Maximum seconds to allow commands to run during execution. Default 3600.",
-        long_desc: "Maximum seconds to allow commands to run during execution. Default 3600. A timed out command is considered an error."
+      option :command_timeout, type: :numeric,
+        desc: "Maximum seconds to allow commands to run during execution.",
+        long_desc: "Maximum seconds to allow commands to run during execution. A timed out command is considered an error."
       option :reporter_include_source, type: :boolean, default: false,
         desc: "Include full source code of controls in the CLI report"
     end

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -321,9 +321,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell"
   option :distinct_exit, type: :boolean, default: true,
     desc: "Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures."
-  option :command_timeout, type: :numeric, default: 3600,
-      desc: "Maximum seconds to allow a command to run. Default 3600.",
-      long_desc: "Maximum seconds to allow commands to run. Default 3600. A timed out command is considered an error."
+  option :command_timeout, type: :numeric,
+      desc: "Maximum seconds to allow a command to run.",
+      long_desc: "Maximum seconds to allow commands to run. A timed out command is considered an error."
   option :inspect, type: :boolean, default: false, desc: "Use verbose/debugging output for resources."
   option :input_file, type: :array,
     desc: "Load one or more input files, a YAML file with values for the shell to use"

--- a/lib/inspec/resources/command.rb
+++ b/lib/inspec/resources/command.rb
@@ -31,17 +31,11 @@ module Inspec::Resources
       end
 
       @command = cmd
-
-      cli_timeout = Inspec::Config.cached["command_timeout"].to_i
+      cli_timeout = Inspec::Config.cached["command_timeout"]&.to_i
       # Can access this via Inspec::InspecCLI.commands["exec"].options[:command_timeout].default,
       # but that may not be loaded for kitchen-inspec and other pure gem consumers
-      default_cli_timeout = 3600
-      cli_timeout = default_cli_timeout if cli_timeout == 0 # Under test-kitchen we get a 0 timeout, which can't be a resonable value
-      if cli_timeout != default_cli_timeout
-        @timeout = cli_timeout
-      else
-        @timeout = options[:timeout]&.to_i || default_cli_timeout
-      end
+      cli_timeout = nil if cli_timeout == 0 # Under test-kitchen we get a 0 timeout, which can't be a resonable value
+      @timeout = cli_timeout || options[:timeout]&.to_i
 
       if options[:redact_regex]
         unless options[:redact_regex].is_a?(Regexp)

--- a/test/unit/resources/json_test.rb
+++ b/test/unit/resources/json_test.rb
@@ -95,7 +95,7 @@ describe "Inspec::Resources::JSON" do
     # stdout:empty, stderr:empty
 
     def run_json_cmd(cmd)
-      Inspec::Config.cached["command_timeout"] = 3600 # Reset to default
+      Inspec::Config.cached["command_timeout"] = nil # Reset to default
       quick_resource("json", :linux, command: cmd)
     end
 


### PR DESCRIPTION
## Description

Removes the default value of 3600 seconds for the --command-timeout CLI option introduced on #5443, which has proven to be problematic. This feature should be opt-in, as we have found several problems.

Currently we are working to address inspec/train#677, and by making the timeout feature opt-in, we can be more aggressive in the remediation approaches. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

inspec/train#677

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
