### PR TITLE
Fix for security_policy resource does not return array for local groups

### DIFF
--- a/lib/inspec/resources/security_policy.rb
+++ b/lib/inspec/resources/security_policy.rb
@@ -147,7 +147,7 @@ module Inspec::Resources
 
     # extracts the values, this methods detects:
     # numbers and SIDs and optimizes them for further usage
-    def extract_value(val)
+    def extract_value(key, val)
       if val =~ /^\d+$/
         val.to_i
       # special handling for SID array
@@ -166,14 +166,15 @@ module Inspec::Resources
       elsif !(m = /^\"(.*)\"$/.match(val)).nil?
         m[1]
       else
-        val
+        # When there is Registry Values we are not spliting the value for backward compatibility
+        key.include?("\\") ? val : val.split(",")
       end
     end
 
     def convert_hash(hash)
       new_hash = {}
       hash.each do |k, v|
-        v.is_a?(Hash) ? value = convert_hash(v) : value = extract_value(v)
+        v.is_a?(Hash) ? value = convert_hash(v) : value = extract_value(k, v)
         new_hash[k.strip] = value
       end
       new_hash

--- a/test/fixtures/cmd/secedit-export
+++ b/test/fixtures/cmd/secedit-export
@@ -5,3 +5,4 @@ MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Setup\RecoveryConsole\Secur
 [Privilege Rights]
 SeUndockPrivilege = *S-1-5-32-544
 SeRemoteInteractiveLogonRight = *S-1-5-32-544,*S-1-5-32-555
+SeServiceLogonRight = DB2ADMNS,db2admin

--- a/test/unit/resources/security_policy_test.rb
+++ b/test/unit/resources/security_policy_test.rb
@@ -11,6 +11,7 @@ describe "Inspec::Resources::SecurityPolicy" do
     _(resource.send('MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Setup\RecoveryConsole\SecurityLevel')).must_equal "4,0"
     _(resource.SeUndockPrivilege).must_equal ["S-1-5-32-544"]
     _(resource.SeRemoteInteractiveLogonRight).must_equal ["S-1-5-32-544", "S-1-5-32-555"]
+    _(resource.SeServiceLogonRight).must_equal %w{ DB2ADMNS db2admin }
   end
 
   it "parse empty policy file" do
@@ -33,5 +34,6 @@ describe "Inspec::Resources::SecurityPolicy" do
     _(resource.send('MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Setup\RecoveryConsole\SecurityLevel')).must_equal "4,0"
     _(resource.SeUndockPrivilege).must_equal ["BUILTIN\\Administrators"]
     _(resource.SeRemoteInteractiveLogonRight).must_equal ["BUILTIN\\Administrators", "S-1-5-32-555"]
+    _(resource.SeServiceLogonRight).must_equal %w{ DB2ADMNS db2admin }
   end
 end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
security_policy resource was not returning values in array format when Privilege rights contain any local groups only. This is fixed in this PR.

So when any security policy for privilege rights containing only local group it does not contain the SID for example values are like below
`SeServiceLogonRight = DB2ADMNS,db2admin`

Where as if there are values other than local group then values are 
`SeServiceLogonRight = DB2ADMNS,db2admin,*S-1-5-80-0`



## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fix #5627 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
