### PR TITLE
Fix url fetcher when default git profile branch is not master

### DIFF
--- a/lib/inspec/fetcher/url.rb
+++ b/lib/inspec/fetcher/url.rb
@@ -74,15 +74,17 @@ module Inspec::Fetcher
     BITBUCKET_URL_REGEX = %r{^https?://(www\.)?bitbucket\.org/(?<user>[\w-]+)/(?<repo>[\w-]+)(\.git)?(/)?$}.freeze
     BITBUCKET_URL_BRANCH_REGEX = %r{^https?://(www\.)?bitbucket\.org/(?<user>[\w-]+)/(?<repo>[\w-]+)/branch/(?<branch>[\w\.]+)(/)?$}.freeze
     BITBUCKET_URL_COMMIT_REGEX = %r{^https?://(www\.)?bitbucket\.org/(?<user>[\w-]+)/(?<repo>[\w-]+)/commits/(?<commit>[\w\.]+)(/)?$}.freeze
+    GITHUB_URL = "https://github.com".freeze
+    BITBUCKET_URL = "https://bitbucket.org".freeze
 
     def self.transform(target)
       transformed_target = if m = GITHUB_URL_REGEX.match(target) # rubocop:disable Lint/AssignmentInCondition
-                             default_branch = default_ref(m)
+                             default_branch = default_ref(m, GITHUB_URL)
                              "https://github.com/#{m[:user]}/#{m[:repo]}/archive/#{default_branch}.tar.gz"
                            elsif m = GITHUB_URL_WITH_TREE_REGEX.match(target) # rubocop:disable Lint/AssignmentInCondition
                              "https://github.com/#{m[:user]}/#{m[:repo]}/archive/#{m[:commit]}.tar.gz"
                            elsif m = BITBUCKET_URL_REGEX.match(target) # rubocop:disable Lint/AssignmentInCondition
-                             default_branch = default_ref(m)
+                             default_branch = default_ref(m, BITBUCKET_URL)
                              "https://bitbucket.org/#{m[:user]}/#{m[:repo]}/get/#{default_branch}.tar.gz"
                            elsif m = BITBUCKET_URL_BRANCH_REGEX.match(target) # rubocop:disable Lint/AssignmentInCondition
                              "https://bitbucket.org/#{m[:user]}/#{m[:repo]}/get/#{m[:branch]}.tar.gz"
@@ -129,8 +131,8 @@ module Inspec::Fetcher
     private
 
     class << self
-      def default_ref(match_data)
-        remote_url = "https://github.com/#{match_data[:user]}/#{match_data[:repo]}.git"
+      def default_ref(match_data, repo_url)
+        remote_url = "#{repo_url}/#{match_data[:user]}/#{match_data[:repo]}.git"
         command_string = "git remote show #{remote_url}"
         cmd = shellout(command_string)
         unless cmd.exitstatus == 0

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -18,6 +18,20 @@ describe Inspec::Fetcher::Url do
       m
     end
 
+    let(:git_remote_head_main) do
+      out = mock
+      out.stubs(:stdout).returns("HEAD branch: main\n")
+      out.stubs(:exitstatus).returns(0)
+      out.stubs(:stderr).returns("")
+      out.stubs(:error!).returns(false)
+      out.stubs(:run_command).returns(true)
+      out
+    end
+
+    def expect_git_remote_head_main(remote_url)
+      Mixlib::ShellOut.expects(:new).returns(git_remote_head_main)
+    end
+
     def expect_url_transform
       @mock_logger = Minitest::Mock.new
       @mock_logger.expect(:warn, nil, [/URL target.*transformed/])
@@ -116,6 +130,7 @@ describe Inspec::Fetcher::Url do
        http://www.bitbucket.org/chef/inspec.git}.each do |bitbucket|
          it "resolves a bitbucket url #{bitbucket}" do
            expect_url_transform do
+             expect_git_remote_head_main(bitbucket)
              res = Inspec::Fetcher::Url.resolve(bitbucket)
              res.expects(:open).returns(mock_open)
              _(res).wont_be_nil

--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -72,7 +72,7 @@ describe Inspec::Fetcher::Url do
              res = Inspec::Fetcher::Url.resolve(github)
              res.expects(:open).returns(mock_open)
              _(res).wont_be_nil
-             _(res.resolved_source).must_equal({ url: "https://github.com/chef/inspec/archive/master.tar.gz", sha256: expected_shasum })
+             _(res.resolved_source).must_equal({ url: "https://github.com/chef/inspec/archive/main.tar.gz", sha256: expected_shasum })
            end
          end
        end
@@ -119,7 +119,7 @@ describe Inspec::Fetcher::Url do
              res = Inspec::Fetcher::Url.resolve(bitbucket)
              res.expects(:open).returns(mock_open)
              _(res).wont_be_nil
-             _(res.resolved_source).must_equal({ url: "https://bitbucket.org/chef/inspec/get/master.tar.gz", sha256: expected_shasum })
+             _(res.resolved_source).must_equal({ url: "https://bitbucket.org/chef/inspec/get/main.tar.gz", sha256: expected_shasum })
            end
          end
        end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix url fetcher when default git profile branch is not master

**Needs strict code review on this**
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5635 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
