### PR TITLE
CFINSPEC-266: resource_ids group 5

### DIFF
--- a/lib/inspec/resources/iis_site.rb
+++ b/lib/inspec/resources/iis_site.rb
@@ -77,6 +77,10 @@ module Inspec::Resources
       iis_site.nil? ? false : (iis_site[:bindings].include? binding)
     end
 
+    def resource_id
+      @site_name
+    end
+
     def to_s
       "iis_site '#{@site_name}'"
     end

--- a/lib/inspec/resources/inetd_conf.rb
+++ b/lib/inspec/resources/inetd_conf.rb
@@ -46,6 +46,10 @@ module Inspec::Resources
       @params = conf.params
     end
 
+    def resource_id
+      @conf_path
+    end
+
     def to_s
       "inetd.conf"
     end

--- a/lib/inspec/resources/interface.rb
+++ b/lib/inspec/resources/interface.rb
@@ -83,6 +83,10 @@ module Inspec::Resources
       interface_info && Array(interface_info[:ipv6_addresses])
     end
 
+    def resource_id
+      @iface
+    end
+
     def to_s
       "Interface #{@iface}"
     end

--- a/lib/inspec/resources/ip6tables.rb
+++ b/lib/inspec/resources/ip6tables.rb
@@ -62,6 +62,10 @@ module Inspec::Resources
       @ip6tables_cache = cmd.stdout.split("\n").map(&:strip)
     end
 
+    def resource_id
+      format("Ip6tables %s %s", @table && "table: #{@table}", @chain && "chain: #{@chain}").strip
+    end
+
     def to_s
       format("Ip6tables %s %s", @table && "table: #{@table}", @chain && "chain: #{@chain}").strip
     end

--- a/lib/inspec/resources/ipfilter.rb
+++ b/lib/inspec/resources/ipfilter.rb
@@ -42,6 +42,10 @@ module Inspec::Resources
       @ipfilter_cache = cmd.stdout.split("\n").map(&:strip)
     end
 
+    def resource_id
+      "Ipfilter"
+    end
+
     def to_s
       "Ipfilter"
     end

--- a/lib/inspec/resources/ipnat.rb
+++ b/lib/inspec/resources/ipnat.rb
@@ -41,6 +41,10 @@ module Inspec::Resources
       @ipnat_cache = cmd.stdout.split("\n").map(&:strip)
     end
 
+    def resource_id
+      "Ipnat"
+    end
+
     def to_s
       "Ipnat"
     end

--- a/lib/inspec/resources/iptables.rb
+++ b/lib/inspec/resources/iptables.rb
@@ -69,6 +69,10 @@ module Inspec::Resources
       end
     end
 
+    def resource_id
+      format("Iptables %s %s", @table && "table: #{@table}", @chain && "chain: #{@chain}").strip
+    end
+
     def to_s
       format("Iptables %s %s", @table && "table: #{@table}", @chain && "chain: #{@chain}").strip
     end

--- a/lib/inspec/resources/json.rb
+++ b/lib/inspec/resources/json.rb
@@ -59,6 +59,10 @@ module Inspec::Resources
       extract_value(key, params)
     end
 
+    def resource_id
+      @resource_name_supplement || "#{resource_base_name}'s content"
+    end
+
     def to_s
       "#{resource_base_name} #{@resource_name_supplement || "content"}"
     end

--- a/test/unit/resources/iis_site_test.rb
+++ b/test/unit/resources/iis_site_test.rb
@@ -26,5 +26,6 @@ describe "Inspec::Resources::IisSite" do
     _(resource.send("has_binding?", "https *:443:")).must_equal false
     _(resource.send("has_binding?", "https :443:example.com sslFlags=0")).must_equal false
     _(resource.send("to_s")).must_equal "iis_site 'Default Web Site'"
+    _(resource.send("resource_id")).must_equal "Default Web Site"
   end
 end

