### PR TITLE
CFINSPEC-265  Group 4 - Added resource_id in resources

### DIFF
--- a/lib/inspec/resources/filesystem.rb
+++ b/lib/inspec/resources/filesystem.rb
@@ -84,6 +84,10 @@ module Inspec::Resources
       info = @fsman.info(@partition)
       info[:name]
     end
+
+    def resource_id
+      partition
+    end
   end
 
   class FsManagement

--- a/lib/inspec/resources/gem.rb
+++ b/lib/inspec/resources/gem.rb
@@ -76,5 +76,9 @@ module Inspec::Resources
     def to_s
       "gem package #{@package_name}"
     end
+
+    def resource_id
+      "#{@package_name}-#{version}"
+    end
   end
 end

--- a/lib/inspec/resources/groups.rb
+++ b/lib/inspec/resources/groups.rb
@@ -154,6 +154,10 @@ module Inspec::Resources
       "Group #{@group}"
     end
 
+    def resource_id
+      gid ? "#{@group}-#{gid}" : ""
+    end
+
     private
 
     def flatten_entry(group_info, prop)

--- a/lib/inspec/resources/grub_conf.rb
+++ b/lib/inspec/resources/grub_conf.rb
@@ -69,6 +69,10 @@ module Inspec::Resources
       "Grub Config"
     end
 
+    def resource_id
+      @conf_path
+    end
+
     private
 
     ######################################################################

--- a/lib/inspec/resources/host.rb
+++ b/lib/inspec/resources/host.rb
@@ -130,6 +130,10 @@ module Inspec::Resources
       resource_name
     end
 
+    def resource_id
+      port ? "#{hostname}-#{port}-#{protocol}" : hostname
+    end
+
     private
 
     def ping

--- a/lib/inspec/resources/http.rb
+++ b/lib/inspec/resources/http.rb
@@ -83,6 +83,10 @@ module Inspec::Resources
           @response = nil
         end
 
+        def resource_id
+          @url
+        end
+
         private
 
         def params
@@ -124,10 +128,6 @@ module Inspec::Resources
 
         def proxy
           opts.fetch(:proxy, nil)
-        end
-
-        def resource_id
-          @url
         end
       end
 

--- a/lib/inspec/resources/http.rb
+++ b/lib/inspec/resources/http.rb
@@ -125,6 +125,10 @@ module Inspec::Resources
         def proxy
           opts.fetch(:proxy, nil)
         end
+
+        def resource_id
+          @url
+        end
       end
 
       class Local < Base

--- a/lib/inspec/resources/iis_app.rb
+++ b/lib/inspec/resources/iis_app.rb
@@ -72,6 +72,10 @@ module Inspec::Resources
       "iis_app '#{@site_name}#{@path}'"
     end
 
+    def resource_id
+      @path
+    end
+
     private
 
     def iis_app

--- a/lib/inspec/resources/iis_app_pool.rb
+++ b/lib/inspec/resources/iis_app_pool.rb
@@ -80,6 +80,10 @@ module Inspec::Resources
       "IIS App Pool '#{@pool_name}'"
     end
 
+    def resource_id
+      @pool_name
+    end
+
     private
 
     def iis_app_pool

--- a/lib/inspec/resources/mssql_sys_conf.rb
+++ b/lib/inspec/resources/mssql_sys_conf.rb
@@ -19,6 +19,8 @@ module Inspec::Resources
     attr_reader :mssql_session, :sql_query
 
     def initialize(conf_param_name, opts = {})
+      @conf_param_name = conf_param_name
+      @opts = opts
       opts[:username] ||= "SA"
       @mssql_session = inspec.mssql_session(opts)
       setting = conf_param_name.to_s.gsub("_", " ").split.map(&:capitalize).join(" ")
@@ -35,6 +37,11 @@ module Inspec::Resources
 
     def to_s
       "MsSql DB Configuration"
+    end
+
+    def resource_id
+      username = @opts[:username] || "SA"
+      "#{@conf_param_name}-#{username}"
     end
 
     private

--- a/lib/inspec/resources/oracledb_conf.rb
+++ b/lib/inspec/resources/oracledb_conf.rb
@@ -17,6 +17,7 @@ module Inspec::Resources
 
     def initialize(opts = {})
       @oracledb_session = inspec.oracledb_session(opts)
