### PR TITLE
Minor MD reformatting for dev-docs page

### DIFF
--- a/dev-docs/inspec-init-plugin.md
+++ b/dev-docs/inspec-init-plugin.md
@@ -1,4 +1,4 @@
-# About `inspec init plugin` cli command
+# About `inspec init plugin` CLI command
 
 ## Purpose
 
@@ -8,39 +8,40 @@
 
 ### Generating InSpec Plugin
 
-    `inspec init plugin --help`
+`inspec init plugin --help`
 
-    ```
-    Usage:
-      inspec init plugin PLUGIN_NAME [options]
+```
+Usage:
+  inspec init plugin PLUGIN_NAME [options]
 
-    Options:
-      [--prompt], [--no-prompt]      # Interactively prompt for information to put in your generated plugin.
-                                     # Default: true
-      [--detail=DETAIL]              # How detailed of a plugin to generate. 'full' is a normal full gem with tests; 'core' has tests but no gemspec; 'test-fixture' is stripped down for a test fixture.
-                                     # Default: full
-      [--author-email=AUTHOR_EMAIL]  # Author Email for gemspec
-                                     # Default: you@example.com
-      [--author-name=AUTHOR_NAME]    # Author Name for gemspec
-                                     # Default: Your Name
-      [--description=DESCRIPTION]    # Multi-line description of the plugin
-      [--summary=SUMMARY]            # One-line summary of your plugin
-                                     # Default: A plugin with a default summary
-      [--license-name=LICENSE_NAME]  # The name of a license
-                                     # Default: Apache-2.0
-      [--activator=one two three]    # A list of plugin activator, in the form type1:name1, type2:name2, etc
-                                     # Default: ["cli_command:my_command"]
-      [--hook=one two three]         # Legacy name for --activator - Deprecated.
-      [--homepage=HOMEPAGE]          # A URL for your project, often a GitHub link
-      [--module-name=MODULE_NAME]    # Module Name for your plugin package.  Will change plugin name to CamelCase by default.
-      [--copyright=COPYRIGHT]        # A copyright statement, to be added to LICENSE
-      [--log-level=LOG_LEVEL]        # Set the log level: info (default), debug, warn, error
-      [--log-location=LOG_LOCATION]  # Location to send diagnostic log messages to. (default: $stdout or Inspec::Log.error)
+Options:
+  [--prompt], [--no-prompt]      # Interactively prompt for information to put in your generated plugin.
+                                 # Default: true
+  [--detail=DETAIL]              # How detailed of a plugin to generate. 'full' is a normal full gem with tests; 'core' has tests but no gemspec; 'test-fixture' is stripped down for a test fixture.
+                                 # Default: full
+  [--author-email=AUTHOR_EMAIL]  # Author Email for gemspec
+                                 # Default: you@example.com
+  [--author-name=AUTHOR_NAME]    # Author Name for gemspec
+                                 # Default: Your Name
+  [--description=DESCRIPTION]    # Multi-line description of the plugin
+  [--summary=SUMMARY]            # One-line summary of your plugin
+                                 # Default: A plugin with a default summary
+  [--license-name=LICENSE_NAME]  # The name of a license
+                                 # Default: Apache-2.0
+  [--activator=one two three]    # A list of plugin activator, in the form type1:name1, type2:name2, etc
+                                 # Default: ["cli_command:my_command"]
+  [--hook=one two three]         # Legacy name for --activator - Deprecated.
+  [--homepage=HOMEPAGE]          # A URL for your project, often a GitHub link
+  [--module-name=MODULE_NAME]    # Module Name for your plugin package.  Will change plugin name to CamelCase by default.
+  [--copyright=COPYRIGHT]        # A copyright statement, to be added to LICENSE
+  [--log-level=LOG_LEVEL]        # Set the log level: info (default), debug, warn, error
+  [--log-location=LOG_LOCATION]  # Location to send diagnostic log messages to. (default: $stdout or Inspec::Log.error)
 
-    Generates an InSpec plugin, which can extend the functionality of InSpec itself.
-    ```
+Generates an InSpec plugin, which can extend the functionality of InSpec itself.
+```
+
 ### Options
-  `inspec init plugin` command requires few details about the plugin to be added. This can be added using command line prompt or by passing them as the options like for e.g `--author-name`,`--author-email`, `--description`, --module-name etc.
+  `inspec init plugin` command requires few details about the plugin to be added. This can be added using command line prompt or by passing them as the options like for e.g `--author-name`,`--author-email`, `--description`, `--module-name`, etc.
 
   `--detail` This option can be used to skip generation of test files or gemspec file. Available values `full`, `core` or `test-fixture`.
 


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>


## Description

Reformat some text in the dev-docs/inspec-init-plugin.md page. 

Mostly this just un-indents the large code block showing the `--help` output so the code block looks better in GH.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
