### PR TITLE
Fix downloads links

### DIFF
--- a/.expeditor/announce-release.sh
+++ b/.expeditor/announce-release.sh
@@ -13,7 +13,7 @@ $(cat release-notes.md)
 ---
 ## Get the Build
 
-You can download binaries directly from [downloads.chef.io](https://downloads.chef.io/$EXPEDITOR_PRODUCT_KEY/$EXPEDITOR_VERSION).
+You can download binaries directly from [Chef Downloads](https://www.chef.io/downloads/tools/$EXPEDITOR_PRODUCT_KEY?v=$EXPEDITOR_VERSION).
 EOH
 )
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ Date:   Wed Sep 18 11:44:40 2015 -0700
 
 ### Release Formats
 
-Our primary shipping vehicle is operating system specific packages that includes all the requirements of InSpec. We call these Omnibus packages, and they are available from [downloads.chef.io](https://downloads.chef.io/inspec). InSpec is also bundled with recent Chef Infra Client and Chef Workstation toolkits.
+Our primary shipping vehicle is operating system specific packages that includes all the requirements of InSpec. We call these Omnibus packages, and they are available from [Chef Downloads](https://www.chef.io/downloads/tools/inspec). InSpec is also bundled with recent Chef Infra Client and Chef Workstation toolkits.
 
 InSpec is also available as a [Docker image](https://hub.docker.com/r/chef/inspec) and a [Habitat package](https://bldr.habitat.sh/#/pkgs/chef/inspec/latest).
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Note: Versions of Chef InSpec 4.0 and later require accepting the EULA to use. P
 
 ### Install as package
 
-The Chef InSpec package is available for MacOS, RedHat, Ubuntu and Windows. Download the latest package at [Chef InSpec Downloads](https://downloads.chef.io/inspec) or install Chef InSpec via script:
+The Chef InSpec package is available for MacOS, RedHat, Ubuntu and Windows. Download the latest package at [Chef InSpec Downloads](https://www.chef.io/downloads/tools/inspec) or install Chef InSpec via script:
 
 ```
 # RedHat, Ubuntu, and macOS
@@ -142,7 +142,7 @@ Finished in 0.04321 seconds (files took 0.54917 seconds to load)
 
 ### Install it from source
 
-Note that installing from OS packages from [the download page](https://downloads.chef.io) is the preferred method.
+Note that installing from OS packages from [the download page](https://www.chef.io/downloads/tools/inspec) is the preferred method.
 
 That requires [bundler](http://bundler.io/):
 

--- a/docs-chef-io/content/inspec/install.md
+++ b/docs-chef-io/content/inspec/install.md
@@ -16,7 +16,7 @@ Users can choose between operating systems of MacOS, Windows, and Linux for Chef
 ## Install Chef InSpec
 
 You can download the latest Chef InSpec package relevant to your operating system
-at [our Downloads Page](https://downloads.chef.io/inspec).
+at [our Downloads Page](https://www.chef.io/downloads/tools/inspec).
 
 Alternatively, Chef InSpec can be installed via installer, script, or package
 manager, according to your operating system and method as listed below.
@@ -47,7 +47,7 @@ curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -P inspec
 
 #### Installer
 
-Once you downloaded the latest [Chef InSpec package](https://downloads.chef.io/inspec)
+Once you downloaded the latest [Chef InSpec package](https://www.chef.io/downloads/tools/inspec)
 relevant to your Microsoft version, double-click the `.msi` file to launch the
 installer and follow the prompts.
 
@@ -73,7 +73,7 @@ curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -P inspec
 ```
 
 If you prefer, you can use a package manager to install Chef InSpec.
-Once you downloaded the latest [Chef InSpec package](https://downloads.chef.io/inspec)
+Once you downloaded the latest [Chef InSpec package](https://www.chef.io/downloads/tools/inspec)
 relevant to your Linux-based platform, use the command for the respective package
 manager listed below. Replace the example file path with the file path leading to
 your downloaded package.


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

Fix links to InSpec downloads

From downloads.chef.io/inspec --> https://www.chef.io/downloads/tools/inspec

Note that I didn't change a few:

- There's one in the changelog
- There a couple in [test/kitchen/cookbooks/os_prepare/recipes/apt.rb](https://github.com/inspec/inspec/blob/main/test/kitchen/cookbooks/os_prepare/recipes/apt.rb) that look like they're still valid
- One in [release_process.md](https://github.com/inspec/inspec/blob/main/RELEASE_PROCESS.md)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
