### PR TITLE
Fix omnibus-test.ps1

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -9,4 +9,4 @@ Write-Host "+++ Testing $Plan"
 
 Set-Location test/artifact
 rake
-If ($lastexitcode -ne 0) { Exit $lastexitcode }
+If ($lastexitcode -ne 0) { Throw $lastexitcode }


### PR DESCRIPTION
Use Throw instead of Exit to ensure the CI job fails when a command has
a non-zero exit code.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>