### PR TITLE
Change the deprecation warning to mention inputs

### DIFF
--- a/etc/deprecations.json
+++ b/etc/deprecations.json
@@ -4,7 +4,7 @@
   "groups": {
     "attrs_value_replaces_default": {
       "action": "warn",
-      "prefix": "The 'default' option for attributes is being replaced by 'value' - please use it instead."
+      "prefix": "The 'default' option for inputs is being replaced by 'value' - please use it instead."
     },
     "attrs_dsl": {
       "action": "ignore",


### PR DESCRIPTION
## Description

Attributes are now referred to as Inputs

## Related Issue

None

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
