### PR TITLE
Fix `--chef-license=accept` option to only show license accepted message

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -43,11 +43,15 @@ module Inspec
       begin
         if (allowed_commands & ARGV.map(&:downcase)).empty? && # Did they use a non-exempt command?
             !ARGV.empty? # Did they supply at least one command?
-          LicenseAcceptance::Acceptor.check_and_persist(
+          license_acceptor_output = LicenseAcceptance::Acceptor.check_and_persist(
             Inspec::Dist::EXEC_NAME,
             Inspec::VERSION,
             logger: Inspec::Log
           )
+          if license_acceptor_output && ARGV.count == 1 && (ARGV.first.include? "--chef-license")
+            Inspec::UI.new.exit
+          end
+          license_acceptor_output
         end
       rescue LicenseAcceptance::LicenseNotAcceptedError
         Inspec::Log.error "#{Inspec::Dist::PRODUCT_NAME} cannot execute without accepting the license"


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

**Problem:**

The usage of command `inspec --chef-license=accept` also printed the help command output while it should just print the license acceptance message and quit. 

**Solution:**

A similar check has been placed in the code to make sure it quits after printing the license accept message when no other command/option is present.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #4064 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
