### PR TITLE
Fixed `automate login` fake feedback on failure

### DIFF
--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/api.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/api.rb
@@ -170,6 +170,23 @@ module InspecPlugins
         [success, msg, access_token]
       end
 
+      # Use API access token to validate login using version API
+      def self.authenticate_login_using_version_api(url, api_token, insecure)
+        uri = URI.parse("#{url}/version")
+        req = Net::HTTP::Get.new(uri.path)
+        req["api-token"] = api_token
+        response = InspecPlugins::Compliance::HTTP.send_request(uri, req, insecure)
+
+        if response.code == "200"
+          msg = "Successfully Logged In"
+          success = true
+        else
+          success = false
+          msg = "Failed to authenticate to #{url} \n\Response code: #{response.code}\nBody: #{response.body}"
+        end
+        [success, msg]
+      end
+
       # Use username and password to get an API access token
       def self.get_token_via_password(url, username, password, insecure)
         uri = URI.parse("#{url}/login")

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
@@ -34,9 +34,8 @@ module InspecPlugins
         desc: "Enterprise for #{AUTOMATE_PRODUCT_NAME} reporting (#{AUTOMATE_PRODUCT_NAME} Only)"
       def login(server)
         options["server"] = server
-        InspecPlugins::Compliance::API.login(options)
-        config = InspecPlugins::Compliance::Configuration.new
-        puts "Stored configuration for Chef #{config["server_type"].capitalize}: #{config["server"]}' with user: '#{config["user"]}'"
+        login_response = InspecPlugins::Compliance::API.login(options)
+        puts login_response
       end
 
       desc "profiles", "list all available profiles in #{AUTOMATE_PRODUCT_NAME}"

--- a/lib/plugins/inspec-compliance/test/unit/api/login_test.rb
+++ b/lib/plugins/inspec-compliance/test/unit/api/login_test.rb
@@ -73,11 +73,10 @@ describe InspecPlugins::Compliance::API do
       end
 
       it "stores an access token" do
-        stub_request(:get, automate_options["server"] + "/compliance/version")
+        stub_request(:get, automate_options["server"] + "/api/v0/version")
           .to_return(status: 200, body: "", headers: {})
         options = automate_options
         InspecPlugins::Compliance::Configuration.expects(:new).returns(fake_config)
-
         InspecPlugins::Compliance::API.login(options)
         _(fake_config["automate"]["ent"]).must_equal("automate")
         _(fake_config["automate"]["token_type"]).must_equal("dctoken")
@@ -85,6 +84,18 @@ describe InspecPlugins::Compliance::API do
         _(fake_config["server"]).must_equal("https://automate.example.com/api/v0")
         _(fake_config["server_type"]).must_equal("automate2")
         _(fake_config["token"]).must_equal("token")
+      end
+
+      it "puts error message when api-token while login is invalid" do
+        stub_body = { "error": "request not authenticated", "code": 16, "message": "request not authenticated", "details": [] }.to_json
+        stub_request(:get, automate_options["server"] + "/api/v0/version")
+          .to_return(status: 401, body: stub_body, headers: {})
+        options = automate_options
+        res = InspecPlugins::Compliance::API.login(options)
+        _(res).must_equal(
+          "Failed to authenticate to https://automate.example.com/api/v0 \n"\
+        "Response code: 401\nBody: {\"error\":\"request not authenticated\",\"code\":16,\"message\":\"request not authenticated\",\"details\":[]}"
+        )
       end
     end
 
@@ -132,6 +143,18 @@ describe InspecPlugins::Compliance::API do
         _(fake_config["server_type"]).must_equal("automate")
         _(fake_config["token"]).must_equal("token")
       end
+
+      it "puts error message when api-token while login is invalid" do
+        stub_body = { "error": "request not authenticated", "code": 16, "message": "request not authenticated", "details": [] }.to_json
+        stub_request(:get, automate_options["server"] + "/compliance/version")
+          .to_return(status: 401, body: stub_body, headers: {})
+        options = automate_options
+        res = InspecPlugins::Compliance::API.login(options)
+        _(res).must_equal(
+          "Failed to authenticate to https://automate.example.com/compliance \n"\
+        "Response code: 401\nBody: {\"error\":\"request not authenticated\",\"code\":16,\"message\":\"request not authenticated\",\"details\":[]}"
+        )
+      end
     end
 
     describe "when target is a Chef Compliance server" do
@@ -169,6 +192,18 @@ describe InspecPlugins::Compliance::API do
         _(fake_config["server"]).must_equal("https://compliance.example.com/api")
         _(fake_config["server_type"]).must_equal("compliance")
         _(fake_config["token"]).must_equal("token")
+      end
+
+      it "puts error message when api-token while login is invalid" do
+        stub_body = { "error": "request not authenticated", "code": 16, "message": "request not authenticated", "details": [] }.to_json
+        stub_request(:get, automate_options["server"] + "/api/version")
+          .to_return(status: 401, body: stub_body, headers: {})
+        options = automate_options
+        res = InspecPlugins::Compliance::API.login(options)
+        _(res).must_equal(
+          "Failed to authenticate to https://automate.example.com/api \n"\
+        "Response code: 401\nBody: {\"error\":\"request not authenticated\",\"code\":16,\"message\":\"request not authenticated\",\"details\":[]}"
+        )
       end
     end
 

--- a/lib/plugins/inspec-compliance/test/unit/api/login_test.rb
+++ b/lib/plugins/inspec-compliance/test/unit/api/login_test.rb
@@ -86,7 +86,7 @@ describe InspecPlugins::Compliance::API do
         _(fake_config["token"]).must_equal("token")
       end
 
-      it "puts error message when api-token while login is invalid" do
+      it "puts error message when api-token is invalid" do
         stub_body = { "error": "request not authenticated", "code": 16, "message": "request not authenticated", "details": [] }.to_json
         stub_request(:get, automate_options["server"] + "/api/v0/version")
           .to_return(status: 401, body: stub_body, headers: {})
@@ -144,7 +144,7 @@ describe InspecPlugins::Compliance::API do
         _(fake_config["token"]).must_equal("token")
       end
 
-      it "puts error message when api-token while login is invalid" do
+      it "puts error message when api-token is invalid" do
         stub_body = { "error": "request not authenticated", "code": 16, "message": "request not authenticated", "details": [] }.to_json
         stub_request(:get, automate_options["server"] + "/compliance/version")
           .to_return(status: 401, body: stub_body, headers: {})
@@ -194,7 +194,7 @@ describe InspecPlugins::Compliance::API do
         _(fake_config["token"]).must_equal("token")
       end
 
-      it "puts error message when api-token while login is invalid" do
+      it "puts error message when api-token is invalid" do
         stub_body = { "error": "request not authenticated", "code": 16, "message": "request not authenticated", "details": [] }.to_json
         stub_request(:get, automate_options["server"] + "/api/version")
           .to_return(status: 401, body: stub_body, headers: {})


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
Fixed `automate login` fake feedback on failure.
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixed `automate login` fake feedback on failure, by validating api-token using automate's version API. 
And only after successful validation the configurations are stored. Else an error message is thrown.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #3535 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