+      @opts = opts
     end
 
     def method_missing(name)
@@ -26,6 +27,10 @@ module Inspec::Resources
 
     def to_s
       "Oracle DB Configuration"
+    end
+
+    def resource_id
+      @opts[:user] || ""
     end
 
     private

--- a/lib/inspec/resources/oracledb_listener_conf.rb
+++ b/lib/inspec/resources/oracledb_listener_conf.rb
@@ -73,6 +73,10 @@ module Inspec::Resources
       "Oracle Listener Configuration"
     end
 
+    def resource_id
+      @conf_path
+    end
+
     private
 
     def read_content

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -76,6 +76,16 @@ module Inspec::Resources
       "Oracle Session"
     end
 
+    def resource_id
+      if @user
+        "#{@host}-#{@port}-#{@user}"
+      elsif @su_user
+        "#{@host}-#{@port}-#{@su_user}"
+      else
+        ""
+      end
+    end
+
     private
 
     # 3 commands

--- a/test/unit/resources/filesystem_test.rb
+++ b/test/unit/resources/filesystem_test.rb
@@ -14,6 +14,7 @@ describe "Inspec::Resources::FileSystemResource" do
     _(resource.type).must_equal "ext4"
     _(resource.free_kb).must_equal 20760728
     _(resource.percent_free).must_equal 68
+    _(resource.resource_id).must_equal "/"
   end
 
   # windows
@@ -25,5 +26,6 @@ describe "Inspec::Resources::FileSystemResource" do
     _(resource.type).must_equal "NTFS"
     _(resource.free_kb).must_equal 30000000
     _(resource.percent_free).must_equal 75
+    _(resource.resource_id).must_equal "c:"
   end
 end

--- a/test/unit/resources/gem_test.rb
+++ b/test/unit/resources/gem_test.rb
@@ -20,6 +20,7 @@ describe "Inspec::Resources::Gem" do
     _(resource.installed?).must_equal true
     _(resource.info).must_equal pkg
     _(resource.gem_binary).must_equal "gem"
+    _(resource.resource_id).must_equal "rubocop-0.33.0"
   end
 
   it "specifying gem binary" do
@@ -34,6 +35,7 @@ describe "Inspec::Resources::Gem" do
     _(resource.installed?).must_equal true
     _(resource.info).must_equal pkg
     _(resource.gem_binary).must_equal "/opt/ruby-2.3.1/embedded/bin/gem"
+    _(resource.resource_id).must_equal "pry-0.10.4"
   end
 
   it "verify gem in :chef" do
@@ -48,6 +50,7 @@ describe "Inspec::Resources::Gem" do
     _(resource.installed?).must_equal true
     _(resource.info).must_equal pkg
     _(resource.gem_binary).must_equal "/opt/chef/embedded/bin/gem"
+    _(resource.resource_id).must_equal "chef-sugar-3.4.0"
   end
 
   it "verifies gem in :chef when multiple versions are installed" do
@@ -56,6 +59,7 @@ describe "Inspec::Resources::Gem" do
     _(resource.versions[0]).must_match(/3\.4/)
     _(resource.versions).wont_include(/2\.4/)
     _(resource.gem_binary).must_equal "/opt/chef/embedded/bin/gem"
+    _(resource.resource_id).must_equal "chef-sugar-3.4.0"
   end
 
   it "verify gem in :chef on windows" do
@@ -70,6 +74,7 @@ describe "Inspec::Resources::Gem" do
     _(resource.installed?).must_equal true
     _(resource.info).must_equal pkg
     _(resource.gem_binary).must_equal 'c:\opscode\chef\embedded\bin\gem.bat'
+    _(resource.resource_id).must_equal "json-1.8.3"
   end
 
   it "verify gem in :chef_server" do
@@ -84,5 +89,6 @@ describe "Inspec::Resources::Gem" do
     _(resource.installed?).must_equal true
     _(resource.info).must_equal pkg
     _(resource.gem_binary).must_equal "/opt/opscode/embedded/bin/gem"
+    _(resource.resource_id).must_equal "knife-backup-0.0.12"
   end
 end

--- a/test/unit/resources/group_test.rb
+++ b/test/unit/resources/group_test.rb
@@ -8,24 +8,28 @@ describe "Inspec::Resources::Group" do
     resource = MockLoader.new(:ubuntu).load_resource("group", "root")
     _(resource.exists?).must_equal true
     _(resource.gid).must_equal 0
