### PR TITLE
Fix the key duplication error warning in the mock_loader.rb

### DIFF
--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -399,9 +399,6 @@ class MockLoader
       "cgget -n -r cpuset.cpus carrotking" => cmd.call("cgget-n-r"),
       "cgget -n -r memory.stat carrotking" => cmd.call("cgget-n-r-stat"),
       %{sh -c 'type "cgget"'} => empty.call,
-      # x509_certificate
-      %{sh -c 'type "openssl"'} => empty.call,
-      "openssl x509 -noout -purpose -in test_certificate.rsa.crt.pem" => cmd.call("x509-crt-purpose"),
       # mail_alias
       "cat /etc/aliases | grep '^daemon:'" => cmd.call("mail-alias"),
       # php_config
@@ -421,8 +418,10 @@ class MockLoader
       "/usr/sbin/auditctl -s | grep pid" => cmd.call("auditctl-s-pid"),
       "/usr/sbin/auditctl -l" => cmd.call("auditctl-l"),
       %{sh -c 'type "/usr/sbin/auditctl"'} => empty.call,
-      # x509_private_key
+      # x509_certificate
       %{sh -c 'type "openssl"'} => empty.call,
+      "openssl x509 -noout -purpose -in test_certificate.rsa.crt.pem" => cmd.call("x509-crt-purpose"),
+      # x509_private_key
       %{type "openssl"} => empty.call,
       "openssl rsa -in /home/openssl_activity/bob_private.pem -check -noout" => empty.call,
       "openssl rsa -in /home/openssl_activity/alice_private.pem -check -noout -passin pass:password@123" => empty.call,


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This fixes the below warning coming in the verify pipeline 
```
Temporarily accepting Chef user license for the duration of testing...
/workdir/test/helpers/mock_loader.rb:403: warning: key "sh -c 'type \"openssl\"'" is duplicated and overwritten on line 425

```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
