### PR TITLE
CFINSPEC-270 Adds resource_id group9

### DIFF
--- a/lib/inspec/resources/os.rb
+++ b/lib/inspec/resources/os.rb
@@ -27,6 +27,10 @@ module Inspec::Resources
       end
     end
 
+    def resource_id
+      @platform.name || "OS"
+    end
+
     def to_s
       "Operating System Detection"
     end

--- a/lib/inspec/resources/os_env.rb
+++ b/lib/inspec/resources/os_env.rb
@@ -47,6 +47,10 @@ module Inspec::Resources
       @content = value_for(@osenv, @target) unless @osenv.nil?
     end
 
+    def resource_id
+      @osenv || ""
+    end
+
     def to_s
       if @osenv.nil?
         "Environment variables"

--- a/lib/inspec/resources/package.rb
+++ b/lib/inspec/resources/package.rb
@@ -96,6 +96,10 @@ module Inspec::Resources
       @latest_version ||= ( @pkgman.latest_version(@package_name) || info[:latest_version] )
     end
 
+    def resource_id
+      @package_name || "System Package"
+    end
+
     def to_s
       "System Package #{@package_name}"
     end

--- a/lib/inspec/resources/parse_config.rb
+++ b/lib/inspec/resources/parse_config.rb
@@ -68,6 +68,10 @@ module Inspec::Resources
       end
     end
 
+    def resource_id
+      @content || "parse_config"
+    end
+
     def to_s
       "Parse Config #{@conf_path}"
     end
@@ -104,8 +108,13 @@ module Inspec::Resources
     EXAMPLE
 
     def initialize(path, opts = nil)
+      @path = path
       super(nil, opts)
-      parse_file(path)
+      parse_file(@path)
+    end
+
+    def resource_id
+      @path || "parse_config_file"
     end
 
     def to_s

--- a/lib/inspec/resources/pip.rb
+++ b/lib/inspec/resources/pip.rb
@@ -56,6 +56,10 @@ module Inspec::Resources
       info[:version]
     end
 
+    def resource_id
+      @package_name || "pip"
+    end
+
     def to_s
       "Pip Package #{@package_name}"
     end

--- a/lib/inspec/resources/platform.rb
+++ b/lib/inspec/resources/platform.rb
@@ -93,6 +93,10 @@ module Inspec::Resources
       key.to_s.tr("-", "_").to_sym
     end
 
+    def resource_id
+      @platform.name || "platform"
+    end
+
     def to_s
       "Platform Detection"
     end

--- a/lib/inspec/resources/postfix_conf.rb
+++ b/lib/inspec/resources/postfix_conf.rb
@@ -22,6 +22,10 @@ module Inspec::Resources
       SimpleConfig.new(content).params
     end
 
+    def resource_id
+      "Postfix Conf"
+    end
+
     def to_s
       "Postfix Mail Transfer Agent"
     end

--- a/lib/inspec/resources/postgres_conf.rb
+++ b/lib/inspec/resources/postgres_conf.rb
@@ -64,6 +64,10 @@ module Inspec::Resources
       param
     end
 
+    def resource_id
+      @conf_path || "postgres_conf"
+    end
+
     def to_s
       "PostgreSQL Configuration"
     end

--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -64,6 +64,10 @@ module Inspec::Resources
       end
     end
 
+    def resource_id
+      "postgress_session:User:#{@user}:Host:#{@host}"
+    end
+
     private
 
     def escaped_query(query)

--- a/test/unit/resources/os_env_test.rb
+++ b/test/unit/resources/os_env_test.rb
@@ -3,6 +3,11 @@ require "inspec/resource"
 require "inspec/resources/os_env"
 
 describe "Inspec::Resources::OsEnv" do
+  it "generates the resource_id for current_resource" do
+    resource = load_resource("os_env", "PATH")
+    _(resource.resource_id).must_equal "PATH"
+  end
+
   it "verify env parsing" do
     resource = load_resource("os_env", "PATH")
     _(resource.split).must_equal %w{/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin}

--- a/test/unit/resources/os_test.rb
+++ b/test/unit/resources/os_test.rb
@@ -5,6 +5,7 @@ require "inspec/resources/os"
 describe "Inspec::Resources::Os" do
   it "verify os parsing on CentOS" do
     resource = MockLoader.new(:centos7).load_resource("os")
+    _(resource.resource_id).must_equal "centos"
     _(resource.name).must_equal "centos"
     _(resource.family).must_equal "redhat"
     _(resource.release).must_equal "7.1.1503"
@@ -13,6 +14,7 @@ describe "Inspec::Resources::Os" do
 
   it "read env variable on Windows" do
     resource = MockLoader.new(:windows).load_resource("os")
+    _(resource.resource_id).must_equal "windows"
     _(resource.name).must_equal "windows"
     _(resource.family).must_equal "windows"
     _(resource.release).must_equal "6.2.9200"
@@ -21,6 +23,7 @@ describe "Inspec::Resources::Os" do
 
   it "verify os parsing on Debian" do
     resource = MockLoader.new(:debian8).load_resource("os")
+    _(resource.resource_id).must_equal "debian"
     _(resource.name).must_equal "debian"
     _(resource.family).must_equal "debian"
     _(resource.release).must_equal "8"

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -4,6 +4,11 @@ require "inspec/resources/package"
 
 describe "Inspec::Resources::Package" do
   # arch linux
