### PR TITLE
Fix mysql_session resource to raise exception if there is a error in connection or in query

### DIFF
--- a/lib/inspec/resources/mysql_session.rb
+++ b/lib/inspec/resources/mysql_session.rb
@@ -45,11 +45,13 @@ module Inspec::Resources
       @socket = socket
       init_fallback if user.nil? || pass.nil?
       raise Inspec::Exceptions::ResourceFailed, "Can't run MySQL SQL checks without authentication." if @user.nil? || @pass.nil?
+
       set_connection
     end
 
     def query(q, db = "")
       raise Inspec::Exceptions::ResourceFailed, "#{resource_exception_message}" if self.resource_failed?
+
       mysql_cmd = create_mysql_cmd(q, db)
       cmd = if !@pass.nil?
               inspec.command(mysql_cmd, redact_regex: /(mysql -u\w+ -p).+(\s-(h|S).*)/)

--- a/lib/inspec/resources/mysql_session.rb
+++ b/lib/inspec/resources/mysql_session.rb
@@ -46,7 +46,7 @@ module Inspec::Resources
       init_fallback if user.nil? || pass.nil?
       raise Inspec::Exceptions::ResourceFailed, "Can't run MySQL SQL checks without authentication." if @user.nil? || @pass.nil?
 
-      set_connection
+      test_connection
     end
 
     def query(q, db = "")
@@ -74,8 +74,8 @@ module Inspec::Resources
 
     # Querying on the database to make sure conneciton can be established. If not this will set the resource exception
     # message which we raise before querying on the database using mysql_session object.
-    def set_connection
-      query("show databases")
+    def test_connection
+      query("select now()")
     end
 
     def escape_string(query)

--- a/lib/inspec/resources/mysql_session.rb
+++ b/lib/inspec/resources/mysql_session.rb
@@ -50,7 +50,7 @@ module Inspec::Resources
     end
 
     def query(q, db = "")
-      raise Inspec::Exceptions::ResourceFailed, "#{resource_exception_message}" if self.resource_failed?
+      raise Inspec::Exceptions::ResourceFailed, "#{resource_exception_message}" if resource_failed?
 
       mysql_cmd = create_mysql_cmd(q, db)
       cmd = if !@pass.nil?

--- a/lib/inspec/resources/mysql_session.rb
+++ b/lib/inspec/resources/mysql_session.rb
@@ -44,10 +44,12 @@ module Inspec::Resources
       @port = port
       @socket = socket
       init_fallback if user.nil? || pass.nil?
-      skip_resource("Can't run MySQL SQL checks without authentication") if @user.nil? || @pass.nil?
+      raise Inspec::Exceptions::ResourceFailed, "Can't run MySQL SQL checks without authentication." if @user.nil? || @pass.nil?
+      set_connection
     end
 
     def query(q, db = "")
+      raise Inspec::Exceptions::ResourceFailed, "#{resource_exception_message}" if self.resource_failed?
       mysql_cmd = create_mysql_cmd(q, db)
       cmd = if !@pass.nil?
               inspec.command(mysql_cmd, redact_regex: /(mysql -u\w+ -p).+(\s-(h|S).*)/)
@@ -56,7 +58,7 @@ module Inspec::Resources
             end
       out = cmd.stdout + "\n" + cmd.stderr
       if cmd.exit_status != 0 || out =~ /Can't connect to .* MySQL server/ || out.downcase =~ /^error:.*/
-        Lines.new(out, "MySQL query with errors: #{q}", cmd.exit_status)
+        raise Inspec::Exceptions::ResourceFailed, "MySQL query with errors: #{out}"
       else
         Lines.new(cmd.stdout.strip, "MySQL query: #{q}", cmd.exit_status)
       end
@@ -67,6 +69,12 @@ module Inspec::Resources
     end
 
     private
+
+    # Querying on the database to make sure conneciton can be established. If not this will set the resource exception
+    # message which we raise before querying on the database using mysql_session object.
+    def set_connection
+      query("show databases")
+    end
 
     def escape_string(query)
       Shellwords.escape(query)

