### PR TITLE
CFINSPEC-272: resource_ids group 11

### DIFF
--- a/lib/inspec/resources/ssh_config.rb
+++ b/lib/inspec/resources/ssh_config.rb
@@ -57,6 +57,10 @@ module Inspec::Resources
       "SSH Configuration"
     end
 
+    def resource_id
+      @conf_path
+    end
+
     private
 
     def read_content

--- a/lib/inspec/resources/ssh_config.rb
+++ b/lib/inspec/resources/ssh_config.rb
@@ -58,7 +58,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      @conf_path
+      @conf_path || "SSH Configuration"
     end
 
     private

--- a/lib/inspec/resources/sybase_conf.rb
+++ b/lib/inspec/resources/sybase_conf.rb
@@ -29,6 +29,10 @@ module Inspec::Resources
       sql_query.row(0).column("Config Value").value
     end
 
+    def resource_id
+      conf_param
+    end
+
     def to_s
       "Sybase Conf #{conf_param}"
     end

--- a/lib/inspec/resources/sybase_conf.rb
+++ b/lib/inspec/resources/sybase_conf.rb
@@ -30,7 +30,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      conf_param
+      conf_param || "Sybase config settings"
     end
 
     def to_s

--- a/lib/inspec/resources/sybase_session.rb
+++ b/lib/inspec/resources/sybase_session.rb
@@ -64,6 +64,10 @@ module Inspec::Resources
       DatabaseHelper::SQLQueryResult.new(isql_cmd, parse_csv_result(isql_cmd.stdout))
     end
 
+    def resource_id
+      "Sybase Session"
+    end
+
     def to_s
       "Sybase Session"
     end

--- a/lib/inspec/resources/sybase_session.rb
+++ b/lib/inspec/resources/sybase_session.rb
@@ -65,7 +65,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      "Sybase Session"
+      @database || "Sybase Session"
     end
 
     def to_s

--- a/lib/inspec/resources/sys_info.rb
+++ b/lib/inspec/resources/sys_info.rb
@@ -112,6 +112,10 @@ module Inspec::Resources
       end
     end
 
+    def resource_id
+      "sys_info"
+    end
+
     def to_s
       "System Information"
     end

--- a/lib/inspec/resources/timezone.rb
+++ b/lib/inspec/resources/timezone.rb
@@ -52,6 +52,10 @@ module Inspec::Resources
       @output["time_offset"]
     end
 
+    def resource_id
+      "timezone"
+    end
+
     def to_s
       "Time Zone resource"
     end

--- a/test/unit/resources/timezone_test.rb
+++ b/test/unit/resources/timezone_test.rb
@@ -9,6 +9,7 @@ describe "Inspec::Resources::TimeZone" do
     _(resource.name).must_equal "IST"
     _(resource.time_offset).must_equal "+0530"
     _(resource.stderr).must_equal ""
+    _(resource.resource_id).must_equal "timezone"
   end
 
   it "verify time configurations" do
@@ -17,5 +18,6 @@ describe "Inspec::Resources::TimeZone" do
     _(resource.name).must_equal "India Standard Time"
     _(resource.time_offset).must_equal "05:30:00"
     _(resource.stderr).must_equal ""
+    _(resource.resource_id).must_equal "timezone"
   end
 end


### PR DESCRIPTION
✅ Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Description
**CFINSPEC-272: resource_ids group 11**
This PR adds resource_id methods to the following resources:
- ssh_config
- sshd_config
- sybase_conf
- sybase_session
- sys_info
- timezone

When a user runs inspec exec [profile] --reporter json
then when they look at the resource_id field for the core controls
then they would be able to see an identifier for each control

## Related Issue
**CFINSPEC-272: resource_ids group 11**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
