### PR TITLE
CFINSPEC-262 Adds resource_id group 1

### DIFF
--- a/lib/inspec/resources/aide_conf.rb
+++ b/lib/inspec/resources/aide_conf.rb
@@ -48,6 +48,10 @@ module Inspec::Resources
 
     filter.install_filter_methods_on_resource(self, :params)
 
+    def resource_id
+      @conf_path
+    end
+
     def to_s
       "AIDE Config"
     end

--- a/lib/inspec/resources/apache.rb
+++ b/lib/inspec/resources/apache.rb
@@ -40,6 +40,10 @@ module Inspec::Resources
       end
     end
 
+    def resource_id
+      @conf_path
+    end
+
     def to_s
       "Apache Environment"
     end

--- a/lib/inspec/resources/apache_conf.rb
+++ b/lib/inspec/resources/apache_conf.rb
@@ -124,6 +124,10 @@ module Inspec::Resources
       @params["ServerRoot"] || @params["serverroot"]
     end
 
+    def resource_id
+      @conf_path
+    end
+
     def to_s
       "Apache Config #{conf_path}"
     end

--- a/lib/inspec/resources/apt.rb
+++ b/lib/inspec/resources/apt.rb
@@ -39,10 +39,11 @@ module Inspec::Resources
     EXAMPLE
 
     def initialize(ppa_name)
+      @ppa_name = ppa_name
       @deb_url = nil
       # check if the os is ubuntu or debian
       if inspec.os.debian?
-        @deb_url = determine_ppa_url(ppa_name)
+        @deb_url = determine_ppa_url(@ppa_name)
       else
         # this resource is only supported on ubuntu and debian
         skip_resource "The `apt` resource is not supported on your OS yet."
@@ -59,6 +60,10 @@ module Inspec::Resources
       actives = find_repo.map { |repo| repo[:active] }
       actives = actives.uniq
       actives.size == 1 && actives[0] = true
+    end
+
+    def resource_id
+      @deb_url || @ppa_name || ""
     end
 
     def to_s

--- a/lib/inspec/resources/audit_policy.rb
+++ b/lib/inspec/resources/audit_policy.rb
@@ -57,6 +57,11 @@ module Inspec::Resources
       values
     end
 
+    # Since this resource does not have any unique identifier for resource, sending the Auditpol command as UUID.
+    def resource_id
+      "Auditpol"
+    end
+
     def to_s
       "Audit Policy"
     end

--- a/lib/inspec/resources/auditd_conf.rb
+++ b/lib/inspec/resources/auditd_conf.rb
@@ -27,6 +27,10 @@ module Inspec::Resources
       read_params[name.to_s]
     end
 
+    def resource_id
+      @conf_path
+    end
+
     def to_s
       "Audit Daemon Config"
     end

--- a/lib/inspec/resources/bash.rb
+++ b/lib/inspec/resources/bash.rb
@@ -28,6 +28,10 @@ module Inspec::Resources
       super(CommandWrapper.wrap(command, options))
     end
 
+    def resource_id
+      @raw_command
+    end
+
     def to_s
       "Bash command #{@raw_command}"
     end

--- a/lib/inspec/resources/bond.rb
+++ b/lib/inspec/resources/bond.rb
@@ -63,6 +63,10 @@ module Inspec::Resources
       params["Bonding Mode"].first
     end
 
+    def resource_id
+      @path
+    end
+
     def to_s
       "Bond #{@bond}"
     end

--- a/lib/inspec/resources/bridge.rb
+++ b/lib/inspec/resources/bridge.rb
@@ -45,6 +45,10 @@ module Inspec::Resources
       bridge_info.nil? ? nil : bridge_info[:interfaces]
     end
 
+    def resource_id
+      @bridge_name
+    end
+
     def to_s
       "Bridge #{@bridge_name}"
     end

--- a/lib/inspec/resources/cassandradb_conf.rb
+++ b/lib/inspec/resources/cassandradb_conf.rb
@@ -31,6 +31,11 @@ module Inspec::Resources
       super(@conf_path)
     end
 
+    # if system unables to determine the cassandra conf path the @conf_path can be nil so in that case sending "" string as resource_id
+    def resource_id
+      @conf_path || ""
+    end
+
     private
 
     def parse(content)

--- a/lib/inspec/resources/cassandradb_session.rb
+++ b/lib/inspec/resources/cassandradb_session.rb
@@ -44,6 +44,10 @@ module Inspec::Resources
       end
     end
 
+    def resource_id
+      "cassandradb_session:User:#{@user}:Host:#{host}"
+    end
+
     def to_s
       "Cassandra DB Session"
     end

--- a/test/unit/resources/aide_conf_test.rb
+++ b/test/unit/resources/aide_conf_test.rb
@@ -5,6 +5,9 @@ require "inspec/resources/aide_conf"
 describe "Inspec::Resources::AideConf" do
   describe "AideConf Parameters" do
     resource = load_resource("aide_conf")
