### PR TITLE
Add k8s section to resources index page

### DIFF
--- a/docs-chef-io/content/inspec/resources/_index.md
+++ b/docs-chef-io/content/inspec/resources/_index.md
@@ -56,3 +56,7 @@ The following resources work on Windows operating systems.
 ## Habitat
 
 {{< inspec/inspec_resources platform="habitat" >}}
+
+## Kubernetes
+
+{{< inspec/inspec_resources platform="k8s" >}}


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

This adds a section in the InSpec [resources page](https://docs.chef.io/inspec/resources/) for [K8s resources](https://github.com/inspec/inspec-k8s/pull/4).

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
