### PR TITLE
Active support version fix for ruby versions less then 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,7 @@ if Gem.ruby_version >= Gem::Version.new("2.7.0")
     gem "git"
   end
 end
+
+if Gem.ruby_version < Gem::Version.new("2.7.0")
+  gem "activesupport", "6.1.4.4"
+end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
`activesupport` gem version pinned for ruby version <= 2.7, since ruby 2.6 tests were failing.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
