### PR TITLE
CFINSPEC-93: Enhance `service` resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/service.md
+++ b/docs-chef-io/content/inspec/resources/service.md
@@ -11,55 +11,62 @@ platform = "os"
     parent = "inspec/resources/os"
 +++
 
-Use the `service` Chef InSpec audit resource to test if the named service is installed, running and/or enabled.
+Use the `service` Chef InSpec audit resource to test whether the installation of the named service is successful and enabled.
 
-Under some circumstances, it may be necessary to specify the service manager by using one of the following service manager-specific resources: `bsd_service`, `launchd_service`, `runit_service`, `systemd_service`, `sysv_service`, or `upstart_service`. These resources are based on the `service` resource.
+It may be necessary to specify the service manager by using one of the following service manager-specific resources: `bsd_service`, `launchd_service`, `runit_service`, `systemd_service`, `sysv_service`, and `upstart_service`. These resources are based on the `service` resource.
 
 ## Availability
 
 ### Installation
 
-This resource is distributed along with Chef InSpec itself. You can use it automatically.
+The Chef InSpec distributes this resource.
 
 ### Version
 
-This resource first became available in v1.0.0 of InSpec.
+This resource is available from Chef Inspec version 1.0.0.
 
 ## Syntax
 
-A `service` resource block declares the name of a service and then one (or more) matchers to test the state of the service:
+A `service` resource block declares the name of a service and one or more matchers to test the service state.
 
-    describe service('service_name') do
+```ruby
+    describe service('NAME') do
       it { should be_installed }
       it { should be_enabled }
       it { should be_running }
     end
+```
 
-where
-
-- `('service_name')` must specify a service name
-- `be_installed`, `be_enabled`, and `be_running` are valid matchers for this resource
+> where
+>
+> - `('service_name')` must specify a service name
+> - `be_installed`, `be_enabled`, and `be_running` are valid matchers for this resource
 
 ## Examples
 
 The following examples show how to use this Chef InSpec audit resource.
 
-### Test if the postgresql service is both running and enabled
+### Test if the PostgreSQL service is both running and enabled
 
-    describe service('postgresql') do
+```ruby
+    describe service('PostgreSQL') do
       it { should be_enabled }
       it { should be_running }
     end
+```
 
-### Test if the mysql service is both running and enabled
+### Test if the MYSQL service is running and enabled
 
-    describe service('mysqld') do
+```ruby
+    describe service('MYSQL') do
       it { should be_enabled }
       it { should be_running }
     end
+```
 
-### Test if ClamAV (an antivirus engine) is installed and running
+### Test if the installation of ClamAV (an antivirus engine) is successful  and running
 
+```ruby
     describe package('clamav') do
       it { should be_installed }
       its('version') { should eq '0.98.7' }
@@ -70,74 +77,93 @@ The following examples show how to use this Chef InSpec audit resource.
       it { should_not be_installed }
       it { should_not be_running }
     end
+```
 
-### Test Unix System V run levels
+### Test Unix SystemV run levels
 
 On targets that are using SystemV services, the existing run levels can also be checked:
 
-    describe service('sshd').runlevels do
+```ruby
+    describe service('SSH').runlevels do
       its('keys') { should include(2) }
     end
 
-    describe service('sshd').runlevels(2,4) do
+    describe service('SSH').runlevels(2,4) do
       it { should be_enabled }
     end
+```
 
 ### Override the service manager
 
-Under some circumstances, it may be required to override the logic in place to select the right service manager. For example, to check a service managed by Upstart:
+It may be required to override the logic to select the right service manager. For example, to check a service managed by Upstart.
 
-    describe upstart_service('service') do
+```ruby
+    describe upstart_service('SERVICE') do
       it { should_not be_enabled }
       it { should be_installed }
       it { should be_running }
     end
+```
 
-This is also possible with `systemd_service`, `runit_service`, `sysv_service`, `bsd_service`, and `launchd_service`. Provide the control command when it is not to be found at the default location. For example, if the `sv` command for services managed by runit is not in the `PATH`:
+This is also possible with `systemd_service`, `runit_service`, `sysv_service`, `bsd_service`, and `launchd_service`. If not found at the default location, provide the **control** command. For example, if the `sv` command for services managed by `runit` is not in the `PATH`.
 
