### PR TITLE
CFINSPEC-353 Suggest- Basic tool for packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ results/
 terraform.tfstate*
 terraform.tfstate.backup
 terraform.tfvars
-test/**/*.lock
+test/**/*.locktmp
+tmp/*

--- a/etc/suggest.yaml
+++ b/etc/suggest.yaml
@@ -1,0 +1,10 @@
+---
+
+# Relative to InSpec installation
+working_directory: tmp
+
+sets:
+ - name: chef-compliance
+   paths:
+    - compliance-profiles/src/inspec/supported/*
+    - compliance-profiles/src/inspec/unsupported/*

--- a/lib/inspec/ui.rb
+++ b/lib/inspec/ui.rb
@@ -106,6 +106,19 @@ module Inspec
       print_or_return(result, opts[:print])
     end
 
+    # Issues a one-line message, with 'INFO: ' prepended in bold cyan.
+    def info(str, opts = { print: true })
+      str = str.dup.to_s
+      result = ""
+      result += color? ? ANSI_CODES[:bold] + ANSI_CODES[:color][:cyan] : ""
+      result += "INFO:"
+      result += color? ? ANSI_CODES[:reset] : ""
+      result += " "
+      result += str
+      result += "\n"
+      print_or_return(result, opts[:print])
+    end
+
     # Issues a one-line message, with 'ERROR: ' prepended in bold red.
     def error(str, opts = { print: true })
       str = str.dup.to_s

--- a/lib/plugins/inspec-suggest/lib/inspec-suggest/cli_command.rb
+++ b/lib/plugins/inspec-suggest/lib/inspec-suggest/cli_command.rb
@@ -1,5 +1,3 @@
-require "inspec/resource"
-
 module InspecPlugins::Suggest
   class CliCommand < Inspec.plugin(2, :cli_command)
     # This isn't provided by Thor, but is needed by InSpec so that it can
@@ -45,5 +43,56 @@ module InspecPlugins::Suggest
       ui.warning("This is a generated plugin with a default implementation.  Edit lib/inspec-suggest/cli_command.rb to make it do what you want.")
       ui.exit(:success) # or :usage_error
     end
-  end
-end
+
+    desc "package SETNAME", "Packages suggestion criteria from a set of source profiles."
+    def package(setname)
+
+      # read config
+      cfg = YAML.load_file(File.join(Inspec.src_root, "etc", "suggest.yaml"))
+
+      # find set output profile directory
+      out_profile_dir = File.join(Inspec.src_root, "etc", "suggest", setname)
+      unless File.exist?(out_profile_dir)
+        ui.error("Output profile directory '#{out_profile_dir}' does not exist")
+        ui.exit(:usage_error)
+      end
+
+      set_cfg = cfg["sets"].detect { |s| s["name"] == setname}
+
+      unless(set_cfg)
+        ui.error("No set named '#{setname}' in config")
+        ui.exit(:usage_error)
+      end
+
+      # TODO: git clone if needed
+      # find working directory
+      working_dir = File.join(Inspec.src_root, cfg["working_directory"])
+      unless File.exist?(working_dir)
+        ui.error("Working directory '#{working_dir}' does not exist")
+        ui.exit(:usage_error)
+      end
+
+      # Open set suggestion file - truncate
+      criteria_out_file = File.join(out_profile_dir, "controls", "criteria.rb")
+      ui.info("Writing to criteria file #{criteria_out_file}")
+      File.open(criteria_out_file, "w") do |set_suggestion_file|
+
+        # find set source directory
+        # for each subdir glob
+        # look for suggest folder
+        # read any .rb files
+        set_cfg["paths"].each do |path|
+          Dir.glob(File.join(working_dir, path, "suggest", "*.rb")).each do |control_file_path|
+            ui.info("found #{control_file_path}")
+            # append them to the set suggestion file
+            File.open(control_file_path) do |control_file|
+              control_file.readlines.each do |line|
+                set_suggestion_file.write(line)
+              end
+            end
+          end
+        end # each path
+      end # file open
+    end # def package
+  end # class
+end # module


### PR DESCRIPTION
Part of InSpec Suggest.

Basic tool to do packaging of suggestion criteria. Simplest thing that could work. Assumes source profiles are already cloned into tmp/ under inspec source directory, and take a list of globs from the config file. Looks for all files in glob/suggest/*.rb and concatenates them into etc/suggest/SETNAME/controls/criteria.rb .

Should probably do more, but that will be on another ticket, this is just to unblock further progress.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
