### PR TITLE
Always expire the git cache when running omnibus jobs

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -18,7 +18,7 @@ pipelines:
      - HAB_NOCOLORING: "true"
      - HAB_STUDIO_SECRET_HAB_NONINTERACTIVE: "true"
  - docker/build
- - omnibus/release
+ - omnibus/release:
     env:
      # The git cache is corrupt more often than not. This always purges the cache.
      # https://chefio.atlassian.net/wiki/spaces/RELENGKB/pages/2204336129/Resolving+git+cache+build+errors+in+Omnibus

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -19,10 +19,15 @@ pipelines:
      - HAB_STUDIO_SECRET_HAB_NONINTERACTIVE: "true"
  - docker/build
  - omnibus/release
+    env:
+     # The git cache is corrupt more often than not. This always purges the cache.
+     # https://chefio.atlassian.net/wiki/spaces/RELENGKB/pages/2204336129/Resolving+git+cache+build+errors+in+Omnibus
+     - EXPIRE_CACHE: 1
  - omnibus/adhoc:
     definition: .expeditor/release.omnibus.yml
     env:
      - ADHOC: true
+     - EXPIRE_CACHE: 1
  - verify:
     description: Pull Request validation tests
     public: true


### PR DESCRIPTION
## Description

The git cache always seems to be corrupt nowdays, and it only saves a few seconds off of an over one-hour build.  Disabling it prevents wasting a lot of time and unneeded dummy PRs.

https://buildkite.com/chef/inspec-inspec-main-omnibus-release/builds/627#4cf98cf1-5b66-46b6-8ab1-0015a7d3f863

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
