### PR TITLE
CFINSPEC-171 Background run option for inspec parallel

### DIFF
--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
@@ -19,6 +19,8 @@ module InspecPlugins::Parallelism
       desc: "Number of jobs to run parallely"
     option :ui, type: :string, default: "status",
       desc: "Which UI to use: status, text"
+    option :daemon, aliases: :d, type: :boolean,
+      desc: "Runs parallel processes in background"
     exec_options
     def exec(default_profile = nil)
       parallel_cmd = InspecPlugins::Parallelism::Command.new(options, default_profile)

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
@@ -19,7 +19,7 @@ module InspecPlugins::Parallelism
       desc: "Number of jobs to run parallely"
     option :ui, type: :string, default: "status",
       desc: "Which UI to use: status, text"
-    option :daemon, aliases: :d, type: :boolean,
+    option :bg, type: :boolean,
       desc: "Runs parallel processes in background"
     exec_options
     def exec(default_profile = nil)

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/command.rb
@@ -91,7 +91,7 @@ module InspecPlugins
                 output = `powershell -File "#{option_file}"`
                 output.split("\n")
               rescue StandardError => e
-                raise "Error reading powershell file #{option_file}: #{e.message}"
+                raise OptionFileNotReadable.new("Error reading powershell file #{option_file}: #{e.message}")
               end
             elsif [".sh", ".csh"].include? File.extname(option_file)
               begin

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -12,8 +12,10 @@ module InspecPlugins
         @sub_cmd = sub_cmd
         @total_jobs = cli_options["jobs"] || Concurrent.physical_processor_count
         @child_tracker = {}
-        @ui = InspecPlugins::Parallelism::SuperReporter.make(cli_options["ui"], total_jobs, invocations)
         @run_in_background = cli_options["bg"]
+        unless run_in_background
+          @ui = InspecPlugins::Parallelism::SuperReporter.make(cli_options["ui"], total_jobs, invocations)
+        end
       end
 
       def run

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -13,7 +13,7 @@ module InspecPlugins
         @total_jobs = cli_options["jobs"] || Concurrent.physical_processor_count
         @child_tracker = {}
         @ui = InspecPlugins::Parallelism::SuperReporter.make(cli_options["ui"], total_jobs, invocations)
-        @run_in_background = cli_options["daemon"]
+        @run_in_background = cli_options["bg"]
       end
 
       def run
@@ -36,7 +36,7 @@ module InspecPlugins
 
       def initiate_background_run
         if Inspec.locally_windows?
-          #TBD
+          Inspec::UI.new.exit(:usage_error)
         else
           Process.daemon(true, false)
         end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added functionality to run parallel operations in background, with `--bg` option. Only supported for unix based platforms.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
