### PR TITLE
Disable resource integration tests

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -45,23 +45,11 @@ pipelines:
      - SLOW: 1
      - NO_AWS: 1
      - MT_CPU: 5
- - integration/resources:
-    description: Test core resources with test-kitchen.
-    definition: .expeditor/integration.resources.yml
-    trigger: pull_request
- # This breaks expeditor as it does not yet exist
- # - integration/libraries:
- #    description: Integration with plugins, gems, resource packs.
- #    definition: .expeditor/integration.libraries.yml
- # - integration/profiles:
- #    description: Integration with compliance-profiles, and dev-sec
- #    definition: .expeditor/integration.profiles.yml
- # - integration/cookbooks:
- #    description: Integration with the audit cookbook
- #    definition: .expeditor/integration.cookbooks.yml
- # - integration/automate:
- #    description: Integration with Chef Automate
- #    definition: .expeditor/integration.automate.yml
+# This has been disabled because it regularly hits Docker API rate limits and fails
+#  - integration/resources:
+#     description: Test core resources with test-kitchen.
+#     definition: .expeditor/integration.resources.yml
+#     trigger: pull_request
  - artifact/habitat:
     description: Execute tests against the habitat artifact
     definition: .expeditor/artifact.habitat.yml


### PR DESCRIPTION
These tests always hit the Docker Hub API rate limit, which is being saturated by calls from across the org. We can't do anything about that. So, these tests are doomed to fail. Disabling them for now.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
