### PR TITLE
Bugfix for `inspec detect --no-color` to not return colourful output

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -181,7 +181,7 @@ module Inspec
       puts "  Patents: chef.io/patents\n\n"
     end
 
-    def self.format_platform_info(params: {}, indent: 0, color: 39)
+    def self.format_platform_info(params: {}, indent: 0, color: 39, enable_color: true)
       str = ""
       params.each do |item, info|
         data = info
@@ -192,7 +192,7 @@ module Inspec
         # Do not output fields of data is missing ('unknown' is fine)
         next if data.nil?
 
-        data = "\e[1m\e[#{color}m#{data}\e[0m"
+        data = "\e[1m\e[#{color}m#{data}\e[0m" if enable_color
         str << format("#{" " * indent}%-10s %s\n", item.to_s.capitalize + ":", data)
       end
       str

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -305,7 +305,12 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       puts res.to_json
     else
       ui.headline("Platform Details")
-      ui.plain Inspec::BaseCLI.format_platform_info(params: res, indent: 0, color: 36)
+
+      if ui.color?
+        ui.plain Inspec::BaseCLI.format_platform_info(params: res, indent: 0, color: 36)
+      else
+        ui.plain Inspec::BaseCLI.format_platform_info(params: res, indent: 0)
+      end
     end
   rescue ArgumentError, RuntimeError, Train::UserError => e
     $stderr.puts e.message

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -305,9 +305,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       puts res.to_json
     else
       ui.headline("Platform Details")
-
-      detect_cmd_ui_color = ui.color? ? 36 : 0
-      ui.plain Inspec::BaseCLI.format_platform_info(params: res, indent: 0, color: detect_cmd_ui_color)
+      ui.plain Inspec::BaseCLI.format_platform_info(params: res, indent: 0, color: 36, enable_color: ui.color?)
     end
   rescue ArgumentError, RuntimeError, Train::UserError => e
     $stderr.puts e.message

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -306,11 +306,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     else
       ui.headline("Platform Details")
 
-      if ui.color?
-        ui.plain Inspec::BaseCLI.format_platform_info(params: res, indent: 0, color: 36)
-      else
-        ui.plain Inspec::BaseCLI.format_platform_info(params: res, indent: 0)
-      end
+      detect_cmd_ui_color = ui.color? ? 36 : 0
+      ui.plain Inspec::BaseCLI.format_platform_info(params: res, indent: 0, color: detect_cmd_ui_color)
     end
   rescue ArgumentError, RuntimeError, Train::UserError => e
     $stderr.puts e.message

--- a/test/functional/ui_test.rb
+++ b/test/functional/ui_test.rb
@@ -100,6 +100,15 @@ describe "InSpec UI behavior" do
         assert_exit_code 0, run_result
       end
     end
+
+    describe "detect command" do
+      let(:result) { inspec("detect") }
+
+      it "has a colorful output" do
+        _(result.stdout).must_include("\e[1m\e[36m")
+        assert_exit_code 0, result
+      end
+    end
   end
 
   describe "with --no-color option" do
@@ -128,6 +137,15 @@ describe "InSpec UI behavior" do
         _(show_spaces(run_result.stdout)).must_equal show_spaces(expected)
 
         assert_exit_code 0, run_result
+      end
+    end
+
+    describe "detect command" do
+      let(:result) { inspec("detect --no-color") }
+
+      it "has no color in the output" do
+        _(result.stdout).must_include("\e[1m\e[0m")
+        assert_exit_code 0, result
       end
     end
   end

--- a/test/functional/ui_test.rb
+++ b/test/functional/ui_test.rb
@@ -105,7 +105,7 @@ describe "InSpec UI behavior" do
       let(:result) { inspec("detect") }
 
       it "has a colorful output" do
-        _(result.stdout).must_include("\e[1m\e[36m")
+        _(result.stdout).must_include("\e[")
         assert_exit_code 0, result
       end
     end
@@ -144,7 +144,7 @@ describe "InSpec UI behavior" do
       let(:result) { inspec("detect --no-color") }
 
       it "has no color in the output" do
-        _(result.stdout).must_include("\e[1m\e[0m")
+        _(result.stdout).wont_include("\e[")
         assert_exit_code 0, result
       end
     end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix for `inspec detect --no-color` to not return colourful output
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #4505 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
