### PR TITLE
Use ruby 2.7 in habitat for inspec 4

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -15,7 +15,7 @@ $pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 $pkg_license=('Apache-2.0')
 
 $pkg_deps=@(
-  "chef/ruby-plus-devkit"
+  "chef/ruby27-plus-devkit"
 )
 $pkg_bin_dirs=@("bin"
                 "vendor/bin")

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -80,7 +80,7 @@ export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
 
-exec $(pkg_path_for core/ruby26)/bin/ruby $real_bin \$@
+exec $(pkg_path_for core/ruby27)/bin/ruby $real_bin \$@
 EOF
   chmod -v 755 "$bin"
 }

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -10,7 +10,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/coreutils
   core/git
-  core/ruby26
+  core/ruby27
   core/bash
 )
 pkg_build_deps=(


### PR DESCRIPTION
We should stop using EOL Ruby 2.6 for InSpec 4 on Habitat. At least use 2.7.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
