### PR TITLE
CFINSPEC-366 Added option to set impact using only_if

### DIFF
--- a/docs-chef-io/content/inspec/dsl_inspec.md
+++ b/docs-chef-io/content/inspec/dsl_inspec.md
@@ -249,6 +249,7 @@ end
 ```
 
 This example checks for if certain pip packages are installed, but only if '/root/.aws' exists:
+
 ```ruby
 control 'pip-packages-installed' do
   title 'Check if essential pips are installed'
@@ -269,7 +270,10 @@ certain controls, which would 100% fail due to the way servers are prepared, but
 you know that the same control suites are reused later in different circumstances
 by different teams.
 
-This example checks for if Gnome Desktop is installed or not, if not then it resets the impact of the control to the new value which is passed as a hash with impact key. Here it resets it to 0:
+This example checks whether the Gnome Desktop is installed. If not installed, it resets the impact of the control to the new value which is passed as a hash with the impact key.
+
+Here, it resets it to 0:
+
 ```ruby
 control 'gnome-destkop-settings' do
   impact 0.5
@@ -290,13 +294,13 @@ end
 
 Some notes about `only_if`:
 
-- `only_if` applies to the entire `control`. If the results of the `only_if`
+* `only_if` applies to the entire `control`. If the results of the `only_if`
   block evaluate to false, any Chef InSpec resources mentioned as part of a
   `describe` block will not be run. Additionally, the contents of the describe
   blocks will not be run. However, bare Ruby expressions and bare Chef InSpec
   resources (not assocated with a describe block) preceding the only_if statement
   will run
-- `only_if` also accepts hash with impact key to reset the impact value of the control. Control's impact is useful in determing it's enhanced outcome.
+* `only_if` also accepts hash with impact key to reset the impact value of the control. Control's impact is helpful in determining it is enhanced outcome.
 
 To illustrate:
 

--- a/docs-chef-io/content/inspec/dsl_inspec.md
+++ b/docs-chef-io/content/inspec/dsl_inspec.md
@@ -269,6 +269,25 @@ certain controls, which would 100% fail due to the way servers are prepared, but
 you know that the same control suites are reused later in different circumstances
 by different teams.
 
+This example checks for if Gnome Desktop is installed or not, if not then it resets the impact of the control to the new value which is passed as a hash with impact key. Here it resets it to 0:
+```ruby
+control 'gnome-destkop-settings' do
+  impact 0.5
+  desc 'some good settings'
+  desc 'check', 'check the settings file for good things'
+  desc 'fix', 'set the good things in the file /etc/gnome/settings'
+  tag nist: 'CM-6'
+
+  only_if("The Gnome Desktop is not installed, this control is Not Applicable", impact: 0) {
+    package('gnome-desktop').installed?
+  }
+
+  describe gnome_settings do
+    it should_be set_well
+  end
+end
+```
+
 Some notes about `only_if`:
 
 - `only_if` applies to the entire `control`. If the results of the `only_if`
@@ -277,6 +296,7 @@ Some notes about `only_if`:
   blocks will not be run. However, bare Ruby expressions and bare Chef InSpec
   resources (not assocated with a describe block) preceding the only_if statement
   will run
+- `only_if` also accepts hash with impact key to reset the impact value of the control. Control's impact is useful in determing it's enhanced outcome.
 
 To illustrate:
 

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -16,6 +16,7 @@ module Inspec
     attr_reader :__waiver_data
     attr_accessor :resource_dsl
     attr_reader :__profile_id
+    attr_accessor :impact
 
     def initialize(id, profile_id, resource_dsl, opts, &block)
       @impact = nil
@@ -133,10 +134,11 @@ module Inspec
     #
     # @param [Type] &block returns true if tests are added, false otherwise
     # @return [nil]
-    def only_if(message = nil)
+    def only_if(message = nil, impact: nil)
       return unless block_given?
       return if @__skip_only_if_eval == true
 
+      self.impact = impact if impact && !yield
       @__skip_rule[:result] ||= !yield
       @__skip_rule[:type] = :only_if
       @__skip_rule[:message] = message

--- a/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
+++ b/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
@@ -63,7 +63,8 @@ end
 
 # Example of setting impact using code and marking it N/A
 control "tmp-6.0.1" do
-  only_if(impact: 0.0) { false }
+  impact 0.5
+  only_if("Some reason for N/A", impact: 0.0) { false }
   describe file("/tmp") do
     it { should be_directory }
   end

--- a/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
+++ b/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
@@ -60,3 +60,19 @@ control "tmp-5.0" do
     it { should cmp "e.1" }
   end
 end
+
+# Example of setting impact using code and marking it N/A
+control "tmp-6.0.1" do
+  only_if(impact: 0.0) { false }
+  describe file("/tmp") do
+    it { should be_directory }
+  end
+end
+
+# Example of setting impact using code and not marked as N/A
+control "tmp-6.0.2" do
+  only_if(impact: 0.5) { false }
+  describe file("/tmp") do
+    it { should be_directory }
+  end
+end

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -1326,14 +1326,14 @@ EOT
     end
 
     it "should show enhanced_outcomes for skipped tests in controls" do
-      _(run_result.stdout).must_include "3 skipped"
-      _(run_result.stdout).must_include "2 controls not reviewed"
+      _(run_result.stdout).must_include "5 skipped"
+      _(run_result.stdout).must_include "3 controls not reviewed"
       _(run_result.stdout).must_include "N/R"
     end
 
     it "should show enhanced_outcomes for controls with impact 0" do
-      _(run_result.stdout).must_include "3 skipped"
-      _(run_result.stdout).must_include "2 controls not applicable"
+      _(run_result.stdout).must_include "5 skipped"
+      _(run_result.stdout).must_include "3 controls not applicable"
       _(run_result.stdout).must_include "N/A"
     end
 
@@ -1349,6 +1349,14 @@ EOT
 
     it "should show enhanced_outcomes for passed controls" do
       _(run_result.stdout).must_include "1 successful control"
+    end
+
+    it "should mark control as N/A using zero impact from only_if" do
+      _(run_result.stdout).must_include "N/A  tmp-6.0.1"
+    end
+
+    it "should not mark control as N/A using non-zeo impact from only_if" do
+      _(run_result.stdout).must_include "N/R  tmp-6.0.2"
     end
   end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -1353,6 +1353,7 @@ EOT
 
     it "should mark control as N/A using zero impact from only_if" do
       _(run_result.stdout).must_include "N/A  tmp-6.0.1"
+      _(run_result.stdout).must_include "Some reason for N/A"
     end
 
     it "should not mark control as N/A using non-zeo impact from only_if" do

--- a/test/functional/inspec_schema_test.rb
+++ b/test/functional/inspec_schema_test.rb
@@ -26,7 +26,7 @@ describe "inspec schema" do
       json_output = JSON.parse(out.stdout)
       _(json_output["definitions"]["Control_Result"]["properties"]["resource_id"]).wont_be_nil
       # status value to be nil when not using enhanced outcomes flag
-      _(json_output["definitions"]["Exec_JSON_Control"]["properties"]["status"]).must_equal nil
+      assert_nil(json_output["definitions"]["Exec_JSON_Control"]["properties"]["status"])
     end
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added option to set impact using only_if. This would be useful in identifying N/A controls if the only_if condition is not satisfied.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
