### PR TITLE
Target support for Alpine Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Remote Targets
 | Gentoo Linux                 |                                                  | x86_64        |
 | Arch Linux                   |                                                  | x86_64        |
 | HP-UX                        | 11.31                                            | ia64          |
+| Alpine Linux                 |                                                  | x86_64        |
 
 \**For Windows, PowerShell 5.0 or above is required.*
 

--- a/lib/inspec/resources/auditd.rb
+++ b/lib/inspec/resources/auditd.rb
@@ -28,12 +28,13 @@ module Inspec::Resources
     EXAMPLE
 
     def initialize
-      unless inspec.command("/sbin/auditctl").exist?
+      @auditctl_cmd_str = inspec.os.name.eql?("alpine") ? "/usr/sbin/auditctl" : "/sbin/auditctl"
+      unless inspec.command(@auditctl_cmd_str).exist?
         raise Inspec::Exceptions::ResourceFailed,
-              "Command `/sbin/auditctl` does not exist"
+              "Command `#{@auditctl_cmd_str}` does not exist"
       end
 
-      auditctl_cmd = "/sbin/auditctl -l"
+      auditctl_cmd = "#{@auditctl_cmd_str} -l"
       result = inspec.command(auditctl_cmd)
 
       if result.exit_status != 0
@@ -68,7 +69,7 @@ module Inspec::Resources
     filter.install_filter_methods_on_resource(self, :params)
 
     def status(name = nil)
-      @status_content ||= inspec.command("/sbin/auditctl -s").stdout.chomp
+      @status_content ||= inspec.command("#{@auditctl_cmd_str} -s").stdout.chomp
 
       # See: https://github.com/inspec/inspec/issues/3113
       if @status_content =~ /^AUDIT_STATUS/

--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -191,6 +191,8 @@ module Inspec::Resources
         Svcs.new(inspec)
       when "yocto"
         Systemd.new(inspec, service_ctl)
+      when "alpine"
+        SysV.new(inspec, service_ctl)
       end
     end
 

--- a/test/fixtures/cmd/apk-info
+++ b/test/fixtures/cmd/apk-info
@@ -1,0 +1,5 @@
+bsm-simple-themes-metacity-1.3-r4 x86_64 {bsm-simple-themes} (GPL)
+http-parser-dev-2.8.1-r0 x86_64 {http-parser} (MIT)
+libsoup-dev-2.62.1-r0 x86_64 {libsoup} (LGPL-2.0-or-later)
+udisks-dev-1.0.5-r3 x86_64 {udisks} (GPL-2.0-or-later)
+rxvt-unicode-9.22-r4 x86_64 {rxvt-unicode} (GPL-3.0+)

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -573,6 +573,7 @@ class MockLoader
 
       # alpine package commands
       "apk info -vv --no-network | grep git" => cmd.call("apk-info-grep-git"),
+      "apk list --no-network" => cmd.call("apk-info"),
 
       # filesystem command
       "2e7e0d4546342cee799748ec7e2b1c87ca00afbe590fa422a7c27371eefa88f0" => cmd.call("get-wmiobject-filesystem"),

--- a/test/unit/resources/packages_test.rb
+++ b/test/unit/resources/packages_test.rb
@@ -76,6 +76,17 @@ describe "Inspec::Resources::Packages" do
     })
   end
 
+  it "packages on alpine" do
+    resource = MockLoader.new(:alpine).load_resource("packages", /^http-parser$/)
+    _(resource.entries.length).must_equal 1
+    _(resource.entries[0].to_h).must_equal({
+      status: "installed",
+      name: "http-parser",
+      version: "2.8.1",
+      architecture: "x86_64",
+    })
+  end
+
   it "skips on non debian platforms" do
     resource = MockLoader.new(:hpux).load_resource("packages", "bash")
     _(resource.resource_exception_message).must_equal "The packages resource is not yet supported on OS hpux"
@@ -88,4 +99,5 @@ describe "Inspec::Resources::Packages" do
       resources.send(:entries, nil)
     }.must_raise(RuntimeError)
   end
+
 end

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -484,6 +484,18 @@ describe "Inspec::Resources::Service" do
     _(resource.params).must_equal params
   end
 
+  it "verify alpine service parsing" do
+    resource = MockLoader.new(:alpine).load_resource("service", "sshd")
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal "sysv"
+    _(resource.name).must_equal "sshd"
+    _(resource.description).must_be_nil
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal true
+    _(resource.params).must_equal params
+  end
+
   # unknown OS
   it "verify service handling on unsupported os" do
     resource = MockLoader.new(:undefined).load_resource("service", "dhcp")


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
Target support for Alpine Linux
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

1. Verified Alpine support for core resource packs.
2. Extended Alpine platform support for `auditd`, `service` and `packages` resources.
3. Updated **README** docs mentioning target alpine linux support
4. Support not provided for the following core resources. These are not supported by Alpine OS or were not verifiable.

> 1. etc_hosts_allow
> 2. etc_hosts_deny
> 3. systemd_service
> 4. yum
> 5. launchd_service
> 6. inetd_conf
> 7. rabbitmq_config
> 8. limits_conf
> 9. login_defs
> 10. iis_app
> 11. iis_site
> 12. cran
> 13. grub_conf
> 14. runit_service
> 15. zfs_dataset
> 16. zfs_pool
> 


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Closes #5698 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
