### PR TITLE
CFINSPEC-361: Add `podman_image` resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/podman_image.md
+++ b/docs-chef-io/content/inspec/resources/podman_image.md
@@ -13,50 +13,56 @@ platform = "unix"
 
 Use the `podman_image` Chef InSpec audit resource to test the properties of a container image on Podman.
 
-
 ## Availability
 
 ### Installation
 
-This resource is distributed with Chef InSpec.
+This resource is distributed with Chef InSpec and is automatically available for use.
 
 ## Syntax
 
-A `podman_image` Chef InSpec audit resource helps to test the properties of a container image on Podman
+A `podman_image` Chef InSpec audit resource aids in testing the properties of a container image on Podman.
 
-    describe podman_image("docker.io/library/busybox") do
-      it { should exist }
-      its("id") { should eq "3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
-      its("repo_tags") { should include "docker.io/library/busybox:latest" }
-      its("size") { should eq 1636053 }
-      its("os") { should eq "linux" }
-    end
+```ruby
+  describe podman_image("docker.io/library/busybox") do
+    it { should exist }
+    its("id") { should eq "3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
+    its("repo_tags") { should include "docker.io/library/busybox:latest" }
+    its("size") { should eq 1636053 }
+    its("os") { should eq "linux" }
+  end
+```
 
-where
-
-- `'id'`, `'repo_tags'`, `'size'`, `'os'` are properties of this resource to fetch the respective value of the container image
-- `exist` is a matcher of this resource
+> where
+>
+> - `id`, `repo_tags`, `size`, and `os` are properties of this resource to fetch the respective value of the container image.
+> - `exist` is a matcher of this resource.
 
 ### Resource Parameter Examples
 
-The resource allows you to pass an image name. If the tag is missing for an image, `latest` is assumed as default.
+- The resource allows you to pass an image name. If the tag is missing for an image, `latest` is assumed as default.
 
-    describe podman_image("docker.io/library/busybox") do
-      it { should exist }
-    end
-    
-The resource allows you to pass the repository and tag values as separate values.
+```ruby
+  describe podman_image("docker.io/library/busybox") do
+    it { should exist }
+  end
+```
 
-    describe podman_image(repo: "docker.io/library/busybox", tag: "latest") do
-      it { should exist }
-    end
+- The resource allows you to pass the repository and tag values as separate values.
 
-The resource allows you to pass with an image ID.
+```ruby
+  describe podman_image(repo: "docker.io/library/busybox", tag: "latest") do
+    it { should exist }
+  end
+```
 
-    describe podman_image(id: "8847e9bf6df8") do
-      it { should exist }
-    end
+- The resource allows you to pass with an image ID.
 
+```ruby
+  describe podman_image(id: "8847e9bf6df8") do
+    it { should exist }
+  end
+```
 
 ## Properties
 
@@ -64,58 +70,89 @@ The resource allows you to pass with an image ID.
 
 The `id` property returns the full image ID.
 
-    its("id") { should eq "3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
+```ruby
+  its("id") { should eq "3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
+```
 
 ### repo_tags
 
 The `repo_tags` property tests the value of the repository name.
 
-    its("repo_tags") { should include "docker.io/library/busybox:latest" }
+```ruby
+  its("repo_tags") { should include "docker.io/library/busybox:latest" }
+```
 
 ### size
+
 The `size` property tests the size of the image in bytes
 
-    its("size") { should eq 1636053 }
+```ruby
+  its("size") { should eq 1636053 }
+```
 
 ### digest
+
 The `digest` property tests the value of the image digest.
 
-    its("digest") { should eq "sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83" }
+```ruby
+  its("digest") { should eq "sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83" }
+```
 
 ### created_at
-The `created_at` property tests the time of creation of the image.
 
-    its("created_at") { should eq "2022-06-08T00:39:28.175020858Z" }
+The `created_at` property tests the time of the image creation.
+
+```ruby
+  its("created_at") { should eq "2022-06-08T00:39:28.175020858Z" }
+```
 
 ### version
-The `version` property tests the version of the image
 
-    its("version") { should eq "20.10.12" }
+The `version` property tests the version of the image.
+
+```ruby
+  its("version") { should eq "20.10.12" }
+```
 
 ### names_history
+
 The `names_history` property tests the names history of the image.
 
-    its("names_history") { should include "docker.io/library/busybox:latest" }
+```ruby
+  its("names_history") { should include "docker.io/library/busybox:latest" }
+```
 
 ### repo_digests
+
 The `repo_digests` tests the digest of the repository of the given image.
 
-    its("repo_digests") { should include "docker.io/library/busybox@sha256:2c5e2045f35086c019e80c86880fd5b7c7a619878b59e3b7592711e1781df51a" }
+```ruby
+  its("repo_digests") { should include "docker.io/library/busybox@sha256:2c5e2045f35086c019e80c86880fd5b7c7a619878b59e3b7592711e1781df51a" }
+```
 
 ### architecture
+
 The `architecture` tests the architecture of the given image.
 
-    its("architecture") { should eq "arm64" }
+```ruby
+  its("architecture") { should eq "arm64" }
+```
 
 ### os
+
 The `os` property tests the operating system of the given image.
 
-    its("os") { should eq "linux" }
+```ruby
+  its("os") { should eq "linux" }
+```
 
 ### virtual_size
+
 The `virtual_size` property tests the virtual size of the given image.
 
-    its("virtual_size") { should eq 1636053 }
+```ruby
+  its("virtual_size") { should eq 1636053 }
+```
 
 ## Matchers
 
@@ -125,24 +162,28 @@ For a full list of available matchers, please visit our [matchers page](/inspec/
 
 The `exist` matcher tests if the image is available on Podman.
 
-    it { should exist }
+```ruby
+  it { should exist }
+```
 
 ## Examples
 
-### Test if an image exists on Podman and verifies the various image properties:
+### Test if an image exists on Podman and verify the various image properties
 
-    describe podman_image("docker.io/library/busybox") do
-      it { should exist }
-      its("id") { should eq "3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
-      its("repo_tags") { should include "docker.io/library/busybox:latest" }
-      its("size") { should eq 1636053 }
-      its("digest") { should eq "sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83" }
-      its("created_at") { should eq "2022-06-08T00:39:28.175020858Z" }
-      its("version") { should eq "20.10.12" }
-      its("names_history") { should include "docker.io/library/busybox:latest" }
-      its("repo_digests") { should include "docker.io/library/busybox@sha256:2c5e2045f35086c019e80c86880fd5b7c7a619878b59e3b7592711e1781df51a" }
-      its("architecture") { should eq "arm64" }
-      its("os") { should eq "linux" }
-      its("virtual_size") { should eq 1636053 }
-      its("resource_id") { should eq "docker.io/library/busybox:latest" }
-    end
+```ruby
+  describe podman_image("docker.io/library/busybox") do
+    it { should exist }
+    its("id") { should eq "3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
+    its("repo_tags") { should include "docker.io/library/busybox:latest" }
+    its("size") { should eq 1636053 }
+    its("digest") { should eq "sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83" }
+    its("created_at") { should eq "2022-06-08T00:39:28.175020858Z" }
+    its("version") { should eq "20.10.12" }
+    its("names_history") { should include "docker.io/library/busybox:latest" }
+    its("repo_digests") { should include "docker.io/library/busybox@sha256:2c5e2045f35086c019e80c86880fd5b7c7a619878b59e3b7592711e1781df51a" }
+    its("architecture") { should eq "arm64" }
+    its("os") { should eq "linux" }
+    its("virtual_size") { should eq 1636053 }
+    its("resource_id") { should eq "docker.io/library/busybox:latest" }
+  end
+```

--- a/docs-chef-io/content/inspec/resources/podman_image.md
+++ b/docs-chef-io/content/inspec/resources/podman_image.md
@@ -83,6 +83,30 @@ The `tag` property tests the value of the image tag.
 
     its('tag') { should eq 'latest' }
 
+### size
+The `size` property tests the size of the image
+
+    its("size") { should eq "1.64 MB" }
+
+### digest
+The `digest` property tests the value of the image digest.
+
+    its("digest") { should eq "sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83" }
+
+### history
+The `history` property tests the history of the image.
+
+    its("history") { should eq "docker.io/library/busybox:latest" }
+
+### created_at
+The `created_at` property tests the time of creation of the image.
+
+    its("created_at") { should eq "2022-06-08 00:39:28 +0000 UTC" }
+
+### created_since
+The `created_since` tests the value for the age of the image.
+
+    its("created_since") { should eq "4 weeks ago" }
 
 ## Matchers
 

--- a/docs-chef-io/content/inspec/resources/podman_image.md
+++ b/docs-chef-io/content/inspec/resources/podman_image.md
@@ -1,0 +1,108 @@
++++
+title = "podman_image resource"
+draft = false
+gh_repo = "inspec"
+platform = "unix"
+
+[menu]
+  [menu.inspec]
+    title = "podman_image"
+    identifier = "inspec/resources/os/podman_image.md podman_image resource"
+    parent = "inspec/resources/os"
++++
+
+Use the `podman_image` Chef InSpec audit resource to test the properties of a container image on Podman.
+
+
+## Availability
+
+### Installation
+
+This resource is distributed with Chef InSpec.
+
+## Syntax
+
+A `podman_image` Chef InSpec audit resource helps to test the properties of a container image on Podman
+
+    describe podman_image("docker.io/library/busybox") do
+      it { should exist }
+      its("id") { should eq "sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
+      its("image") { should eq "docker.io/library/busybox:latest" }
+      its("repo") { should eq "docker.io/library/busybox" }
+      its("tag") { should eq "latest" }
+    end
+where
+
+- `'id'`, `'image'`, `'repo'`, `'tag'` are properties of this resource to fetch the respective properties of the container image
+- `exist` is a matcher of this resource
+
+### Resource Parameter Examples
+
+The resource allows you to pass an image name. If the tag is missing for an image, `latest` is assumed as default.
+
+    describe podman_image("docker.io/library/busybox") do
+      it { should exist }
+    end
+    
+The resource allows you to pass the repository and tag values as separate values.
+
+    describe podman_image(repo: "docker.io/library/busybox", tag: "latest") do
+      it { should exist }
+    end
+
+The resource allows you to pass with an image ID.
+
+    describe podman_image(id: "8847e9bf6df8") do
+      it { should exist }
+    end
+
+
+## Properties
+
+### id
+
+The `id` property returns the full image ID.
+
+    its('id') { should eq 'sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6' }
+
+### image
+
+The `image` property tests the value of the image. It is a combination of `repository:tag`.
+
+    its('image') { should eq 'docker.io/library/busybox:latest' }
+
+### repo
+
+The `repo` property tests the value of the repository name.
+
+    its('repo') { should eq 'docker.io/library/busybox' }
+
+### tag
+
+The `tag` property tests the value of the image tag.
+
+    its('tag') { should eq 'latest' }
+
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).
+
+### exist
+
+The `exist` matcher tests if the image is available on Podman.
+
+    it { should exist }
+
+## Examples
+
+### Test if an image exists on Podman and verifies the image properties: id, image, repo, and tag
+
+    describe podman_image("docker.io/library/busybox") do
+      it { should exist }
+      its("id") { should eq "sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
+      its("image") { should eq "docker.io/library/busybox:latest" }
+      its("repo") { should eq "docker.io/library/busybox" }
+      its("tag") { should eq "latest" }
+    end
+

--- a/docs-chef-io/content/inspec/resources/podman_image.md
+++ b/docs-chef-io/content/inspec/resources/podman_image.md
@@ -108,6 +108,11 @@ The `created_since` tests the value for the age of the image.
 
     its("created_since") { should eq "4 weeks ago" }
 
+### inspec_info
+The `inspect_info` tests the low-level information of the image
+
+    its("inspect_info") { should include {"Architecture"=>"arm64"} }
+
 ## Matchers
 
 For a full list of available matchers, please visit our [matchers page](/inspec/matchers/).

--- a/docs-chef-io/content/inspec/resources/podman_image.md
+++ b/docs-chef-io/content/inspec/resources/podman_image.md
@@ -26,14 +26,15 @@ A `podman_image` Chef InSpec audit resource helps to test the properties of a co
 
     describe podman_image("docker.io/library/busybox") do
       it { should exist }
-      its("id") { should eq "sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
-      its("image") { should eq "docker.io/library/busybox:latest" }
-      its("repo") { should eq "docker.io/library/busybox" }
-      its("tag") { should eq "latest" }
+      its("id") { should eq "3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
+      its("repo_tags") { should include "docker.io/library/busybox:latest" }
+      its("size") { should eq 1636053 }
+      its("os") { should eq "linux" }
     end
+
 where
 
-- `'id'`, `'image'`, `'repo'`, `'tag'` are properties of this resource to fetch the respective properties of the container image
+- `'id'`, `'repo_tags'`, `'size'`, `'os'` are properties of this resource to fetch the respective value of the container image
 - `exist` is a matcher of this resource
 
 ### Resource Parameter Examples
@@ -63,55 +64,58 @@ The resource allows you to pass with an image ID.
 
 The `id` property returns the full image ID.
 
-    its('id') { should eq 'sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6' }
+    its("id") { should eq "3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
 
-### image
+### repo_tags
 
-The `image` property tests the value of the image. It is a combination of `repository:tag`.
+The `repo_tags` property tests the value of the repository name.
 
-    its('image') { should eq 'docker.io/library/busybox:latest' }
-
-### repo
-
-The `repo` property tests the value of the repository name.
-
-    its('repo') { should eq 'docker.io/library/busybox' }
-
-### tag
-
-The `tag` property tests the value of the image tag.
-
-    its('tag') { should eq 'latest' }
+    its("repo_tags") { should include "docker.io/library/busybox:latest" }
 
 ### size
-The `size` property tests the size of the image
+The `size` property tests the size of the image in bytes
 
-    its("size") { should eq "1.64 MB" }
+    its("size") { should eq 1636053 }
 
 ### digest
 The `digest` property tests the value of the image digest.
 
     its("digest") { should eq "sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83" }
 
-### history
-The `history` property tests the history of the image.
-
-    its("history") { should eq "docker.io/library/busybox:latest" }
-
 ### created_at
 The `created_at` property tests the time of creation of the image.
 
-    its("created_at") { should eq "2022-06-08 00:39:28 +0000 UTC" }
+    its("created_at") { should eq "2022-06-08T00:39:28.175020858Z" }
 
-### created_since
-The `created_since` tests the value for the age of the image.
+### version
+The `version` property tests the version of the image
 
-    its("created_since") { should eq "4 weeks ago" }
+    its("version") { should eq "20.10.12" }
 
-### inspec_info
-The `inspect_info` tests the low-level information of the image
+### names_history
+The `names_history` property tests the names history of the image.
 
-    its("inspect_info") { should include {"Architecture"=>"arm64"} }
+    its("names_history") { should include "docker.io/library/busybox:latest" }
+
+### repo_digests
+The `repo_digests` tests the digest of the repository of the given image.
+
+    its("repo_digests") { should include "docker.io/library/busybox@sha256:2c5e2045f35086c019e80c86880fd5b7c7a619878b59e3b7592711e1781df51a" }
+
+### architecture
+The `architecture` tests the architecture of the given image.
+
+    its("architecture") { should eq "arm64" }
+
+### os
+The `os` property tests the operating system of the given image.
+
+    its("os") { should eq "linux" }
+
+### virtual_size
+The `virtual_size` property tests the virtual size of the given image.
+
+    its("virtual_size") { should eq 1636053 }
 
 ## Matchers
 
@@ -125,13 +129,20 @@ The `exist` matcher tests if the image is available on Podman.
 
 ## Examples
 
-### Test if an image exists on Podman and verifies the image properties: id, image, repo, and tag
+### Test if an image exists on Podman and verifies the various image properties:
 
     describe podman_image("docker.io/library/busybox") do
       it { should exist }
-      its("id") { should eq "sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
-      its("image") { should eq "docker.io/library/busybox:latest" }
-      its("repo") { should eq "docker.io/library/busybox" }
-      its("tag") { should eq "latest" }
+      its("id") { should eq "3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
+      its("repo_tags") { should include "docker.io/library/busybox:latest" }
+      its("size") { should eq 1636053 }
+      its("digest") { should eq "sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83" }
+      its("created_at") { should eq "2022-06-08T00:39:28.175020858Z" }
+      its("version") { should eq "20.10.12" }
+      its("names_history") { should include "docker.io/library/busybox:latest" }
+      its("repo_digests") { should include "docker.io/library/busybox@sha256:2c5e2045f35086c019e80c86880fd5b7c7a619878b59e3b7592711e1781df51a" }
+      its("architecture") { should eq "arm64" }
+      its("os") { should eq "linux" }
+      its("virtual_size") { should eq 1636053 }
+      its("resource_id") { should eq "docker.io/library/busybox:latest" }
     end
-

--- a/lib/inspec/resources/podman_image.rb
+++ b/lib/inspec/resources/podman_image.rb
@@ -40,49 +40,49 @@ module Inspec::Resources
     end
 
     def exist?
-      inspect_info.key?("id")
+      get_value("id") != nil
     end
 
     def repo_tags
-      inspect_info["repo_tags"]
+      get_value("repo_tags")
     end
 
     def size
       # TODO: Convert bytes to KB or MB; if required
-      inspect_info["size"]
+      get_value("size")
     end
 
     def digest
-      inspect_info["digest"]
+      get_value("digest")
     end
 
     def created_at
-      inspect_info["created_at"]
+      get_value("created_at")
     end
 
     def version
-      inspect_info["version"]
+      get_value("version")
     end
 
     def names_history
-      inspect_info["names_history"]
+      get_value("names_history")
     end
 
     def repo_digests
-      inspect_info["repo_digests"]
+      get_value("repo_digests")
     end
 
     def architecture
-      inspect_info["architecture"]
+      get_value("architecture")
     end
 
     def os
-      inspect_info["os"]
+      get_value("os")
     end
 
     def virtual_size
       # TODO: Convert bytes to KB or MB
-      inspect_info["virtual_size"]
+      get_value("virtual_size")
     end
 
     def resource_id
@@ -129,6 +129,12 @@ module Inspec::Resources
 
       require "json" unless defined?(JSON)
       JSON.parse(podman_inspect_cmd.stdout)
+    end
+
+    def get_value(key)
+      return nil if inspect_info.nil?
+
+      inspect_info[key]
     end
   end
 end

--- a/lib/inspec/resources/podman_image.rb
+++ b/lib/inspec/resources/podman_image.rb
@@ -43,6 +43,10 @@ module Inspec::Resources
       get_value("id") != nil
     end
 
+    def id
+      get_value("id")
+    end
+
     def repo_tags
       get_value("repo_tags")
     end

--- a/lib/inspec/resources/podman_image.rb
+++ b/lib/inspec/resources/podman_image.rb
@@ -30,13 +30,13 @@ module Inspec::Resources
       end
     EXAMPLE
 
-    attr_reader :opts, :inspect_info
+    attr_reader :opts, :image_info
 
     def initialize(opts)
       skip_resource "The `podman_image` resource is not yet available on your OS." unless inspec.os.unix?
       opts = { image: opts } if opts.is_a?(String)
       @opts = sanitize_options(opts)
-      @inspect_info = get_inspect_info
+      @image_info = get_image_info
     end
 
     def exist?
@@ -111,7 +111,7 @@ module Inspec::Resources
       opts
     end
 
-    def get_inspect_info
+    def get_image_info
       current_image = @opts[:id] || @opts[:image] || @opts [:repo] + ":" + @opts[:tag]
       labels = {
         "id" => "ID",
@@ -136,9 +136,9 @@ module Inspec::Resources
     end
 
     def get_value(key)
-      return nil if inspect_info.nil?
+      return nil if image_info.nil?
 
-      inspect_info[key]
+      image_info[key]
     end
   end
 end

--- a/lib/inspec/resources/podman_image.rb
+++ b/lib/inspec/resources/podman_image.rb
@@ -71,7 +71,7 @@ module Inspec::Resources
     end
 
     def resource_id
-      object_info.ids[0] || @opts[:id] || @opts[:image] || ""
+      @opts[:id] || @opts[:image] || ""
     end
 
     def inspect_info

--- a/lib/inspec/resources/podman_image.rb
+++ b/lib/inspec/resources/podman_image.rb
@@ -1,0 +1,89 @@
+require "inspec/resources/podman"
+require_relative "docker_object"
+
+module Inspec::Resources
+  class PodmanImage < Inspec.resource(1)
+    include Inspec::Resources::DockerObject
+    name "podman_image"
+    supports platform: "unix"
+
+    desc "InSpec core resource to retrieve information about podman image"
+
+    example <<~EXAMPLE
+      describe podman_image("docker.io/library/busybox") do
+        it { should exist }
+        its("id") { should eq "sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
+        its("image") { should eq "docker.io/library/busybox:latest" }
+        its("repo") { should eq "docker.io/library/busybox" }
+        its("tag") { should eq "latest" }
+        its("resource_id") { should eq "sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
+      end
+    
+      describe podman_image(repo: "docker.io/library/busybox", tag: "latest") do
+        it { should exist }
+        its("id") { should eq "sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
+        its("image") { should eq "docker.io/library/busybox:latest" }
+      end
+    
+      describe podman_image(id: "8847e9bf6df8") do
+        it { should exist }
+      end
+    EXAMPLE
+
+    def initialize(opts = {})
+      skip_resource "The `podman_image` resource is not yet available on your OS." unless inspec.os.unix?
+      # do sanitizion of input values
+      o = opts.dup
+      o = { image: opts } if opts.is_a?(String)
+      @opts = sanitize_options(o)
+    end
+
+    def image
+      "#{repo}:#{tag}" if object_info.entries.size == 1
+    end
+
+    def repo
+      object_info.repositories[0] if object_info.entries.size == 1
+    end
+
+    def tag
+      object_info.tags[0] if object_info.entries.size == 1
+    end
+
+    def resource_id
+      object_info.ids[0] || @opts[:id] || @opts[:image] || ""
+    end
+
+    def to_s
+      "podman_image #{resource_id}"
+    end
+
+    private
+
+    def sanitize_options(opts)
+      opts.merge!(parse_components_from_image(opts[:image]))
+
+      # assume a "latest" tag if we don't have one
+      opts[:tag] ||= "latest"
+
+      # if the ID isn't nil and doesn't contain a hash indicator (indicated by the presence
+      # of a colon, which separates the indicator from the actual hash), we assume it's sha256.
+      opts[:id] = "sha256:" + opts[:id] unless opts[:id].nil? || opts[:id].include?(":")
+
+      # Assemble/reassemble the image from the repo and tag
+      opts[:image] = "#{opts[:repo]}:#{opts[:tag]}" unless opts[:repo].nil?
+
+      # return the santized opts back to the caller
+      opts
+    end
+
+    def object_info
+      return @info if defined?(@info)
+
+      opts = @opts
+      @info = inspec.podman.images.where do
+        (repository == opts[:repo] && tag == opts[:tag]) || (!id.nil? && !opts[:id].nil? && (id == opts[:id] || id.start_with?(opts[:id])))
+      end
+    end
+  end
+end

--- a/lib/inspec/resources/podman_image.rb
+++ b/lib/inspec/resources/podman_image.rb
@@ -129,7 +129,6 @@ module Inspec::Resources
       json_label_format = labels.map { |k, v| "\"#{k}\": {{json .#{v}}}" }
       podman_inspect_cmd = inspec.command("podman image inspect --format '{#{json_label_format.join(", ")}}' #{current_image}")
 
-      # require "byebug"; byebug
       raise Inspec::Exceptions::ResourceFailed, "Unable to retrieve podman image info for #{current_image}.\nError message: #{podman_inspect_cmd.stderr}" if podman_inspect_cmd.exit_status != 0
 
       require "json" unless defined?(JSON)

--- a/lib/inspec/resources/podman_image.rb
+++ b/lib/inspec/resources/podman_image.rb
@@ -74,6 +74,13 @@ module Inspec::Resources
       object_info.ids[0] || @opts[:id] || @opts[:image] || ""
     end
 
+    def inspect_info
+      return @inspect_info if defined?(@inspect_info)
+
+      @inspect_info = inspec.podman.object(@opts[:image] || (!@opts[:id].nil? && @opts[:id]))
+      @inspect_info
+    end
+
     def to_s
       "podman_image #{resource_id}"
     end

--- a/lib/inspec/resources/podman_image.rb
+++ b/lib/inspec/resources/podman_image.rb
@@ -18,13 +18,13 @@ module Inspec::Resources
         its("tag") { should eq "latest" }
         its("resource_id") { should eq "sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
       end
-    
+
       describe podman_image(repo: "docker.io/library/busybox", tag: "latest") do
         it { should exist }
         its("id") { should eq "sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
         its("image") { should eq "docker.io/library/busybox:latest" }
       end
-    
+
       describe podman_image(id: "8847e9bf6df8") do
         it { should exist }
       end

--- a/lib/inspec/resources/podman_image.rb
+++ b/lib/inspec/resources/podman_image.rb
@@ -116,12 +116,8 @@ module Inspec::Resources
       json_key_label = get_json_key_label
       podman_inspect_cmd = inspec.command("podman image inspect --format '{#{json_key_label}}' #{current_image}")
 
-      if podman_inspect_cmd.exit_status != 0
-        raise Inspec::Exceptions::ResourceFailed, "Unable to retrieve podman image info for #{current_image}.\nError message: #{podman_inspect_cmd.stderr}"
-      else
-        require "json" unless defined?(JSON)
-        JSON.parse(podman_inspect_cmd.stdout)
-      end
+      require "json" unless defined?(JSON)
+      podman_inspect_cmd.exit_status !=0 ? nil : JSON.parse(podman_inspect_cmd.stdout)
     end
 
     def get_value(key)

--- a/lib/inspec/resources/podman_image.rb
+++ b/lib/inspec/resources/podman_image.rb
@@ -50,6 +50,26 @@ module Inspec::Resources
       object_info.tags[0] if object_info.entries.size == 1
     end
 
+    def size
+      object_info.sizes[0] if object_info.entries.size == 1
+    end
+
+    def digest
+      object_info.digests[0] if object_info.entries.size == 1
+    end
+
+    def created_at
+      object_info.created_at[0] if object_info.entries.size == 1
+    end
+
+    def created_since
+      object_info.created_since[0] if object_info.entries.size == 1
+    end
+
+    def history
+      object_info.history[0] if object_info.entries.size == 1
+    end
+
     def resource_id
       object_info.ids[0] || @opts[:id] || @opts[:image] || ""
     end

--- a/lib/inspec/resources/podman_image.rb
+++ b/lib/inspec/resources/podman_image.rb
@@ -129,7 +129,8 @@ module Inspec::Resources
       json_label_format = labels.map { |k, v| "\"#{k}\": {{json .#{v}}}" }
       podman_inspect_cmd = inspec.command("podman image inspect --format '{#{json_label_format.join(", ")}}' #{current_image}")
 
-      raise Inspec::Exceptions::ResourceFailed, "Unable to retrieve podman image info for #{current_image}" if podman_inspect_cmd.exit_status != 0
+      # require "byebug"; byebug
+      raise Inspec::Exceptions::ResourceFailed, "Unable to retrieve podman image info for #{current_image}.\nError message: #{podman_inspect_cmd.stderr}" if podman_inspect_cmd.exit_status != 0
 
       require "json" unless defined?(JSON)
       JSON.parse(podman_inspect_cmd.stdout)

--- a/test/fixtures/cmd/podman-inspect-info
+++ b/test/fixtures/cmd/podman-inspect-info
@@ -1,17 +1,1 @@
-[
-     {
-          "Id": "cd4e03b35a8e938f7bf1257fbd19fc2d7becae39974c0328236fd7df49c0a92a",
-          "Digest": "sha256:10f14ffa93f8dedf1057897b745e5ac72ac5655c299dade0aa434c71557697ea",
-          "RepoTags": [
-               "docker.io/library/nginx:latest"
-          ],
-          "Parent": "",
-          "Comment": "",
-          "Created": "2022-06-23T04:04:53.272855015Z",
-          "Version": "20.10.12",
-          "Author": "",
-          "Architecture": "arm64",
-          "Os": "linux",
-          "Size": 138861442
-     }
-]
+{"id": "3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6", "repo_tags": ["docker.io/library/busybox:latest"], "size": 1636053, "digest": "sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83", "created_at": "2022-06-08T00:39:28.175020858Z", "version": "20.10.12", "names_history": ["docker.io/library/busybox:latest"], "repo_digests": ["docker.io/library/busybox@sha256:2c5e2045f35086c019e80c86880fd5b7c7a619878b59e3b7592711e1781df51a","docker.io/library/busybox@sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83"], "architecture": "arm64", "os": "linux", "virtual_size": 1636053}

--- a/test/fixtures/cmd/podman-inspect-info
+++ b/test/fixtures/cmd/podman-inspect-info
@@ -1,0 +1,17 @@
+[
+     {
+          "Id": "cd4e03b35a8e938f7bf1257fbd19fc2d7becae39974c0328236fd7df49c0a92a",
+          "Digest": "sha256:10f14ffa93f8dedf1057897b745e5ac72ac5655c299dade0aa434c71557697ea",
+          "RepoTags": [
+               "docker.io/library/nginx:latest"
+          ],
+          "Parent": "",
+          "Comment": "",
+          "Created": "2022-06-23T04:04:53.272855015Z",
+          "Version": "20.10.12",
+          "Author": "",
+          "Architecture": "arm64",
+          "Os": "linux",
+          "Size": 138861442
+     }
+]

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -691,6 +691,7 @@ class MockLoader
       "podman version --format json" => cmd.call("podman-version"),
       "podman volume ls --format json" => cmd.call("podman-volume-ls"),
       "podman inspect 591270d8d80d --format json" => cmd.call("podman-inspec"),
+      "podman inspect docker.io/library/nginx:latest --format json" => cmd.call("podman-inspect-info"),
     }
 
     if @platform && (@platform[:name] == "windows" || @platform[:name] == "freebsd")

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -691,7 +691,7 @@ class MockLoader
       "podman version --format json" => cmd.call("podman-version"),
       "podman volume ls --format json" => cmd.call("podman-volume-ls"),
       "podman inspect 591270d8d80d --format json" => cmd.call("podman-inspec"),
-      "podman inspect docker.io/library/nginx:latest --format json" => cmd.call("podman-inspect-info"),
+      "podman image inspect --format '{\"id\": {{json .ID}}, \"repo_tags\": {{json .RepoTags}}, \"size\": {{json .Size}}, \"digest\": {{json .Digest}}, \"created_at\": {{json .Created}}, \"version\": {{json .Version}}, \"names_history\": {{json .NamesHistory}}, \"repo_digests\": {{json .RepoDigests}}, \"architecture\": {{json .Architecture}}, \"os\": {{json .Os}}, \"virtual_size\": {{json .VirtualSize}}}' docker.io/library/busybox:latest" => cmd.call("podman-inspect-info"),
     }
 
     if @platform && (@platform[:name] == "windows" || @platform[:name] == "freebsd")

--- a/test/unit/resources/podman_image_test.rb
+++ b/test/unit/resources/podman_image_test.rb
@@ -17,5 +17,8 @@ describe Inspec::Resources::PodmanImage do
     _(resource.created_at).must_equal "2022-06-23 04:13:24 +0000 UTC"
     _(resource.created_since).must_equal "13 days ago"
     _(resource.history).must_equal "docker.io/library/nginx:latest"
+    _(resource.inspect_info).must_include "Architecture"
+    _(resource.inspect_info.Architecture).must_equal "arm64"
+    _(resource.to_s).must_equal "podman_image sha256:55f4b40fe486a5b734b46bb7bf28f52fa31426bf23be068c8e7b19e58d9b8deb"
   end
 end

--- a/test/unit/resources/podman_image_test.rb
+++ b/test/unit/resources/podman_image_test.rb
@@ -11,7 +11,7 @@ describe Inspec::Resources::PodmanImage do
     _(resource.tag).must_equal "latest"
     _(resource.image).must_equal "docker.io/library/nginx:latest"
     _(resource.repo).must_equal "docker.io/library/nginx"
-    _(resource.resource_id).must_equal "sha256:55f4b40fe486a5b734b46bb7bf28f52fa31426bf23be068c8e7b19e58d9b8deb"
+    _(resource.resource_id).must_equal "docker.io/library/nginx:latest"
     _(resource.size).must_equal "146 MB"
     _(resource.digest).must_equal "sha256:10f14ffa93f8dedf1057897b745e5ac72ac5655c299dade0aa434c71557697ea"
     _(resource.created_at).must_equal "2022-06-23 04:13:24 +0000 UTC"
@@ -19,6 +19,6 @@ describe Inspec::Resources::PodmanImage do
     _(resource.history).must_equal "docker.io/library/nginx:latest"
     _(resource.inspect_info).must_include "Architecture"
     _(resource.inspect_info.Architecture).must_equal "arm64"
-    _(resource.to_s).must_equal "podman_image sha256:55f4b40fe486a5b734b46bb7bf28f52fa31426bf23be068c8e7b19e58d9b8deb"
+    _(resource.to_s).must_equal "podman_image docker.io/library/nginx:latest"
   end
 end

--- a/test/unit/resources/podman_image_test.rb
+++ b/test/unit/resources/podman_image_test.rb
@@ -7,6 +7,7 @@ describe Inspec::Resources::PodmanImage do
   it "test podman image properties and matchers" do
     resource = MockLoader.new("unix".to_sym).load_resource("podman_image", "docker.io/library/busybox")
     _(resource.exist?).must_equal true
+    _(resource.id).must_equal "3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6"
     _(resource.repo_tags).must_include "docker.io/library/busybox:latest"
     _(resource.created_at).must_equal "2022-06-08T00:39:28.175020858Z"
     _(resource.version).must_equal "20.10.12"

--- a/test/unit/resources/podman_image_test.rb
+++ b/test/unit/resources/podman_image_test.rb
@@ -5,20 +5,27 @@ require_relative "../../../lib/inspec/resources/podman_image"
 
 describe Inspec::Resources::PodmanImage do
   it "test podman image properties and matchers" do
-    resource = MockLoader.new("unix".to_sym).load_resource("podman_image", "docker.io/library/nginx")
+    resource = MockLoader.new("unix".to_sym).load_resource("podman_image", "docker.io/library/busybox")
     _(resource.exist?).must_equal true
-    _(resource.id).must_equal "sha256:55f4b40fe486a5b734b46bb7bf28f52fa31426bf23be068c8e7b19e58d9b8deb"
-    _(resource.tag).must_equal "latest"
-    _(resource.image).must_equal "docker.io/library/nginx:latest"
-    _(resource.repo).must_equal "docker.io/library/nginx"
-    _(resource.resource_id).must_equal "docker.io/library/nginx:latest"
-    _(resource.size).must_equal "146 MB"
-    _(resource.digest).must_equal "sha256:10f14ffa93f8dedf1057897b745e5ac72ac5655c299dade0aa434c71557697ea"
-    _(resource.created_at).must_equal "2022-06-23 04:13:24 +0000 UTC"
-    _(resource.created_since).must_equal "13 days ago"
-    _(resource.history).must_equal "docker.io/library/nginx:latest"
-    _(resource.inspect_info).must_include "Architecture"
-    _(resource.inspect_info.Architecture).must_equal "arm64"
-    _(resource.to_s).must_equal "podman_image docker.io/library/nginx:latest"
+    _(resource.repo_tags).must_include "docker.io/library/busybox:latest"
+    _(resource.created_at).must_equal "2022-06-08T00:39:28.175020858Z"
+    _(resource.version).must_equal "20.10.12"
+    _(resource.size).must_equal 1636053
+    _(resource.digest).must_equal "sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83"
+    _(resource.names_history).must_include "docker.io/library/busybox:latest"
+    _(resource.repo_digests).must_include "docker.io/library/busybox@sha256:2c5e2045f35086c019e80c86880fd5b7c7a619878b59e3b7592711e1781df51a"
+    _(resource.architecture).must_equal "arm64"
+    _(resource.os).must_equal "linux"
+    _(resource.virtual_size).must_equal 1636053
+    _(resource.resource_id).must_equal "docker.io/library/busybox:latest"
+    _(resource.to_s).must_equal "podman_image docker.io/library/busybox:latest"
+  end
+
+  it "test for a non-existing container image" do
+    resource = MockLoader.new("ubuntu".to_sym).load_resource("podman_image", "nginx")
+    _(resource.exist?).must_equal false
+    assert_nil resource.repo_tags
+    assert_nil resource.size
+    assert_nil resource.digest
   end
 end

--- a/test/unit/resources/podman_image_test.rb
+++ b/test/unit/resources/podman_image_test.rb
@@ -1,0 +1,16 @@
+# If we can load the InSpec globals definition file...
+require "inspec/globals"
+require "#{Inspec.src_root}/test/helper"
+require_relative "../../../lib/inspec/resources/podman_image"
+
+describe Inspec::Resources::PodmanImage do
+  it "test podman image properties and matchers" do
+    resource = MockLoader.new("unix".to_sym).load_resource("podman_image", "docker.io/library/nginx")
+    _(resource.exist?).must_equal true
+    _(resource.id).must_equal "sha256:55f4b40fe486a5b734b46bb7bf28f52fa31426bf23be068c8e7b19e58d9b8deb"
+    _(resource.tag).must_equal "latest"
+    _(resource.image).must_equal "docker.io/library/nginx:latest"
+    _(resource.repo).must_equal "docker.io/library/nginx"
+    _(resource.resource_id).must_equal "sha256:55f4b40fe486a5b734b46bb7bf28f52fa31426bf23be068c8e7b19e58d9b8deb"
+  end
+end

--- a/test/unit/resources/podman_image_test.rb
+++ b/test/unit/resources/podman_image_test.rb
@@ -12,5 +12,10 @@ describe Inspec::Resources::PodmanImage do
     _(resource.image).must_equal "docker.io/library/nginx:latest"
     _(resource.repo).must_equal "docker.io/library/nginx"
     _(resource.resource_id).must_equal "sha256:55f4b40fe486a5b734b46bb7bf28f52fa31426bf23be068c8e7b19e58d9b8deb"
+    _(resource.size).must_equal "146 MB"
+    _(resource.digest).must_equal "sha256:10f14ffa93f8dedf1057897b745e5ac72ac5655c299dade0aa434c71557697ea"
+    _(resource.created_at).must_equal "2022-06-23 04:13:24 +0000 UTC"
+    _(resource.created_since).must_equal "13 days ago"
+    _(resource.history).must_equal "docker.io/library/nginx:latest"
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
✅ Signed-off-by: Sonu Saha [sonu.saha@progress.com](mailto:sonu.saha@progress.com)

## Related Issue
**CFINSPEC-361: Add `podman_image` resource**

## Description
- This PR adds a new resource: `podman_image`
- Using the`podman_image` resource
Given that the user has called the `podman_image` resource
then the resource allows to test with the container image properties.
- Syntax:
```ruby
  describe podman_image("docker.io/library/busybox") do
      it { should exist }
      its("resource_id") { should eq "sha256:3c19bafed22355e11a608c4b613d87d06b9cdd37d378e6e0176cbc8e7144d5c6" }
  end
```




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
