### PR TITLE
CFINSPEC-267: resource_ids group 6

### DIFF
--- a/lib/inspec/resources/kernel_module.rb
+++ b/lib/inspec/resources/kernel_module.rb
@@ -69,6 +69,10 @@ module Inspec::Resources
       cmd.exit_status == 0 ? cmd.stdout.delete("\n") : nil
     end
 
+    def resource_id
+      @module
+    end
+
     def to_s
       "Kernel Module #{@module}"
     end

--- a/lib/inspec/resources/kernel_parameter.rb
+++ b/lib/inspec/resources/kernel_parameter.rb
@@ -29,6 +29,10 @@ module Inspec::Resources
       cmd
     end
 
+    def resource_id
+      @parameter
+    end
+
     def to_s
       "Kernel Parameter #{@parameter}"
     end

--- a/lib/inspec/resources/key_rsa.rb
+++ b/lib/inspec/resources/key_rsa.rb
@@ -59,6 +59,10 @@ module Inspec::Resources
       @key.public_key.n.num_bytes * 8
     end
 
+    def resource_id
+      @key_path
+    end
+
     def to_s
       "rsa_key #{@key_path}"
     end

--- a/lib/inspec/resources/ksh.rb
+++ b/lib/inspec/resources/ksh.rb
@@ -26,6 +26,10 @@ module Inspec::Resources
       super(CommandWrapper.wrap(command, options))
     end
 
+    def resource_id
+      @raw_command
+    end
+
     def to_s
       "KornShell command #{@raw_command}"
     end

--- a/lib/inspec/resources/limits_conf.rb
+++ b/lib/inspec/resources/limits_conf.rb
@@ -38,6 +38,10 @@ module Inspec::Resources
       @params = conf.params
     end
 
+    def resource_id
+      @conf_path
+    end
+
     def to_s
       "limits.conf"
     end

--- a/lib/inspec/resources/login_defs.rb
+++ b/lib/inspec/resources/login_defs.rb
@@ -49,6 +49,10 @@ module Inspec::Resources
       @params = conf.params
     end
 
+    def resource_id
+      @conf_path
+    end
+
     def to_s
       "login.defs"
     end

--- a/lib/inspec/resources/mongodb.rb
+++ b/lib/inspec/resources/mongodb.rb
@@ -19,6 +19,10 @@ module Inspec::Resources
       end
     end
 
+    def resource_id
+      @conf_path
+    end
+
     def to_s
       "MongoDB"
     end

--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -297,6 +297,10 @@ module Inspec::Resources
       current_monitoring_tool.is_service_monitored?
     end
 
+    def resource_id
+      @service_name
+    end
+
     def to_s
       "Service #{@service_name}"
     end

--- a/test/unit/resources/kernel_module_test.rb
+++ b/test/unit/resources/kernel_module_test.rb
@@ -9,6 +9,7 @@ describe "Inspec::Resources::KernelModule" do
   it "Verify kernel_module version" do
     resource = load_resource("kernel_module", "dhcp")
     _(resource.version).must_equal "3.2.2"
+    _(resource.resource_id).must_equal "dhcp"
   end
 
   # loaded
@@ -16,12 +17,14 @@ describe "Inspec::Resources::KernelModule" do
   it "Verify kernel_module parsing `loaded` - true" do
     resource = load_resource("kernel_module", "bridge")
     _(resource.loaded?).must_equal true
+    _(resource.resource_id).must_equal "bridge"
   end
 
   # 3
   it "Verify kernel_module parsing `loaded` - false" do
     resource = load_resource("kernel_module", "bridges")
     _(resource.loaded?).must_equal false
+    _(resource.resource_id).must_equal "bridges"
   end
 
   # disabled
@@ -29,12 +32,14 @@ describe "Inspec::Resources::KernelModule" do
   it "Verify kernel_module parsing `disabled` - true " do
     resource = load_resource("kernel_module", "nvidiafb")
     _(resource.disabled?).must_equal true
