### PR TITLE
Disable CookStyle integration on Windows 

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -122,8 +122,13 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       end
       puts
 
+      enable_offenses = !Inspec.locally_windows? # See 5723
       if result[:errors].empty? && result[:warnings].empty? && result[:offenses].empty?
-        ui.plain_line("No errors, warnings, or offenses")
+        if enable_offenses
+          ui.plain_line("No errors, warnings, or offenses")
+        else
+          ui.plain_line("No errors or warnings")
+        end
       else
         item_msg = lambda { |item|
           pos = [item[:file], item[:line], item[:column]].compact.join(":")
@@ -135,7 +140,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 
         puts
 
-        unless result[:offenses].empty?
+        if enable_offenses && !result[:offenses].empty?
           puts "Offenses:\n"
           result[:offenses].each { |item| ui.cyan(" #{Inspec::UI::GLYPHS[:script_x]} #{item_msg.call(item)}\n\n") }
         end
@@ -143,7 +148,11 @@ class Inspec::InspecCLI < Inspec::BaseCLI
         offenses = ui.cyan("#{result[:offenses].length} offenses", print: false)
         errors = ui.red("#{result[:errors].length} errors", print: false)
         warnings = ui.yellow("#{result[:warnings].length} warnings", print: false)
-        ui.plain_line("Summary:     #{errors}, #{warnings}, #{offenses}")
+        if enable_offenses
+          ui.plain_line("Summary:     #{errors}, #{warnings}, #{offenses}")
+        else
+          ui.plain_line("Summary:     #{errors}, #{warnings}")
+        end
       end
     end
 

--- a/lib/inspec/globals.rb
+++ b/lib/inspec/globals.rb
@@ -18,4 +18,9 @@ module Inspec
     require "etc" unless defined?(Etc)
     Etc.getpwuid.dir
   end
+
+  def self.locally_windows?
+    require "rbconfig" unless defined?(RbConfig)
+    RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
+  end
 end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -450,6 +450,8 @@ module Inspec
 
     def cookstyle_linting_check
       msgs = []
+      return msgs if Inspec.locally_windows? # See #5723
+
       output = cookstyle_rake_output.split("Offenses:").last
       msgs = output.split("\n").select { |x| x =~ /[A-Z]:/ } unless output.nil?
       msgs

--- a/test/functional/inspec_check_test.rb
+++ b/test/functional/inspec_check_test.rb
@@ -120,12 +120,14 @@ describe "inspec check" do
 
   describe "inspec check also check for cookstyle offenses" do
     it "finds no offenses in a complete profile" do
+      skip if windows? # see #5723
       out = inspec("check #{profile_path}/complete-profile")
       _(out.stdout).must_match(/No errors, warnings, or offenses/)
       assert_exit_code 0, out
     end
 
     it "fails and returns offenses in a profile" do
+      skip if windows? # see #5723
       out = inspec("check #{profile_path}/inputs/metadata-basic")
       _(out.stdout).must_match(/1 offenses/)
       assert_exit_code 1, out


### PR DESCRIPTION
It appears that the current approach to CookStyle integration is broken under Windows (when InSpec is run from a Windows workstation, not necessarily on a Windows target). The feature fails to work, and a message is emitted to STDERR reading "Process.fork is not supported by this Ruby".  The root cause has not yet been identified but it appears to be in a Rake task.

For now, we are withdrawing the feature from Windows installations until such time as it can be fixed.

Refs #5723 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
