### PR TITLE
Add aliyun3 support to service resource

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -152,6 +152,12 @@ module Inspec::Resources
         else
           SysV.new(inspec, service_ctl || "/sbin/service")
         end
+      when "alibaba"
+        if os[:release].to_i >= 3
+          Systemd.new(inspec, service_ctl)
+        else
+          SysV.new(inspec, service_ctl || "/sbin/service")
+        end
       when "wrlinux"
         SysV.new(inspec, service_ctl)
       when "mac_os_x", "darwin"

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -34,6 +34,7 @@ class MockLoader
     aix: { name: "aix", family: "aix", release: "7.2", arch: "powerpc" },
     amazon: { name: "amazon", family: "redhat", release: "2015.03", arch: "x86_64" },
     amazon2: { name: "amazon", family: "redhat", release: "2", arch: "x86_64" },
+    aliyun3: { name: "alibaba", family: "redhat", release: "3", arch: "x86_64" },
     yocto: { name: "yocto", family: "yocto", release: "0.0.1", arch: "aarch64" },
     undefined: { name: nil, family: nil, release: nil, arch: nil },
   }

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -152,6 +152,19 @@ describe "Inspec::Resources::Service" do
     _(resource.params).must_equal params
   end
 
+  # Aliyun Linux 3 (Alibaba)
+  it "verify aliyun linux 3 service parsing" do
+    resource = MockLoader.new(:aliyun3).load_resource("service", "sshd")
+    params = Hashie::Mash.new({ "ActiveState" => "active", "Description" => "OpenSSH server daemon", "Id" => "sshd.service", "LoadState" => "loaded", "Names" => "sshd.service", "SubState" => "running", "UnitFileState" => "enabled" })
+    _(resource.type).must_equal "systemd"
+    _(resource.name).must_equal "sshd.service"
+    _(resource.description).must_equal "OpenSSH server daemon"
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+  end
+
   # centos 6 with sysv
   it "verify centos 6 service parsing" do
     resource = MockLoader.new(:centos6).load_resource("service", "sshd")


### PR DESCRIPTION
Add support for Aliyun3 Linux.

## Description
Allows latest Alibaba cloud major distribution (Ailyun3) to be identified for service resource.

## Related Issue
https://github.com/inspec/inspec/issues/5577


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