+    _(resource.resource_id).must_equal "nvidiafb"
   end
 
   # 5
   it "Verify kernel_module parsing `disabled` - false" do
     resource = load_resource("kernel_module", "bridge")
     _(resource.disabled?).must_equal false
+    _(resource.resource_id).must_equal "bridge"
   end
 
   # /bin/true
@@ -42,12 +47,14 @@ describe "Inspec::Resources::KernelModule" do
   it "Verify a kernel_module is disabled via /bin/true - true" do
     resource = load_resource("kernel_module", "nvidiafb")
     _(resource.blacklisted?).must_equal true
+    _(resource.resource_id).must_equal "nvidiafb"
   end
 
   # 7
   it "Verify a kernel_module is not disabled via /bin/true - false" do
     resource = load_resource("kernel_module", "ssftb")
     _(resource.blacklisted?).must_equal false
+    _(resource.resource_id).must_equal "ssftb"
   end
 
   # 8
@@ -55,12 +62,14 @@ describe "Inspec::Resources::KernelModule" do
   it "Verify a kernel_module is disabled via /bin/false - true" do
     resource = load_resource("kernel_module", "sstfb")
     _(resource.blacklisted?).must_equal true
+    _(resource.resource_id).must_equal "sstfb"
   end
 
   # 9
   it "Verify a kernel_module is not disabled via /bin/false - true " do
     resource = load_resource("kernel_module", "bridge")
     _(resource.blacklisted?).must_equal false
+    _(resource.resource_id).must_equal "bridge"
   end
 
   # 10
@@ -68,12 +77,14 @@ describe "Inspec::Resources::KernelModule" do
   it "Verify an unlisted kernel_module is not disabled via /bin/true - false" do
     resource = load_resource("kernel_module", "fakemod")
     _(resource.blacklisted?).must_equal false
+    _(resource.resource_id).must_equal "fakemod"
   end
 
   # 11
   it "Verify an unlisted kernel_module is not disabled via /bin/false - false" do
     resource = load_resource("kernel_module", "fakemod")
     _(resource.blacklisted?).must_equal false
+    _(resource.resource_id).must_equal "fakemod"
   end
 
   # 12
@@ -81,12 +92,14 @@ describe "Inspec::Resources::KernelModule" do
   it "Verify a kernel_module is blacklisted - true" do
     resource = load_resource("kernel_module", "floppy")
     _(resource.blacklisted?).must_equal true
+    _(resource.resource_id).must_equal "floppy"
   end
 
   # 13
   it "Verify a kernel_module is not blacklisted - false" do
     resource = load_resource("kernel_module", "ssftb")
     _(resource.blacklisted?).must_equal false
+    _(resource.resource_id).must_equal "ssftb"
   end
 
   # 14
@@ -94,29 +107,34 @@ describe "Inspec::Resources::KernelModule" do
   it "Verify an unlisted kernel_module is not `loaded` - false" do
     resource = load_resource("kernel_module", "not_a_module")
     _(resource.loaded?).must_equal false
+    _(resource.resource_id).must_equal "not_a_module"
   end
 
   # 15
   it "Verify an unlisted kernel_module is not `disabled` - false" do
     resource = load_resource("kernel_module", "not_a_module")
     _(resource.disabled?).must_equal false
+    _(resource.resource_id).must_equal "not_a_module"
   end
 
   # 16
   it "Verify an unlisted kernel_module is not blacklisted - false" do
     resource = load_resource("kernel_module", "not_a_module")
     _(resource.blacklisted?).must_equal false
+    _(resource.resource_id).must_equal "not_a_module"
   end
 
   # 17
   it "Verify an unlisted kernel_module is not disabled_via_bin_true - false" do
     resource = load_resource("kernel_module", "not_a_module")
     _(resource.blacklisted?).must_equal false