--- a/test/fixtures/profiles/skippy-controls/controls/skipper.rb
+++ b/test/fixtures/profiles/skippy-controls/controls/skipper.rb
@@ -3,9 +3,3 @@ control 'CONTROL super' do
     skip 'This will be skipped super intentionally.'
   end
 end
-
-control 'CONTROL database' do
-  describe mysql_session do
-    its('something') { should be 3 }
-  end
-end

--- a/test/functional/inspec_exec_junit_test.rb
+++ b/test/functional/inspec_exec_junit_test.rb
@@ -97,7 +97,7 @@ describe "inspec exec with junit formatter" do
         _(run_result.stderr).must_equal ""
         _(schema.validate(doc)).must_be_empty
         suite = doc.xpath("//testsuite").first
-        _(suite.attr("skipped")).must_equal "2"
+        _(suite.attr("skipped")).must_equal "1"
         testcase = doc.xpath("//testcase").first
         _(testcase.xpath("//skipped")).wont_be_empty
       end

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -299,8 +299,7 @@ Test Summary: 0 successful, 0 failures, 0 skipped
 
     it "exits with an error" do
       _(stdout).must_include "skippy\n     ↺  This will be skipped super intentionally.\n"
-      _(stdout).must_include "  ↺  CONTROL database: MySQL Session\n     ↺  Can't run MySQL SQL checks without authentication\n"
-      _(stdout).must_include "Profile Summary: 0 successful controls, 0 control failures, 2 controls skipped\nTest Summary: 0 successful, 0 failures, 2 skipped\n"
+      _(stdout).must_include "Profile Summary: 0 successful controls, 0 control failures, 1 control skipped\nTest Summary: 0 successful, 0 failures, 1 skipped\n"
 
       _(stderr).must_equal ""
 
@@ -312,7 +311,7 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     let(:out) { inspec("exec " + File.join(profile_path, "skippy-controls") + " --no-distinct-exit --no-create-lockfile") }
 
     it "exits with code 0 and skipped tests in output" do
-      _(stdout).must_include "Profile Summary: 0 successful controls, 0 control failures, 2 controls skipped\nTest Summary: 0 successful, 0 failures, 2 skipped\n"
+      _(stdout).must_include "Profile Summary: 0 successful controls, 0 control failures, 1 control skipped\nTest Summary: 0 successful, 0 failures, 1 skipped\n"
 
       _(stderr).must_equal ""
 

--- a/test/unit/resources/mysql_session_test.rb
+++ b/test/unit/resources/mysql_session_test.rb
@@ -31,7 +31,7 @@ describe "Inspec::Resources::MysqlSession" do
     _(resource.resource_failed?).must_equal true
     _(resource.resource_exception_message).must_equal "Can't run MySQL SQL checks without authentication."
   end
-  it "failes when no connection established" do
+  it "fails when no connection established" do
     resource = load_resource("mysql_session", "root", "root", "localhost", 3306)
     _(resource.resource_failed?).must_equal true
     _(resource.resource_exception_message).must_include "MySQL query with errors"

--- a/test/unit/resources/mysql_session_test.rb
+++ b/test/unit/resources/mysql_session_test.rb
@@ -26,4 +26,15 @@ describe "Inspec::Resources::MysqlSession" do
     expected_to_s = %q{Command: `mysql -uroot -pREDACTED -h localhost -s -e "SELECT 1 FROM DUAL;"`}
     _(resource.to_s).must_equal(expected_to_s)
   end
+  it "fails when no user, password" do
+    resource = load_resource("mysql_session", nil, nil, "localhost", 3306)
+    _(resource.resource_failed?).must_equal true
+    _(resource.resource_exception_message).must_equal "Can't run MySQL SQL checks without authentication."
+  end
+  it "failes when no connection established" do
+    resource = load_resource("mysql_session", "root", "root", "localhost", 3306)
+    _(resource.resource_failed?).must_equal true
+    _(resource.resource_exception_message).must_include "MySQL query with errors"
+  end
+
 end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix mysql_session resource to handle the exceptions if the mysql session is not established. Currently it does not raise any exception due to which the InSpec test gives false result
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5309 for mysql_session resource.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