+    _(resource.resource_id).must_equal "root-0"
   end
 
   it "verify group on ubuntu with mixed case" do
     resource = MockLoader.new(:ubuntu).load_resource("group", "GroupWithCaps")
     _(resource.exists?).must_equal true
     _(resource.gid).must_equal 999
+    _(resource.resource_id).must_equal "GroupWithCaps-999"
   end
 
   it "verify group on ubuntu with members" do
     resource = MockLoader.new(:ubuntu).load_resource("group", "www-data")
     _(resource.exists?).must_equal true
     _(resource.members).must_equal "www-data,root"
+    _(resource.resource_id).must_equal "www-data-33"
   end
 
   it "verify group on ubuntu with members_array" do
     resource = MockLoader.new(:ubuntu).load_resource("group", "www-data")
     _(resource.exists?).must_equal true
     _(resource.members_array).must_equal %w{www-data root}
+    _(resource.resource_id).must_equal "www-data-33"
   end
 
   # ubuntu with non-existent group
@@ -33,6 +37,7 @@ describe "Inspec::Resources::Group" do
     resource = MockLoader.new(:ubuntu).load_resource("group", "nogroup")
     _(resource.exists?).must_equal false
     _(resource.gid).must_be_nil
+    _(resource.resource_id).must_equal ""
   end
 
   # mac

--- a/test/unit/resources/grub_conf_test.rb
+++ b/test/unit/resources/grub_conf_test.rb
@@ -10,6 +10,7 @@ describe "Inspec::Resources::GrubConfig" do
 
     _(resource.kernel).must_include "/vmlinuz-yup-kernel-works"
     _(resource.initrd).must_equal "/initramfs-yup-initrd-works"
+    _(resource.resource_id).must_equal "/boot/grub2/grub.cfg"
   end
 
   # Grub2 with `GRUB_DEFAULT=saved`
@@ -25,6 +26,7 @@ describe "Inspec::Resources::GrubConfig" do
 
     _(resource.kernel).must_include "/vmlinuz-3.10.0-229.el7.x86_64"
     _(resource.initrd).must_equal "/initramfs-3.10.0-229.el7.x86_64.img"
+    _(resource.resource_id).must_equal "/boot/grub2/grub.cfg"
   end
 
   it "parses correctly with grub2 and an invalid grubenv entry" do
@@ -44,6 +46,7 @@ describe "Inspec::Resources::GrubConfig" do
 
     _(resource.kernel).must_include "/vmlinuz-yup-kernel-works"
     _(resource.initrd).must_equal "/initramfs-yup-initrd-works"
+    _(resource.resource_id).must_equal "/boot/grub2/grub.cfg"
   end
 
   # Grub2 with a specified kernel
@@ -56,6 +59,7 @@ describe "Inspec::Resources::GrubConfig" do
 
     _(resource.kernel).must_include "/vmlinuz-0-rescue"
     _(resource.initrd).must_equal "/initramfs-0-rescue.img"
+    _(resource.resource_id).must_equal "/boot/grub2/grub.cfg"
   end
 
   # Legacy Grub
@@ -66,6 +70,7 @@ describe "Inspec::Resources::GrubConfig" do
     _(resource.initrd).must_equal "/initramfs-2.6.32-573.7.1.el6.x86_64.img"
     _(resource.default).must_equal "0"
     _(resource.timeout).must_equal "5"
+    _(resource.resource_id).must_equal "/etc/grub.conf"
   end
 
   # Legacy Grub with a specified kernel
@@ -80,6 +85,7 @@ describe "Inspec::Resources::GrubConfig" do
     _(resource.initrd).must_equal "/initramfs-2.6.32-573.el6.x86_64.img"
     _(resource.default).must_equal "0"
     _(resource.timeout).must_equal "5"
+    _(resource.resource_id).must_equal "/etc/grub.conf"
   end
 
   it "parses data with no identations correctly with grub1" do
@@ -93,5 +99,6 @@ describe "Inspec::Resources::GrubConfig" do
     _(resource.initrd).must_equal "/initramfs-2.6.32-573.el6.x86_64.img"
     _(resource.default).must_equal "0"
     _(resource.timeout).must_equal "5"
