### PR TITLE
Fix plugin list smoke test

### DIFF
--- a/test/artifact/inspec_plugin_test.rb
+++ b/test/artifact/inspec_plugin_test.rb
@@ -1,7 +1,13 @@
 require_relative "artifact_helper"
 
 class TestInspecPlugin < ArtifactTest
-  def test_plugin_lsit
-    assert_artifact("plugin list")
+  def test_plugin_list
+    # This one is custom because it emits a special warning to stderr
+    inspec_command = "plugin list"
+    stdout, stderr, status = run_cmd "inspec #{inspec_command} #{TEST_CLI_OPTS}"
+
+    assert_empty stderr.sub(/#< CLIXML\n/, "").sub(/The table size exceeds the currently set width\.Defaulting to vertical orientation\.\n/, "")
+    assert stdout
+    assert status
   end
 end


### PR DESCRIPTION
Intercept width warning message for plugin list in `plugin list` smoke test. Only appears in post-merge smoke testing, like here - https://buildkite.com/chef/inspec-inspec-main-omnibus-release/builds/672#29519047-b0be-4bd4-b494-c39030bf2098

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
