### PR TITLE
Fix windows_firewall resource fails to validate more than 1 rule depending on how it's executed

### DIFF
--- a/lib/inspec/resources/windows_firewall.rb
+++ b/lib/inspec/resources/windows_firewall.rb
@@ -77,7 +77,7 @@ module Inspec::Resources
 
     def load_firewall_profile(profile_name)
       <<-EOH
-        Remove-TypeData System.Array # workaround for PS bug here: https://bit.ly/2SRMQ8M
+        Get-TypeData -TypeName System.Array | Remove-TypeData # workaround for PS bug here: https://bit.ly/2SRMQ8M
         $profile = Get-NetFirewallProfile -Name "#{profile_name}"
         $count = @($profile | Get-NetFirewallRule).Count
         ([PSCustomObject]@{


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This is a similar issue which we fixed for the windows_firewall_rule resource in #5502. The detailed description for the cause of the issue given on the #5502 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fix #5703 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
