### PR TITLE
Added alias command `automate` for `inspec compliance`

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ $ inspec --help
 Commands:
   inspec archive PATH                                       # archive a profile to tar.gz (default) ...
   inspec check PATH                                         # verify all tests at the specified PATH
-  inspec compliance SUBCOMMAND or automate SUBCOMMAND ...   # Chef Compliance commands
+  inspec automate SUBCOMMAND ...                            # Chef Automate commands
+  inspec compliance SUBCOMMAND ...                          # Chef Automate commands (backwards compatible alias)
   inspec detect                                             # detect the target OS
   inspec exec PATH(S)                                       # run all test files at the specified PATH.
   inspec help [COMMAND]                                     # Describe available commands or one spe...

--- a/README.md
+++ b/README.md
@@ -177,17 +177,17 @@ You should now be able to run:
 ```bash
 $ inspec --help
 Commands:
-  inspec archive PATH                # archive a profile to tar.gz (default) ...
-  inspec check PATH                  # verify all tests at the specified PATH
-  inspec compliance SUBCOMMAND ...   # Chef Compliance commands
-  inspec detect                      # detect the target OS
-  inspec exec PATH(S)                # run all test files at the specified PATH.
-  inspec help [COMMAND]              # Describe available commands or one spe...
-  inspec init TEMPLATE ...           # Scaffolds a new project
-  inspec json PATH                   # read all tests in PATH and generate a ...
-  inspec shell                       # open an interactive debugging shell
-  inspec supermarket SUBCOMMAND ...  # Supermarket commands
-  inspec version                     # prints the version of this tool
+  inspec archive PATH                                       # archive a profile to tar.gz (default) ...
+  inspec check PATH                                         # verify all tests at the specified PATH
+  inspec compliance SUBCOMMAND or automate SUBCOMMAND ...   # Chef Compliance commands
+  inspec detect                                             # detect the target OS
+  inspec exec PATH(S)                                       # run all test files at the specified PATH.
+  inspec help [COMMAND]                                     # Describe available commands or one spe...
+  inspec init TEMPLATE ...                                  # Scaffolds a new project
+  inspec json PATH                                          # read all tests in PATH and generate a ...
+  inspec shell                                              # open an interactive debugging shell
+  inspec supermarket SUBCOMMAND ...                         # Supermarket commands
+  inspec version                                            # prints the version of this tool
 
 Options:
   [--diagnose], [--no-diagnose]  # Show diagnostics (versions, configurations)

--- a/dev-docs/compliance.md
+++ b/dev-docs/compliance.md
@@ -2,13 +2,13 @@
 
 ## Purpose
 
-The `compliance` set of subcommands handle user-initiated communication with Chef Automate. The commands are provided so that a user can interact with an Automate installation.
+The `automate` set of subcommands handle user-initiated communication with Chef Automate. The commands are provided so that a user can interact with an Automate installation.
 
-`inspec compliance` is somewhat analogous to `knife` in that it can be used to upload, download, and manage profiles for distribution to other clients.
+`inspec automate` is somewhat analogous to `knife` in that it can be used to upload, download, and manage profiles for distribution to other clients.
 
-When Automate initiates scans, the `compliance` subcommand is not used.
+When Automate initiates scans, the `automate` subcommand is not used.
 
-`inspec automate` is an alias for `inspec compliance` and works the same way
+`inspec compliance` is a backwards compatible alias for `inspec automate` and works the same way
 
 ## Operational Notes
 
@@ -67,10 +67,10 @@ There are several other minor commands not listed here - see `lib/cli.rb` for a 
 
 ### login
 
-Saves a credentials file locally. Future invocations of `inspec compliance` or `inspec automate` use the credentials file to authenticate.
+Saves a credentials file locally. Future invocations of `inspec automate` or `inspec compliance` use the credentials file to authenticate.
 
-`be inspec compliance login --user=admin --token='1234567890asdfghjkl' --insecure https://chef-automate.test` or
-`be inspec automate login --user=admin --token='1234567890asdfghjkl' --insecure https://chef-automate.test`
+`be inspec automate login --user=admin --token='1234567890asdfghjkl' --insecure https://chef-automate.test` or
+`be inspec compliance login --user=admin --token='1234567890asdfghjkl' --insecure https://chef-automate.test`
 
 Here are the results of running login, from `.inspec/compliance/config.json`:
 

--- a/dev-docs/compliance.md
+++ b/dev-docs/compliance.md
@@ -8,7 +8,7 @@ The `compliance` set of subcommands handle user-initiated communication with Che
 
 When Automate initiates scans, the `compliance` subcommand is not used.
 
-An alternate subcommand to `compliance` is `automate`. And it works similarly using `inspec automate`.
+`inspec automate` is an alias for `inspec compliance` and works the same way
 
 ## Operational Notes
 

--- a/dev-docs/compliance.md
+++ b/dev-docs/compliance.md
@@ -8,6 +8,8 @@ The `compliance` set of subcommands handle user-initiated communication with Che
 
 When Automate initiates scans, the `compliance` subcommand is not used.
 
+An alternate subcommand to `compliance` is `automate`. And it works similarly using `inspec automate`.
+
 ## Operational Notes
 
 ### Obtaining an a test Automate server
@@ -65,9 +67,10 @@ There are several other minor commands not listed here - see `lib/cli.rb` for a 
 
 ### login
 
-Saves a credentials file locally. Future invocations of `inspec compliance` use the credentials file to authenticate.
+Saves a credentials file locally. Future invocations of `inspec compliance` or `inspec automate` use the credentials file to authenticate.
 
