### PR TITLE
Fix main in expeditor script

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.sh
+++ b/.expeditor/buildkite/artifact.habitat.test.sh
@@ -16,7 +16,7 @@ uname -a
 
 echo "--- Installing Habitat"
 id -a
-curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
 
 
 echo "--- Generating fake origin key"

--- a/.expeditor/update_dockerfile.sh
+++ b/.expeditor/update_dockerfile.sh
@@ -3,7 +3,7 @@
 # This file updates the default VERSION build argument in the Dockerfile to the
 # VERSION passed in to the file via environment variables.
 #
-# This ensures the Dockerfile in inspec master will list the version of the latest
+# This ensures the Dockerfile in inspec main will list the version of the latest
 # stable release for any community member who wishes to build their own container
 # from scratch.
 #


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

## Description
Updates a reference to `master` where it should be `main` in a script.

## Related Issue
We're trying to find the reason that the release notes automation didn't work in the last release.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
