### PR TITLE
Fix AWS secret key environment variable name in docs

### DIFF
--- a/docs-chef-io/content/inspec/platforms.md
+++ b/docs-chef-io/content/inspec/platforms.md
@@ -35,7 +35,7 @@ create an IAM user specifically for auditing activities.
 #### Using Environment Variables to provide credentials
 
 You may provide the credentials to Chef InSpec by setting the following environment
-variables: `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_KEY_ID`. You may
+variables: `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`. You may
 also use `AWS_PROFILE`, or if you are using MFA, `AWS_SESSION_TOKEN`. See the
 [AWS Command Line Interface Docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
 for details.


### PR DESCRIPTION
Signed-off-by: Sandra Tiffin <sandra.tiffin@progress.com>

The AWS platform support instructions give the wrong environment variable name for the secret access key, this fixes it.

## Description

If you follow the [AWS Command Line Interface Docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) link on this page, it leads you to https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html which gives the correct variable name -- AWS_SECRET_ACCESS_KEY instead of AWS_SECRET_KEY_ID.

The same info is also in the ruby AWS SDK docs at https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html#aws-ruby-sdk-credentials-environment.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