-`be inspec compliance login --user=admin --token='1234567890asdfghjkl' --insecure https://chef-automate.test`
+`be inspec compliance login --user=admin --token='1234567890asdfghjkl' --insecure https://chef-automate.test` or
+`be inspec automate login --user=admin --token='1234567890asdfghjkl' --insecure https://chef-automate.test`
 
 Here are the results of running login, from `.inspec/compliance/config.json`:
 

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -187,6 +187,10 @@ Chef Automate:
 inspec compliance login
 inspec exec compliance://username/linux-baseline
 ```
+An alternate command for login:
+```
+inspec automate login
+```
 
 Chef Supermarket:
 ```

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -184,14 +184,14 @@ Below are some examples of using `exec` with different test locations:
 
 Chef Automate:
 ```
-inspec compliance login
+inspec automate login
 inspec exec compliance://username/linux-baseline
 ```
 
-`inspec automate` is an alias for `inspec compliance` and works the same way:
+`inspec compliance` is a backwards compatible alias for `inspec automate` and works the same way:
 
 ```
-inspec automate login
+inspec compliance login
 ```
 
 Chef Supermarket:

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -187,7 +187,9 @@ Chef Automate:
 inspec compliance login
 inspec exec compliance://username/linux-baseline
 ```
-An alternate command for login:
+
+`inspec automate` is an alias for `inspec compliance` and works the same way:
+
 ```
 inspec automate login
 ```

--- a/docs-chef-io/content/inspec/plugin_kitchen_inspec.md
+++ b/docs-chef-io/content/inspec/plugin_kitchen_inspec.md
@@ -35,15 +35,15 @@ suites:
 and then run the following command:
 
 ```bash
-inspec compliance login https://compliance.test --user admin --insecure --token ''
+inspec automate login https://compliance.test --user admin --insecure --token ''
 ```
 
 where `--insecure` is required when using self-signed certificates.
 
-`inspec automate` is an alias for `inspec compliance` and works the same way:
+`inspec compliance` is a backwards compatible alias for `inspec automate` and works the same way:
 
 ```bash
-inspec automate login https://compliance.test --user admin --insecure --token ''
+inspec compliance login https://compliance.test --user admin --insecure --token ''
 ```
 
 Use a compliance profile from the Chef Supermarket:

--- a/docs-chef-io/content/inspec/plugin_kitchen_inspec.md
+++ b/docs-chef-io/content/inspec/plugin_kitchen_inspec.md
@@ -40,6 +40,11 @@ inspec compliance login https://compliance.test --user admin --insecure --token 
 
 where `--insecure` is required when using self-signed certificates.
 
+An alternate command for login:
+```bash
+inspec automate login https://compliance.test --user admin --insecure --token ''
+```
+
 Use a compliance profile from the Chef Supermarket:
 
 ```YML

--- a/docs-chef-io/content/inspec/plugin_kitchen_inspec.md
+++ b/docs-chef-io/content/inspec/plugin_kitchen_inspec.md
@@ -40,7 +40,8 @@ inspec compliance login https://compliance.test --user admin --insecure --token 
 
 where `--insecure` is required when using self-signed certificates.
 
-An alternate command for login:
+`inspec automate` is an alias for `inspec compliance` and works the same way:
+
 ```bash
 inspec automate login https://compliance.test --user admin --insecure --token ''
 ```

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -221,7 +221,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       #{Inspec::Dist::EXEC_NAME} compliance login
       #{Inspec::Dist::EXEC_NAME} exec compliance://username/linux-baseline
       ```
-      An alternate command for login:
+      `inspec automate` is an alias for `inspec compliance` and works the same way:
       ```
       #{Inspec::Dist::EXEC_NAME} automate login
       ```

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -221,6 +221,10 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       #{Inspec::Dist::EXEC_NAME} compliance login
       #{Inspec::Dist::EXEC_NAME} exec compliance://username/linux-baseline
       ```
+      An alternate command for login:
+      ```
+      #{Inspec::Dist::EXEC_NAME} automate login
+      ```
 
     Supermarket:
       ```

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -218,12 +218,12 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 
     Automate:
       ```
-      #{Inspec::Dist::EXEC_NAME} compliance login
+      #{Inspec::Dist::EXEC_NAME} automate login
       #{Inspec::Dist::EXEC_NAME} exec compliance://username/linux-baseline
       ```
-      `inspec automate` is an alias for `inspec compliance` and works the same way:
+      `inspec compliance` is a backwards compatible alias for `inspec automate` and works the same way:
       ```
