### PR TITLE
Check for latest - package resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/package.md
+++ b/docs-chef-io/content/inspec/resources/package.md
@@ -78,7 +78,7 @@ The following examples show how to use this Chef InSpec audit resource.
       its('telnet') { should eq nil }
     end
 
-### Test if ClamAV (an antivirus engine) is installed and running
+### Test if ClamAV (an antivirus engine) is installed, latest and running
 
     describe package('clamav') do
       it { should be_installed }
@@ -88,6 +88,7 @@ The following examples show how to use this Chef InSpec audit resource.
     describe service('clamd') do
       it { should be_enabled }
       it { should be_installed }
+      it { should be_latest }
       it { should be_running }
     end
 
@@ -97,7 +98,7 @@ The following examples show how to use this Chef InSpec audit resource.
       it { should be_installed }
     end
 
-### Verify if Memcached is installed, enabled, and running
+### Verify if Memcached is installed, latest, enabled, and running
 
 Memcached is an in-memory key-value store that helps improve the performance of database-driven websites and can be installed, maintained, and tested using the `memcached` cookbook (maintained by Chef). The following example is from the `memcached` cookbook and shows how to use a combination of the `package`, `service`, and `port` Chef InSpec audit resources to test if Memcached is installed, enabled, and running:
 
@@ -107,6 +108,7 @@ Memcached is an in-memory key-value store that helps improve the performance of 
 
     describe service('memcached') do
       it { should be_installed }
+      it { should be_latest }
       it { should be_enabled }
       it { should be_running }
     end
@@ -131,3 +133,9 @@ will not be upgraded to a later version.
 The `be_installed` matcher tests if the named package is installed on the system:
 
     it { should be_installed }
+
+### be_latest
+
+The `be_latest` matcher tests if the named installed package is latest on the system. It is not supported in Oracle Solaris, IBM AIX and HP UX operating systems.
+
+    it { should be_latest }

--- a/lib/inspec/resources/package.rb
+++ b/lib/inspec/resources/package.rb
@@ -127,8 +127,7 @@ module Inspec::Resources
     def fetch_latest_version(cmd_string)
       cmd = inspec.command(cmd_string)
       if cmd.exit_status != 0
-        Inspec::Log.error "Failed to fetch latest version. Error: #{cmd.stderr}"
-        nil
+        raise Inspec::Exceptions::ResourceFailed, "Failed to fetch latest version. Error: #{cmd.stderr}"
       else
         fetch_version_no(cmd.stdout)
       end

--- a/test/fixtures/cmd/apk-info-cmd
+++ b/test/fixtures/cmd/apk-info-cmd
@@ -1,0 +1,1 @@
+git-2.18.4-r0 description:\nDistributed version control system\n\ngit-2.18.4-r0 webpage:\nhttps://www.git-scm.com/\n\ngit-2.18.4-r0 installed size:\n13213696\n\n

--- a/test/fixtures/cmd/apt-list-curl
+++ b/test/fixtures/cmd/apt-list-curl
@@ -1,0 +1,3 @@
+Listing... Done
+curl/focal-updates,focal-security 7.68.0-1ubuntu2.7 amd64 [upgradable from: 7.68.0-1ubuntu2.4]
+curl/focal-updates,focal-security 7.68.0-1ubuntu2.7 i386

--- a/test/fixtures/cmd/get-pkg-versions
+++ b/test/fixtures/cmd/get-pkg-versions
@@ -1,0 +1,3 @@
+Name                           Version          Source                           ProviderName
+----                           -------          ------                           ------------
+Chef Client                    17.8.25                                           Programs

--- a/test/fixtures/cmd/get-pkg-versions
+++ b/test/fixtures/cmd/get-pkg-versions
@@ -1,3 +1,3 @@
 Name                           Version          Source                           ProviderName
 ----                           -------          ------                           ------------
-Chef Client                    17.8.25                                           Programs
+Chef Client                    12.12.15.1                                        Programs

--- a/test/fixtures/cmd/pacman-ss-grep-curl
+++ b/test/fixtures/cmd/pacman-ss-grep-curl
@@ -1,0 +1,1 @@
+core/curl 7.80.0-1 [installed: 7.37.0-1]

--- a/test/fixtures/cmd/pkg-version-grep-vim-console
+++ b/test/fixtures/cmd/pkg-version-grep-vim-console
@@ -1,0 +1,1 @@
+"vim-console-8.1.1954                         =   up-to-date with remote\n"

--- a/test/fixtures/cmd/yum-list-curl
+++ b/test/fixtures/cmd/yum-list-curl
@@ -1,0 +1,8 @@
+Loaded plugins: fastestmirror
+Loading mirror speeds from cached hostfile
+ * base: mirrors.piconets.webwerks.in
+ * epel: repo.extreme-ix.org
+ * extras: mirrors.piconets.webwerks.in
+ * updates: mirrors.piconets.webwerks.in
+Installed Packages
+curl.x86_64                                                               7.29.0-59.el7_9.1                                                               @updates

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -241,7 +241,7 @@ class MockLoader
       "dpkg -s held-package" => cmd.call("dpkg-s-held-package"),
       "rpm -qi curl" => cmd.call("rpm-qi-curl"),
       "yum list curl" => cmd.call("yum-list-curl"),
