### PR TITLE
CFINSPEC-264 Group 3 - Added resource_id in resources

### DIFF
--- a/lib/inspec/resources/docker_container.rb
+++ b/lib/inspec/resources/docker_container.rb
@@ -92,6 +92,10 @@ module Inspec::Resources
       "Docker Container #{name}"
     end
 
+    def resource_id
+      object_info.ids[0] || @opts[:id] || ""
+    end
+
     private
 
     def object_info

--- a/lib/inspec/resources/docker_container.rb
+++ b/lib/inspec/resources/docker_container.rb
@@ -93,7 +93,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      object_info.ids[0] || @opts[:id] || ""
+      object_info.ids[0] || @opts[:id] || @opts[:name] || ""
     end
 
     private

--- a/lib/inspec/resources/docker_image.rb
+++ b/lib/inspec/resources/docker_image.rb
@@ -73,7 +73,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      object_info.ids[0] || @opts[:id] || ""
+      object_info.ids[0] || @opts[:id] || @opts[:image] || ""
     end
 
     private

--- a/lib/inspec/resources/docker_image.rb
+++ b/lib/inspec/resources/docker_image.rb
@@ -72,6 +72,10 @@ module Inspec::Resources
       "Docker Image #{img}"
     end
 
+    def resource_id
+      object_info.ids[0] || @opts[:id] || ""
+    end
+
     private
 
     def sanitize_options(opts)

--- a/lib/inspec/resources/docker_plugin.rb
+++ b/lib/inspec/resources/docker_plugin.rb
@@ -51,7 +51,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      id || @opts[:id] || ""
+      id || @opts[:id] || @opts[:name] || ""
     end
 
     private

--- a/lib/inspec/resources/docker_plugin.rb
+++ b/lib/inspec/resources/docker_plugin.rb
@@ -50,6 +50,10 @@ module Inspec::Resources
       "Docker plugin #{plugin}"
     end
 
+    def resource_id
+      id || @opts[:id] || ""
+    end
+
     private
 
     def object_info

--- a/lib/inspec/resources/docker_service.rb
+++ b/lib/inspec/resources/docker_service.rb
@@ -74,7 +74,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      object_info.ids[0] || @opts[:id] || ""
+      object_info.ids[0] || @opts[:id] || @opts[:name] || ""
     end
 
     private

--- a/lib/inspec/resources/docker_service.rb
+++ b/lib/inspec/resources/docker_service.rb
@@ -73,6 +73,10 @@ module Inspec::Resources
       "Docker Service #{service}"
     end
 
+    def resource_id
+      object_info.ids[0] || @opts[:id] || ""
+    end
+
     private
 
     def sanitize_options(opts)

--- a/lib/inspec/resources/etc_group.rb
+++ b/lib/inspec/resources/etc_group.rb
@@ -95,6 +95,10 @@ module Inspec::Resources
       "/etc/group"
     end
 
+    def resource_id
+      @path
+    end
+
     private
 
     def parse_group(path)

--- a/lib/inspec/resources/etc_hosts_allow_deny.rb
+++ b/lib/inspec/resources/etc_hosts_allow_deny.rb
@@ -37,6 +37,10 @@ module Inspec::Resources
       "hosts.allow Configuration"
     end
 
+    def resource_id
+      @conf_path
+    end
+
     private
 
     def read_content
@@ -110,5 +114,6 @@ module Inspec::Resources
     def to_s
       "hosts.deny Configuration"
     end
+
   end
 end

--- a/lib/inspec/resources/file.rb
+++ b/lib/inspec/resources/file.rb
@@ -35,11 +35,12 @@ module Inspec::Resources
       end
     EXAMPLE
 
-    attr_reader :file, :mount_options
+    attr_reader :file, :mount_options, :path
     def initialize(path)
       # select permissions style
       @perms_provider = select_file_perms_style(inspec.os)
       @file = inspec.backend.file(path)
