### PR TITLE
CFINSPEC-255 Add --profile-content-id option to inspec sign profile command

### DIFF
--- a/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
+++ b/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
@@ -54,6 +54,11 @@ module InspecPlugins
 
         # Read name and version from metadata and use them to form the filename
         profile_md = artifact.read_profile_metadata(path_to_profile)
+
+        # Writes the profile content id in the inspec.yml
+        if options[:profile_content_id] && !options[:profile_content_id].strip.empty?
+          artifact.write_profile_content_id(path_to_profile, options[:profile_content_id])
+        end
         artifact_filename = "#{profile_md["name"]}-#{profile_md["version"]}.#{SIGNED_PROFILE_SUFFIX}"
 
         # Generating tar.gz file using archive method of Inspec Cli
@@ -129,6 +134,14 @@ module InspecPlugins
         end
 
         yaml
+      end
+
+      def write_profile_content_id(path_to_profile, profile_content_id)
+        p = Pathname.new(path_to_profile)
+        p = p.join("inspec.yml")
+        yaml = YAML.load_file(p.to_s)
+        yaml["profile_content_id"] = profile_content_id
+        File.open("#{p}", "w") { |f| f.write yaml.to_yaml }
       end
     end
   end

--- a/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
+++ b/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
@@ -140,8 +140,17 @@ module InspecPlugins
         p = Pathname.new(path_to_profile)
         p = p.join("inspec.yml")
         yaml = YAML.load_file(p.to_s)
-        yaml["profile_content_id"] = profile_content_id
-        File.open("#{p}", "w") { |f| f.write yaml.to_yaml }
+        existing_profile_content_id = yaml["profile_content_id"]
+        motdobj = IO.readlines(p)
+        if existing_profile_content_id.nil?
+          motdobj << "profile_content_id: #{profile_content_id}\n"
+        else
+          motdobj = motdobj.map {|s| s.gsub("profile_content_id: #{existing_profile_content_id}", "profile_content_id: #{profile_content_id}")}
+        end
+
+        File.open("#{p}", "w" ) do | f |
+          f.puts motdobj
+        end
       end
     end
   end

--- a/lib/plugins/inspec-sign/lib/inspec-sign/cli.rb
+++ b/lib/plugins/inspec-sign/lib/inspec-sign/cli.rb
@@ -95,7 +95,7 @@ module InspecPlugins
       option :keyname, type: :string, required: true,
         desc: "Desriptive name of key"
       option :profile_content_id, type: :string,
-        desc: "UUID of the profile. This will overwrite existing profile content id if already exist in the metadata file."
+        desc: "UUID of the profile. This will overwrite an existing profile content id if it already exists in the metadata file."
       def profile
         InspecPlugins::Sign::Base.profile_sign(options)
       end

--- a/lib/plugins/inspec-sign/lib/inspec-sign/cli.rb
+++ b/lib/plugins/inspec-sign/lib/inspec-sign/cli.rb
@@ -95,7 +95,7 @@ module InspecPlugins
       option :keyname, type: :string, required: true,
         desc: "Desriptive name of key"
       option :profile_content_id, type: :string,
-        desc: "UUID of the profile. This will overwrite an existing profile content id if it already exists in the metadata file."
+        desc: "UUID of the profile. This will write the profile_content_id in the metadata file if it does not already exist in the metadata file."
       def profile
         InspecPlugins::Sign::Base.profile_sign(options)
       end

--- a/lib/plugins/inspec-sign/lib/inspec-sign/cli.rb
+++ b/lib/plugins/inspec-sign/lib/inspec-sign/cli.rb
@@ -94,6 +94,8 @@ module InspecPlugins
         desc: "Path to profile directory"
       option :keyname, type: :string, required: true,
         desc: "Desriptive name of key"
+      option :profile_content_id, type: :string,
+        desc: "UUID of the profile. This will overwrite existing profile content id if already exist in the metadata file."
       def profile
         InspecPlugins::Sign::Base.profile_sign(options)
       end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
* It adds --profile-content-id option to the `inspec sign profile` command
* It writes the provided profile_content_id to the inspec metadata (inspec.yml) file 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
