### PR TITLE
Properly split args and kwargs for Ruby 3.x when loading resources.

### DIFF
--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -253,11 +253,11 @@ module Inspec
 
           registry = profile_context.resource_registry
           registry.each do |id, r|
-            define_method(id) { |*args| r.new(be, id.to_s, *args) }
+            define_method(id) { |*args, **kwargs| r.new(be, id.to_s, *args, **kwargs) }
 
             next if be.respond_to?(id)
 
-            bec.define_method(id) { |*args| r.new(be, id.to_s, *args) }
+            bec.define_method(id) { |*args, **kwargs| r.new(be, id.to_s, *args, **kwargs) }
           end
         end # add_resource_methods
       end # ClassMethods

--- a/lib/inspec/resource.rb
+++ b/lib/inspec/resource.rb
@@ -121,10 +121,10 @@ module Inspec
         # initialize methods from having to call super, which is,
         # quite frankly, dumb. Avoidable even with some simple
         # documentation.
-        def initialize(backend, name, *args)
+        def initialize(backend, name, *args, **kwargs)
           supersuper_initialize(backend, name) do
             @resource_params = args
-            super(*args)
+            super(*args, **kwargs)
           end
         end
       end


### PR DESCRIPTION
## Description
By default, InSpec calls super on defined resources automatically. On Ruby 3.x this is broken since args and kwargs are handled differently. This fixes the problem by properly splitting out the parameters.

## Related Issue
Fixes #6154
Fixes https://github.com/GoogleCloudPlatform/inspec-gcp-helpers/issues/12

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