+      @path = path
     end
 
     %w{
@@ -215,6 +216,10 @@ module Inspec::Resources
       else
         "Bad File on %s" % [inspec.backend.class]
       end
+    end
+
+    def resource_id
+      path
     end
 
     private

--- a/test/unit/resources/docker_container_test.rb
+++ b/test/unit/resources/docker_container_test.rb
@@ -12,6 +12,7 @@ describe "Inspec::Resources::DockerContainer" do
       _(resource.tag).must_be_nil
       _(resource.command).must_equal "/bin/sh"
       _(resource.ports).must_equal ""
+      _(resource.resource_id).must_equal "d94f854370d2b02912e8fc636502bc72b74fbd567a7eba3fc6a52045bb28904e"
     end
 
     it "check container parsing for alpine" do
@@ -23,6 +24,7 @@ describe "Inspec::Resources::DockerContainer" do
       _(resource.command).must_equal "/bin/bash"
       _(resource.ports).must_equal ""
       _(resource.labels).must_equal ["app=example", "version=1.5.4"]
+      _(resource.resource_id).must_equal "3def9aa450f8bd772c3d5b07e27ec934e5f58575e955367a0aca2d93e0687536"
     end
 
     it "returns an empty array when parsing a container with no labels specified" do

--- a/test/unit/resources/docker_image_test.rb
+++ b/test/unit/resources/docker_image_test.rb
@@ -20,7 +20,7 @@ describe "Inspec::Resources::DockerImage" do
       _(resource["Config.Cmd"]).must_include "bash"
       _(resource.inspection).must_include "Architecture"
       _(resource.inspection.Architecture).must_equal "arm64"
-      _(resource.resource_id).must_equal ""
+      _(resource.resource_id).must_equal "ubuntu:latest"
     end
 
     # Test case for inspect image information with invalid keys

--- a/test/unit/resources/docker_image_test.rb
+++ b/test/unit/resources/docker_image_test.rb
@@ -10,6 +10,7 @@ describe "Inspec::Resources::DockerImage" do
       _(resource.tag).must_equal "latest"
       _(resource.image).must_equal "alpine:latest"
       _(resource.repo).must_equal "alpine"
+      _(resource.resource_id).must_equal "sha256:4a415e3663882fbc554ee830889c68a33b3585503892cc718a4698e91ef2a526"
     end
 
     # Test case for inspect image information handled by inspection and method_missing
@@ -19,6 +20,7 @@ describe "Inspec::Resources::DockerImage" do
       _(resource["Config.Cmd"]).must_include "bash"
       _(resource.inspection).must_include "Architecture"
       _(resource.inspection.Architecture).must_equal "arm64"
+      _(resource.resource_id).must_equal ""
     end
 
     # Test case for inspect image information with invalid keys

--- a/test/unit/resources/docker_plugin_test.rb
+++ b/test/unit/resources/docker_plugin_test.rb
@@ -10,6 +10,7 @@ describe "Inspec::Resources::DockerContainer" do
       _(resource.version).must_equal "18.03.1-ce-aws1"
       _(resource.enabled?).must_equal false
       _(resource.exist?).must_equal true
+      _(resource.resource_id).must_equal "771d3ee7c7ea"
     end
 
     it "check plugin parsing for store/weaveworks/net-plugin" do
@@ -18,6 +19,7 @@ describe "Inspec::Resources::DockerContainer" do
       _(resource.version).must_equal "2.3.0"
       _(resource.enabled?).must_equal true
       _(resource.exist?).must_equal true
+      _(resource.resource_id).must_equal "6ea8176de74b"
     end
 
     it "check plugin parsing when there are no plugins" do
@@ -26,6 +28,7 @@ describe "Inspec::Resources::DockerContainer" do
       assert_nil resource.version
       assert_nil resource.id
       assert_nil resource.enabled?
+      _(resource.resource_id).must_equal ""
       _(resource.exist?).must_equal false
     end
 

--- a/test/unit/resources/docker_service_test.rb
+++ b/test/unit/resources/docker_service_test.rb
@@ -14,6 +14,7 @@ describe "Inspec::Resources::DockerService" do
       _(resource.replicas).must_equal "3/3"
       _(resource.mode).must_equal "replicated"
       _(resource.ports).must_equal "*:1234->1234/tcp"
+      _(resource.resource_id).must_equal "2ghswegspre1"
     end
 
     it "check docker service from id" do
@@ -26,6 +27,7 @@ describe "Inspec::Resources::DockerService" do
       _(resource.replicas).must_equal "3/3"
       _(resource.mode).must_equal "replicated"
       _(resource.ports).must_equal "*:1234->1234/tcp"
+      _(resource.resource_id).must_equal "2ghswegspre1"
     end
 
     it "check docker service from image" do
@@ -38,6 +40,7 @@ describe "Inspec::Resources::DockerService" do
       _(resource.replicas).must_equal "3/3"
       _(resource.mode).must_equal "replicated"
       _(resource.ports).must_equal "*:1234->1234/tcp"
+      _(resource.resource_id).must_equal "2ghswegspre1"
     end
 
     it "prints as a docker_image resource" do

--- a/test/unit/resources/etc_group_test.rb
+++ b/test/unit/resources/etc_group_test.rb
@@ -9,6 +9,7 @@ describe "Inspec::Resources::EtcGroup" do
     _(resource.gids).must_equal [0, 33, 999, 1000]
     _(resource.groups).must_equal %w{ root www-data GroupWithCaps sftpusers }
     _(resource.users).must_equal %w{ www-data root sftponly }
+    _(resource.resource_id).must_equal "/etc/group"
   end
 
   it "verify group filter with no users" do

--- a/test/unit/resources/etc_hosts_allow_deny_test.rb
+++ b/test/unit/resources/etc_hosts_allow_deny_test.rb
@@ -23,6 +23,9 @@ describe "Inspec::Resources::EtcHostsAllow" do
     it "has a to_s" do
       _(resource.to_s).must_equal "hosts.allow Configuration"
     end
+    it "has a resource_id" do
+      _(resource.resource_id).must_equal "/etc/hosts.allow"
+    end
   end
 
   describe "#parse_line" do
@@ -72,6 +75,9 @@ describe "Inspec::Resources::EtcHostsDeny" do
     end
     it "has a to_s" do
       _(resource.to_s).must_equal "hosts.deny Configuration"
+    end
+    it "has a resource_id" do
+      _(resource.resource_id).must_equal "/etc/hosts.deny"
     end
   end
 end

--- a/test/unit/resources/file_test.rb
+++ b/test/unit/resources/file_test.rb
@@ -10,6 +10,7 @@ describe Inspec::Resources::FileResource do
     resource.stubs(:exist?).returns(true)
     resource.stubs(:mounted?).returns(true)
     resource.stubs(:source_path).returns("/fakepath/fakefile")
+    resource.stubs(:path).returns("/fakepath/fakefile")
     resource.stubs(:file).returns(file)
     resource.stubs(:content).returns("content")
     resource.stubs(:mode).returns(000)
@@ -34,6 +35,7 @@ describe Inspec::Resources::FileResource do
     _(resource.suid).must_equal true
     _(resource.sgid).must_equal true
     _(resource.sticky).must_equal true
+    _(resource.resource_id).must_equal "/fakepath/fakefile"
     _(proc { resource.send(:more_permissive_than?, nil) }).must_raise(ArgumentError)
     _(proc { resource.send(:more_permissive_than?, 0700) }).must_raise(ArgumentError)
   end
@@ -43,6 +45,7 @@ describe Inspec::Resources::FileResource do
     resource.stubs(:exist?).returns(true)
     resource.stubs(:mounted?).returns(true)
     resource.stubs(:content).returns("content")
+    resource.stubs(:path).returns("C:/fakepath/fakefile")
     resource.stubs(:file_permission_granted?).with("read", "by_usergroup", "by_specific_user").returns("test_result")
     resource.stubs(:file_permission_granted?).with("write", "by_usergroup", "by_specific_user").returns("test_result")
     resource.stubs(:file_permission_granted?).with("execute", "by_usergroup", "by_specific_user").returns("test_result")
@@ -51,6 +54,7 @@ describe Inspec::Resources::FileResource do
     _(resource.content).must_equal "content"
     _(resource.exist?).must_equal true
     _(resource.mounted?).must_equal true
+    _(resource.resource_id).must_equal "C:/fakepath/fakefile"
     _(resource.readable?("by_usergroup", "by_specific_user")).must_equal "test_result"
     _(resource.allowed?("read", by: "by_usergroup", by_user: "by_specific_user")).must_equal "test_result"
     _(resource.writable?("by_usergroup", "by_specific_user")).must_equal "test_result"
@@ -117,6 +121,8 @@ describe Inspec::Resources::FileResource do
   it "when file does not exist" do
     resource = MockLoader.new(:ubuntu).load_resource("file", "file_does_not_exist")
     assert_nil(resource.send(:more_permissive_than?, nil))
+    resource.stubs(:path).returns("file_does_not_exist")
+    _(resource.resource_id).must_equal "file_does_not_exist"
   end
 end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added resource_id in following resources:

- directory
- docker_container
- docker_image
- docker_plugin
- docker_service
- etc_group
- etc_hosts_allow
- etc_hosts_deny
- file

On `bundle exec PROFILE --reporter json`, resource_id should contain a unique value for each initialization. It is loosely unique at this point.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
