### PR TITLE
Fixes for Buildkite Issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :test do
   gem "json_schemer", ">= 0.2.1", "< 0.2.19"
   gem "m"
   gem "minitest-sprint", "~> 1.0"
-  gem "minitest", "~> 5.5"
+  gem "minitest", "5.15.0"
   gem "mocha", "~> 1.1"
   gem "nokogiri", "~> 1.9"
   gem "pry-byebug"

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -227,7 +227,7 @@ class MockLoader
       'sh -c \'type "/sbin/auditctl"\'' => empty.call,
       'sh -c \'type "sql"\'' => cmd_exit_1.call,
       'type "pwsh"' => empty.call,
-      'type "netstat"' => empty.call,
+      'type "/usr/sbin/netstat"' => empty.call,
       "sh -c 'find /etc/apache2/ports.conf -type l -maxdepth 1'" => empty.call,
       "sh -c 'find /etc/httpd/conf.d/*.conf -type l -maxdepth 1'" => empty.call,
       "sh -c 'find /etc/httpd/mods-enabled/*.conf -type l -maxdepth 1'" => empty.call,

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -409,6 +409,7 @@ class MockLoader
       "php -c /etc/php/7.4/cli/php.ini -r 'echo get_cfg_var(\"default_mimetype\");'" => cmd.call("get-cfg-var"),
       # routing_table
       "netstat -rn" => cmd.call("netstat-rn-linux"),
+      "/usr/sbin/netstat -rn" => cmd.call("netstat-rn-linux"),
       %{sh -c 'type "netstat"'} => empty.call,
       # mocks for be_immutable matcher for file resource
       "lsattr constantfile.txt" => cmd.call("lsattr-output"),

--- a/test/unit/resources/cgroup_test.rb
+++ b/test/unit/resources/cgroup_test.rb
@@ -26,7 +26,7 @@ describe Inspec::Resources::Cgroup do
 
   # undefined
   it "check carrotking cgroup information on unsupported os" do
-    resource = MockLoader.new("undefined".to_sym).load_resource("cgroup", "carrotking")
+    resource = MockLoader.new("exsi".to_sym).load_resource("cgroup", "carrotking")
     _(resource.resource_skipped?).must_equal true
     _(resource.resource_exception_message).must_equal "The `cgroup` resource is not supported on your OS yet."
   end

--- a/test/unit/resources/default_gateway_test.rb
+++ b/test/unit/resources/default_gateway_test.rb
@@ -19,7 +19,7 @@ describe Inspec::Resources::Defaultgateway do
 
   # unsupported os
   it "check ipaddress and interface of default gateway on unsupported os" do
-    resource = MockLoader.new("undefined".to_sym).load_resource("default_gateway")
+    resource = MockLoader.new("esxi".to_sym).load_resource("default_gateway")
     _(resource.resource_skipped?).must_equal true
     _(resource.resource_failed?).must_equal true
   end

--- a/test/unit/resources/routing_table_test.rb
+++ b/test/unit/resources/routing_table_test.rb
@@ -26,7 +26,7 @@ describe Inspec::Resources::Routingtable do
 
   # unsupported os
   it "check routing table information on unsupported os" do
-    resource = MockLoader.new("undefined".to_sym).load_resource("routing_table")
+    resource = MockLoader.new("esxi".to_sym).load_resource("routing_table")
     _(resource.resource_skipped?).must_equal true
     _(resource.resource_failed?).must_equal true
   end


### PR DESCRIPTION
* Temporarily pins minitest to 5.15.0 to avoid issues with mock breaking Inspec::ShellDetector.
* Adds /usr/sbin/netstat -rn to mockloader to fix failing route_table and default_gateway tests
* Silences (at least one set of) warnings about running Command.exist?(netstat) on unknown OS

and hopefully gets things green again


Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixes for Buildkite Issues
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
