### PR TITLE
Pin mongo gem to 2.13.2 to avoid broken symlink

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "train-habitat", "~> 0.1"
   spec.add_dependency "train-aws",     "~> 0.1"
   spec.add_dependency "train-winrm",   "~> 0.2"
-  spec.add_dependency "mongo"
+  spec.add_dependency "mongo", "= 2.13.2" # 2.14 introduces a broken symlink in mongo-2.14.0/spec/support/ocsp
 end


### PR DESCRIPTION
The mongo gem version 2.14.0 introduces a broken symlink in a test file, at `spec/support/ocsp` . 2.13.2 does not include this file. This PR pins to 2.13.2 to fix the omnibus builds.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
