### PR TITLE
CFINSPEC 271 Group10 - Added resource_id in resources

### DIFF
--- a/lib/inspec/resources/powershell.rb
+++ b/lib/inspec/resources/powershell.rb
@@ -49,6 +49,10 @@ module Inspec::Resources
     def to_s
       "Powershell"
     end
+
+    def resource_id
+      "Powershell"
+    end
   end
 
   PowershellScript = Powershell

--- a/lib/inspec/resources/rabbitmq_config.rb
+++ b/lib/inspec/resources/rabbitmq_config.rb
@@ -32,6 +32,10 @@ module Inspec::Resources
       "rabbitmq_config #{@conf_path}"
     end
 
+    def resource_id
+      @conf_path
+    end
+
     private
 
     def read_content

--- a/lib/inspec/resources/registry_key.rb
+++ b/lib/inspec/resources/registry_key.rb
@@ -140,6 +140,10 @@ module Inspec::Resources
       "Registry Key #{@options[:name]}"
     end
 
+    def resource_id
+      @options[:path]
+    end
+
     private
 
     def prep_prop(property)

--- a/lib/inspec/resources/security_identifier.rb
+++ b/lib/inspec/resources/security_identifier.rb
@@ -51,6 +51,10 @@ module Inspec::Resources
       "Security Identifier"
     end
 
+    def resource_id
+      @name
+    end
+
     private
 
     def fetch_sids

--- a/lib/inspec/resources/security_policy.rb
+++ b/lib/inspec/resources/security_policy.rb
@@ -112,6 +112,10 @@ module Inspec::Resources
       "Security Policy"
     end
 
+    def resource_id
+      "Security Policy"
+    end
+
     private
 
     def read_content

--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -301,6 +301,10 @@ module Inspec::Resources
       "Service #{@service_name}"
     end
 
+    def resource_id
+      @service_name
+    end
+
     private :info
   end
 

--- a/test/unit/resources/powershell_test.rb
+++ b/test/unit/resources/powershell_test.rb
@@ -12,9 +12,11 @@ describe "Inspec::Resources::Powershell" do
   it "properly generates command" do
     resource = MockLoader.new(:windows).load_resource("powershell", "Get-Help")
     _(resource.command).must_equal "Get-Help"
+    _(resource.resource_id).must_equal "Powershell"
 
     resource = MockLoader.new(:macos10_10).load_resource("powershell", "Get-Help")
     _(resource.command).must_equal("pwsh -encodedCommand '#{base64_command}'")
+    _(resource.resource_id).must_equal "Powershell"
   end
 
   it "properly generates command if deprecated `script` is used" do

--- a/test/unit/resources/rabbitmq_conf_test.rb
+++ b/test/unit/resources/rabbitmq_conf_test.rb
@@ -9,6 +9,7 @@ describe "Inspec::Resources::RabbitmqConf" do
       resource = load_resource("rabbitmq_config")
       _(resource.params("rabbit", "ssl_listeners")).must_equal [5671]
       _(resource.params("rabbit", "tcp_listeners")).must_equal({ "127.0.0.1" => 5672, "::1" => 5672 })
+      _(resource.resource_id).must_equal "/etc/rabbitmq/rabbitmq.config"
     end
   end
 end