-      #{Inspec::Dist::EXEC_NAME} automate login
+      #{Inspec::Dist::EXEC_NAME} compliance login
       ```
 
     Supermarket:

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -117,6 +117,15 @@ module Inspec::Plugin::V2
         # `inspec dosomething` => activate the :dosomething hook
         activate_me ||= cli_args.include?(act.activator_name.to_s)
 
+        # Only one compliance command to be activated at one time.
+        # Since both commands are defined in the same class,
+        # activators were not getting fetched uniquely.
+        if cli_args.include?("automate") && act.activator_name.to_s.eql?("compliance")
+          activate_me = false
+        elsif cli_args.include?("compliance") && act.activator_name.to_s.eql?("automate")
+          activate_me = false
+        end
+
         # OK, activate.
         if activate_me
           act.activate

--- a/lib/plugins/inspec-compliance/README.md
+++ b/lib/plugins/inspec-compliance/README.md
@@ -6,7 +6,7 @@ This extensions offers the following features:
  - execute profiles directly from Chef Automate/Chef Compliance locally
  - upload a local profile to Chef Automate/Chef Compliance
 
-The subcommand `compliance` has an alternate `automate`. And it works similarly using `inspec automate`.
+`inspec automate` is an alias for `inspec compliance` and works the same way.
 To use the CLI, this InSpec add-on adds the following commands:
 
  * `$ inspec compliance login` - authentication of the API token against Chef Automate/Chef Compliance

--- a/lib/plugins/inspec-compliance/README.md
+++ b/lib/plugins/inspec-compliance/README.md
@@ -6,25 +6,26 @@ This extensions offers the following features:
  - execute profiles directly from Chef Automate/Chef Compliance locally
  - upload a local profile to Chef Automate/Chef Compliance
 
-`inspec automate` is an alias for `inspec compliance` and works the same way.
+`inspec compliance` is a backwards compatible alias for `inspec automate` and works the same way.
+
 To use the CLI, this InSpec add-on adds the following commands:
-
- * `$ inspec compliance login` - authentication of the API token against Chef Automate/Chef Compliance
- * `$ inspec compliance profiles` - list all available Compliance profiles
- * `$ inspec exec compliance://profile` - runs a Compliance profile
- * `$ inspec compliance upload path/to/local/profile` - uploads a local profile to Chef Automate/Chef Compliance
- * `$ inspec compliance logout` - logout of Chef Automate/Chef Compliance
-
- Similar to these CLI commands are:
 
  * `$ inspec automate login` - authentication of the API token against Chef Automate/Chef Compliance
  * `$ inspec automate profiles` - list all available Compliance profiles
+ * `$ inspec exec compliance://profile` - runs a Compliance profile
  * `$ inspec automate upload path/to/local/profile` - uploads a local profile to Chef Automate/Chef Compliance
  * `$ inspec automate logout` - logout of Chef Automate/Chef Compliance
+ 
+ Similar to these CLI commands are:
+
+ * `$ inspec compliance login` - authentication of the API token against Chef Automate/Chef Compliance
+ * `$ inspec compliance profiles` - list all available Compliance profiles
+ * `$ inspec compliance upload path/to/local/profile` - uploads a local profile to Chef Automate/Chef Compliance
+ * `$ inspec compliance logout` - logout of Chef Automate/Chef Compliance
 
 Compliance profiles can be executed in two ways:
 
-- via compliance exec: `inspec compliance exec profile` or `inspec automate exec profile`
+- via compliance exec: `inspec automate exec profile` or `inspec compliance exec profile`
 - via compliance scheme: `inspec exec compliance://profile`
 
 
@@ -33,21 +34,6 @@ Compliance profiles can be executed in two ways:
 ## Usage
 
 ### Command options
-
-```
-$ inspec compliance
-Commands:
-  inspec compliance download PROFILE  # downloads a profile from Chef Compliance
-  inspec compliance exec PROFILE      # executes a Chef Compliance profile
-  inspec compliance help [COMMAND]    # Describe subcommands or one specific subcommand
-  inspec compliance login SERVER      # Log in to a Chef Automate/Chef Compliance SERVER
-  inspec compliance logout            # user logout from Chef Compliance
-  inspec compliance profiles          # list all available profiles in Chef Compliance
-  inspec compliance upload PATH       # uploads a local profile to Chef Compliance
-  inspec compliance version           # displays the version of the Chef Compliance server
-```
-
-or
 
 ```
 $ inspec automate
@@ -62,9 +48,30 @@ Commands:
   inspec automate version           # displays the version of the Chef Compliance server
 ```
 
+or
+
+```
+$ inspec compliance
+Commands:
+  inspec compliance download PROFILE  # downloads a profile from Chef Compliance
+  inspec compliance exec PROFILE      # executes a Chef Compliance profile
+  inspec compliance help [COMMAND]    # Describe subcommands or one specific subcommand
+  inspec compliance login SERVER      # Log in to a Chef Automate/Chef Compliance SERVER
+  inspec compliance logout            # user logout from Chef Compliance
+  inspec compliance profiles          # list all available profiles in Chef Compliance
+  inspec compliance upload PATH       # uploads a local profile to Chef Compliance
+  inspec compliance version           # displays the version of the Chef Compliance server
+```
+
 ### Login with Chef Automate 2
 
 You will need an API token for authentication. You can retrieve one via the admin section of your A2 web gui.
+
+```
+$ inspec automate login https://automate2.compliance.test --insecure --user 'admin' --token 'zuop..._KzE'
+```
+
+or
 
 ```
 $ inspec compliance login https://automate2.compliance.test --insecure --user 'admin' --token 'zuop..._KzE'
@@ -89,13 +96,13 @@ Example:
 You will need an access token for authentication. You can retrieve one via [UI](https://docs.chef.io/api_delivery.html) or [CLI](https://docs.chef.io/ctl_delivery.html#delivery-token).
 
 ```
-$ inspec compliance login https://automate.compliance.test --insecure --user 'admin' --ent 'brewinc' --token 'zuop..._KzE'
+$ inspec automate login https://automate.compliance.test --insecure --user 'admin' --ent 'brewinc' --token 'zuop..._KzE'
 ```
 
 or
 
 ```
-$ inspec automate login https://automate.compliance.test --insecure --user 'admin' --ent 'brewinc' --token 'zuop..._KzE'
+$ inspec compliance login https://automate.compliance.test --insecure --user 'admin' --ent 'brewinc' --token 'zuop..._KzE'
 ```
 
 ### Login with Chef Compliance
@@ -107,19 +114,19 @@ You will need an access token for authentication. You can retrieve one via:
 You can choose the access token (`--token`) or the refresh token (`--refresh_token`)
 
 ```
