### PR TITLE
Fix --controls option was not working for dependent profile

### DIFF
--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -226,6 +226,11 @@ module Inspec
       id_exist_in_list
     end
 
+    # Returns true if configuration hash is empty or configuration hash does not have the list of controls that needs to be included
+    def controls_list_empty?
+      !@conf.empty? && @conf.key?("profile") && @conf["profile"].include_controls_list.empty? || @conf.empty?
+    end
+
     private
 
     def block_location(block, alternate_caller)
@@ -244,47 +249,6 @@ module Inspec
 
     def profile_tag_config_exist?
       !@conf.empty? && @conf.key?("profile") && !@conf["profile"].include_tags_list.empty?
-    end
-
-    # Returns true if configuration hash is empty or configuration hash does not have the list of controls that needs to be included
-    def controls_list_empty?
-      !@conf.empty? && @conf.key?("profile") && @conf["profile"].include_controls_list.empty? || @conf.empty?
-    end
-
-    # Check if the given control exist in the --controls option
-    def control_exist_in_controls_list?(id)
-      id_exist_in_list = false
-      if profile_config_exist?
-        id_exist_in_list = @conf["profile"].include_controls_list.any? do |inclusion|
-          # Try to see if the inclusion is a regex, and if it matches
-          inclusion == id || (inclusion.is_a?(Regexp) && inclusion =~ id)
-        end
-      end
-      id_exist_in_list
-    end
-
-    def tags_list_empty?
-      !@conf.empty? && @conf.key?("profile") && @conf["profile"].include_tags_list.empty? || @conf.empty?
-    end
-
-    # Check if the given control exist in the --tags option
-    def tag_exist_in_control_tags?(tag_ids)
-      tag_option_matches_with_list = false
-      if !tag_ids.empty? && !tag_ids.nil? && profile_tag_config_exist?
-        tag_option_matches_with_list = !(tag_ids & @conf["profile"].include_tags_list).empty?
-        unless tag_option_matches_with_list
-          @conf["profile"].include_tags_list.any? do |inclusion|
-            # Try to see if the inclusion is a regex, and if it matches
-            if inclusion.is_a?(Regexp)
-              tag_ids.each do |id|
-                tag_option_matches_with_list = (inclusion =~ id)
-                break if tag_option_matches_with_list
-              end
-            end
-          end
-        end
-      end
-      tag_option_matches_with_list
     end
   end
 end

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -214,6 +214,18 @@ module Inspec
       !@conf.empty? && @conf.key?("profile") && @conf["profile"].include_tags_list.empty? || @conf.empty?
     end
 
+    # Check if the given control exist in the --controls option
+    def control_exist_in_controls_list?(id)
+      id_exist_in_list = false
+      if profile_config_exist?
+        id_exist_in_list = @conf["profile"].include_controls_list.any? do |inclusion|
+          # Try to see if the inclusion is a regex, and if it matches
+          inclusion == id || (inclusion.is_a?(Regexp) && inclusion =~ id)
+        end
+      end
+      id_exist_in_list
+    end
+
     private
 
     def block_location(block, alternate_caller)
@@ -249,6 +261,30 @@ module Inspec
         end
       end
       id_exist_in_list
+    end
+
+    def tags_list_empty?
+      !@conf.empty? && @conf.key?("profile") && @conf["profile"].include_tags_list.empty? || @conf.empty?
+    end
+
+    # Check if the given control exist in the --tags option
+    def tag_exist_in_control_tags?(tag_ids)
+      tag_option_matches_with_list = false
+      if !tag_ids.empty? && !tag_ids.nil? && profile_tag_config_exist?
+        tag_option_matches_with_list = !(tag_ids & @conf["profile"].include_tags_list).empty?
+        unless tag_option_matches_with_list
+          @conf["profile"].include_tags_list.any? do |inclusion|
+            # Try to see if the inclusion is a regex, and if it matches
+            if inclusion.is_a?(Regexp)
+              tag_ids.each do |id|
+                tag_option_matches_with_list = (inclusion =~ id)
+                break if tag_option_matches_with_list
+              end
+            end
+          end
+        end
+      end
+      tag_option_matches_with_list
     end
   end
 end

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -93,8 +93,12 @@ module Inspec::DSL
     context = dep_entry.profile.runner_context
     # if we don't want all the rules, then just make 1 pass to get all rule_IDs
     # that we want to keep from the original
+<<<<<<< HEAD
     filter_included_controls(context, dep_entry.profile, opts, &block) if !opts[:include_all] || !(opts[:conf]["profile"].include_tags_list.empty?)
 
+=======
+    filter_included_controls(context, dep_entry.profile, opts, &block) if !opts[:include_all] || !opts[:conf]["profile"].include_controls_list.empty?
+>>>>>>> 9b8307fc0 (Fix - controls option was not working for depedent profile)
     # interpret the block and skip/modify as required
     context.load(block) if block_given?
     bind_context.add_subcontext(context)
@@ -104,13 +108,24 @@ module Inspec::DSL
     mock = Inspec::Backend.create(Inspec::Config.mock)
     include_ctx = Inspec::ProfileContext.for_profile(profile, mock)
     include_ctx.load(block) if block_given?
+<<<<<<< HEAD
     include_ctx.control_eval_context.conf = opts[:conf]
+=======
+    # this sets the conf variable required in control_exist_in_control_list? method
+    include_ctx.control_eval_context.instance_variable_set(:@conf, opts[:conf])
+>>>>>>> 9b8307fc0 (Fix - controls option was not working for depedent profile)
     control_eval_ctx = include_ctx.control_eval_context
     # remove all rules that were not registered
     context.all_rules.each do |r|
       id = Inspec::Rule.rule_id(r)
       fid = Inspec::Rule.profile_id(r) + "/" + id
       if !opts[:include_all] && !(include_ctx.rules[id] || include_ctx.rules[fid])