--- a/test/unit/resources/registry_key_test.rb
+++ b/test/unit/resources/registry_key_test.rb
@@ -6,16 +6,19 @@ describe "Inspec::Resources::RegistryKey" do
   it "read reg key with human readable name" do
     resource = MockLoader.new(:windows).load_resource("registry_key", "Task Scheduler", 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule')
     _(resource.Start).must_equal 2
+    _(resource.resource_id).must_equal "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\services\\Schedule"
   end
 
   it "read reg key without human readable name" do
     resource_without_name = MockLoader.new(:windows).load_resource("registry_key", 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule')
     _(resource_without_name.Start).must_equal 2
+    _(resource_without_name.resource_id).must_equal "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\services\\Schedule"
   end
 
   it "supports array syntax for keys with periods in them" do
     resource = MockLoader.new(:windows).load_resource("registry_key", 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Schedule')
     _(resource.send(:[], "key.with.period")).must_equal 12345
+    _(resource.resource_id).must_equal "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\services\\Schedule"
   end
 
   it "generates a proper path from options" do
@@ -25,6 +28,7 @@ describe "Inspec::Resources::RegistryKey" do
       { hive: "my_hive", key: '\\my_prefixed_key' }
     )
     _(resource.send(:generate_registry_key_path_from_options)).must_equal 'my_hive\\my_prefixed_key'
+    _(resource.resource_id).must_equal "my_hive\\my_prefixed_key"
   end
 
   it "generates a proper path from options when the key has no leading slash" do
@@ -34,6 +38,7 @@ describe "Inspec::Resources::RegistryKey" do
       { hive: "my_hive", key: "key_with_no_slash" }
     )
     _(resource.send(:generate_registry_key_path_from_options)).must_equal 'my_hive\\key_with_no_slash'
+    _(resource.resource_id).must_equal "my_hive\\key_with_no_slash"
   end
 
   it "returns user permissions values" do
@@ -41,6 +46,7 @@ describe "Inspec::Resources::RegistryKey" do
     resource.stubs(:exist?).returns(true)
     resource.stubs(:user_permissions).returns({ "NT AUTHORITY\\SYSTEM" => "FullControl", "NT AUTHORITY\\Authenticated Users" => "ReadAndExecute", "BUILTIN\\Administrators" => "FullControl" })
     _(resource.user_permissions).must_equal({ "NT AUTHORITY\\SYSTEM" => "FullControl", "NT AUTHORITY\\Authenticated Users" => "ReadAndExecute", "BUILTIN\\Administrators" => "FullControl" })
+    _(resource.resource_id).must_equal "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\services\\Schedule"
   end
 
   it "returns true if file has inherit enabled on Windows." do
@@ -48,5 +54,6 @@ describe "Inspec::Resources::RegistryKey" do
     resource.stubs(:exist?).returns(true)
     resource.stubs(:inherited?).returns(true)
     _(resource.inherited?).must_equal true
+    _(resource.resource_id).must_equal "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\services\\Schedule"
   end
 end

--- a/test/unit/resources/security_identifier_test.rb
+++ b/test/unit/resources/security_identifier_test.rb
@@ -7,36 +7,42 @@ describe "Inspec::Resources::SecurityIdentifier" do
     resource = load_resource("security_identifier", { user: "Alice" })
     _(resource.exist?).must_equal true
     _(resource.sid).must_equal "S-1-5-21-1601936709-1892662786-3840804712-315762"
+    _(resource.resource_id).must_equal "Alice"
   end
 
   it "returns nil for a non-existent  user" do
     resource = MockLoader.new(:windows).load_resource("security_identifier", { user: "Bob" })
     _(resource.exist?).must_equal false
     _(resource.sid).must_be_nil
+    _(resource.resource_id).must_equal "Bob"
   end
 
   it "returns a SID for an existing group" do
     resource = load_resource("security_identifier", { group: "Guests" })
     _(resource.exist?).must_equal true
     _(resource.sid).must_equal "S-1-5-32-546"
+    _(resource.resource_id).must_equal "Guests"
   end
 
   it "returns nil for a non-existent group" do
     resource = MockLoader.new(:windows).load_resource("security_identifier", { group: "DontExist" })
     _(resource.exist?).must_equal false
     _(resource.sid).must_be_nil
+    _(resource.resource_id).must_equal "DontExist"
   end
 
   it "returns a SID for an existing entity with type :unspecified" do
     resource = load_resource("security_identifier", { unspecified: "Guests" })
     _(resource.exist?).must_equal true
     _(resource.sid).must_equal "S-1-5-32-546"
+    _(resource.resource_id).must_equal "Guests"
   end
 
   it "returns nil for a non-existent entity with type :unspecified" do
     resource = MockLoader.new(:windows).load_resource("security_identifier", { unspecified: "DontExist" })
     _(resource.exist?).must_equal false
     _(resource.sid).must_be_nil
+    _(resource.resource_id).must_equal "DontExist"
   end
 
   it "raises ArgumentError for an unsupported type" do

--- a/test/unit/resources/security_policy_test.rb
+++ b/test/unit/resources/security_policy_test.rb
@@ -12,6 +12,7 @@ describe "Inspec::Resources::SecurityPolicy" do
     _(resource.SeUndockPrivilege).must_equal ["S-1-5-32-544"]
     _(resource.SeRemoteInteractiveLogonRight).must_equal ["S-1-5-32-544", "S-1-5-32-555"]
     _(resource.SeServiceLogonRight).must_equal %w{ DB2ADMNS db2admin }
+    _(resource.resource_id).must_equal "Security Policy"
   end
 
   it "parse empty policy file" do

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -19,6 +19,7 @@ describe "Inspec::Resources::Service" do
     _(resource.startmode). must_equal "Auto"
     _(resource.startname). must_equal "LocalSystem"
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "dhcp"
   end
 
   # ubuntu
@@ -32,6 +33,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "ssh"
   end
 
   it "verify ubuntu service parsing with default upstart_service" do
@@ -45,6 +47,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.UnitFileState).must_be_nil
+    _(resource.resource_id).must_equal "ssh"
   end
 
   it "verify ubuntu service parsing" do
