### PR TITLE
fixing bad markdown syntax

### DIFF
--- a/docs-chef-io/content/inspec/resources/file.md
+++ b/docs-chef-io/content/inspec/resources/file.md
@@ -417,7 +417,7 @@ or,
       it { should_not be_file }
       it { should_not be_directory }
     end
-```ruby
+```
 
 ### Test if a file is a block device
 
@@ -428,7 +428,7 @@ or,
       it { should_not be_file }
       it { should_not be_directory }
     end
-```ruby
+```
 
 ### Test the mode for a file
 
@@ -436,7 +436,7 @@ or,
     describe file('/dev') do
      its('mode') { should cmp '00755' }
     end
-```ruby
+```
 
 ### Test the owner of a file
 


### PR DESCRIPTION
code blocks don't have specifiers for the closing triple quotes

<!--- Provide a short summary of your changes in the Title above -->

## Description

This change should fix markdown rendering of the documentation for the "file" ressource documentation page of inspec (see https://docs.chef.io/inspec/resources/file/)

## Related Issue

This PR don't suggest a new feature or change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have read the **CONTRIBUTING** document.

> Note: while I did read the *CONTRIBUTING** document, I'm also aware that I'm not a frequent contributor and thus may have missed some of the point mentionned in that document. Let me know please if there is anything I need to fix in the form of this PR :)