### PR TITLE
Renamed Inspec DSL to Inspec Language

### DIFF
--- a/docs-chef-io/content/inspec/dsl_inspec.md
+++ b/docs-chef-io/content/inspec/dsl_inspec.md
@@ -1,12 +1,12 @@
 +++
-title = "Chef InSpec DSL"
+title = "Chef InSpec Language"
 draft = false
 gh_repo = "inspec"
 
 [menu]
   [menu.inspec]
-    title = "Chef InSpec DSL"
-    identifier = "inspec/reference/dsl_inspec.md Chef InSpec DSL"
+    title = "Chef InSpec Language"
+    identifier = "inspec/reference/dsl_inspec.md Chef InSpec Language"
     parent = "inspec/reference"
     weight = 70
 +++
@@ -17,7 +17,7 @@ you write auditing controls quickly and easily. The syntax used by both open sou
 and [Chef compliance](/compliance/) auditing is the same. The open source [Chef InSpec resource](/inspec/resources/)
 framework is compatible with [Chef compliance](/compliance/).
 
-The Chef InSpec DSL is a Ruby DSL for writing audit controls, which includes audit resources that you can invoke.
+The Chef InSpec Language is a Ruby DSL for writing audit controls, which includes audit resources that you can invoke.
 
 The following sections describe the syntax and show some simple examples of using the Chef InSpec resources.
 
@@ -336,7 +336,7 @@ end
 
 ## Using Ruby in InSpec
 
-The Chef InSpec DSL is a Ruby based language. This allows you to be flexible with
+The Chef InSpec Language is a Ruby based language. This allows you to be flexible with
 Ruby code in controls:
 
 ```ruby

--- a/docs-chef-io/content/inspec/glossary.md
+++ b/docs-chef-io/content/inspec/glossary.md
@@ -152,9 +152,9 @@ end
 
 ### DSL
 
-_DSL_ is an acronym for _Domain Specific Language_. It refers to the language extensions Chef InSpec provides to make authoring resources and controls easier. While Chef InSpec control files are use Ruby, the _Control DSL_ makes it easy to write controls without knowledge of Ruby by providing DSL keywords such as [describe](#describe), [control](#control), [it](#it) and [its](#its). See the [Chef InSpec DSL page](/inspec/dsl_inspec/) for details about keywords available to control authors.
+_DSL_ is an acronym for _Domain Specific Language_. It refers to the language extensions Chef InSpec provides to make authoring resources and controls easier. While Chef InSpec control files are use Ruby, the _Control DSL_ makes it easy to write controls without knowledge of Ruby by providing DSL keywords such as [describe](#describe), [control](#control), [it](#it) and [its](#its). See the [Chef InSpec Language page](/inspec/dsl_inspec/) for details about keywords available to control authors.
 
-For [custom resource](#custom-resource) authors, an additional DSL is available - see the [Resource DSL page](/inspec/dsl_resource/).
+For [custom resource](#custom-resource) authors, an additional DSL is available - see the [Resource Language page](/inspec/dsl_resource/).
 
 ### Expected Result
 

--- a/docs-chef-io/content/inspec/shell.md
+++ b/docs-chef-io/content/inspec/shell.md
@@ -14,7 +14,7 @@ gh_repo = "inspec"
 The Chef InSpec interactive shell is a pry based REPL that can be used to
 quickly run Chef InSpec controls and tests without having to write it to a
 file. Its functionality is similar to [chef-shell](/chef_shell/) as it provides a way
-to exercise the Chef InSpec DSL, its resources, tests, and plugins without
+to exercise the Chef InSpec Language, its resources, tests, and plugins without
 having to create a profile or write a test file. See
 [http://pryrepl.org/](http://pryrepl.org/) for an introduction to what pry is and what it can
 do.
@@ -94,7 +94,7 @@ inspec> 1 + 2
 inspec> exit
 ```
 
-## Using Chef InSpec DSL in Chef InSpec shell
+## Using Chef InSpec Language in Chef InSpec shell
 
 Chef InSpec shell will automatically evaluate the result of every command as
 if it were a test file. If you type in a Ruby command that is not an


### PR DESCRIPTION
Signed-off-by: Dishank Tiwari <dtiwari@progress.com>

## Description

We're trying not to use the word DSL anywhere. It's a scary thing that new users do not understand and it means day 1 they need to google a CS term to get started. This should just be InSpec Language similar to what we did renaming Recipe DSL to Infra Language.

## Related Issue

- https://github.com/chef/chef-web-docs/issues/3382

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
