### PR TITLE
Adds user_permissions property and be_inherited matcher to the registry_key resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/registry_key.md
+++ b/docs-chef-io/content/inspec/resources/registry_key.md
@@ -99,7 +99,7 @@ where `'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule'` is the f
 
 ### user_permissions
 
-The `user_permissions` property returns the hash containing the list of users or groups and their registry key permissions. for e.g. `{ "NT AUTHORITY\\SYSTEM" => "FullControl", "NT AUTHORITY\\Authenticated Users" => "ReadAndExecute", "BUILTIN\\Administrators" => "FullControl" }`
+The `user_permissions` property returns a hash containing a list of users or groups and their registry key permissions on Windows. For example:
 
     its('user_permissions') { should cmp { "NT AUTHORITY\\SYSTEM" => "FullControl", "NT AUTHORITY\\Authenticated Users" => "ReadAndExecute", "BUILTIN\\Administrators" => "FullControl" } }
 
@@ -165,9 +165,11 @@ The `name` matcher tests the value for the specified registry setting:
 
 ### be_inherited
 
-The `be_inherited` matcher returns the `Boolean`. It will return `true` if registry key has inheritance enabled.
+`be_inherited` is a boolean matcher which returns `true` if a registry key has inheritance enabled, otherwise `false`. This matcher only works on Windows systems.
 
-    it { should be_inherited }
+    registry_key('HKEY_USERS\S-1-5-20\Software\Policies\Microsoft\Windows\Control Panel\Desktop') do
+      it { should be_inherited }
+    end
 
 **Warning**: Any name with a dot will not work as expected: <code>its('explorer.exe') { should eq 'test' }</code>. For details, see <a href="https://github.com/inspec/inspec/issues/1281">https://github.com/inspec/inspec/issues/1281</a>
 

--- a/docs-chef-io/content/inspec/resources/registry_key.md
+++ b/docs-chef-io/content/inspec/resources/registry_key.md
@@ -163,11 +163,11 @@ The `name` matcher tests the value for the specified registry setting:
 
     its('name') { should eq 'value' }
 
-### be_inherit
+### be_inherited
 
-The `be_inherit` matcher returns the `Boolean`. It will return `true` if registry key has inheritance enabled.
+The `be_inherited` matcher returns the `Boolean`. It will return `true` if registry key has inheritance enabled.
 
-    it { should be_inherit }
+    it { should be_inherited }
 
 **Warning**: Any name with a dot will not work as expected: <code>its('explorer.exe') { should eq 'test' }</code>. For details, see <a href="https://github.com/inspec/inspec/issues/1281">https://github.com/inspec/inspec/issues/1281</a>
 

--- a/docs-chef-io/content/inspec/resources/registry_key.md
+++ b/docs-chef-io/content/inspec/resources/registry_key.md
@@ -95,6 +95,16 @@ where `'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule'` is the f
       its('ProductName') { should match /^[a-zA-Z0-9\(\)\s]*2012\s[rR]2[a-zA-Z0-9\(\)\s]*$/ }
     end
 
+## Properties
+
+### user_permissions
+
+The `user_permissions` property returns the hash containing the list of users or groups and their registry key permissions. for e.g. `{ "NT AUTHORITY\\SYSTEM" => "FullControl", "NT AUTHORITY\\Authenticated Users" => "ReadAndExecute", "BUILTIN\\Administrators" => "FullControl" }`
+
+    its('user_permissions') { should cmp { "NT AUTHORITY\\SYSTEM" => "FullControl", "NT AUTHORITY\\Authenticated Users" => "ReadAndExecute", "BUILTIN\\Administrators" => "FullControl" } }
+
+    its('user_permissions') { should include "NT AUTHORITY\\SYSTEM"=>"FullControl" }
+
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).
@@ -152,6 +162,12 @@ The `have_value` matcher tests if a value exists for a registry key:
 The `name` matcher tests the value for the specified registry setting:
 
     its('name') { should eq 'value' }
+
+### be_inherit
+
+The `be_inherit` matcher returns the `Boolean`. It will return `true` if registry key has inheritance enabled.
+
+    it { should be_inherit }
 
 **Warning**: Any name with a dot will not work as expected: <code>its('explorer.exe') { should eq 'test' }</code>. For details, see <a href="https://github.com/inspec/inspec/issues/1281">https://github.com/inspec/inspec/issues/1281</a>
 

--- a/lib/inspec/resources/registry_key.rb
+++ b/lib/inspec/resources/registry_key.rb
@@ -105,6 +105,21 @@ module Inspec::Resources
       children_keys(@options[:path], filter)
     end
 
