### PR TITLE
Remove support for EOL Ruby 2.5

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -17,14 +17,6 @@ steps:
         docker:
           image: ruby:2.6
 
-  - label: run-tests-ruby-2.5
-    command:
-      - /workdir/.expeditor/buildkite/verify.sh
-    expeditor:
-      executor:
-        docker:
-          image: ruby:2.5
-
   - label: run-tests-ruby-2.6
     command:
       - /workdir/.expeditor/buildkite/verify.sh

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,6 @@ gem "inspec-bin", path: "./inspec-bin"
 
 gem "ffi", ">= 1.9.14", "!= 1.13.0", "!= 1.14.2"
 
-if Gem.ruby_version.to_s.start_with?("2.5")
-  # 16.7.23 required ruby 2.6+
-  gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
-end
-
 # inspec tests depend text output that changed in the 3.10 release
 # but our runtime dep is still 3.9+
 gem "rspec", ">= 3.10"
@@ -30,11 +25,7 @@ end
 group :test do
   gem "chefstyle", "~> 2.0.3"
   gem "concurrent-ruby", "~> 1.0"
-  if Gem.ruby_version.to_s.start_with?("2.5")
-    gem "html-proofer", "= 3.19.1" , platforms: :ruby # do not attempt to run proofer on windows
-  else
-    gem "html-proofer", platforms: :ruby # do not attempt to run proofer on windows
-  end
+  gem "html-proofer", platforms: :ruby # do not attempt to run proofer on windows
   gem "json_schemer", ">= 0.2.1", "< 0.2.19"
   gem "m"
   gem "minitest-sprint", "~> 1.0"

--- a/README.md
+++ b/README.md
@@ -55,12 +55,7 @@ inspec exec test.rb -t docker://container_id
 
 ## Installation
 
-Chef InSpec requires Ruby ( >= 2.6 ). Ruby 2.5 support is limited and requires Bundler with an entry in the Gemfile:
-
-```
-  # 16.7.23 required ruby 2.6+
-  gem "chef-utils", "< 16.7.23"
-```
+Chef InSpec requires Ruby ( >= 2.6 ).
 
 Note: Versions of Chef InSpec 4.0 and later require accepting the EULA to use. Please visit the [license acceptance page](https://docs.chef.io/chef_license_accept.html) on the Chef docs site for more information.
 

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.6"
 
   # the gemfile and gemspec are necessary for appbundler so don't remove it
   spec.files =

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.6"
 
   # ONLY the aws/azure/gcp files. The rest will come in from inspec-core
   # the gemspec is necessary for appbundler so don't remove it

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -263,9 +263,3 @@ module Inspec
     end # DomainSpecificLunacy
   end # ProfileContext
 end
-
-if RUBY_VERSION < "2.5"
-  class Module
-    public :define_method
-  end
-end


### PR DESCRIPTION
With the release of Ruby 3.1, Ruby 2.5 is now EOL. We should not be supporting an EOL release of Ruby.

Signed-off-by: Tim Smith <tsmith@chef.io>