-    describe runit_service('service', '/opt/chef/embedded/sbin/sv') do
+```ruby
+    describe runit_service('SERVICE', '/opt/chef/embedded/sbin/sv') do
       it { should be_enabled }
       it { should be_installed }
       it { should be_running }
     end
+```
 
-### Verify that IIS is running
+### Verify IIS is running
 
+```ruby
     describe service('W3SVC') do
       it { should be_installed }
       it { should be_running }
     end
+```
 
 ## Matchers
 
-For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).
+For a full list of available matchers, please visit the [matchers page](/inspec/matchers/).
 
 ### be_enabled
 
 The `be_enabled` matcher tests if the named service is enabled:
 
+```ruby
     it { should be_enabled }
+```
 
 ### be_installed
 
-The `be_installed` matcher tests if the named service is installed:
+The `be_installed` matcher tests if the named service is installed.
 
+```ruby
     it { should be_installed }
+```
 
 ### be_running
 
-The `be_running` matcher tests if the named service is running:
+The `be_running` matcher tests if the named service is running.
 
+```ruby
     it { should be_running }
+```
 
 ### be_monitored_by
 
-The `be_monitored_by` matcher accepts name of a monitoring tool as an input and tests if the named service is monitored by the given monitoring tool. The monitoring tools currently supported by this resource are: `monit` and `god`.
+The `be_monitored_by` matcher accepts the name of a monitoring tool as input and test if the named service is monitored respectively. The monitoring tool supports `monit` and `god` resources.
 
+```ruby
     it { should be_monitored_by("god") }
+```
 
 ### have_start_mode
 
-The `have_start_mode` matcher tests accepts a mode as an input and tests if the named service's start mode is the same as specified in the input. This matcher is currently supported only on Windows system.
+The `have_start_mode` matcher tests accept a mode as input and test if the named service's start mode is the same as specified in the input. This matcher  is supported on the Windows systems only.
 
+```ruby
     it { should have_start_mode('Manual') }
+```

--- a/docs-chef-io/content/inspec/resources/service.md
+++ b/docs-chef-io/content/inspec/resources/service.md
@@ -129,3 +129,15 @@ The `be_installed` matcher tests if the named service is installed:
 The `be_running` matcher tests if the named service is running:
 
     it { should be_running }
+
+### be_monitored_by
+
+The `be_monitored_by` matcher accepts name of a monitoring tool as an input and tests if the named service is monitored by the given monitoring tool. The monitoring tools currently supported by this resource are: `monit` and `god`.
+
+    it { should be_monitored_by("god") }
+
+### have_start_mode
+
+The `have_start_mode` matcher tests accepts a mode as an input and tests if the named service's start mode is the same as specified in the input. This matcher is currently supported only on Windows system.
+
+    it { should have_start_mode('Manual') }

--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -944,7 +944,7 @@ module Inspec::Resources
       utility = find_utility_or_error("monit")
       utility_cmd = inspec.command("#{utility} summary")
 
-      raise Inspec::Exceptions::ResourceFailed, "Executing #{utility} failed: #{cmd.stderr}" if utility_cmd.exit_status.to_i != 0
+      raise Inspec::Exceptions::ResourceFailed, "Executing #{utility} summary failed: #{utility_cmd.stderr}" if utility_cmd.exit_status.to_i != 0
 
       monitoring_info = utility_cmd.stdout.split("\n")
       monitoring_info.map! { |info| info.strip.squeeze(" ") }
@@ -974,7 +974,7 @@ module Inspec::Resources
       utility = find_utility_or_error("god")
       utility_cmd = inspec.command("#{utility} status #{service_name}")
 
-      raise Inspec::Exceptions::ResourceFailed, "Executing #{utility} failed: #{cmd.stderr}" if utility_cmd.exit_status.to_i != 0
+      raise Inspec::Exceptions::ResourceFailed, "Executing #{utility} status #{service_name} failed: #{utility_cmd.stderr}" if utility_cmd.exit_status.to_i != 0
 
       monitoring_info = utility_cmd.stdout.strip
       monitoring_info =~ /^#{service_name}: up/

--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -274,11 +274,16 @@ module Inspec::Resources
     # matcher equivalent to startmode property; compares start-up mode
     # supported only on windows.
     def has_start_mode?(mode)
+      raise Inspec::Exceptions::ResourceSkipped, "The `has_start_mode` matcher is not supported on your OS yet." unless inspec.os.windows?
+
       mode == startmode
     end
 
     # matcher to check if the service is monitored by the given monitoring tool/software
     def monitored_by?(monitoring_tool)
