### PR TITLE
CFINSPEC-81: Add `php_config` resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/php_config.md
+++ b/docs-chef-io/content/inspec/resources/php_config.md
@@ -1,0 +1,71 @@
++++
+title = "php_config resource"
+draft = false
+gh_repo = "inspec"
+
+[menu]
+  [menu.inspec]
+    title = "php_config"
+    identifier = "inspec/resources/os/php_config.md php_config resource"
+    parent = "inspec/resources/os"
++++
+
+Use the `php_config` Chef InSpec audit resource to test PHP config parameters from the default php.ini file or a custom php configuration file.
+
+
+## Availability
+
+### Installation
+
+This resource is distributed along with Chef InSpec itself.
+
+## Syntax
+
+A `php_config` Chef InSpec audit resource allows to test PHP config parameters from the default php.ini file or a custom php configuration file. The path for custom configuration file is given in a hash format with `ini` as the key and path as the value.
+
+```ruby
+    describe php_config("config_param") do
+      its("value") { should eq "some_value" }
+    end
+
+    describe php_config("config_param", { "ini" => "path_to_ini_file" }) do
+      its("value") { should eq "some_value"  }
+    end
+```
+> where
+> 
+> - `config_param` is a valid parameter of php configuration
+> - `value` is a property of this resource
+> - `some_value` is the value of the given `config_param`
+> - `path_to_ini_file` is the path for custom php configuration file
+
+## Properties
+
+- The property of this resource is `value`
+
+### value
+
+The value property fetches the value of the given config parameter from the default php.ini file or a custom php configuration file.
+
+```ruby
+    its("value") { should eq "some_value"  }
+```
+
+## Examples
+The following examples show how to use this Chef InSpec audit resource.
+
+### Fetch the value for a config parameter from the default configuration file
+
+```ruby
+    describe php_config("default_mimetype") do
+      its("value") { should eq "text/html" }
+    end
+```
+
+### Fetch the value for a config parameter from a custom configuration file
+
+```ruby
+    describe php_config("default_mimetype", { "ini" => "/etc/php/7.4/cli/php.ini" }) do
+      its("value") { should eq "text/html" }
+    end
+```

--- a/docs-chef-io/content/inspec/resources/php_config.md
+++ b/docs-chef-io/content/inspec/resources/php_config.md
@@ -2,6 +2,7 @@
 title = "php_config resource"
 draft = false
 gh_repo = "inspec"
+platform = "os"
 
 [menu]
   [menu.inspec]

--- a/docs-chef-io/content/inspec/resources/php_config.md
+++ b/docs-chef-io/content/inspec/resources/php_config.md
@@ -11,51 +11,52 @@ platform = "os"
     parent = "inspec/resources/os"
 +++
 
-Use the `php_config` Chef InSpec audit resource to test PHP config parameters from the default php.ini file or a custom php configuration file.
-
+Use the `php_config` Chef InSpec audit resource to test the PHP configuration parameters from the default `php.ini` file or a custom *php* file.
 
 ## Availability
 
 ### Installation
 
-This resource is distributed along with Chef InSpec itself.
+The Chef InSpec distributes This resource.
 
 ## Syntax
 
-A `php_config` Chef InSpec audit resource allows to test PHP config parameters from the default php.ini file or a custom php configuration file. The path for custom configuration file is given in a hash format with `ini` as the key and path as the value.
+A `php_config` Chef InSpec audit resource allows to test PHP configuration parameters from the default `php.ini` or a custom *php* file. The custom configuration file path is provided in a hash format with `ini` as the key and path as the value.
 
 ```ruby
     describe php_config("config_param") do
-      its("value") { should eq "some_value" }
+      its("value") { should eq "VALUE" }
     end
 
     describe php_config("config_param", { "ini" => "path_to_ini_file" }) do
-      its("value") { should eq "some_value"  }
+      its("value") { should eq "VALUE"  }
     end
 ```
+
 > where
-> 
-> - `config_param` is a valid parameter of php configuration
-> - `value` is a property of this resource
-> - `some_value` is the value of the given `config_param`
-> - `path_to_ini_file` is the path for custom php configuration file
+>
+> - `config_param` is a valid parameter of php configuration.
+> - `value` is a property of this resource.
+> - `some_value` is the value of the specified `config_param`.
+> - `path_to_ini_file` is the path for custom php configuration file.
 
 ## Properties
 
