### PR TITLE
CFINSPEC-268 Adds resource_id group 7

### DIFF
--- a/lib/inspec/resources/ibmdb2_conf.rb
+++ b/lib/inspec/resources/ibmdb2_conf.rb
@@ -24,6 +24,14 @@ module Inspec::Resources
       @output = run_command
     end
 
+    def resource_id
+      if inspec.os.platform?("windows")
+        "ibmdb2_conf"
+      else
+        "ibmdb2_conf:DatabaseInstance:#{@db_instance}"
+      end
+    end
+
     def to_s
       "IBM Db2 Conf"
     end

--- a/lib/inspec/resources/ibmdb2_session.rb
+++ b/lib/inspec/resources/ibmdb2_session.rb
@@ -63,6 +63,14 @@ module Inspec::Resources
       end
     end
 
+    def resource_id
+      if inspec.os.platform?("windows")
+        "ibmdb2_session:DatabaseName#{@db_name}"
+      else
+        "ibmdb2_session:DatabaseInstance:#{@db_instance}:DatabaseName#{@db_name}"
+      end
+    end
+
     def to_s
       "IBM Db2 Session"
     end

--- a/lib/inspec/resources/mongodb_conf.rb
+++ b/lib/inspec/resources/mongodb_conf.rb
@@ -24,6 +24,10 @@ module Inspec::Resources
       super(@conf_path)
     end
 
+    def resource_id
+      @conf_path
+    end
+
     private
 
     def parse(content)

--- a/lib/inspec/resources/mongodb_conf.rb
+++ b/lib/inspec/resources/mongodb_conf.rb
@@ -24,8 +24,9 @@ module Inspec::Resources
       super(@conf_path)
     end
 
+    # set resource_id to "" if system is not able to determine the @conf_path
     def resource_id
-      @conf_path
+      @conf_path || "mongodb_conf"
     end
 
     private

--- a/lib/inspec/resources/mongodb_session.rb
+++ b/lib/inspec/resources/mongodb_session.rb
@@ -63,6 +63,10 @@ module Inspec::Resources
       raise Inspec::Exceptions::ResourceFailed, "Can't run MongoDB command Error: #{e.message}"
     end
 
+    def resource_id
+      "mongodb_session:User:#{@user}:Host:#{@host}:Database:#{@database}"
+    end
+
     private
 
     def create_session

--- a/lib/inspec/resources/mount.rb
+++ b/lib/inspec/resources/mount.rb
@@ -52,7 +52,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      "mount: #{@path}"
+      @path || "mount"
     end
 
     def to_s

--- a/lib/inspec/resources/mount.rb
+++ b/lib/inspec/resources/mount.rb
@@ -51,6 +51,10 @@ module Inspec::Resources
       @mount_options[name]
     end
 
+    def resource_id
+      "mount: #{@path}"
+    end
+
     def to_s
       "Mount #{@path}"
     end

--- a/lib/inspec/resources/mssql_session.rb
+++ b/lib/inspec/resources/mssql_session.rb
@@ -80,6 +80,10 @@ module Inspec::Resources
       end
     end
 
+    def resource_id
+      "mssql_session:User:#{@user}:Host:#{@host}:Database:#{@db_name}:Instance:#{@instance}"
+    end
+
     def to_s
       "MSSQL session"
     end

--- a/lib/inspec/resources/mysql_conf.rb
+++ b/lib/inspec/resources/mysql_conf.rb
@@ -122,7 +122,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      "mysql_conf: #{@conf_path}"
+      @conf_path || "mysql_conf"
     end
 
     def to_s

--- a/lib/inspec/resources/mysql_conf.rb
+++ b/lib/inspec/resources/mysql_conf.rb
@@ -121,6 +121,10 @@ module Inspec::Resources
       @files_contents[path] ||= read_file_content(path)
     end
 
+    def resource_id
+      "mysql_conf: #{@conf_path}"
+    end
+
     def to_s
       "MySQL Configuration"
     end

--- a/lib/inspec/resources/mysql_session.rb
+++ b/lib/inspec/resources/mysql_session.rb
@@ -43,6 +43,7 @@ module Inspec::Resources
       @host = host
       @port = port
       @socket = socket
+      @db = nil
       init_fallback if user.nil? || pass.nil?
       raise Inspec::Exceptions::ResourceFailed, "Can't run MySQL SQL checks without authentication." if @user.nil? || @pass.nil?
 
@@ -52,7 +53,9 @@ module Inspec::Resources
     def query(q, db = "")
       raise Inspec::Exceptions::ResourceFailed, "#{resource_exception_message}" if resource_failed?
 
