### PR TITLE
CFINSPEC-250: Fix for inspec json command does not populate the inputs for the profile

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -850,7 +850,12 @@ module Inspec
         f = load_rule_filepath(prefix, rule)
         load_rule(rule, f, controls, groups)
       end
-      params[:inputs] = Inspec::InputRegistry.list_inputs_for_profile(@profile_id)
+      if @profile_id.nil?
+        # identifying inputs using profile name
+        params[:inputs] = Inspec::InputRegistry.list_inputs_for_profile(params[:name])
+      else
+        params[:inputs] = Inspec::InputRegistry.list_inputs_for_profile(@profile_id)
+      end
       params
     end
 

--- a/test/functional/inspec_json_profile_test.rb
+++ b/test/functional/inspec_json_profile_test.rb
@@ -26,6 +26,10 @@ describe "inspec json" do
       _(json["generator"]["version"]).must_equal Inspec::VERSION
     end
 
+    it "has empty array of inputs" do
+      _(json["inputs"]).must_be_empty
+    end
+
     it "has a name" do
       _(json["name"]).must_equal "profile"
     end
@@ -82,6 +86,14 @@ describe "inspec json" do
       it "has a the source code" do
         _(control["code"]).must_match(/\Acontrol 'tmp-1.0' do.*end\n\Z/m)
       end
+    end
+  end
+
+  describe "json profile data with inputs" do
+    let(:json) { JSON.load(inspec("json " + examples_path + "/profile-attribute").stdout) }
+
+    it "has a inputs" do
+      _(json["inputs"]).must_equal [{ "name" => "user", "options" => { "value" => "alice" } }, { "name" => "password", "options" => { "value" => "Input 'password' does not have a value. Skipping test." } }]
     end
   end
 


### PR DESCRIPTION
…

Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Adds the condition so that inputs can be fetched using  profile name when profile id is nil.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #5412 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
