### PR TITLE
Fix `--insecure` not working with profile 

### DIFF
--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -6,9 +6,9 @@ module Inspec
     extend Forwardable
 
     attr_reader :cache, :target, :fetcher
-    def initialize(target, cache)
+    def initialize(target, cache, opts = {})
       @target = target
-      @fetcher = Inspec::Fetcher::Registry.resolve(target)
+      @fetcher = Inspec::Fetcher::Registry.resolve(target, opts)
 
       if @fetcher.nil?
         raise("Could not fetch inspec profile in #{target.inspect}.")

--- a/lib/inspec/fetcher.rb
+++ b/lib/inspec/fetcher.rb
@@ -2,12 +2,12 @@ require "inspec/plugin/v1"
 
 module Inspec
   class FetcherRegistry < PluginRegistry
-    def resolve(target)
+    def resolve(target, opts = {})
       if fetcher_specified?(target)
-        super(target)
+        super(target, opts)
       else
         Inspec::Log.debug("Assuming default supermarket source for #{target}")
-        super(with_default_fetcher(target))
+        super(with_default_fetcher(target), opts)
       end
     end
 

--- a/lib/inspec/plugin/v1/registry.rb
+++ b/lib/inspec/plugin/v1/registry.rb
@@ -11,7 +11,7 @@ class PluginRegistry
   # @return [Plugin] plugin instance if it can be resolved, nil otherwise
   def resolve(target, opts = {})
     modules.each do |m|
-      res = if [Inspec::Fetcher::Url, Inspec::Fetcher::Git, Supermarket::Fetcher].include? m
+      res = if Inspec::Fetcher::Url == m
               m.resolve(target, opts)
             else
               m.resolve(target)

--- a/lib/inspec/plugin/v1/registry.rb
+++ b/lib/inspec/plugin/v1/registry.rb
@@ -9,9 +9,13 @@ class PluginRegistry
   #
   # @param [String] target to resolve
   # @return [Plugin] plugin instance if it can be resolved, nil otherwise
-  def resolve(target)
+  def resolve(target, opts = {})
     modules.each do |m|
-      res = m.resolve(target)
+      res = if [Inspec::Fetcher::Url, Inspec::Fetcher::Git, Supermarket::Fetcher].include? m
+              m.resolve(target, opts)
+            else
+              m.resolve(target)
+            end
       return res unless res.nil?
     end
     nil

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -71,7 +71,7 @@ module Inspec
     def self.for_target(target, opts = {})
       opts[:vendor_cache] ||= Cache.new
       config = {}
-      unless opts[:runner_conf].nil? || opts[:runner_conf].empty?
+      unless opts[:runner_conf].nil?
         config = opts[:runner_conf].respond_to?(:final_options) ? opts[:runner_conf].final_options : opts[:runner_conf]
       end
       fetcher = resolve_target(target, opts[:vendor_cache], config)

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -18,9 +18,9 @@ module Inspec
   class Profile
     extend Forwardable
 
-    def self.resolve_target(target, cache)
+    def self.resolve_target(target, cache, opts = {})
       Inspec::Log.debug "Resolve #{target} into cache #{cache.path}"
-      Inspec::CachedFetcher.new(target, cache)
+      Inspec::CachedFetcher.new(target, cache, opts)
     end
 
     # Check if the profile contains a vendored cache, move content into global cache
@@ -70,7 +70,11 @@ module Inspec
 
     def self.for_target(target, opts = {})
       opts[:vendor_cache] ||= Cache.new
-      fetcher = resolve_target(target, opts[:vendor_cache])
+      config = {}
+      unless opts[:runner_conf].nil? || opts[:runner_conf].empty?
+        config = opts[:runner_conf].respond_to?(:final_options) ? opts[:runner_conf].final_options : opts[:runner_conf]
+      end
+      fetcher = resolve_target(target, opts[:vendor_cache], config)
       for_fetcher(fetcher, opts)
     end
 


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix `--insecure` usage which should bypass SSL verification when downloading profiles over https

**Problem:**
It crashed with `--insecure` usage

```
inspec exec https://self-signed.badssl.com/test.tar.gz  --insecure --chef-license=accept
+---------------------------------------------+
✔ 1 product license accepted.
+---------------------------------------------+
Traceback (most recent call last):
        33: from /usr/bin/inspec:23:in `<main>'
        32: from /usr/bin/inspec:23:in `load'
        31: from /usr/lib/ruby/gems/2.5.0/gems/inspec-bin-4.18.39/bin/inspec:11:in `<top (required)>'
        30: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/inspec/base_cli.rb:33:in `start'
        29: from /usr/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
        28: from /usr/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
        27: from /usr/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
        26: from /usr/lib/ruby/gems/2.5.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
        25: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/inspec/cli.rb:285:in `exec'
        24: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/inspec/cli.rb:285:in `each'
        23: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/inspec/cli.rb:285:in `block in exec'
        22: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/inspec/runner.rb:192:in `add_target'
        21: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/inspec/profile.rb:73:in `for_target'
        20: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/inspec/profile.rb:66:in `for_fetcher'
        19: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/inspec/cached_fetcher.rb:38:in `fetch'
        18: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/inspec/cached_fetcher.rb:31:in `cache_key'
        17: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/fetchers/url.rb:114:in `cache_key'
        16: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/fetchers/url.rb:130:in `sha256'
        15: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/fetchers/url.rb:150:in `temp_archive_path'
        14: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/fetchers/url.rb:197:in `download_archive_to_temp'
        13: from /usr/lib/ruby/gems/2.5.0/gems/inspec-4.18.39/lib/fetchers/url.rb:215:in `open_via_uri'
        12: from /usr/lib/ruby/2.5.0/open-uri.rb:35:in `open'
        11: from /usr/lib/ruby/2.5.0/open-uri.rb:735:in `open'
        10: from /usr/lib/ruby/2.5.0/open-uri.rb:165:in `open_uri'
         9: from /usr/lib/ruby/2.5.0/open-uri.rb:224:in `open_loop'
         8: from /usr/lib/ruby/2.5.0/open-uri.rb:224:in `catch'
         7: from /usr/lib/ruby/2.5.0/open-uri.rb:226:in `block in open_loop'
         6: from /usr/lib/ruby/2.5.0/open-uri.rb:755:in `buffer_open'
         5: from /usr/lib/ruby/2.5.0/open-uri.rb:337:in `open_http'
         4: from /usr/lib/ruby/2.5.0/net/http.rb:909:in `start'
         3: from /usr/lib/ruby/2.5.0/net/http.rb:920:in `do_start'
         2: from /usr/lib/ruby/2.5.0/net/http.rb:985:in `connect'
         1: from /usr/lib/ruby/2.5.0/net/protocol.rb:44:in `ssl_socket_connect'
/usr/lib/ruby/2.5.0/net/protocol.rb:44:in `connect_nonblock': SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate) (OpenSSL::SSL::SSLError)

```
**Implemented Solution:**
Since `insecure` flag was not accessible in [url](https://github.com/inspec/inspec/blob/master/lib/inspec/fetcher/url.rb#L98) fetcher, passing opts using `runner_conf` to target will help in resolving this issue as values of options will then be accessible to url fetcher.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #4873 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