+    _(resource.resource_id).must_equal "/etc/non_indented_grub.conf"
   end
 end

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -10,6 +10,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ["12.34.56.78", "2606:2800:220:1:248:1893:25c8:1946"]
     _(resource.to_s).must_equal "Host example.com"
+    _(resource.resource_id).must_equal "example.com"
   end
 
   it "check host ping on centos 7" do
@@ -18,6 +19,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ["12.34.56.78", "2606:2800:220:1:248:1893:25c8:1946"]
     _(resource.to_s).must_equal "Host example.com"
+    _(resource.resource_id).must_equal "example.com"
   end
 
   it "check host ping on darwin" do
@@ -26,6 +28,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ["12.34.56.78", "2606:2800:220:1:248:1893:25c8:1946"]
     _(resource.to_s).must_equal "Host example.com"
+    _(resource.resource_id).must_equal "example.com"
   end
 
   it "check host ping on windows" do
@@ -34,6 +37,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal false
     _(resource.ipaddress).must_equal ["134.170.188.221", "2404:6800:4009:827::200e"]
     _(resource.to_s).must_equal "Host microsoft.com"
+    _(resource.resource_id).must_equal "microsoft.com"
   end
 
   it "check host ping on unsupported os" do
@@ -42,6 +46,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal false
     _(resource.ipaddress).must_be_nil
     _(resource.to_s).must_equal "Host example.com"
+    _(resource.resource_id).must_equal "example.com"
   end
 
   it "check host tcp on ubuntu" do
@@ -50,6 +55,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ["12.34.56.78", "2606:2800:220:1:248:1893:25c8:1946"]
     _(resource.to_s).must_equal "Host example.com port 1234 proto tcp"
+    _(resource.resource_id).must_equal "example.com-1234-tcp"
   end
 
   it "check host udp on ubuntu" do
@@ -58,6 +64,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ["12.34.56.78", "2606:2800:220:1:248:1893:25c8:1946"]
     _(resource.to_s).must_equal "Host example.com port 1234 proto udp"
+    _(resource.resource_id).must_equal "example.com-1234-udp"
   end
 
   it "check host tcp on centos 7" do
@@ -66,6 +73,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ["12.34.56.78", "2606:2800:220:1:248:1893:25c8:1946"]
     _(resource.to_s).must_equal "Host example.com port 1234 proto tcp"
+    _(resource.resource_id).must_equal "example.com-1234-tcp"
   end
 
   it "check host udp on centos 7" do
@@ -74,6 +82,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ["12.34.56.78", "2606:2800:220:1:248:1893:25c8:1946"]
     _(resource.to_s).must_equal "Host example.com port 1234 proto udp"
+    _(resource.resource_id).must_equal "example.com-1234-udp"
   end
 
   it "check host tcp on darwin" do
@@ -82,6 +91,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ["12.34.56.78", "2606:2800:220:1:248:1893:25c8:1946"]
     _(resource.to_s).must_equal "Host example.com port 1234 proto tcp"
+    _(resource.resource_id).must_equal "example.com-1234-tcp"
   end
 
   it "check host udp on darwin" do
@@ -90,6 +100,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ["12.34.56.78", "2606:2800:220:1:248:1893:25c8:1946"]
     _(resource.to_s).must_equal "Host example.com port 1234 proto udp"
+    _(resource.resource_id).must_equal "example.com-1234-udp"
   end
 
   it "check host tcp on windows" do
@@ -98,6 +109,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal true
     _(resource.ipaddress).must_equal ["134.170.188.221", "2404:6800:4009:827::200e"]
     _(resource.to_s).must_equal "Host microsoft.com port 1234 proto tcp"
+    _(resource.resource_id).must_equal "microsoft.com-1234-tcp"
   end
 
   it "check host tcp on unsupported os" do
@@ -106,6 +118,7 @@ describe "Inspec::Resources::Host" do
     _(resource.reachable?).must_equal false
     _(resource.ipaddress).must_be_nil
     _(resource.to_s).must_equal "Host example.com port 1234 proto tcp"
+    _(resource.resource_id).must_equal "example.com-1234-tcp"
   end
 end
 

--- a/test/unit/resources/http_test.rb
+++ b/test/unit/resources/http_test.rb
@@ -16,6 +16,7 @@ describe "Inspec::Resources::Http" do
 
         _(worker.status).must_equal 200
         _(worker.body).must_equal "pong"
