### PR TITLE
Remove the instance_eval and eval_gemfile calls in omnibus

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -19,9 +19,3 @@ group :development do
   gem "test-kitchen", ">= 1.23"
   gem "winrm-fs", "~> 1.0"
 end
-
-instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
-
-# If you want to load debugging tools into the bundle exec sandbox,
-# add these additional dependencies into Gemfile.local
-eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")


### PR DESCRIPTION
Dependabot won't work with these and they're not being used anyways.

Signed-off-by: Tim Smith <tsmith@chef.io>