### PR TITLE
Implemented CLI option for executing private supermarket profiles

### DIFF
--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -208,7 +208,7 @@ Chef Supermarket:
 
 ``` ruby
 inspec exec supermarket://username/linux-baseline
-inspec exec supermarket://username/linux-baseline --supermarket_url="https://myprivatesupermarket.mydomain.com"
+inspec exec supermarket://username/linux-baseline --supermarket_url="https://privatesupermarket.example.com"
 ```
 
 Local profile (executes all tests in `controls/`):
@@ -572,7 +572,7 @@ inspec supermarket SUBCOMMAND ...
 This subcommand has additional options:
 
 * ``--supermarket_url``
-    Specify private supermarket url to run supermarket commands on private supermarket.
+    Specify the URL of a private Chef Supermarket.
 
 
 ## vendor

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -208,6 +208,7 @@ Chef Supermarket:
 
 ``` ruby
 inspec exec supermarket://username/linux-baseline
+inspec exec supermarket://username/linux-baseline --supermarket_url="https://myprivatesupermarket.mydomain.com"
 ```
 
 Local profile (executes all tests in `controls/`):
@@ -565,6 +566,14 @@ This subcommand has the following syntax:
 ```bash
 inspec supermarket SUBCOMMAND ...
 ```
+
+### Options
+
+This subcommand has additional options:
+
+* ``--supermarket_url``
+    Specify private supermarket url to run supermarket commands on private supermarket.
+
 
 ## vendor
 

--- a/lib/bundles/inspec-supermarket/README.md
+++ b/lib/bundles/inspec-supermarket/README.md
@@ -8,8 +8,27 @@ To use the CLI, this InSpec add-on adds the following commands:
 
  Compliance profiles from Supermarket can be executed in two ways:
 
- - via supermarket exec: `inspec supermarket exec nathenharvey/tmp-compliance-profile`
- - via supermarket scheme: `inspec exec supermarket://nathenharvey/tmp-compliance-profile`
+ - via supermarket exec:
+
+ **Public Supermarket**
+
+ `inspec supermarket exec nathenharvey/tmp-compliance-profile`
+
+ **Private Supermarket**
+
+ `inspec supermarket exec nathenharvey/tmp-compliance-profile --supermarket_url="PRIVATE_SUPERMARKET_URL"`
+
+
+ - via supermarket scheme:
+
+ **Public Supermarket**
+
+ `inspec exec supermarket://nathenharvey/tmp-compliance-profile`
+
+ **Private Supermarket**
+
+ `inspec exec supermarket://nathenharvey/tmp-compliance-profile --supermarket_url="PRIVATE_SUPERMARKET_URL"`
+
 
 ## Usage
 

--- a/lib/bundles/inspec-supermarket/cli.rb
+++ b/lib/bundles/inspec-supermarket/cli.rb
@@ -15,10 +15,18 @@ module Supermarket
     end
 
     desc "profiles", "list all available profiles in Chef Supermarket"
+    supermarket_options
     def profiles
-      # display profiles in format user/profile
-      supermarket_profiles = Supermarket::API.profiles
+      o = config
+      diagnose(o)
+      configure_logger(o)
 
+      # display profiles in format user/profile
+      supermarket_profiles =  if o["supermarket_url"]
+                                Supermarket::API.profiles(o["supermarket_url"])
+                              else
+                                Supermarket::API.profiles
+                              end
       headline("Available profiles:")
       supermarket_profiles.each do |p|
         li("#{p["tool_name"]} #{mark_text(p["tool_owner"] + "/" + p["slug"])}")
@@ -45,9 +53,18 @@ module Supermarket
     end
 
     desc "info PROFILE", "display Supermarket profile details"
+    supermarket_options
     def info(profile)
+      o = config
+      diagnose(o)
+      configure_logger(o)
+
       # check that the profile is available
-      supermarket_profiles = Supermarket::API.profiles
+      supermarket_profiles =  if o["supermarket_url"]
+                                Supermarket::API.profiles(o["supermarket_url"])
+                              else
+                                Supermarket::API.profiles
+                              end
       found = supermarket_profiles.select do |p|
         profile == "#{p["tool_owner"]}/#{p["slug"]}"
       end

--- a/lib/bundles/inspec-supermarket/target.rb
+++ b/lib/bundles/inspec-supermarket/target.rb
@@ -9,10 +9,11 @@ module Supermarket
     priority 500
 
     def self.resolve(target, opts = {})
+      supermarket_url = opts["supermarket_url"] || Supermarket::API::SUPERMARKET_URL
       supermarket_uri, supermarket_server = if target.is_a?(String) && URI(target).scheme == "supermarket"
-                                              [target, Supermarket::API::SUPERMARKET_URL]
+                                              [target, supermarket_url]
                                             elsif target.respond_to?(:key?) && target.key?(:supermarket)
-                                              supermarket_server = target[:supermarket_url] || Supermarket::API::SUPERMARKET_URL
+                                              supermarket_server = target[:supermarket_url] || supermarket_url
                                               ["supermarket://#{target[:supermarket]}", supermarket_server]
                                             end
       return nil unless supermarket_uri

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -137,7 +137,7 @@ module Inspec
 
     def self.supermarket_options
       option :supermarket_url, type: :string,
-        desc: "Specify private supermarket url to run supermarket commands on private supermarket"
+        desc: "Specify the URL of a private Chef Supermarket."
     end
 
     def self.exec_options

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -135,9 +135,15 @@ module Inspec
         desc: "Use the given path for caching dependencies. (default: ~/.inspec/cache)"
     end
 
+    def self.supermarket_options
+      option :supermarket_url, type: :string,
+        desc: "Specify supermarket url to run supermarket commands"
+    end
+
     def self.exec_options
       target_options
       profile_options
