### PR TITLE
Remove Hugo version from Netlify config

### DIFF
--- a/docs-chef-io/netlify.toml
+++ b/docs-chef-io/netlify.toml
@@ -1,9 +1,7 @@
 [build]
 
 [build.environment]
-  HUGO_VERSION = "0.91.2"
   HUGO_ENABLEGITINFO = "true"
-  GO_VERSION = "1.15"
   NODE_ENV = "development"
 
 [build.processing]


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

Remove Hugo and Go versions from Netlify config.

There's a bug in the current Hugo version specified in the Netlify config, so builds are failing because of work I've been doing in other repos. 

Also it's easier to specify these versions in the Netlify Web UI.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
