### PR TITLE
CFINSPEC-80: Add mail alias resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/mail_alias.md
+++ b/docs-chef-io/content/inspec/resources/mail_alias.md
@@ -11,49 +11,59 @@ platform = "unix"
     parent = "inspec/resources/os"
 +++
 
-Use the `mail_alias` Chef InSpec audit resource to test mail alias present in the aliases file.
+Use the `mail_alias` Chef InSpec audit resource to test the mail alias present in the aliases file.
 
 ## Availability
 
 ### Installation
 
-This resource is distributed along with Chef InSpec itself.
+This resource is distributed along with Chef InSpec.
 
 ## Syntax
 
-A `mail_alias` Chef InSpec audit resource allows to test mail alias present in the aliases file.
+A `mail_alias` Chef InSpec audit resource allows testing the mail alias present in the aliases file.
 
+```ruby
     describe mail_alias("daemon") do
         it { should be_aliased_to "root" }
     end
-where
+```
 
-- `'daemon'` is an alias present in `/etc/aliases` of the target system
-- `'root'` is the value assigned to the alias
-- `be_aliased_to` is a matcher of this resource
+> where
+>
+> - `'daemon'` is an alias present in `/etc/aliases` of the target system
+> - `'root'` is the value assigned to the alias
+> - `be_aliased_to` is a matcher of this resource
 
 ## Matchers
 
