### PR TITLE
Fix: Alpine packages list command to only list installed packages

### DIFF
--- a/lib/inspec/resources/packages.rb
+++ b/lib/inspec/resources/packages.rb
@@ -114,7 +114,7 @@ module Inspec::Resources
   # RedHat family
   class AlpinePkgs < PkgsManagement
     def build_package_list
-      command = "apk list --no-network"
+      command = "apk list --no-network --installed"
       cmd = inspec.command(command)
       all = cmd.stdout.split("\n")
       return [] if all.nil? || cmd.exit_status.to_i != 0

--- a/test/fixtures/cmd/apk-info
+++ b/test/fixtures/cmd/apk-info
@@ -1,5 +1,6 @@
-bsm-simple-themes-metacity-1.3-r4 x86_64 {bsm-simple-themes} (GPL)
-http-parser-dev-2.8.1-r0 x86_64 {http-parser} (MIT)
-libsoup-dev-2.62.1-r0 x86_64 {libsoup} (LGPL-2.0-or-later)
-udisks-dev-1.0.5-r3 x86_64 {udisks} (GPL-2.0-or-later)
-rxvt-unicode-9.22-r4 x86_64 {rxvt-unicode} (GPL-3.0+)
+libxmu-1.1.2-r1 x86_64 {libxmu} (custom) [installed]
+virtualbox-guest-modules-virt-4.14.167-r0 x86_64 {virtualbox-guest-modules-vanilla} (GPL-2.0 custom) [installed]
+pkgconf-1.5.3-r0 x86_64 {pkgconf} (ISC) [installed]
+nginx-1.14.2-r2 x86_64 {nginx} (BSD-2-Clause) [installed]
+dmidecode-3.1-r0 x86_64 {dmidecode} (GPL) [installed]
+syslinux-6.04_pre1-r1 x86_64 {syslinux} (GPL) [installed]

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -573,7 +573,7 @@ class MockLoader
 
       # alpine package commands
       "apk info -vv --no-network | grep git" => cmd.call("apk-info-grep-git"),
-      "apk list --no-network" => cmd.call("apk-info"),
+      "apk list --no-network --installed" => cmd.call("apk-info"),
 
       # filesystem command
       "2e7e0d4546342cee799748ec7e2b1c87ca00afbe590fa422a7c27371eefa88f0" => cmd.call("get-wmiobject-filesystem"),

--- a/test/unit/resources/packages_test.rb
+++ b/test/unit/resources/packages_test.rb
@@ -77,12 +77,12 @@ describe "Inspec::Resources::Packages" do
   end
 
   it "packages on alpine" do
-    resource = MockLoader.new(:alpine).load_resource("packages", /^http-parser$/)
+    resource = MockLoader.new(:alpine).load_resource("packages", /^nginx$/)
     _(resource.entries.length).must_equal 1
     _(resource.entries[0].to_h).must_equal({
       status: "installed",
-      name: "http-parser",
-      version: "2.8.1",
+      name: "nginx",
+      version: "1.14.2",
       architecture: "x86_64",
     })
   end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
Fix: Alpine packages list command to only list installed packages
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Fix to only list installed packages in packages resource for Alpine target os
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
