### PR TITLE
CFINSPEC-231 Suggest - Basic Reporters

### DIFF
--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -384,12 +384,21 @@ module Inspec
       end
 
       # check to make sure we are only reporting one type to stdout
-      stdout_reporters = 0
-      reporters.each_value do |reporter_config|
-        stdout_reporters += 1 if reporter_config["stdout"] == true
+      # You can have one streaming reporter and one onieshot reporter write to
+      # stdout, though, because they write at different times
+      stdout_oneshot_reporters = 0
+      stdout_streaming_reporters = 0
+      reporters.each do |reporter_name, reporter_config|
+        if reporter_config["stdout"] == true
+          if streaming_reporters.include? reporter_name
+            stdout_streaming_reporters += 1
+          else
+            stdout_oneshot_reporters += 1
+          end
+        end
       end
 
-      raise ArgumentError, "The option --reporter can only have a single report outputting to stdout." if stdout_reporters > 1
+      raise ArgumentError, "The option --reporter can only have a single report outputting to stdout." if stdout_oneshot_reporters > 1 || stdout_streaming_reporters > 1
 
       # reporter_message_truncation needs to either be the string "ALL", an Integer, or a string representing an integer
       if (truncation = @merged_options["reporter_message_truncation"])

--- a/lib/plugins/inspec-suggest/lib/inspec-suggest/plugin.rb
+++ b/lib/plugins/inspec-suggest/lib/inspec-suggest/plugin.rb
@@ -14,6 +14,14 @@ module InspecPlugins
         require_relative "reporter/debug"
         InspecPlugins::Suggest::Reporter::Debug
       end
+
+      # Streaming reporter which gives a progress bar during the run. Intended
+      # to be used at the same time as one of the other reporters.
+      streaming_reporter :"suggest-progress" do
+        require_relative "reporter/progress"
+        InspecPlugins::Suggest::Reporter::Progress
+      end
+
     end
   end
 end

--- a/lib/plugins/inspec-suggest/lib/inspec-suggest/plugin.rb
+++ b/lib/plugins/inspec-suggest/lib/inspec-suggest/plugin.rb
@@ -15,6 +15,12 @@ module InspecPlugins
         InspecPlugins::Suggest::Reporter::Debug
       end
 
+      # Basic text reporter, shows only matches.
+      reporter :"suggest-text" do
+        require_relative "reporter/text"
+        InspecPlugins::Suggest::Reporter::Text
+      end
+
       # Streaming reporter which gives a progress bar during the run. Intended
       # to be used at the same time as one of the other reporters.
       streaming_reporter :"suggest-progress" do

--- a/lib/plugins/inspec-suggest/lib/inspec-suggest/plugin.rb
+++ b/lib/plugins/inspec-suggest/lib/inspec-suggest/plugin.rb
@@ -5,8 +5,14 @@ module InspecPlugins
       plugin_name :"inspec-suggest"
 
       cli_command :suggest do
-        require "inspec-suggest/cli_command"
+        require_relative "cli_command"
         InspecPlugins::Suggest::CliCommand
+      end
+
+      # Diagnostic reporter, which summarizes the results of the run.
+      reporter :"suggest-debug" do
+        require_relative "reporter/debug"
+        InspecPlugins::Suggest::Reporter::Debug
       end
     end
   end

--- a/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/base.rb
+++ b/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/base.rb
@@ -1,0 +1,17 @@
+module InspecPlugins::Suggest
+  module Reporter
+    class Base < Inspec.plugin(2, :reporter)
+      def self.run_data_schema_constraints
+        "~> 0.0"
+      end
+
+      # Assumes --no-enhanced-outcomes
+      def match?(ctl)
+        return false if ctl.results.any? { |r| r.status == "failed" } # control outcome failed
+        return false if ctl.results.all? { |r| r.status == "skipped" } # control outcome skipped
+        return true # passed
+      end
+
+    end
+  end
+end

--- a/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/debug.rb
+++ b/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/debug.rb
@@ -19,18 +19,18 @@ module InspecPlugins::Suggest
               controls_by_cat[control.tags[:category]] << control
             end
           end
+        end
 
-          if controls_by_cat.empty?
-            puts(("-" * 20) + " No Matches " + ("-" * 20))
-          else
-            puts(("-" * 20) + " Winners " + ("-" * 20))
-            # Loop over matched categories. Sort results.
-            controls_by_cat.each do |category, controls|
-              controls.sort! { |a,b| a.impact <=> b.impact }
-              puts "Category: #{category}"
-              controls.each do |control|
-                puts "\t#{control.impact}\t#{control.id}"
-              end
+        if controls_by_cat.empty?
+          puts(("-" * 20) + " No Matches " + ("-" * 20))
+        else
+          puts(("-" * 20) + " Winners " + ("-" * 20))
+          # Loop over matched categories. Sort results.
+          controls_by_cat.each do |category, controls|
+            controls.sort! { |a,b| a.impact <=> b.impact }
+            puts "Category: #{category}"
+            controls.each do |control|
+              puts "\t#{control.impact}\t#{control.id}"
             end
           end
         end

