### PR TITLE
Fixes for the integration-resources pipeline

### DIFF
--- a/.expeditor/buildkite/bk_linux_exec.sh
+++ b/.expeditor/buildkite/bk_linux_exec.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Enable IPv6 in docker
+echo "--- Enabling ipv6 on docker"
+sudo systemctl stop docker
+dockerd_config="/etc/docker/daemon.json"
+sudo echo "$(jq '. + {"ipv6": true, "fixed-cidr-v6": "2001:2019:6002::/80", "ip-forward": false}' $dockerd_config)" > $dockerd_config
+sudo systemctl start docker
+
+# Install C and C++
+echo "--- Installing package deps"
+sudo yum install -y gcc gcc-c++ openssl-devel readline-devel zlib-devel
+
+# Install ASDF
+echo "--- Installing asdf to ${HOME}/.asdf"
+git clone https://github.com/asdf-vm/asdf.git "${HOME}/.asdf"
+cd "${HOME}/.asdf"; git checkout "$(git describe --abbrev=0 --tags)"; cd -
+. "${HOME}/.asdf/asdf.sh"
+
+# Install Ruby
+ruby_version=$(sed -n '/"ruby"/{s/.*version: "//;s/"//;p;}' omnibus_overrides.rb)
+echo "--- Installing Ruby $ruby_version"
+asdf plugin add ruby
+asdf install ruby $ruby_version
+asdf global ruby $ruby_version
+
+# Set Environment Variables
+export BUNDLE_GEMFILE=$PWD/Gemfile
+export FORCE_FFI_YAJL=ext
+export CHEF_LICENSE="accept-silent"
+
+# Update Gems
+echo "--- Installing Gems"
+echo 'gem: --no-document' >> ~/.gemrc
+sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+bundle install --jobs=3 --retry=3 --path=../vendor/bundle
+
+echo "--- Config information"
+
+echo "!!!! RUBY VERSION !!!!"
+ruby --version
+echo "!!!! BUNDLER LOCATION !!!!"
+which bundle
+echo "!!!! BUNDLER VERSION !!!!"
+bundle -v
+echo "!!!! DOCKER VERSION !!!!"
+docker version
+echo "!!!! DOCKER STATUS !!!!"
+sudo service docker status
+
+echo "+++ Running tests"

--- a/.expeditor/integration.resources.yml
+++ b/.expeditor/integration.resources.yml
@@ -10,12 +10,8 @@ expeditor:
 steps:
   - label: Resource-Platform Tests
     command:
-      - RAKE_TASK=test:kitchen /workdir/.expeditor/buildkite/verify.sh
+      - CONCURRENCY=3 DOCKER=1 KITCHEN_YAML=kitchen.dokken.yml RAKE_TASK=test:kitchen /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:
-          environment:
-            - CONCURRENCY: 3
-            - DOCKER: 1
-            - KITCHEN_YAML: kitchen.dokken.yml
           image: ruby:2.7

--- a/.expeditor/integration.resources.yml
+++ b/.expeditor/integration.resources.yml
@@ -23,3 +23,160 @@ steps:
         linux:
           privileged: true
           single-use: true
+
+  - label: "Kitchen: resources-centos-7"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-centos-7
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+          single-use: true
+
+  - label: "Kitchen: resources-centos-8"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-centos-8
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+          single-use: true
+
+  - label: "Kitchen: resources-debian-9"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-debian-9
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+          single-use: true
+  - label: "Kitchen: resources-debian-10"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-debian-10
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+          single-use: true
+
+  - label: "Kitchen: resources-fedora-latest"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-fedora-latest
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+          single-use: true
+
+  - label: "Kitchen: resources-oraclelinux-7"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-oraclelinux-7
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+          single-use: true
+  - label: "Kitchen: resources-oraclelinux-8"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-oraclelinux-8
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+          single-use: true
+
+  - label: "Kitchen: resources-opensuse-leap"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-opensuse-leap
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+          single-use: true
+
+  - label: "Kitchen: resources-ubuntu-1804"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-ubuntu-1804
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+          single-use: true
+  - label: "Kitchen: resources-ubuntu-2004"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-ubuntu-2004
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+          single-use: true

--- a/.expeditor/integration.resources.yml
+++ b/.expeditor/integration.resources.yml
@@ -8,14 +8,6 @@ expeditor:
           limit: 1
 
 steps:
-  # - label: Resource-Platform Tests
-  #   command:
-  #     - CONCURRENCY=3 DOCKER=1 KITCHEN_YAML=kitchen.dokken.yml RAKE_TASK=test:kitchen /workdir/.expeditor/buildkite/verify.sh
-  #   expeditor:
-  #     executor:
-  #       docker:
-  #         image: ruby:2.7
-
   - label: "Kitchen: resources-amazonlinux-2"
     commands:
       - .expeditor/buildkite/bk_linux_exec.sh
@@ -25,6 +17,7 @@ steps:
       - $PWD/.kitchen/logs/kitchen.log
     env:
         KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
     expeditor:
       executor:
         linux:

--- a/.expeditor/integration.resources.yml
+++ b/.expeditor/integration.resources.yml
@@ -8,10 +8,25 @@ expeditor:
           limit: 1
 
 steps:
-  - label: Resource-Platform Tests
-    command:
-      - CONCURRENCY=3 DOCKER=1 KITCHEN_YAML=kitchen.dokken.yml RAKE_TASK=test:kitchen /workdir/.expeditor/buildkite/verify.sh
+  # - label: Resource-Platform Tests
+  #   command:
+  #     - CONCURRENCY=3 DOCKER=1 KITCHEN_YAML=kitchen.dokken.yml RAKE_TASK=test:kitchen /workdir/.expeditor/buildkite/verify.sh
+  #   expeditor:
+  #     executor:
+  #       docker:
+  #         image: ruby:2.7
+
+  - label: "Kitchen: resources-amazonlinux-2"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-amazonlinux-2
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
     expeditor:
       executor:
-        docker:
-          image: ruby:2.7
+        linux:
+          privileged: true
+          single-use: true

--- a/test/kitchen/cookbooks/os_prepare/recipes/iptables.rb
+++ b/test/kitchen/cookbooks/os_prepare/recipes/iptables.rb
@@ -14,12 +14,15 @@ if platform_family?("rhel", "debian", "fedora", "amazon", "suse")
   execute "iptables -A INPUT -j derby-cognos-web"
   execute "iptables -A derby-cognos-web -p tcp -m tcp --dport 80 "\
           '-m comment --comment "derby-cognos-web" -j ACCEPT'
-  # IPv6
-  execute "ip6tables -A INPUT -i eth0 -p tcp -m tcp "\
-          "--dport 80 -m state --state NEW -m comment "\
-          '--comment "http v6 on 80" -j ACCEPT'
-  execute "ip6tables -N derby-cognos-web-v6"
-  execute "ip6tables -A INPUT -j derby-cognos-web-v6"
-  execute "ip6tables -A derby-cognos-web-v6 -p tcp -m tcp --dport 80 "\
-          '-m comment --comment "derby-cognos-web-v6" -j ACCEPT'
+
+  if ENV['IPV6']
+    # IPv6
+    execute "ip6tables -A INPUT -i eth0 -p tcp -m tcp "\
+            "--dport 80 -m state --state NEW -m comment "\
+            '--comment "http v6 on 80" -j ACCEPT'
+    execute "ip6tables -N derby-cognos-web-v6"
+    execute "ip6tables -A INPUT -j derby-cognos-web-v6"
+    execute "ip6tables -A derby-cognos-web-v6 -p tcp -m tcp --dport 80 "\
+            '-m comment --comment "derby-cognos-web-v6" -j ACCEPT'
+  end
 end

--- a/test/kitchen/policies/default/controls/ip6tables_spec.rb
+++ b/test/kitchen/policies/default/controls/ip6tables_spec.rb
@@ -1,3 +1,8 @@
+unless ENV['IPV6']
+  $stderr.puts "\033[1;33mTODO: Not running #{__FILE__.split("/").last} because we are running without IPv6\033[0m"
+  return
+end
+
 case os[:family]
 when 'ubuntu', 'fedora', 'debian', 'suse'
   describe ip6tables do


### PR DESCRIPTION
* Switch to using single-use runners, borrowing setup script from chef/chef
* Add DOCKER=1 flag
* Break out each platform into an individual runner step, moving the parallelization out of kitchen. This duplicates the config but makes the testing much more stable and faster.
* Makes IPv6 testing conditional - the docker images do not typically have IPv6 enabled, or else I have something else misconfigured.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
