### PR TITLE
CFINSPEC-92: Enhance `processes` resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/processes.md
+++ b/docs-chef-io/content/inspec/resources/processes.md
@@ -11,45 +11,45 @@ platform = "os"
     parent = "inspec/resources/os"
 +++
 
-Use the `processes` Chef InSpec audit resource to test properties for programs that are running on the system.
+Use the `processes` Chef InSpec audit resource to test the properties of system programs.
 
 ## Availability
 
 ### Installation
 
-This resource is distributed with Chef InSpec.
+The Chef InSpec distributes this resource.
 
 ### Version
 
-This resource first became available in v1.0.0 of InSpec.
+This resource is available from InSpec 1.0 version.
 
 ## Syntax
 
-A `processes` resource block declares the name of the process to be tested, and then declares one (or more) property/value pairs:
+A `processes` resource block declares the process name that must be tested and defines one or more property and value pairs.
 
-    describe processes('process_name') do
-      its('property_name') { should eq ['property_value'] }
+    describe processes('NAME') do
+      its('property_name') { should eq ['VALUE'] }
     end
 
-where
-
-- `'process_name'` specifies the name of a process to check. If this is a string, it will be converted to a Regexp. For more specificity, pass a Regexp directly. If left blank, all processes will be returned.
-- `property_name` is some valid property of this resource.
-- `property_value` is the expected value for the specified property.
+> where
+>
+> - `process_name` specifies the name of the process to test. If the value is a string, it is converted to a `Regexp`. You can pass a `Regexp` directly for more accurate results. If left blank returns all processes.
+> - `property_name` is a valid property of this resource.
+> - `property_value` is the expected value for the specified property.
 
 ## Properties
 
-The specific properties of this resource are: `labels`, `pids`, `cpus`, `mem`, `vsz`, `rss`, `tty`, `states`, `start`, `time`, `users`, `commands`, `count` and `list`
+The specific properties of this resource are: `labels`, `pids`, `cpus`, `mem`, `vsz`, `rss`, `tty`, `states`, `start`, `time`, `users`, `commands`, `count`, and `list`
 
-The properties can be used as:
+Usage of these properties is as follows:
 
-    its('property_name') { should eq ['property_value'] }
+    its('property_name') { should eq ['VALUE'] }
 
 ## Matchers
 
-For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).
+For a full list of available matchers, please visit the [matchers page](/inspec/matchers/).
 
-The specific matcher of this resource is: `be_running`
+The specific matcher of this resource is: `be_running`.
 
 ### be_running
 
@@ -61,22 +61,22 @@ The `be_running` matcher tests if the named process is running:
 
 The following examples show how to use this Chef InSpec audit resource.
 
-### Test if the list length for the mysqld process is 1
+### Test if the mysqld process list length is 1
 
-    describe processes('mysqld') do
+    describe processes('SQLD') do
       its('list.length') { should eq 1 }
     end
 
-### Test if the process count for the mysqld process is 1
+### Test if the mysqld process count is 1
 
-    describe processes('mysqld') do
+    describe processes('SQLD') do
       its('count') { should eq 1 }
     end
 
-### Test if the process is owned by a specific user
+### Test if the user owns the process
 
     describe processes('init') do
-      its('users') { should eq ['root'] }
+      its('users') { should eq ['ROOT'] }
     end
 
     describe processes('winlogon') do
@@ -90,7 +90,7 @@ The following examples show how to use this Chef InSpec audit resource.
     end
 
     describe processes('windows_process') do
-      its('labels') { should cmp "High" }
+      its('labels') { should cmp "HIGH" }
     end
 
 ### Test if a process exists on the system
@@ -107,9 +107,7 @@ The following examples show how to use this Chef InSpec audit resource.
 
 ### Test for a process using a specific Regexp
 
-If the process name is too common for a string to uniquely find it,
-you may use a regexp. Inclusion of whitespace characters may be
-needed.
+Use `regexp` if the process name is too common for a string to find it uniquely. You may need to include whitespace characters.
 
     describe processes(Regexp.new("/usr/local/bin/swap -d")) do
       its('list.length') { should eq 1 }