--- a/test/unit/resources/inetd_conf_test.rb
+++ b/test/unit/resources/inetd_conf_test.rb
@@ -8,5 +8,6 @@ describe "Inspec::Resources::InetdConf" do
     _(resource.send("shell")).must_be_nil
     _(resource.send("login")).must_be_nil
     _(resource.send("ftp")).must_equal %w{stream tcp nowait root /usr/sbin/in.ftpd in.ftpd}
+    _(resource.send("resource_id")).must_equal "/etc/inetd.conf"
   end
 end

--- a/test/unit/resources/ini_test.rb
+++ b/test/unit/resources/ini_test.rb
@@ -8,5 +8,6 @@ describe "Inspec::Resources::Ini" do
     result = { "DEFAULT" => { "filters_path" => "/etc/cinder/rootwrap.d,/usr/share/cinder/rootwrap", "exec_dirs" => "/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin" } }
     _(resource.params).must_equal result
     _(resource.value(%w{DEFAULT exec_dirs})).must_equal "/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin"
+    _(resource.resource_id).must_equal "rootwrap.conf"
   end
 end

--- a/test/unit/resources/interface_test.rb
+++ b/test/unit/resources/interface_test.rb
@@ -20,6 +20,7 @@ describe "Inspec::Resources::Interface" do
     _(resource.ipv6_addresses).must_include "::1"
     _(resource.ipv4_address?).must_equal true
     _(resource.ipv6_address?).must_equal true
+    _(resource.resource_id).must_equal "eth0"
   end
 
   it "verify invalid interface on ubuntu" do
@@ -37,6 +38,7 @@ describe "Inspec::Resources::Interface" do
     _(resource.ipv6_addresses).must_be_empty
     _(resource.ipv4_address?).must_equal false
     _(resource.ipv6_address?).must_equal false
+    _(resource.resource_id).must_equal "eth1"
   end
 
   # windows
@@ -55,6 +57,7 @@ describe "Inspec::Resources::Interface" do
     _(resource.ipv6_addresses).must_be_empty
     _(resource.ipv4_cidrs).must_be_empty
     _(resource.ipv6_cidrs).must_be_empty
+    _(resource.resource_id).must_equal "ethernet0"
   end
 
   it "verify interface on windows" do
@@ -72,6 +75,7 @@ describe "Inspec::Resources::Interface" do
     _(resource.ipv6_addresses).must_include "::1"
     _(resource.ipv4_address?).must_equal true
     _(resource.ipv6_address?).must_equal true
+    _(resource.resource_id).must_equal "vEthernet (Intel(R) PRO 1000 MT Network Connection - Virtual Switch)"
   end
 
   it "verify invalid interface on windows" do
@@ -87,6 +91,7 @@ describe "Inspec::Resources::Interface" do
     _(resource.ipv6_addresses).must_be_empty
     _(resource.ipv4_cidrs).must_be_empty
     _(resource.ipv6_cidrs).must_be_empty
+    _(resource.resource_id).must_equal "eth1"
   end
 
   it "verify interface on macos" do
@@ -104,6 +109,7 @@ describe "Inspec::Resources::Interface" do
     _(resource.ipv6_addresses).must_include "fe80::8b6:c2cc:2928:3b61"
     _(resource.ipv4_address?).must_equal true
     _(resource.ipv6_address?).must_equal true
+    _(resource.resource_id).must_equal "en0"
   end
 
   # undefined
@@ -113,6 +119,7 @@ describe "Inspec::Resources::Interface" do
     _(resource.up?).must_equal false
     _(resource.name).must_be_nil
     _(resource.speed).must_be_nil
+    _(resource.resource_id).must_equal "eth0"
   end
 
 end

--- a/test/unit/resources/ip6tables_test.rb
+++ b/test/unit/resources/ip6tables_test.rb
@@ -9,17 +9,20 @@ describe "Inspec::Resources::Ip6tables" do
     resource = MockLoader.new(:ubuntu1404).load_resource("ip6tables")
     _(resource.has_rule?("-P OUTPUT ACCEPT")).must_equal true
     _(resource.has_rule?("-P OUTPUT DROP")).must_equal false