+    _(resource.resource_id).must_equal "not_a_module"
   end
 
   # 18
   it "Verify an unlisted kernel_module is not disabled_via_bin_false - false" do
     resource = load_resource("kernel_module", "not_a_module")
     _(resource.blacklisted?).must_equal false
+    _(resource.resource_id).must_equal "not_a_module"
   end
 end

--- a/test/unit/resources/kernel_parameter_test.rb
+++ b/test/unit/resources/kernel_parameter_test.rb
@@ -6,5 +6,6 @@ describe "Inspec::Resources::KernelParameter" do
   it "verify kernel_parameter parsing" do
     resource = load_resource("kernel_parameter", "net.ipv4.conf.all.forwarding")
     _(resource.value).must_equal 1
+    _(resource.resource_id).must_equal "net.ipv4.conf.all.forwarding"
   end
 end

--- a/test/unit/resources/key_rsa_test.rb
+++ b/test/unit/resources/key_rsa_test.rb
@@ -7,9 +7,11 @@ describe "Inspec::Resources::RsaKey" do
 
   it "parses the public key" do
     _(resource_key.send("public_key")).must_match "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxi1Tp4dPQ+GU+RipsguU\nWT50a6fsBCpe+QT0YdW/7GG6kynRzR+fzQ0q1LDxpgqAH+eDIWEAFYoTPc8haAjZ\nvAYn7JlXUQpeoK7fc2BPgYA0lr33Ee0H9nqeZlnytQ+/EVUqqDx61cgeW3ARAK1I\nODwhuziuTi7XNu+HTx3feH4ohq/FppB26PYfJo1jCmt7YxHxl6AGrYrEX5zubQR0\nAtPAJzg0/aqDH5GJHJETjloIxh/KLnGlbG3DJylFU+vPxvns1TKM0dezg8UefXer\nRtxDAwSix7sNctXwa0xToc6O+e/StNPR0eLvILS8iR89fuML57Z4AGFWMNdqTYoj\nqwIDAQAB\n-----END PUBLIC KEY-----\n"
+    _(resource_key.resource_id).must_equal "test_certificate.rsa.key.pem"
   end
 
   it "decodes the key length" do
     _(resource_key.send("key_length")).must_equal 2048
+    _(resource_key.resource_id).must_equal "test_certificate.rsa.key.pem"
   end
 end

--- a/test/unit/resources/ksh_test.rb
+++ b/test/unit/resources/ksh_test.rb
@@ -8,6 +8,7 @@ describe Inspec::Resources::Ksh do
 
   it "prints as a ksh command" do
     _(resource.to_s).must_equal 'KornShell command $("' + x + '")'
+    _(resource.resource_id).must_equal '$("' + x + '")'
   end
 
   it "wraps the command" do

--- a/test/unit/resources/limits_conf_test.rb
+++ b/test/unit/resources/limits_conf_test.rb
@@ -7,5 +7,6 @@ describe "Inspec::Resources::LimitsConf" do
     resource = load_resource("limits_conf")
     _(resource.send("*")).must_equal [%w{soft core 0}, %w{hard rss 10000}]
     _(resource.send("ftp")).must_equal [%w{hard nproc 0}]
+    _(resource.resource_id).must_equal "/etc/security/limits.conf"
   end
 end

--- a/test/unit/resources/login_def_test.rb
+++ b/test/unit/resources/login_def_test.rb
@@ -9,5 +9,6 @@ describe "Inspec::Resources::LoginDef" do
     _(resource.PASS_MIN_DAYS).must_equal "0"
     _(resource.PASS_WARN_AGE).must_equal "7"
     _(resource.USERDEL_CMD).must_be_nil
+    _(resource.resource_id).must_equal "/etc/login.defs"
   end
 end

--- a/test/unit/resources/lxc_test.rb
+++ b/test/unit/resources/lxc_test.rb
@@ -12,6 +12,7 @@ describe "Inspec::Resources::Lxc" do
     _(resource.exists?).must_equal true
     _(resource.running?).must_equal true
     _(resource.resource_skipped?).must_equal false
