### PR TITLE
CFINSPEC-30 Fix sestatus command not found error on Amazon Linux 2

### DIFF
--- a/lib/inspec/resources/selinux.rb
+++ b/lib/inspec/resources/selinux.rb
@@ -84,9 +84,8 @@ module Inspec::Resources
 
     def initialize(selinux_path = "/etc/selinux/config")
       @path = selinux_path
-
-      if inspec.os.redhat? || inspec.os.name == "fedora"
-        lcmd = "/sbin/sestatus"
+      if inspec.os.redhat? && inspec.os.name == "amazon"
+        lcmd = "/usr/sbin/sestatus"
       else
         lcmd = "sestatus"
       end

--- a/lib/inspec/resources/selinux.rb
+++ b/lib/inspec/resources/selinux.rb
@@ -84,8 +84,14 @@ module Inspec::Resources
 
     def initialize(selinux_path = "/etc/selinux/config")
       @path = selinux_path
-      cmd = inspec.command("sestatus")
 
+      if inspec.os.redhat? || inspec.os.name == "fedora"
+        lcmd = "/sbin/sestatus"
+      else
+        lcmd = "sestatus"
+      end
+
+      cmd = inspec.command(lcmd)
       if cmd.exit_status != 0
         # `sestatus` command not found error message comes in stdout so handling both here
         out = cmd.stdout + "\n" + cmd.stderr

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -586,6 +586,7 @@ class MockLoader
 
       # filesystem command
       "2e7e0d4546342cee799748ec7e2b1c87ca00afbe590fa422a7c27371eefa88f0" => cmd.call("get-wmiobject-filesystem"),
+      "/usr/sbin/sestatus" => cmd.call("sestatus"),
       "sestatus" => cmd.call("sestatus"),
       "semodule -lfull" => cmd.call("semodule-lfull"),
       "semanage boolean -l -n" => cmd.call("semanage-boolean"),

--- a/test/unit/resources/selinux_test.rb
+++ b/test/unit/resources/selinux_test.rb
@@ -45,6 +45,12 @@ describe "Inspec::Resources::Selinux" do
     _(resource.enforcing?).must_equal false
   end
 
+  it "verify selinux on Amazon Linux" do
+    resource = MockLoader.new(:amazon2).load_resource("selinux")
+    _(resource.installed?).must_equal false
+    _(resource.enforcing?).must_equal true
+  end
+
   it "verify selinux.modules is exist" do
     _(resource.modules.exist?).must_equal true
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
`sestatus` command returns the command not found error when executed as a nonprivileged user. Using \sbin\sestatus resolves and allows to run the command without sudo on the Amazon Linux 2
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#5818 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
