### PR TITLE
Updates habitat test for windows to match install logic for linux

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -15,12 +15,15 @@ $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
 
 Write-Host "--- Installing the version of Habitat required"
-$hab_version = (hab --version)
-$hab_minor_version = $hab_version.split('.')[1]
-if ( -not $? -Or $hab_minor_version -lt 85 ) {
-    Install-Habitat --version 0.85.0.20190916
-} else {
-    Write-Host ":habicat: I think I have the version I need to build."
+try {
+  hab --version
+}
+catch {
+  Set-ExecutionPolicy Bypass -Scope Process -Force
+  Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+}
+finally {
+  Write-Host ":habicat: I think I have the version I need to build."
 }
 
 


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Currently the Windows Artifact test for Habitat is trying to use legacy logic for installation of Habitat and is failing with an unknown function.  This updates the logic for the Windows installation of Habitat, within the test script, to perform similar to how the Linux test installs Habitat.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
