### PR TITLE
Fix postgres_session resource to raise exception if there is a error in connection or in query

### DIFF
--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -51,7 +51,7 @@ module Inspec::Resources
     end
 
     def query(query, db = [])
-      raise Inspec::Exceptions::ResourceFailed, "#{resource_exception_message}" if self.resource_failed?
+      raise Inspec::Exceptions::ResourceFailed, "#{resource_exception_message}" if resource_failed?
 
       psql_cmd = create_psql_cmd(query, db)
       cmd = inspec.command(psql_cmd, redact_regex: /(PGPASSWORD=').+(' psql .*)/)

--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -47,7 +47,7 @@ module Inspec::Resources
       @port = port || 5432
       raise Inspec::Exceptions::ResourceFailed, "Can't run PostgreSQL SQL checks without authentication." if @user.nil? || @pass.nil?
 
-      set_connection
+      test_connection
     end
 
     def query(query, db = [])
@@ -65,8 +65,8 @@ module Inspec::Resources
 
     private
 
-    def set_connection
-      query('\du')
+    def test_connection
+      query("select now()")
     end
 
     def escaped_query(query)

--- a/test/unit/resources/postgres_session_test.rb
+++ b/test/unit/resources/postgres_session_test.rb
@@ -28,4 +28,14 @@ describe "Inspec::Resources::PostgresSession" do
     resource = load_resource("postgres_session", "myuser", "mypass")
     _(resource.send(:create_psql_cmd, "SELECT * FROM STUDENTS;", ["testdb"])).must_equal "PGPASSWORD='mypass' psql -U myuser -d testdb -h localhost -p 5432 -A -t -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;"
   end
+  it "fails when no user, password" do
+    resource = load_resource("postgres_session", nil, nil, "localhost", 5432)
+    _(resource.resource_failed?).must_equal true
+    _(resource.resource_exception_message).must_equal "Can't run PostgreSQL SQL checks without authentication."
+  end
+  it "fails when no connection established" do
+    resource = load_resource("postgres_session", "postgres", "postgres", "localhost", 5432)
+    _(resource.resource_failed?).must_equal true
+    _(resource.resource_exception_message).must_include "PostgreSQL query with errors"
+  end
 end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix postgres_session resource to raise exception if database connection is not established due to any reason or there is error with query. Currently it does not raise any exception due to which the InSpec test gives false result.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5309 for postgres_session resource
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