+<<<<<<< HEAD
+=======
+        context.remove_rule(fid)
+      elsif !control_eval_ctx.control_exist_in_controls_list?(id)
+      # filter the dependent profile controls which are not in the --controls options list
+>>>>>>> 9b8307fc0 (Fix - controls option was not working for depedent profile)
         context.remove_rule(fid)
       elsif !control_eval_ctx.tags_list_empty?
         # filter included controls using --tags

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -199,9 +199,9 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     assert_exit_code 0, out
   end
 
-  # it filters the control from its depedent profile_c
+  # it filters the control from its dependent profile_c
   it "executes only specified controls from parent and child profile when selecting the controls by regex" do
-    inspec("exec " + File.join(profile_path, "dependencies/profile_a") + " --no-create-lockfile --controls '/^profilec/'")
+    inspec("exec " + File.join(profile_path, "dependencies", "profile_a") + " --no-create-lockfile --controls '/^profilec/'")
     _(out.stdout).must_include "profilec-1"
     _(out.stdout).wont_include "profilea-1"
     _(out.stdout).wont_include "only-describe"
@@ -210,9 +210,9 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     assert_exit_code 0, out
   end
 
-  # it filters the control from its depedent profile_c
+  # it filters the control from its dependent profile_c
   it "executes only specified controls from parent and child profile when selecting the controls by id" do
-    inspec("exec " + File.join(profile_path, "dependencies/profile_a") + " --no-create-lockfile --controls 'profilec-1'")
+    inspec("exec " + File.join(profile_path, "dependencies", "profile_a") + " --no-create-lockfile --controls 'profilec-1'")
     _(out.stdout).must_include "profilec-1"
     _(out.stdout).wont_include "profilea-1"
     _(out.stdout).wont_include "only-describe"
@@ -221,11 +221,23 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     assert_exit_code 0, out
   end
 
-  # it filters the control from its depedent profile_c
+  # it filters the control from its dependent profile_c
   it "executes only specified controls from parent and child profile when selecting the controls by space seprated id" do
-    inspec("exec " + File.join(profile_path, "dependencies/profile_a") + " --no-create-lockfile --controls 'profilec-1' 'profilea-1'")
+    inspec("exec " + File.join(profile_path, "dependencies", "profile_a") + " --no-create-lockfile --controls 'profilec-1' 'profilea-1'")
     _(out.stdout).must_include "profilec-1"
     _(out.stdout).must_include "profilea-1"
+    _(out.stdout).wont_include "profilea-2"
+    _(out.stdout).wont_include "only-describe"
+    _(stderr).must_equal ""
+
+    assert_exit_code 0, out
+  end
+
+  # it filters the control from its dependent profile_c
+  it "executes only specified controls of required dependent profile when selecting the controls by space seprated id" do
+    inspec("exec " + File.join(profile_path, "dependencies", "require_controls_test") + " --no-create-lockfile --controls 'profileb-2'")
+    _(out.stdout).must_include "profileb-2"
+    _(out.stdout).wont_include "profilea-1"
     _(out.stdout).wont_include "profilea-2"
     _(out.stdout).wont_include "only-describe"
     _(stderr).must_equal ""

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -199,6 +199,40 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     assert_exit_code 0, out
   end
 
+  # it filters the control from its depedent profile_c
+  it "executes only specified controls from parent and child profile when selecting the controls by regex" do
+    inspec("exec " + File.join(profile_path, "dependencies/profile_a") + " --no-create-lockfile --controls '/^profilec/'")
+    _(out.stdout).must_include "profilec-1"
+    _(out.stdout).wont_include "profilea-1"
+    _(out.stdout).wont_include "only-describe"
+    _(stderr).must_equal ""
+
+    assert_exit_code 0, out
+  end
+
+  # it filters the control from its depedent profile_c
+  it "executes only specified controls from parent and child profile when selecting the controls by id" do
+    inspec("exec " + File.join(profile_path, "dependencies/profile_a") + " --no-create-lockfile --controls 'profilec-1'")
+    _(out.stdout).must_include "profilec-1"
+    _(out.stdout).wont_include "profilea-1"
+    _(out.stdout).wont_include "only-describe"
+    _(stderr).must_equal ""
+
+    assert_exit_code 0, out
+  end
+
+  # it filters the control from its depedent profile_c
+  it "executes only specified controls from parent and child profile when selecting the controls by space seprated id" do
+    inspec("exec " + File.join(profile_path, "dependencies/profile_a") + " --no-create-lockfile --controls 'profilec-1' 'profilea-1'")
+    _(out.stdout).must_include "profilec-1"
+    _(out.stdout).must_include "profilea-1"
+    _(out.stdout).wont_include "profilea-2"
+    _(out.stdout).wont_include "only-describe"
+    _(stderr).must_equal ""
+
+    assert_exit_code 0, out
+  end
+
   it "executes only specified controls when selecting passing controls by literal names" do
     inspec("exec " + File.join(profile_path, "filter_table") + " --no-create-lockfile --controls 2943_pass_undeclared_field_in_hash 2943_pass_irregular_row_key")
 


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- This fix the filtering not working for the dependent profile with `--controls` options
- Tested the same for `include_controls` and `require_controls`
- Tested the profile_a > profile_b > profile_c > profile_d >profile_e
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fix #5647 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
