### PR TITLE
Fix merging of included conf and main conf params in apache conf 

### DIFF
--- a/lib/inspec/resources/apache_conf.rb
+++ b/lib/inspec/resources/apache_conf.rb
@@ -82,7 +82,7 @@ module Inspec::Resources
           end
         end
 
-        @params.merge!(params)
+        @params.merge!(params) { |key, current_val, new_val| [*current_val].to_a + [*new_val].to_a }
 
         to_read = to_read.drop(1)
         to_read += include_files(params).find_all do |fp|


### PR DESCRIPTION

Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Bug fix in `apache_conf` resource for including all the configurations of main and included conf files. It was not merging all the values and the data was getting lost of all the configurations.

- Test cases not included since already included unit test cases are valid for that. Have done manual testing for this.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5319 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
