### PR TITLE
CFINSPEC-88: Extend `file` resource documentation with be_mounted matcher

### DIFF
--- a/docs-chef-io/content/inspec/resources/file.md
+++ b/docs-chef-io/content/inspec/resources/file.md
@@ -831,7 +831,8 @@ The `have_mode` matcher tests if a file has a mode assigned to it.
 ```
 
 ### be_mounted
-`be_mounted` is a boolean matcher which returns `true` if the specified directory is mounted on the system, otherwise `false`. Additionally, to test the attributes of the mounted directory, use the `mount` resource.
+
+`be_mounted` is a boolean matcher which returns `true` if the specified directory is mounted on the system. Else `false`. In addition, to test the attributes of the mounted directory, use the `mount` resource.
 
 ```ruby
     describe file("/") do

--- a/docs-chef-io/content/inspec/resources/file.md
+++ b/docs-chef-io/content/inspec/resources/file.md
@@ -829,3 +829,12 @@ The `have_mode` matcher tests if a file has a mode assigned to it.
       it { should be_immutable }
     end
 ```
+
+### be_mounted
+`be_mounted` is a boolean matcher which returns `true` if the specified directory is mounted on the system, otherwise `false`. Additionally, to test the attributes of the mounted directory, use the `mount` resource.
+
+```ruby
+    describe file("/") do
+      it { should be_mounted }
+    end
+```


### PR DESCRIPTION
✅ Signed-off-by: Sonu Saha <sonu.saha@progress.com>

## Related Issue
**CFINSPEC-88: Enhance Directory resource to support matchers with be_mounted**

## Description
- The existing `file` resource supports the `be_mounted` matcher. However, it was not included in the documentation. This PR adds the `be_mounted` matcher information in the `file` resource documentation.
- Syntax to test the matcher:
  ```
  describe file("/") do
    it { should be_mounted }
  end
  ```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
