### PR TITLE
Remove default port for mssql_session, allowing named connections

### DIFF
--- a/lib/inspec/resources/mssql_session.rb
+++ b/lib/inspec/resources/mssql_session.rb
@@ -42,11 +42,7 @@ module Inspec::Resources
       @local_mode = opts[:local_mode]
       unless local_mode?
         @host = opts[:host] || "localhost"
-        if opts.key?(:port)
-          @port = opts[:port]
-        else
-          @port = "1433"
-        end
+        @port = opts[:port]
       end
       @instance = opts[:instance]
       @db_name = opts[:db_name]

--- a/test/unit/resources/mssql_session_test.rb
+++ b/test/unit/resources/mssql_session_test.rb
@@ -8,7 +8,6 @@ describe "Inspec::Resources::MssqlSession" do
     _(resource.user).must_equal "sa"
     _(resource.password).must_equal "yourStrong(!)Password"
     _(resource.host).must_equal "localhost"
-    _(resource.port).must_equal "1433"
   end
 
   it "verify mssql_session configuration with custom hostname" do
@@ -16,7 +15,6 @@ describe "Inspec::Resources::MssqlSession" do
     _(resource.user).must_equal "sa"
     _(resource.password).must_equal "yourStrong(!)Password"
     _(resource.host).must_equal "inspec.domain.tld"
-    _(resource.port).must_equal "1433"
   end
 
   it "verify mssql_session configuration with custom instance" do
@@ -24,7 +22,6 @@ describe "Inspec::Resources::MssqlSession" do
     _(resource.user).must_equal "sa"
     _(resource.password).must_equal "yourStrong(!)Password"
     _(resource.host).must_equal "localhost"
-    _(resource.port).must_equal "1433"
     _(resource.instance).must_equal "SQL2012INSPEC"
   end
 
@@ -63,7 +60,7 @@ describe "Inspec::Resources::MssqlSession" do
   end
 
   it "run a SQL query" do
-    resource = load_resource("mssql_session", user: "sa", password: "yourStrong(!)Password", host: "localhost")
+    resource = load_resource("mssql_session", user: "sa", password: "yourStrong(!)Password", host: "localhost", port: "1433")
     query = resource.query("SELECT SERVERPROPERTY('ProductVersion') as result")
     _(query.size).must_equal 1
     _(query.row(0).column("result").value).must_equal "14.0.600.250"


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
MSSQL resource fix for named instances (used with no port)
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
In current code, the default port was 1433 and so named instances had issue running without any port. So this change will enable using named instances without any port as well.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5548 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
