### PR TITLE
Move shortcodes from chef-web-docs to inspec repo

### DIFF
--- a/docs-chef-io/Makefile
+++ b/docs-chef-io/Makefile
@@ -12,7 +12,7 @@ preview_netlify: chef_web_docs
 
 serve: chef_web_docs
 	echo "replace github.com/inspec/inspec/docs-chef-io => ../" >> chef-web-docs/go.mod
-	pushd chef-web-docs && make bundle; hugo server --buildDrafts --buildFuture --noHTTPCache && popd
+	pushd chef-web-docs && make bundle; hugo server --buildDrafts --buildFuture --noHTTPCache --ignoreVendorPaths "github.com/inspec/inspec/*" && popd
 
 chef_web_docs:
 	if [ -d "chef-web-docs/" ]; then \

--- a/docs-chef-io/content/inspec/_index.md
+++ b/docs-chef-io/content/inspec/_index.md
@@ -45,6 +45,6 @@ InSpec to target applications and services running on AWS and Azure.
 
 ### Resources
 
-Chef InSpec nearly 500 [resources](/inspec/resources/) ready use--Apache2 to ZFS pool.
+Chef InSpec has {{% inspec_count_resources %}} [resources](/inspec/resources/) ready to use--from Apache2 to ZFS pool.
 If you need a solution that we haven’t provided, you can write your own [custom
 resource](/inspec/dsl_resource/).

--- a/docs-chef-io/layouts/shortcodes/inspec_count_resources.md
+++ b/docs-chef-io/layouts/shortcodes/inspec_count_resources.md
@@ -1,0 +1,4 @@
+{{/* Counts the number of resource pages from all repositories in content/inspec/resources */}}
+
+{{- $inspecResources := .Site.GetPage "inspec/resources" -}}
+{{- len $inspecResources.Pages -}}

--- a/docs-chef-io/layouts/shortcodes/inspec_filter_table.md
+++ b/docs-chef-io/layouts/shortcodes/inspec_filter_table.md
@@ -1,0 +1,8 @@
+
+<div class="admonition-note">
+<p class="admonition-note-title">Note</p>
+<div class="admonition-note-text">
+<p>See the documentation on <a href="https://github.com/inspec/inspec/blob/main/dev-docs/filtertable-usage.md">FilterTable</a> for information on using filter criteria on plural resources.
+</p>
+</div>
+</div>

--- a/docs-chef-io/layouts/shortcodes/inspec_matchers_link.md
+++ b/docs-chef-io/layouts/shortcodes/inspec_matchers_link.md
@@ -1,0 +1,2 @@
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [Universal Matchers page](/inspec/matchers/).

--- a/docs-chef-io/layouts/shortcodes/inspec_resources.html
+++ b/docs-chef-io/layouts/shortcodes/inspec_resources.html
@@ -1,0 +1,21 @@
+{{/* Lists all resource pages by the specified platform. */}}
+{{/* Platforms are defined in the page front matter of each InSpec resource page. */}}
+{{/* See https://github.com/inspec/inspec/blob/main/docs-chef-io/content/inspec/resources/_index.md */}}
+
+{{ $platform := (.Get "platform") | lower }}
+<ul class="inspec-resources-list">
+  {{ range $index, $element := (where site.RegularPages "Section" "eq" "inspec") }}
+
+    {{ if hasPrefix .RelPermalink "/inspec/resources"}}
+      {{ if eq (lower .Params.platform) $platform }}
+        <li class="inspec-resource">
+          <a href="{{ .RelPermalink }}">{{.Title}}
+          {{- with .Params.title_append }}
+            {{ . }}
+          {{- end -}}</a>
+        </li>
+      {{ end }}
+    {{ end }}
+
+{{ end }}
+</ul>

--- a/docs-chef-io/layouts/shortcodes/inspec_resources_filter.html
+++ b/docs-chef-io/layouts/shortcodes/inspec_resources_filter.html
@@ -1,0 +1,4 @@
+<input type="text" id="filter-inspec" onkeyup="filterInspecResources()" placeholder="Resource Filter...">
+
+{{/* Add an input so users can filter resources on the https://docs.chef.io/inspec/resources/ page */}}
+{{/* Works with javascript defined here: https://github.com/chef/chef-web-docs/blob/main/themes/docs-new/assets/js/inspec-filter.js */}}


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

Move inspec shortcodes from chef-web-docs to inspec repository.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
https://chefio.atlassian.net/browse/CHEFDOCS-179

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
