### PR TITLE
Remove mention of AWS tests from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,11 +384,10 @@ As a reminder, all participants are expected to follow the [Code of Conduct](htt
 
 ## Testing Chef InSpec
 
-We offer `unit`, `integration`, and `aws` tests.
+We offer `unit` and `integration` tests.
 
 - `unit` tests ensure the intended behaviour of the implementation
 - `integration` tests run against Docker-based VMs via test-kitchen and [kitchen-inspec](https://github.com/chef/kitchen-inspec)
-- `aws` tests exercise the AWS resources against real AWS accounts
 
 ### Unit tests
 


### PR DESCRIPTION
AWS testing is performed in the `inspec-aws` resource pack, not in the inspec core.

This PR is mainly to bump the version.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