+  it "generates the resource_id for current resource" do
+    resource = MockLoader.new(:arch).load_resource("package", "curl")
+    _(resource.resource_id).must_equal "curl"
+  end
+
   it "verify arch linux package parsing" do
     resource = MockLoader.new(:arch).load_resource("package", "curl")
     pkg = { name: "curl", installed: true, version: "7.37.0-1", type: "pacman", only_version_no: "7.37.0" }

--- a/test/unit/resources/parse_config_test.rb
+++ b/test/unit/resources/parse_config_test.rb
@@ -10,6 +10,7 @@ describe "Inspec::Resources::ParseConfig" do
     }
     resource = MockLoader.new(:centos6).load_resource("parse_config", "kernel.domainname = example.com", options)
     result = { "kernel.domainname" => "example.com" }
+    _(resource.resource_id).must_equal "kernel.domainname = example.com"
     _(resource.params).must_equal result
     _(resource.content).must_equal "kernel.domainname = example.com"
     _(resource.send("kernel.domainname")).must_equal "example.com"
@@ -21,6 +22,7 @@ describe "Inspec::Resources::ParseConfig" do
     }
     resource = MockLoader.new(:centos6).load_resource("parse_config_file", "/etc/sysctl.conf", options)
     result = { "kernel.domainname" => "example.com" }
+    _(resource.resource_id).must_equal "/etc/sysctl.conf"
     _(resource.params).must_equal result
     _(resource.send("kernel.domainname")).must_equal "example.com"
   end

--- a/test/unit/resources/pip_test.rb
+++ b/test/unit/resources/pip_test.rb
@@ -3,6 +3,11 @@ require "inspec/resource"
 require "inspec/resources/pip"
 
 describe "Inspec::Resources::Pip" do
+  it "generates resource_id for the current resource" do
+    resource = load_resource("pip", "jinja2")
+    _(resource.resource_id).must_equal "jinja2"
+  end
+
   it "verify pip package detail parsing" do
     resource = load_resource("pip", "jinja2")
     pkg = { name: "Jinja2", installed: true, version: "2.8", type: "pip" }

--- a/test/unit/resources/platform_test.rb
+++ b/test/unit/resources/platform_test.rb
@@ -5,6 +5,10 @@ require "inspec/resources/platform"
 describe "Inspec::Resources::Platform" do
   let(:resource) { MockLoader.new(:ubuntu).load_resource("platform") }
 
+  it "generates the resource_id for the current resource" do
+    _(resource.resource_id).must_equal "ubuntu"
+  end
+
   it "verify platform parsing on Ubuntu" do
     _(resource.name).must_equal "ubuntu"
     _(resource.family).must_equal "debian"

--- a/test/unit/resources/postfix_conf_test.rb
+++ b/test/unit/resources/postfix_conf_test.rb
@@ -4,6 +4,11 @@ require "inspec/resources/postfix_conf"
 
 describe "Inspec::Resources::Postfix_Conf" do
 
+  it "generates the resource_id for the current resource" do
+    resource = MockLoader.new(:centos7).load_resource("postfix_conf")
+    _(resource.resource_id).must_equal "Postfix Conf"
+  end
+
   it "Test default parsing of main.cf on Centos 7" do
     resource = MockLoader.new(:centos7).load_resource("postfix_conf")
     result = { "test_parameter" => "value", "other_test_param" => "$value" }

--- a/test/unit/resources/postgres_conf_test.rb
+++ b/test/unit/resources/postgres_conf_test.rb
@@ -3,6 +3,11 @@ require "inspec/resource"
 require "inspec/resources/postgres_conf"
 
 describe "Inspec::Resources::Postgres" do
+  it "generates the resource_id for the current resource" do
+    resource = load_resource("postgres_conf", "/etc/postgresql/9.4/main/postgresql.conf")
+    _(resource.resource_id).must_equal("/etc/postgresql/9.4/main/postgresql.conf")
+  end
+
   it "verify postgresql.conf config parsing of a simple key value" do
     resource = load_resource("postgres_conf", "/etc/postgresql/9.4/main/postgresql.conf")
     _(resource.params("log_connections")).must_equal "on"

--- a/test/unit/resources/postgres_session_test.rb
+++ b/test/unit/resources/postgres_session_test.rb
@@ -4,6 +4,10 @@ require "inspec/resources/postgres_session"
 require "inspec/resources/command"
 
 describe "Inspec::Resources::PostgresSession" do
+  it "generates the resource_id for the current resource" do
+    resource = load_resource("postgres_session", "myuser", "mypass", "127.0.0.1", 5432)
+    _(resource.resource_id).must_equal "postgress_session:User:myuser:Host:127.0.0.1"
+  end
   it "verify postgres_session create_psql_cmd with a basic query" do
     resource = load_resource("postgres_session", "myuser", "mypass", "127.0.0.1", 5432)
     _(resource.send(:create_psql_cmd, "SELECT * FROM STUDENTS;", ["testdb"])).must_equal "psql -d postgresql://myuser:mypass@127.0.0.1:5432/testdb -A -t -w -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;"


### PR DESCRIPTION


Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This adds resource_id to the following resources.
* os
* os_env
* package
* parse_config
* parse_config_file
* pip
* platform
* postfix_conf
* postgres_conf
* postgres_session

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
