### PR TITLE
Updated the Resource Count of Chef InSpec

### DIFF
--- a/docs-chef-io/content/inspec/_index.md
+++ b/docs-chef-io/content/inspec/_index.md
@@ -52,6 +52,6 @@ InSpec to target applications and services running on AWS and Azure.
 
 ### Resources
 
-Chef InSpec has 80+ [resources](/inspec/resources/) ready use--apache to zfs pool.
+Chef InSpec has around 500 [resources](/inspec/resources/) ready use--apache to zfs pool.
 If you need a solution that we haven’t provided, you can write your own [custom
 resource](/inspec/dsl_resource/).

--- a/docs-chef-io/content/inspec/_index.md
+++ b/docs-chef-io/content/inspec/_index.md
@@ -52,6 +52,6 @@ InSpec to target applications and services running on AWS and Azure.
 
 ### Resources
 
-Chef InSpec has around 500 [resources](/inspec/resources/) ready use--apache to zfs pool.
+Chef InSpec has 500+ [resources](/inspec/resources/) ready use--apache to zfs pool.
 If you need a solution that we haven’t provided, you can write your own [custom
 resource](/inspec/dsl_resource/).


### PR DESCRIPTION
Signed-off-by: Dishank Tiwari <dtiwari@progress.com>

## Description

As new resources are merged this number should get updated. Right now it says 80 when the real number is just shy of 500. It makes the product look bad when we don't talk about its full capabilities.

## Related Issue

https://github.com/chef/chef-web-docs/issues/3392

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
