### PR TITLE
Add rocky and almalinux to service resource

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -141,7 +141,7 @@ module Inspec::Resources
         elsif version > 0
           SysV.new(inspec, service_ctl || "/usr/sbin/service")
         end
-      when "redhat", "fedora", "centos", "oracle", "cloudlinux", "scientific"
+      when "redhat", "fedora", "centos", "oracle", "cloudlinux", "scientific", "rocky", "almalinux"
         version = os[:release].to_i
 
         systemd = ((platform != "fedora" && version >= 7) ||


### PR DESCRIPTION
Add support for rockylinux and almalinux to the service resource

## Description
Currently the service resource doesn't support rockylinux and almalinux.

```
  Service chef-client
     ↺  The `service` resource is not supported on your OS yet.
  Service sshd
     ↺  The `service` resource is not supported on your OS yet.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the **CONTRIBUTING** document.
