### PR TITLE
Stop producing packages for macOS 10.14

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -27,8 +27,7 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
-  mac_os_x-10.14-x86_64:
-    - mac_os_x-10.14-x86_64
+  mac_os_x-10.15-x86_64:
     - mac_os_x-10.15-x86_64
     - mac_os_x-11-x86_64
     - mac_os_x-12-x86_64


### PR DESCRIPTION
We support N-2 macOS releases which is now 12, 11, and 10.15

Signed-off-by: Tim Smith <tsmith@chef.io>