### PR TITLE
Move cookstyle dep from inspec gemspec to inspec-core, add rake

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -45,5 +45,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "semverse",           "~> 3.0"
   spec.add_dependency "multipart-post",     "~> 2.0"
 
+  # cookstyle support for inspec check
+  spec.add_dependency "cookstyle"
+  spec.add_dependency "rake"
+
   spec.add_dependency "train-core", "~> 3.0"
 end

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -35,6 +35,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "train-winrm",   "~> 0.2"
   spec.add_dependency "mongo", "= 2.13.2" # 2.14 introduces a broken symlink in mongo-2.14.0/spec/support/ocsp
 
-  # checks code offenses with inspec check
-  spec.add_dependency "cookstyle"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

The cookstyle dep should have been added to inspec-core, as it is part of inspec check (and not part of the compiled/cloud optional set of offerings in the superset). 

We also missed a new runtime dep on rake, which was breaking the habitat builds and possibly others.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