-- The property of this resource is `value`
+The property of this resource is `value`.
 
 ### value
 
-The value property fetches the value of the given config parameter from the default php.ini file or a custom php configuration file.
+The value property fetches the provided configuration parameter value from the default `php.ini` file or a custom `php` file.
 
 ```ruby
-    its("value") { should eq "some_value"  }
+    its("value") { should eq "VALUE"  }
 ```
 
 ## Examples
+
 The following examples show how to use this Chef InSpec audit resource.
 
-### Fetch the value for a config parameter from the default configuration file
+### Fetch the configuration parameter value from the default configuration file
 
 ```ruby
     describe php_config("default_mimetype") do
@@ -63,7 +64,7 @@ The following examples show how to use this Chef InSpec audit resource.
     end
 ```
 
-### Fetch the value for a config parameter from a custom configuration file
+### Fetch the configuration parameter value from a custom configuration file
 
 ```ruby
     describe php_config("default_mimetype", { "ini" => "/etc/php/7.4/cli/php.ini" }) do

--- a/lib/inspec/resources/php_config.rb
+++ b/lib/inspec/resources/php_config.rb
@@ -1,0 +1,68 @@
+require "inspec/resources/command"
+
+module Inspec::Resources
+  class PhpConfig < Inspec.resource(1)
+    # Resource's internal name.
+    name "php_config"
+    desc "Use the php_config InSpec audit resource to test PHP config parameters"
+
+    example <<~EXAMPLE
+      describe php_config("config_param") do
+        its("value") { should eq "some_value" }
+      end
+
+      describe php_config("config_param", { "ini" => "path_to_ini_file" }) do
+        its("value") { should eq "some_value"  }
+      end
+    EXAMPLE
+
+    # Resource initialization.
+    attr_reader :config_param, :config_file_or_path
+    def initialize(config_param, config_file_or_path = {})
+      @config_param = config_param
+      @config_file_or_path = config_file_or_path
+    end
+
+    # Unique resource id
+    def resource_id
+      config_param
+    end
+
+    # Resource appearance in test reports.
+    def to_s
+      "php_config #{resource_id}"
+    end
+
+    # Returns the value evaluated for the initialized config parameter
+    def value
+      php_utility = find_utility_or_error
+
+      # The keys in the hash provided by user can be string or symbols.
+      # Converting the key to symbols to handle scenario when "ini" key is provided as string.
+      config_file_or_path.transform_keys(&:to_sym)
+
+      # Assign the path with -c option for ini file provided by the user if any.
+      php_ini_file = !config_file_or_path.empty? && config_file_or_path.key?(:ini) ? "-c #{config_file_or_path[:ini]}" : ""
+
+      # The below command `get_cfg_var` is used to fetch the value for any config parameter.
+      php_cmd = "#{php_utility} #{php_ini_file} -r 'echo get_cfg_var(\"#{config_param}\");'"
+      config_value_cmd = inspec.command(php_cmd)
+
+      raise Inspec::Exceptions::ResourceFailed, "Executing #{php_cmd} failed: #{config_value_cmd.stderr}" if config_value_cmd.exit_status.to_i != 0
+
+      # Return the standard output of the command executed.
+      config_value_cmd.stdout.strip
+    end
+
+    private
+
+    # Method to check if php is present or not on the system.
+    def find_utility_or_error
+      %w{/usr/sbin/php /sbin/php php}.each do |cmd|
+        return cmd if inspec.command(cmd).exist?
+      end
+
+      raise Inspec::Exceptions::ResourceFailed, "Could not find `php` on your system."
+    end
+  end
+end

--- a/lib/inspec/resources/php_config.rb
+++ b/lib/inspec/resources/php_config.rb
@@ -4,6 +4,8 @@ module Inspec::Resources
   class PhpConfig < Inspec.resource(1)
     # Resource's internal name.
     name "php_config"
+    supports platform: "unix"
+    supports platform: "windows"
     desc "Use the php_config InSpec audit resource to test PHP config parameters"
 
     example <<~EXAMPLE

--- a/lib/inspec/resources/php_config.rb
+++ b/lib/inspec/resources/php_config.rb
@@ -50,8 +50,10 @@ module Inspec::Resources
 
       raise Inspec::Exceptions::ResourceFailed, "Executing #{php_cmd} failed: #{config_value_cmd.stderr}" if config_value_cmd.exit_status.to_i != 0
 
-      # Return the standard output of the command executed.
-      config_value_cmd.stdout.strip
+      config_value = config_value_cmd.stdout.strip
+
+      # Convert value to integer if the config value are digits.
+      config_value.match(/^(\d)+$/) ? config_value.to_i : config_value
     end
 
     private

--- a/test/fixtures/cmd/get-cfg-var
+++ b/test/fixtures/cmd/get-cfg-var
@@ -1,0 +1,1 @@
+text/html

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -401,6 +401,12 @@ class MockLoader
       %{sh -c 'type "cgget"'} => empty.call,
       # mail_alias
       "cat /etc/aliases | grep '^daemon:'" => cmd.call("mail-alias"),
+      # php_config
+      %{sh -c 'type "php"'} => empty.call,
+      'Get-Command "php"' => empty.call,
+      'type "php"' => empty.call,
+      "php  -r 'echo get_cfg_var(\"default_mimetype\");'" => cmd.call("get-cfg-var"),
+      "php -c /etc/php/7.4/cli/php.ini -r 'echo get_cfg_var(\"default_mimetype\");'" => cmd.call("get-cfg-var"),
       # routing_table
       "netstat -rn" => cmd.call("netstat-rn-linux"),
       %{sh -c 'type "netstat"'} => empty.call,

--- a/test/unit/resources/php_config_test.rb
+++ b/test/unit/resources/php_config_test.rb
@@ -1,0 +1,41 @@
+# If we can load the InSpec globals definition file...
+require "inspec/globals"
+require "#{Inspec.src_root}/test/helper"
+require_relative "../../../lib/inspec/resources/php_config"
+
+describe Inspec::Resources::PhpConfig do
+  # ubuntu
+  it "checks php config parameters on ubuntu from default ini file." do
+    resource = MockLoader.new("ubuntu".to_sym).load_resource("php_config", "default_mimetype")
+    _(resource.value).must_equal "text/html"
+    _(resource.resource_id).must_equal "default_mimetype"
+  end
+
+  # ubuntu with custom ini file.
+  it "checks php config parameters on ubuntu from default ini file." do
+    resource = MockLoader.new("ubuntu".to_sym).load_resource("php_config", "default_mimetype", { "ini" => "/etc/php/7.4/cli/php.ini" })
+    _(resource.value).must_equal "text/html"
+    _(resource.resource_id).must_equal "default_mimetype"
+  end
+
+  # windows
+  it "checks php config parameters on windows from default ini file." do
+    resource = MockLoader.new("windows".to_sym).load_resource("php_config", "default_mimetype")
+    _(resource.value).must_equal "text/html"
+    _(resource.resource_id).must_equal "default_mimetype"
+  end
+
+  # macos10_10
+  it "checks php config parameters on darwin from default ini file." do
+    resource = MockLoader.new("macos10_10".to_sym).load_resource("php_config", "default_mimetype")
+    _(resource.value).must_equal "text/html"
+    _(resource.resource_id).must_equal "default_mimetype"
+  end
+
+  # ubuntu with invalid config param
+  it "checks invalid php config parameters on ubuntu from default ini file." do
+    resource = MockLoader.new("ubuntu".to_sym).load_resource("php_config", "an_invalid_param")
+    ex = _ { resource.value }.must_raise(Inspec::Exceptions::ResourceFailed)
+    _(ex.message).must_include "Executing php  -r 'echo get_cfg_var(\"an_invalid_param\");' failed"
+  end
+end


### PR DESCRIPTION
✅ Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Related Issue
**CFINSPEC-81: Add `php_config` resource**

## Description
- Using the **`php_config`** resource
Given that the user has called the **`php_config`**
then the resource allows to test php configuration parameters
- Property: **`value`**
- Syntax:
  ```ruby
      describe php_config("config_param") do
        its("value") { should eq "some_value" }
      end
      describe php_config("config_param", { "ini" => "path_to_ini_file" }) do
        its("value") { should eq "some_value"  }
      end
  ```




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
