### PR TITLE
Remove outdated instructions about testing AWS and Azure resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,18 +445,6 @@ You may test all instances in parallel with:
 bundle exec kitchen test -c
 ```
 
-### AWS Tests
-
-Use the rake task `bundle exec rake test:aws` to test the AWS resources against a pair of real AWS accounts.
-
-Please see [TESTING_AGAINST_AWS.md](./test/integration/aws/TESTING_AGAINST_AWS.md) for details on how to setup the needed AWS accounts to perform testing.
-
-### Azure Tests
-
-Use the rake task `bundle exec rake test:azure` to test the Azure resources against an Azure account.
-
-Please see [TESTING_AGAINST_AZURE.md](./test/integration/azure/TESTING_AGAINST_AZURE.md) for details on how to setup the needed Azure accounts to perform testing.
-
 ## License
 
 |                |                                           |

--- a/README.md
+++ b/README.md
@@ -430,19 +430,19 @@ In addition, these test require Docker to be available on your machine or a remo
 List the various test instances available:
 
 ```bash
-bundle exec kitchen list
+KITCHEN_YAML=kitchen.dokken.yml bundle exec kitchen list
 ```
 
-The platforms and test suites are configured in the `.kitchen.yml` file. Once you know which instance you wish to test, test that instance:
+The platforms and test suites are configured in the `kitchen.dokken.yml` file. Once you know which instance you wish to test, test that instance:
 
 ```bash
-bundle exec kitchen test <INSTANCE_NAME>
+KITCHEN_YAML=kitchen.dokken.yml bundle exec kitchen test <INSTANCE_NAME>
 ```
 
 You may test all instances in parallel with:
 
 ```bash
-bundle exec kitchen test -c
+KITCHEN_YAML=kitchen.dokken.yml bundle exec kitchen test -c 3
 ```
 
 ## License


### PR DESCRIPTION
AWS and Azure resources are testsed in their individual projects, inspec/inspec-aws and inspec/inspec-azure. The instructions in the README were cruft.

This PR is mainly a test of the new test kitchen test from #5204.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
