### PR TITLE
CFINSPEC-75: Add default_gateway resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/default_gateway.md
+++ b/docs-chef-io/content/inspec/resources/default_gateway.md
@@ -30,9 +30,9 @@ A `default_gateway` Chef InSpec audit resource allows to test the assigned ip ad
     end
 where
 
-- `'ipaddress' and 'interface'` are property of this resource
+- `'ipaddress' and 'interface'` are properties of this resource
 - `172.26.0.1` is the expected value for `'ipaddress'`
-- `172.26.4.74` is the expected value for `'interface'`
+- `eth0` is the expected value for `'interface'`
 
 ## Properties
 

--- a/docs-chef-io/content/inspec/resources/default_gateway.md
+++ b/docs-chef-io/content/inspec/resources/default_gateway.md
@@ -11,8 +11,7 @@ platform = "unix"
     parent = "inspec/resources/os"
 +++
 
-Use the `default_gateway` Chef InSpec audit resource to test the assigned ip address and interface for the default route.
-
+Use the **default_gateway** Chef InSpec audit resource to test the assigned IP address and interface for the default route.
 
 ## Availability
 
@@ -22,46 +21,56 @@ This resource is distributed with Chef InSpec.
 
 ## Syntax
 
-A `default_gateway` Chef InSpec audit resource allows to test the assigned ip address and interface for the default route.
+A `default_gateway` Chef InSpec audit resource allows to test the assigned IP address and interface for the default route.
+
+```ruby
 
     describe default_gateway do
       its("ipaddress") { should eq '172.26.0.1' }
       its("interface") { should eq 'eth0' }
     end
-where
+```
 
-- `'ipaddress' and 'interface'` are properties of this resource
-- `172.26.0.1` is the expected value for `'ipaddress'`
-- `eth0` is the expected value for `'interface'`
+> where
+>
+> - `'ipaddress' and 'interface'` are properties of this resource
+> - `172.26.0.1` is the expected value for `'ipaddress'`
+> - `eth0` is the expected value for `'interface'`
 
 ## Properties
 
-- Properties of the resources: `ipaddress` and `interface`
+Properties of the resources: `ipaddress` and `interface`.
 
 ### ipaddress
 
-The ipaddress property tests the assigned ip address for the default route.
+The `ipaddress` property tests the assigned IP address for the default route.
 
 ### interface
 
-The interface property tests the assigned network interface for the default route.
+The `interface` property tests the assigned network interface for the default route.
 
 ## Examples
+
 The following examples show how to use this Chef InSpec audit resource.
 
-### ipaddress 
+### Ensure IP address matches default route
 
-`ipaddress` fetches the assigned ip address for the default route and comparison is done using the `eq` matcher against the value.
+`ipaddress` fetches the assigned IP address for the default route and by making an comparison using the `eq` matcher.
+
+```ruby
 
     describe default_gateway do
       its("ipaddress") { should eq '172.26.0.1' }
     end
+```
 
-### interface
+### Ensure interface matches default route
 
-`interface` fetches the assigned network interface for the default route and comparison is done using the `eq` matcher against the value.
+`interface` fetches the assigned network interface for the default route and by making an comparison using the `eq` matcher.
+
+```ruby
 
     describe default_gateway do
       its("interface") { should eq 'eth0' }
     end
-
+```

--- a/docs-chef-io/content/inspec/resources/default_gateway.md
+++ b/docs-chef-io/content/inspec/resources/default_gateway.md
@@ -1,0 +1,67 @@
++++
+title = "default_gateway resource"
+draft = false
+gh_repo = "inspec"
+platform = "unix"
+
+[menu]
+  [menu.inspec]
+    title = "default_gateway"
+    identifier = "inspec/resources/os/default_gateway.md default_gateway resource"
+    parent = "inspec/resources/os"
++++
+
+Use the `default_gateway` Chef InSpec audit resource to test the assigned ip address and interface for the default route.
+
+
+## Availability
+
+### Installation
+
+This resource is distributed with Chef InSpec.
+
+## Syntax
+
+A `default_gateway` Chef InSpec audit resource allows to test the assigned ip address and interface for the default route.
+
+    describe default_gateway do
+      its("ipaddress") { should eq '172.26.0.1' }
+      its("interface") { should eq 'eth0' }
+    end
+where
+
+- `'ipaddress' and 'interface'` are property of this resource
+- `172.26.0.1` is the expected value for `'ipaddress'`
+- `172.26.4.74` is the expected value for `'interface'`
+
+## Properties
+
+- Properties of the resources: `ipaddress` and `interface`
+
+### ipaddress
+
+The ipaddress property tests the assigned ip address for the default route.
+
+### interface
+
+The interface property tests the assigned network interface for the default route.
+
+## Examples
+The following examples show how to use this Chef InSpec audit resource.
+
+### ipaddress 
+
+`ipaddress` fetches the assigned ip address for the default route and comparison is done using the `eq` matcher against the value.
+
+    describe default_gateway do
+      its("ipaddress") { should eq '172.26.0.1' }
+    end
+
+### interface
+
+`interface` fetches the assigned network interface for the default route and comparison is done using the `eq` matcher against the value.
+
+    describe default_gateway do
+      its("interface") { should eq 'eth0' }
+    end
+

