### PR TITLE
Fix range based filtering in filter tables

### DIFF
--- a/lib/inspec/utils/filter.rb
+++ b/lib/inspec/utils/filter.rb
@@ -256,7 +256,7 @@ module FilterTable
     end
 
     def matches(x, y)
-      x === y # rubocop:disable Style/CaseEquality
+      y === x # rubocop:disable Style/CaseEquality
     end
 
     def filter_raw_data(current_raw_data, field, desired_value)

--- a/test/unit/utils/filter_table_test.rb
+++ b/test/unit/utils/filter_table_test.rb
@@ -35,6 +35,11 @@ describe FilterTable do
     _(resource.new(nil).where { false }.params).must_equal []
   end
 
+  it "supports range" do
+    factory.add_accessor(:where).connect(resource, :data)
+    _(instance.where({ foo: (3..5) }).params).must_equal [data[0]]
+  end
+
   it "retrieves the resource from all entries" do
     factory.add_accessor(:where)
       .add(:baz?) { |x| x.resource } # rubocop: disable Style/SymbolProc
@@ -179,6 +184,18 @@ describe FilterTable do
 
     it "filter by missing regex" do
       _(instance.baz(/zzz/).params).must_equal []
+    end
+  end
+
+  describe "with a range filter" do
+    before { factory.add(:foo).connect(resource, :data) }
+
+    it "filter and retrieves data with matching range" do
+      _(instance.foo((3..5)).params).must_equal [data[0]]
+    end
+
+    it "filter and retrieves empty result if no data in matching range" do
+      _(instance.foo((4..5)).params).must_equal []
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixed range based filtering in filter tables for issue explained below.

**Problem:** 

Issue with range based filtering : 
```
things.where(thing_id: (1..2)).entries
```
where data is 
```
[
   { thing_id: 1, color: :red },
   { thing_id: 2, color: :blue, tackiness: 'very' },
   { thing_id: 3, color: :red },
]
```
Returned [] entries while it should return first 2 entries.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5116 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