+        _(worker.resource_id).must_equal "pong"
       end
     end
 

--- a/test/unit/resources/http_test.rb
+++ b/test/unit/resources/http_test.rb
@@ -16,7 +16,7 @@ describe "Inspec::Resources::Http" do
 
         _(worker.status).must_equal 200
         _(worker.body).must_equal "pong"
-        _(worker.resource_id).must_equal "pong"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -28,6 +28,7 @@ describe "Inspec::Resources::Http" do
 
         _(worker.status).must_equal 200
         _(worker.body).must_equal "auth ok"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -40,6 +41,7 @@ describe "Inspec::Resources::Http" do
 
         _(worker.status).must_equal 200
         _(worker.body).must_equal "redirect ok"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
 
       it "does not exceed max_redirects" do
@@ -60,6 +62,7 @@ describe "Inspec::Resources::Http" do
 
         _(worker.status).must_equal 200
         _(worker.body).must_equal "post ok"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -72,6 +75,7 @@ describe "Inspec::Resources::Http" do
         _(worker.status).must_equal 200
         _(worker.body).must_equal "headers ok"
         _(worker.response_headers["mock"]).must_equal "ok"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -83,6 +87,7 @@ describe "Inspec::Resources::Http" do
 
         _(worker.status).must_equal 200
         _(worker.body).must_equal "params ok"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -104,6 +109,7 @@ describe "Inspec::Resources::Http" do
         _(worker.response_headers["access-control-allow-origin"]).must_equal "http://www.example.com"
         _(worker.response_headers["access-control-allow-methods"]).must_equal "POST, GET, OPTIONS, DELETE"
         _(worker.response_headers["access-control-max-age"]).must_equal "86400"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
   end
@@ -119,6 +125,7 @@ describe "Inspec::Resources::Http" do
       it "returns correct data" do
         _(worker.status).must_equal 200
         _(worker.body).must_equal "no options"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -128,6 +135,7 @@ describe "Inspec::Resources::Http" do
       it "returns correct data" do
         _(worker.status).must_equal 200
         _(worker.body).must_equal "auth ok"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -137,6 +145,7 @@ describe "Inspec::Resources::Http" do
       it "follows the redirect" do
         _(worker.status).must_equal 200
         _(worker.body).must_equal "followed redirect"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -147,6 +156,7 @@ describe "Inspec::Resources::Http" do
       it "returns correct data" do
         _(worker.status).must_equal 200
         _(worker.body).must_equal "post ok"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -157,6 +167,7 @@ describe "Inspec::Resources::Http" do
         _(worker.status).must_equal 200
         _(worker.body).must_equal "headers ok"
         _(worker.response_headers["mock"]).must_equal "ok"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -166,6 +177,7 @@ describe "Inspec::Resources::Http" do
       it "returns correct data" do
         _(worker.status).must_equal 200
         _(worker.body).must_equal "params ok"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -175,6 +187,7 @@ describe "Inspec::Resources::Http" do
       it "returns correct data" do
         _(worker.status).must_equal 301
         _(worker.response_headers["Location"]).must_equal "http://www.google.com/"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -191,6 +204,7 @@ describe "Inspec::Resources::Http" do
         _(worker.response_headers["Access-Control-Allow-Origin"]).must_equal "http://www.example.com"
         _(worker.response_headers["Access-Control-Allow-Methods"]).must_equal "POST, GET, OPTIONS, DELETE"
         _(worker.response_headers["Access-Control-Max-Age"]).must_equal "86400"
+        _(worker.resource_id).must_equal "http://www.example.com"
       end
     end
 
@@ -259,6 +273,7 @@ describe "Inspec::Resources::Http" do
           .returns(true)
         _(worker.status).must_equal 200
         _(worker.response_headers["Content-Type"]).must_equal "text/html; charset=UTF-8"
+        _(worker.resource_id).must_equal "https://www.example.com"
       end
     end
   end
@@ -277,6 +292,7 @@ describe "Inspec::Resources::Http" do
           .returns(true)
         _(worker.status).must_equal 200
         _(worker.response_headers["Content-Type"]).must_equal "text/html; charset=UTF-8"
+        _(worker.resource_id).must_equal "https://www.example.com"
       end
     end
   end