--- a/lib/inspec/resources/default_gateway.rb
+++ b/lib/inspec/resources/default_gateway.rb
@@ -1,0 +1,61 @@
+require "inspec/resources/command"
+require_relative "routing_table"
+
+module Inspec::Resources
+  class Defaultgateway < Routingtable
+    # resource internal name.
+    name "default_gateway"
+
+    # Restrict to only run on the below platforms (if none were given,
+    # all OS's and cloud API's supported)
+    supports platform: "unix"
+    supports platform: "windows"
+
+    desc "Use the `default_gateway` Chef InSpec audit resource to test the assigned ip address and interface for the default route."
+
+    example <<~EXAMPLE
+      describe default_gateway do
+        its(:ipaddress) { should eq '172.31.80.1' }
+      end
+      describe default_gateway do
+        its("interface") { should eq 'eth0' }
+      end
+    EXAMPLE
+
+    def initialize
+      skip_resource "The `default_gateway` resource is not yet available on your OS." unless inspec.os.unix? || inspec.os.windows?
+      # invoke the routing_table initialize; which populates the @routing_info
+      super()
+    end
+
+    # resource appearance in test reports.
+    def to_s
+      "default_gateway"
+    end
+
+    # fetches the ipaddress assigned to the default gateway
+    # default gateway's destination is either `default` or `0.0.0.0`
+    def ipaddress
+      # @routing_info is the hash populated in routing_table resource
+      # @routing_info contain values as:
+      # {
+      #   destination1: [ [gateway1x, interface1x], [gateway1y, interface1y] ],
+      #   destination2: [gateway2, interface2]
+      # }
+      %w{default 0.0.0.0}.each do |destination|
+        return @routing_info[destination][0][0] if @routing_info.key?(destination)
+      end
+      # raise exception because no destination with value default or 0.0.0.0 is found in the routing table
+      raise Inspec::Exceptions::ResourceFailed, "No routing found as part of default gateway"
+    end
+
+    # fetches the interface assigned to the default gateway
+    def interface
+      %w{default 0.0.0.0}.each do |destination|
+        return @routing_info[destination][0][1] if @routing_info.key?(destination)
+      end
+      # raise exception because no destination with value default or 0.0.0.0 is found in the routing table
+      raise Inspec::Exceptions::ResourceFailed, "No routing found as part of default gateway"
+    end
+  end
+end

--- a/test/unit/resources/default_gateway_test.rb
+++ b/test/unit/resources/default_gateway_test.rb
@@ -1,0 +1,26 @@
+require "inspec/globals"
+require "#{Inspec.src_root}/test/helper"
+require_relative "../../../lib/inspec/resources/default_gateway"
+
+describe Inspec::Resources::Defaultgateway do
+  # ubuntu
+  it "check ipaddress and interface of default gateway on ubuntu" do
+    resource = MockLoader.new("ubuntu".to_sym).load_resource("default_gateway")
+    _(resource.ipaddress).must_equal "172.31.80.1"
+    _(resource.interface).must_equal "eth0"
+  end
+
+  # darwin
+  it "check ipaddress and interface of default gateway on darwin" do
+    resource = MockLoader.new("macos10_10".to_sym).load_resource("default_gateway")
+    _(resource.ipaddress).must_equal "172.31.80.1"
+    _(resource.interface).must_equal "eth0"
+  end
+
+  # unsupported os
+  it "check ipaddress and interface of default gateway on unsupported os" do
+    resource = MockLoader.new("undefined".to_sym).load_resource("default_gateway")
+    _(resource.resource_skipped?).must_equal true
+    _(resource.resource_failed?).must_equal true
+  end
+end


### PR DESCRIPTION
✅ Signed-off-by: Sonu Saha <sonu.saha@progress.com>
## Related Issue
**CFINSPEC-75: Add `default_gateway` resource**

## Description
Using the default_gateway resource
Given that the user has called the `default_gateway` resource
then the resource _allows to test the assigned ip address and interface_ for the default route.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