-      mysql_cmd = create_mysql_cmd(q, db)
+      @db = db
+      mysql_cmd = create_mysql_cmd(q, @db)
+
       cmd = if !@pass.nil?
               inspec.command(mysql_cmd, redact_regex: /(mysql -u\w+ -p).+(\s-(h|S).*)/)
             else
@@ -64,6 +67,10 @@ module Inspec::Resources
       else
         Lines.new(cmd.stdout.strip, "MySQL query: #{q}", cmd.exit_status)
       end
+    end
+
+    def resource_id
+      "mysql_session:User:#{@user}:Host:#{@host}:Database:#{@db}"
     end
 
     def to_s

--- a/lib/inspec/resources/nginx.rb
+++ b/lib/inspec/resources/nginx.rb
@@ -18,12 +18,13 @@ module Inspec::Resources
         its('modules') { should include 'my_module' }
       end
     EXAMPLE
-    attr_reader :params, :bin_dir
+    attr_reader :params, :bin_dir, :nginx_path
 
     def initialize(nginx_path = "/usr/sbin/nginx")
       return skip_resource "The `nginx` resource is not yet available on your OS." if inspec.os.windows?
       return skip_resource "The `nginx` binary not found in the path provided." unless inspec.command(nginx_path).exist?
 
+      @nginx_path = nginx_path
       cmd = inspec.command("#{nginx_path} -V 2>&1")
       if cmd.exit_status != 0
         return skip_resource "Error using the command nginx -V"
@@ -57,6 +58,10 @@ module Inspec::Resources
 
     def modules
       @data.scan(/--with-(\S+)_module/).flatten
+    end
+
+    def resource_id
+      nginx_path || "nginx"
     end
 
     def to_s

--- a/lib/inspec/resources/nginx_conf.rb
+++ b/lib/inspec/resources/nginx_conf.rb
@@ -50,6 +50,10 @@ module Inspec::Resources
 
     def_delegators :http, :servers, :locations
 
+    def resource_id
+      @conf_path || "nginx_conf"
+    end
+
     def to_s
       "nginx_conf #{@conf_path}"
     end

--- a/lib/inspec/resources/noop.rb
+++ b/lib/inspec/resources/noop.rb
@@ -2,6 +2,10 @@ module Inspec::Resources
   class Noop < Inspec.resource(1)
     name "noop"
 
+    def resource_id
+      "No-op"
+    end
+
     def to_s
       "No-op"
     end

--- a/test/unit/resources/ibmdb2_conf_test.rb
+++ b/test/unit/resources/ibmdb2_conf_test.rb
@@ -3,6 +3,11 @@ require "inspec/resource"
 require "inspec/resources/ibmdb2_conf"
 
 describe "Inspec::Resources::ibmdb2_conf" do
+  it "generates the resource_id for the current resource" do
+    resource = load_resource("ibmdb2_conf", db_instance: "db2inst1")
+    _(resource.resource_id).must_equal "ibmdb2_conf:DatabaseInstance:db2inst1"
+  end
+
   it "fails when no IBM db2 executable path is provided" do
     resource = load_resource("ibmdb2_conf", db_instance: "db2inst1")
     _(resource.resource_failed?).must_equal true
@@ -17,6 +22,7 @@ describe "Inspec::Resources::ibmdb2_conf" do
 
   it "verify ibmdb2_conf on windows" do
     resource = MockLoader.new(:windows).load_resource("ibmdb2_conf")
+    _(resource.resource_id).must_equal "ibmdb2_conf"
     _(resource.resource_failed?).must_equal false
     _(resource.output).must_be_kind_of Array
   end

--- a/test/unit/resources/ibmdb2_session_test.rb
+++ b/test/unit/resources/ibmdb2_session_test.rb
@@ -3,6 +3,16 @@ require "inspec/resource"
 require "inspec/resources/ibmdb2_session"
 
 describe "Inspec::Resources::ibmdb2_session" do
+  it "generates the resource_id for the current resource" do
+    resource = load_resource("ibmdb2_session", db_instance: "db2inst1", db_name: "sample")
+    _(resource.resource_id).must_equal "ibmdb2_session:DatabaseInstance:db2inst1:DatabaseNamesample"
+  end
+
+  it "generates the resource_id for the current resource when on Windows" do
+    resource = MockLoader.new(:windows).load_resource("ibmdb2_session", db_name: "sample")
+    _(resource.resource_id).must_equal "ibmdb2_session:DatabaseNamesample"
+  end
+
   it "fails when no IBM db2 instance name is provided" do
     resource = load_resource("ibmdb2_session", db_instance: "db2inst1", db_name: "sample")
     _(resource.resource_failed?).must_equal true

--- a/test/unit/resources/mongodb_conf_test.rb
+++ b/test/unit/resources/mongodb_conf_test.rb
@@ -5,6 +5,7 @@ require "inspec/resources/mongodb_conf"
 describe "Inspec::Resources::MongodbConf" do
   it "verify mongd.conf config parsing" do
     resource = load_resource("mongodb_conf", "/etc/mongod.conf")
