### PR TITLE
CFINSPEC-15 Allows inheritance of core resource into the custom resource.

### DIFF
--- a/lib/inspec/library_eval_context.rb
+++ b/lib/inspec/library_eval_context.rb
@@ -30,6 +30,8 @@ module Inspec
 
       c3 = Class.new do
         include Inspec::DSL::RequireOverride
+        include Inspec::Resources
+
         def initialize(require_loader)
           @require_loader = require_loader
           @inspec_binding = nil

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -68,6 +68,7 @@ module Inspec
     end
 
     def reload_dsl
+      @resource_registry.merge!(Inspec::Resource.new_registry)
       @control_eval_context = nil
     end
 

--- a/test/fixtures/files/node.json
+++ b/test/fixtures/files/node.json
@@ -1,0 +1,10 @@
+{
+  "name" : "hello",
+  "meta" : {
+    "creator" : "John Doe"
+  },
+  "array": [
+    "zero",
+    "one"
+  ]
+}

--- a/test/fixtures/profiles/custom-resource-inheritance/README.md
+++ b/test/fixtures/profiles/custom-resource-inheritance/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec profile.

--- a/test/fixtures/profiles/custom-resource-inheritance/controls/example.rb
+++ b/test/fixtures/profiles/custom-resource-inheritance/controls/example.rb
@@ -1,0 +1,23 @@
+# copyright: 2018, The Authors
+
+# title "sample section"
+
+# # you can also use plain tests
+# describe file("/tmp") do
+#   it { should be_directory }
+# end
+
+# # you add controls here
+# control "tmp-1.0" do                        # A unique ID for this control
+#   impact 0.7                                # The criticality, if this control fails.
+#   title "Create /tmp directory"             # A human-readable title
+#   desc "An optional description..."
+#   describe file("/tmp") do                  # The actual test
+#     it { should be_directory }
+#   end
+# end
+
+describe node do
+  its("name") { should eq "hello" }
+  its(['meta','creator']) { should eq 'John Doe' }
+end

--- a/test/fixtures/profiles/custom-resource-inheritance/inspec.yml
+++ b/test/fixtures/profiles/custom-resource-inheritance/inspec.yml
@@ -1,0 +1,10 @@
+name: custom-resource-inheritance
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  platform: os

--- a/test/fixtures/profiles/custom-resource-inheritance/libraries/node.rb
+++ b/test/fixtures/profiles/custom-resource-inheritance/libraries/node.rb
@@ -1,0 +1,13 @@
+require "inspec/resources/json"
+
+class NodeAttributes < JsonConfig
+  name 'node'
+
+  def initialize
+    super('./test/fixtures/files/node.json')
+  end
+
+  def to_s
+    "Node Json"
+  end
+end

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -1,4 +1,5 @@
 require "functional/helper"
+require "helpers/mock_loader"
 
 describe "inspec exec" do
   parallelize_me!
@@ -163,7 +164,6 @@ Test Summary: 0 successful, 0 failures, 0 skipped
 
   it "executes a specs-only profile" do
     inspec("exec " + File.join(profile_path, "spec_only") + " --no-create-lockfile")
-
     _(stdout).must_include "Target:  local://"
     _(stdout).must_include "working"
     _(stdout).must_include "✔  is expected to eq \"working\""
@@ -517,6 +517,25 @@ Test Summary: 0 successful, 0 failures, 0 skipped
     it "executes the profile without error" do
       _(stderr).must_equal ""
 
+      assert_exit_code 0, out
+    end
+  end
+
+  describe "with a profile that inherits core resource into custom reosuce" do
+    let(:out) { inspec("exec " + File.join(profile_path, "custom-resource-inheritance") + " --no-create-lockfile") }
+    it "executes the custom resoruc without error" do
+      _(stdout).must_equal "
+Profile: InSpec Profile (custom-resource-inheritance)
+Version: 0.1.0
+Target:  local://
+
+  Node Json
+     ✔  name is expected to eq \"hello\"
+     ✔  [\"meta\", \"creator\"] is expected to eq \"John Doe\"
+
+Test Summary: 2 successful, 0 failures, 0 skipped
+"
+      _(stderr).must_equal ""
       assert_exit_code 0, out
     end
   end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This code change fixes 2 issues
1) uninitialized constant error
2) undefined local variable or method error

For core resource inheritance in custom resources to work along with these code changes, the user needs to require the core resource. E.g. If I want to inherit the `json` resource, I need to add this line `require inspec\resources\json` at the top of the Custom resource. Inheritance of Core resource will inherit the functionality but the user has to configure the attributes like supports in the Custom resource as that won't be inherited.

Ref
#1355
#1300
#1613
#4323

Thanks @jeremymv2  and @KrisShannon 

Below is the custom resource which I have tested

```
require "inspec/resources/json"

class NodeAttributes < JsonConfig
  name 'node'

  def initialize
    super('/tmp/node.json')
  end

  def to_s
    "Node Json"
  end
end
```
And

```
require "inspec/resources/grub_conf"

class GrubLegacyConfig < GrubConfig
  name 'grub_legacy_conf'
  
   supports platform: "unix"

  def initialize(path = nil, kernel = nil)
    @conf_path = path || '/boot/grub/grub.conf'
    @version = 'legacy'
    @content = read_file(@conf_path)
    @kernel = kernel || 'default'
  end

  def to_s
    "Grub Legacy Conf"
  end
end
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
