### PR TITLE
Add back Ubuntu 16.04 packages + testing

### DIFF
--- a/.expeditor/integration.resources.yml
+++ b/.expeditor/integration.resources.yml
@@ -71,6 +71,7 @@ steps:
         linux:
           privileged: true
           single-use: true
+          
   - label: "Kitchen: resources-debian-10"
     commands:
       - .expeditor/buildkite/bk_linux_exec.sh
@@ -118,6 +119,7 @@ steps:
         linux:
           privileged: true
           single-use: true
+
   - label: "Kitchen: resources-oraclelinux-8"
     commands:
       - .expeditor/buildkite/bk_linux_exec.sh
@@ -150,6 +152,22 @@ steps:
           privileged: true
           single-use: true
 
+  - label: "Kitchen: resources-ubuntu-1604"
+    commands:
+      - .expeditor/buildkite/bk_linux_exec.sh
+      - . /var/lib/buildkite-agent/.asdf/asdf.sh
+      - bundle exec kitchen test resources-ubuntu-1604
+    artifact_paths:
+      - $PWD/.kitchen/logs/kitchen.log
+    env:
+        KITCHEN_YAML: kitchen.dokken.yml
+        DOCKER: 1
+    expeditor:
+      executor:
+        linux:
+          privileged: true
+          single-use: true
+
   - label: "Kitchen: resources-ubuntu-1804"
     commands:
       - .expeditor/buildkite/bk_linux_exec.sh
@@ -165,6 +183,7 @@ steps:
         linux:
           privileged: true
           single-use: true
+
   - label: "Kitchen: resources-ubuntu-2004"
     commands:
       - .expeditor/buildkite/bk_linux_exec.sh

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -43,7 +43,8 @@ builder-to-testers-map:
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
-  ubuntu-18.04-x86_64:
+  ubuntu-16.04-x86_64:
+    - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
   windows-2012r2-x86_64:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -66,12 +66,20 @@ platforms:
     image: dokken/opensuse-leap-15
     pid_one_command: /bin/systemd
 
+- name: ubuntu-16.04
+  driver:
+    image: dokken/ubuntu-16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update -y
+
 - name: ubuntu-18.04
   driver:
     image: dokken/ubuntu-18.04
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update -y
+
 - name: ubuntu-20.04
   driver:
     image: dokken/ubuntu-20.04


### PR DESCRIPTION
Ubuntu 16.04 is no longer EOL. They've extended support for a full 10 years so it goes EOL in 2026 now.

Signed-off-by: Tim Smith <tsmith@chef.io>