### PR TITLE
Fix --tags filter for dependent profiles

### DIFF
--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -18,6 +18,7 @@ module Inspec
     attr_accessor :skip_file
     attr_accessor :profile_context
     attr_accessor :resources_dsl
+    attr_accessor :conf
 
     def initialize(profile_context, resources_dsl, backend, conf, dependencies, require_loader, skip_only_if_eval)
       @profile_context = profile_context

--- a/lib/inspec/control_eval_context.rb
+++ b/lib/inspec/control_eval_context.rb
@@ -189,6 +189,30 @@ module Inspec
       @skip_file = true
     end
 
+    # Check if the given control exist in the --tags option
+    def tag_exist_in_control_tags?(tag_ids)
+      tag_option_matches_with_list = false
+      if !tag_ids.empty? && !tag_ids.nil? && profile_tag_config_exist?
+        tag_option_matches_with_list = !(tag_ids & @conf["profile"].include_tags_list).empty?
+        unless tag_option_matches_with_list
+          @conf["profile"].include_tags_list.any? do |inclusion|
+            # Try to see if the inclusion is a regex, and if it matches
+            if inclusion.is_a?(Regexp)
+              tag_ids.each do |id|
+                tag_option_matches_with_list = (inclusion =~ id)
+                break if tag_option_matches_with_list
+              end
+            end
+          end
+        end
+      end
+      tag_option_matches_with_list
+    end
+
+    def tags_list_empty?
+      !@conf.empty? && @conf.key?("profile") && @conf["profile"].include_tags_list.empty? || @conf.empty?
+    end
+
     private
 
     def block_location(block, alternate_caller)
@@ -214,10 +238,6 @@ module Inspec
       !@conf.empty? && @conf.key?("profile") && @conf["profile"].include_controls_list.empty? || @conf.empty?
     end
 
-    def tags_list_empty?
-      !@conf.empty? && @conf.key?("profile") && @conf["profile"].include_tags_list.empty? || @conf.empty?
-    end
-
     # Check if the given control exist in the --controls option
     def control_exist_in_controls_list?(id)
       id_exist_in_list = false
@@ -228,26 +248,6 @@ module Inspec
         end
       end
       id_exist_in_list
-    end
-
-    # Check if the given control exist in the --tags option
-    def tag_exist_in_control_tags?(tag_ids)
-      tag_option_matches_with_list = false
-      if !tag_ids.empty? && !tag_ids.nil? && profile_tag_config_exist?
-        tag_option_matches_with_list = !(tag_ids & @conf["profile"].include_tags_list).empty?
-        unless tag_option_matches_with_list
-          @conf["profile"].include_tags_list.any? do |inclusion|
-            # Try to see if the inclusion is a regex, and if it matches
-            if inclusion.is_a?(Regexp)
-              tag_ids.each do |id|
-                tag_option_matches_with_list = (inclusion =~ id)
-                break if tag_option_matches_with_list
-              end
-            end
-          end
-        end
-      end
-      tag_option_matches_with_list
     end
   end
 end

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -104,7 +104,7 @@ module Inspec::DSL
     mock = Inspec::Backend.create(Inspec::Config.mock)
     include_ctx = Inspec::ProfileContext.for_profile(profile, mock)
     include_ctx.load(block) if block_given?
-    include_ctx.control_eval_context.instance_variable_set(:@conf, opts[:conf])
+    include_ctx.control_eval_context.conf = opts[:conf]
     control_eval_ctx = include_ctx.control_eval_context
     # remove all rules that were not registered
     context.all_rules.each do |r|

--- a/test/fixtures/profiles/dependencies/profile_a/controls/example.rb
+++ b/test/fixtures/profiles/dependencies/profile_a/controls/example.rb
@@ -14,12 +14,14 @@ control 'profilea-1' do                        # A unique ID for this control
   impact 0.7                                # The criticality, if this control fails.
   title 'Create / directory'             # A human-readable title
   desc 'An optional description...'
+  tag "tag-profilea1"
   describe file('/') do                  # The actual test
     it { should be_directory }
   end
 end
 
 control 'profilea-2' do
+  tag "tag-profilea2"
   describe example_config do
     its('version') { should eq('1.0') }
   end

