### PR TITLE
Remove license note + update resource count in main docs page

### DIFF
--- a/docs-chef-io/content/inspec/_index.md
+++ b/docs-chef-io/content/inspec/_index.md
@@ -16,13 +16,6 @@ gh_repo = "inspec"
 
 Chef InSpec is an open-source framework for testing and auditing your applications and infrastructure. Chef InSpec works by comparing the actual state of your system with the desired state that you express in easy-to-read and easy-to-write Chef InSpec code. Chef InSpec detects violations and displays findings in the form of a report, but puts you in control of remediation.
 
-{{< note >}}
-
-Versions of Chef InSpec 4.0 and later require accepting the EULA. Please
-visit the [license acceptance page](/chef_license_accept/) for more information.
-
-{{< /note >}}
-
 ## Getting started with Chef InSpec
 
 Below are some of the core concepts that make up Chef InSpec.
@@ -40,7 +33,7 @@ including tests from the [Chef Supermarket](https://supermarket.chef.io/)
 or by adding tests from the [Dev-Sec Project](http://dev-sec.io/) as dependencies.
 You can also customize your tests--pulling in the tests from our Supermarket and
 change them to suit your unique needs with the easy-to-read and easy-to-write Chef
-InSpec domain specific language.
+InSpec language.
 
 ### Target your system
 
@@ -52,6 +45,6 @@ InSpec to target applications and services running on AWS and Azure.
 
 ### Resources
 
-Chef InSpec has 80+ [resources](/inspec/resources/) ready use--apache to zfs pool.
+Chef InSpec nearly 500 [resources](/inspec/resources/) ready use--Apache2 to ZFS pool.
 If you need a solution that we haven’t provided, you can write your own [custom
 resource](/inspec/dsl_resource/).


### PR DESCRIPTION
This is not the place to throw a weird licensing reminder and we have
500 resources not 80.

Signed-off-by: Tim Smith <tsmith@chef.io>