### PR TITLE
Remove trailing slash from server url

### DIFF
--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/api/login.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/api/login.rb
@@ -12,6 +12,7 @@ module InspecPlugins
           raise ArgumentError, "Please specify a server using `#{EXEC_NAME} automate login https://SERVER` or `#{EXEC_NAME} compliance login https://SERVER`" unless options["server"]
 
           options["server"] = URI("https://#{options["server"]}").to_s if URI(options["server"]).scheme.nil?
+          options["server"].delete_suffix!("/")
 
           options["server_type"] = InspecPlugins::Compliance::API.determine_server_type(options["server"], options["insecure"])
 


### PR DESCRIPTION
## Description
Remove any trailing `/` from the compliance login URL.

## Related Issue
Didn't open one but had a customer trying to login and got an unhelpful failure message of:

```
Unable to determine if https://server/ is a Chef Automate or Chef Compliance server (InspecPlugins::Compliance::API::Login::CannotDetermineServerType)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
