### PR TITLE
Move rake and cookstyle deps out of inspec core gemspec

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -45,9 +45,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "semverse",           "~> 3.0"
   spec.add_dependency "multipart-post",     "~> 2.0"
 
-  # cookstyle support for inspec check
-  spec.add_dependency "cookstyle"
-  spec.add_dependency "rake"
-
   spec.add_dependency "train-core", "~> 3.0"
 end

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,6 +26,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "train", "~> 3.0"
 
+  # cookstyle support for inspec check
+  # Added here not because they are compiled, but to keep chef-client lightweight
+  spec.add_dependency "cookstyle"
+  spec.add_dependency "rake"
+
   # Used for Azure profile until integrated into train
   spec.add_dependency "faraday_middleware", ">= 0.12.2", "< 1.1"
 


### PR DESCRIPTION
Partial revert of #5722, to move rake and cookstyle deps back to the non-core gemspec to avoid packaging them with Chef Infra Client.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
