### PR TITLE
Support zfs_pool and zfs_dataset resources on Linux. Handled #5075

### DIFF
--- a/docs-chef-io/content/inspec/resources/zfs_dataset.md
+++ b/docs-chef-io/content/inspec/resources/zfs_dataset.md
@@ -11,7 +11,7 @@ platform = "linux"
     parent = "inspec/resources/os"
 +++
 
-Use the `zfs_dataset` Chef InSpec audit resource to test the ZFS datasets on FreeBSD systems.
+Use the `zfs_dataset` Chef InSpec audit resource to test the ZFS datasets on FreeBSD & Linux (Centos, RHEL, Ubuntu, CloudLinux, Debian) systems.
 
 ## Availability
 

--- a/docs-chef-io/content/inspec/resources/zfs_dataset.md
+++ b/docs-chef-io/content/inspec/resources/zfs_dataset.md
@@ -11,7 +11,7 @@ platform = "linux"
     parent = "inspec/resources/os"
 +++
 
-Use the `zfs_dataset` Chef InSpec audit resource to test the ZFS datasets on FreeBSD & Linux (Centos, RHEL, Ubuntu, CloudLinux, Debian) systems.
+Use the `zfs_dataset` Chef InSpec audit resource to test the ZFS datasets on FreeBSD & Linux (Check [OS Family Details](https://docs.chef.io/inspec/resources/os/#osfamily-helpers) for more details).
 
 ## Availability
 

--- a/docs-chef-io/content/inspec/resources/zfs_pool.md
+++ b/docs-chef-io/content/inspec/resources/zfs_pool.md
@@ -11,7 +11,7 @@ platform = "linux"
     parent = "inspec/resources/os"
 +++
 
-Use the `zfs_pool` Chef InSpec audit resource to test the ZFS pools on FreeBSD systems.
+Use the `zfs_pool` Chef InSpec audit resource to test the ZFS pools on FreeBSD & Linux (Centos, RHEL, Ubuntu, CloudLinux, Debian) systems.
 
 ## Availability
 

--- a/lib/inspec/resources/windows_feature.rb
+++ b/lib/inspec/resources/windows_feature.rb
@@ -83,7 +83,7 @@ module Inspec::Resources
         feature_info = {
           name: result.match(feature_name_regex).captures[0].chomp,
           description: result.match(description_regex).captures[0].chomp,
-          installed: result.match(state_regex).captures[0].chomp == 'Enabled',
+          installed: result.match(state_regex).captures[0].chomp == "Enabled",
         }
       end
 

--- a/lib/inspec/resources/zfs_dataset.rb
+++ b/lib/inspec/resources/zfs_dataset.rb
@@ -16,11 +16,14 @@ module Inspec::Resources
     EXAMPLE
 
     def initialize(zfs_dataset)
-      return skip_resource "The `zfs_dataset` resource is not supported on your OS yet." unless (inspec.os.bsd? or inspec.os.linux?)
+      return skip_resource "The `zfs_dataset` resource is not supported on your OS yet." unless inspec.os.bsd? || inspec.os.linux?
+
       @zfs_dataset = zfs_dataset
       find_zfs = inspec.command("which zfs")
       @zfs_cmd = find_zfs.stdout.strip
+
       return skip_resource "zfs is not installed" if find_zfs.exit_status != 0
+
       @params = gather
     end
 

--- a/lib/inspec/resources/zfs_dataset.rb
+++ b/lib/inspec/resources/zfs_dataset.rb
@@ -29,7 +29,7 @@ module Inspec::Resources
 
     # method called by 'it { should exist }'
     def exists?
-      inspec.command("#{@zfs_cli} get -Hp all #{@zfs_dataset}").exit_status == 0
+      inspec.command("#{@zfs_cmd} get -Hp all #{@zfs_dataset}").exit_status == 0
     end
 
     def mounted?

--- a/lib/inspec/resources/zfs_pool.rb
+++ b/lib/inspec/resources/zfs_pool.rb
@@ -15,11 +15,14 @@ module Inspec::Resources
     EXAMPLE
 
     def initialize(zfs_pool)
-      return skip_resource "The `zfs_pool` resource is not supported on your OS yet." unless (inspec.os.bsd? or inspec.os.linux?)      
+      return skip_resource "The `zfs_pool` resource is not supported on your OS yet." unless inspec.os.bsd? || inspec.os.linux?
+
       @zfs_pool = zfs_pool
       find_zpool = inspec.command("which zpool")
       @zpool_cmd = find_zpool.stdout.strip
+
       return skip_resource "zfs is not installed" if find_zpool.exit_status != 0
+
       @params = gather
     end
 

--- a/test/fixtures/cmd/zfs-which
+++ b/test/fixtures/cmd/zfs-which
@@ -1,0 +1,1 @@
+/sbin/zfs

--- a/test/fixtures/cmd/zpool-which
+++ b/test/fixtures/cmd/zpool-which
@@ -1,0 +1,1 @@
+/sbin/zpool

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -596,16 +596,16 @@ class MockLoader
     end
 
     # zfs dynamic commands
-    if @platform && ["centos", "debian", "ubuntu", "amazon"].include?(@platform[:name])
+    if @platform && %w{centos debian ubuntu amazon}.include?(@platform[:name])
       mock_cmds.merge!(
         # zfs output for dataset tank/tmp
         %{`which zfs` get -Hp all tank/tmp} => cmd.call("zfs-get-all-tank-tmp"),
         # zfs output for pool tank
-        %{`which zpool` get -Hp all tank} => cmd.call("zpool-get-all-tank"),
+        %{`which zpool` get -Hp all tank} => cmd.call("zpool-get-all-tank")
       )
     end
 
-    if @platform && !["centos", "cloudlinux", "coreos", "debian", "freebsd", "ubuntu", "amazon"].include?(@platform[:name])
+    if @platform && ! %w{centos cloudlinux coreos debian freebsd ubuntu amazon}.include?(@platform[:name])
       mock_cmds.delete("/sbin/zfs get -Hp all tank/tmp")
       mock_cmds.delete("/sbin/zpool get -Hp all tank")
       mock_cmds.delete("which zfs")

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -427,6 +427,10 @@ class MockLoader
       "/sbin/zfs get -Hp all tank/tmp" => cmd.call("zfs-get-all-tank-tmp"),
       # zfs output for pool tank
       "/sbin/zpool get -Hp all tank" => cmd.call("zpool-get-all-tank"),
+      # which zfs
+      "which zfs" => cmd.call("zfs-which"),
+      # which zpool
+      "which zpool" => cmd.call("zpool-which"),
       # docker
       "4f8e24022ea8b7d3b117041ec32e55d9bf08f11f4065c700e7c1dc606c84fd17" => cmd.call("docker-ps-a"),
       "b40ed61c006b54f155b28a85dc944dc0352b30222087b47c6279568ec0e59d05" => cmd.call("df-PT"),
@@ -590,6 +594,24 @@ class MockLoader
         "netstat -tulpen" => cmd.call("netstat-tulpen")
       )
     end
+
+    # zfs dynamic commands
+    if @platform && ["centos", "debian", "ubuntu", "amazon"].include?(@platform[:name])
+      mock_cmds.merge!(
+        # zfs output for dataset tank/tmp
+        %{`which zfs` get -Hp all tank/tmp} => cmd.call("zfs-get-all-tank-tmp"),
+        # zfs output for pool tank
+        %{`which zpool` get -Hp all tank} => cmd.call("zpool-get-all-tank"),
+      )
+    end
+
+    if @platform && !["centos", "cloudlinux", "coreos", "debian", "freebsd", "ubuntu", "amazon"].include?(@platform[:name])
+      mock_cmds.delete("/sbin/zfs get -Hp all tank/tmp")
+      mock_cmds.delete("/sbin/zpool get -Hp all tank")
+      mock_cmds.delete("which zfs")
+      mock_cmds.delete("which zpool")
+    end
+
     mock.commands = mock_cmds
 
     @backend

--- a/test/unit/resources/zfs_dataset_test.rb
+++ b/test/unit/resources/zfs_dataset_test.rb
@@ -16,7 +16,6 @@ describe Inspec::Resources::ZfsDataset do
   end
 end
 
-
 describe Inspec::Resources::ZfsDataset do
   let(:loader) { MockLoader.new(:centos7) }
   let(:tank_tmp_resource) { loader.send("load_resource", "zfs_dataset", "tank/tmp") }
@@ -41,7 +40,6 @@ describe Inspec::Resources::ZfsDataset do
     end
   end
 end
-
 
 describe Inspec::Resources::ZfsDataset do
   it "parses the ZFS dataset properly" do

--- a/test/unit/resources/zfs_dataset_test.rb
+++ b/test/unit/resources/zfs_dataset_test.rb
@@ -7,9 +7,46 @@ describe Inspec::Resources::ZfsDataset do
   let(:tank_tmp_resource) { loader.send("load_resource", "zfs_dataset", "tank/tmp") }
 
   it "parses the ZFS dataset data properly" do
-    _(tank_tmp_resource.send(:mountpoint)).must_equal("/tmp")
-    _(tank_tmp_resource.send(:type)).must_equal("filesystem")
-    _(tank_tmp_resource.send(:exec)).must_equal("off")
-    _(tank_tmp_resource.send(:setuid)).must_equal("off")
+    if _(tank_tmp_resource)
+      _(tank_tmp_resource.send(:mountpoint)).must_equal("/tmp")
+      _(tank_tmp_resource.send(:type)).must_equal("filesystem")
+      _(tank_tmp_resource.send(:exec)).must_equal("off")
+      _(tank_tmp_resource.send(:setuid)).must_equal("off")
+    end
   end
 end
+
+
+describe Inspec::Resources::ZfsDataset do
+  let(:loader) { MockLoader.new(:centos7) }
+  let(:tank_tmp_resource) { loader.send("load_resource", "zfs_dataset", "tank/tmp") }
+
+  it "parses the ZFS dataset data properly" do
+    if _(tank_tmp_resource)
+      _(tank_tmp_resource.send(:mountpoint)).must_equal("/tmp")
+      _(tank_tmp_resource.send(:type)).must_equal("filesystem")
+      _(tank_tmp_resource.send(:exec)).must_equal("off")
+      _(tank_tmp_resource.send(:setuid)).must_equal("off")
+    end
+  end
+end
+
+describe Inspec::Resources::ZfsDataset do
+  let(:loader) { MockLoader.new(:macos10_16) }
+  let(:tank_resource) { loader.send("load_resource", "zfs_dataset", "tank") }
+
+  it "parses the ZFS pool data properly" do
+    if _(tank_resource)
+      _(tank_resource.resource_exception_message).must_equal("zfs is not installed")
+    end
+  end
+end
+
+
+describe Inspec::Resources::ZfsDataset do
+  it "parses the ZFS dataset properly" do
+    resource = MockLoader.new(:macos10_16).load_resource("zfs_dataset", "tank")
+    _(resource.resource_exception_message).must_equal "zfs is not installed"
+  end
+end
+

--- a/test/unit/resources/zfs_pool_test.rb
+++ b/test/unit/resources/zfs_pool_test.rb
@@ -7,9 +7,44 @@ describe Inspec::Resources::ZfsPool do
   let(:tank_resource) { loader.send("load_resource", "zfs_pool", "tank") }
 
   it "parses the ZFS pool data properly" do
-    _(tank_resource.send(:health)).must_equal("ONLINE")
-    _(tank_resource.send(:guid)).must_equal("4711279777582057513")
-    _(tank_resource.send(:failmode)).must_equal("continue")
-    _(tank_resource.send(:'feature@lz4_compress')).must_equal("active")
+    if _(tank_resource)
+      _(tank_resource.send(:health)).must_equal("ONLINE")
+      _(tank_resource.send(:guid)).must_equal("4711279777582057513")
+      _(tank_resource.send(:failmode)).must_equal("continue")
+      _(tank_resource.send(:'feature@lz4_compress')).must_equal("active")
+    end
+  end
+end
+
+describe Inspec::Resources::ZfsPool do
+  let(:loader) { MockLoader.new(:centos7) }
+  let(:tank_resource) { loader.send("load_resource", "zfs_pool", "tank") }
+
+  it "parses the ZFS pool data properly" do
+    if _(tank_resource)
+      _(tank_resource.send(:health)).must_equal("ONLINE")
+      _(tank_resource.send(:guid)).must_equal("4711279777582057513")
+      _(tank_resource.send(:failmode)).must_equal("continue")
+      _(tank_resource.send(:'feature@lz4_compress')).must_equal("active")
+    end
+  end
+end
+
+describe Inspec::Resources::ZfsPool do
+  let(:loader) { MockLoader.new(:macos10_16) }
+  let(:tank_resource) { loader.send("load_resource", "zfs_pool", "tank") }
+
+  it "parses the ZFS pool data properly" do
+    if _(tank_resource)
+      _(tank_resource.resource_exception_message).must_equal("zfs is not installed")
+    end
+  end
+end
+
+
+describe Inspec::Resources::ZfsPool do
+  it "parses the ZFS pool data properly" do
+    resource = MockLoader.new(:macos10_16).load_resource("zfs_pool", "tank")
+    _(resource.resource_exception_message).must_equal "zfs is not installed"
   end
 end

--- a/test/unit/resources/zfs_pool_test.rb
+++ b/test/unit/resources/zfs_pool_test.rb
@@ -41,7 +41,6 @@ describe Inspec::Resources::ZfsPool do
   end
 end
 
-
 describe Inspec::Resources::ZfsPool do
   it "parses the ZFS pool data properly" do
     resource = MockLoader.new(:macos10_16).load_resource("zfs_pool", "tank")


### PR DESCRIPTION
Signed-off-by: @kannanr

<!--- Provide a short summary of your changes in the Title above -->

## Description
Support zfs_pool and zfs_dataset resources on Linux. Currently zfs_pool and zfs_dataset are restricted only to freebsd systems. An [issue](https://github.com/inspec/inspec/issues/5075) has been raised and discussed in detail from 6th Jun 2020

## Changes included in this PR.
1. Added inspec.os.linux to the condition check to relax the restriction only to freebsd.
2. Dynamically taking the zfs path instead of hard coded /sbin/zfs
3. Testcases added to cover centos besides freebsd. Also added a negative scenario for macos.


## Related Issue
https://github.com/inspec/inspec/issues/5075

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] New content (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have read the **CONTRIBUTING** document.
