### PR TITLE
Backport fix for processes resource on windows when path is empty

### DIFF
--- a/lib/inspec/resources/processes.rb
+++ b/lib/inspec/resources/processes.rb
@@ -41,9 +41,10 @@ module Inspec::Resources
         grep = Regexp.new(grep)
       end
 
+      # require "byebug"; byebug
       all_cmds = ps_axo
       @list = all_cmds.find_all do |hm|
-        hm[:command] =~ grep
+        hm[:command] =~ grep || hm[:process_name] =~ grep
       end
     end
 
@@ -73,6 +74,7 @@ module Inspec::Resources
       .register_column(:time,     field: "time")
       .register_column(:users,    field: "user")
       .register_column(:commands, field: "command")
+      .register_column(:process_name, field: "process_name")
       .install_filter_methods_on_resource(self, :filtered_processes)
 
     private
@@ -87,9 +89,9 @@ module Inspec::Resources
       if os.linux?
         command, regex, field_map = ps_configuration_for_linux
       elsif os.windows?
-        command = '$Proc = Get-Process -IncludeUserName | Where-Object {$_.Path -ne $null } | Select-Object PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path | ConvertTo-Csv -NoTypeInformation;$Proc.Replace("""","").Replace("`r`n","`n")'
+        command = '$Proc = Get-Process -IncludeUserName | Select-Object PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path,ProcessName | ConvertTo-Csv -NoTypeInformation;$Proc.Replace("""","").Replace("`r`n","`n")'
         # Wanted to use /(?:^|,)([^,]*)/; works on rubular.com not sure why here?
-        regex = /^(.+),(.+),(.+),(.+),(.+),(.+),(.+),(.+),(.+),(.+),(.+),(.+)$/
+        regex = /^(.*),(.*),(.*),(.*),(.*),(.*),(.*),(.*),(.*),(.*),(.*),(.*),(.*)$/
         field_map = {
           pid: 2,
           cpu: 3,
@@ -102,6 +104,7 @@ module Inspec::Resources
           time: 10,
           user: 11,
           command: 12,
+          process_name: 13,
         }
       else
         command = "ps axo pid,pcpu,pmem,vsz,rss,tty,stat,start,time,user,command"
@@ -176,6 +179,7 @@ module Inspec::Resources
     end
 
     def build_process_list(command, regex, field_map)
+      # require "byebug"; byebug
       cmd = inspec.command(command)
       all = cmd.stdout.split("\n")[1..-1]
       return [] if all.nil?
@@ -193,7 +197,7 @@ module Inspec::Resources
 
         # build a hash of process data that we'll turn into a struct for FilterTable
         process_data = {}
-        %i{label pid cpu mem vsz rss tty stat start time user command}.each do |param|
+        %i{label pid cpu mem vsz rss tty stat start time user command process_name}.each do |param|
           # not all operating systems support all fields, so skip the field if we don't have it
           process_data[param] = line[field_map[param]] if field_map.key?(param)
         end

--- a/lib/inspec/resources/processes.rb
+++ b/lib/inspec/resources/processes.rb
@@ -41,7 +41,6 @@ module Inspec::Resources
         grep = Regexp.new(grep)
       end
 
-      # require "byebug"; byebug
       all_cmds = ps_axo
       @list = all_cmds.find_all do |hm|
         hm[:command] =~ grep || hm[:process_name] =~ grep
@@ -179,7 +178,6 @@ module Inspec::Resources
     end
 
     def build_process_list(command, regex, field_map)
-      # require "byebug"; byebug
       cmd = inspec.command(command)
       all = cmd.stdout.split("\n")[1..-1]
       return [] if all.nil?

--- a/test/fixtures/cmd/get-process_processes
+++ b/test/fixtures/cmd/get-process_processes
@@ -1,3 +1,4 @@
 PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path,ProcessName
 Normal,2456,0.296875,4808704,118202368,14576,1,True,5/31/2017 9:13:17 AM,00:00:00.2968750,WINVAGR-QQQNHPN\Administrator,C:\Windows\system32\mmc.exe,,
 High,396,0.15625,1323008,53710848,7776,1,True,5/31/2017 9:12:56 AM,00:00:00.1562500,NT AUTHORITY\SYSTEM,C:\Windows\system32\winlogon.exe,winlogon
+,1360,3505.90625,270106624,644595712,88624,0,True,5/11/2022 5:17:04 PM,00:58:25.9062500,,,MsMpEng

--- a/test/fixtures/cmd/get-process_processes
+++ b/test/fixtures/cmd/get-process_processes
@@ -1,3 +1,3 @@
-PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path
-Normal,2456,0.296875,4808704,118202368,14576,1,True,5/31/2017 9:13:17 AM,00:00:00.2968750,WINVAGR-QQQNHPN\Administrator,C:\Windows\system32\mmc.exe
-High,396,0.15625,1323008,53710848,7776,1,True,5/31/2017 9:12:56 AM,00:00:00.1562500,NT AUTHORITY\SYSTEM,C:\Windows\system32\winlogon.exe
+PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path,ProcessName
+Normal,2456,0.296875,4808704,118202368,14576,1,True,5/31/2017 9:13:17 AM,00:00:00.2968750,WINVAGR-QQQNHPN\Administrator,C:\Windows\system32\mmc.exe,,
+High,396,0.15625,1323008,53710848,7776,1,True,5/31/2017 9:12:56 AM,00:00:00.1562500,NT AUTHORITY\SYSTEM,C:\Windows\system32\winlogon.exe,winlogon

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -464,7 +464,6 @@ class MockLoader
       # modprobe for kernel_module
       "modprobe --showconfig" => cmd.call("modprobe-config"),
       # get-process cmdlet for processes resource
