### PR TITLE
Include x25519 KEX module in omnibus build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :omnibus do
   gem "appbundler"
   gem "ed25519" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
   gem "bcrypt_pbkdf" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
+  gem "x25519" # ed25519 KEX module
 end
 
 group :test do
@@ -55,6 +56,7 @@ end
 if Gem.ruby_version >= Gem::Version.new("2.7.0")
   group :kitchen do
     gem "berkshelf"
+    gem "chef", ">= 16.0" # Required to allow net-ssh > 6
     gem "test-kitchen", ">= 2.8"
     gem "kitchen-inspec", ">= 2.0"
     gem "kitchen-dokken", ">= 2.11"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Resolves a customer issue, see https://github.com/inspec/train/issues/691 . Allows InSpec to connect to machines that have restricted SSH connections to use specific ED25519 key exchange algorithms.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #2472 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
