### PR TITLE
Fix related to loading dependent profiles from a profile in shell

### DIFF
--- a/lib/inspec/fetcher/local.rb
+++ b/lib/inspec/fetcher/local.rb
@@ -4,6 +4,7 @@ module Inspec::Fetcher
   class Local < Inspec.fetcher(1)
     name "local"
     priority 1
+    # Priority is used for setting precedence of fetchers. And registry plugin(v1) decides which fetcher to use for loading profiles by using this priority
 
     def self.resolve(target)
       if target.is_a?(String)

--- a/lib/inspec/fetcher/local.rb
+++ b/lib/inspec/fetcher/local.rb
@@ -3,7 +3,7 @@ require "openssl" unless defined?(OpenSSL)
 module Inspec::Fetcher
   class Local < Inspec.fetcher(1)
     name "local"
-    priority 0
+    priority 1
 
     def self.resolve(target)
       if target.is_a?(String)

--- a/lib/inspec/fetcher/mock.rb
+++ b/lib/inspec/fetcher/mock.rb
@@ -6,9 +6,11 @@ module Inspec::Fetcher
     priority 0
 
     def self.resolve(target)
-      return nil unless target.is_a? Hash
-
-      new(target)
+      if (target.is_a? Hash) && ((target.keys & %i{cwd path backend}).empty?)
+        new(target)
+      else
+        nil
+      end
     end
 
     def initialize(data)

--- a/test/fixtures/profiles/dependencies/shell-inheritance/controls/example.rb
+++ b/test/fixtures/profiles/dependencies/shell-inheritance/controls/example.rb
@@ -1,0 +1,2 @@
+include_controls 'profile_a'
+include_controls 'profile_b'

--- a/test/fixtures/profiles/dependencies/shell-inheritance/inspec.yml
+++ b/test/fixtures/profiles/dependencies/shell-inheritance/inspec.yml
@@ -1,0 +1,12 @@
+name: Shell Inheritance
+title: InSpec example of using inheritance profile in shell
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
+copyright_email: support@chef.io
+license: Apache 2 license
+version: 1.0.0
+depends:
+  - name: profile_a
+    path: test/fixtures/profiles/dependencies/profile_a
+  - name: profile_b
+    path: test/fixtures/profiles/dependencies/profile_b

--- a/test/functional/helper.rb
+++ b/test/functional/helper.rb
@@ -34,6 +34,7 @@ module FunctionalHelper
   let(:meta_profile) { File.join(examples_path, "meta-profile") }
   let(:example_control) { File.join(example_profile, "controls", "example-tmp.rb") }
   let(:inheritance_profile) { File.join(examples_path, "inheritance") }
+  let(:shell_inheritance_profile) { File.join(repo_path, "test", "fixtures", "profiles", "dependencies", "shell-inheritance") }
   let(:failure_control) { File.join(profile_path, "failures", "controls", "failures.rb") }
   let(:simple_inheritance) { File.join(profile_path, "simple-inheritance") }
   let(:sensitive_profile) { File.join(examples_path, "profile-sensitive") }

--- a/test/functional/inspec_shell_test.rb
+++ b/test/functional/inspec_shell_test.rb
@@ -49,6 +49,16 @@ describe "inspec shell tests" do
       assert_exit_code 0, res
     end
 
+    it "loads a profile and its dependencies" do
+      res = inspec("shell -c 'example_config' --depends #{shell_inheritance_profile}")
+
+      _(res.stdout.chop).must_equal "example_config"
+
+      _(res.stderr).must_equal ""
+
+      assert_exit_code 0, res
+    end
+
     it "confirm file caching is disabled" do
       out = assert_shell_c("inspec.backend.cache_enabled?(:file)", 0)
 
@@ -236,6 +246,15 @@ describe "inspec shell tests" do
 
       it "loads a dependency" do
         cmd = "echo 'example_config' | #{exec_inspec} shell --depends #{example_profile}"
+        res = CMD.run_command(cmd)
+
+        _(res.stdout).must_include "=> example_config"
+
+        assert_exit_code 0, res
+      end
+
+      it "loads a profile and its dependencies" do
+        cmd = "echo 'example_config' | #{exec_inspec} shell --depends #{shell_inheritance_profile}"
         res = CMD.run_command(cmd)
 
         _(res.stdout).must_include "=> example_config"


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
Fix related to loading dependent profiles from a profile in shell
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixes the issue of inspec shell which does not work when --depends is used for a profile that itself have dependencies 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #3411 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