--- a/test/fixtures/profiles/dependencies/profile_b/controls/example.rb
+++ b/test/fixtures/profiles/dependencies/profile_b/controls/example.rb
@@ -8,12 +8,14 @@ control 'profileb-1' do                        # A unique ID for this control
   impact 0.7                                # The criticality, if this control fails.
   title 'Create / directory'             # A human-readable title
   desc 'An optional description...'
+  tag "tag-profileb1"
   describe file('/') do                  # The actual test
     it { should be_directory }
   end
 end
 
 control 'profileb-2' do
+  tag "tag-profileb2"
   describe example_config do
     its('version') { should eq('2.0') }
   end

--- a/test/fixtures/profiles/dependencies/profile_c/controls/example.rb
+++ b/test/fixtures/profiles/dependencies/profile_c/controls/example.rb
@@ -3,6 +3,7 @@ control 'profilec-1' do                        # A unique ID for this control
   impact 0.7                                # The criticality, if this control fails.
   title 'Create /tmp directory'             # A human-readable title
   desc 'An optional description...'
+  tag 'tag-profilec1'
   describe file('/') do                  # The actual test
     it { should be_directory }
   end

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -291,6 +291,53 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     assert_exit_code 0, out
   end
 
+  it "executes only specified controls of included dependent profile by using literal names of tags" do
+    inspec("exec " + File.join(profile_path, "dependencies", "profile_a") + " --no-create-lockfile --tags tag-profilea1 tag-profilec1")
+    _(stdout).must_include "✔  profilea-1: Create / directory\n"
+    _(stdout).must_include "✔  profilec-1: Create /tmp directory\n"
+    _(stdout).must_include "✔  File / is expected to be directory\n"
+    _(stdout).wont_include "✔  profilea-2: example_config\n"
+    _(stdout).must_include "Test Summary: 2 successful, 0 failures, 0 skipped\n"
+    _(stderr).must_equal ""
+
+    assert_exit_code 0, out
+  end
+
+  it "executes only specified controls of included dependent profile by using regex on tags" do
+    inspec("exec " + File.join(profile_path, "dependencies", "profile_a") + " --no-create-lockfile --tags '/^tag-profilea/'")
+    _(stdout).must_include "✔  profilea-1: Create / directory\n"
+    _(stdout).must_include "✔  profilea-2: example_config\n"
+    _(stdout).wont_include "✔  profilec-1: Create /tmp directory\n"
+    _(stdout).must_include "Test Summary: 2 successful, 0 failures, 0 skipped\n"
+    _(stderr).must_equal ""
+
+    assert_exit_code 0, out
+  end
+
+  it "executes only specified controls of required dependent profile by using literal names of tags" do
+    inspec("exec " + File.join(profile_path, "dependencies", "require_controls_test") + " --no-create-lockfile --tags tag-profileb2")
+    _(stdout).must_include "✔  profileb-2: example_config\n"
+    _(stdout).must_include "✔  example_config version is expected to eq \"2.0\"\n"
+    _(stdout).wont_include "✔  profilea-1: Create / directory\n"
+    _(stdout).wont_include "✔  profilea-2: example_config\n"
+    _(stdout).must_include "Test Summary: 2 successful, 0 failures, 0 skipped\n"
+    _(stderr).must_equal ""
+
+    assert_exit_code 0, out
+  end
+
+  it "executes only specified controls of required dependent profile by using regex on tags" do
+    inspec("exec " + File.join(profile_path, "dependencies", "require_controls_test") + " --no-create-lockfile --tags '/^tag-profileb/'")
+    _(stdout).must_include "✔  profileb-2: example_config\n"
+    _(stdout).must_include "✔  example_config version is expected to eq \"2.0\"\n"
+    _(stdout).wont_include "✔  profilea-1: Create / directory\n"
+    _(stdout).wont_include "✔  profilea-2: example_config\n"
+    _(stdout).must_include "Test Summary: 2 successful, 0 failures, 0 skipped\n"
+    _(stderr).must_equal ""
+
+    assert_exit_code 0, out
+  end
+
   it "reports whan a profile cannot be loaded" do
     inspec("exec " + File.join(profile_path, "raise_outside_control") + " --no-create-lockfile")
     _(stdout).must_match(/Profile:[\W]+InSpec Profile \(raise_outside_control\)/)


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Fix `--tags` filter for dependent profiles, it was not able to filter dependent profiles till now.
- Introduced filtering logic for both `include_controls` and `require_controls` cases.
- Tested manually till 4 levels, A->B->C->D
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5653 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
