### PR TITLE
CFINSPEC-274: resource_ids group 13

### DIFF
--- a/lib/inspec/resources/wmi.rb
+++ b/lib/inspec/resources/wmi.rb
@@ -95,6 +95,10 @@ module Inspec::Resources
       @content
     end
 
+    def resource_id
+      @options[:class] || "WMI"
+    end
+
     def to_s
       "WMI with #{@options}"
     end

--- a/lib/inspec/resources/x509_certificate.rb
+++ b/lib/inspec/resources/x509_certificate.rb
@@ -185,6 +185,10 @@ module Inspec::Resources
       extensions["subjectAltName"]
     end
 
+    def resource_id
+      @opts[:filepath] || subject.CN
+    end
+
     def to_s
       cert = @opts[:filepath]
       cert ||= subject.CN

--- a/lib/inspec/resources/x509_certificate.rb
+++ b/lib/inspec/resources/x509_certificate.rb
@@ -186,7 +186,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      @opts[:filepath] || subject.CN
+      @opts[:filepath] || subject.CN || "x509 Certificate"
     end
 
     def to_s

--- a/lib/inspec/resources/yum.rb
+++ b/lib/inspec/resources/yum.rb
@@ -89,6 +89,10 @@ module Inspec::Resources
       repo(name.to_s) unless name.nil?
     end
 
+    def resource_id
+      "Yum repository"
+    end
+
     def to_s
       "Yum Repository"
     end

--- a/lib/inspec/resources/zfs_dataset.rb
+++ b/lib/inspec/resources/zfs_dataset.rb
@@ -39,7 +39,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      @zfs_dataset
+      @zfs_dataset || "ZFS Dataset"
     end
 
     def to_s

--- a/lib/inspec/resources/zfs_dataset.rb
+++ b/lib/inspec/resources/zfs_dataset.rb
@@ -38,6 +38,10 @@ module Inspec::Resources
       inspec.mount(@params["mountpoint"]).mounted?
     end
 
+    def resource_id
+      @zfs_dataset
+    end
+
     def to_s
       "ZFS Dataset #{@zfs_dataset}"
     end

--- a/lib/inspec/resources/zfs_pool.rb
+++ b/lib/inspec/resources/zfs_pool.rb
@@ -32,7 +32,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      @zfs_pool
+      @zfs_pool || "ZFS Pool"
     end
 
     def to_s

--- a/lib/inspec/resources/zfs_pool.rb
+++ b/lib/inspec/resources/zfs_pool.rb
@@ -31,6 +31,10 @@ module Inspec::Resources
       inspec.command("#{@zpool_cmd} get -Hp all #{@zfs_pool}").exit_status == 0
     end
 
+    def resource_id
+      @zfs_pool
+    end
+
     def to_s
       "ZFS Pool #{@zfs_pool}"
     end

--- a/test/unit/resources/wmi_test.rb
+++ b/test/unit/resources/wmi_test.rb
@@ -17,6 +17,7 @@ describe "Inspec::Resources::WMI" do
   it "verify wmi parsing on windows" do
     resource = MockLoader.new(:windows).load_resource("wmi", { class: "win32_service", filter: "name like '%winrm%'" })
     _(resource.send("DisplayName")).must_equal "Windows Remote Management (WS-Management)"
+    _(resource.resource_id).must_equal "win32_service"
   end
 
   # ubuntu
@@ -25,5 +26,6 @@ describe "Inspec::Resources::WMI" do
     _(resource.resource_failed?).must_equal true
     _(resource.resource_exception_message)
       .must_equal "Resource `wmi` is not supported on platform ubuntu/20.04."
+    _(resource.resource_id).must_equal "win32_service"
   end
 end

--- a/test/unit/resources/x509_certificate_test.rb
+++ b/test/unit/resources/x509_certificate_test.rb
@@ -112,4 +112,10 @@ describe "Inspec::Resources::X509Certificate" do
     _(resource.has_purpose?("SSL server CA : Yes")).must_equal true
     _(resource.has_purpose?("SSL client CA : Yes")).must_equal true
   end