+    _(resource.resource_id).must_equal "/etc/mongod.conf"
     _(resource.params["storage"]["dbPath"]).must_equal "/var/lib/mongodb"
     _(resource.params["systemLog"]["path"]).must_equal "/var/log/mongodb/mongod.log"
     _(resource.params["net"]["port"]).must_equal 27017

--- a/test/unit/resources/mongodb_session_test.rb
+++ b/test/unit/resources/mongodb_session_test.rb
@@ -5,12 +5,14 @@ require "inspec/resources/mongodb_session"
 describe "Inspec::Resources::MongodbSession" do
   it "fails when no user, password" do
     resource = load_resource("mongodb_session", host: "localhost", port: 27017, database: "test")
+    _(resource.resource_id).must_equal("mongodb_session:User::Host:localhost:Database:test")
     _(resource.resource_failed?).must_equal true
     _(resource.resource_exception_message).must_equal "Can't run MongoDB command. Error: Can't run MongoDB checks without authentication."
   end
 
   it "fails when no database name is provided" do
     resource = load_resource("mongodb_session", user: "foo", password: "bar", host: "localhost", port: 27017)
+    _(resource.resource_id).must_equal("mongodb_session:User:foo:Host:localhost:Database:")
     _(resource.resource_failed?).must_equal true
     _(resource.resource_exception_message).must_equal "Can't run MongoDB command. Error: You must provide a database name for the session."
   end

--- a/test/unit/resources/mount_test.rb
+++ b/test/unit/resources/mount_test.rb
@@ -6,8 +6,11 @@ require "inspec/resources/mount"
 describe Inspec::Resources::FileResource do
   let(:root_resource) { load_resource("mount", "/") }
 
+  it "generates the resource_id for current resource" do
+    _(root_resource.resource_id).must_equal "/"
+  end
+
   it "parses the mount data properly" do
-    _(root_resource.resource_id).must_equal "mount: /"
     _(root_resource.send(:device)).must_equal("/dev/xvda1")
     _(root_resource.send(:type)).must_equal("ext4")
     _(root_resource.send(:options)).must_equal(%w{rw discard})
@@ -16,8 +19,11 @@ describe Inspec::Resources::FileResource do
 
   let(:iso_resource) { load_resource("mount", "/mnt/iso-disk") }
 
+  it "generates resource_id for current resource" do
+    _(iso_resource.resource_id).must_equal "/mnt/iso-disk"
+  end
+
   it "parses the mount data properly" do
-    _(iso_resource.resource_id).must_equal "mount: /mnt/iso-disk"
     _(iso_resource.send(:device)).must_equal("/root/alpine-3.3.0-x86_64_2.iso")
     _(iso_resource.send(:type)).must_equal("iso9660")
     _(iso_resource.send(:options)).must_equal(["ro"])

--- a/test/unit/resources/mount_test.rb
+++ b/test/unit/resources/mount_test.rb
@@ -7,6 +7,7 @@ describe Inspec::Resources::FileResource do
   let(:root_resource) { load_resource("mount", "/") }
 
   it "parses the mount data properly" do
+    _(root_resource.resource_id).must_equal "mount: /"
     _(root_resource.send(:device)).must_equal("/dev/xvda1")
     _(root_resource.send(:type)).must_equal("ext4")
     _(root_resource.send(:options)).must_equal(%w{rw discard})
@@ -16,6 +17,7 @@ describe Inspec::Resources::FileResource do
   let(:iso_resource) { load_resource("mount", "/mnt/iso-disk") }
 
   it "parses the mount data properly" do
+    _(iso_resource.resource_id).must_equal "mount: /mnt/iso-disk"
     _(iso_resource.send(:device)).must_equal("/root/alpine-3.3.0-x86_64_2.iso")
     _(iso_resource.send(:type)).must_equal("iso9660")
     _(iso_resource.send(:options)).must_equal(["ro"])

--- a/test/unit/resources/mssql_session_test.rb
+++ b/test/unit/resources/mssql_session_test.rb
@@ -5,6 +5,7 @@ require "inspec/resources/mssql_session"
 describe "Inspec::Resources::MssqlSession" do
   it "verify default mssql_session configuration" do
     resource = load_resource("mssql_session", user: "sa", password: "yourStrong(!)Password")
+    _(resource.resource_id).must_equal "mssql_session:User:sa:Host:localhost:Database::Instance:"
     _(resource.user).must_equal "sa"
     _(resource.password).must_equal "yourStrong(!)Password"
     _(resource.host).must_equal "localhost"