-For a full list of available matchers, please visit our [matchers page](https://docs.chef.io/inspec/matchers/). The specific matchers of this resource is: `be_aliased_to`.
+For a full list of available matchers, please visit the [matchers page](https://docs.chef.io/inspec/matchers/). The specific matchers of this resource is: `be_aliased_to`.
 
 ### be_aliased_to
 
-The `be_aliased_to` matcher tests if the given input value is assigned to the initialized alias.
+The `be_aliased_to` matcher tests if the input value is assigned to the initialized alias.
 
+```ruby
     it { should be_aliased_to "root" }
+```
 
 ## Examples
+
 The following examples show how to use this Chef InSpec audit resource.
 
-### Check if the alias `daemon` is aliased to `root`
+### Check if the daemon alias is mapped to root
 
+```ruby
     describe mail_alias("daemon") do
       it { should be_aliased_to "root" }
     end
+```
 
-### Check if the alias `mailadmin` are aliased to `inspecadmin@chef.io` and `chefadmin@chef.io`
+### Check if the mail admin alias is mapped to inspecadmin@chef.io and chefadmin@chef.io
 
+```ruby
     describe mail_alias("mailadmin") do
       it { should be_aliased_to "inspecadmin@chef.io" }
       it { should be_aliased_to "chefadmin@chef.io" }
     end
+```

--- a/docs-chef-io/content/inspec/resources/mail_alias.md
+++ b/docs-chef-io/content/inspec/resources/mail_alias.md
@@ -11,67 +11,49 @@ platform = "unix"
     parent = "inspec/resources/os"
 +++
 
-Use the `mail_alias` Chef InSpec audit resource to test the ...
-
+Use the `mail_alias` Chef InSpec audit resource to test mail alias present in the aliases file.
 
 ## Availability
 
 ### Installation
 
-This resource is distributed along with Chef InSpec itself. You can use it automatically.
+This resource is distributed along with Chef InSpec itself.
 
 ## Syntax
 
-A `mail_alias` Chef InSpec audit resource ...
+A `mail_alias` Chef InSpec audit resource allows to test mail alias present in the aliases file.
 
-    describe mail_alias do
-      its('shoe_size') { should cmp 42 }
-      it { should be_purple }
-      it { should have_bells }
+    describe mail_alias("daemon") do
+        it { should be_aliased_to "root" }
     end
 where
 
-- `'shoe_size'` is some property of this resource
-- `42` is the value to test for shoe size
-- `be_purple` is a matcher of this resource
-- `have_bells` is a matcher of this resource
-
-## Properties
-
-- Properties of the resources: `shoe_size`
-
-### shoe_size
-
-The shoe_size property tests ....
+- `'daemon'` is an alias present in `/etc/aliases` of the target system
+- `'root'` is the value assigned to the alias
+- `be_aliased_to` is a matcher of this resource
 
 ## Matchers
 
-For a full list of available matchers, please visit our [matchers page](https://docs.chef.io/inspec/matchers/).
+For a full list of available matchers, please visit our [matchers page](https://docs.chef.io/inspec/matchers/). The specific matchers of this resource is: `be_aliased_to`.
 
-The specific matchers of this resource are: `be_purple`, `have_bells`
+### be_aliased_to
 
-### be_purple
+The `be_aliased_to` matcher tests if the given input value is assigned to the initialized alias.
 
-The `be_purple` matcher tests the ...:
-
-    it { should be_purple }
+    it { should be_aliased_to "root" }
 
 ## Examples
 The following examples show how to use this Chef InSpec audit resource.
 
-### Example 1
+### Check if the alias `daemon` is aliased to `root`
 
-`shoe_size` returns ...
-
-    describe mail_alias do
-      its("shoe_size") { should eq 42 }
+    describe mail_alias("daemon") do
+      it { should be_aliased_to "root" }
     end
 
-### Example 2
+### Check if the alias `mailadmin` are aliased to `inspecadmin@chef.io` and `chefadmin@chef.io`
 
-`be_purple` checks for ...
-
-    describe mail_alias do
-      it { should be_purple }
+    describe mail_alias("mailadmin") do
+      it { should be_aliased_to "inspecadmin@chef.io" }
+      it { should be_aliased_to "chefadmin@chef.io" }
     end
-

--- a/docs-chef-io/content/inspec/resources/mail_alias.md
+++ b/docs-chef-io/content/inspec/resources/mail_alias.md
@@ -1,0 +1,77 @@
++++
+title = "mail_alias resource"
+draft = false
+gh_repo = "inspec"
+platform = "unix"
+
+[menu]
+  [menu.inspec]
+    title = "mail_alias"
+    identifier = "inspec/resources/os/mail_alias.md mail_alias resource"
+    parent = "inspec/resources/os"
++++
+
+Use the `mail_alias` Chef InSpec audit resource to test the ...
+
+
+## Availability
+
+### Installation
+
+This resource is distributed along with Chef InSpec itself. You can use it automatically.
+
+## Syntax
+
+A `mail_alias` Chef InSpec audit resource ...
+
+    describe mail_alias do
+      its('shoe_size') { should cmp 42 }
+      it { should be_purple }
+      it { should have_bells }
+    end
+where
+
+- `'shoe_size'` is some property of this resource
+- `42` is the value to test for shoe size
+- `be_purple` is a matcher of this resource
+- `have_bells` is a matcher of this resource
+
+## Properties
+
+- Properties of the resources: `shoe_size`
+
+### shoe_size
+
+The shoe_size property tests ....
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](https://docs.chef.io/inspec/matchers/).
+
+The specific matchers of this resource are: `be_purple`, `have_bells`
+
+### be_purple
+
+The `be_purple` matcher tests the ...:
+
+    it { should be_purple }
+
+## Examples
+The following examples show how to use this Chef InSpec audit resource.
+
+### Example 1
+
+`shoe_size` returns ...
+
+    describe mail_alias do
+      its("shoe_size") { should eq 42 }
+    end
+
+### Example 2
+
+`be_purple` checks for ...
+
+    describe mail_alias do
+      it { should be_purple }
+    end
+

--- a/lib/inspec/resources/mail_alias.rb
+++ b/lib/inspec/resources/mail_alias.rb
@@ -32,16 +32,11 @@ module Inspec::Resources
       "mail_alias #{resource_id}"
     end
 
-    def is_aliased_to?(alias_value)
-      # positive or negative expectations specific to this resource instance
-      true
-    end
+    def aliased_to?(alias_value)
+      cmd = inspec.command("cat /etc/aliases | grep #{@alias_key}")
+      raise Inspec::Exceptions::ResourceFailed, "#{@alias_key} is not a valid key in the aliases" if cmd.exit_status.to_i != 0
 
-    private
-
-    # Methods to help the resource's public methods
-    def helper_method
-      # Add anything you need here
+      alias_value == cmd.stdout.split(":").map(&:strip)[1]
     end
   end
 end

--- a/lib/inspec/resources/mail_alias.rb
+++ b/lib/inspec/resources/mail_alias.rb
@@ -1,5 +1,4 @@
 require "inspec/resources/command"
-
 module Inspec::Resources
   class Mailalias < Inspec.resource(1)
     # resource internal name.
@@ -9,11 +8,11 @@ module Inspec::Resources
     # all OS's and cloud API's supported)
     supports platform: "unix"
 
-    desc "Use the mail_alias InSpec audit resource to test mail_alias parameters"
+    desc "Use the mail_alias InSpec audit resource to test mail alias present in the aliases file"
 
     example <<~EXAMPLE
-      describe mail_alias('toor') do
-        it { should be_aliased_to 'root' }
+      describe mail_alias("toor") do
+        it { should be_aliased_to "root" }
       end
     EXAMPLE
 
@@ -27,16 +26,21 @@ module Inspec::Resources
       "#{@alias_key}"
     end
 
-    # Define how you want your resource to appear in test reports. Commonly, this is just the resource name and the resource ID.
+    # resource appearance in test reports.
     def to_s
       "mail_alias #{resource_id}"
     end
 
+    # aliased_to matcher checks if the given alias_value is set to the initialized alias_key
     def aliased_to?(alias_value)
+      # /etc/aliases if the file where the alias and its value(s) are stored
       cmd = inspec.command("cat /etc/aliases | grep #{@alias_key}")
       raise Inspec::Exceptions::ResourceFailed, "#{@alias_key} is not a valid key in the aliases" if cmd.exit_status.to_i != 0
 
-      alias_value == cmd.stdout.split(":").map(&:strip)[1]
+      # in general aliases file contains : separated values like alias_key : alias_value1, alias_value2
+      alias_values_combined = cmd.stdout.split(":").map(&:strip)[1]
+      alias_values_splitted = alias_values_combined.split(",").map(&:strip)
+      alias_values_splitted.include?(alias_value)
     end
   end
 end

--- a/lib/inspec/resources/mail_alias.rb
+++ b/lib/inspec/resources/mail_alias.rb
@@ -34,7 +34,7 @@ module Inspec::Resources
     # aliased_to matcher checks if the given alias_value is set to the initialized alias_key
     def aliased_to?(alias_value)
       # /etc/aliases if the file where the alias and its value(s) are stored
-      cmd = inspec.command("cat /etc/aliases | grep #{@alias_key}")
+      cmd = inspec.command("cat /etc/aliases | grep '^#{@alias_key}:'")
       raise Inspec::Exceptions::ResourceFailed, "#{@alias_key} is not a valid key in the aliases" if cmd.exit_status.to_i != 0
 
       # in general aliases file contains : separated values like alias_key : alias_value1, alias_value2

--- a/lib/inspec/resources/mail_alias.rb
+++ b/lib/inspec/resources/mail_alias.rb
@@ -1,0 +1,47 @@
+require "inspec/resources/command"
+
+module Inspec::Resources
+  class Mailalias < Inspec.resource(1)
+    # resource internal name.
+    name "mail_alias"
+
+    # Restrict to only run on the below platforms (if none were given,
+    # all OS's and cloud API's supported)
+    supports platform: "unix"
+
+    desc "Use the mail_alias InSpec audit resource to test mail_alias parameters"
+
+    example <<~EXAMPLE
+      describe mail_alias('toor') do
+        it { should be_aliased_to 'root' }
+      end
+    EXAMPLE
+
+    def initialize(alias_key)
+      skip_resource "The `mail_alias` resource is not yet available on your OS." unless inspec.os.unix?
+      @alias_key = alias_key
+    end
+
+    # resource_id is used in reporting engines to uniquely identify the individual resource.
+    def resource_id
+      "#{@alias_key}"
+    end
+
+    # Define how you want your resource to appear in test reports. Commonly, this is just the resource name and the resource ID.
+    def to_s
+      "mail_alias #{resource_id}"
+    end
+
+    def is_aliased_to?(alias_value)
+      # positive or negative expectations specific to this resource instance
+      true
+    end
+
+    private
+
+    # Methods to help the resource's public methods
+    def helper_method
+      # Add anything you need here
+    end
+  end
+end

--- a/test/fixtures/cmd/mail-alias
+++ b/test/fixtures/cmd/mail-alias
@@ -1,0 +1,1 @@
+daemon:		root

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -384,7 +384,7 @@ class MockLoader
       "cgget -n -r memory.stat carrotking" => cmd.call("cgget-n-r-stat"),
       %{sh -c 'type "cgget"'} => empty.call,
       # mail_alias
-      "cat /etc/aliases | grep daemon" => cmd.call("mail-alias"),
+      "cat /etc/aliases | grep '^daemon:'" => cmd.call("mail-alias"),
       # apache_conf
       "sh -c 'find /etc/apache2/ports.conf -type f -maxdepth 1'" => cmd.call("find-apache2-ports-conf"),
       "sh -c 'find /etc/httpd/conf.d/*.conf -type f -maxdepth 1'" => cmd.call("find-httpd-ssl-conf"),

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -383,6 +383,8 @@ class MockLoader
       "cgget -n -r cpuset.cpus carrotking" => cmd.call("cgget-n-r"),
       "cgget -n -r memory.stat carrotking" => cmd.call("cgget-n-r-stat"),
       %{sh -c 'type "cgget"'} => empty.call,
+      # mail_alias
+      "cat /etc/aliases | grep daemon" => cmd.call("mail-alias"),
       # apache_conf
       "sh -c 'find /etc/apache2/ports.conf -type f -maxdepth 1'" => cmd.call("find-apache2-ports-conf"),
       "sh -c 'find /etc/httpd/conf.d/*.conf -type f -maxdepth 1'" => cmd.call("find-httpd-ssl-conf"),

--- a/test/unit/resources/mail_alias_test.rb
+++ b/test/unit/resources/mail_alias_test.rb
@@ -1,0 +1,20 @@
+require "inspec/globals"
+require "#{Inspec.src_root}/test/helper"
+require_relative "../../../lib/inspec/resources/mail_alias"
+
+describe Inspec::Resources::Mailalias do
+  it "check mail alias on ubuntu" do
+    resource = MockLoader.new(:ubuntu).load_resource("mail_alias", "daemon")
+    _(resource.is_aliased_to?("root")).must_equal true
+  end
+
+  it "check mail alias on macos" do
+    resource = MockLoader.new(:macos10_10).load_resource("mail_alias", "daemon")
+    _(resource.is_aliased_to?("root")).must_equal true
+  end
+
+  it "check mail alias on freebsd" do
+    resource = MockLoader.new(:freebsd11).load_resource("mail_alias", "daemon")
+    _(resource.is_aliased_to?("root")).must_equal true
+  end
+end

--- a/test/unit/resources/mail_alias_test.rb
+++ b/test/unit/resources/mail_alias_test.rb
@@ -3,18 +3,24 @@ require "#{Inspec.src_root}/test/helper"
 require_relative "../../../lib/inspec/resources/mail_alias"
 
 describe Inspec::Resources::Mailalias do
-  it "check mail alias on ubuntu" do
+  it "check mail_alias on ubuntu" do
     resource = MockLoader.new(:ubuntu).load_resource("mail_alias", "daemon")
-    _(resource.is_aliased_to?("root")).must_equal true
+    _(resource.aliased_to?("root")).must_equal true
   end
 
-  it "check mail alias on macos" do
+  it "check mail_alias on macos" do
     resource = MockLoader.new(:macos10_10).load_resource("mail_alias", "daemon")
-    _(resource.is_aliased_to?("root")).must_equal true
+    _(resource.aliased_to?("root")).must_equal true
   end
 
-  it "check mail alias on freebsd" do
+  it "check mail_alias on freebsd" do
     resource = MockLoader.new(:freebsd11).load_resource("mail_alias", "daemon")
-    _(resource.is_aliased_to?("root")).must_equal true
+    _(resource.aliased_to?("root")).must_equal true
+  end
+
+  it "check mail_alias on ubuntu with a key that is not included as an alias" do
+    resource = MockLoader.new(:ubuntu).load_resource("mail_alias", "cheesecake")
+    ex = _ { resource.aliased_to?("root") }.must_raise(Inspec::Exceptions::ResourceFailed)
+    _(ex.message).must_include "cheesecake is not a valid key in the aliases"
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
✅ Signed-off-by: Sonu Saha <sonu.saha@progress.com> 

## Related Issue
**⚡️ CFINSPEC-80: Add `mail alias` resource**

## Description
Using the `mail_alias` resource 
Given that the user has called the `mail_alias` resource
and given that the system is unix-based
then the resource allows to test mail alias parameters

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