@@ -58,6 +61,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.SubState).must_equal "running"
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify ubuntu service parsing with default systemd_service" do
@@ -70,6 +74,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # linux mint 17 with upstart
@@ -83,6 +88,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "ssh"
   end
 
   it "verify mint service parsing with default upstart_service" do
@@ -96,6 +102,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.UnitFileState).must_be_nil
+    _(resource.resource_id).must_equal "ssh"
   end
 
   # mint 18 with systemd
@@ -110,6 +117,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.SubState).must_equal "running"
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify mint service parsing with default systemd_service" do
@@ -122,6 +130,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # [-] Todo: Check with team if we can remove the below unit test or find a way to include it.
@@ -154,6 +163,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # Aliyun Linux 3 (Alibaba)
@@ -167,6 +177,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # centos 6 with sysv
@@ -181,6 +192,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.SubState).must_be_nil
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify centos 6 service parsing with default sysv_service" do
@@ -193,6 +205,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # centos 7 with systemd
@@ -206,6 +219,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify centos 7 service parsing with systemd_service and service_ctl override" do
@@ -218,6 +232,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify centos 7 service parsing with static loaded service" do
@@ -232,6 +247,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.UnitFileState).must_equal "static"
+    _(resource.resource_id).must_equal "dbus"
   end
 
   # cloudlinux 7 with systemd
@@ -245,6 +261,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify cloudlinux 7 service parsing with systemd_service and service_ctl override" do
@@ -257,6 +274,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify cloudlinux 7 service parsing with static loaded service" do
@@ -271,6 +289,7 @@ describe "Inspec::Resources::Service" do
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
     _(resource.params.UnitFileState).must_equal "static"
+    _(resource.resource_id).must_equal "dbus"
   end
 
   # freebsd 9
@@ -284,6 +303,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sendmail"
   end
 
   it "verify freebsd9 service parsing with default bsd_service" do
@@ -296,11 +316,13 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sendmail"
   end
 
   it "verify freebsd9 service parsing when one service is a suffix of another" do
     resource = MockLoader.new(:freebsd9).load_resource("service", "mail") # "mail" is suffix of "sendmail", which is enabled
     _(resource.enabled?).must_equal false
+    _(resource.resource_id).must_equal "mail"
   end
 
   # freebsd 10+
@@ -314,6 +336,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sendmail"
   end
 
   it "verify freebsd10 service parsing with default bsd_service" do
@@ -326,6 +349,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sendmail"
   end
 
   # arch linux with systemd
@@ -339,6 +363,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # coreos linux with systemd
@@ -352,6 +377,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # debian 7 with systemv
@@ -365,6 +391,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # debian 8 with systemd
@@ -378,6 +405,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # debian 10 with systemd
@@ -391,6 +419,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # debian 8 with systemd but no service file
@@ -412,6 +441,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "apache2"
   end
 
   # macos test
@@ -425,6 +455,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "ssh"
   end
 
   it "verify macos 10.16 (11 / big sur) service parsing" do
@@ -437,6 +468,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "ssh"
   end
 
   it "verify mac osx service parsing with not-running service" do
@@ -449,6 +481,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal false
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "FilesystemUI"
   end
 
   it "verify mac osx service parsing with default launchd_service" do
@@ -461,6 +494,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "ssh"
   end
 
   # wrlinux
@@ -474,6 +508,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # yocto
@@ -487,6 +522,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   it "verify alpine service parsing" do
@@ -499,6 +535,7 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal true
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "sshd"
   end
 
   # unknown OS
@@ -508,6 +545,7 @@ describe "Inspec::Resources::Service" do
     _(resource.installed?).must_equal false
     _(resource.description).must_be_nil
     _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "dhcp"
   end
 
   # runlevel detection
@@ -555,6 +593,7 @@ describe "Inspec::Resources::Service" do
       resource = MockLoader.new(:windows).load_resource("service", "dhcp")
       _(resource.name).must_equal "dhcp"
       _(resource.has_start_mode?("Auto")).must_equal true
+      _(resource.resource_id).must_equal "dhcp"
     end
 
     # ubuntu
@@ -564,6 +603,7 @@ describe "Inspec::Resources::Service" do
       _(resource.monitored_by?("monit")).must_equal true
       ex = _ { resource.has_start_mode?("Auto") }.must_raise(Inspec::Exceptions::ResourceSkipped)
       _(ex.message).must_include "The `has_start_mode` matcher is not supported on your OS yet."
+      _(resource.resource_id).must_equal "ssh"
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added resource_id in following resources:

- powershell
- rabbitmq_conf
- rabbitmq_config
- registry_key
- runit_service
- script
- security_identifier
- security_policy

On `bundle exec PROFILE --reporter json`, resource_id should contain a unique value for each initialization. It is loosely unique at this point.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
