### PR TITLE
Fix : windows_firewall_rule fails to validate more than 1 rule depending on how it's executed 

### DIFF
--- a/lib/inspec/resources/windows_firewall_rule.rb
+++ b/lib/inspec/resources/windows_firewall_rule.rb
@@ -105,7 +105,7 @@ module Inspec::Resources
     # @see https://github.com/chef/chef/blob/master/lib/chef/resource/windows_firewall_rule.rb
     def load_firewall_state(rule_name)
       <<-EOH
-        Remove-TypeData System.Array # workaround for PS bug here: https://bit.ly/2SRMQ8M
+        Get-TypeData -TypeName System.Array | Remove-TypeData # workaround for PS bug here: https://bit.ly/2SRMQ8M
         $rule = Get-NetFirewallRule -Name "#{rule_name}"
         $addressFilter = $rule | Get-NetFirewallAddressFilter
         $portFilter = $rule | Get-NetFirewallPortFilter


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
windows_firewall_rule is using `Remove-TypeData System.Array` as a workaround for PS bug here: https://bit.ly/2SRMQ8M,
`Remove-TypeData` Deletes extended types from the current session.[Ref](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/remove-typedata?view=powershell-7.1)  So when we are executing more that one rules using different describe blocks as we have already deleted the extended type in the same session when next describe was getting called that command was giving error. due to which the cmd output was coming blank due to which the result was empty for next set of rules.

Following is the output of executing the Remove-TypeData in same Poweshell window(same session)
```
PS C:\Users\Vasundhara> Get-TypeData -TypeName System.Array

TypeName     Members
--------     -------
System.Array {[Count, System.Management.Automation.Runspaces.AliasPropertyData]}


PS C:\Users\Vasundhara> Remove-TypeData -TypeName System.Array
PS C:\Users\Vasundhara> Remove-TypeData -TypeName System.Array
Remove-TypeData : Error in TypeData "System.Array": The type "System.Array" was not found. The type name value must be
the full name of the type. Verify the type name and run the command again.
At line:1 char:1
+ Remove-TypeData -TypeName System.Array
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Remove-TypeData], RuntimeException
    + FullyQualifiedErrorId : TypesDynamicRemoveException,Microsoft.PowerShell.Commands.RemoveTypeDataCommand

PS C:\Users\Vasundhara>
```
So as a solution we are using `Get-TypeData` command to get extended type in current session and pipe it to the `Remove-TypeData` so if there is not System.Array in current session then it will not cause any issue. REF : https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-typedata?view=powershell-7.1

```
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

PS C:\Users\Vasundhara> Get-TypeData -TypeName System.Array

TypeName     Members
--------     -------
System.Array {[Count, System.Management.Automation.Runspaces.AliasPropertyData]}


PS C:\Users\Vasundhara> Get-TypeData -TypeName System.Array | Remove-TypeData
PS C:\Users\Vasundhara> Get-TypeData -TypeName System.Array
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fix #5464 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