+      supermarket_options
       option :controls, type: :array,
         desc: "A list of control names to run, or a list of /regexes/ to match against control names. Ignore all other tests."
       option :tags, type: :array,

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -137,7 +137,7 @@ module Inspec
 
     def self.supermarket_options
       option :supermarket_url, type: :string,
-        desc: "Specify supermarket url to run supermarket commands"
+        desc: "Specify private supermarket url to run supermarket commands on private supermarket"
     end
 
     def self.exec_options

--- a/lib/inspec/plugin/v1/registry.rb
+++ b/lib/inspec/plugin/v1/registry.rb
@@ -11,7 +11,7 @@ class PluginRegistry
   # @return [Plugin] plugin instance if it can be resolved, nil otherwise
   def resolve(target, opts = {})
     modules.each do |m|
-      res = if Inspec::Fetcher::Url == m
+      res = if [Inspec::Fetcher::Url, Supermarket::Fetcher].include? m
               m.resolve(target, opts)
             else
               m.resolve(target)

--- a/lib/inspec/plugin/v1/registry.rb
+++ b/lib/inspec/plugin/v1/registry.rb
@@ -11,7 +11,7 @@ class PluginRegistry
   # @return [Plugin] plugin instance if it can be resolved, nil otherwise
   def resolve(target, opts = {})
     modules.each do |m|
-      res = if [Inspec::Fetcher::Url, Supermarket::Fetcher].include? m
+      res = if ["Inspec::Fetcher::Url", "Supermarket::Fetcher"].include? m.to_s
               m.resolve(target, opts)
             else
               m.resolve(target)

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -642,6 +642,26 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
       end
     end
 
+    it "can run supermarket profiles directly from the command line with --supermarket_url option" do
+
+      skip_windows! # Breakage confirmed, only on CI: https://buildkite.com/chef-oss/inspec-inspec-master-verify/builds/2355#2c9d032e-4a24-4e7c-aef2-1c9e2317d9e2
+      inspec("exec supermarket://nathenharvey/tmp-compliance-profile --supermarket_url='https://supermarket.chef.io' --no-create-lockfile")
+
+      if is_windows?
+        _(stdout).must_include "Profile Summary: 1 successful control, 1 control failure, 0 controls skipped\n"
+      else
+        _(stdout).must_include "Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped\n"
+      end
+
+      _(stderr).must_equal ""
+
+      if is_windows?
+        assert_exit_code 100, out # references root
+      else
+        assert_exit_code 0, out
+      end
+    end
+
     it "can run supermarket profiles from inspec.yml" do
       skip_windows! # Breakage confirmed, only on CI: https://buildkite.com/chef-oss/inspec-inspec-master-verify/builds/2355#2c9d032e-4a24-4e7c-aef2-1c9e2317d9e2
 

--- a/test/functional/inspec_supermarket_test.rb
+++ b/test/functional/inspec_supermarket_test.rb
@@ -39,4 +39,49 @@ describe "inspec supermarket" do
 
     assert_exit_code 100, out
   end
+
+  it "supermarket profiles" do
+    out = inspec("supermarket profiles --supermarket_url='https://supermarket.chef.io'")
+
+    _(out.stdout).must_include "dev-sec/linux-patch-baseline"
+    _(out.stdout).must_include "dev-sec/windows-baseline"
+    _(out.stderr).must_equal ""
+
+    assert_exit_code 0, out
+  end
+
+  it "info with --supermarket_url option" do
+    out = inspec("supermarket info dev-sec/ssh-baseline --supermarket_url='https://supermarket.chef.io'")
+
+    _(out.stdout).must_include "name: \e[0m  ssh-baseline"
+    _(out.stderr).must_equal ""
+
+    assert_exit_code 0, out
+  end
+
+  it "supermarket exec with --supermarket_url option" do
+    if is_windows?
+      out = inspec("supermarket exec dev-sec/windows-patch-baseline --supermarket_url='https://supermarket.chef.io'")
+    else
+      out = inspec("supermarket exec dev-sec/ssh-baseline --supermarket_url='https://supermarket.chef.io'")
+    end
+
+    _(out.stdout).must_include "Profile Summary"
+    _(out.stdout).must_include "Test Summary"
+    _(out.stderr).must_equal ""
+
+    skip_windows! # Breakage confirmed, only on CI: https://buildkite.com/chef-oss/inspec-inspec-master-verify/builds/2355#2c9d032e-4a24-4e7c-aef2-1c9e2317d9e2
+
+    assert_exit_code 100, out
+  end
+
+  it "supermarket profiles with --supermarket_url option" do
+    out = inspec("supermarket profiles --supermarket_url='https://supermarket.chef.io'")
+
+    _(out.stdout).must_include "dev-sec/linux-patch-baseline"
+    _(out.stdout).must_include "dev-sec/windows-baseline"
+    _(out.stderr).must_equal ""
+
+    assert_exit_code 0, out
+  end
 end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
Implemented CLI option for executing private supermarket profiles
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

1. Added a cli option `supermarket_url` for `inspec exec` to run private profiles.
2. Added a cli option `supermarket_url` for `inspec supermarket` commands to run and fetch private supermarket profiles information.
 
For example, implemented working of following commands: 
```
- inspec exec supermarket://PRIVATE_PROFILE --supermarket_url=PRIVATE_SUPERMARKET_URL
- inspec supermarket exec PRIVATE_PROFILE  --supermarket_url=PRIVATE_SUPERMARKET_URL
- inspec supermarket profiles --supermarket_url=PRIVATE_SUPERMARKET_URL
- inspec supermarket info PRIVATE_PROFILE --supermarket_url=PRIVATE_SUPERMARKET_URL
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Closes #1236 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
