### PR TITLE
CFINSPEC-189 Added logging for inspec parallel

### DIFF
--- a/lib/inspec/reporters.rb
+++ b/lib/inspec/reporters.rb
@@ -37,7 +37,7 @@ module Inspec::Reporters
     output = reporter.rendered_output
     config_file = config["file"]
     if config_file
-      config_file.gsub!("CHILD_PID", $$.to_s)
+      config_file.gsub!("CHILD_PID", Process.pid.to_s)
       # create destination directory if it does not exist
       dirname = File.dirname(config_file)
       FileUtils.mkdir_p(dirname) unless File.directory?(dirname)

--- a/lib/inspec/reporters.rb
+++ b/lib/inspec/reporters.rb
@@ -35,13 +35,14 @@ module Inspec::Reporters
 
     reporter.render
     output = reporter.rendered_output
-
-    if config["file"]
+    config_file = config["file"]
+    if config_file
+      config_file.gsub!("CHILD_PID", $$.to_s)
       # create destination directory if it does not exist
-      dirname = File.dirname(config["file"])
+      dirname = File.dirname(config_file)
       FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
 
-      File.write(config["file"], output)
+      File.write(config_file, output)
     elsif config["stdout"] == true
       print output
       $stdout.flush

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
@@ -21,6 +21,8 @@ module InspecPlugins::Parallelism
       desc: "Which UI to use: status, text"
     option :bg, type: :boolean,
       desc: "Runs parallel processes in background"
+    option :log_path, type: :string,
+      desc: "Path to the runner and error logs"
     exec_options
     def exec(default_profile = nil)
       parallel_cmd = InspecPlugins::Parallelism::Command.new(options, default_profile)

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/command.rb
@@ -42,7 +42,7 @@ module InspecPlugins
           exit Inspec::UI::EXIT_TERMINATED_BY_CTL_C
         end
       end
-      
+
       def validate_thor_options
         # only log path validation needed for now
         validate_log_path
@@ -91,8 +91,7 @@ module InspecPlugins
         end
         content.each.with_index(1) do |str, index|
           data_hash = { line_no: index }
-          str = "<% pid = 'CHILD_PID' %>" + str if str.include? "pid"
-          str = ERB.new(str).result.strip
+          str = ERB.new(str).result_with_hash(pid: 'CHILD_PID').strip
           str_has_comment = str.start_with?("#")
           next if str.empty? || str_has_comment
 

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/command.rb
@@ -91,7 +91,7 @@ module InspecPlugins
         end
         content.each.with_index(1) do |str, index|
           data_hash = { line_no: index }
-          str = ERB.new(str).result_with_hash(pid: 'CHILD_PID').strip
+          str = ERB.new(str).result_with_hash(pid: "CHILD_PID").strip
           str_has_comment = str.start_with?("#")
           next if str.empty? || str_has_comment
 

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/command.rb
@@ -21,6 +21,7 @@ module InspecPlugins
       end
 
       def run
+        validate_thor_options
         validate_invocations!
         catch_ctl_c_and_exit unless run_in_background
         Runner.new(invocations, cli_options_to_parallel_cmd, sub_cmd).run
@@ -41,10 +42,23 @@ module InspecPlugins
           exit Inspec::UI::EXIT_TERMINATED_BY_CTL_C
         end
       end
+      
+      def validate_thor_options
+        # only log path validation needed for now
+        validate_log_path
+      end
+
+      def validate_log_path
+        error, message = Validator.new(invocations, cli_options_to_parallel_cmd, sub_cmd).validate_log_path
+        if error
+          @logger.error message
+          Inspec::UI.new.exit(:usage_error)
+        end
+      end
 
       def validate_invocations!
         # Validation logic stays in Validator class...
-        Validator.new(invocations, sub_cmd).validate
+        Validator.new(invocations, cli_options_to_parallel_cmd, sub_cmd).validate
         # UI logic stays in Command class.
         valid = true
         invocations.each do |invocation_data|

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/command.rb
@@ -77,6 +77,7 @@ module InspecPlugins
         end
         content.each.with_index(1) do |str, index|
           data_hash = { line_no: index }
+          str = "<% pid = 'CHILD_PID' %>" + str if str.include? "pid"
           str = ERB.new(str).result.strip
           str_has_comment = str.start_with?("#")
           next if str.empty? || str_has_comment

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -107,6 +107,12 @@ module InspecPlugins
           rescue StandardError => e
             $stderr.puts "#{Time.now.iso8601} Error Message: #{e.message}"
             $stderr.puts "#{Time.now.iso8601} Error Backtrace: #{e.backtrace}"
+          ensure
+            logs_dir_path = log_path || Dir.pwd
+            error_file_path = File.join(logs_dir_path, "logs", "#{Process.pid}.err")
+            if File.exist?("#{error_file_path}") && !File.size?("#{error_file_path}")
+              File.delete("#{error_file_path}")
+            end
           end
 
           # should be unreachable but child MUST exit

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -5,7 +5,7 @@ require_relative "super_reporter/base"
 module InspecPlugins
   module Parallelism
     class Runner
