### PR TITLE
CFINSPEC-252: Fix profile gem dependency installation is failing when  gem version is not specified

### DIFF
--- a/lib/inspec/dependency_loader.rb
+++ b/lib/inspec/dependency_loader.rb
@@ -50,7 +50,11 @@ module Inspec
     end
 
     def gem_version_installed?(name, version)
-      list_installed_gems.any? { |s| s.name == name && Gem::Requirement.new(version.split(",")) =~ s.version }
+      if version.nil?
+        list_installed_gems.any? { |s| s.name == name }
+      else
+        list_installed_gems.any? { |s| s.name == name && Gem::Requirement.new(version.split(",")) =~ s.version }
+      end
     end
 
     private

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -410,7 +410,7 @@ module Inspec
           else
             ui = Inspec::UI.new
             gem_dependencies.each { |gem_dependency| ui.list_item("#{gem_dependency[:name]} #{gem_dependency[:version]}") }
-            choice = ui.prompt.select("Would you like to install profile gem dependencies listed above?", %w{Yes No})
+            choice = ui.prompt.select("The above listed gem dependencies are required to run the profile. Would you like to install them ?", %w{Yes No})
             if choice == "Yes"
               Inspec::Config.cached[:auto_install_gems] = true
               load_gem_dependencies

--- a/test/fixtures/profiles/profile-without-gem-version/controls/example.rb
+++ b/test/fixtures/profiles/profile-without-gem-version/controls/example.rb
@@ -1,0 +1,11 @@
+require "money"
+
+control "tmp-1.0" do
+  Money.rounding_mode = BigDecimal::ROUND_HALF_UP
+  m = Money.from_cents(1000, "USD")
+  cents = m.cents
+
+  describe cents do
+    it { should eq 1000 }
+  end
+end

--- a/test/fixtures/profiles/profile-without-gem-version/inspec.yml
+++ b/test/fixtures/profiles/profile-without-gem-version/inspec.yml
@@ -1,0 +1,12 @@
+name: profile-without-gem-version
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  platform: os
+gem_dependencies:
+- name: money

--- a/test/functional/profile_gem_dependency_test.rb
+++ b/test/functional/profile_gem_dependency_test.rb
@@ -6,7 +6,8 @@ describe "profile with gem dependencies" do
   let(:config_dir_path) { File.expand_path "test/fixtures/config_dirs" }
   let(:depdent_profile_gem_dependency) { File.join(profile_path, "profile-with-dependent-gem-dependency") }
   let(:ruby_abi_version) { RbConfig::CONFIG["ruby_version"] }
-  let(:illformatted_gem_dependncy) { File.join(profile_path, "profile-with-illformed-gem-depedency") }
+  let(:illformatted_gem_dependency) { File.join(profile_path, "profile-with-illformed-gem-depedency") }
+  let(:profile_with_gem_dependency_without_gem_version) { File.join(profile_path, "profile-without-gem-version") }
 
   def reset_globals
     ENV["HOME"] = Dir.home
@@ -36,6 +37,13 @@ describe "profile with gem dependencies" do
     assert_exit_code 0, out
   end
 
+  it "installs the gem dependencies and load them if --auto-install-gems is provided and gem version is not mentioned." do
+    out = inspec_with_env("exec #{profile_with_gem_dependency_without_gem_version} --no-create-lockfile --auto-install-gems")
+    _(out.stderr).must_equal ""
+    _(File.directory?(File.join(config_dir_path, "profile_gems", ".inspec/gems/#{ruby_abi_version}/gems"))).must_equal true
+    assert_exit_code 0, out
+  end
+
   it "installs the gem dependencies in dendent profile and load them if --auto-install-gems is provided." do
     out = inspec_with_env("exec #{depdent_profile_gem_dependency} --no-create-lockfile --auto-install-gems")
     _(out.stderr).must_equal ""
@@ -44,7 +52,7 @@ describe "profile with gem dependencies" do
   end
 
   it "raises error for illformated gem dependencies found in the meta data file" do
-    out = inspec_with_env("exec #{illformatted_gem_dependncy} --no-create-lockfile --auto-install-gems")
+    out = inspec_with_env("exec #{illformatted_gem_dependency} --no-create-lockfile --auto-install-gems")
     _(out.stderr).must_include "Unparseable gem dependency '[\"+ 2.3.12\"]' for 'mongo'"
     assert_exit_code 1, out
   end


### PR DESCRIPTION

Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
* Profile gem dependency installation works now if the gem version is not specified in the inspec.yml
* Updated the User prompt text for the profile gem dependency installation to be self-explanatory.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #6053
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