@@ -27,6 +28,7 @@ describe "Inspec::Resources::MssqlSession" do
 
   it "verify mssql_session configuration with custom instance and port" do
     resource = load_resource("mssql_session", user: "sa", password: "yourStrong(!)Password", instance: "SQL2012INSPEC", port: "1691")
+    _(resource.resource_id).must_equal "mssql_session:User:sa:Host:localhost:Database::Instance:SQL2012INSPEC"
     _(resource.user).must_equal "sa"
     _(resource.password).must_equal "yourStrong(!)Password"
     _(resource.host).must_equal "localhost"

--- a/test/unit/resources/mysql_conf_test.rb
+++ b/test/unit/resources/mysql_conf_test.rb
@@ -5,6 +5,7 @@ require "inspec/resources/mysql_conf"
 describe "Inspec::Resources::MysqlConf" do
   it "verify mysql.conf config parsing" do
     resource = load_resource("mysql_conf", "/etc/mysql/my.cnf")
+    _(resource.resource_id).must_equal "mysql_conf: /etc/mysql/my.cnf"
     _(resource.client["port"]).must_equal "3306"
     _(resource.mysqld["user"]).must_equal "mysql"
     _(resource.mysqld["key_buffer_size"]).must_equal "16M"

--- a/test/unit/resources/mysql_conf_test.rb
+++ b/test/unit/resources/mysql_conf_test.rb
@@ -3,9 +3,13 @@ require "inspec/resource"
 require "inspec/resources/mysql_conf"
 
 describe "Inspec::Resources::MysqlConf" do
+  it "generates the resource_id for current resource" do
+    resource = load_resource("mysql_conf", "/etc/mysql/my.cnf")
+    _(resource.resource_id).must_equal "/etc/mysql/my.cnf"
+  end
+
   it "verify mysql.conf config parsing" do
     resource = load_resource("mysql_conf", "/etc/mysql/my.cnf")
-    _(resource.resource_id).must_equal "mysql_conf: /etc/mysql/my.cnf"
     _(resource.client["port"]).must_equal "3306"
     _(resource.mysqld["user"]).must_equal "mysql"
     _(resource.mysqld["key_buffer_size"]).must_equal "16M"

--- a/test/unit/resources/mysql_session_test.rb
+++ b/test/unit/resources/mysql_session_test.rb
@@ -11,12 +11,14 @@ describe "Inspec::Resources::MysqlSession" do
 
     _(resource.send(:create_mysql_cmd, "SELECT 1 FROM DUAL;"))
       .must_equal(%q{mysql -uroot -p\'\%\"\'\"\&\^\*\&\(\)\'\*\% -h localhost -s -e "SELECT 1 FROM DUAL;"})
+    _(resource.resource_id).must_equal("mysql_session:User:root:Host:localhost:Database:")
   end
   it "verify mysql_session omits optional username and password" do
     resource = load_resource("mysql_session")
 
     _(resource.send(:create_mysql_cmd, "SELECT 1 FROM DUAL;"))
       .must_equal('mysql -h localhost -s -e "SELECT 1 FROM DUAL;"')
+    _(resource.resource_id).must_equal("mysql_session:User::Host:localhost:Database:")
   end
   it "verify mysql_session redacts output" do
     cmd = %q{mysql -uroot -p\'\%\"\'\"\&\^\*\&\(\)\'\*\% -h localhost -s -e "SELECT 1 FROM DUAL;"}

--- a/test/unit/resources/nginx_conf_test.rb
+++ b/test/unit/resources/nginx_conf_test.rb
@@ -9,6 +9,10 @@ describe "Inspec::Resources::NginxConf" do
 
   let(:nginx_conf) { MockLoader.new(:ubuntu).load_resource("nginx_conf") }
 
+  it "generates the resource_id for the current resource" do
+    _(nginx_conf.resource_id).must_equal "/etc/nginx/nginx.conf"
+  end
+
   it "doesnt fail with a missing file" do
     # This path is not mocked because we cannot mock File.exist?
     # ...As far as I know

--- a/test/unit/resources/nginx_test.rb
+++ b/test/unit/resources/nginx_test.rb
@@ -87,5 +87,9 @@ describe "Inspec::Resources::Nginx" do
       resource = load_resource("nginx")
       _(resource.http_scgi_temp_path).must_match "/var/cache/nginx/scgi_temp"
     end
+    it "generates resource_id for the current_resource" do
+      resource = load_resource("nginx")
+      _(resource.resource_id).must_equal "/usr/sbin/nginx"
+    end
   end
 end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This adds resource_id to the following resources.
* ibmdb2_conf
* ibmdb2_session
* mongodb_conf
* mongodb_session
* mount
* mssql_session
* mysql_conf 
* nginx
* nginx_conf
* noop

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
