### PR TITLE
Fix FreeBSD service enabled check substring edge-case

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -504,7 +504,7 @@ module Inspec::Resources
 
       # search for the service
 
-      srv = %r{^.*/#{service_name}$)}.match(cmd.stdout)
+      srv = %r{^.*/(#{service_name}$)}.match(cmd.stdout)
       return nil if srv.nil? || srv[0].nil?
 
       enabled = true

--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -504,7 +504,7 @@ module Inspec::Resources
 
       # search for the service
 
-      srv = /(^.*\/#{service_name}$)/.match(cmd.stdout)
+      srv = %r{^.*/#{service_name}$)}.match(cmd.stdout)
       return nil if srv.nil? || srv[0].nil?
 
       enabled = true

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -640,7 +640,7 @@ class MockLoader
 
     if @platform && (@platform[:name] == "freebsd" && @platform[:release].to_f >= 10)
       mock_cmds.merge!(
-        "service sendmail enabled" => cmd.call("service-sendmail-enabled"),
+        "service sendmail enabled" => cmd.call("service-sendmail-enabled")
       )
     end
 

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -13,6 +13,7 @@ class MockLoader
     debian7: { name: "debian", family: "debian", release: "7", arch: "x86_64" },
     debian8: { name: "debian", family: "debian", release: "8", arch: "x86_64" },
     debian10: { name: "debian", family: "debian", release: "buster/sid", arch: "x86_64" },
+    freebsd9: { name: "freebsd", family: "bsd", release: "9", arch: "amd64" },
     freebsd10: { name: "freebsd", family: "bsd", release: "10", arch: "amd64" },
     freebsd11: { name: "freebsd", family: "bsd", release: "11", arch: "amd64" },
     freebsd12: { name: "freebsd", family: "bsd", release: "12", arch: "amd64" },
@@ -298,7 +299,7 @@ class MockLoader
       "/path/to/systemctl show --no-pager --all dbus" => cmd.call("systemctl-show-all-dbus"),
       # services on macos
       "launchctl list" => cmd.call("launchctl-list"),
-      # services on freebsd 11
+      # services on freebsd 6+
       "service -e" => cmd.call("service-e"),
       "service sendmail onestatus" => cmd.call("service-sendmail-onestatus"),
       # services for system 5 e.g. centos6, debian 6
@@ -635,6 +636,12 @@ class MockLoader
       mock_cmds.delete("/sbin/zpool get -Hp all tank")
       mock_cmds.delete("which zfs")
       mock_cmds.delete("which zpool")
+    end
+
+    if @platform && (@platform[:name] == "freebsd" && @platform[:release].to_f >= 10)
+      mock_cmds.merge!(
+        "service sendmail enabled" => cmd.call("service-sendmail-enabled"),
+      )
     end
 
     mock.commands = mock_cmds

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -268,7 +268,37 @@ describe "Inspec::Resources::Service" do
     _(resource.params.UnitFileState).must_equal "static"
   end
 
-  # freebsd
+  # freebsd 9
+  it "verify freebsd9 service parsing" do
+    resource = MockLoader.new(:freebsd9).load_resource("service", "sendmail")
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal "bsd-init"
+    _(resource.name).must_equal "sendmail"
+    _(resource.description).must_be_nil
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+  end
+
+  it "verify freebsd9 service parsing with default bsd_service" do
+    resource = MockLoader.new(:freebsd9).load_resource("bsd_service", "sendmail")
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal "bsd-init"
+    _(resource.name).must_equal "sendmail"
+    _(resource.description).must_be_nil
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+  end
+
+  it "verify freebsd9 service parsing when one service is a suffix of another" do
+    resource = MockLoader.new(:freebsd9).load_resource("service", "mail") # "mail" is suffix of "sendmail", which is enabled
+    _(resource.enabled?).must_equal false
+  end
+
+  # freebsd 10+
   it "verify freebsd10 service parsing" do
     resource = MockLoader.new(:freebsd10).load_resource("service", "sendmail")
     params = Hashie::Mash.new({})


### PR DESCRIPTION
* Now services named a suffix of another service don't have false positives for being enabled
* Use new 'enabled' service command on FreeBSD 10+

<!--- Provide a short summary of your changes in the Title above -->

## Description

Without this patch, inspec will falsely detect services as enabled on FreeBSD if their name is a suffix of another, enabled, service.

Example:

If `openntpd` is enabled, and `ntpd` is disabled, this check will fail when it shouldn't:

```
describe service('ntpd') do
  it { should_not be_enabled }
end
```

This patch fixes the bug by updating the regular expression used to search the list of enabled services, but it also makes use of the new `enabled` service command that was added in FreeBSD 10 when the detected FreeBSD version is 10 or greater.

When support for FreeBSD 9 is dropped, the old regex method could be removed entirely.

<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
