### PR TITLE
Build - Fix cannot load such file -- aws-sdk-batch (LoadError)

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   # Train plugins we ship with InSpec
   spec.add_dependency "train-habitat", "~> 0.1"
-  spec.add_dependency "train-aws",     "~> 0.1"
+  spec.add_dependency "train-aws",     "~> 0.2"
   spec.add_dependency "train-winrm",   "~> 0.2"
   spec.add_dependency "mongo", "= 2.13.2" # 2.14 introduces a broken symlink in mongo-2.14.0/spec/support/ocsp
 end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The build for ruby 2.7 is failing with the following error 
```
Expected "/Users/workspace/inspec/lib/inspec/dsl_shared.rb:33:in `require': cannot load such file -- aws-sdk-batch (LoadError)\n\tfrom /Users/workspace/inspec/lib/inspec/dsl_shared.rb:33:in 
`require'\n\tfrom libraries/aws_backend.rb:4:in `create'\n\tfrom /Users/workspace/inspec/lib/inspec/dsl_shared.rb:47:in `eval'\n\tfrom /Users/workspace/inspec/lib/inspec/dsl_shared.rb:47:in 
`require'\n\tfrom libraries/aws_alb.rb:3:in `load_with_context'\n\tfrom /Users/workspace/inspec/lib/inspec/profile_context.rb:170:in `instance_eval'\n\tfrom 
/Users/workspace/inspec/lib/inspec/profile_context.rb:170:in 
`load_with_context'\n\tfrom 
/Users/workspace/inspec/lib/inspec/profile_context.rb:159:in `load_library_file'\n\tfrom 
/Users/workspace/inspec/lib/inspec/profile_context.rb:144:in `block in load_libraries'\n\tfrom 
/Users/workspace/inspec/lib/inspec/profile_context.rb:143:in `each'\n\tfrom /Users/workspace/inspec/lib/inspec/profile_context.rb:143:in `load_libraries'\n\tfrom 
/Users/workspace/inspec/lib/inspec/profile.rb:314:in `load_libraries'\n\tfrom 
/Users/workspace/inspec/lib/inspec/profile.rb:307:in `block in load_libraries'\n\tfrom 
/Users/workspace/inspec/lib/inspec/profile.rb:288:in `each'\n\tfrom /Users/workspace/inspec/lib/inspec/profile.rb:288:in `each_with_index'\n\tfrom /Users/workspace/inspec/lib/inspec/profile.rb:288:in `load_libraries'\n\tfrom 
/Users/workspace/inspec/lib/inspec/runner.rb:108:in `block in load'\n\tfrom 
/Users/workspace/inspec/lib/inspec/runner.rb:102:in `each'\n\tfrom 
/Users/workspace/inspec/lib/inspec/runner.rb:102:in `load'\n\tfrom 
/Users/workspace/inspec/lib/inspec/runner.rb:136:in `run'\n\tfrom /Users/workspace/inspec/lib/inspec/cli.rb:287:in `exec'\n\tfrom /Users/.rvm/gems/ruby-2.7.1/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'\n\tfrom 
/Users/.rvm/gems/ruby-2.7.1/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'\n\tfrom /Users/.rvm/gems/ruby-2.7.1/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'\n\tfrom 
/Users/.rvm/gems/ruby-2.7.1/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'\n\tfrom 
/Users/workspace/inspec/lib/inspec/base_cli.rb:35:in `start'\n\tfrom /Users/workspace/inspec/inspec-bin/bin/inspec:11:in `<main>'\n" to be empty.
```
Upgrading train-aws resolves that.
#5626  is the same issue and should fix that
## Related Issue
Fix #5626 
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
