### PR TITLE
CFINSPEC-96: Add `zfs` resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/zfs.md
+++ b/docs-chef-io/content/inspec/resources/zfs.md
@@ -21,29 +21,30 @@ Chef Inspec distributes this resource.
 
 ## Syntax
 
-A `zfs` Chef InSpec audit resource allows to test if the named ZFS Pool is present and/or has certain properties.
+A `zfs` Chef InSpec audit resource allows you to test if the ZFS Pool is present and has specific properties.
 
 ```ruby
     describe zfs(zfs_pool_name) do
       it { should exist }
-      it { should have_property({ "key1" => "value1", "key2" => "value2" }) }
+      it { should have_property({ "key1" => "VALUE1", "key2" => "VALUE2" }) }
     end
 ```
+
 > where
 >
-> - `'zfs_pool_name'` is the name of a ZFS Pool
-> - `exist` and `have_property` are matchers of this resource
+> - `'zfs_pool_name'` is the name of a ZFS Pool,
+> - `exist` and `have_property` are matchers of this resource,
 > - `{ "key1" => "value1", "key2" => "value2" }` are properties of the ZFS Pool to test.
 
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](https://docs.chef.io/inspec/matchers/).
 
-The specific matchers of this resource are: `exist` and `have_property`
+The specific matchers of this resource are: `exist` and `have_property`.
 
 ### exist
 
-The `exist` matcher tests if the ZFS Pool exist on the system.
+The `exist` matcher tests if the ZFS Pool exists on the system.
 
 ```ruby
     it { should exist }
@@ -51,31 +52,32 @@ The `exist` matcher tests if the ZFS Pool exist on the system.
 
 ### have_property
 
-The `have_property` matcher accepts properties in hash format and tests if the given properties are valid ZFS Pool properties.
+The `have_property` matcher accepts properties in hash format and tests if the specified properties are valid ZFS Pool properties.
 
 ```ruby
-    it { should have_property({ "key1" => "value1", "key2" => "value2" }) }
+    it { should have_property({ "key1" => "VALUE1", "key2" => "VALUE2" }) }
 ```
 
 ## Examples
+
 The following examples show how to use this Chef InSpec audit resource.
 
-### Test if the ZFS Pool exist on the system
+### Test if the ZFS Pool exists on the system
 
-`exist` matcher allows to test if the ZFS Pool exist on the system.
+`exist` matcher allows to test if the ZFS Pool exists on the system.
 
 ```ruby
-    describe zfs("new-pool") do
+    describe zfs("POOL") do
       it { should exist }
     end
 ```
 
-### Test if the given properties are valid ZFS Pool properties.
+### Test if the specified properties are valid ZFS Pool properties
 
-`have_property` matcher allows to test if the given properties are valid ZFS Pool properties.
+`have_property` matcher allows you to test if the specified properties are valid ZFS Pool properties.
 
 ```ruby
-    describe zfs("new-pool") do
-      it { should have_property({ "failmode" => "wait", "capacity" => "0" }) }
+    describe zfs("POOL") do
+      it { should have_property({ "failmode" => "WAIT", "capacity" => "0" }) }
     end
 ```

--- a/docs-chef-io/content/inspec/resources/zfs.md
+++ b/docs-chef-io/content/inspec/resources/zfs.md
@@ -11,14 +11,13 @@ platform = "linux"
     parent = "inspec/resources/os"
 +++
 
-Use the `zfs` Chef InSpec audit resource to test if the named ZFS Pool is present and/or has certain properties.
-
+Use the `zfs` Chef InSpec audit resource to test the named ZFS Pool file system and its respective properties.
 
 ## Availability
 
 ### Installation
 
-This resource is distributed with Chef InSpec.
+Chef Inspec distributes this resource.
 
 ## Syntax
 

--- a/docs-chef-io/content/inspec/resources/zfs.md
+++ b/docs-chef-io/content/inspec/resources/zfs.md
@@ -1,0 +1,82 @@
++++
+title = "zfs resource"
+draft = false
+gh_repo = "inspec"
+platform = "linux"
+
+[menu]
+  [menu.inspec]
+    title = "zfs"
+    identifier = "inspec/resources/os/zfs.md zfs resource"
+    parent = "inspec/resources/os"
++++
+
+Use the `zfs` Chef InSpec audit resource to test if the named ZFS Pool is present and/or has certain properties.
+
+
+## Availability
+
+### Installation
+
+This resource is distributed with Chef InSpec.
+
+## Syntax
+
+A `zfs` Chef InSpec audit resource allows to test if the named ZFS Pool is present and/or has certain properties.
+
+```ruby
+    describe zfs(zfs_pool_name) do
+      it { should exist }
+      it { should have_property({ "key1" => "value1", "key2" => "value2" }) }
+    end
+```
+> where
+>
+> - `'zfs_pool_name'` is the name of a ZFS Pool
+> - `exist` and `have_property` are matchers of this resource
+> - `{ "key1" => "value1", "key2" => "value2" }` are properties of the ZFS Pool to test.
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](https://docs.chef.io/inspec/matchers/).
+
+The specific matchers of this resource are: `exist` and `have_property`
+
+### exist
+
+The `exist` matcher tests if the ZFS Pool exist on the system.
+
+```ruby
+    it { should exist }
+```
+
+### have_property
+
+The `have_property` matcher accepts properties in hash format and tests if the given properties are valid ZFS Pool properties.
+
+```ruby
+    it { should have_property({ "key1" => "value1", "key2" => "value2" }) }
+```
+
+## Examples
+The following examples show how to use this Chef InSpec audit resource.
+
+### Test if the ZFS Pool exist on the system
+
+`exist` matcher allows to test if the ZFS Pool exist on the system.
+
+```ruby
+    describe zfs("new-pool") do
+      it { should exist }
+    end
+```
+
+### Test if the given properties are valid ZFS Pool properties.
+
+`have_property` matcher allows to test if the given properties are valid ZFS Pool properties.
+
+```ruby
+    describe zfs("new-pool") do
+      it { should have_property({ "failmode" => "wait", "capacity" => "0" }) }
+    end
+```

--- a/lib/inspec/resources/zfs.rb
+++ b/lib/inspec/resources/zfs.rb
@@ -13,7 +13,7 @@ module Inspec::Resources
     example <<~EXAMPLE
       describe zfs("new-pool") do
         it { should exist }
-        it { should have_property({"failmode" => "wait", "capacity" => "0"}) }
+        it { should have_property({ "failmode" => "wait", "capacity" => "0" }) }
       end
     EXAMPLE
 

--- a/lib/inspec/resources/zfs.rb
+++ b/lib/inspec/resources/zfs.rb
@@ -1,0 +1,46 @@
+require "inspec/resources/zfs_pool"
+
+module Inspec::Resources
+  class MyCustomResource < ZfsPool
+    # resource's internal name.
+    name "zfs"
+
+    # Restrict to only run on the below platforms
+    supports platform: "unix"
+
+    desc "Use the zfs InSpec audit resource to test if the named ZFS Pool is present and/or has certain properties."
+
+    example <<~EXAMPLE
+      describe zfs("new-pool") do
+        it { should exist }
+        it { should have_property({"failmode" => "wait", "capacity"=>"0"}) }
+      end
+    EXAMPLE
+
+    # Resource initialization is done in the parent class i.e. ZfsPool
+
+    # Unique identity for the resource.
+    def resource_id
+      # @zfs_pool is the zfs pool name assigned during initialization in the parent class i.e. ZfsPool
+      @zfs_pool
+    end
+
+    # Resource appearance in test reports.
+    def to_s
+      "zfs #{resource_id}"
+    end
+
+    # The below matcher checks if the given properties are valid properties of the zfs pool.
+    def has_property?(properties_hash)
+      raise Inspec::Exceptions::ResourceSkipped, "Provide a valid key-value pair of the zfs properties." if properties_hash.empty?
+
+      # Transform all the keys to string, since hash keys provided by user can be symbols or strings.
+      # @params is a hash populated in the parent class with the properties(key-value) of the current zfs pool.
+      # The keys in the @params are of string type.
+      properties_hash.transform_keys(&:to_s)
+
+      # check if the given properties is a subset of @params
+      properties_hash <= @params
+    end
+  end
+end

--- a/lib/inspec/resources/zfs.rb
+++ b/lib/inspec/resources/zfs.rb
@@ -13,7 +13,7 @@ module Inspec::Resources
     example <<~EXAMPLE
       describe zfs("new-pool") do
         it { should exist }
-        it { should have_property({"failmode" => "wait", "capacity"=>"0"}) }
+        it { should have_property({"failmode" => "wait", "capacity" => "0"}) }
       end
     EXAMPLE
 
@@ -34,10 +34,12 @@ module Inspec::Resources
     def has_property?(properties_hash)
       raise Inspec::Exceptions::ResourceSkipped, "Provide a valid key-value pair of the zfs properties." if properties_hash.empty?
 
-      # Transform all the keys to string, since hash keys provided by user can be symbols or strings.
+      # Transform all the key & values provided by user to string,
+      # since hash keys can be symbols or strings & values can be integers or strings.
       # @params is a hash populated in the parent class with the properties(key-value) of the current zfs pool.
-      # The keys in the @params are of string type.
+      # and the key-value in @params are of string type.
       properties_hash.transform_keys(&:to_s)
+      properties_hash.transform_values(&:to_s)
 
       # check if the given properties is a subset of @params
       properties_hash <= @params

--- a/lib/inspec/resources/zfs.rb
+++ b/lib/inspec/resources/zfs.rb
@@ -1,7 +1,7 @@
 require "inspec/resources/zfs_pool"
 
 module Inspec::Resources
-  class MyCustomResource < ZfsPool
+  class Zfs < ZfsPool
     # resource's internal name.
     name "zfs"
 

--- a/test/unit/resources/zfs_test.rb
+++ b/test/unit/resources/zfs_test.rb
@@ -2,7 +2,7 @@ require "inspec/globals"
 require "#{Inspec.src_root}/test/helper"
 require_relative "../../../lib/inspec/resources/zfs"
 
-describe Inspec::Resources::MyCustomResource do
+describe Inspec::Resources::Zfs do
   # freebsd
   it "checks zfs pool properties on freebsd" do
     resource = MockLoader.new("freebsd10".to_sym).load_resource("zfs", "tank")
@@ -25,7 +25,7 @@ describe Inspec::Resources::MyCustomResource do
   end
 
   # windows
-  it "checks zfs poop properties on windows" do
+  it "checks zfs pool properties on windows" do
     resource = MockLoader.new("windows".to_sym).load_resource("zfs", "tank")
     _(resource.resource_skipped?).must_equal true
     _(resource.resource_failed?).must_equal true

--- a/test/unit/resources/zfs_test.rb
+++ b/test/unit/resources/zfs_test.rb
@@ -1,0 +1,33 @@
+require "inspec/globals"
+require "#{Inspec.src_root}/test/helper"
+require_relative "../../../lib/inspec/resources/zfs"
+
+describe Inspec::Resources::MyCustomResource do
+  # freebsd
+  it "checks zfs pool properties on freebsd" do
+    resource = MockLoader.new("freebsd10".to_sym).load_resource("zfs", "tank")
+    _(resource.exists?).must_equal true
+    _(resource.has_property?({ "health" => "ONLINE", "failmode" => "continue", "feature@sha512" => "enabled" })).must_equal true
+  end
+
+  # ubuntu
+  it "checks zfs pool properties on ubuntu" do
+    resource = MockLoader.new("ubuntu".to_sym).load_resource("zfs", "tank")
+    _(resource.exists?).must_equal true
+    _(resource.has_property?({ "guid" => "4711279777582057513", "feature@extensible_dataset" => "enabled", "feature@sha512" => "enabled" })).must_equal true
+  end
+
+  # ubuntu
+  it "checks zfs pool properties on ubuntu providing empty input" do
+    resource = MockLoader.new("ubuntu".to_sym).load_resource("zfs", "tank")
+    ex = _ { resource.has_property?({}) }.must_raise(Inspec::Exceptions::ResourceSkipped)
+    _(ex.message).must_include "Provide a valid key-value pair of the zfs properties."
+  end
+
+  # windows
+  it "checks zfs poop properties on windows" do
+    resource = MockLoader.new("windows".to_sym).load_resource("zfs", "tank")
+    _(resource.resource_skipped?).must_equal true
+    _(resource.resource_failed?).must_equal true
+  end
+end


### PR DESCRIPTION
✅ Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Related Issue
**CFINSPEC-96: Add `zfs` resource**

## Description
- `zfs` resource inherits the functionality from existing `zfs_pool` resource.
- Using the `zfs` resource
Given that the user has called the `zfs`  resource
then the resource allows to test with new matchers.
- Matchers: `exist` and `have_property`
- Syntax:
  ```ruby
      describe zfs(zfs_pool_name) do
        it { should exist }
        it { should have_property({ "key1" => "value1", "key2" => "value2" }) }
      end
  ```



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
