### PR TITLE
InSpec Sign: Several small bugs and usability fixes

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -323,6 +323,9 @@ module Inspec
 
     def pretty_handle_exception(exception)
       case exception
+      when Inspec::InvalidProfileSignature
+        $stderr.puts exception.message
+        Inspec::UI.new.exit(:bad_signature)
       when Inspec::Error
         $stderr.puts exception.message
         exit(1)

--- a/lib/inspec/errors.rb
+++ b/lib/inspec/errors.rb
@@ -23,5 +23,5 @@ module Inspec
     attr_accessor :version
   end
 
-  class InvalidProfile < Error; end
+  class InvalidProfileSignature < Error; end
 end

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -20,7 +20,7 @@ module Inspec
         if iaf_file.valid?
           IafProvider.new(path)
         else
-          raise Inspec::InvalidProfile, "Profile is invalid."
+          raise Inspec::InvalidProfileSignature, "Profile signature is invalid."
         end
       elsif File.exist?(path)
         DirProvider.new(path)
@@ -239,7 +239,7 @@ module Inspec
         f.close
         content = content.slice(490, content.length).lstrip
       else
-        raise Inspec::InvalidProfile, "Profile is invalid."
+        raise Inspec::InvalidProfileSignature, "Unrecognized IAF version."
       end
 
       tmpfile = nil

--- a/lib/inspec/iaf_file.rb
+++ b/lib/inspec/iaf_file.rb
@@ -56,15 +56,18 @@ module Inspec
       false
     end
 
+    attr_reader :key_name, :version
+
     def initialize(path)
       @path = path
+      @key_name = nil
     end
 
     def valid?
       header = []
       valid = true
       f = File.open(@path, "rb")
-      version = f.readline.strip!
+      @version = f.readline.strip!
       if version == INSPEC_PROFILE_VERSION_1
         header << version
         header << f.readline.strip!
@@ -96,6 +99,7 @@ module Inspec
         valid = false
       end
 
+      @key_name = header[1]
       validation_key_path = Inspec::IafFile.find_validation_key(header[1])
 
       unless valid_header?(header)

--- a/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
+++ b/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
@@ -36,11 +36,11 @@ module InspecPlugins
         FileUtils.mkdir_p(path)
 
         puts "Generating signing key in #{path}/#{options["keyname"]}.pem.key"
-        open "#{options["keyname"]}.pem.key", "w" do |io|
+        open "#{path}/#{options["keyname"]}.pem.key", "w" do |io|
           io.write key.to_pem
         end
         puts "Generating validation key in #{path}/#{options["keyname"]}.pem.pub"
-        open "#{options["keyname"]}.pem.pub", "w" do |io|
+        open "#{path}/#{options["keyname"]}.pem.pub", "w" do |io|
           io.write key.public_key.to_pem
         end
       end
@@ -89,9 +89,13 @@ module InspecPlugins
 
         iaf_file = Inspec::IafFile.new(file_to_verify)
         if iaf_file.valid?
+          puts "Detected format version '#{iaf_file.version}'"
+          puts "Attempting to verify using key '#{iaf_file.key_name}'"
           puts "Profile is valid."
           Inspec::UI.new.exit(:normal)
         else
+          puts "Detected format version '#{iaf_file.version}'"
+          puts "Attempting to verify using key '#{iaf_file.key_name}'" if iaf_file.key_name
           puts "Profile is invalid"
           Inspec::UI.new.exit(:bad_signature)
         end


### PR DESCRIPTION
Several small usability fixes.

* Rename the exception to be InvalidProfileSignature to clarify that the signature is invalid, not necessarily the profile (which can be invalid in several other ways, see inspec check)
* Reword some error messages to match
* Make sure we exit with code 5 (BAD_SIGNATURE) if exec fails due to bad sig
* Fix bug in which keys claimed to be created in user dir but were actually created in current dir
* Add diagnostic messaging to inspec sign verify


## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
