### PR TITLE
Group & User Resources - Resolve name case-sensitivity issue for windows

### DIFF
--- a/lib/inspec/resources/groups.rb
+++ b/lib/inspec/resources/groups.rb
@@ -150,7 +150,11 @@ module Inspec::Resources
     def group_info
       # we need a local copy for the block
       group = @group.dup
-      @groups_cache ||= inspec.groups.where { name == group }
+      if inspec.os.windows?
+        @groups_cache ||= inspec.groups.where { name.casecmp?(group) }
+      else
+        @groups_cache ||= inspec.groups.where { name == group }
+      end
     end
 
     def empty_value_for_members

--- a/lib/inspec/resources/groups.rb
+++ b/lib/inspec/resources/groups.rb
@@ -22,6 +22,18 @@ module Inspec::Resources
     end
   end
 
+  # Class defined to check for members without case-sensitivity
+  class Members < Array
+    def initialize(group_members)
+      @group_members = group_members
+      super
+    end
+
+    def include?(user)
+      !(@group_members.select { |group_member| group_member.casecmp?(user) }.empty?)
+    end
+  end
+
   class Groups < Inspec.resource(1)
     include GroupManagementSelector
 
@@ -82,6 +94,7 @@ module Inspec::Resources
   #   its('gid') { should eq 0 }
   # end
   #
+
   class Group < Inspec.resource(1)
     include GroupManagementSelector
 
@@ -118,11 +131,13 @@ module Inspec::Resources
     end
 
     def members
-      flatten_entry(group_info, "members") || empty_value_for_members
+      members_list = flatten_entry(group_info, "members") || empty_value_for_members
+      inspec.os.windows? ? Members.new(members_list) : members_list
     end
 
     def members_array
-      flatten_entry(group_info, "members_array") || []
+      members_list = flatten_entry(group_info, "members_array") || []
+      inspec.os.windows? ? Members.new(members_list) : members_list
     end
 
     def local

--- a/lib/inspec/resources/users.rb
+++ b/lib/inspec/resources/users.rb
@@ -622,7 +622,7 @@ module Inspec::Resources
       name, _domain = parse_windows_account(username)
       return if collect_user_details.nil?
 
-      res = collect_user_details.select { |user| user[:username] == name }
+      res = collect_user_details.select { |user| user[:username].casecmp? name }
       res[0] unless res.empty?
     end
 

--- a/lib/inspec/resources/users.rb
+++ b/lib/inspec/resources/users.rb
@@ -204,7 +204,9 @@ module Inspec::Resources
     alias group groupname
 
     def groups
-      identity[:groups] unless identity.nil?
+      unless identity.nil?
+        inspec.os.windows? ? UserGroups.new(identity[:groups]) : identity[:groups]
+      end
     end
 
     def home
@@ -311,6 +313,18 @@ module Inspec::Resources
       return @cred_cache if defined?(@cred_cache)
 
       @cred_cache = @user_provider.credentials(@username) unless @user_provider.nil?
+    end
+  end
+
+  # Class defined to compare for groups without case-sensitivity
+  class UserGroups < Array
+    def initialize(user_groups)
+      @user_groups = user_groups
+      super
+    end
+
+    def include?(group)
+      !(@user_groups.select { |user_group| user_group.casecmp?(group) }.empty?)
     end
   end
 

--- a/test/unit/resources/group_test.rb
+++ b/test/unit/resources/group_test.rb
@@ -66,6 +66,13 @@ describe "Inspec::Resources::Group" do
     _(resource.members).must_equal ["Administrators", "Domain Admins"]
   end
 
+  it "verify administrator group with case insensitivity handling on windows" do
+    resource = MockLoader.new(:windows).load_resource("group", "administrators")
+    _(resource.exists?).must_equal true
+    _(resource.gid).must_equal "S-1-5-32-544"
+    _(resource.members).must_equal ["Administrators", "Domain Admins"]
+  end
+
   it "verify power users group on windows" do
     resource = MockLoader.new(:windows).load_resource("group", "Power Users")
     _(resource.exists?).must_equal true

