### PR TITLE
Fix sestatus commadn not found error.

### DIFF
--- a/lib/inspec/resources/selinux.rb
+++ b/lib/inspec/resources/selinux.rb
@@ -84,8 +84,14 @@ module Inspec::Resources
 
     def initialize(selinux_path = "/etc/selinux/config")
       @path = selinux_path
-      cmd = inspec.command("sestatus")
 
+      if inspec.os.redhat? || inspec.os.name == "fedora"
+        lcmd = "/sbin/sestatus"
+      else
+        lcmd = "sestatus"
+      end
+
+      cmd = inspec.command(lcmd)
       if cmd.exit_status != 0
         # `sestatus` command not found error message comes in stdout so handling both here
         out = cmd.stdout + "\n" + cmd.stderr


### PR DESCRIPTION

Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
`sestatus` command returns the command not found error when executed as a nonprivileged user. Using \sbin\sestatus resolves and allows to run the command without sudo on the redhat and fedora.
## Related Issue
Fixed #5818 
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