-      "Get-Package Chef Client -AllVersions" => cmd.call("get-pkg-versions"),
+      "Get-Package Chef Client v12.12.15 -AllVersions" => cmd.call("get-pkg-versions"),
       "rpm -qi --dbpath /var/lib/fake_rpmdb curl" => cmd.call("rpm-qi-curl"),
       "rpm -qi --dbpath /var/lib/rpmdb_does_not_exist curl" => cmd_exit_1.call,
       "pacman -Qi curl" => cmd.call("pacman-qi-curl"),

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -237,11 +237,15 @@ class MockLoader
       "/sbin/auditctl -l" => cmd.call("auditctl"),
       "/sbin/auditctl -s" => cmd.call("auditctl-s"),
       "dpkg -s curl" => cmd.call("dpkg-s-curl"),
+      "apt list curl -a" => cmd.call("apt-list-curl"),
       "dpkg -s held-package" => cmd.call("dpkg-s-held-package"),
       "rpm -qi curl" => cmd.call("rpm-qi-curl"),
+      "yum list curl" => cmd.call("yum-list-curl"),
+      "Get-Package Chef Client -AllVersions" => cmd.call("get-pkg-versions"),
       "rpm -qi --dbpath /var/lib/fake_rpmdb curl" => cmd.call("rpm-qi-curl"),
       "rpm -qi --dbpath /var/lib/rpmdb_does_not_exist curl" => cmd_exit_1.call,
       "pacman -Qi curl" => cmd.call("pacman-qi-curl"),
+      "pacman -Ss curl | grep curl | grep installed" => cmd.call("pacman-ss-grep-curl"),
       "brew info --json=v1 curl" => cmd.call("brew-info--json-v1-curl"),
       "brew info --json=v1 nginx" => cmd.call("brew-info--json-v1-nginx"),
       "brew info --json=v1 nope" => cmd_exit_1.call,
@@ -387,6 +391,7 @@ class MockLoader
       "rpm -qa --queryformat '%{NAME}  %{VERSION}-%{RELEASE}  %{ARCH}\\n'" => cmd.call("rpm-qa-queryformat"),
       # pkg query all packages
       "pkg info vim-console" => cmd.call("pkg-info-vim-console"),
+      "pkg version -v | grep vim-console" => cmd.call("pkg-version-grep-vim-console"),
       # port netstat on solaris 10 & 11
       "netstat -an -f inet -f inet6" => cmd.call("s11-netstat-an-finet-finet6"),
       # xinetd configuration
@@ -574,6 +579,7 @@ class MockLoader
       # alpine package commands
       "apk info -vv --no-network | grep git" => cmd.call("apk-info-grep-git"),
       "apk list --no-network --installed" => cmd.call("apk-info"),
+      "apk info git" => cmd.call("apk-info-cmd"),
 
       # filesystem command
       "2e7e0d4546342cee799748ec7e2b1c87ca00afbe590fa422a7c27371eefa88f0" => cmd.call("get-wmiobject-filesystem"),

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -50,7 +50,7 @@ describe "Inspec::Resources::Package" do
         installed: true,
         version: "7.29.0-19.el7",
         type: "rpm",
-        only_version_no: "7.29.0"
+        only_version_no: "7.29.0",
       }
     end
 
@@ -108,7 +108,7 @@ describe "Inspec::Resources::Package" do
     _(resource.installed?).must_equal true
     _(resource.version).must_equal "12.12.15.1"
     _(resource.info).must_equal pkg
-    _(resource.latest?).must_equal false
+    _(resource.latest?).must_equal true
   end
 
   # solaris 10

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -6,25 +6,27 @@ describe "Inspec::Resources::Package" do
   # arch linux
   it "verify arch linux package parsing" do
     resource = MockLoader.new(:arch).load_resource("package", "curl")
-    pkg = { name: "curl", installed: true, version: "7.37.0-1", type: "pacman" }
+    pkg = { name: "curl", installed: true, version: "7.37.0-1", type: "pacman", only_version_no: "7.37.0" }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal "7.37.0-1"
     _(resource.info).must_equal pkg
+    _(resource.latest?).must_equal false
   end
 
   # ubuntu
   it "verify ubuntu package parsing" do
     resource = MockLoader.new(:ubuntu).load_resource("package", "curl")
-    pkg = { name: "curl", installed: true, held: false, version: "7.35.0-1ubuntu2", type: "deb" }
+    pkg = { name: "curl", installed: true, held: false, version: "7.35.0-1ubuntu2", type: "deb", only_version_no: "7.35.0" }
     _(resource.installed?).must_equal true
     _(resource.held?).must_equal false
     _(resource.version).must_equal "7.35.0-1ubuntu2"
     _(resource.info).must_equal pkg