+    _(resource.resource_id).must_equal "Ip6tables"
   end
 
   it "verify ip6tables with comments on ubuntu" do
     resource = MockLoader.new(:ubuntu1404).load_resource("ip6tables")
     _(resource.has_rule?('-A INPUT -i eth0 -p tcp -m tcp --dport 80 -m state --state NEW -m comment --comment "http-v6 like its 1990" -j ACCEPT')).must_equal true
+    _(resource.resource_id).must_equal "Ip6tables"
   end
 
   it "verify ip6tables on windows" do
     resource = MockLoader.new(:windows).load_resource("ip6tables")
     _(resource.has_rule?("-P OUTPUT ACCEPT")).must_equal false
     _(resource.has_rule?("-P OUTPUT DROP")).must_equal false
+    _(resource.resource_id).must_equal "Ip6tables"
   end
 
   # undefined
@@ -27,6 +30,7 @@ describe "Inspec::Resources::Ip6tables" do
     resource = MockLoader.new(:undefined).load_resource("ip6tables")
     _(resource.has_rule?("-P OUTPUT ACCEPT")).must_equal false
     _(resource.has_rule?("-P OUTPUT DROP")).must_equal false
+    _(resource.resource_id).must_equal "Ip6tables"
   end
 
 end

--- a/test/unit/resources/ipfilter_test.rb
+++ b/test/unit/resources/ipfilter_test.rb
@@ -9,6 +9,7 @@ describe "Inspec::Resources::Ipfilter" do
     _(resource.has_rule?("pass in quick on lo0 all")).must_equal true
     _(resource.has_rule?("rule which does not exist")).must_equal false
     _(resource.has_rule?(nil)).must_equal false
+    _(resource.resource_id).must_equal "Ipfilter"
   end
 
   # solaris11
@@ -16,24 +17,28 @@ describe "Inspec::Resources::Ipfilter" do
     resource = MockLoader.new(:solaris11).load_resource("ipfilter")
     _(resource.has_rule?("pass out quick on lo0 all")).must_equal true
     _(resource.has_rule?("rule which does not exist")).must_equal false
+    _(resource.resource_id).must_equal "Ipfilter"
   end
 
   # ubuntu
   it "verify ipfilter on ubuntu" do
     resource = MockLoader.new(:ubuntu).load_resource("ipfilter")
     _(resource.has_rule?("pass out quick on lo0 all")).must_equal false
+    _(resource.resource_id).must_equal "Ipfilter"
   end
 
   # windows
   it "verify ipfilter on windows" do
     resource = MockLoader.new(:windows).load_resource("ipfilter")
     _(resource.has_rule?("pass out quick on lo0 all")).must_equal false
+    _(resource.resource_id).must_equal "Ipfilter"
   end
 
   # undefined
   it "verify ipfilter on unsupported os" do
     resource = MockLoader.new(:undefined).load_resource("ipfilter")
     _(resource.has_rule?("pass out quick on lo0 all")).must_equal false
+    _(resource.resource_id).must_equal "Ipfilter"
   end
 
 end

--- a/test/unit/resources/ipnat_test.rb
+++ b/test/unit/resources/ipnat_test.rb
@@ -8,6 +8,7 @@ describe "Inspec::Resources::Ipnat" do
     resource = MockLoader.new(:freebsd11).load_resource("ipnat")
     _(resource.has_rule?("map net1 192.168.0.0/24 -> 0/32")).must_equal true
     _(resource.has_rule?(nil)).must_equal false
+    _(resource.resource_id).must_equal "Ipnat"
   end
 
   # solaris11
@@ -15,24 +16,28 @@ describe "Inspec::Resources::Ipnat" do
     resource = MockLoader.new(:solaris11).load_resource("ipnat")
     _(resource.has_rule?("map net1 192.168.0.0/24 -> 0/32")).must_equal true
     _(resource.has_rule?("rule which does not exist")).must_equal false
