### PR TITLE
Fix test failure for plugin due to ambiguity in method name

### DIFF
--- a/lib/plugins/inspec-init/lib/inspec-init/cli_resource.rb
+++ b/lib/plugins/inspec-init/lib/inspec-init/cli_resource.rb
@@ -20,7 +20,7 @@ module InspecPlugins
       option :path, type: :string, default: ".", desc: "Subdirectory under which to create files"
 
       # Wishlist:
-      #  Make make_rename_map dynamic:
+      #  Make make_rename_map_resource dynamic:
       #   + Add a --path option which defaults to ., which will create the tree under that path
       #   + Add a --layout option which changes all the tree to act as placing the files in core inspec (lib/inspec/resources, docs-chef-io/)
       #   - Add a --template=plural option which changes the templates to use a set of Filtertable based templates
@@ -35,7 +35,7 @@ module InspecPlugins
       #  + Add --overwrite option
 
       def resource(resource_name)
-        resource_vars_from_opts
+        resource_vars_from_opts_resource
         template_vars = {
           name: options[:path], # This is used for the path prefix
           resource_name: resource_name,
@@ -46,7 +46,7 @@ module InspecPlugins
         render_opts = {
           templates_path: TEMPLATES_PATH,
           overwrite: options[:overwrite],
-          file_rename_map: make_rename_map(template_vars),
+          file_rename_map: make_rename_map_resource(template_vars),
         }
         renderer = InspecPlugins::Init::Renderer.new(ui, render_opts)
         renderer.render_with_values(template_path, "resource", template_vars)
@@ -54,7 +54,7 @@ module InspecPlugins
 
       private
 
-      def make_rename_map(vars)
+      def make_rename_map_resource(vars)
         if vars["layout"] == "resource-pack"
           {
             File.join("libraries", "inspec-resource-template.erb") => File.join("libraries", vars[:resource_name] + ".rb"),
@@ -73,9 +73,9 @@ module InspecPlugins
         end
       end
 
-      def resource_vars_from_opts
+      def resource_vars_from_opts_resource
         if options[:prompt] && ui.interactive?
-          options.dup.merge(prompt_for_options)
+          options.dup.merge(prompt_for_options_resource)
         elsif !options[:prompt]
           # Nothing to do - unless we need to calculate dynamic defaults in the future
         else
@@ -84,7 +84,7 @@ module InspecPlugins
         end
       end
 
-      def prompt_for_options # rubocop: disable Metrics/AbcSize
+      def prompt_for_options_resource # rubocop: disable Metrics/AbcSize
         option_defs = self.class.all_commands["resource"].options
         options_order = {
           path: {},
@@ -98,8 +98,8 @@ module InspecPlugins
           template: {
             mode: :select,
             choices: [
-              { name: "Basic",  value: "basic",  default: true },
-              { name: "Plural", value: "plural",               },
+              { name: "Basic", value: "basic", default: true },
+              { name: "Plural", value: "plural" },
             ],
           },
           supports_platform: {},

--- a/lib/plugins/inspec-init/lib/inspec-init/renderer.rb
+++ b/lib/plugins/inspec-init/lib/inspec-init/renderer.rb
@@ -60,7 +60,7 @@ module InspecPlugins
           if File.file?(source_file)
             # Be git-like and only create directories if they contain a file
             containing_directory = full_destination_item_path.dirname
-            unless File.exists?(containing_directory)
+            unless File.exist?(containing_directory)
               ui.list_item "Creating directory #{ui.emphasis(containing_directory)}"
               FileUtils.mkdir_p(containing_directory)
             end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Signed-off-by: Sonu Saha <sonu.saha@progress.com>
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The functional test for plugin was failing due to same methods name used in cli_resource.
The lint issue is resolved and file.exists deprecation is removed in favor of file.exist
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