@@ -295,6 +311,7 @@ describe "Inspec::Resources::Http" do
       _(worker.status).must_equal 200
       _(worker.body).must_equal "post ok"
       _(worker.response_headers["Content-Type"]).must_equal "text/html; charset=UTF-8"
+      _(worker.resource_id).must_equal "https://www.example.com"
     end
   end
 end

--- a/test/unit/resources/iis_app_pool_test.rb
+++ b/test/unit/resources/iis_app_pool_test.rb
@@ -19,5 +19,6 @@ describe "Inspec::Resources::IisAppPool" do
     _(resource.send("user_identity_type")).must_equal "SpecificUser"
     _(resource.send("username")).must_include "vagrant"
     _(resource.send("exists?")).must_equal true
+    _(resource.send("resource_id")).must_equal "DefaultAppPool"
   end
 end

--- a/test/unit/resources/oracledb_listener_conf_test.rb
+++ b/test/unit/resources/oracledb_listener_conf_test.rb
@@ -7,23 +7,27 @@ describe "Inspec::Resources::OracledbListenerConf" do
     resource = MockLoader.new(:centos7).load_resource("oracledb_listener_conf", "/opt/oracle/product/18c/dbhomeXE/network/admin/listener.ora")
     _(resource.params["DEFAULT_SERVICE_LISTENER"]).must_equal "XE"
     _(resource.params["EM_EXPRESS_PORT"]).must_equal "5500"
+    _(resource.resource_id).must_equal "/opt/oracle/product/18c/dbhomeXE/network/admin/listener.ora"
   end
 
   it "verify listener settings of oracle DB in windows when listener conf path is passed" do
     resource = MockLoader.new(:windows).load_resource("oracledb_listener_conf", "C:\\app\\Administrator\\product\\18.0.0\\dbhomeXE\\network\\admin\\listener.ora")
     _(resource.params["DEFAULT_SERVICE_LISTENER"]).must_equal "XE"
     _(resource.params["EM_EXPRESS_PORT"]).must_equal "5500"
+    _(resource.resource_id).must_equal "C:\\app\\Administrator\\product\\18.0.0\\dbhomeXE\\network\\admin\\listener.ora"
   end
 
   it "verify listener settings of oracle DB in linux when listener conf path is not passed" do
     resource = MockLoader.new(:centos7).load_resource("oracledb_listener_conf", nil)
     _(resource.params["DEFAULT_SERVICE_LISTENER"]).must_equal "XE"
     _(resource.params["EM_EXPRESS_PORT"]).must_equal "5500"
+    _(resource.resource_id).must_equal "/opt/oracle/product/18c/dbhomeXE/network/admin/listener.ora"
   end
 
   it "verify listener settings of oracle DB in windows when listener conf path is not passed" do
     resource = MockLoader.new(:windows).load_resource("oracledb_listener_conf", nil)
     _(resource.params["DEFAULT_SERVICE_LISTENER"]).must_equal "XE"
     _(resource.params["EM_EXPRESS_PORT"]).must_equal "5500"
+    _(resource.resource_id).must_equal "C:\\app\\Administrator\\product\\18.0.0\\dbhomeXE\\network\\admin\\listener.ora"
   end
 end

--- a/test/unit/resources/oracledb_session_test.rb
+++ b/test/unit/resources/oracledb_session_test.rb
@@ -18,6 +18,7 @@ describe "Inspec::Resources::OracledbSession" do
     query = resource.query("SELECT NAME AS VALUE FROM v$database;")
     _(query.size).must_equal 1
     _(query.row(0).column("value").value).must_equal "ORCL"
+    _(resource.resource_id).must_equal "localhost-1527-USER"
   end
 
   it "sqlplus Linux with os user and db role" do
@@ -35,6 +36,7 @@ describe "Inspec::Resources::OracledbSession" do
     query = resource.query("SELECT NAME AS VALUE FROM v$database;")
     _(query.size).must_equal 1
     _(query.row(0).column("value").value).must_equal "ORCL"
+    _(resource.resource_id).must_equal "localhost-1527-OSUSER"
   end
 
   it "sqlplus Linux with null in query output" do
@@ -52,6 +54,7 @@ describe "Inspec::Resources::OracledbSession" do
     query = resource.query("SELECT NAME AS VALUE FROM v$database;")
     _(query.size).must_equal 2
     _(query.row(1).column("value").value).must_equal "ORCL"