@@ -117,13 +115,11 @@ needed.
 
 ### Notes for auditing Windows systems
 
-Sometimes with system properties there isn't a direct comparison between different operating systems.
-Most of the `property_name`'s do align between the different OS's.
+Sometimes there is no direct comparison between different operating systems and system properties. Most of the `property_name` do align between the various operating systems.
 
-There are however some exception's, for example, within linux `states` offers multiple properties.
-Windows doesn't have direct comparison that is a single property so instead `states` is mapped to the property of `Responding`, This is a boolean true/false flag to help determine if the process is hung.
+However, there are some exceptions. For example, within Linux operating system, `states` offer multiple properties. Windows operating systems do not have a direct comparison on a single property. Hence, `states` is mapped to the property of `Responding` and determines a boolean (true/false) flag if the process is hung.
 
-Below is a mapping table to help you understand what property the unix field maps to the windows `Get-Process` Property
+The following mapping table aids you in understanding the Unix field property mapping to the Windows `Get-Process` property:
 
 | _unix ps field_ | _windows PowerShell Property_ |
 | :-------------: | :---------------------------: |
@@ -139,4 +135,3 @@ Below is a mapping table to help you understand what property the unix field map
 |      time       |      TotalProcessorTime       |
 |      users      |           UserName            |
 |    commands     |             Path              |
-

--- a/docs-chef-io/content/inspec/resources/processes.md
+++ b/docs-chef-io/content/inspec/resources/processes.md
@@ -17,7 +17,7 @@ Use the `processes` Chef InSpec audit resource to test properties for programs t
 
 ### Installation
 
-This resource is distributed along with Chef InSpec itself. You can use it automatically.
+This resource is distributed with Chef InSpec.
 
 ### Version
 
@@ -33,8 +33,29 @@ A `processes` resource block declares the name of the process to be tested, and 
 
 where
 
-- `processes('process_name')` specifies the name of a process to check. If this is a string, it will be converted to a Regexp. For more specificity, pass a Regexp directly. If left blank, all processes will be returned.
-- `property_name` may be used to test user (`its('users')`) and state properties (`its('states')`)
+- `'process_name'` specifies the name of a process to check. If this is a string, it will be converted to a Regexp. For more specificity, pass a Regexp directly. If left blank, all processes will be returned.
+- `property_name` is some valid property of this resource.
+- `property_value` is the expected value for the specified property.
+
+## Properties
+
+The specific properties of this resource are: `labels`, `pids`, `cpus`, `mem`, `vsz`, `rss`, `tty`, `states`, `start`, `time`, `users`, `commands`, `count` and `list`
+
+The properties can be used as:
+
+    its('property_name') { should eq ['property_value'] }
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).
+
+The specific matcher of this resource is: `be_running`
+
+### be_running
+
+The `be_running` matcher tests if the named process is running:
+
+    it { should be_running }
 
 ## Examples
 
@@ -44,6 +65,12 @@ The following examples show how to use this Chef InSpec audit resource.
 
     describe processes('mysqld') do
       its('list.length') { should eq 1 }
+    end
+
+### Test if the process count for the mysqld process is 1
+
+    describe processes('mysqld') do
+      its('count') { should eq 1 }
     end
 
 ### Test if the process is owned by a specific user
@@ -70,6 +97,12 @@ The following examples show how to use this Chef InSpec audit resource.
 
     describe processes('some_process') do
       it { should exist }
+    end
+
+### Test if a process is running on the system
+
+    describe processes('some_process') do
+      it { should be_running }
     end
 
 ### Test for a process using a specific Regexp
@@ -107,12 +140,3 @@ Below is a mapping table to help you understand what property the unix field map
 |      users      |           UserName            |
 |    commands     |             Path              |
 
-## Matchers
-
-For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).
-
-### property_name
-
-The `property_name` matcher tests the named property for the specified value:
-
-    its('property_name') { should eq ['property_value'] }

--- a/lib/inspec/resources/processes.rb
+++ b/lib/inspec/resources/processes.rb
@@ -62,11 +62,13 @@ module Inspec::Resources
 
     # Matcher to check if the process is running
     def running?
