### PR TITLE
CFINSPEC-43 Init plugin functionality extended for streaming_reporter

### DIFF
--- a/dev-docs/inspec-init-plugin.md
+++ b/dev-docs/inspec-init-plugin.md
@@ -45,10 +45,13 @@ Generates an InSpec plugin, which can extend the functionality of InSpec itself.
 
   `--detail` This option can be used to skip generation of test files or gemspec file. Available values `full`, `core` or `test-fixture`.
 
-  `--activator` Available activator type are `cli_command` and `reporter`. The default activator type is "cli_command".
+  `--activator` Available activator type are `cli_command`, `reporter` and `streaming_reporter`. The default activator type is "cli_command".
   Usage: `inspec init pluign <inspec-plugin-name> --activator "cli_command:my_test"`
     `OR`
   `inspec init plugin <inspec-plugin-reporter-name> --activator "reporter:my_reporter"`
+    `OR`
+  `inspec init plugin <inspec-plugin-streaming-reporter-name> --activator "streaming_reporter:my_streaming_reporter"`
+
 
   **Note:** The InSpec plugin generator can currently only generate one activator of each type.
 

--- a/lib/plugins/inspec-init/lib/inspec-init/cli_plugin.rb
+++ b/lib/plugins/inspec-init/lib/inspec-init/cli_plugin.rb
@@ -81,6 +81,7 @@ module InspecPlugins
           File.join("lib", "inspec-plugin-template.erb") => File.join("lib", plugin_name + ".rb"),
           File.join("lib", "inspec-plugin-template", "cli_command.erb") => File.join("lib", plugin_name, "cli_command.rb"),
           File.join("lib", "inspec-plugin-template", "reporter.erb") => File.join("lib", plugin_name, "reporter.rb"),
+          File.join("lib", "inspec-plugin-template", "streaming_reporter.erb") => File.join("lib", plugin_name, "streaming_reporter.rb"),
           File.join("lib", "inspec-plugin-template", "plugin.erb") => File.join("lib", plugin_name, "plugin.rb"),
           File.join("lib", "inspec-plugin-template", "version.erb") => File.join("lib", plugin_name, "version.rb"),
           File.join("test", "functional", "inspec_plugin_template_test.erb") => File.join("test", "functional", snake_case + "_test.rb"),
@@ -183,6 +184,9 @@ module InspecPlugins
         elsif activators_by_type.key?(:reporter)
           vars[:reporter_name_dashes] = activators_by_type[:reporter].tr("_", "-")
           vars[:reporter_name_snake] = activators_by_type[:reporter].tr("-", "_")
+        elsif activators_by_type.key?(:streaming_reporter)
+          vars[:streaming_reporter_name_dashes] = activators_by_type[:streaming_reporter].tr("_", "-")
+          vars[:streaming_reporter_name_snake] = activators_by_type[:streaming_reporter].tr("-", "_")
         end
         vars
       end
@@ -265,6 +269,11 @@ module InspecPlugins
         unless requested_activators.include?(:reporter)
           skips += [
             File.join("lib", "inspec-plugin-template", "reporter.erb"),
+          ]
+        end
+        unless requested_activators.include?(:streaming_reporter)
+          skips += [
+            File.join("lib", "inspec-plugin-template", "streaming_reporter.erb"),
           ]
         end
 

--- a/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/lib/inspec-plugin-template/plugin.erb
+++ b/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/lib/inspec-plugin-template/plugin.erb
@@ -66,6 +66,22 @@ module InspecPlugins
         InspecPlugins::<%= module_name %>::Reporter
       end
       <% end %>
+
+      <% if activators[:streaming_reporter] %>
+      # Define a new Streaming Reporter.
+      # The argument here will be used to match against the CLI --reporter option.
+      # `--reporter <%= streaming_reporter_name_snake %>` will load your streaming reporter and perform streaming real-time on each passing, failing or pending test.
+      streaming_reporter :<%= streaming_reporter_name_snake %> do
+        # Calling this activator doesn't mean the reporter is being executed - just
+        # that we should be ready to do so. So, load the file that defines the
+        # functionality.
+        require "<%= plugin_name %>/streaming_reporter"
+
+        # Having loaded our functionality, return a class that will let the
+        # reporting engine tap into it.
+        InspecPlugins::<%= module_name %>::StreamingReporter
+      end
+      <% end %>
     end
   end
 end

--- a/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/lib/inspec-plugin-template/streaming_reporter.erb
+++ b/lib/plugins/inspec-init/templates/plugins/inspec-plugin-template/lib/inspec-plugin-template/streaming_reporter.erb
@@ -1,0 +1,31 @@
+module InspecPlugins::<%= module_name %>
+  # This class will provide the actual Streaming Reporter implementation.
+  # Its superclass is provided by another call to Inspec.plugin,
+  # this time with two args.  The first arg specifies we are requesting
+  # version 2 of the Plugins API.  The second says we are making a
+  # Streaming Reporter plugin component, so please make available any DSL needed
+  # for that.
+
+  class StreamingReporter < Inspec.plugin(2, :streaming_reporter)
+
+    # Registering these methods with RSpec::Core::Formatters class is mandatory
+    RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending
+
+    def initialize(output)
+      @output = output
+    end
+
+    def example_passed(notification) # ExampleNotification
+      # some logic to run on passing test case
+    end
+
+    def example_failed(notification) # FailedExampleNotification
+      # some logic to run on failing test case
+    end
+
+    def example_pending(notification) # ExampleNotification
+      # some logic to run on pending test case
+    end
+
+  end
+end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Init plugin functionality extended for new activator`streaming_reporter`.

Command to generate streaming reporter plugin: 

`inspec init plugin inspec-test-one --activator "streaming_reporter"`
**OR**
`inspec init plugin inspec-test-one --activator "streaming_reporter:inspec_test_one"`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
