### PR TITLE
Update Amazon to grub2

### DIFF
--- a/lib/inspec/resources/grub_conf.rb
+++ b/lib/inspec/resources/grub_conf.rb
@@ -37,7 +37,7 @@ module Inspec::Resources
 
     def config_for_platform(path)
       os = inspec.os
-      if os[:name] == "amazon" 
+      if os[:name] == "amazon"
         if os[:release] == "2"
           @conf_path = path || "/boot/grub2/grub.cfg"
           @defaults_path = GRUB2DEFAULTS

--- a/lib/inspec/resources/grub_conf.rb
+++ b/lib/inspec/resources/grub_conf.rb
@@ -34,7 +34,7 @@ module Inspec::Resources
 
     def config_for_platform(path)
       os = inspec.os
-      if (( os.redhat? || os[:name] == "fedora") && ! (os[:name] == "amazon" ))
+      if (( os.redhat? || os[:name] == "fedora") &&  (os[:name] != "amazon" ))
         config_for_redhatish(path)
       elsif os.debian?
         @conf_path = path || "/boot/grub/grub.cfg"

--- a/lib/inspec/resources/grub_conf.rb
+++ b/lib/inspec/resources/grub_conf.rb
@@ -22,8 +22,8 @@ module Inspec::Resources
 
     include FileReader
 
-    GRUB2DEFAULTS = "/etc/default/grub"
-    GRUB2ENV = "/boot/grub2/grubenv"
+    GRUB2DEFAULTS = "/etc/default/grub".freeze
+    GRUB2ENV = "/boot/grub2/grubenv".freeze
 
     class UnknownGrubConfig < StandardError; end
 
@@ -42,7 +42,7 @@ module Inspec::Resources
         @defaults_path = GRUB2DEFAULTS
         @grubenv_path = path || GRUB2ENV
         @version = "grub2"
-      elsif  os.redhat? || os[:name] == "fedora"
+      elsif os.redhat? || os[:name] == "fedora"
         config_for_redhatish(path)
       elsif os.debian?
         @conf_path = path || "/boot/grub/grub.cfg"
@@ -60,7 +60,7 @@ module Inspec::Resources
         @version = "legacy"
       else
         @conf_path = path || "/boot/grub2/grub.cfg"
-        @defaults_path = GRUB2DEFAULTS 
+        @defaults_path = GRUB2DEFAULTS
         @grubenv_path = GRUB2ENV
         @version = "grub2"
       end

--- a/lib/inspec/resources/grub_conf.rb
+++ b/lib/inspec/resources/grub_conf.rb
@@ -34,7 +34,7 @@ module Inspec::Resources
 
     def config_for_platform(path)
       os = inspec.os
-      if os.redhat? || os[:name] == "fedora"
+      if (( os.redhat? || os[:name] == "fedora") && ! (os[:name] == "amazon" ))
         config_for_redhatish(path)
       elsif os.debian?
         @conf_path = path || "/boot/grub/grub.cfg"
@@ -42,8 +42,10 @@ module Inspec::Resources
         @grubenv_path = "/boot/grub2/grubenv"
         @version = "grub2"
       elsif os[:name] == "amazon"
-        @conf_path = path || "/etc/grub.conf"
-        @version = "legacy"
+        @conf_path = path || "/boot/grub2/grub.cfg"
+        @defaults_path = "/etc/default/grub"
+        @grubenv_path = path || "/boot/grub2/grubenv"
+        @version = "grub2"
       else
         raise UnknownGrubConfig
       end

--- a/lib/inspec/resources/grub_conf.rb
+++ b/lib/inspec/resources/grub_conf.rb
@@ -22,6 +22,9 @@ module Inspec::Resources
 
     include FileReader
 
+    GRUB2DEFAULTS = "/etc/default/grub"
+    GRUB2ENV = "/boot/grub2/grubenv"
+
     class UnknownGrubConfig < StandardError; end
 
     def initialize(path = nil, kernel = nil)
@@ -38,13 +41,13 @@ module Inspec::Resources
         config_for_redhatish(path)
       elsif os.debian?
         @conf_path = path || "/boot/grub/grub.cfg"
-        @defaults_path = "/etc/default/grub"
-        @grubenv_path = "/boot/grub2/grubenv"
+        @defaults_path = GRUB2DEFAULTS
+        @grubenv_path = GRUB2ENV
         @version = "grub2"
       elsif os[:name] == "amazon"
         @conf_path = path || "/boot/grub2/grub.cfg"
-        @defaults_path = "/etc/default/grub"
-        @grubenv_path = path || "/boot/grub2/grubenv"
+        @defaults_path = GRUB2DEFAULTS
+        @grubenv_path = path || GRUB2ENV
         @version = "grub2"
       else
         raise UnknownGrubConfig
@@ -57,8 +60,8 @@ module Inspec::Resources
         @version = "legacy"
       else
         @conf_path = path || "/boot/grub2/grub.cfg"
-        @defaults_path = "/etc/default/grub"
-        @grubenv_path = "/boot/grub2/grubenv"
+        @defaults_path = GRUB2DEFAULTS 
+        @grubenv_path = GRUB2ENV
         @version = "grub2"
       end
     end

--- a/lib/inspec/resources/grub_conf.rb
+++ b/lib/inspec/resources/grub_conf.rb
@@ -37,11 +37,16 @@ module Inspec::Resources
 
     def config_for_platform(path)
       os = inspec.os
-      if os[:name] == "amazon"
-        @conf_path = path || "/boot/grub2/grub.cfg"
-        @defaults_path = GRUB2DEFAULTS
-        @grubenv_path = path || GRUB2ENV
-        @version = "grub2"
+      if os[:name] == "amazon" 
+        if os[:release] == "2"
+          @conf_path = path || "/boot/grub2/grub.cfg"
+          @defaults_path = GRUB2DEFAULTS
+          @grubenv_path = path || GRUB2ENV
+          @version = "grub2"
+        else
+          @conf_path = path || "/boot/grub/grub.cfg"
+          @version = "legacy"
+        end
       elsif os.redhat? || os[:name] == "fedora"
         config_for_redhatish(path)
       elsif os.debian?

--- a/lib/inspec/resources/grub_conf.rb
+++ b/lib/inspec/resources/grub_conf.rb
@@ -37,17 +37,17 @@ module Inspec::Resources
 
     def config_for_platform(path)
       os = inspec.os
-      if (( os.redhat? || os[:name] == "fedora") &&  (os[:name] != "amazon" ))
+      if os[:name] == "amazon"
+        @conf_path = path || "/boot/grub2/grub.cfg"
+        @defaults_path = GRUB2DEFAULTS
+        @grubenv_path = path || GRUB2ENV
+        @version = "grub2"
+      elsif  os.redhat? || os[:name] == "fedora"
         config_for_redhatish(path)
       elsif os.debian?
         @conf_path = path || "/boot/grub/grub.cfg"
         @defaults_path = GRUB2DEFAULTS
         @grubenv_path = GRUB2ENV
-        @version = "grub2"
-      elsif os[:name] == "amazon"
-        @conf_path = path || "/boot/grub2/grub.cfg"
-        @defaults_path = GRUB2DEFAULTS
-        @grubenv_path = path || GRUB2ENV
         @version = "grub2"
       else
         raise UnknownGrubConfig


### PR DESCRIPTION
Amazon was using legacy grub_conf and the conditional could never be reached

## Description
When running inspec grub_conf against Amazon it uses legacy grub which results in failures. Amazon Linux 2 uses grub 2 and also will return true to os.redhat? so the previous conditional would never be reached. 

## Related Issue
#5826

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