-      # Check if Regex needs to be tightened.
-      # States value can be as:
-      # for Unix: R, R< or R+
-      # for Windows "True" or "False"
-      states.any? and !!(states[0] =~ /True/ || states[0] =~ /^R+/)
+      # A process is considered running if:
+      # unix: it is in running(R) state or either of sleep state(D: Uninterruptible or S: Interruptible)
+      # windows: it is responding i.e. state is True.
+
+      # Other codes like <(high priorty), N(low priority), +(foreground process group) etc. may appear after the state code in unix.
+      # Hence the regex used is /^statecode+/ where statecode is either R, S, or D.
+      states.any? and !!(states[0] =~ /True/ || states[0] =~ /^R+/ || states[0] =~ /^D+/ || states[0] =~ /^S+/)
     end
 
     filter = FilterTable.create

--- a/lib/inspec/resources/processes.rb
+++ b/lib/inspec/resources/processes.rb
@@ -60,6 +60,15 @@ module Inspec::Resources
       @list
     end
 
+    # Matcher to check if the process is running
+    def running?
+      # Check if Regex needs to be tightened.
+      # States value can be as:
+      # for Unix: R, R< or R+
+      # for Windows "True" or "False"
+      states.any? and !!(states[0] =~ /True/ || states[0] =~ /^R+/)
+    end
+
     filter = FilterTable.create
     filter.register_column(:labels, field: "label")
       .register_column(:pids,     field: "pid")

--- a/test/fixtures/cmd/ps-axo
+++ b/test/fixtures/cmd/ps-axo
@@ -2,3 +2,4 @@
   7115   0.3  0.0  2516588   3052 ttys008  U    Fri05PM   0:00.05 root            login -fp apop
   7116   0.0  0.0  2499948   1292 ttys008  S+   Fri05PM   0:00.97 apop            -bash
   7853   0.0  0.1  2526272   8804 ttys009  Ss   Fri05PM   0:00.06 apop            /Users/apop/Applications/iTerm.app/Contents/MacOS/iTerm2 --server login -fp apop
+  7854   0.0  0.0  2499948   1292 ttys008  R<   Fri05PM   0:00.97 apop            some_linux_process

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -230,4 +230,10 @@ describe "Inspec::Resources::Processes" do
     resource.expects(:busybox_ps?).returns(false)
     _(resource.send(:ps_configuration_for_linux)[0]).must_equal "ps wwaxo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command"
   end
+
+  # Verify count property on BSD
+  it "verify count property of processes resource" do
+    resource = MockLoader.new(:freebsd10).load_resource("processes", "login -fp apop")
+    _(resource.count).must_equal 2
+  end
 end

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -231,9 +231,17 @@ describe "Inspec::Resources::Processes" do
     _(resource.send(:ps_configuration_for_linux)[0]).must_equal "ps wwaxo label,pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user:32,command"
   end
 
-  # Verify count property on BSD
-  it "verify count property of processes resource" do
-    resource = MockLoader.new(:freebsd10).load_resource("processes", "login -fp apop")
-    _(resource.count).must_equal 2
+  # `count` & `be_running` verification on BSD(Unix/Linux) system
+  it "verify count property and be_running matcher of processes resource" do
+    resource = MockLoader.new(:freebsd10).load_resource("processes", "some_linux_process")
+    _(resource.count).must_equal 1
+    _(resource.running?).must_equal true
+  end
+
+  # `count` & `be_running` verification on Windows
+  it "verify count property and be_running matcher of processes resource on Windows" do
+    resource = MockLoader.new(:windows).load_resource("processes", "winlogon.exe")
+    _(resource.count).must_equal 1
+    _(resource.running?).must_equal true
   end
 end


### PR DESCRIPTION
✅ Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Related Issue
**CFINSPEC-92: Enhance `processes` resource with `count` property and `be_running` matcher**

## Description
- Using the `processes` resource
Given that the user has called the `processes` resource
then the resource allows to test with new property & matcher
- Property: `count`
- Matcher: `be_running`
- Syntax:
  ```
  describe processes(Regexp.new("some_process")) do
      it { should be_running }
      its("count") { should eq 3 }
  end
  ```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
