### PR TITLE
Add option to set ssh config file path for ssh transport

### DIFF
--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -42,7 +42,7 @@ This subcommand has the following additional options:
 * ``--tar``, ``--no-tar``
     Generates a tar.gz archive.
 * ``--vendor-cache=VENDOR_CACHE``
-    Use the given path for caching dependencies, (default: ~/.inspec/cache).
+    Use the given path for caching dependencies, (default: `~/.inspec/cache`).
 * ``--zip``, ``--no-zip``
     Generates a zip archive.
 
@@ -79,7 +79,7 @@ This subcommand has the following additional options:
 * ``--profiles-path=PROFILES_PATH``
     Folder which contains referenced profiles.
 * ``--vendor-cache=VENDOR_CACHE``
-    Use the given path for caching dependencies, (default: ~/.inspec/cache).
+    Use the given path for caching dependencies, (default: `~/.inspec/cache`).
 
 ## detect
 
@@ -343,6 +343,8 @@ This subcommand has the following additional options:
     Show progress while executing tests.
 * ``--silence-deprecations=all|GROUP GROUP...``
     Suppress deprecation warnings. See install_dir/etc/deprecations.json for list of GROUPs or use 'all'.
+* ``--ssh-config-file=one two three``
+    A list of paths to the ssh config file, e.g `~/.ssh/config` or `/etc/ssh/ssh_config`.
 * ``--ssl``, ``--no-ssl``
     Use SSL for transport layer encryption (WinRM).
 * ``--sudo``, ``--no-sudo``
@@ -362,7 +364,7 @@ This subcommand has the following additional options:
 * ``--user=USER``
     The login user for a remote scan.
 * ``--vendor-cache=VENDOR_CACHE``
-    Use the given path for caching dependencies. (default: ~/.inspec/cache).
+    Use the given path for caching dependencies. (default: `~/.inspec/cache`).
 * ``--waiver-file=one two three``
     Load one or more waiver files.
 * ``--winrm-basic-auth-only``, ``--no-winrm-basic-auth-only``
@@ -433,7 +435,7 @@ This subcommand has the following additional options:
 * ``--tags=one two three``
     A list of tags that reference certain controls. Other controls are ignored.
 * ``--vendor-cache=VENDOR_CACHE``
-    Use the given path for caching dependencies. (default: ~/.inspec/cache).
+    Use the given path for caching dependencies. (default: `~/.inspec/cache`).
 
 ## nothing
 
@@ -535,6 +537,8 @@ This subcommand has the following additional options:
     Specify a particular shell to use.
 * ``--shell-options=SHELL_OPTIONS``
     Additional shell options.
+* ``--ssh-config-file=one two three``
+    A list of paths to the ssh config file, e.g `~/.ssh/config` or `/etc/ssh/ssh_config`.
 * ``--ssl``, ``--no-ssl``
     Use SSL for transport layer encryption (WinRM).
 * ``--sudo``, ``--no-sudo``

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -344,7 +344,7 @@ This subcommand has the following additional options:
 * ``--silence-deprecations=all|GROUP GROUP...``
     Suppress deprecation warnings. See install_dir/etc/deprecations.json for list of GROUPs or use 'all'.
 * ``--ssh-config-file=one two three``
-    A list of paths to the ssh config file, e.g `~/.ssh/config` or `/etc/ssh/ssh_config`.
+    A list of paths to the SSH configuration file, for example: `~/.ssh/config` or `/etc/ssh/ssh_config`.
 * ``--ssl``, ``--no-ssl``
     Use SSL for transport layer encryption (WinRM).
 * ``--sudo``, ``--no-sudo``

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -538,7 +538,7 @@ This subcommand has the following additional options:
 * ``--shell-options=SHELL_OPTIONS``
     Additional shell options.
 * ``--ssh-config-file=one two three``
-    A list of paths to the ssh config file, e.g `~/.ssh/config` or `/etc/ssh/ssh_config`.
+    A list of paths to the SSH configuration file, for example: `~/.ssh/config` or `/etc/ssh/ssh_config`.
 * ``--ssl``, ``--no-ssl``
     Use SSL for transport layer encryption (WinRM).
 * ``--sudo``, ``--no-sudo``

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -126,6 +126,8 @@ module Inspec
         desc: "Specify a shell type for winrm (eg. 'elevated' or 'powershell')"
       option :docker_url, type: :string,
         desc: "Provides path to Docker API endpoint (Docker)"
+      option :ssh_config_file, type: :array,
+        desc: "A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config"
     end
 
     def self.profile_options


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added `--ssh-config-file` option to accept the list of paths to the ssh config file.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #2338 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