--- a/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/debug.rb
+++ b/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/debug.rb
@@ -1,0 +1,40 @@
+require_relative "base"
+module InspecPlugins::Suggest
+  module Reporter
+    class Debug < Base
+      def render
+
+        controls_by_cat = {}
+
+        run_data.profiles.each do |profile|
+          profile.controls.each do |control|
+            puts("-" * 20)
+            puts "id: " + control.id
+            puts "match?: " + (match?(control) ? "yes" : "no")
+            puts "impact: " + control.impact.to_s
+            puts "category: " + control.tags[:category]
+
+            if match?(control)
+              controls_by_cat[control.tags[:category]] ||= []
+              controls_by_cat[control.tags[:category]] << control
+            end
+          end
+
+          if controls_by_cat.empty?
+            puts(("-" * 20) + " No Matches " + ("-" * 20))
+          else
+            puts(("-" * 20) + " Winners " + ("-" * 20))
+            # Loop over matched categories. Sort results.
+            controls_by_cat.each do |category, controls|
+              controls.sort! { |a,b| a.impact <=> b.impact }
+              puts "Category: #{category}"
+              controls.each do |control|
+                puts "\t#{control.impact}\t#{control.id}"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/progress.rb
+++ b/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/progress.rb
@@ -1,0 +1,42 @@
+require "progress_bar"
+
+module InspecPlugins::Suggest
+  module Reporter
+    # Does not inherit from Base - needs a different superclass
+    class Progress < Inspec.plugin(2, :streaming_reporter)
+
+      RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending
+
+      def initialize(output)
+        @bar = nil
+        initialize_streaming_reporter
+      end
+
+      def example_passed(notification)
+        set_example(notification)
+      end
+
+      def example_failed(notification)
+        set_example(notification)
+      end
+
+      def example_pending(notification)
+        set_example(notification)
+      end
+
+      private
+
+      def set_example(notification)
+        control_id = notification.example.metadata[:id]
+        show_progress(control_id) if control_ended?(control_id)
+      end
+
+      def show_progress(control_id)
+        @bar ||= ProgressBar.new(controls_count, :bar, :counter, :percentage)
+        @bar.increment!
+      rescue StandardError => e
+        raise "Exception in suggest-progress reporter: #{e}"
+      end
+    end
+  end
+end

--- a/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/progress.rb
+++ b/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/progress.rb
@@ -32,7 +32,7 @@ module InspecPlugins::Suggest
       end
 
       def show_progress(control_id)
-        @bar ||= ProgressBar.new(controls_count, :bar, :counter, :percentage)
+        @bar ||= ProgressBar.new(controls_count, :bar, :percentage)
         @bar.increment!
       rescue StandardError => e
         raise "Exception in suggest-progress reporter: #{e}"

--- a/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/text.rb
+++ b/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/text.rb
@@ -15,6 +15,8 @@ module InspecPlugins::Suggest
           end
         end
 
+        puts "\n\n"
+
         if controls_by_cat.empty?
           puts "Sorry, no recommendations at this time."
         else

--- a/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/text.rb
+++ b/lib/plugins/inspec-suggest/lib/inspec-suggest/reporter/text.rb
@@ -1,0 +1,34 @@
+require_relative "base"
+module InspecPlugins::Suggest
+  module Reporter
+    class Text < Base
+      def render
+
+        controls_by_cat = {}
+
+        run_data.profiles.each do |profile|
+          profile.controls.each do |control|
+            if match?(control)
+              controls_by_cat[control.tags[:category]] ||= []
+              controls_by_cat[control.tags[:category]] << control
+            end
+          end
+        end
+
+        if controls_by_cat.empty?
+          puts "Sorry, no recommendations at this time."
+        else
+          puts "Recommendations:"
+          # Loop over matched categories. Sort results.
+          controls_by_cat.each do |category, controls|
+            controls.sort! { |a,b| a.impact <=> b.impact }
+            puts "Category: #{category.upcase}"
+            controls.each do |control|
+              puts "\t#{control.id}"
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A set of reporters for InSpec suggest.

First, a diagnostic reporter, suggest-debug.
Next, a streaming reporter, suggest-progress. Simple progress bar, no text output.
Modifies the core reporter validation to allow both streaming reporter and one-shot reporter output to STDOUT.
Finally, a simple reporter that outputs the results of the scan contest, suggest-text.

Intended to be run in normal use with both suggest-progress and suggest-text enabled.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
