### PR TITLE
Remove pipeline-specific logic from test scripts

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -1,32 +1,6 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$channel = "$Env:CHANNEL"
-If ([string]::IsNullOrEmpty($channel)) { $channel = "unstable" }
-
-$product = "$Env:PRODUCT"
-If ([string]::IsNullOrEmpty($product)) { $product = "inspec" }
-
-$version = "$Env:VERSION"
-If ([string]::IsNullOrEmpty($version)) { $version = "latest" }
-
-$package_file = "$Env:PACKAGE_FILE"
-If ([string]::IsNullOrEmpty($package_file)) { $package_file = "" }
-
-If ($package_file -eq "") {
-  Write-Output "--- Installing $channel $product $version"
-  $package_file = $(.omnibus-buildkite-plugin\install-omnibus-product.ps1 -Product "$product" -Channel "$channel" -Version "$version" | Select-Object -Last 1)
-} 
-Else {
-  Write-Output "--- Installing $product $version"
-  $package_file = $(.omnibus-buildkite-plugin\install-omnibus-product.ps1 -Package "$package_file" -Product "$product" -Version "$version" | Select-Object -Last 1)
-}
-
-Write-Output "--- Verifying omnibus package is signed"
-C:\opscode\omnibus-toolchain\bin\check-omnibus-package-signed.ps1 "$package_file"
-
-Write-Output "--- Running verification for $channel $product $version"
-
 # reload Env:PATH to ensure it gets any changes that the install made (e.g. C:\opscode\inspec\bin\ )
 $Env:PATH = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -1,37 +1,6 @@
 #!/bin/bash
 set -ueo pipefail
 
-channel="${CHANNEL:-unstable}"
-product="${PRODUCT:-inspec}"
-version="${VERSION:-latest}"
-package_file=${PACKAGE_FILE:-""}
-
-echo "--- Installing $channel $product $version"
-if [[ -z $package_file ]]; then
-  package_file="$(.omnibus-buildkite-plugin/install-omnibus-product.sh -c "$channel" -P "$product" -v "$version" | tail -1)"
-else
-  .omnibus-buildkite-plugin/install-omnibus-product.sh -f "$package_file" -P "$product" -v "$version" &> /dev/null
-fi
-
-echo "--- Verifying omnibus package is signed"
-/opt/omnibus-toolchain/bin/check-omnibus-package-signed "$package_file"
-
-sudo rm -f "$package_file"
-
-echo "--- Verifying ownership of package files"
-
-export INSTALL_DIR=/opt/inspec
-NONROOT_FILES="$(find "$INSTALL_DIR" ! -user 0 -print)"
-if [[ "$NONROOT_FILES" == "" ]]; then
-  echo "Packages files are owned by root.  Continuing verification."
-else
-  echo "Exiting with an error because the following files are not owned by root:"
-  echo "$NONROOT_FILES"
-  exit 1
-fi
-
-echo "--- Running verification for $channel $product $version"
-
 # Set GEM_HOME and GEM_PATH to verify our appbundle inspec shim is correctly
 # removing them from the environment while launching from our embedded ruby.
 export GEM_HOME=/SHOULD_NOT_EXIST


### PR DESCRIPTION
This logic has been moved into the Omnibus Buildkite Plugin.
These scripts can now be used outside of the Buildkite pipelines.

Signed-off-by: Tom Duffield <github@tomduffield.com>