+    _(resource.resource_id).must_equal "Ipnat"
   end
 
   # ubuntu
   it "verify ipfilter on ubuntu" do
     resource = MockLoader.new(:ubuntu).load_resource("ipnat")
     _(resource.has_rule?("map net1 192.168.0.0/24 -> 0/32")).must_equal false
+    _(resource.resource_id).must_equal "Ipnat"
   end
 
   # windows
   it "verify ipfilter on windows" do
     resource = MockLoader.new(:windows).load_resource("ipnat")
     _(resource.has_rule?("map net1 192.168.0.0/24 -> 0/32")).must_equal false
+    _(resource.resource_id).must_equal "Ipnat"
   end
 
   # undefined
   it "verify ipfilter on unsupported os" do
     resource = MockLoader.new(:undefined).load_resource("ipnat")
     _(resource.has_rule?("map net1 192.168.0.0/24 -> 0/32")).must_equal false
+    _(resource.resource_id).must_equal "Ipnat"
   end
 
 end

--- a/test/unit/resources/iptables_test.rb
+++ b/test/unit/resources/iptables_test.rb
@@ -9,22 +9,26 @@ describe "Inspec::Resources::Iptables" do
     resource = MockLoader.new(:ubuntu).load_resource("iptables")
     _(resource.has_rule?("-P OUTPUT ACCEPT")).must_equal true
     _(resource.has_rule?("-P OUTPUT DROP")).must_equal false
+    _(resource.resource_id).must_equal "Iptables"
   end
 
   it "verify iptables with comments on ubuntu" do
     resource = MockLoader.new(:ubuntu).load_resource("iptables")
     _(resource.has_rule?('-A INPUT -i eth0 -p tcp -m tcp --dport 80 -m state --state NEW -m comment --comment "http like its 1990" -j ACCEPT')).must_equal true
+    _(resource.resource_id).must_equal "Iptables"
   end
 
   it "verify iptables without comments on ubuntu" do
     resource = MockLoader.new(:ubuntu).load_resource("iptables", ignore_comments: true)
     _(resource.has_rule?("-A INPUT -i eth0 -p tcp -m tcp --dport 80 -m state --state NEW -j ACCEPT")).must_equal true
+    _(resource.resource_id).must_equal "Iptables"
   end
 
   it "verify iptables on windows" do
     resource = MockLoader.new(:windows).load_resource("iptables")
     _(resource.has_rule?("-P OUTPUT ACCEPT")).must_equal false
     _(resource.has_rule?("-P OUTPUT DROP")).must_equal false
+    _(resource.resource_id).must_equal "Iptables"
   end
 
   # undefined
@@ -32,6 +36,7 @@ describe "Inspec::Resources::Iptables" do
     resource = MockLoader.new(:undefined).load_resource("iptables")
     _(resource.has_rule?("-P OUTPUT ACCEPT")).must_equal false
     _(resource.has_rule?("-P OUTPUT DROP")).must_equal false
+    _(resource.resource_id).must_equal "Iptables"
   end
 
 end

--- a/test/unit/resources/json_test.rb
+++ b/test/unit/resources/json_test.rb
@@ -6,6 +6,10 @@ describe "Inspec::Resources::JSON" do
   describe "when loading a valid json" do
     let(:resource) { load_resource("json", "policyfile.lock.json") }
 
+    it "gets the resource id" do
+      _(resource.resource_id).must_equal "policyfile.lock.json"
+    end
+
     it "gets params as a hashmap" do
       _(resource.params).must_be_kind_of Hash
     end
@@ -41,6 +45,10 @@ describe "Inspec::Resources::JSON" do
 
   describe "when loading a nonexistent file" do
     let(:resource) { load_resource("json", "nonexistent.json") }