+    _(resource.resource_id).must_equal "my-ubuntu-container"
   end
 
   # # ubuntu
@@ -20,6 +21,7 @@ describe "Inspec::Resources::Lxc" do
     _(resource.exists?).must_equal false
     _(resource.running?).must_equal false
     _(resource.resource_skipped?).must_equal false
+    _(resource.resource_id).must_equal "my-ubuntu-container-1"
   end
 
   # windows
@@ -27,6 +29,7 @@ describe "Inspec::Resources::Lxc" do
     resource = MockLoader.new(:windows).load_resource("lxc", "my-ubuntu-container")
     _(resource.resource_skipped?).must_equal true
     _(resource.resource_exception_message).must_equal "The `lxc` resource is not supported on your OS yet."
+    _(resource.resource_id).must_equal "my-ubuntu-container"
   end
 
   # undefined
@@ -34,5 +37,6 @@ describe "Inspec::Resources::Lxc" do
     resource = MockLoader.new(:undefined).load_resource("lxc", "my-ubuntu-container")
     _(resource.resource_skipped?).must_equal true
     _(resource.resource_exception_message).must_equal "The `lxc` resource is not supported on your OS yet."
+    _(resource.resource_id).must_equal "my-ubuntu-container"
   end
 end

--- a/test/unit/resources/mongodb_test.rb
+++ b/test/unit/resources/mongodb_test.rb
@@ -6,11 +6,13 @@ describe "Inspec::Resources::Mongodb" do
   it "sets default configuration path" do
     resource = MockLoader.new(:windows).load_resource("mongodb")
     _(resource.conf_path).must_equal "C:\\Program Files\\MongoDB\\Server\\4.4\\bin\\mongod.cfg"
+    _(resource.resource_id).must_equal "C:\\Program Files\\MongoDB\\Server\\4.4\\bin\\mongod.cfg"
   end
 
   it "sets default configuration path" do
     resource = MockLoader.new(:centos7).load_resource("mongodb")
     _(resource.conf_path).must_equal "/etc/mongod.conf"
+    _(resource.resource_id).must_equal "/etc/mongod.conf"
   end
 end
 

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -19,6 +19,7 @@ describe "Inspec::Resources::Service" do
     _(resource.startmode). must_equal "Auto"
     _(resource.startname). must_equal "LocalSystem"
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "dhcp"
   end
 
   # ubuntu
@@ -32,6 +33,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "ssh"
   end
 
   it "verify ubuntu service parsing with default upstart_service" do
@@ -45,6 +47,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.UnitFileState).must_be_nil
+    _(resource.resource_id).must_equal "ssh"
   end
 
   it "verify ubuntu service parsing" do
@@ -58,6 +61,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.SubState).must_equal "running"
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify ubuntu service parsing with default systemd_service" do
@@ -70,6 +74,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # linux mint 17 with upstart
@@ -83,6 +88,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "ssh"
   end
 
   it "verify mint service parsing with default upstart_service" do
@@ -96,6 +102,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.UnitFileState).must_be_nil
+    _(resource.resource_id).must_equal "ssh"
   end
 
   # mint 18 with systemd
@@ -110,6 +117,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.SubState).must_equal "running"
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify mint service parsing with default systemd_service" do
@@ -122,6 +130,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # [-] Todo: Check with team if we can remove the below unit test or find a way to include it.
@@ -154,6 +163,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # Aliyun Linux 3 (Alibaba)
@@ -167,6 +177,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # centos 6 with sysv
@@ -181,6 +192,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.SubState).must_be_nil
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify centos 6 service parsing with default sysv_service" do
@@ -193,6 +205,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # centos 7 with systemd
@@ -206,6 +219,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify centos 7 service parsing with systemd_service and service_ctl override" do
@@ -218,6 +232,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify centos 7 service parsing with static loaded service" do
@@ -232,6 +247,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.UnitFileState).must_equal "static"
+    _(resource.resource_id).must_equal "dbus"
   end
 
   # cloudlinux 7 with systemd