+    _(resource.resource_id).must_equal "localhost-1527-OSUSER"
   end
 
   it "sqlplus Linux with empty output" do
@@ -69,6 +72,7 @@ describe "Inspec::Resources::OracledbSession" do
     query = resource.query("SELECT NAME AS VALUE FROM v$database;")
     _(query.size).must_equal 0
     _(query.row(1).column("value").value).must_equal ""
+    _(resource.resource_id).must_equal "localhost-1527-OSUSER"
   end
 
   it "sqlplus Windows" do
@@ -86,6 +90,7 @@ describe "Inspec::Resources::OracledbSession" do
     query = resource.query("SELECT NAME AS VALUE FROM v$database;")
     _(query.size).must_equal 1
     _(query.row(0).column("value").value).must_equal "ORCL"
+    _(resource.resource_id).must_equal "localhost-1527-USER"
   end
 
   it "sqlplus Windows with null in query output" do
@@ -103,6 +108,7 @@ describe "Inspec::Resources::OracledbSession" do
     query = resource.query("SELECT NAME AS VALUE FROM v$database;")
     _(query.size).must_equal 2
     _(query.row(1).column("value").value).must_equal "ORCL"
+    _(resource.resource_id).must_equal "localhost-1527-USER"
   end
 
   it "sqlplus Windows with empty output" do
@@ -120,6 +126,7 @@ describe "Inspec::Resources::OracledbSession" do
     query = resource.query("SELECT NAME AS VALUE FROM v$database;")
     _(query.size).must_equal 0
     _(query.row(1).column("value").value).must_equal ""
+    _(resource.resource_id).must_equal "localhost-1527-USER"
   end
 
   it "skipped when sqlplus Windows as_os_user" do
@@ -127,6 +134,7 @@ describe "Inspec::Resources::OracledbSession" do
 
     _(resource.resource_skipped?).must_equal true
     _(resource.resource_exception_message).must_equal "Option 'as_os_user' not available in Windows"
+    _(resource.resource_id).must_equal "localhost-1527-USER"
   end
 
   it "fails when no user, password, or su" do
@@ -134,12 +142,14 @@ describe "Inspec::Resources::OracledbSession" do
 
     _(resource.resource_failed?).must_equal true
     _(resource.resource_exception_message).must_equal "Can't run Oracle checks without authentication"
+    _(resource.resource_id).must_equal ""
   end
 
   it "does not fails when no service name is provided" do
     resource = quick_resource(:oracledb_session, :windows, user: "USER", password: "password", host: "localhost", port: 1527, sqlplus_bin: "C:/sqlplus.exe")
 
     _(resource.resource_failed?).must_equal false
+    _(resource.resource_id).must_equal "localhost-1527-USER"
   end
 
   it "verify oracledb_session configuration" do
@@ -152,6 +162,7 @@ describe "Inspec::Resources::OracledbSession" do
     _(resource.db_role).must_equal "dbrole"
     _(resource.su_user).must_equal "osuser"
     _(resource.bin).must_equal "sqlplus"
+    _(resource.resource_id).must_equal "localhost-1521-USER"
   end
 
   it "fails when no connection established in linux" do
@@ -166,6 +177,7 @@ describe "Inspec::Resources::OracledbSession" do
     end
     ex = assert_raises(Inspec::Exceptions::ResourceFailed) { resource.query("SELECT NAME AS VALUE FROM v$database") }
     _(ex.message).must_include("Oracle query with errors")
+    _(resource.resource_id).must_equal "localhost-1527-USER"
   end
 
   it "fails when no connection established in windows" do
@@ -179,6 +191,7 @@ describe "Inspec::Resources::OracledbSession" do
       end
       ex = assert_raises(Inspec::Exceptions::ResourceFailed) { resource.query("SELECT NAME AS VALUE FROM v$database") }
       _(ex.message).must_include("Oracle query with errors")
+      _(resource.resource_id).must_equal "localhost-1527-USER"
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added resource_id in following resources:

- filesystem
- gem
- group
- grub_conf
- host
- http
- iis_app
- iis_app_pool
- oracledb_conf
- oracledb_listener_conf
- oracledb_session
- mssql_sys_conf

On `bundle exec PROFILE --reporter json`, resource_id should contain a unique value for each initialization. It is loosely unique at this point.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