+    _(resource.latest?).must_equal false
   end
 
   it "verify ubuntu package which is held" do
     resource = MockLoader.new(:ubuntu).load_resource("package", "held-package")
-    pkg = { name: "held-package", installed: true, held: true, version: "1.2.3-1", type: "deb" }
+    pkg = { name: "held-package", installed: true, held: true, version: "1.2.3-1", type: "deb", only_version_no: "1.2.3" }
     _(resource.installed?).must_equal true
     _(resource.held?).must_equal true
     _(resource.version).must_equal "1.2.3-1"
@@ -34,7 +36,7 @@ describe "Inspec::Resources::Package" do
   # mint
   it "verify mint package parsing" do
     resource = MockLoader.new(:mint17).load_resource("package", "curl")
-    pkg = { name: "curl", installed: true, held: false, version: "7.35.0-1ubuntu2", type: "deb" }
+    pkg = { name: "curl", installed: true, held: false, version: "7.35.0-1ubuntu2", type: "deb", only_version_no: "7.35.0" }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal "7.35.0-1ubuntu2"
     _(resource.info).must_equal pkg
@@ -48,6 +50,7 @@ describe "Inspec::Resources::Package" do
         installed: true,
         version: "7.29.0-19.el7",
         type: "rpm",
+        only_version_no: "7.29.0"
       }
     end
 
@@ -56,6 +59,7 @@ describe "Inspec::Resources::Package" do
       _(resource.installed?).must_equal true
       _(resource.version).must_equal "7.29.0-19.el7"
       _(resource.info).must_equal pkg
+      _(resource.latest?).must_equal true
     end
 
     it "can build an `rpm` command containing `--dbpath`" do
@@ -91,7 +95,7 @@ describe "Inspec::Resources::Package" do
   # wrlinux
   it "verify wrlinux package parsing" do
     resource = MockLoader.new(:wrlinux).load_resource("package", "curl")
-    pkg = { name: "curl", installed: true, version: "7.29.0-19.el7", type: "rpm" }
+    pkg = { name: "curl", installed: true, version: "7.29.0-19.el7", type: "rpm", only_version_no: "7.29.0" }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal "7.29.0-19.el7"
     _(resource.info).must_equal pkg
@@ -100,10 +104,11 @@ describe "Inspec::Resources::Package" do
   # windows
   it "verify windows package parsing" do
     resource = MockLoader.new(:windows).load_resource("package", "Chef Client v12.12.15")
-    pkg = { name: "Chef Client v12.12.15 ", installed: true, version: "12.12.15.1", type: "windows" }
+    pkg = { name: "Chef Client v12.12.15 ", installed: true, version: "12.12.15.1", type: "windows", only_version_no: "12.12.15.1" }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal "12.12.15.1"
     _(resource.info).must_equal pkg
+    _(resource.latest?).must_equal false
   end
 
   # solaris 10
@@ -127,10 +132,11 @@ describe "Inspec::Resources::Package" do
   # darwin (brew)
   it "can parse ouptut from 'brew' when package is installed" do
     resource = MockLoader.new(:macos10_10).load_resource("package", "curl")
-    pkg = { name: "curl", installed: true, version: "7.52.1", type: "brew" }
+    pkg = { name: "curl", installed: true, version: "7.52.1", type: "brew", latest_version: "7.52.1", only_version_no: "7.52.1" }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal "7.52.1"
     _(resource.info).must_equal pkg
+    _(resource.latest?).must_equal true
   end
 
   it "can parse ouptut from 'brew' when package is not installed but exists" do
@@ -152,19 +158,21 @@ describe "Inspec::Resources::Package" do
   # alpine
   it "can parse Alpine packages" do
     resource = MockLoader.new(:alpine).load_resource("package", "git")
-    pkg = { name: "git", installed: true, version: "2.15.0-r1", type: "pkg" }
+    pkg = { name: "git", installed: true, version: "2.15.0-r1", type: "pkg", only_version_no: "2.15.0" }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal "2.15.0-r1"
     _(resource.info).must_equal pkg
+    _(resource.latest?).must_equal false
   end
 
   # freebsd
   it "can parse FreeBSD packages" do
     resource = MockLoader.new(:freebsd11).load_resource("package", "vim-console")
-    pkg = { name: "vim-console", installed: true, version: "8.1.1954", type: "pkg" }
+    pkg = { name: "vim-console", installed: true, version: "8.1.1954", type: "pkg", only_version_no: "8.1.1954" }
     _(resource.installed?).must_equal true
     _(resource.version).must_equal "8.1.1954"
     _(resource.info).must_equal pkg
+    _(resource.latest?).must_equal true
   end
 
   # undefined


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Added matcher `be_latest` for package resource.
- Does not support **HP UX, IBM AIX and Oracle Solaris** operating systems.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Closes #4606 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