@@ -245,6 +261,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify cloudlinux 7 service parsing with systemd_service and service_ctl override" do
@@ -257,6 +274,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify cloudlinux 7 service parsing with static loaded service" do
@@ -271,6 +289,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.UnitFileState).must_equal "static"
+    _(resource.resource_id).must_equal "dbus"
   end
 
   # freebsd 9
@@ -284,6 +303,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sendmail"
   end
 
   it "verify freebsd9 service parsing with default bsd_service" do
@@ -296,11 +316,13 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sendmail"
   end
 
   it "verify freebsd9 service parsing when one service is a suffix of another" do
     resource = MockLoader.new(:freebsd9).load_resource("service", "mail") # "mail" is suffix of "sendmail", which is enabled
     _(resource.enabled?).must_equal false
+    _(resource.resource_id).must_equal "mail"
   end
 
   # freebsd 10+
@@ -314,6 +336,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sendmail"
   end
 
   it "verify freebsd10 service parsing with default bsd_service" do
@@ -326,6 +349,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sendmail"
   end
 
   # arch linux with systemd
@@ -339,6 +363,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # coreos linux with systemd
@@ -352,6 +377,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # debian 7 with systemv
@@ -365,6 +391,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # debian 8 with systemd
@@ -378,6 +405,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # debian 10 with systemd
@@ -391,6 +419,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # debian 8 with systemd but no service file
@@ -412,6 +441,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "apache2"
   end
 
   # macos test
@@ -425,6 +455,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "ssh"
   end
 
   it "verify macos 10.16 (11 / big sur) service parsing" do
@@ -437,6 +468,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "ssh"
   end
 
   it "verify mac osx service parsing with not-running service" do
@@ -449,6 +481,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal false
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "FilesystemUI"
   end
 
   it "verify mac osx service parsing with default launchd_service" do
@@ -461,6 +494,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "ssh"
   end
 
   # wrlinux
@@ -474,6 +508,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # yocto
@@ -487,6 +522,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify alpine service parsing" do
@@ -499,6 +535,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # unknown OS
@@ -508,6 +545,7 @@ describe "Inspec::Resources::Service" do
     _(resource.installed?).must_equal false
     _(resource.description).must_be_nil
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "dhcp"
   end
 
   # runlevel detection
@@ -555,6 +593,7 @@ describe "Inspec::Resources::Service" do
       resource = MockLoader.new(:windows).load_resource("service", "dhcp")
       _(resource.name).must_equal "dhcp"
       _(resource.has_start_mode?("Auto")).must_equal true
+      _(resource.resource_id).must_equal "dhcp"
     end
 
     # ubuntu
@@ -564,6 +603,7 @@ describe "Inspec::Resources::Service" do
       _(resource.monitored_by?("monit")).must_equal true
       ex = _ { resource.has_start_mode?("Auto") }.must_raise(Inspec::Exceptions::ResourceSkipped)
       _(ex.message).must_include "The `has_start_mode` matcher is not supported on your OS yet."
+      _(resource.resource_id).must_equal "ssh"
     end
   end
 end


### PR DESCRIPTION
✅ Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Description
**CFINSPEC-267: resource_ids group 6**
This PR adds `resource_id` methods to the following resources:
- kernel_module
- kernel_parameter
- key_rsa
- ksh
- launchd_service
- limits_conf
- linux_kernel_parameter
- login_defs
- lxc
- mongodb

When a user runs inspec exec [profile] --reporter json
then when they look at the resource_id field for the core controls
then they would be able to see an identifier for each control

## Related Issue
**CFINSPEC-267: resource_ids group 6**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