+    it "Verify resource_id" do
+      _(resource.resource_id).must_equal "/etc/aide.conf"
+    end
     it "Verify aide_conf all_have_rule property - true case" do
       _(resource.all_have_rule("p")).must_equal true
     end

--- a/test/unit/resources/apache_conf_test.rb
+++ b/test/unit/resources/apache_conf_test.rb
@@ -10,6 +10,7 @@ describe "Inspec::Resources::ApacheConf" do
                                                          "/etc/apache2/apache2.conf")
     _(resource.params).must_be_kind_of Hash
     _(resource.content).must_be_kind_of String
+    _(resource.resource_id).must_equal "/etc/apache2/apache2.conf"
     _(resource.params("ServerRoot")).must_equal ["/etc/apache2"]
     _(resource.params("ServerAlias")).must_equal ["inspec.test www.inspec.test io.inspec.test"]
     _(resource.params("Listen").sort).must_equal %w{443 80}
@@ -25,6 +26,7 @@ describe "Inspec::Resources::ApacheConf" do
     resource = MockLoader.new(:ubuntu).load_resource("apache_conf", "/etc/test-serverroot/apache2/apache2.conf")
     _(resource.params).must_be_kind_of Hash
     _(resource.content).must_be_kind_of String
+    _(resource.resource_id).must_equal "/etc/test-serverroot/apache2/apache2.conf"
     _(resource.params("ServerAlias")).must_equal ["inspec.test www.inspec.test io.inspec.test"]
     assert_nil(resource.params("ServerRoot"))
     assert_nil(resource.params("Listen"))

--- a/test/unit/resources/apt_test.rb
+++ b/test/unit/resources/apt_test.rb
@@ -6,12 +6,14 @@ describe "Inspec::Resources::AptRepo" do
 
   it "check apt on ubuntu" do
     resource = MockLoader.new(:ubuntu).load_resource("apt", "http://archive.ubuntu.com/ubuntu/")
+    _(resource.resource_id).must_equal "http://archive.ubuntu.com/ubuntu/"
     _(resource.exists?).must_equal true
     _(resource.enabled?).must_equal true
   end
 
   it "check apt on ubuntu with ppa" do
     resource = MockLoader.new(:ubuntu).load_resource("apt", "ubuntu-wine/ppa")
+    _(resource.resource_id).must_equal "http://ppa.launchpad.net/ubuntu-wine/ppa/ubuntu"
     _(resource.exists?).must_equal true
     _(resource.enabled?).must_equal true
   end
@@ -48,6 +50,7 @@ describe "Inspec::Resources::AptRepo" do
 
   it "check apt on unknown os" do
     resource = MockLoader.new(:undefined).load_resource("apt", "ubuntu-wine/ppa")
+    _(resource.resource_id).must_equal "ubuntu-wine/ppa"
     _(resource.exists?).must_equal false
     _(resource.enabled?).must_equal false
   end

--- a/test/unit/resources/audit_policy_test.rb
+++ b/test/unit/resources/audit_policy_test.rb
@@ -5,6 +5,7 @@ require "inspec/resources/audit_policy"
 describe "Inspec::Resources::AuditPolicy" do
   it "check audit policy parsing" do
     resource = MockLoader.new(:windows).load_resource("audit_policy")
+    _(resource.resource_id).must_equal "Auditpol"
     _(resource.send("User Account Management")).must_equal "Success"
   end
 end

--- a/test/unit/resources/auditd_conf_test.rb
+++ b/test/unit/resources/auditd_conf_test.rb
@@ -5,6 +5,7 @@ require "inspec/resources/auditd_conf"
 describe "Inspec::Resources::AuditDaemonConf" do
   it "check audit daemon config parsing" do
     resource = MockLoader.new(:windows).load_resource("auditd_conf")
+    _(resource.resource_id).must_equal "/etc/audit/auditd.conf"
     _(resource.space_left_action).must_equal "SYSLOG"
     _(resource.action_mail_acct).must_equal "root"
     _(resource.tcp_listen_queue).must_equal "5"

--- a/test/unit/resources/bash_test.rb
+++ b/test/unit/resources/bash_test.rb
@@ -7,6 +7,7 @@ describe "Inspec::Resources::Bash" do
   let(:resource) { load_resource("bash", '$("' + x + '")') }
 
   it "prints as a bash command" do
+    _(resource.resource_id).must_equal "$(\"#{x}\")"
     _(resource.to_s).must_equal 'Bash command $("' + x + '")'
   end
 
@@ -16,6 +17,7 @@ describe "Inspec::Resources::Bash" do
 
   it "can specify an executable path" do
     resource = load_resource("bash", '$("' + x + '")', path: "/bin/bash")