+
+  it "checks for resource_id for current resource" do
+    _(resource_cert.resource_id).must_equal "test_certificate.rsa.crt.pem"
+    _(resource_cert_with_content.resource_id).must_equal "Inspec Test Certificate"
+    _(resource_cert_with_filepath.resource_id).must_equal "test_certificate.rsa.crt.pem"
+  end
 end

--- a/test/unit/resources/yum_test.rb
+++ b/test/unit/resources/yum_test.rb
@@ -165,4 +165,9 @@ describe "Inspec::Resources::YumRepo" do
     _(repo.status).must_equal "enabled"
     _(repo.updated).must_equal "Fri 20 Sep 2019 10:05:43 PM UTC"
   end
+
+  it "checks for resource_id for the current resource" do
+    resource = centos7
+    _(resource.resource_id).must_equal "Yum repository"
+  end
 end

--- a/test/unit/resources/zfs_dataset_test.rb
+++ b/test/unit/resources/zfs_dataset_test.rb
@@ -12,6 +12,7 @@ describe Inspec::Resources::ZfsDataset do
       _(tank_tmp_resource.send(:type)).must_equal("filesystem")
       _(tank_tmp_resource.send(:exec)).must_equal("off")
       _(tank_tmp_resource.send(:setuid)).must_equal("off")
+      _(tank_tmp_resource.resource_id).must_equal "tank/tmp"
     end
   end
 end
@@ -26,6 +27,7 @@ describe Inspec::Resources::ZfsDataset do
       _(tank_tmp_resource.send(:type)).must_equal("filesystem")
       _(tank_tmp_resource.send(:exec)).must_equal("off")
       _(tank_tmp_resource.send(:setuid)).must_equal("off")
+      _(tank_tmp_resource.resource_id).must_equal "tank/tmp"
     end
   end
 end
@@ -45,6 +47,7 @@ describe Inspec::Resources::ZfsDataset do
   it "parses the ZFS dataset properly" do
     resource = MockLoader.new(:macos10_16).load_resource("zfs_dataset", "tank")
     _(resource.resource_exception_message).must_equal "zfs is not installed"
+    _(resource.resource_id).must_equal "tank"
   end
 end
 

--- a/test/unit/resources/zfs_pool_test.rb
+++ b/test/unit/resources/zfs_pool_test.rb
@@ -12,6 +12,7 @@ describe Inspec::Resources::ZfsPool do
       _(tank_resource.send(:guid)).must_equal("4711279777582057513")
       _(tank_resource.send(:failmode)).must_equal("continue")
       _(tank_resource.send(:'feature@lz4_compress')).must_equal("active")
+      _(tank_resource.resource_id).must_equal "tank"
     end
   end
 end
@@ -26,6 +27,7 @@ describe Inspec::Resources::ZfsPool do
       _(tank_resource.send(:guid)).must_equal("4711279777582057513")
       _(tank_resource.send(:failmode)).must_equal("continue")
       _(tank_resource.send(:'feature@lz4_compress')).must_equal("active")
+      _(tank_resource.resource_id).must_equal "tank"
     end
   end
 end
@@ -37,6 +39,7 @@ describe Inspec::Resources::ZfsPool do
   it "parses the ZFS pool data properly" do
     if _(tank_resource)
       _(tank_resource.resource_exception_message).must_equal("zfs is not installed")
+      _(tank_resource.resource_id).must_equal "tank"
     end
   end
 end
@@ -45,5 +48,6 @@ describe Inspec::Resources::ZfsPool do
   it "parses the ZFS pool data properly" do
     resource = MockLoader.new(:macos10_16).load_resource("zfs_pool", "tank")
     _(resource.resource_exception_message).must_equal "zfs is not installed"
+    _(resource.resource_id).must_equal "tank"
   end
 end


### PR DESCRIPTION
✅ Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Description
**CFINSPEC-274: resource_ids group 13**
This PR adds resource_id methods to the following resources:

- wmi
- x509_certificate
- yum
- zfs_dataset
- zfs_pool



When a user runs inspec exec [profile] --reporter json
then when they look at the resource_id field for the core controls
then they would be able to see an identifier for each control

## Related Issue
**CFINSPEC-274: resource_ids group 13**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