-$ inspec compliance login https://compliance.test --user admin --insecure --token '...'
+$ inspec automate login https://compliance.test --user admin --insecure --token '...'
 ```
 
 or
 
 ```
-$ inspec automate login https://compliance.test --user admin --insecure --token '...'
+$ inspec compliance login https://compliance.test --user admin --insecure --token '...'
 ```
 
 ### List available profiles via Chef Compliance / Automate
 
 ```
-$ inspec compliance profiles
+ $ inspec automate profiles
 Available profiles:
 -------------------
  * base/apache
@@ -143,7 +150,7 @@ Available profiles:
 or
 
 ```
-$ inspec automate profiles
+$ inspec compliance profiles
 Available profiles:
 -------------------
  * base/apache
@@ -167,9 +174,9 @@ Available profiles:
 ### Upload a profile to Chef Compliance / Automate
 
 ```
-$ inspec compliance version
+$ inspec automate version
 Chef Compliance version: 1.0.11
-➜  inspec git:(chris-rock/cc-error-not-loggedin) ✗ b inspec compliance upload examples/profile
+➜  inspec git:(chris-rock/cc-error-not-loggedin) ✗ b inspec automate upload examples/profile
 I, [2016-05-06T14:27:20.907547 #37592]  INFO -- : Checking profile in examples/profile
 I, [2016-05-06T14:27:20.907668 #37592]  INFO -- : Metadata OK.
 I, [2016-05-06T14:27:20.968584 #37592]  INFO -- : Found 4 controls.
@@ -183,7 +190,7 @@ Uploading to Chef Compliance
 Successfully uploaded profile
 
 # display all profiles
-$ inspec compliance profiles
+$ inspec automate profiles
 Available profiles:
 -------------------
  * admin/profile
@@ -208,9 +215,9 @@ Available profiles:
 or
 
 ```
-$ inspec automate version
+$ inspec compliance version
 Chef Compliance version: 1.0.11
-➜  inspec git:(chris-rock/cc-error-not-loggedin) ✗ b inspec automate upload examples/profile
+➜  inspec git:(chris-rock/cc-error-not-loggedin) ✗ b inspec compliance upload examples/profile
 I, [2016-05-06T14:27:20.907547 #37592]  INFO -- : Checking profile in examples/profile
 I, [2016-05-06T14:27:20.907668 #37592]  INFO -- : Metadata OK.
 I, [2016-05-06T14:27:20.968584 #37592]  INFO -- : Found 4 controls.
@@ -224,7 +231,7 @@ Uploading to Chef Compliance
 Successfully uploaded profile
 
 # display all profiles
-$ inspec automate profiles
+$ inspec compliance profiles
 Available profiles:
 -------------------
  * admin/profile
@@ -271,20 +278,26 @@ $ inspec exec compliance://admin/apache-baseline#2.0.1
 
 Download a specific version(2.0.2) of a profile when logged in with Automate:
 ```
+$ inspec automate download compliance://admin/apache-baseline#2.0.2
+```
+
+or
+
+```
 $ inspec compliance download compliance://admin/apache-baseline#2.0.2
 ```
 
 ### To Logout from Chef Compliance
 
 ```
-$ inspec compliance logout
+$ inspec automate logout
 Successfully logged out
 ```
 
 or
 
 ```
-$ inspec automate logout
+$ inspec compliance logout
 Successfully logged out
 ```
 

--- a/lib/plugins/inspec-compliance/README.md
+++ b/lib/plugins/inspec-compliance/README.md
@@ -6,6 +6,7 @@ This extensions offers the following features:
  - execute profiles directly from Chef Automate/Chef Compliance locally
  - upload a local profile to Chef Automate/Chef Compliance
 
+The subcommand `compliance` has an alternate `automate`. And it works similarly using `inspec automate`.
 To use the CLI, this InSpec add-on adds the following commands:
 
  * `$ inspec compliance login` - authentication of the API token against Chef Automate/Chef Compliance
@@ -14,10 +15,19 @@ To use the CLI, this InSpec add-on adds the following commands:
  * `$ inspec compliance upload path/to/local/profile` - uploads a local profile to Chef Automate/Chef Compliance
  * `$ inspec compliance logout` - logout of Chef Automate/Chef Compliance
 
+ Similar to these CLI commands are:
+
+ * `$ inspec automate login` - authentication of the API token against Chef Automate/Chef Compliance
+ * `$ inspec automate profiles` - list all available Compliance profiles
+ * `$ inspec automate upload path/to/local/profile` - uploads a local profile to Chef Automate/Chef Compliance
+ * `$ inspec automate logout` - logout of Chef Automate/Chef Compliance
+
 Compliance profiles can be executed in two ways:
 
-- via compliance exec: `inspec compliance exec profile`
+- via compliance exec: `inspec compliance exec profile` or `inspec automate exec profile`
 - via compliance scheme: `inspec exec compliance://profile`
+
+
 
 
 ## Usage
@@ -35,6 +45,21 @@ Commands:
   inspec compliance profiles          # list all available profiles in Chef Compliance
   inspec compliance upload PATH       # uploads a local profile to Chef Compliance
   inspec compliance version           # displays the version of the Chef Compliance server
+```
+
+or
+
+```
+$ inspec automate
+Commands:
+  inspec automate download PROFILE  # downloads a profile from Chef Compliance
+  inspec automate exec PROFILE      # executes a Chef Compliance profile
+  inspec automate help [COMMAND]    # Describe subcommands or one specific subcommand
+  inspec automate login SERVER      # Log in to a Chef Automate/Chef Compliance SERVER
+  inspec automate logout            # user logout from Chef Compliance
+  inspec automate profiles          # list all available profiles in Chef Compliance
+  inspec automate upload PATH       # uploads a local profile to Chef Compliance
+  inspec automate version           # displays the version of the Chef Compliance server
 ```
 
 ### Login with Chef Automate 2
@@ -67,6 +92,12 @@ You will need an access token for authentication. You can retrieve one via [UI](
 $ inspec compliance login https://automate.compliance.test --insecure --user 'admin' --ent 'brewinc' --token 'zuop..._KzE'
 ```
 
+or
+
+```
+$ inspec automate login https://automate.compliance.test --insecure --user 'admin' --ent 'brewinc' --token 'zuop..._KzE'
+```
+
 ### Login with Chef Compliance
 
 You will need an access token for authentication. You can retrieve one via:
@@ -79,10 +110,40 @@ You can choose the access token (`--token`) or the refresh token (`--refresh_tok
 $ inspec compliance login https://compliance.test --user admin --insecure --token '...'
 ```
 
+or
+
+```
+$ inspec automate login https://compliance.test --user admin --insecure --token '...'
+```
+
 ### List available profiles via Chef Compliance / Automate
 
 ```
 $ inspec compliance profiles
+Available profiles:
+-------------------
+ * base/apache
+ * base/linux
+ * base/mysql
+ * base/postgres
+ * base/ssh
+ * base/windows
+ * cis/cis-centos6-level1
+ * cis/cis-centos6-level2
+ * cis/cis-centos7-level1
+ * cis/cis-centos7-level2
+ * cis/cis-rhel7-level1
+ * cis/cis-rhel7-level2
+ * cis/cis-ubuntu12.04lts-level1
+ * cis/cis-ubuntu12.04lts-level2
+ * cis/cis-ubuntu14.04lts-level1
+ * cis/cis-ubuntu14.04lts-level2
+```
+
+or
+
+```
+$ inspec automate profiles
 Available profiles:
 -------------------
  * base/apache
@@ -144,6 +205,47 @@ Available profiles:
  * cis/cis-ubuntu14.04lts-level2
 ```
 
+or
+
+```
+$ inspec automate version
+Chef Compliance version: 1.0.11
+➜  inspec git:(chris-rock/cc-error-not-loggedin) ✗ b inspec automate upload examples/profile
+I, [2016-05-06T14:27:20.907547 #37592]  INFO -- : Checking profile in examples/profile
+I, [2016-05-06T14:27:20.907668 #37592]  INFO -- : Metadata OK.
+I, [2016-05-06T14:27:20.968584 #37592]  INFO -- : Found 4 controls.
+I, [2016-05-06T14:27:20.968638 #37592]  INFO -- : Control definitions OK.
+Profile is valid
+Generate temporary profile archive at /var/folders/jy/2bnrfb4s36jbjtzllvhhyqhw0000gn/T/profile20160506-37592-1tf326f.tar.gz
+I, [2016-05-06T14:27:21.020017 #37592]  INFO -- : Generate archive /var/folders/jy/2bnrfb4s36jbjtzllvhhyqhw0000gn/T/profile20160506-37592-1tf326f.tar.gz.
+I, [2016-05-06T14:27:21.024837 #37592]  INFO -- : Finished archive generation.
+Start upload to admin/profile
+Uploading to Chef Compliance
+Successfully uploaded profile
+
+# display all profiles
+$ inspec automate profiles
+Available profiles:
+-------------------
+ * admin/profile
+ * base/apache
+ * base/linux
+ * base/mysql
+ * base/postgres
+ * base/ssh
+ * base/windows
+ * cis/cis-centos6-level1
+ * cis/cis-centos6-level2
+ * cis/cis-centos7-level1
+ * cis/cis-centos7-level2
+ * cis/cis-rhel7-level1
+ * cis/cis-rhel7-level2
+ * cis/cis-ubuntu12.04lts-level1
+ * cis/cis-ubuntu12.04lts-level2
+ * cis/cis-ubuntu14.04lts-level1
+ * cis/cis-ubuntu14.04lts-level2
+```
+
 ### Run a profile from Chef Compliance / Chef Automate on Workstation
 
 ```
@@ -178,6 +280,14 @@ $ inspec compliance download compliance://admin/apache-baseline#2.0.2
 $ inspec compliance logout
 Successfully logged out
 ```
+
+or
+
+```
+$ inspec automate logout
+Successfully logged out
+```
+
 
 ## Integration Tests
 

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance.rb
@@ -7,6 +7,11 @@ module InspecPlugins
         require_relative "inspec-compliance/cli"
         InspecPlugins::Compliance::CLI
       end
+
+      cli_command :automate do
+        require_relative "inspec-compliance/cli"
+        InspecPlugins::Compliance::CLI
+      end
     end
 
     autoload :Configuration, "plugins/inspec-compliance/lib/inspec-compliance/configuration"

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/api.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/api.rb
@@ -357,7 +357,7 @@ module InspecPlugins
 
         Inspec::Log.debug(
           "Received 200 from #{url}#{compliance_endpoint} - " \
-          "assuming target is a #{COMPLIANCE_PRODUCT_NAME} server"
+          "assuming target is a #{AUTOMATE_PRODUCT_NAME} server"
         )
         true
       end

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/api/login.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/api/login.rb
@@ -9,7 +9,7 @@ module InspecPlugins
         class CannotDetermineServerType < StandardError; end
 
         def login(options)
-          raise ArgumentError, "Please specify a server using `#{EXEC_NAME} compliance login https://SERVER`" unless options["server"]
+          raise ArgumentError, "Please specify a server using `#{EXEC_NAME} compliance login https://SERVER` or `#{EXEC_NAME} automate login https://SERVER`" unless options["server"]
 
           options["server"] = URI("https://#{options["server"]}").to_s if URI(options["server"]).scheme.nil?
 
@@ -179,7 +179,7 @@ module InspecPlugins
           def self.compliance_verify_thor_options(o)
             error_msg = []
 
-            error_msg.push("Please specify a server using `#{EXEC_NAME} compliance login https://SERVER`") if o["server"].nil?
+            error_msg.push("Please specify a server using `#{EXEC_NAME} compliance login https://SERVER` or `#{EXEC_NAME} automate login https://SERVER`") if o["server"].nil?
 
             if o["user"].nil? && o["refresh_token"].nil?
               error_msg.push("Please specify a `--user='USER'` or a `--refresh-token='TOKEN'`")

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/api/login.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/api/login.rb
@@ -9,7 +9,7 @@ module InspecPlugins
         class CannotDetermineServerType < StandardError; end
 
         def login(options)
-          raise ArgumentError, "Please specify a server using `#{EXEC_NAME} compliance login https://SERVER` or `#{EXEC_NAME} automate login https://SERVER`" unless options["server"]
+          raise ArgumentError, "Please specify a server using `#{EXEC_NAME} automate login https://SERVER` or `#{EXEC_NAME} compliance login https://SERVER`" unless options["server"]
 
           options["server"] = URI("https://#{options["server"]}").to_s if URI(options["server"]).scheme.nil?
 
@@ -179,7 +179,7 @@ module InspecPlugins
           def self.compliance_verify_thor_options(o)
             error_msg = []
 
-            error_msg.push("Please specify a server using `#{EXEC_NAME} compliance login https://SERVER` or `#{EXEC_NAME} automate login https://SERVER`") if o["server"].nil?
+            error_msg.push("Please specify a server using `#{EXEC_NAME} automate login https://SERVER` or `#{EXEC_NAME} compliance login https://SERVER`") if o["server"].nil?
 
             if o["user"].nil? && o["refresh_token"].nil?
               error_msg.push("Please specify a `--user='USER'` or a `--refresh-token='TOKEN'`")

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
@@ -6,12 +6,12 @@ module InspecPlugins
   module Compliance
     class CLI < Inspec.plugin(2, :cli_command)
       include Inspec::Dist
-      subcommand_desc "automate SUBCOMMAND or compliance SUBCOMMAND", "#{COMPLIANCE_PRODUCT_NAME} commands"
+      subcommand_desc "automate SUBCOMMAND or compliance SUBCOMMAND", "#{AUTOMATE_PRODUCT_NAME} commands"
 
       # desc "login https://SERVER --insecure --user='USER' --ent='ENTERPRISE' --token='TOKEN'", 'Log in to a Chef Compliance/Chef Automate SERVER'
-      desc "login", "Log in to a #{COMPLIANCE_PRODUCT_NAME}/#{AUTOMATE_PRODUCT_NAME} SERVER"
+      desc "login", "Log in to a #{AUTOMATE_PRODUCT_NAME} SERVER"
       long_desc <<-LONGDESC
-        `login` allows you to use InSpec with #{AUTOMATE_PRODUCT_NAME} or a #{COMPLIANCE_PRODUCT_NAME} Server
+        `login` allows you to use InSpec with #{AUTOMATE_PRODUCT_NAME} Server
 
         You need to a token for communication. More information about token retrieval
         is available at:
@@ -23,11 +23,11 @@ module InspecPlugins
       option :user, type: :string, required: false,
         desc: "Username"
       option :password, type: :string, required: false,
-        desc: "Password (#{COMPLIANCE_PRODUCT_NAME} Only)"
+        desc: "Password (#{AUTOMATE_PRODUCT_NAME} Only)"
       option :token, type: :string, required: false,
         desc: "Access token"
       option :refresh_token, type: :string, required: false,
-        desc: "#{COMPLIANCE_PRODUCT_NAME} refresh token (#{COMPLIANCE_PRODUCT_NAME} Only)"
+        desc: "#{AUTOMATE_PRODUCT_NAME} refresh token (#{AUTOMATE_PRODUCT_NAME} Only)"
       option :dctoken, type: :string, required: false,
         desc: "Data Collector token (#{AUTOMATE_PRODUCT_NAME} Only)"
       option :ent, type: :string, required: false,
@@ -39,7 +39,7 @@ module InspecPlugins
         puts "Stored configuration for Chef #{config["server_type"].capitalize}: #{config["server"]}' with user: '#{config["user"]}'"
       end
 
-      desc "profiles", "list all available profiles in #{COMPLIANCE_PRODUCT_NAME}"
+      desc "profiles", "list all available profiles in #{AUTOMATE_PRODUCT_NAME}"
       option :owner, type: :string, required: false,
         desc: "owner whose profiles to list"
       def profiles
@@ -68,7 +68,7 @@ module InspecPlugins
         exit 1
       end
 
-      desc "exec PROFILE", "executes a #{COMPLIANCE_PRODUCT_NAME} profile"
+      desc "exec PROFILE", "executes a #{AUTOMATE_PRODUCT_NAME} profile"
       exec_options
       def exec(*tests)
         compliance_config = InspecPlugins::Compliance::Configuration.new
@@ -90,7 +90,7 @@ module InspecPlugins
         exit 1
       end
 
-      desc "download PROFILE", "downloads a profile from #{COMPLIANCE_PRODUCT_NAME}"
+      desc "download PROFILE", "downloads a profile from #{AUTOMATE_PRODUCT_NAME}"
       option :name, type: :string,
         desc: "Name of the archive filename (file type will be added)"
       def download(profile_name)
@@ -115,12 +115,12 @@ module InspecPlugins
           file_name = fetcher.fetch(o.name || id)
           puts "Profile stored to #{file_name}"
         else
-          puts "Profile #{profile_name} is not available in #{COMPLIANCE_PRODUCT_NAME}."
+          puts "Profile #{profile_name} is not available in #{AUTOMATE_PRODUCT_NAME}."
           exit 1
         end
       end
 
-      desc "upload PATH", "uploads a local profile to #{COMPLIANCE_PRODUCT_NAME}"
+      desc "upload PATH", "uploads a local profile to #{AUTOMATE_PRODUCT_NAME}"
       option :overwrite, type: :boolean, default: false,
         desc: "Overwrite existing profile on Server."
       option :owner, type: :string, required: false,
@@ -201,11 +201,8 @@ module InspecPlugins
         puts "Start upload to #{config["owner"]}/#{profile_name}"
         pname = ERB::Util.url_encode(profile_name)
 
-        if InspecPlugins::Compliance::API.is_automate_server?(config) || InspecPlugins::Compliance::API.is_automate2_server?(config)
-          puts "Uploading to #{AUTOMATE_PRODUCT_NAME}"
-        else
-          puts "Uploading to #{COMPLIANCE_PRODUCT_NAME}"
-        end
+        puts "Uploading to #{AUTOMATE_PRODUCT_NAME}"
+
         success, msg = InspecPlugins::Compliance::API.upload(config, config["owner"], pname, archive_path)
 
         # delete temp file if it was temporary generated
@@ -220,7 +217,7 @@ module InspecPlugins
         end
       end
 
-      desc "version", "displays the version of the #{COMPLIANCE_PRODUCT_NAME} server"
+      desc "version", "displays the version of the #{AUTOMATE_PRODUCT_NAME} server"
       def version
         config = InspecPlugins::Compliance::Configuration.new
         info = InspecPlugins::Compliance::API.version(config)
@@ -236,7 +233,7 @@ module InspecPlugins
         exit 1
       end
 
-      desc "logout", "user logout from #{COMPLIANCE_PRODUCT_NAME}"
+      desc "logout", "user logout from #{AUTOMATE_PRODUCT_NAME}"
       def logout
         config = InspecPlugins::Compliance::Configuration.new
         unless config.supported?(:oidc) || config["token"].nil? || config["server_type"] == "automate"

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
@@ -6,7 +6,7 @@ module InspecPlugins
   module Compliance
     class CLI < Inspec.plugin(2, :cli_command)
       include Inspec::Dist
-      subcommand_desc "compliance SUBCOMMAND or automate SUBCOMMAND", "#{COMPLIANCE_PRODUCT_NAME} commands"
+      subcommand_desc "automate SUBCOMMAND or compliance SUBCOMMAND", "#{COMPLIANCE_PRODUCT_NAME} commands"
 
       # desc "login https://SERVER --insecure --user='USER' --ent='ENTERPRISE' --token='TOKEN'", 'Log in to a Chef Compliance/Chef Automate SERVER'
       desc "login", "Log in to a #{COMPLIANCE_PRODUCT_NAME}/#{AUTOMATE_PRODUCT_NAME} SERVER"

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
@@ -6,8 +6,7 @@ module InspecPlugins
   module Compliance
     class CLI < Inspec.plugin(2, :cli_command)
       include Inspec::Dist
-
-      subcommand_desc "compliance SUBCOMMAND", "#{COMPLIANCE_PRODUCT_NAME} commands"
+      subcommand_desc "compliance SUBCOMMAND or automate SUBCOMMAND", "#{COMPLIANCE_PRODUCT_NAME} commands"
 
       # desc "login https://SERVER --insecure --user='USER' --ent='ENTERPRISE' --token='TOKEN'", 'Log in to a Chef Compliance/Chef Automate SERVER'
       desc "login", "Log in to a #{COMPLIANCE_PRODUCT_NAME}/#{AUTOMATE_PRODUCT_NAME} SERVER"
@@ -65,7 +64,7 @@ module InspecPlugins
           exit 1
         end
       rescue InspecPlugins::Compliance::ServerConfigurationMissing
-        $stderr.puts "\nServer configuration information is missing. Please login using `#{EXEC_NAME} compliance login`"
+        $stderr.puts "\nServer configuration information is missing. Please login using `#{EXEC_NAME} #{subcommand_name} login`"
         exit 1
       end
 
@@ -167,7 +166,7 @@ module InspecPlugins
 
         # determine user information
         if (config["token"].nil? && config["refresh_token"].nil?) || config["user"].nil?
-          error.call("Please login via `#{EXEC_NAME} compliance login`")
+          error.call("Please login via `#{EXEC_NAME} #{subcommand_name} login`")
         end
 
         # read profile name from inspec.yml
@@ -233,7 +232,7 @@ module InspecPlugins
           exit 1
         end
       rescue InspecPlugins::Compliance::ServerConfigurationMissing
-        puts "\nServer configuration information is missing. Please login using `#{EXEC_NAME} compliance login`"
+        puts "\nServer configuration information is missing. Please login using `#{EXEC_NAME} #{subcommand_name} login`"
         exit 1
       end
 
@@ -258,8 +257,12 @@ module InspecPlugins
 
       def loggedin(config)
         serverknown = !config["server"].nil?
-        puts "You need to login first with `#{EXEC_NAME} compliance login`" unless serverknown
+        puts "You need to login first with `#{EXEC_NAME} #{subcommand_name} login`" unless serverknown
         serverknown
+      end
+
+      def subcommand_name
+        @_invocations[Inspec::InspecCLI]&.first || "automate"
       end
     end
 

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/target.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/target.rb
@@ -34,13 +34,13 @@ module InspecPlugins
         if config["token"].nil? && config["refresh_token"].nil?
           if config["server_type"] == "automate"
             server = "automate"
-            msg = "#{EXEC_NAME} compliance login https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --token USERTOKEN"
+            msg = "#{EXEC_NAME} compliance or automate login https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --token USERTOKEN"
           elsif config["server_type"] == "automate2"
             server = "automate2"
-            msg = "#{EXEC_NAME} compliance login https://your_automate2_server --user USER --token APITOKEN"
+            msg = "#{EXEC_NAME} compliance or automate login https://your_automate2_server --user USER --token APITOKEN"
           else
             server = "compliance"
-            msg = "#{EXEC_NAME} compliance login https://your_compliance_server --user admin --insecure --token 'PASTE TOKEN HERE' "
+            msg = "#{EXEC_NAME} compliance or automate login https://your_compliance_server --user admin --insecure --token 'PASTE TOKEN HERE' "
           end
           raise Inspec::FetcherFailure, <<~EOF
 
@@ -136,7 +136,8 @@ module InspecPlugins
         if m.nil?
           raise "Unable to determine compliance profile name. This can be caused by " \
             "an incorrect server in your configuration. Try to login to compliance " \
-            "via the `#{EXEC_NAME} compliance login` command."
+            "via the `#{EXEC_NAME} compliance login` command or " \
+            "via the `#{EXEC_NAME} automate login` command."
         end
 
         "#{m[:owner]}/#{m[:id]}"

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/target.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/target.rb
@@ -112,7 +112,7 @@ module InspecPlugins
       end
 
       def to_s
-        "#{COMPLIANCE_PRODUCT_NAME} Profile Loader"
+        "#{AUTOMATE_PRODUCT_NAME} Profile Loader"
       end
 
       private

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/target.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/target.rb
@@ -34,13 +34,13 @@ module InspecPlugins
         if config["token"].nil? && config["refresh_token"].nil?
           if config["server_type"] == "automate"
             server = "automate"
-            msg = "#{EXEC_NAME} compliance or automate login https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --token USERTOKEN"
+            msg = "#{EXEC_NAME} [automate|compliance] login https://your_automate_server --user USER --ent ENT --dctoken DCTOKEN or --token USERTOKEN"
           elsif config["server_type"] == "automate2"
             server = "automate2"
-            msg = "#{EXEC_NAME} compliance or automate login https://your_automate2_server --user USER --token APITOKEN"
+            msg = "#{EXEC_NAME} [automate|compliance] login https://your_automate2_server --user USER --token APITOKEN"
           else
             server = "compliance"
-            msg = "#{EXEC_NAME} compliance or automate login https://your_compliance_server --user admin --insecure --token 'PASTE TOKEN HERE' "
+            msg = "#{EXEC_NAME} [automate|compliance] login https://your_compliance_server --user admin --insecure --token 'PASTE TOKEN HERE' "
           end
           raise Inspec::FetcherFailure, <<~EOF
 
@@ -136,8 +136,8 @@ module InspecPlugins
         if m.nil?
           raise "Unable to determine compliance profile name. This can be caused by " \
             "an incorrect server in your configuration. Try to login to compliance " \
-            "via the `#{EXEC_NAME} compliance login` command or " \
-            "via the `#{EXEC_NAME} automate login` command."
+            "via the `#{EXEC_NAME} automate login` command or " \
+            "via the `#{EXEC_NAME} compliance login` command."
         end
 
         "#{m[:owner]}/#{m[:id]}"

--- a/lib/plugins/inspec-compliance/test/functional/inspec_compliance_test.rb
+++ b/lib/plugins/inspec-compliance/test/functional/inspec_compliance_test.rb
@@ -50,4 +50,54 @@ class ComplianceCli < Minitest::Test
 
     assert_exit_code 0, out # TODO: make this error
   end
+
+  ## testing automate command for compliances
+
+  def test_help_output_using_automate_cmd
+    out = run_inspec_process("automate help")
+
+    assert_includes out.stdout, "inspec automate exec PROFILE"
+
+    assert_exit_code 0, out
+  end
+
+  def test_logout_command_using_automate_cmd
+    out = run_inspec_process("automate logout")
+
+    assert_includes out.stdout, ""
+
+    assert_exit_code 0, out
+  end
+
+  def test_error_login_with_invalid_url_using_automate_cmd
+    out = run_inspec_process("automate login")
+
+    assert_includes out.stderr, 'ERROR: "inspec automate login" was called with no arguments'
+
+    assert_exit_code 1, out
+  end
+
+  def test_profile_list_without_auth_using_automate_cmd
+    out = run_inspec_process("automate profiles")
+
+    assert_includes out.stdout, "You need to login first with `inspec automate login`"
+
+    assert_exit_code 0, out # TODO: make this error
+  end
+
+  def test_error_upload_without_args_using_automate_cmd
+    out = run_inspec_process("automate upload")
+
+    assert_includes out.stderr, 'ERROR: "inspec automate upload" was called with no arguments'
+
+    assert_exit_code 1, out
+  end
+
+  def test_error_upload_with_fake_path_using_automate_cmd
+    out = run_inspec_process("automate upload /path/to/dir")
+
+    assert_includes out.stdout, "You need to login first with `inspec automate login`"
+
+    assert_exit_code 0, out # TODO: make this error
+  end
 end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
Added new command alias `automate` for InSpec compliance command 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Compliance command `automate` introduced for compliance commands, which works similarly to `inspec compliance`.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Implements #5157 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
