### PR TITLE
CFINSPEC-89: Enhance `group` resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/group.md
+++ b/docs-chef-io/content/inspec/resources/group.md
@@ -15,66 +15,71 @@ Use the `group` Chef InSpec audit resource to test a single group on the system.
 
 The `group` resource uses the following system groups:
 
-- On **non-Windows** systems the group resource tests a local group defined in the`/etc/group` file.
+- On **non-Windows** systems, the group resource tests a local group defined in the`/etc/group` file.
 
-- On **Windows** systems the group resource tests a local group defined by Local Users and Groups.
-
+- On **Windows** systems, the group resource tests a local group defined by Local Users and Groups.
 
 ## Availability
 
 ### Installation
 
-This resource is distributed along with Chef InSpec itself. You can use it automatically.
+The Chef InSpec resource distributes this resource.
 
 ### Version
 
-This resource first became available in v1.0.0 of InSpec.
+This resource is available from Chef Inspec 1.0.0.
 
 ## Syntax
 
-A `group` resource block declares a group, and then the details to be tested, such as if the group is a local group, the group identifier, or if the group exists:
+A `group` resource block declares a group and the details to be tested, such as if the group is a local group, the group identifier, or if the group exists.
 
+```ruby
     describe group('group_name') do
       it { should exist }
       its('gid') { should eq 0 }
     end
+```
 
-where
-
-- `'group_name'` must specify the name of a group to be tested on the system
-- `exist` and `'gid'` are valid matchers for this resource
+> where
+>
+> - `group_name` must specify the group's name to be tested on the system.
+> - `exist` and `gid` are valid matchers for this resource.
 
 ## Properties
 
 ### gid
 
-The `gid` property returns the named group identifier:
+The `gid` property returns the named group identifier.
 
+```ruby
     its('gid') { should eq 1234 }
+```
 
 ### members
 
-The `members` property returns the members that belong to the group:
+The `members` property returns the members that belong to the group.
 
+```ruby
     its('members') { should include 'root' }
+```
 
-where `members` returns:
-
-- an array of group members for **Windows Platform**.
-
-    Example: `["member1", "member2"]`
-
-- a CSV formatted string of group members for **Non-Windows Platforms**.
-
-    Example: `"member1,member2"`
+> where `members` returns:
+>
+> - an array of group members for **Windows Platform**.
+>
+> For example, ["member1", "member2"]
+>
+> - a CSV formatted string of group members for **Non-Windows Platforms**.
+>
+> For example, `"member1,member2"`
 
 ### members_array
 
-The `members_array` property returns the members that belong to a group just like the
-`members` property,
-but the value returned by this property is always an array of group members.
+The `members_array` property returns the members that belong to a group like the `members` property, however the value returned by this property is always an array of group members.
 
+```ruby
     its('members_array') { should include 'root' }
+```
 
 ## Examples
 
@@ -82,11 +87,12 @@ The following examples show how to use this Chef InSpec audit resource.
 
 ### Test the group identifier for the root group
 
+```ruby
     describe group('root') do
       it { should exist }
       its('gid') { should eq 0 }
     end
-
+```
 
 ## Matchers
 
@@ -94,18 +100,24 @@ For a full list of available matchers, please visit our [matchers page](/inspec/
 
 ### be_local
 
-The `be_local` matcher tests if the group is a local group:
+The `be_local` matcher tests if the group is a local group.
 
+```ruby
     it { should be_local }
+```
 
 ### exist
 
-The `exist` matcher tests if the named group exists:
+The `exist` matcher tests if the named group exists.
 
+```ruby
     it { should exist }
+```
 
 ### have_gid
 
 The `have_gid` matcher tests if the named group has the given gid.
 
+```ruby
     it { should have_gid 0 }
+```

--- a/docs-chef-io/content/inspec/resources/group.md
+++ b/docs-chef-io/content/inspec/resources/group.md
@@ -103,3 +103,9 @@ The `be_local` matcher tests if the group is a local group:
 The `exist` matcher tests if the named group exists:
 
     it { should exist }
+
+### have_gid
+
+The `have_gid` matcher tests if the named group has the given gid.
+
+    it { should have_gid 0 }

--- a/lib/inspec/resources/groups.rb
+++ b/lib/inspec/resources/groups.rb
@@ -145,6 +145,11 @@ module Inspec::Resources
       true
     end
 
+    # matcher equivalent to gid property.
+    def has_gid?(gid_value)
+      gid_value == gid
+    end
+
     def to_s
       "Group #{@group}"
     end

--- a/test/unit/resources/group_test.rb
+++ b/test/unit/resources/group_test.rb
@@ -130,4 +130,16 @@ describe "Inspec::Resources::Group" do
     _(resource.exists?).must_equal true
     _(resource.members).must_equal ""
   end
+
+  # ubuntu
+  it "verify have_gid matcher on ubuntu" do
+    resource = MockLoader.new(:ubuntu).load_resource("group", "root")
+    _(resource.has_gid?(0)).must_equal true
+  end
+
+  # freebsd
+  it "verify have_gid matcher on freebsd" do
+    resource = MockLoader.new(:freebsd10).load_resource("group", "root")
+    _(resource.has_gid?(0)).must_equal true
+  end
 end


### PR DESCRIPTION
✅ Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Related Issue
**CFINSPEC-89: Enhance `group` resource to have `have_gid` matcher.**

## Description
- Using the `group` resource
Given that the user has called the `group` resource
then the resource allows to test with `have_gid` matcher
- Syntax: `it { should have_gid 0 }`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
