### PR TITLE
Add option in `postgres_session` resource to establish socket connection

### DIFF
--- a/docs-chef-io/content/inspec/resources/postgres_session.md
+++ b/docs-chef-io/content/inspec/resources/postgres_session.md
@@ -48,7 +48,7 @@ A full example is:
 
 where
   - `its('output') { should eq '' }` compares the results of the query against the expected result in the test
-  - `socketpath` is an optional parameter. It can be used to establish socket connection with postgres by specifying one of the postgres unix domain sockets path. Only supported for unix based platforms.
+  - `socketpath` is an optional parameter. Use `socketpath` to establish a socket connection with Postgres by specifying one of the Postgres Unix domain socket paths. Only supported on Unix-based platforms.
 
 ## Examples
 

--- a/docs-chef-io/content/inspec/resources/postgres_session.md
+++ b/docs-chef-io/content/inspec/resources/postgres_session.md
@@ -28,24 +28,27 @@ This resource first became available in v1.0.0 of InSpec.
 A `postgres_session` resource block declares the username and password to use for the session, and then the command to be run:
 
     # Create a PostgreSQL session:
-    sql = postgres_session('username', 'password', 'host', 'port')
+    sql = postgres_session('username', 'password', 'host', 'port', 'socketpath')
 
     # default values:
     #   username: 'postgres'
     #   host: 'localhost'
     #   port: 5432
+    #   socketpath (optional): nil
 
     # Run an SQL query with an optional database to execute
     sql.query('sql_query', ['database_name'])`
 
 A full example is:
 
-    sql = postgres_session('username', 'password', 'host', 'port')
+    sql = postgres_session('username', 'password', 'host', 'port', 'socketpath')
     describe sql.query('SELECT * FROM pg_shadow WHERE passwd IS NULL;') do
       its('output') { should eq '' }
     end
 
-where `its('output') { should eq '' }` compares the results of the query against the expected result in the test
+where
+  - `its('output') { should eq '' }` compares the results of the query against the expected result in the test
+  - `socketpath` is an optional parameter. It can be used to establish socket connection with postgres by specifying one of the postgres unix domain sockets path. Only supported for unix based platforms.
 
 ## Examples
 

--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -40,11 +40,12 @@ module Inspec::Resources
       end
     EXAMPLE
 
-    def initialize(user, pass, host = nil, port = nil)
+    def initialize(user, pass, host = nil, port = nil, socket_path = nil)
       @user = user || "postgres"
       @pass = pass
       @host = host || "localhost"
       @port = port || 5432
+      @socket_path = socket_path
       raise Inspec::Exceptions::ResourceFailed, "Can't run PostgreSQL SQL checks without authentication." if @user.nil? || @pass.nil?
     end
 
@@ -69,10 +70,20 @@ module Inspec::Resources
 
     def create_psql_cmd(query, db = [])
       dbs = db.map { |x| "#{x}" }.join(" ")
-      if inspec.os.windows?
-        "psql -d postgresql://#{@user}:#{@pass}@#{@host}:#{@port}/#{dbs} -A -t -w -c \"#{query}\""
+
+      if @socket_path && !inspec.os.windows?
+        # Socket path and empty host in the connection string establishes socket connection
+        # Socket connection only enabled for non-windows platforms
+        # Windows does not support unix domain sockets
+        "psql -d postgresql://#{@user}:#{@pass}@/#{dbs}?host=#{@socket_path} -A -t -w -c #{escaped_query(query)}"
       else
-        "psql -d postgresql://#{@user}:#{@pass}@#{@host}:#{@port}/#{dbs} -A -t -w -c #{escaped_query(query)}"
+        # Host in connection string establishes tcp/ip connection
+        if inspec.os.windows?
+          warn "Socket based connection not supported in windows, connecting using host" if @socket_path
+          "psql -d postgresql://#{@user}:#{@pass}@#{@host}:#{@port}/#{dbs} -A -t -w -c \"#{query}\""
+        else
+          "psql -d postgresql://#{@user}:#{@pass}@#{@host}:#{@port}/#{dbs} -A -t -w -c #{escaped_query(query)}"
+        end
       end
     end
   end

--- a/test/unit/resources/postgres_session_test.rb
+++ b/test/unit/resources/postgres_session_test.rb
@@ -37,4 +37,9 @@ describe "Inspec::Resources::PostgresSession" do
     resource = load_resource("postgres_session", "postgres", "postgres", "localhost", 5432)
     _(proc { resource.send(:query, "Select 5;", ["mydatabase"]) }).must_raise Inspec::Exceptions::ResourceFailed
   end
+
+  it "verify postgres_session create_psql_cmd in socket connection" do
+    resource = load_resource("postgres_session", "myuser", "mypass", "127.0.0.1", 5432, "/var/run/postgresql")
+    _(resource.send(:create_psql_cmd, "SELECT * FROM STUDENTS;", ["testdb"])).must_equal "psql -d postgresql://myuser:mypass@/testdb?host=/var/run/postgresql -A -t -w -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;"
+  end
 end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

Add option in `postgres_session` resource to establish socket connection

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- An optional parameter `socket_path` is added in `postgres_session` resource to establish socket based connection. Only works for unix based platforms.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Closes #5652 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
