### PR TITLE
Fix for dependent profiles to run with --insecure

### DIFF
--- a/lib/inspec/dependencies/requirement.rb
+++ b/lib/inspec/dependencies/requirement.rb
@@ -102,7 +102,8 @@ module Inspec
     end
 
     def fetcher
-      @fetcher ||= Inspec::CachedFetcher.new(opts, @cache)
+      @runner_options ||= (Inspec::Config.cached || {})
+      @fetcher ||= Inspec::CachedFetcher.new(opts, @cache, @runner_options)
     end
 
     # load dependencies of the dependency


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Since `--insecure` flag was not accessible at fetcher level for dependent profiles, the runner configurations values are passed using requirement class, which is a class covering logic for dependencies.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5781 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
