### PR TITLE
Update OpenSSL on macOS to 1.1.1l

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -6,4 +6,4 @@ override "train", version: "v#{train_stable}"
 override "ruby", version: "2.7.4"
 
 # Mac m1
-override "openssl", version: "1.1.1k" if mac_os_x?
+override "openssl", version: "1.1.1l" if mac_os_x?


### PR DESCRIPTION
1.1.1k is no longer there

Signed-off-by: Tim Smith <tsmith@chef.io>