### PR TITLE
Proposed implementation for installation warnings

### DIFF
--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -397,14 +397,14 @@ module InspecPlugins
         elsif what_we_would_install_is_already_installed && !they_explicitly_asked_for_a_version
           ui.red("Plugin already installed at latest version - plugin " \
                  "#{plugin_name} #{requested_version} - refusing to install.\n")
-        else
-          # There are existing versions installed, but none of them are what was requested
-          ui.red("Update required - plugin #{plugin_name}, requested " \
-                 "#{requested_version}, have " \
-                 "#{pre_installed_versions.join(", ")}; use `inspec " \
-                 "plugin update` - refusing to install.\n")
+          ui.exit Inspec::UI::EXIT_NORMAL
         end
 
+        # There are existing versions installed, but none of them are what was requested
+        ui.red("Update required - plugin #{plugin_name}, requested " \
+               "#{requested_version}, have " \
+               "#{pre_installed_versions.join(", ")}; use `inspec " \
+               "plugin update` - refusing to install.\n")
         ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
       end
 

--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -232,10 +232,10 @@ module InspecPlugins
 
         # Already installed?
         if registry.known_plugin?(plugin_name.to_sym)
-          ui.red("Plugin already installed - #{plugin_name} - Use '#{EXEC_NAME} " \
-                 "plugin list' to see previously installed plugin - " \
-                 "installation failed.\n")
-          ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
+          ui.bold("Plugin already installed - #{plugin_name} - Use '#{EXEC_NAME} " \
+                  "plugin list' to see previously installed plugin - " \
+                  "installation failed.\n")
+          ui.exit Inspec::UI::EXIT_NORMAL
         end
 
         # Can we figure out how to load it?
@@ -391,8 +391,9 @@ module InspecPlugins
         they_explicitly_asked_for_a_version = !options[:version].nil?
         what_we_would_install_is_already_installed = pre_installed_versions.include?(requested_version)
         if what_we_would_install_is_already_installed && they_explicitly_asked_for_a_version
-          ui.red("Plugin already installed at requested version - plugin " \
+          ui.bold("Plugin already installed at requested version - plugin " \
                  "#{plugin_name} #{requested_version} - refusing to install.\n")
+          ui.exit Inspec::UI::EXIT_NORMAL
         elsif what_we_would_install_is_already_installed && !they_explicitly_asked_for_a_version
           ui.red("Plugin already installed at latest version - plugin " \
                  "#{plugin_name} #{requested_version} - refusing to install.\n")
@@ -462,10 +463,10 @@ module InspecPlugins
         latest_version = latest_version[plugin_name]&.last
 
         if pre_update_versions.include?(latest_version)
-          ui.plain_line("#{ui.red("Already installed at latest version:", print: false)} " \
+          ui.plain_line("#{ui.bold("Already installed at latest version:", print: false)} " \
                    "#{plugin_name} is at #{latest_version}, which the " \
                    "latest - refusing to update")
-          ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
+          ui.exit Inspec::UI::EXIT_NORMAL
         end
       end
 

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
@@ -131,7 +131,7 @@ class PluginManagerCliInstall < Minitest::Test
 
     assert_empty install_result.stderr
 
-    assert_exit_code 2, install_result
+    assert_exit_code 0, install_result
   end
 
   def test_fail_install_from_path_when_the_dir_structure_is_wrong
@@ -268,7 +268,7 @@ class PluginManagerCliInstall < Minitest::Test
 
     assert_empty install_result.stderr
 
-    assert_exit_code 2, install_result
+    assert_exit_code 0, install_result
   end
 
   def test_refuse_install_when_already_installed_can_update

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/update_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/update_test.rb
@@ -46,7 +46,7 @@ class PluginManagerCliUpdate < Minitest::Test
 
     assert_empty update_result.stderr
 
-    assert_exit_code 2, update_result
+    assert_exit_code 0, update_result
   end
 
   def test_fail_update_from_nonexistant_gem


### PR DESCRIPTION
## Description

Exit code `0` when plugin is already installed in correct version, instead of `2`.

## Related Issue

Proposed implementation for #5624 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