+    # returns hash containing users / groups and their permission
+    def user_permissions
+      return {} unless exists?
+
+      get_permissions(@options[:path])
+    end
+
+    # returns true if inheritance is enabled for registry key.
+    def inherit?
+      return false unless exists?
+
+      cmd = inspec.command("(Get-Acl -Path 'Registry::#{@options[:path]}').access| Where-Object {$_.IsInherited -eq $true} | measure | % { $_.Count }")
+      cmd.stdout.chomp == "0" ? false : true
+    end
+
     # returns nil, if not existent or value
     def method_missing(*keys)
       # allow the use of array syntax in an `its` block so that users
@@ -282,6 +297,21 @@ module Inspec::Resources
       return "" unless key
 
       key.start_with?("\\") ? key : "\\#{key}"
+    end
+
+    def get_permissions(path)
+      script = <<~EOH
+      $path = '#{path}'
+      $Acl = Get-Acl -Path ('Registry::' + $path)
+      $Result = foreach ($Access in $acl.Access) {
+        [PSCustomObject]@{
+          $Access.IdentityReference = $Access.RegistryRights.ToString()
+        }
+      }
+      $Result | ConvertTo-Json
+      EOH
+      result = inspec.powershell(script)
+      JSON.load(result.stdout).inject(&:merge) unless result.stdout.empty?
     end
   end
 

--- a/lib/inspec/resources/registry_key.rb
+++ b/lib/inspec/resources/registry_key.rb
@@ -113,7 +113,7 @@ module Inspec::Resources
     end
 
     # returns true if inheritance is enabled for registry key.
-    def inherit?
+    def inherited?
       return false unless exists?
 
       cmd = inspec.command("(Get-Acl -Path 'Registry::#{@options[:path]}').access| Where-Object {$_.IsInherited -eq $true} | measure | % { $_.Count }")

--- a/test/unit/resources/registry_key_test.rb
+++ b/test/unit/resources/registry_key_test.rb
@@ -36,7 +36,7 @@ describe "Inspec::Resources::RegistryKey" do
     _(resource.send(:generate_registry_key_path_from_options)).must_equal 'my_hive\\key_with_no_slash'
   end
 
-  it "returns inherit and user permissions values" do
+  it "returns user permissions values" do
     resource = MockLoader.new(:windows).load_resource("registry_key", 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule')
     resource.stubs(:exist?).returns(true)
     resource.stubs(:user_permissions).returns({ "NT AUTHORITY\\SYSTEM" => "FullControl", "NT AUTHORITY\\Authenticated Users" => "ReadAndExecute", "BUILTIN\\Administrators" => "FullControl" })
@@ -46,7 +46,7 @@ describe "Inspec::Resources::RegistryKey" do
   it "returns true if file has inherit enabled on Windows." do
     resource = MockLoader.new(:windows).load_resource("registry_key", 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule')
     resource.stubs(:exist?).returns(true)
-    resource.stubs(:inherit?).returns(true)
-    _(resource.inherit?).must_equal true
+    resource.stubs(:inherited?).returns(true)
+    _(resource.inherited?).must_equal true
   end
 end

--- a/test/unit/resources/registry_key_test.rb
+++ b/test/unit/resources/registry_key_test.rb
@@ -36,4 +36,17 @@ describe "Inspec::Resources::RegistryKey" do
     _(resource.send(:generate_registry_key_path_from_options)).must_equal 'my_hive\\key_with_no_slash'
   end
 
+  it "returns inherit and user permissions values" do
+    resource = MockLoader.new(:windows).load_resource("registry_key", 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule')
+    resource.stubs(:exist?).returns(true)
+    resource.stubs(:user_permissions).returns({ "NT AUTHORITY\\SYSTEM" => "FullControl", "NT AUTHORITY\\Authenticated Users" => "ReadAndExecute", "BUILTIN\\Administrators" => "FullControl" })
+    _(resource.user_permissions).must_equal({ "NT AUTHORITY\\SYSTEM" => "FullControl", "NT AUTHORITY\\Authenticated Users" => "ReadAndExecute", "BUILTIN\\Administrators" => "FullControl" })
+  end
+
+  it "returns true if file has inherit enabled on Windows." do
+    resource = MockLoader.new(:windows).load_resource("registry_key", 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule')
+    resource.stubs(:exist?).returns(true)
+    resource.stubs(:inherit?).returns(true)
+    _(resource.inherit?).must_equal true
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
* Adds `user_permissions` property to list user or group permissions on the registry key.
* Adds `be_inherited` matcher to check whether inheritance is enabled on the registry key.
* Updated docs
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5769 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
