### PR TITLE
Restrict x25519 gem to x86 architectures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,12 +20,22 @@ end
 # but our runtime dep is still 3.9+
 gem "rspec", ">= 3.10"
 
+def probably_x86?
+  # We don't currently build on ARM windows, so assume x86 there
+  return true if RUBY_PLATFORM =~ /windows|mswin|msys|mingw|cygwin/
+
+  # Otherwise rely on uname -m
+  `uname -m`.match?(/^(x86_64|i\d86)/)
+end
+
 group :omnibus do
   gem "rb-readline"
   gem "appbundler"
   gem "ed25519" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
   gem "bcrypt_pbkdf" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
-  gem "x25519" # ed25519 KEX module
+  if probably_x86?
+    gem "x25519" # ed25519 KEX module, not supported on ARM
+  end
 end
 
 group :test do


### PR DESCRIPTION
## Description

Turns out that the x25519 gem does not build on ARM, so conditionalize its inclusion to be x86 only.

The check for architecture is `uname -m`-based, which has its tradeoffs. I'm open to better ideas.

A (relevant parts, anyway) successful omnibus build using this fix is here - https://buildkite.com/chef/inspec-inspec-master-omnibus-release/builds/475#0c6be3f8-2d6c-43e6-8759-279b991fb98b

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#2472 related
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