-      attr_accessor :invocations, :sub_cmd, :total_jobs, :run_in_background
+      attr_accessor :invocations, :sub_cmd, :total_jobs, :run_in_background, :log_path
 
       def initialize(invocations, cli_options, sub_cmd = "exec")
         @invocations = invocations
@@ -16,6 +16,7 @@ module InspecPlugins
         unless run_in_background
           @ui = InspecPlugins::Parallelism::SuperReporter.make(cli_options["ui"], total_jobs, invocations)
         end
+        @log_path = cli_options["log_path"]
       end
 
       def run
@@ -170,14 +171,15 @@ module InspecPlugins
       end
 
       def create_run_logs(child_pid, run_log , err_log = nil)
-        log_dir_name = "logs"
-        FileUtils.mkdir_p(log_dir_name) unless File.directory?(log_dir_name)
+        logs_dir_path = log_path || Dir.pwd
+        log_dir = File.join(logs_dir_path, "logs")
+        FileUtils.mkdir_p(log_dir) unless File.directory?(log_dir)
 
         if err_log
-          log_file = File.join(log_dir_name, "#{child_pid}.err") unless File.exist?("#{child_pid}.err")
+          log_file = File.join(log_dir, "#{child_pid}.err") unless File.exist?("#{child_pid}.err")
           File.write(log_file, err_log, mode: "a")
         else
-          log_file = File.join(log_dir_name, "#{child_pid}.log") unless File.exist?("#{child_pid}.log")
+          log_file = File.join(log_dir, "#{child_pid}.log") unless File.exist?("#{child_pid}.log")
           File.write(log_file, run_log, mode: "a")
         end
       end

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -41,7 +41,7 @@ module InspecPlugins
         if Inspec.locally_windows?
           Inspec::UI.new.exit(:usage_error)
         else
-          Process.daemon(true, false)
+          Process.daemon(true, true)
         end
       end
 
@@ -90,7 +90,7 @@ module InspecPlugins
           # In parent with newly forked child
           parent_writer.close
           @child_tracker[child_pid] = { io: child_reader }
-          @ui.child_forked(child_pid, invocation)
+          @ui.child_forked(child_pid, invocation) unless run_in_background
         else
           # In child
           child_reader.close
@@ -125,7 +125,7 @@ module InspecPlugins
             create_logs(pid, "#{Time.now.iso8601} Exit code: #{$?}\n")
 
             # child exited - status in $?
-            @ui.child_exited(pid)
+            @ui.child_exited(pid) unless run_in_background
             @child_tracker.delete pid
           end
         end
@@ -148,7 +148,7 @@ module InspecPlugins
                 pipe_ready_for_reading.close
                 break
               end
-              update_ui_with_line(pid, update_line)
+              update_ui_with_line(pid, update_line) unless run_in_background
               # Only pull one line if we are doing normal updates; slurp the whole file
               # if we are doing a final pull on a targeted PID
               break unless target_pid

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/super_reporter/status.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/super_reporter/status.rb
@@ -25,7 +25,7 @@ module InspecPlugins::Parallelism
       end
 
       def child_exited(pid)
-        slots[status_by_pid[pid][:slot]] = nil
+        slots[status_by_pid[pid][:slot]] = "exited"
 
         status_by_pid[pid][:pct] = 100.0
         status_by_pid[pid][:slot] = nil
@@ -62,7 +62,7 @@ module InspecPlugins::Parallelism
 
         # Assign first empty slot
         slots.each_index do |idx|
-          next unless slots[idx].nil?
+          next unless slots[idx].nil? || slots[idx] == "exited"
 
           slots[idx] = pid
           status_by_pid[pid][:slot] = idx
@@ -90,6 +90,8 @@ module InspecPlugins::Parallelism
         slots.each_index do |idx|
           if slots[idx].nil?
             line += "idle".center(slot_width)
+          elsif slots[idx] == "exited"
+            line += "Done".center(slot_width)
           else
             pid = slots[idx]
             with_pid = format("%s: %0.1f%%", pid, status_by_pid[pid][:pct])

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/validator.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/validator.rb
@@ -85,8 +85,12 @@ module InspecPlugins
         # if there is no child-status reporter, add one to the raw value and the parsed array
         unless have_child_status_reporter
           # Eww
+          reporter_value = invocation_data[:thor_opts]["reporter"][0]
+          invocation_data[:value].gsub!(
+            "--reporter #{reporter_value}",
+            "--reporter child-status #{reporter_value}"
+          )
           invocation_data[:thor_opts]["reporter"] << "child-status"
-          invocation_data[:value] += " --reporter child-status"
         end
       end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
1. To create runner logs and errors log using child process id
2. Feature to use ERB escape `<%= pid %>` instead of reporter file name within options file, which will be then replaced by child process id.
3. By default logs are created in current directory. Option `--log-path` added to provide custom log path where logs should be created.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