--- a/test/unit/resources/group_test.rb
+++ b/test/unit/resources/group_test.rb
@@ -66,20 +66,20 @@ describe "Inspec::Resources::Group" do
     _(resource.members).must_equal ["Administrators", "Domain Admins"]
   end
 
-  it "verify administrator group with case insensitivity handling on windows" do
+  it "verify administrator group name case insensitivity handling on windows" do
     resource = MockLoader.new(:windows).load_resource("group", "administrators")
     _(resource.exists?).must_equal true
     _(resource.members).must_equal ["Administrators", "Domain Admins"]
   end
 
-  it "verify members insensitivity on windows" do
+  it "verify members insensitivity on windows using include matcher" do
     resource = MockLoader.new(:windows).load_resource("group", "administrators")
     _(resource.exists?).must_equal true
     _(resource.members).must_include "administrators"
     _(resource.members).must_include "domain admins"
   end
 
-  it "verify members_array insensitivity on windows" do
+  it "verify members_array insensitivity on windows using include matcher" do
     resource = MockLoader.new(:windows).load_resource("group", "administrators")
     _(resource.exists?).must_equal true
     _(resource.members_array).must_include "administrators"

--- a/test/unit/resources/group_test.rb
+++ b/test/unit/resources/group_test.rb
@@ -69,8 +69,21 @@ describe "Inspec::Resources::Group" do
   it "verify administrator group with case insensitivity handling on windows" do
     resource = MockLoader.new(:windows).load_resource("group", "administrators")
     _(resource.exists?).must_equal true
-    _(resource.gid).must_equal "S-1-5-32-544"
     _(resource.members).must_equal ["Administrators", "Domain Admins"]
+  end
+
+  it "verify members insensitivity on windows" do
+    resource = MockLoader.new(:windows).load_resource("group", "administrators")
+    _(resource.exists?).must_equal true
+    _(resource.members).must_include "administrators"
+    _(resource.members).must_include "domain admins"
+  end
+
+  it "verify members_array insensitivity on windows" do
+    resource = MockLoader.new(:windows).load_resource("group", "administrators")
+    _(resource.exists?).must_equal true
+    _(resource.members_array).must_include "administrators"
+    _(resource.members_array).must_include "domain admins"
   end
 
   it "verify power users group on windows" do

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -186,4 +186,12 @@ describe "Inspec::Resources::User" do
     _(resource.maxdays).must_be_nil
     _(resource.warndays).must_be_nil
   end
+
+  it "read user on Windows without case-sensitivity" do
+    resource = MockLoader.new(:windows).load_resource("user", "administrator")
+    _(resource.exists?).must_equal true
+    _(resource.uid).wont_be_nil
+    _(resource.group).must_be_nil
+    _(resource.groups).must_equal %w{Administrators Users}
+  end
 end

--- a/test/unit/resources/user_test.rb
+++ b/test/unit/resources/user_test.rb
@@ -194,4 +194,13 @@ describe "Inspec::Resources::User" do
     _(resource.group).must_be_nil
     _(resource.groups).must_equal %w{Administrators Users}
   end
+
+  it "read user groups on Windows without case-sensitivity using include matcher" do
+    resource = MockLoader.new(:windows).load_resource("user", "administrator")
+    _(resource.exists?).must_equal true
+    _(resource.uid).wont_be_nil
+    _(resource.group).must_be_nil
+    _(resource.groups).must_include "Administrators"
+    _(resource.groups).must_include "administrators"
+  end
 end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- **Group name** will be evaluated case insensitively for windows group in **group** resource.
- **Group members** will be evaluated case insensitively using `include` matcher for windows group members in **group** resource.
- **User name** will be evaluated case insensitively for windows in **user** resource.
- **User groups** will be evaluated case insensitively using `include` matcher for windows user groups in **user** resource.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Closes #5632 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
