### PR TITLE
CFINSPEC-181: Make cookstyle checks optional by default - backport to inspec 4

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -95,6 +95,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   desc "check PATH", "verify all tests at the specified PATH"
   option :format, type: :string,
     desc: "The output format to use doc (default), json. If valid format is not provided then it will use the default."
+  option :with_cookstyle, type: :boolean,
+    desc: "Enable or disable cookstyle checks.", default: false
   profile_options
   def check(path) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
     o = config

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -103,6 +103,7 @@ module Inspec
       @check_mode = options[:check_mode] || false
       @parent_profile = options[:parent_profile]
       @legacy_profile_path = options[:profiles_path] || false
+      @check_cookstyle = options[:with_cookstyle]
       Metadata.finalize(@source_reader.metadata, @profile_id, options)
 
       # if a backend has already been created, clone it so each profile has its own unique backend object
@@ -593,12 +594,13 @@ module Inspec
       end
 
       # Running cookstyle to check for code offenses
-      cookstyle_linting_check.each do |lint_output|
-        data = lint_output.split(":")
-        msg = "#{data[-2]}:#{data[-1]}"
-        offense.call(data[0], data[1], data[2], nil, msg)
+      if @check_cookstyle
+        cookstyle_linting_check.each do |lint_output|
+          data = lint_output.split(":")
+          msg = "#{data[-2]}:#{data[-1]}"
+          offense.call(data[0], data[1], data[2], nil, msg)
+        end
       end
-
       # profile is valid if we could not find any error & offenses
       result[:summary][:valid] = result[:errors].empty? && result[:offenses].empty?
 

--- a/test/functional/inspec_check_test.rb
+++ b/test/functional/inspec_check_test.rb
@@ -119,16 +119,16 @@ describe "inspec check" do
   end
 
   describe "inspec check also check for cookstyle offenses" do
-    it "finds no offenses in a complete profile" do
+    it "finds no offenses in a complete profile when --with-cookstyle option is provided" do
       skip if windows? # see #5723
-      out = inspec("check #{profile_path}/complete-profile")
+      out = inspec("check #{profile_path}/complete-profile --with-cookstyle")
       _(out.stdout).must_match(/No errors, warnings, or offenses/)
       assert_exit_code 0, out
     end
 
-    it "fails and returns offenses in a profile" do
+    it "fails and returns offenses in a profile when --with-cookstyle option is provided" do
       skip if windows? # see #5723
-      out = inspec("check #{profile_path}/inputs/metadata-basic")
+      out = inspec("check #{profile_path}/inputs/metadata-basic --with-cookstyle")
       _(out.stdout).must_match(/1 offenses/)
       assert_exit_code 1, out
     end


### PR DESCRIPTION
… Chef Automate.

Add --with-cookstyle option to inspec check command to disable cookstyle check as default

Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
