### PR TITLE
Replace deprecated --without flag with bundle config

### DIFF
--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -5,7 +5,8 @@ ruby -v
 bundle --version
 
 echo "--- bundle install"
-bundle install --jobs=7 --retry=3 --without tools maintenance deploy
+bundle config set --local without tools maintenance deploy
+bundle install --jobs=7 --retry=3
 
 echo "+++ bundle exec rake test:parallel"
 bundle exec rake test:parallel K=4

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -25,7 +25,8 @@ pull_bundle
 
 echo "--- bundle"
 bundle config --local path vendor/bundle
-bundle install --jobs=7 --retry=3 --without tools maintenance deploy
+bundle config set --local without tools maintenance deploy
+bundle install --jobs=7 --retry=3
 
 echo "--- push bundle cache"
 push_bundle

--- a/.expeditor/buildkite/wwwrelease.sh
+++ b/.expeditor/buildkite/wwwrelease.sh
@@ -7,7 +7,8 @@ set -ue
 echo "--- bundle install"
 
 cd www
-bundle install --jobs=7 --retry=3 --without tools maintenance deploy
+bundle config set --local without tools maintenance deploy
+bundle install --jobs=7 --retry=3
 
 echo "+++ bundle exec rake"
 bundle exec rake www V=1 PUSH=1

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -9,7 +9,7 @@ gem "ffi", ">= 1.9.14", "!= 1.13.0"
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need
 # the Test Kitchen-based build lab. You can skip these unnecessary dependencies
-# by running `bundle install --without development` to speed up build times.
+# by running `bundle config set --local without development` to speed up build times.
 group :development do
   # Use Berkshelf for resolving cookbook dependencies
   gem "berkshelf", ">= 7.0"

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -121,7 +121,8 @@ $ bundle exec kitchen converge i386```
 # Now inside the kitchen vm, open a cmd/ps shell
 $ C:\vagrant\load-omnibus-toolchain.ps1 # (or .bar if you're on cmd)
 $ cd C:\vagrant\code\inspec\omnibus
-$ bundle install --without development
+$ bundle config set --local without development
+$ bundle install
 $ bundle exec omnibus build inspec -l debug
 
 # If you get a 'can't sign this msi because I don't have a key to do so' error

--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -35,7 +35,8 @@ build do
 
   # We bundle install to ensure the versions of gems we are going to
   # appbundle-lock to are definitely installed
-  bundle "install --without test integration tools maintenance", env: env
+  bundle "config set --local without test integration tools maintenance", env: env
+  bundle "install", env: env
 
   gem "build #{name}-core.gemspec", env: env
   gem "install #{name}-core*.gem --no-document", env: env


### PR DESCRIPTION
Replacing **--without** flag with **bundle config** to get rid of bundler deprecated warning :

[DEPRECATED] The --without flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set without 'development doc', and stop using this flag



Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