+
+    it "gets the resource id" do
+      _(resource.resource_id).must_equal "nonexistent.json"
+    end
 
     it "produces an error" do
       _(resource.resource_exception_message).must_equal "Can't find file: nonexistent.json"

--- a/test/unit/resources/toml_test.rb
+++ b/test/unit/resources/toml_test.rb
@@ -28,5 +28,9 @@ describe "Inspec::Resources::TOML" do
       _(resource.params["mytable"]).must_be_kind_of Hash
       _(resource.params["mytable"]).must_equal h
     end
+
+    it "gets resource_id of the current resource" do
+      _(resource.resource_id).must_equal "default.toml"
+    end
   end
 end

--- a/test/unit/resources/xml_test.rb
+++ b/test/unit/resources/xml_test.rb
@@ -7,6 +7,10 @@ describe "Inspec::Resources::XML" do
   describe "when loading valid XML" do
     let(:resource) { load_resource("xml", "default.xml") }
 
+    it "gets resource_id for current resource" do
+      _(resource.resource_id).must_equal "default.xml"
+    end
+
     it "gets params as a document" do
       _(resource.params).must_be_kind_of REXML::Document
     end
@@ -29,6 +33,10 @@ describe "Inspec::Resources::XML" do
   describe "when loading xml with attributes" do
     let(:resource) { load_resource("xml", "database.xml") }
 
+    it "gets resource_id for current resource" do
+      _(resource.resource_id).must_equal "database.xml"
+    end
+
     it "gets params as a document" do
       _(resource.params).must_be_kind_of REXML::Document
     end
@@ -46,6 +54,10 @@ describe "Inspec::Resources::XML" do
   describe "when loading xml and requesting a count" do
     let(:resource) { load_resource("xml", "database.xml") }
 
+    it "gets resource_id for current resource" do
+      _(resource.resource_id).must_equal "database.xml"
+    end
+
     it "gets count of nodes in the document" do
       _(resource.send("count(//*)")).must_equal [9]
     end
@@ -54,6 +66,10 @@ describe "Inspec::Resources::XML" do
   describe "when loading xml and evaluating a boolean result" do
     let(:resource) { load_resource("xml", "database.xml") }
 
+    it "gets resource_id for current resource" do
+      _(resource.resource_id).must_equal "database.xml"
+    end
+
     it "checks if a node is true-like" do
       _(resource.send("boolean(/beans/bean/@lazy-init)")).must_equal [true]
     end
@@ -61,6 +77,10 @@ describe "Inspec::Resources::XML" do
 
   describe "when loading xml and evaluating a string result" do
     let(:resource) { load_resource("xml", "database.xml") }
+
+    it "gets resource_id for current resource" do
+      _(resource.resource_id).must_equal "database.xml"
+    end
 
     it "checks if a node is string-like" do
       _(resource.send('concat(string(/beans/bean/@lazy-init)," <--")')).must_equal ["true <--"]

--- a/test/unit/resources/yaml_test.rb
+++ b/test/unit/resources/yaml_test.rb
@@ -6,6 +6,10 @@ describe "Inspec::Resources::YAML" do
   describe "when loading a valid yaml" do
     let(:resource) { load_resource("yaml", "kitchen.yml") }
 
+    it "gets resource_id for the current resource" do
+      _(resource.resource_id).must_equal "kitchen.yml"
+    end
+
     it "gets params as a hashmap" do
       _(resource.params).must_be_kind_of Hash
     end


### PR DESCRIPTION
✅ Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Description
**CFINSPEC-266: resource_ids group 5**
This PR adds resource_id methods to the following resources:

- iis_site
- iis_website (Child class of iis_site and is deprecated)
- inetd_conf
- ini
- interface
- ip6tables
- ipfilter
- ipnat
- iptables
- json
- xml
- yaml

When a user runs inspec exec [profile] --reporter json
then when they look at the resource_id field for the core controls
then they would be able to see an identifier for each control

## Related Issue
**CFINSPEC-266: resource_ids group 5**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
