### PR TITLE
Update `bond0` example to use params properly

### DIFF
--- a/docs-chef-io/content/inspec/resources/bond.md
+++ b/docs-chef-io/content/inspec/resources/bond.md
@@ -75,11 +75,10 @@ The `params` matcher tests arbitrary parameters for the bonded network interface
 
     describe bond('bond0') do
       its('mode') { should eq 'IEEE 802.3ad Dynamic link aggregation' }
-      its('Transmit Hash Policy') { should eq 'layer3+4 (1)' }
-      its('MII Status') { should eq 'up' }
-      its('MII Polling Interval (ms)') { should eq '100' }
-      its('Up Delay (ms)') { should eq '0' }
-      its('Down Delay (ms)') { should eq '0' }
+      its('params') { should have_key 'Transmit Hash Policy' }
+      its('params') { should include 'Transmit Hash Policy' => 'layer3+4 (1)' }
+      its('params') { should have_key 'MII Status' }
+      its('params') { should include 'MII Status' => 'up' }
     end
 
 ## Matchers


### PR DESCRIPTION
## Description
Update the `bond0` resource docs with a valid example on how to use the `params` hash.

## Related Issue
https://github.com/inspec/inspec/issues/4890

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
