### PR TITLE
Deprecation note for azurerm resources

### DIFF
--- a/docs-chef-io/Makefile
+++ b/docs-chef-io/Makefile
@@ -3,8 +3,10 @@
 SHELL=bash
 
 preview_netlify: chef_web_docs
-	cp -R content/* chef-web-docs/_vendor/github.com/inspec/inspec/docs-chef-io/content
-	cp -R static/* chef-web-docs/_vendor/github.com/inspec/inspec/docs-chef-io/static
+	rm -rf chef-web-docs/_vendor/github.com/inspec/inspec/docs-chef-io/*
+	cp -R content chef-web-docs/_vendor/github.com/inspec/inspec/docs-chef-io/
+	cp -R static chef-web-docs/_vendor/github.com/inspec/inspec/docs-chef-io/
+	cp -R layouts chef-web-docs/_vendor/github.com/inspec/inspec/docs-chef-io/
 	cp -R config.toml chef-web-docs/_vendor/github.com/inspec/inspec/docs-chef-io/
 	pushd chef-web-docs && make bundle; hugo --gc --minify --buildFuture && popd
 

--- a/docs-chef-io/content/inspec/resources/azurerm_ad_user.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_ad_user.md
@@ -11,6 +11,12 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< warning >}}
+
+This resource will be deprecated when version 2 of the inspec-azure resource pack is released.
+
+{{< /warning >}}
+
 Use the `azurerm_ad_user` InSpec audit resource to test properties of
 an Azure Active Directory user within a Tenant.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_ad_users.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_ad_users.md
@@ -11,6 +11,12 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< warning >}}
+
+This resource will be deprecated when version 2 of the inspec-azure resource pack is released.
+
+{{< /warning >}}
+
 Use the `azurerm_ad_users` InSpec audit resource to test properties of
 some or all Azure Active Directory users within a Tenant.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_aks_cluster.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_aks_cluster.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_aks_cluster" >}}
+
 Use the `azurerm_aks_cluster` InSpec audit resource to test properties of an Azure AKS Cluster.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_aks_clusters.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_aks_clusters.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_aks_clusters" >}}
+
 Use the `azurerm_aks_clusters` InSpec audit resource to enumerate AKS Clusters.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_cosmosdb_database_account.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_cosmosdb_database_account.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_cosmosdb_database_account" >}}
+
 Use the `azurerm_cosmosdb_database_account` InSpec audit resource to test properties and configuration of
 an Azure CosmosDb Database Account within a Resource Group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_event_hub_authorization_rule.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_event_hub_authorization_rule.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_event_hub_authorization_rule" >}}
+
 Use the `azurerm_event_hub_authorization_rule` InSpec audit resource to test properties and configuration of
 an Azure Event Hub Authorization Rule within a Resource Group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_event_hub_event_hub.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_event_hub_event_hub.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_event_hub_event_hub" >}}
+
 Use the `azurerm_event_hub_event_hub` InSpec audit resource to test properties and configuration of
 an Azure Event Hub Event Hub within a Resource Group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_event_hub_namespace.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_event_hub_namespace.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_event_hub_namespace" >}}
+
 Use the `azurerm_event_hub_namespace` InSpec audit resource to test properties and configuration of
 an Azure Event Hub Namespace within a Resource Group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_iothub.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_iothub.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_iothub" >}}
+
 Use the `azurerm_iothub` InSpec audit resource to test properties and configuration of
 an Azure Event Hub Namespace within a Resource Group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_iothub_event_hub_consumer_group.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_iothub_event_hub_consumer_group.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_iothub_event_hub_consumer_group" >}}
+
 Use the `azurerm_iothub_event_hub_consumer_group` InSpec audit resource to test
 properties and configuration of an Azure IoT Hub Event Hub Consumer Group within
 a Resource Group.

--- a/docs-chef-io/content/inspec/resources/azurerm_iothub_event_hub_consumer_groups.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_iothub_event_hub_consumer_groups.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_iothub_event_hub_consumer_groups" >}}
+
 Use the `azurerm_iothub_event_hub_consumer_groups` InSpec audit resource to test properties and configuration of
 an Azure IoT Hub Event Hub Consumer Groups within a Resource Group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_key_vault.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_key_vault.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_key_vault" >}}
+
 Use the `azurerm_key_vault` InSpec audit resource to test properties and configuration of
 an Azure Key Vault.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_key_vault_key.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_key_vault_key.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_key_vault_key" >}}
+
 Use the `azurerm_key_vault_key` InSpec audit resource to test properties and configuration of
 an Azure Key within a Vault.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_key_vault_keys.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_key_vault_keys.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_key_vault_keys" >}}
+
 Use the `azurerm_key_vault_keys` InSpec audit resource to test properties and
 configuration of Azure Keys within Vaults.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_key_vault_secret.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_key_vault_secret.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_key_vault_secret" >}}
+
 Use the `azurerm_key_vault_secret` InSpec audit resource to test properties and configuration of
 an Azure Secret within a Vault.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_key_vault_secrets.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_key_vault_secrets.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_key_vault_secrets" >}}
+
 Use the `azurerm_key_vault_secrets` InSpec audit resource to test properties and configuration of Azure Secrets within Vaults.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_key_vaults.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_key_vaults.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_key_vaults" >}}
+
 Use the `azurerm_key_vaults` InSpec audit resource to test properties and configuration of Azure Key Vaults.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_load_balancer.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_load_balancer.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_load_balancer" >}}
+
 Use the `azurerm_load_balancer` InSpec audit resource to test properties and configuration of
 an Azure Load Balancer.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_load_balancers.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_load_balancers.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_load_balancer" >}}
+
 Use the `azurerm_load_balancers` InSpec audit resource to test properties and configuration of Azure Load Balancers.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_locks.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_locks.md
@@ -11,8 +11,9 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
-Use the `azurerm_locks` InSpec audit resource to test properties of
-some or all Azure Resource Locks.
+{{< azurerm_deprecated resource="azure_locks" >}}
+
+Use the `azurerm_locks` InSpec audit resource to test properties of some or all Azure Resource Locks.
 
 ## Azure REST API version
 

--- a/docs-chef-io/content/inspec/resources/azurerm_management_group.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_management_group.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_management_group" >}}
+
 Use the `azurerm_management_group` InSpec audit resource to test properties related to a
 management group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_management_groups.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_management_groups.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_management_groups" >}}
+
 Use the `azurerm_management_groups` InSpec audit resource to test properties related to
 management groups.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_monitor_activity_log_alert.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_monitor_activity_log_alert.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_monitor_activity_log_alert" >}}
+
 Use the `azurerm_monitor_activity_log_alert` InSpec audit resource to test properties
 of an Azure Monitor Activity Log Alert.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_monitor_activity_log_alerts.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_monitor_activity_log_alerts.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_monitor_activity_log_alerts" >}}
+
 Use the `azurerm_monitor_activity_log_alerts` InSpec audit resource to verify that an
 Activity Log Alert exists.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_monitor_log_profile.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_monitor_log_profile.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_monitor_log_profile" >}}
+
 Use the `azurerm_monitor_log_profile` InSpec audit resource to test properties
 of an Azure Monitor Log Profile.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_monitor_log_profiles.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_monitor_log_profiles.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_monitor_log_profiles" >}}
+
 Use the `azurerm_monitor_log_profiles` InSpec audit resource to verify that a Log Profile
 exists.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_mysql_database.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_mysql_database.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_mysql_database" >}}
+
 Use the `azurerm_mysql_database` InSpec audit resource to test properties and configuration of
 an Azure MySQL Database on a MySQL Server.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_mysql_databases.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_mysql_databases.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_mysql_databases" >}}
+
 Use the `azurerm_mysql_databases` InSpec audit resource to test properties and configuration of Azure MySQL Databases.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_mysql_server.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_mysql_server.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_mysql_server" >}}
+
 Use the `azurerm_mysql_server` InSpec audit resource to test properties and configuration of
 an Azure MySQL Server.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_mysql_servers.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_mysql_servers.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_mysql_servers" >}}
+
 Use the `azurerm_mysql_servers` InSpec audit resource to test properties and configuration of multiple Azure MySQL Servers.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_network_interface.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_network_interface.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_network_interface" >}}
+
 Use the `azurerm_network_interface` InSpec audit resource to test properties and configuration of Azure Network Interface.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_network_interfaces.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_network_interfaces.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_network_interfaces" >}}
+
 Use the `azurerm_network_interfaces` InSpec audit resource to test properties and configuration of Azure Network interfaces.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_network_security_group.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_network_security_group.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_network_security_group" >}}
+
 Use the `azurerm_network_security_group` InSpec audit resource to test properties of an
 Azure Network Security Group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_network_security_groups.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_network_security_groups.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_network_security_groups" >}}
+
 Use the `azurerm_network_security_groups` InSpec audit resource to enumerate Network
 Security Groups.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_network_watcher.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_network_watcher.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_network_watcher" >}}
+
 Use the `azurerm_network_watcher` InSpec audit resource to test properties of an Azure
 Network Watcher.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_network_watchers.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_network_watchers.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_network_watchers" >}}
+
 Use the `azurerm_network_watchers` InSpec audit resource to verify that a Network Watcher
 exists.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_postgresql_database.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_postgresql_database.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_postgresql_database" >}}
+
 Use the `azurerm_postgresql_database` InSpec audit resource to test properties and configuration of
 an Azure PostgreSQL Database on a PostgreSQL Server.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_postgresql_databases.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_postgresql_databases.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_postgresql_databases" >}}
+
 Use the `azurerm_postgresql_databases` InSpec audit resource to test properties and configuration of Azure PostgreSQL Databases.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_postgresql_server.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_postgresql_server.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_postgresql_server" >}}
+
 Use the `azurerm_postgresql_server` InSpec audit resource to test properties and configuration of
 an Azure PostgreSQL Server.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_postgresql_servers.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_postgresql_servers.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_postgresql_servers" >}}
+
 Use the `azurerm_postgresql_servers` InSpec audit resource to test properties and configuration of multiple Azure PostgreSQL Servers.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_resource_groups.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_resource_groups.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_resource_groups" >}}
+
 Use the `azurerm_resource_groups` InSpec audit resource to test properties of
 some or all Azure Resource Groups
 

--- a/docs-chef-io/content/inspec/resources/azurerm_role_definition.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_role_definition.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_role_definition" >}}
+
 Use the `azurerm_role_definition` InSpec audit resource to test properties of
 an Azure Role Definition.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_role_definitions.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_role_definitions.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_role_definitions" >}}
+
 Use the `azurerm_role_definitions` InSpec audit resource to test properties of
 some or all Azure Role Definitions.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_security_center_policies.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_security_center_policies.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_security_center_policies" >}}
+
 Use the `azurerm_security_center_policies` InSpec audit resource to test
 properties of some or all Azure Security Center Policies.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_security_center_policy.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_security_center_policy.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_security_center_policy" >}}
+
 Use the `azurerm_security_center_policy` InSpec audit resource to test properties
 of the `default` Security Center Policy. Azure currently only supports looking
 up the `default` policy via their Rest API. If you attempt to look up a

--- a/docs-chef-io/content/inspec/resources/azurerm_sql_database.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_sql_database.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_sql_database" >}}
+
 Use the `azurerm_sql_database` InSpec audit resource to test properties and configuration of
 an Azure SQL Database on a SQL Server.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_sql_databases.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_sql_databases.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_sql_databases" >}}
+
 Use the `azurerm_sql_databases` InSpec audit resource to test properties and configuration of Azure SQL Databases.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_sql_server.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_sql_server.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_sql_server" >}}
+
 Use the `azurerm_sql_server` InSpec audit resource to test properties and configuration of
 an Azure SQL Server within a Resource Group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_sql_servers.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_sql_servers.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_sql_servers" >}}
+
 Use the `azurerm_sql_servers` InSpec audit resource to test properties and configuration of Azure SQL Servers.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_storage_account_blob_container.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_storage_account_blob_container.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_storage_account_blob_container" >}}
+
 Use the `azurerm_storage_account_blob_container` InSpec audit resource to test properties related to a
 Blob Container in an Azure Storage Account.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_storage_account_blob_containers.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_storage_account_blob_containers.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_storage_account_blob_containers" >}}
+
 Use the `azurerm_storage_account_blob_containers` InSpec audit resource to test properties and configuration of Blob Containers within an Azure Storage Account.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_subnet.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_subnet.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_subnet" >}}
+
 Use the `azurerm_subnet` InSpec audit resource to test properties related to a
 subnet for a given virtual network.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_subnets.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_subnets.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_subnet" >}}
+
 Use the `azurerm_subnets` InSpec audit resource to test properties related to
 subnets for a resource group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_subscription.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_subscription.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_subscription" >}}
+
 Use the `azurerm_subscription` InSpec audit resource to test properties related to the current subscription
 subscription.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_virtual_machine.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_virtual_machine.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_virtual_machine" >}}
+
 Use the `azurerm_virtual_machine` InSpec audit resource to test properties related to a
 virtual machine.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_virtual_machine_disk.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_virtual_machine_disk.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_virtual_machine_disk" >}}
+
 Use the `azurerm_virtual_machine_disk` InSpec audit resource to test properties related to
 a virtual machine's disk. This resource will only support managed disks. If your disk is
 not managed it will not `exist` to the matcher.

--- a/docs-chef-io/content/inspec/resources/azurerm_virtual_machine_disks.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_virtual_machine_disks.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_virtual_machine_disks" >}}
+
 Use the `azurerm_virtual_machine_disks` InSpec audit resource to test properties of
 some or all Azure Disks within a subscription.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_virtual_machines.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_virtual_machines.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_virtual_machines" >}}
+
 Use the `azurerm_virtual_machines` InSpec audit resource to test properties related to
 virtual machines for a resource group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_virtual_network.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_virtual_network.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_virtual_network" >}}
+
 Use the `azurerm_virtual_network` InSpec audit resource to test properties related to a
 virtual network.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_virtual_networks.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_virtual_networks.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_virtual_networks" >}}
+
 Use the `azurerm_virtual_networks` InSpec audit resource to test properties related to
 virtual networks for a resource group.
 

--- a/docs-chef-io/content/inspec/resources/azurerm_webapp.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_webapp.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_webapp" >}}
+
 Use the `azurerm_webapp` InSpec audit resource to test properties of an Azure Webapp.
 
 ## Azure REST API version

--- a/docs-chef-io/content/inspec/resources/azurerm_webapps.md
+++ b/docs-chef-io/content/inspec/resources/azurerm_webapps.md
@@ -11,6 +11,8 @@ platform = "azure"
     parent = "inspec/resources/azure"
 +++
 
+{{< azurerm_deprecated resource="azure_webapps" >}}
+
 Use the `azurerm_webapps` InSpec audit resource to enumerate Webapps.
 
 ## Azure REST API version

--- a/docs-chef-io/layouts/shortcodes/azurerm_deprecated.html
+++ b/docs-chef-io/layouts/shortcodes/azurerm_deprecated.html
@@ -1,0 +1,8 @@
+<div class="admonition-warning">
+    <p class="admonition-warning-title">Warning</p>
+    <div class="admonition-warning-text">
+        <p>
+            This resource will be deprecated when version 2 of the inspec-azure resource pack is released. Please use the <a href="/inspec/resources/{{.Get "resource" }}/">{{ .Get "resource" }} resource</a> instead.
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>



## Description
This adds a deprecation note to all azurerm resource pages.

It says: 

> This resource will be deprecated when version 2 of the inspec-azure resource pack is released. Please use the OTHER_RESOURCE resource instead.

with a link to the matching inspec-azure resource.

I couldn't find a matching resource for the azurerm_ad_user and azurerm_ad_users resources, so those pages just have warnings without a link.

https://deploy-preview-5923--chef-inspec.netlify.app/inspec/resources/

## Related Issue

inspec/inspec-azure#602

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