+    _(resource.resource_id).must_equal "$(\"#{x}\")"
     _(resource.command).must_equal "/bin/bash -c \\$\\(\\\"#{x}\\\"\\)"
   end
 

--- a/test/unit/resources/bond_test.rb
+++ b/test/unit/resources/bond_test.rb
@@ -7,6 +7,7 @@ describe "Inspec::Resources::Bond" do
   it "check linux bond on ubuntu" do
     resource = MockLoader.new(:ubuntu).load_resource("bond", "bond0")
     # bond must be available
+    _(resource.resource_id).must_equal "/proc/net/bonding/bond0"
     _(resource.exist?).must_equal true
     # get bonding mode
     _(resource.mode).must_equal "IEEE 802.3ad Dynamic link aggregation"

--- a/test/unit/resources/bridge_test.rb
+++ b/test/unit/resources/bridge_test.rb
@@ -6,6 +6,7 @@ describe "Inspec::Resources::Bridge" do
 
   it "check linux bridge on ubuntu" do
     resource = MockLoader.new(:ubuntu).load_resource("bridge", "br0")
+    _(resource.resource_id).must_equal "br0"
     _(resource.exists?).must_equal true
 
     # check network interfaced attached to bridge
@@ -32,6 +33,7 @@ describe "Inspec::Resources::Bridge" do
 
   it "check windows bridge" do
     resource = MockLoader.new(:windows).load_resource("bridge", "Network Bridge")
+    _(resource.resource_id).must_equal "Network Bridge"
     _(resource.exists?).must_equal true
 
     # get associated interfaces is not supported on windows
@@ -40,6 +42,7 @@ describe "Inspec::Resources::Bridge" do
 
   it "check bridge on unsupported os" do
     resource = MockLoader.new(:undefined).load_resource("bridge", "br0")
+    _(resource.resource_id).must_equal "br0"
     _(resource.exists?).must_equal false
 
     # check network interfaced attached to bridge

--- a/test/unit/resources/cassandradb_conf_test.rb
+++ b/test/unit/resources/cassandradb_conf_test.rb
@@ -5,6 +5,7 @@ require "inspec/resources/cassandradb_conf"
 describe "Inspec::Resources::CassandradbConf" do
   it "verify configurations of cassandra DB in linux when conf path is passed" do
     resource = MockLoader.new(:centos7).load_resource("cassandradb_conf", "/etc/cassandra/cassandra.yaml")
+    _(resource.resource_id).must_equal "/etc/cassandra/cassandra.yaml"
     _(resource.params["listen_address"]).must_equal "localhost"
     _(resource.params["native_transport_port"]).must_equal 9042
     _(resource.params["audit_logging_options"]["enabled"]).must_equal false

--- a/test/unit/resources/cassandradb_session_test.rb
+++ b/test/unit/resources/cassandradb_session_test.rb
@@ -24,6 +24,7 @@ describe "Inspec::Resources::CassandradbSession" do
       end
     end
 
+    _(resource.resource_id).must_equal "cassandradb_session:User:USER:Host:localhost"
     _(resource.resource_failed?).must_equal false
     query = resource.query("SELECT cluster_name FROM system.local")
     _(query.output).must_match(/Test Cluster/)

--- a/test/unit/resources/ppa_test.rb
+++ b/test/unit/resources/ppa_test.rb
@@ -6,12 +6,14 @@ describe Inspec::Resources::PpaRepository do
 
   it "checks on ubuntu as name/ppa" do
     resource = MockLoader.new(:ubuntu).load_resource("ppa", "ubuntu-wine/ppa")
+    _(resource.resource_id).must_equal "http://ppa.launchpad.net/ubuntu-wine/ppa/ubuntu"
     _(resource.exists?).must_equal true
     _(resource.enabled?).must_equal true
   end
 
   it "checks on ubuntu as ppa:name/ppa" do
     resource = MockLoader.new(:ubuntu).load_resource("ppa", "ppa:ubuntu-wine/ppa")
+    _(resource.resource_id).must_equal "http://ppa.launchpad.net/ubuntu-wine/ppa/ubuntu"
     _(resource.exists?).must_equal true
     _(resource.enabled?).must_equal true
   end
@@ -36,6 +38,7 @@ describe Inspec::Resources::PpaRepository do
 
   it "checks on unknown os" do
     resource = MockLoader.new(:undefined).load_resource("ppa", "ubuntu-wine/ppa")
+    _(resource.resource_id).must_equal "ubuntu-wine/ppa"
     _(resource.exists?).must_equal false
     _(resource.enabled?).must_equal false
   end


### PR DESCRIPTION

Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
This adds the resource_id to following resources
* aide_conf
* apache, apache_conf
* apt / ppa
* audit_policy
* auditd_conf
* bash
* bond
* bridge
* cassandradb_session
* cassandradb_conf


## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
