### PR TITLE
CFINSPEC-83: Add routing table resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/routing_table.md
+++ b/docs-chef-io/content/inspec/resources/routing_table.md
@@ -11,8 +11,7 @@ platform = "linux"
     parent = "inspec/resources/os"
 +++
 
-Use the `routing_table` Chef InSpec audit resource to test the routing information parameters (viz. destination, gateway and interface) present in the routing table. The rule match is done against the output information of `netstat -rn`.
-
+Use the `routing_table` Chef InSpec audit resource to test the routing information parameters, destination, gateway, and interface present in the routing table. The rule matches with the output information of `netstat -rn`.
 
 ## Availability
 
@@ -22,41 +21,48 @@ This resource is distributed with Chef InSpec.
 
 ## Syntax
 
-A `routing_table` Chef InSpec audit resource test if an entry of destination, gateway and interface is present as part of the routing table information. All three keys and its value must be passed when testing.
+A `routing_table` Chef InSpec audit resource tests if an entry of destination, gateway, and interface is present as part of the routing table information. All three keys and their values must be passed when testing.
 
+```ruby
     describe routing_table do
       it { should have_entry(destination: '0.0.0.0', interface: 'eth0', gateway: '172.31.80.1') }
     end
-where
+```
 
-- `'destination', 'interface' and 'gateway'` are parameters of the routing table 
-- `have_entry` is a matcher of this resource
+> where
+>
+> - `destination`, `interface`, and `gateway` are parameters of the routing table.
+> - `have_entry` is a matcher of this resource.
 
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](https://docs.chef.io/inspec/matchers/).
 
-The specific matchers of this resource is: `have_entry`
-
 ### have_entry
 
-The `have_entry` matcher tests the if the given destination, interface and gateway exists as an entry in the routing table
+The `have_entry` matcher tests the if the given destination, interface, and gateway exist as an entry in the routing table.
 
+```ruby
     it { should have_entry(destination: '0.0.0.0', interface: 'eth0', gateway: '172.31.80.1') }
+```
 
 ## Examples
+
 The following examples show how to use this Chef InSpec audit resource.
 
-### Check if an entry with destination as '10.123.137.0', gateway as '0.0.0.0' and interface as 'eth0' exists in the routing table
+### Ensures an entry with the destination as '10.123.137.0', gateway as '0.0.0.0', and interface as 'eth0' exists in the routing table
 
-`have_entry` returns true if the given combination of destination, gateway and interface is a valid entry in the routing table
+`have_entry` returns *true* if the given combination of destination, gateway, and interface is a valid entry in the routing table.
 
+```ruby
     describe routing_table do
       it { should have_entry(destination: '10.123.137.0', interface: 'eth0', gateway: '0.0.0.0') }
     end
+```
 
-### Check if an entry with destination as '192.168.43.1/32', gateway as '172.31.80.1' and interface as 'lxdbr0' exists in the routing table
+### Ensures an entry with the destination as '192.168.43.1/32', gateway as '172.31.80.1', and interface as 'lxdbr0' exists in the routing table
 
+```ruby
     describe routing_table do
       it do
         should have_entry(
@@ -66,4 +72,4 @@ The following examples show how to use this Chef InSpec audit resource.
         )
       end
     end
-
+```

--- a/docs-chef-io/content/inspec/resources/routing_table.md
+++ b/docs-chef-io/content/inspec/resources/routing_table.md
@@ -1,0 +1,69 @@
++++
+title = "routing_table resource"
+draft = false
+gh_repo = "inspec"
+platform = "linux"
+
+[menu]
+  [menu.inspec]
+    title = "routing_table"
+    identifier = "inspec/resources/os/routing_table.md routing_table resource"
+    parent = "inspec/resources/os"
++++
+
+Use the `routing_table` Chef InSpec audit resource to test the routing information parameters (viz. destination, gateway and interface) present in the routing table. The rule match is done against the output information of `netstat -rn`.
+
+
+## Availability
+
+### Installation
+
+This resource is distributed with Chef InSpec.
+
+## Syntax
+
+A `routing_table` Chef InSpec audit resource test if an entry of destination, gateway and interface is present as part of the routing table information. All three keys and its value must be passed when testing.
+
+    describe routing_table do
+      it { should have_entry(destination: '0.0.0.0', interface: 'eth0', gateway: '172.31.80.1') }
+    end
+where
+
+- `'destination', 'interface' and 'gateway'` are parameters of the routing table 
+- `have_entry` is a matcher of this resource
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](https://docs.chef.io/inspec/matchers/).
+
+The specific matchers of this resource is: `have_entry`
+
+### have_entry
+
+The `have_entry` matcher tests the if the given destination, interface and gateway exists as an entry in the routing table
+
+    it { should have_entry(destination: '0.0.0.0', interface: 'eth0', gateway: '172.31.80.1') }
+
+## Examples
+The following examples show how to use this Chef InSpec audit resource.
+
+### Check if an entry with destination as '10.123.137.0', gateway as '0.0.0.0' and interface as 'eth0' exists in the routing table
+
+`have_entry` returns true if the given combination of destination, gateway and interface is a valid entry in the routing table
+
+    describe routing_table do
+      it { should have_entry(destination: '10.123.137.0', interface: 'eth0', gateway: '0.0.0.0') }
+    end
+
+### Check if an entry with destination as '192.168.43.1/32', gateway as '172.31.80.1' and interface as 'lxdbr0' exists in the routing table
+
+    describe routing_table do
+      it do
+        should have_entry(
+          :destination => '192.168.43.1/32',
+          :interface   => 'lxdbr0',
+          :gateway     => '172.31.80.1',
+        )
+      end
+    end
+

--- a/lib/inspec/resources/routing_table.rb
+++ b/lib/inspec/resources/routing_table.rb
@@ -43,9 +43,9 @@ module Inspec::Resources
     def has_entry?(input_route)
       # check if the destination, gateway, interface exists as part of the routing_info
       if input_route.key?(:destination) && input_route.key?(:gateway) && input_route.key?(:interface)
-        @routing_info[input_route[:destination]].include?([input_route[:gateway], input_route[:interface]])
+        @routing_info.key?(input_route[:destination]) ? @routing_info[input_route[:destination]].include?([input_route[:gateway], input_route[:interface]]) : false
       else
-        raise Inspec::Exceptions::ResourceSkipped, "One or more missing key, have_entry? matcher expects a hash with 3 keys: destination, gateway and interfacer"
+        raise Inspec::Exceptions::ResourceSkipped, "One or more missing key, have_entry? matcher expects a hash with 3 keys: destination, gateway and interface"
       end
     end
 

--- a/lib/inspec/resources/routing_table.rb
+++ b/lib/inspec/resources/routing_table.rb
@@ -1,0 +1,134 @@
+require "inspec/resources/command"
+
+module Inspec::Resources
+  class Routingtable < Inspec.resource(1)
+    # resource internal name.
+    name "routing_table"
+
+    # Restrict to only run on the below platforms (if none were given,
+    # all OS's and cloud API's supported)
+    supports platform: "unix"
+    supports platform: "windows"
+
+    desc "It allows testing routing table parameters"
+
+    example <<~EXAMPLE
+      describe "routing_table" do
+        it do
+          should have_entry(
+            :destination => '192.168.100.0/24',
+            :interface   => 'eth1',
+            :gateway     => '192.168.10.1',
+          )
+        end
+      end
+
+      describe routing_table do
+        it { should have_entry(:destination => '192.168.100.0/24', :interface => 'eth1', :gateway => '192.168.10.1') }
+      end
+    EXAMPLE
+
+    def initialize
+      skip_resource "The `routing_table` resource is not yet available on your OS." unless inspec.os.unix? || inspec.os.windows?
+      # fetch the routing information and store it in @routing_info (could be hash, tbd)
+      @routing_info = {}
+      fetch_routing_information
+    end
+
+    # resource appearance in test reports.
+    def to_s
+      "routing_table"
+    end
+
+    def has_entry?(input_route)
+      # check if the destination, gateway, interface exists as part of the routing_info
+      if input_route.key?(:destination) && input_route.key?(:gateway) && input_route.key?(:interface)
+        @routing_info[input_route[:destination]].include?([input_route[:gateway], input_route[:interface]])
+      else
+        raise Inspec::Exceptions::ResourceSkipped, "One or more missing key, have_entry? matcher expects a hash with 3 keys: destination, gateway and interfacer"
+      end
+    end
+
+    private
+
+    # fetches the routing information for the system
+    def fetch_routing_information
+      # check if netstat is available on the system
+      utility = find_netstat_or_error
+
+      # the command to fetch the routing information
+      fetch_route_cmd = "#{utility} -rn"
+
+      # execute the above netstat command
+      cmd = inspec.command(fetch_route_cmd)
+
+      # raise error if the exit status is not zero;
+      raise Inspec::Exceptions::ResourceFailed, "Executing netstat failed: #{cmd.stderr}" if cmd.exit_status.to_i != 0
+
+      # Todo:
+      # Improve logic to fetch destination, gateway & interface efficiently.
+      # The below logic assumes the following:
+      # 1. destination, gateway & interface header is present as Destination, Gateway & (Iface or Netif or Interface) respectively.
+      #    (Netif on BSD, Darwin,Iface on linux & Interface on Windows)
+      # 2. there is no blank data for any columns or the blank data are present after the interface column.
+
+      # cmd.stdout is the standard out of netstat -rn; split on new line to get the rows
+      raw_route_info = cmd.stdout.split("\n")
+
+      # since raw_route_info contains some row before the header (i.e. Destination Gateway ...); remove those rows
+      raw_route_info.shift until raw_route_info[0] =~ /Destination/i
+
+      # split each rows based on space to get the individual columns
+      # raw_route_info is now array of arrays with the routing information
+      raw_route_info.map! { |info| info.strip.split }
+
+      # these variables will store the indices where destination, gateway and interface are present
+      destination_index, gateway_index, interface_index = -1, -1, -1
+
+      # The headers in windows are as:
+      # Network Destination        Netmask          Gateway       Interface  Metric
+      # Splitting on space makes "Network Destination" to be two separate values as "Network" & "Destination"
+      # Remove "Network" value to apply the logic of finding index
+      raw_route_info[0].shift if inspec.os.windows?
+
+      # find the indices of destination, gateway and interface;
+      # because the position of gateway & interface varies with operating system
+      raw_route_info[0].each_with_index do |header, index|
+        if header =~ /Destination/i
+          destination_index = index
+        elsif header =~ /Gateway/i
+          gateway_index = index
+        elsif header =~ /Iface|Netif|Interface/i
+          interface_index = index
+        end
+      end
+
+      # remove the initial header consisting of Destination, Gateway, Mask, ... since this is of no use
+      raw_route_info.shift
+
+      # check the indices are assigned with some index and not -1
+      if destination_index != -1 && gateway_index != -1 && interface_index != -1
+        # iterate through the route_info; and find destination, gateway and interface from each row
+        raw_route_info.each do |info|
+          # if value exists at the destination_index, gateway_index, and interface_index; store the value in @routing_info
+          if !info[destination_index].nil? && !info[gateway_index].nil? && !info[interface_index].nil?
+            # if the destination_key is already present, append the gateway & interface; else create new array and add them
+            if @routing_info.key?(info[destination_index])
+              @routing_info[info[destination_index]] << [info[gateway_index], info[interface_index]]
+            else
+              @routing_info[info[destination_index]] = [[info[gateway_index], info[interface_index]]]
+            end
+          end
+        end
+      end
+    end
+
+    def find_netstat_or_error
+      %w{/usr/sbin/netstat /sbin/netstat /usr/bin/netstat /bin/netstat netstat}.each do |cmd|
+        return cmd if inspec.command(cmd).exist?
+      end
+
+      raise Inspec::Exceptions::ResourceFailed, "Could not find `netstat` utility to view routing table information"
+    end
+  end
+end

--- a/test/fixtures/cmd/netstat-rn-linux
+++ b/test/fixtures/cmd/netstat-rn-linux
@@ -1,0 +1,7 @@
+Kernel IP routing table
+Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
+0.0.0.0         172.31.80.1     0.0.0.0         UG        0 0          0 eth0
+10.0.3.0        0.0.0.0         255.255.255.0   U         0 0          0 lxcbr0
+10.123.137.0    0.0.0.0         255.255.255.0   U         0 0          0 lxdbr0
+172.31.80.0     0.0.0.0         255.255.240.0   U         0 0          0 eth0
+172.31.80.1     0.0.0.0         255.255.255.255 UH        0 0          0 eth0

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -388,6 +388,9 @@ class MockLoader
       %{sh -c 'type "cgget"'} => empty.call,
       # mail_alias
       "cat /etc/aliases | grep '^daemon:'" => cmd.call("mail-alias"),
+      # routing_table
+      "netstat -rn" => cmd.call("netstat-rn-linux"),
+      %{sh -c 'type "netstat"'} => empty.call,
       # apache_conf
       "sh -c 'find /etc/apache2/ports.conf -type f -maxdepth 1'" => cmd.call("find-apache2-ports-conf"),
       "sh -c 'find /etc/httpd/conf.d/*.conf -type f -maxdepth 1'" => cmd.call("find-httpd-ssl-conf"),

--- a/test/unit/resources/routing_table_test.rb
+++ b/test/unit/resources/routing_table_test.rb
@@ -17,7 +17,7 @@ describe Inspec::Resources::Routingtable do
     _(resource.has_entry?(destination: "172.31.80.1", interface: "eth0", gateway: "0.0.0.0")).must_equal true
   end
 
-  # darwin
+  # Ubuntu with missing key
   it "check routing table information on ubuntu with missing key input" do
     resource = MockLoader.new("ubuntu".to_sym).load_resource("routing_table")
     ex = _ { resource.has_entry?(destination: "172.31.80.1", interface: "eth0") }.must_raise(Inspec::Exceptions::ResourceSkipped)

--- a/test/unit/resources/routing_table_test.rb
+++ b/test/unit/resources/routing_table_test.rb
@@ -1,0 +1,33 @@
+require "inspec/globals"
+require "#{Inspec.src_root}/test/helper"
+require_relative "../../../lib/inspec/resources/routing_table"
+
+describe Inspec::Resources::Routingtable do
+  # ubuntu
+  it "check routing table information on ubuntu" do
+    resource = MockLoader.new("ubuntu".to_sym).load_resource("routing_table")
+    _(resource.has_entry?(destination: "0.0.0.0", interface: "eth0", gateway: "172.31.80.1")).must_equal true
+    _(resource.has_entry?(destination: "10.123.137.0", interface: "lxdbr0", gateway: "0.0.0.0")).must_equal true
+  end
+
+  # darwin
+  it "check routing table information on darwin" do
+    resource = MockLoader.new("macos10_10".to_sym).load_resource("routing_table")
+    _(resource.has_entry?(destination: "10.123.137.0", interface: "lxdbr0", gateway: "0.0.0.0")).must_equal true
+    _(resource.has_entry?(destination: "172.31.80.1", interface: "eth0", gateway: "0.0.0.0")).must_equal true
+  end
+
+  # darwin
+  it "check routing table information on ubuntu with missing key input" do
+    resource = MockLoader.new("ubuntu".to_sym).load_resource("routing_table")
+    ex = _ { resource.has_entry?(destination: "172.31.80.1", interface: "eth0") }.must_raise(Inspec::Exceptions::ResourceSkipped)
+    _(ex.message).must_include "One or more missing key, have_entry? matcher expects a hash with 3 keys: destination, gateway and interface"
+  end
+
+  # unsupported os
+  it "check routing table information on unsupported os" do
+    resource = MockLoader.new("undefined".to_sym).load_resource("routing_table")
+    _(resource.resource_skipped?).must_equal true
+    _(resource.resource_failed?).must_equal true
+  end
+end


### PR DESCRIPTION
Signed-off-by: Sonu Saha <sonu.saha@progress.com>

## Related Issue
**CFINSPEC-83: Add routing table resource**

## Description
Using the routing_table resource
Given that the user has called the routing_table resource
then the resource allows to test routing_table parameters _(viz. destination, gateway & interface)_
**Syntax:**
```
describe routing_table do
    it { should have_entry(destination: destination_ip, interface: network_interface, gateway: gateway_ip) }
end
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