+      # Currently supported monitoring tools are: monit & god
+      # To add support for new monitoring tools, extend the case statement with additional monitoring tool and
+      # add the definition and logic in a new class (inheriting the base class MonitoringTool: optional)
       case monitoring_tool
       when "monit"
         current_monitoring_tool = Monit.new(inspec, @service_name)

--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -936,10 +936,6 @@ module Inspec::Resources
   end
 
   class Monit < MonitoringTool
-    def initialize(inspec, service_name)
-      super
-    end
-
     def is_service_monitored?
       utility = find_utility_or_error("monit")
       utility_cmd = inspec.command("#{utility} summary")
@@ -957,19 +953,9 @@ module Inspec::Resources
       end
       is_monitored
     end
-
-    private
-
-    def find_utility_or_error(utility_name)
-      super
-    end
   end
 
   class God < MonitoringTool
-    def initialize(inspec, service_name)
-      super
-    end
-
     def is_service_monitored?
       utility = find_utility_or_error("god")
       utility_cmd = inspec.command("#{utility} status #{service_name}")
@@ -978,12 +964,6 @@ module Inspec::Resources
 
       monitoring_info = utility_cmd.stdout.strip
       monitoring_info =~ /^#{service_name}: up/
-    end
-
-    private
-
-    def find_utility_or_error(utility_name)
-      super
     end
   end
 end

--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -271,6 +271,12 @@ module Inspec::Resources
       info[:startname]
     end
 
+    # matcher equivalent to startmode property; compares start-up mode
+    # supported only on windows.
+    def has_start_mode?(mode)
+      mode == startmode
+    end
+
     def to_s
       "Service #{@service_name}"
     end

--- a/test/fixtures/cmd/monit-summary
+++ b/test/fixtures/cmd/monit-summary
@@ -1,0 +1,4 @@
+Monit 5.26.0 uptime: 3d 17h 59m 
+Service Name                     Status                      Type          
+ip-172-31-83-240                 OK                          System         
+ssh                              OK                          Process       

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -312,6 +312,9 @@ class MockLoader
       "service sendmail onestatus" => cmd.call("service-sendmail-onestatus"),
       # mock for FreeBSD10Init info
       "service -l" => cmd.call("service-l"),
+      # service mock for monit
+      "monit summary" => cmd.call("monit-summary"),
+      %{sh -c 'type "monit"'} => empty.call,
       # services for system 5 e.g. centos6, debian 6
       "service sshd status" => cmd.call("service-sshd-status"),
       'find /etc/rc*.d /etc/init.d/rc*.d -name "S*"' => cmd.call("find-etc-rc-d-name-S"),

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -544,5 +544,21 @@ describe "Inspec::Resources::Service" do
     it "checks disabled false if some services are not disabled" do
       _(service.runlevels(0, 4).enabled?).must_equal false
     end
+
+    # windows
+    it "verify serverspec compatible matchers on windows" do
+      resource = MockLoader.new(:windows).load_resource("service", "dhcp")
+      _(resource.name).must_equal "dhcp"
+      _(resource.has_start_mode?("Auto")).must_equal true
+    end
+
+    # ubuntu
+    it "verify serverspec compatible matchers on ubuntu" do
+      resource = MockLoader.new(:ubuntu1404).load_resource("service", "ssh")
+      _(resource.name).must_equal "ssh"
+      _(resource.monitored_by?("monit")).must_equal true
+      ex = _ { resource.has_start_mode?("Auto") }.must_raise(Inspec::Exceptions::ResourceSkipped)
+      _(ex.message).must_include "The `has_start_mode` matcher is not supported on your OS yet."
+    end
   end
 end


### PR DESCRIPTION
✅ Signed-off-by: Sonu Saha <sonu.saha@progress.com>
<!--- Provide a short summary of your changes in the Title above -->
## Related Issue
**CFINSPEC-93: Enhance `service` resource with `be_monitored_by` and `have_start_mode` matchers**

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Using the `service` resource
Given that the user has called the `service` resource
then the resource allows to test with new matchers viz. `be_monitored_by` and `have_start_mode` matchers
- Syntax
  ```
  it { should be_monitored_by("god") }
  it { should have_start_mode("Manual") }
  ```
- The monitoring tools currently supported by this resource are: `monit` and `god`.
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
