### PR TITLE
Mssql session fix : Parsing multiline results

### DIFF
--- a/test/fixtures/cmd/mssql-multiline-result
+++ b/test/fixtures/cmd/mssql-multiline-result
@@ -1,0 +1,4 @@
+result
+------
+This is
+a multiline field

--- a/test/unit/resources/mssql_session_test.rb
+++ b/test/unit/resources/mssql_session_test.rb
@@ -65,4 +65,19 @@ describe "Inspec::Resources::MssqlSession" do
     _(query.size).must_equal 1
     _(query.row(0).column("result").value).must_equal "14.0.600.250"
   end
+
+  it "run a SQL query with multiline output" do
+    resource = quick_resource(:mssql_session, :linux, user: "sa", password: "yourStrong(!)Password", host: "localhost", port: "1433") do |cmd|
+      cmd.strip!
+      case cmd
+      when "sqlcmd -Q \"set nocount on; SELECT * FROM example as result\" -W -w 1024 -s ',' -U 'sa' -P 'yourStrong(!)Password' -S 'localhost,1433'" then
+        stdout_file "test/fixtures/cmd/mssql-multiline-result"
+      else
+        raise cmd.inspect
+      end
+    end
+
+    query = resource.query("SELECT * FROM example as result")
+    _(query.row(1).column("result").value).must_include "multiline"
+  end
 end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Mssql session fix : Parsing multiline results
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5730 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