-      # '$Proc = Get-Process -IncludeUserName | Where-Object {$_.Path -ne $null } | Select-Object PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path | ConvertTo-Csv -NoTypeInformation;$Proc.Replace("""","").Replace("`r`n","`n")' => cmd.call("get-process_processes"),
       '$Proc = Get-Process -IncludeUserName | Select-Object PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path,ProcessName | ConvertTo-Csv -NoTypeInformation;$Proc.Replace("""","").Replace("`r`n","`n")' => cmd.call("get-process_processes"),
       # host resource: TCP/UDP reachability check on linux
       %{sh -c 'type "nc"'} => empty.call,

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -464,7 +464,8 @@ class MockLoader
       # modprobe for kernel_module
       "modprobe --showconfig" => cmd.call("modprobe-config"),
       # get-process cmdlet for processes resource
-      '$Proc = Get-Process -IncludeUserName | Where-Object {$_.Path -ne $null } | Select-Object PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path | ConvertTo-Csv -NoTypeInformation;$Proc.Replace("""","").Replace("`r`n","`n")' => cmd.call("get-process_processes"),
+      # '$Proc = Get-Process -IncludeUserName | Where-Object {$_.Path -ne $null } | Select-Object PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path | ConvertTo-Csv -NoTypeInformation;$Proc.Replace("""","").Replace("`r`n","`n")' => cmd.call("get-process_processes"),
+      '$Proc = Get-Process -IncludeUserName | Select-Object PriorityClass,Id,CPU,PM,VirtualMemorySize,NPM,SessionId,Responding,StartTime,TotalProcessorTime,UserName,Path,ProcessName | ConvertTo-Csv -NoTypeInformation;$Proc.Replace("""","").Replace("`r`n","`n")' => cmd.call("get-process_processes"),
       # host resource: TCP/UDP reachability check on linux
       %{sh -c 'type "nc"'} => empty.call,
       %{sh -c 'type "ncat"'} => empty.call,

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -29,6 +29,7 @@ describe "Inspec::Resources::Processes" do
       time: "0:00.05",
       user: "root",
       command: "login -fp apop",
+      process_name: nil,
     })
   end
 
@@ -48,6 +49,7 @@ describe "Inspec::Resources::Processes" do
       time: "00:00:00",
       user: "opscode-pgsql",
       command: "postgres: bifrost bifrost 127.0.0.1(43699) idle",
+      process_name: nil,
     })
   end
 
@@ -68,6 +70,7 @@ describe "Inspec::Resources::Processes" do
       time: "00:00:00",
       user: "opscode-pgsql",
       command: "postgres: bifrost bifrost 127.0.0.1(43699) idle",
+      process_name: nil,
     })
   end
 
@@ -87,6 +90,7 @@ describe "Inspec::Resources::Processes" do
       time: "00:01:01",
       user: "root",
       command: "/usr/local/apache2/bin/httpd -k start",
+      process_name: nil,
     })
   end
 
@@ -96,7 +100,7 @@ describe "Inspec::Resources::Processes" do
     _(process.user).must_equal "opscode-pgsql"
     _(process[:user]).must_equal "opscode-pgsql"
     _(process["user"]).must_equal "opscode-pgsql"
-    _(process[-1]).must_equal "postgres: bifrost bifrost 127.0.0.1(43699) idle"
+    _(process[-2]).must_equal "postgres: bifrost bifrost 127.0.0.1(43699) idle"
     _(process[1]).must_equal 5127
   end
 
@@ -139,6 +143,7 @@ describe "Inspec::Resources::Processes" do
       time: "00:00:00",
       user: "ntp",
       command: "/usr/sbin/ntpd -p /var/run/ntpd.pid -g -u 112:117",
+      process_name: nil,
     })
   end
 
@@ -158,6 +163,7 @@ describe "Inspec::Resources::Processes" do
       time: "0:00",
       user: "joe",
       command: "/some/other/coolprogram",
+      process_name: nil,
     })
   end
 
@@ -177,6 +183,7 @@ describe "Inspec::Resources::Processes" do
       time: "3:50",
       user: "frank",
       command: "/a/bigger/program",
+      process_name: nil,
     })
   end
 
@@ -196,6 +203,7 @@ describe "Inspec::Resources::Processes" do
       time: "39:00",
       user: "tim",
       command: "/the/biggest/program",
+      process_name: nil,
     })
   end
 

--- a/test/unit/resources/processes_test.rb
+++ b/test/unit/resources/processes_test.rb
@@ -222,6 +222,11 @@ describe "Inspec::Resources::Processes" do
     _(resource.exists?).must_equal true
   end
 
+  it "process without path should exist" do
+    resource = MockLoader.new(:windows).load_resource("processes", "MsMpEng")
+    _(resource.exists?).must_equal true
+  end
+
   it "process should_not exist" do
     resource = MockLoader.new(:windows).load_resource("processes", "unicorn.exe")
     _(resource.exists?).must_equal false


### PR DESCRIPTION
backports #6100 to inspec 4


## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
