### PR TITLE
Fix apache_conf issue when Server Root is not present in configuration

### DIFF
--- a/docs-chef-io/content/inspec/resources/apache_conf.md
+++ b/docs-chef-io/content/inspec/resources/apache_conf.md
@@ -19,6 +19,10 @@ Use the `apache_conf` Chef InSpec audit resource to test the configuration setti
 
 This resource is distributed along with Chef InSpec itself. You can use it automatically.
 
+### Requirements
+
+`ServerRoot` should be included in a apache conf file. If not present the included configs will not be accessible to the resource.
+
 ### Version
 
 This resource first became available in v1.0.0 of InSpec.

--- a/lib/inspec/resources/apache_conf.rb
+++ b/lib/inspec/resources/apache_conf.rb
@@ -101,12 +101,14 @@ module Inspec::Resources
       include_files_optional = params["IncludeOptional"] || []
 
       includes = []
-      (include_files + include_files_optional).each do |f|
-        id    = Pathname.new(f).absolute? ? f : File.join(conf_dir, f)
-        files = find_files(id, depth: 1, type: "file")
-        files += find_files(id, depth: 1, type: "link")
+      unless conf_dir.nil?
+        (include_files + include_files_optional).each do |f|
+          id    = Pathname.new(f).absolute? ? f : File.join(conf_dir, f)
+          files = find_files(id, depth: 1, type: "file")
+          files += find_files(id, depth: 1, type: "link")
 
-        includes.push(files) if files
+          includes.push(files) if files
+        end
       end
 
       # [].flatten! == nil

--- a/test/fixtures/files/apache2_server_root_void.conf
+++ b/test/fixtures/files/apache2_server_root_void.conf
@@ -1,0 +1,4 @@
+# This is the modified Apache server configuration file.  It contains comments.
+# ServerRoot "/etc/apache2" --> This is commented to test non configuration of serverRoot.
+ServerAlias inspec.test www.inspec.test io.inspec.test 
+Include ports.conf

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -88,7 +88,7 @@ class MockLoader
       mockfile.call("emptyfile")
     }
 
-    mock.files = {
+    mock_files = {
       "/proc/net/bonding/bond0" => mockfile.call("bond0"),
       "/etc/ssh/ssh_config" => mockfile.call("ssh_config"),
       "/etc/ssh/sshd_config" => mockfile.call("sshd_config"),
@@ -118,7 +118,6 @@ class MockLoader
       "nonexistent.json" => mockfile.call("nonexistent.json"),
       "/sys/class/net/br0/bridge" => mockdir.call(true),
       "rootwrap.conf" => mockfile.call("rootwrap.conf"),
-      "/etc/apache2/apache2.conf" => mockfile.call("apache2.conf"),
       "/etc/apache2/ports.conf" => mockfile.call("ports.conf"),
       "/etc/httpd/conf/httpd.conf" => mockfile.call("httpd.conf"),
       "/etc/httpd/conf.d/ssl.conf" => mockfile.call("ssl.conf"),
@@ -174,6 +173,19 @@ class MockLoader
       "/etc/postfix/other.cf" => mockfile.call("other.cf"),
       "/etc/selinux/selinux_conf" => mockfile.call("selinux_conf"),
     }
+
+    if @platform[:name] == "ubuntu" && @platform[:release] == "14.04"
+      mock_files.merge!(
+        "/etc/apache2/apache2.conf" => mockfile.call("apache2.conf")
+      )
+    elsif @platform[:name] == "ubuntu" && @platform[:release] == "15.04"
+      # using this ubuntu version to test apache_conf with non configured server root in conf file
+      mock_files.merge!(
+        "/etc/apache2/apache2.conf" => mockfile.call("apache2_server_root_void.conf")
+      )
+    end
+
+    mock.files = mock_files
 
     # create all mock commands
     cmd = lambda { |x|

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -174,7 +174,7 @@ class MockLoader
       "/etc/selinux/selinux_conf" => mockfile.call("selinux_conf"),
     }
 
-    if @platform[:name] == "ubuntu" && @platform[:release] == "14.04"
+    if @platform[:name] == "ubuntu" && @platform[:release] == "18.04"
       mock_files.merge!(
         "/etc/apache2/apache2.conf" => mockfile.call("apache2.conf")
       )

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -174,15 +174,17 @@ class MockLoader
       "/etc/selinux/selinux_conf" => mockfile.call("selinux_conf"),
     }
 
-    if @platform[:name] == "ubuntu" && @platform[:release] == "18.04"
-      mock_files.merge!(
-        "/etc/apache2/apache2.conf" => mockfile.call("apache2.conf")
-      )
-    elsif @platform[:name] == "ubuntu" && @platform[:release] == "15.04"
-      # using this ubuntu version to test apache_conf with non configured server root in conf file
-      mock_files.merge!(
-        "/etc/apache2/apache2.conf" => mockfile.call("apache2_server_root_void.conf")
-      )
+    if @platform
+      if @platform[:name] == "ubuntu" && @platform[:release] == "18.04"
+        mock_files.merge!(
+          "/etc/apache2/apache2.conf" => mockfile.call("apache2.conf")
+        )
+      elsif @platform[:name] == "ubuntu" && @platform[:release] == "15.04"
+        # using this ubuntu version to test apache_conf with non configured server root in conf file
+        mock_files.merge!(
+          "/etc/apache2/apache2.conf" => mockfile.call("apache2_server_root_void.conf")
+        )
+      end
     end
 
     mock.files = mock_files

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -21,6 +21,15 @@ describe "Inspec::Resources::ApacheConf" do
                                              ENABLE_USR_LIB_CGI_BIN}
   end
 
+  it "reads values successfully from apache2.conf and ignores Include, IncludeOptional params when server root is not configured" do
+    resource = MockLoader.new(:ubuntu1504).load_resource("apache_conf", "/etc/apache2/apache2.conf")
+    _(resource.params).must_be_kind_of Hash
+    _(resource.content).must_be_kind_of String
+    _(resource.params("ServerAlias")).must_equal ["inspec.test www.inspec.test io.inspec.test"]
+    assert_nil(resource.params("ServerRoot"))
+    assert_nil(resource.params("Listen"))
+  end
+
   # non debian style httpd
   it "reads values in httpd.conf and from Include, IncludeOptional params" do
     resource = MockLoader.new(:centos6).load_resource("apache_conf",

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -6,7 +6,7 @@ require "hashie"
 describe "Inspec::Resources::ApacheConf" do
   # debian style apache2
   it "reads values in apache2.conf and from Include, IncludeOptional params" do
-    resource = MockLoader.new(:ubuntu1404).load_resource("apache_conf",
+    resource = MockLoader.new(:ubuntu1804).load_resource("apache_conf",
                                                          "/etc/apache2/apache2.conf")
     _(resource.params).must_be_kind_of Hash
     _(resource.content).must_be_kind_of String


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
**Description**
<!--- Describe your changes in detail, what problems does it solve? -->

### Problem:

Raised following error while running profile using apache_conf in case `ServerRoot` value is not present in the configuration file. 

`Failure Message: Failed to load source for controls/example.rb: no implicit conversion of nil into String`

It was caused because of `nil` value returned by `conf_dir` method which is derived from `ServerRoot` value of conf file.

### Solution

A simple fix of `nil` check solves this problem. But it should be noted that without setting this value in the configuration file, `Include` and `IncludeOptional` params are not accessible to the resource.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5583 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
