### PR TITLE
Add csv without headers support in csv resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/csv.md
+++ b/docs-chef-io/content/inspec/resources/csv.md
@@ -31,7 +31,7 @@ A `csv` resource block declares the configuration data to be tested:
       its('name') { should cmp 'foo' }
     end
 
-Test ``csv`` without headers
+Test `csv` file without headers
 
     describe csv('file', false).params do
       its([0]) { should cmp 'name' }
@@ -40,17 +40,17 @@ Test ``csv`` without headers
 where
 
 - `'file'` is the path to a CSV file
-- 'true' is the value for headers. Default `true`. If `false` then it considers csv does not have headers.
+- `true` or `false` tests a CSV file with or without headers. Default value: `true`.
 - `name` is a configuration setting in a CSV file
 - `should eq 'foo'` tests a value of `name` as read from a CSV file versus the value declared in the test
-- `params` when headers are set to false use this method to fetch the data.
+- `params` is the method for fetching data from a CSV file without headers.
 - `[0]` is the array element position.
 
 ## Examples
 
 The following examples show how to use this Chef InSpec audit resource.
 
-### Test a csv file without headers
+### Test a CSV file without headers
 
     describe csv('some_file.csv', false).params do
       its([0]) { should eq ["name"] }

--- a/docs-chef-io/content/inspec/resources/csv.md
+++ b/docs-chef-io/content/inspec/resources/csv.md
@@ -40,7 +40,7 @@ Test ``csv`` without headers
 where
 
 - `'file'` is the path to a CSV file
-- 'true' is the value for headers by default value is true. If set to false it consider csv file does not have headers,
+- 'true' is the value for headers. Default `true`. If `false` then it considers csv does not have headers.
 - `name` is a configuration setting in a CSV file
 - `should eq 'foo'` tests a value of `name` as read from a CSV file versus the value declared in the test
 - `params` when headers are set to false use this method to fetch the data.

--- a/docs-chef-io/content/inspec/resources/csv.md
+++ b/docs-chef-io/content/inspec/resources/csv.md
@@ -27,19 +27,34 @@ This resource first became available in v1.0.0 of InSpec.
 
 A `csv` resource block declares the configuration data to be tested:
 
-    describe csv('file') do
+    describe csv('file', true) do
       its('name') { should cmp 'foo' }
+    end
+
+Test ``csv`` without headers
+
+    describe csv('file', false).params do
+      its([0]) { should cmp 'name' }
     end
 
 where
 
 - `'file'` is the path to a CSV file
+- 'true' is the value for headers by default value is true. If set to false it consider csv file does not have headers,
 - `name` is a configuration setting in a CSV file
 - `should eq 'foo'` tests a value of `name` as read from a CSV file versus the value declared in the test
+- `params` when headers are set to false use this method to fetch the data.
+- `[0]` is the array element position.
 
 ## Examples
 
 The following examples show how to use this Chef InSpec audit resource.
+
+### Test a csv file without headers
+
+    describe csv('some_file.csv', false).params do
+      its([0]) { should eq ["name"] }
+    end
 
 ### Test a CSV file
 

--- a/lib/inspec/resources/csv.rb
+++ b/lib/inspec/resources/csv.rb
@@ -11,13 +11,27 @@ module Inspec::Resources
       describe csv('example.csv') do
         its('name') { should eq(['John', 'Alice']) }
       end
+
+      describe csv('example.csv', false).params do
+        its[[0]] { should eq (['name', 'col1', 'col2']) }
+      emd
     EXAMPLE
+
+    def initialize(path, headers = true)
+      @headers = headers
+      super(path)
+    end
 
     # override the parse method from JsonConfig
     # Assuming a header row of name,col1,col2, it will output an array of hashes like so:
     #    [
     #      { 'name' => 'row1', 'col1' => 'value1', 'col2' => 'value2' },
     #      { 'name' => 'row2', 'col1' => 'value3', 'col2' => 'value4' }
+    #    ]
+    # When headers is set to false it will return data as array of array
+    #    [
+    #      ['name', col1', 'col2'],
+    #      ['row2', 'value3', 'value4']
     #    ]
     def parse(content)
       require "csv" unless defined?(CSV)
@@ -28,10 +42,14 @@ module Inspec::Resources
       end
 
       # implicit conversion of values
-      csv = CSV.new(content, headers: true, converters: %i{all blank_to_nil})
+      csv = CSV.new(content, headers: @headers, converters: %i{all blank_to_nil})
 
       # convert to hash
-      csv.to_a.map(&:to_hash)
+      if @headers
+        csv.to_a.map(&:to_hash)
+      else
+        csv.to_a
+      end
     rescue => e
       raise Inspec::Exceptions::ResourceFailed, "Unable to parse CSV: #{e.message}"
     end
@@ -42,7 +60,12 @@ module Inspec::Resources
     # #value method from JsonConfig (which uses ObjectTraverser.extract_value)
     # doesn't make sense here.
     def value(key)
-      @params.map { |x| x[key.first.to_s] }.compact
+      if @headers
+        @params.map { |x| x[key.first.to_s] }.compact
+      else
+        # when headers is set to false send the array as it is.
+        @params
+      end
     end
 
     private

--- a/test/unit/resources/csv_test.rb
+++ b/test/unit/resources/csv_test.rb
@@ -3,7 +3,7 @@ require "inspec/resource"
 require "inspec/resources/csv"
 
 describe "Inspec::Resources::CSV" do
-  describe "when loading a valid csv" do
+  describe "when loading a valid csv using default header true" do
     let(:resource) { load_resource("csv", "example.csv") }
     let(:params) do
       {}
@@ -31,6 +31,25 @@ describe "Inspec::Resources::CSV" do
 
     it "returns an array of values by column name" do
       _(resource.value(["name"])).must_equal(%w{addressable ast astrolabe berkshelf})
+    end
+  end
+
+  describe "when loading a valid csv using default header false" do
+    let(:resource) { load_resource("csv", "example.csv", false) }
+    let(:params) do
+      {}
+    end
+
+    it "captures an array of params" do
+      _(resource.params).must_be_kind_of Array
+    end
+
+    it "gets all value lines" do
+      _(resource.params.length).must_equal 5
+    end
+
+    it "gets params by row" do
+      _(resource.params[0]).must_equal(%w{name version license title description})
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Add support for csv without headers in csv resource.
To use above options now user has to send the headers value as false in the csv resource as follows

```
describe csv('example.csv', false).params do
  its([0]) { should eq (['Product','Size','Color', 'Price']) }
end
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fix #5450 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
