### PR TITLE
Make sure we use chef-telemetry 1.0.8+

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
       .reject { |f| File.directory?(f) }
 
   # Implementation dependencies
-  spec.add_dependency "chef-telemetry",     "~> 1.0"
+  spec.add_dependency "chef-telemetry",     "~> 1.0", ">= 1.0.8" # 1.0.8+ removes the http dep
   spec.add_dependency "license-acceptance", ">= 0.2.13", "< 3.0"
   spec.add_dependency "thor",               ">= 0.20", "< 2.0"
   spec.add_dependency "method_source",      ">= 0.8", "< 2.0"


### PR DESCRIPTION
This version drops the http dep which greatly reduces the overall size
of deps.

Signed-off-by: Tim Smith <tsmith@chef.io>