### PR TITLE
CFINSPEC-154: Fix postgres_session resource to allow query errors to be treat as failures.

### DIFF
--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -55,8 +55,10 @@ module Inspec::Resources
       psql_cmd = create_psql_cmd(query, db)
       cmd = inspec.command(psql_cmd, redact_regex: %r{(:\/\/[a-z]*:).*(@)})
       out = cmd.stdout + "\n" + cmd.stderr
-      if cmd.exit_status != 0 || out =~ /could not connect to .*/ || out.downcase =~ /^error:.*/
-        raise Inspec::Exceptions::ResourceFailed, "PostgreSQL query with errors: #{out}"
+      if cmd.exit_status != 0 && ( out =~ /could not connect to/ || out =~ /password authentication failed/ ) && out.downcase =~ /error:/
+        raise Inspec::Exceptions::ResourceFailed, "PostgreSQL connection error: #{out}"
+      elsif cmd.exit_status != 0 && out.downcase =~ /error:/
+        Lines.new(out, "PostgreSQL query with error: #{query}")
       else
         Lines.new(cmd.stdout.strip, "PostgreSQL query: #{query}")
       end

--- a/test/fixtures/cmd/psql-connection-error
+++ b/test/fixtures/cmd/psql-connection-error
@@ -1,0 +1,1 @@
+psql: error: could not connect to server: Connection refused\n\tIs the server running on host \"127.0.0.1\" and accepting\n\tTCP/IP connections on port 5432?\n

--- a/test/fixtures/cmd/psql-password-authentication-error
+++ b/test/fixtures/cmd/psql-password-authentication-error
@@ -1,0 +1,1 @@
+psql: error: FATAL:  password authentication failed for user "postgres"\nFATAL:  password authentication failed for user

--- a/test/fixtures/cmd/psql-query-error
+++ b/test/fixtures/cmd/psql-query-error
@@ -1,0 +1,1 @@
+ERROR:  must be owner of table accounts\n

--- a/test/helpers/resources.rb
+++ b/test/helpers/resources.rb
@@ -50,7 +50,8 @@ module Fake
       stdout = stdout_path ? File.read(stdout_path) : ""
       stderr = stderr_path ? File.read(stderr_path) : ""
 
-      ::Fake::Command.new(stdout, stderr, 0)
+      exit_code = exit || 0
+      ::Fake::Command.new(stdout, stderr, exit_code)
     end
   end
 


### PR DESCRIPTION

Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Updated postgres_session resource to only raise an exception for connection or authentication failure and allow query errors to be treated as failures(keep the earlier behavior). 

Example

```
sql = postgres_session('postgres', 'postgres', '127.0.0.1', 5432)

describe sql.query(' DROP TABLE accounts;', ['postgres']) do
  its('output') { should match /must be owner of table accounts/ }
end
```
inspec run output

```
Profile:   InSpec Profile (postgre-conf-profile)
Version:   0.1.0
Target:    ssh://ubuntu@ec2-3-17-72-78.us-east-2.compute.amazonaws.com:22
Target ID: 2d3eb7d5-a424-5b57-ae0c-01778b3c52b0

  PostgreSQL query with error:  DROP TABLE accounts;
     ✔  output is expected to match /must be owner of table accounts/
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5900
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
