### PR TITLE
Fix postgres_session error Unable to connect to database

### DIFF
--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -46,8 +46,6 @@ module Inspec::Resources
       @host = host || "localhost"
       @port = port || 5432
       raise Inspec::Exceptions::ResourceFailed, "Can't run PostgreSQL SQL checks without authentication." if @user.nil? || @pass.nil?
-
-      test_connection
     end
 
     def query(query, db = [])
@@ -64,10 +62,6 @@ module Inspec::Resources
     end
 
     private
-
-    def test_connection
-      query("select now()\;")
-    end
 
     def escaped_query(query)
       Shellwords.escape(query)

--- a/test/unit/resources/postgres_session_test.rb
+++ b/test/unit/resources/postgres_session_test.rb
@@ -35,7 +35,6 @@ describe "Inspec::Resources::PostgresSession" do
   end
   it "fails when no connection established" do
     resource = load_resource("postgres_session", "postgres", "postgres", "localhost", 5432)
-    _(resource.resource_failed?).must_equal true
-    _(resource.resource_exception_message).must_include "PostgreSQL query with errors"
+    _(proc { resource.send(:query, "Select 5;", ["mydatabase"]) }).must_raise Inspec::Exceptions::ResourceFailed
   end
 end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixed error coming while querying on the database for postgres_session resource.
The User was getting the error as we were querying on the database to check the connection. The query that was getting executed was not using any particular database to connect with due to which by default, Postgres considers that the database with the username exists and tries to query on that, which was throwing error ```database does not exist```  We can't use the default database to check the connection as we don't know that the server's default database(postgres) exists. 

We have added the test_connection method just to query on the Database and see if it's working and raise exceptions. The querying on the database itself is solving that purpose so removed the code which was causing the issue and updated the test.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fix #5599
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
