### PR TITLE
Add sonarscanner

### DIFF
--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -37,3 +37,33 @@ echo "+++ bundle exec rake ${RAKE_TASK:-}"
 # su normal -c "bundle exec rake ${RAKE_TASK:-}"
 # shellcheck disable=SC2086
 bundle exec rake ${RAKE_TASK:-}
+RAKE_EXIT=$?
+
+# If coverage is enabled, then we need to pick up the coverage/coverage.json file
+if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
+  echo "--- installing sonarscanner"
+  export SONAR_SCANNER_VERSION=4.6.2.2472
+  export SONAR_SCANNER_HOME=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux
+  curl --create-dirs -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
+  unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
+  export PATH=$SONAR_SCANNER_HOME/bin:$PATH
+  export SONAR_SCANNER_OPTS="-server"
+
+  echo "--- installing vault"
+  export VAULT_VERSION=1.9.3
+  export VAULT_HOME=$HOME/vault
+  curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
+  unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
+
+  echo "--- fetching Sonar token from vault"
+  export SONAR_TOKEN=$($VAULT_HOME/vault kv get -field token secret/inspec/sonar)
+
+  echo "--- running sonarscanner"
+  sonar-scanner \
+  -Dsonar.organization=inspec \
+  -Dsonar.projectKey=inspec_inspec \
+  -Dsonar.sources=. \
+  -Dsonar.host.url=https://sonarcloud.io
+fi
+
+exit $RAKE_EXIT

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -20,6 +20,18 @@ mount
 df /tmp
 echo ${TMPDIR:-unknown}
 
+if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
+  # Fetch token from vault ASAP so that long-running tests don't cause our vault token to expire
+  echo "--- installing vault"
+  export VAULT_VERSION=1.9.3
+  export VAULT_HOME=$HOME/vault
+  curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
+  unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
+
+  echo "--- fetching Sonar token from vault"
+  export SONAR_TOKEN=$($VAULT_HOME/vault kv get -field token secret/inspec/sonar)
+fi
+
 echo "--- pull bundle cache"
 pull_bundle
 
@@ -48,15 +60,6 @@ if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
   unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
   export PATH=$SONAR_SCANNER_HOME/bin:$PATH
   export SONAR_SCANNER_OPTS="-server"
-
-  echo "--- installing vault"
-  export VAULT_VERSION=1.9.3
-  export VAULT_HOME=$HOME/vault
-  curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
-  unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
-
-  echo "--- fetching Sonar token from vault"
-  export SONAR_TOKEN=$($VAULT_HOME/vault kv get -field token secret/inspec/sonar)
 
   echo "--- running sonarscanner"
   sonar-scanner \

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -25,7 +25,6 @@ pipelines:
      - ADHOC: true
  - verify:
     description: Pull Request validation tests
-    public: true
     env:
      - LANG: "C.UTF-8"
      - SLOW: 1

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -30,6 +30,15 @@ pipelines:
      - SLOW: 1
      - NO_AWS: 1
      - MT_CPU: 5
+ - coverage:
+    description: Unit test coverage
+    # Private due to use of tokens
+    trigger: pull_request
+    env:
+     - LANG: "C.UTF-8"
+     - SLOW: 1
+     - NO_AWS: 1
+     - MT_CPU: 5
  - integration/resources:
     description: Test core resources with test-kitchen.
     definition: .expeditor/integration.resources.yml

--- a/.expeditor/coverage.pipeline.yml
+++ b/.expeditor/coverage.pipeline.yml
@@ -1,0 +1,19 @@
+---
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 45
+      retry:
+        automatic:
+          limit: 1
+
+steps:
+
+  - label: coverage-ruby-3.0
+    command:
+      - CI_ENABLE_COVERAGE=1 RAKE_TASK=test:unit /workdir/.expeditor/buildkite/verify.sh
+    expeditor:
+      secrets: true
+      executor:
+        docker:
+          image: ruby:3.0

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -19,7 +19,7 @@ steps:
 
   - label: run-tests-ruby-2.7
     command:
-      - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
+      - /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:
@@ -27,7 +27,7 @@ steps:
 
   - label: run-tests-ruby-3.0
     command:
-      - /workdir/.expeditor/buildkite/verify.sh
+      - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       secrets: true
       executor:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -27,9 +27,8 @@ steps:
 
   - label: run-tests-ruby-3.0
     command:
-      - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
+      - /workdir/.expeditor/buildkite/verify.sh
     expeditor:
-      secrets: true
       executor:
         docker:
           image: ruby:3.0

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -29,6 +29,7 @@ steps:
     command:
       - /workdir/.expeditor/buildkite/verify.sh
     expeditor:
+      secrets: true
       executor:
         docker:
           image: ruby:3.0


### PR DESCRIPTION
## Description

Adds SonarScanner to our CI setup, allowing unit coverage testing to be collected.

Creates a new private pipeline, coverage, which must be private to use the secrets store.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
