### PR TITLE
fix(service): ensure `installed: true` isn't always returned on FreeBSD

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -537,9 +537,22 @@ module Inspec::Resources
     end
 
     def info(service_name)
+      # `service -l` lists all files in /etc/rc.d and the local startup directories
+      # % service -l
+      # accounting
+      # addswap
+      # adjkerntz
+      # apm
+      # archdep
+      cmd = inspec.command("#{service_ctl} -l")
+      return nil if cmd.exit_status != 0
+
+      # search for the service
+      srv = /^#{service_name}$/.match(cmd.stdout)
+      return nil if srv.nil? || srv[0].nil?
+
       # check if service is enabled
       cmd = inspec.command("#{service_ctl} #{service_name} enabled")
-
       enabled = cmd.exit_status == 0
 
       # check if the service is running


### PR DESCRIPTION
Signed-off-by: Imran Iqbal <iqbalmy@hotmail.com>

<!--- Provide a short summary of your changes in the Title above -->

A regression was introduced by #5606, FreeBSD service testing now always returns `installed: true`, which is a problem when checking for `it { should_not be_installed }`.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

I've explained the problem in #5947.

Worked out the fix when looking through 41ea0da4a99f3b55b1be182c110a2442e7de8447.

https://github.com/inspec/inspec/blob/26e197a3a506f596152c0dc30d6a9a5ca6fdd811/lib/inspec/resources/service.rb#L165-L171

Did a diff of `BSDInit` and `FreeBSD10Init`, found this block missing from the latter:

https://github.com/inspec/inspec/blob/26e197a3a506f596152c0dc30d6a9a5ca6fdd811/lib/inspec/resources/service.rb#L496-L510

That's the portion which deals with ensuring `installed` resolves as `false`, particularly the last two lines.  Added that to our fork of InSpec and confirmed that our CI testing is working again (as explained at the bottom of #5947).  Note, that CI covers multiple suites, which test FreeBSD services for both `it { should_not be_installed }` and `it { should be_installed }`.

CC: @zofrex.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

* Fix regression introduced in 41ea0da4a99f3b55b1be182c110a2442e7de8447 (#5606).
* Close #5947.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
