### PR TITLE
Using 'hab pkg exec'  instead of binlinking

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.sh
+++ b/.expeditor/buildkite/artifact.habitat.test.sh
@@ -45,17 +45,13 @@ if [ -f ./results/last_build.env ]; then
     export pkg_artifact
 fi
 
+
 echo "+++ Installing ${pkg_ident:?is undefined}"
-hab pkg install -b "${project_root:?is undefined}/results/${pkg_artifact:?is undefined}"
+hab pkg install "${project_root:?is undefined}/results/${pkg_artifact:?is undefined}"
 
 echo "--- Removing world readability from /usr/local/bundle"
 chmod go-w /usr/local/bundle
 
 echo "+++ Testing $PLAN"
-
-PATH="$(hab pkg path ci/inspec)/bin:$PATH"
-export PATH
-echo "PATH is $PATH"
-
 pushd "$project_root/test/artifact"
 rake

--- a/test/artifact/artifact_helper.rb
+++ b/test/artifact/artifact_helper.rb
@@ -14,8 +14,8 @@ class ArtifactTest < Minitest::Test
     Open3.capture3(env, cmd, opts)
   end
 
-  def assert_artifact(inspec_command)
-    stdout, stderr, status = run_cmd "inspec #{inspec_command} #{TEST_CLI_OPTS}"
+  def assert_artifact(inspec_command, origin = "ci")
+    stdout, stderr, status = run_cmd "hab pkg exec #{origin}/inspec inspec #{inspec_command} #{TEST_CLI_OPTS}"
 
     assert_empty stderr.sub(/#< CLIXML\n/, "")
     assert stdout


### PR DESCRIPTION
**DRAFT** More as a placeholder at the moment. @mwrock 

Fixing artifact tests when building against the 2021 q2 set of refresh packages. 

## Description
The runtime environment for `core/ruby26` needs to be preserved when calling inspec, requiring the use of `hab pkg exec <origin>/inspec` instead of simply binlinking (`hab pkg install -b`) and calling inspec.

## Related Issue
This issue does not yet exist, as the refreshed packages have not yet been promoted to `stable`, but can be seen [here](https://buildkite.com/chef/inspec-inspec-master-artifact-habitat/builds/2575#74fdac33-7485-40cc-9fa1-fdb4e4ea6a0e/1163-1168). See [inspec-test.log](https://github.com/inspec/inspec/files/7018053/inspec-test.log) for successful tests run outside of CI. 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
