### PR TITLE
Adds tls1.3 support in ssl resource.

### DIFF
--- a/docs-chef-io/content/inspec/resources/ssl.md
+++ b/docs-chef-io/content/inspec/resources/ssl.md
@@ -154,4 +154,11 @@ or:
       it { should_not be_enabled }
     end
 
-Supported Protocols : `ssl2`, `ssl3`, `tls1.0`, `tls1.1`, `tls1.2`, `tls1.3`
+Supported protocols:
+
+- `ssl2`
+- `ssl3`
+- `tls1.0`
+- `tls1.1`
+- `tls1.2`
+- `tls1.3`

--- a/docs-chef-io/content/inspec/resources/ssl.md
+++ b/docs-chef-io/content/inspec/resources/ssl.md
@@ -129,3 +129,29 @@ For a full list of available matchers, please visit our [matchers page](/inspec/
 The `be_enabled` matcher tests if SSL is enabled:
 
     it { should be_enabled }
+
+### ciphers
+
+The `ciphers` matcher tests the named cipher:
+
+    its('ciphers') { should_not eq '/rc4/i' }
+
+or:
+
+    describe ssl(port: 443).ciphers(/rc4/i) do
+      it { should_not be_enabled }
+    end
+
+### protocols
+
+The `protocols` matcher tests what protocol versions (SSLv3, TLSv1.1, etc) are enabled:
+
+    its('protocols') { should eq 'ssl2' }
+
+or:
+
+    describe ssl(port: 443).protocols('ssl2') do
+      it { should_not be_enabled }
+    end
+
+Supported Protocols : `ssl2`, `ssl3`, `tls1.0`, `tls1.1`, `tls1.2`, `tls1.3`

--- a/lib/inspec/resources/ssl.rb
+++ b/lib/inspec/resources/ssl.rb
@@ -38,6 +38,7 @@ module Inspec::Resources
       "tls1.0",
       "tls1.1",
       "tls1.2",
+      "tls1.3",
     ].freeze
 
     attr_reader :host, :port, :timeout, :retries
@@ -89,6 +90,7 @@ module Inspec::Resources
         { "protocol" => "tls1.0", "ciphers" => SSLShake::TLS::TLS10_CIPHERS.keys },
         { "protocol" => "tls1.1", "ciphers" => SSLShake::TLS::TLS10_CIPHERS.keys },
         { "protocol" => "tls1.2", "ciphers" => SSLShake::TLS::TLS_CIPHERS.keys },
+        { "protocol" => "tls1.3", "ciphers" => SSLShake::TLS::TLS13_CIPHERS.keys },
       ].map do |line|
         line["ciphers"].map do |cipher|
           { "protocol" => line["protocol"], "cipher" => cipher }

--- a/lib/inspec/resources/ssl.rb
+++ b/lib/inspec/resources/ssl.rb
@@ -73,6 +73,11 @@ module Inspec::Resources
             protocol: proto, ciphers: e.map(&:cipher),
             timeout: x.resource.timeout, retries: x.resource.retries, servername: x.resource.host)]
         end
+
+        if !res[0].empty? && res[0][1].key?("error") && res[0][1]["error"].include?("Connection error Errno::ECONNREFUSED")
+          raise "#{res[0][1]["error"]}"
+        end
+
         Hash[res]
       end
       .install_filter_methods_on_resource(self, :scan_config)

--- a/test/unit/resources/ssl_test.rb
+++ b/test/unit/resources/ssl_test.rb
@@ -42,7 +42,8 @@ describe "Inspec::Resources::SSL" do
   it "verify host unreachable" do
     SSLShake.expects(:hello).at_least_once.returns({ "error" => "Connection error Errno::ECONNREFUSED, can't connect to localhost:443." })
     resource = load_resource("ssl", host: "localhost")
-    _(resource.enabled?).must_equal false
+    err = _ { resource.enabled? }.must_raise(RuntimeError)
+    _(err.message).must_equal "Connection error Errno::ECONNREFUSED, can't connect to localhost:443."
   end
 
   it "error with nil host" do

--- a/test/unit/resources/ssl_test.rb
+++ b/test/unit/resources/ssl_test.rb
@@ -21,6 +21,12 @@ describe "Inspec::Resources::SSL" do
     _(resource.enabled?).must_equal true
   end
 
+  it "verify protocol enabled" do
+    SSLShake.expects(:hello).at_least_once.returns({ "version" => "tls1.3", "success" => true })
+    resource = load_resource("ssl", host: "localhost").protocols("tls1.3")
+    _(resource.enabled?).must_equal true
+  end
+
   it "verify protocol disabled" do
     SSLShake.expects(:hello).at_least_once.returns({ "error" => "Failed to parse response. Cannot handle SSLv2 responses" })
     resource = load_resource("ssl", host: "localhost").protocols("ssl2")
@@ -47,8 +53,8 @@ describe "Inspec::Resources::SSL" do
 
   it "verify sslshake resources" do
     resource = load_resource("ssl", host: "localhost")
-    _(resource.protocols.uniq).must_equal ["ssl2", "ssl3", "tls1.0", "tls1.1", "tls1.2"]
+    _(resource.protocols.uniq).must_equal ["ssl2", "ssl3", "tls1.0", "tls1.1", "tls1.2", "tls1.3"]
     _(resource.ciphers.include?("TLS_RSA_WITH_AES_128_CBC_SHA256")).must_equal true
-    _([681, 993, 1003]).must_include(resource.ciphers.count)
+    _([681, 993, 1003, 1008]).must_include(resource.ciphers.count)
   end
 end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Resouce `ssl` fails as it's not having support for TLS 1.3 protocol, this PR adds the support for TLS1.3 protocol. 
Ref :  https://github.com/arlimus/sslshake/commit/549f75bfcb084e4e03cc21a7bd3e2857ae38f75c

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5719
Fixes #4956 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
