### PR TITLE
Build fix for ruby version 2.5 - HTML Proofer gem installation error 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,11 @@ end
 group :test do
   gem "chefstyle", "~> 2.0.3"
   gem "concurrent-ruby", "~> 1.0"
-  gem "html-proofer", platforms: :ruby # do not attempt to run proofer on windows
+  if Gem.ruby_version.to_s.start_with?("2.5")
+    gem "html-proofer", "= 3.19.1" , platforms: :ruby # do not attempt to run proofer on windows
+  else
+    gem "html-proofer", platforms: :ruby # do not attempt to run proofer on windows
+  end
   gem "json_schemer", ">= 0.2.1", "< 0.2.19"
   gem "m"
   gem "minitest-sprint", "~> 1.0"


### PR DESCRIPTION
Build fix for ruby version 2.5 - HTML Proofer gem installation error 

Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Ruby version 2.5 does not support latest version of HTML proofer gem, hence a supported version of it with ruby 2.5 is defined in Gemfile to fix this. 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5605 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
