### PR TITLE
CFINSPEC-426 InSpec Parallel List Command

### DIFF
--- a/lib/plugins/inspec-parallel/lib/inspec-parallel.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel.rb
@@ -13,6 +13,11 @@ module InspecPlugins
         InspecPlugins::Parallelism::StreamingReporter
       end
 
+      streaming_reporter :"parallel-list" do
+        require_relative "inspec-parallel/list_reporter"
+        InspecPlugins::Parallelism::ListReporter
+      end
+
     end
   end
 end

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
@@ -32,5 +32,13 @@ module InspecPlugins::Parallelism
         parallel_cmd.run
       end
     end
+
+    desc "list", "Generate a list of targets as an option file for `parallel exec`"
+    option :resource, aliases: :r, type: :string, required: true,
+      desc: "Plural resource to list. See docs for current list of accepted values."
+    def list
+      require_relative "list_command"
+      InspecPlugins::Parallelism::ListCommand.new(options).run
+    end
   end
 end

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
@@ -1,4 +1,4 @@
-require_relative "command"
+require_relative "exec_command"
 require "inspec/dist"
 require "inspec/base_cli"
 
@@ -25,7 +25,7 @@ module InspecPlugins::Parallelism
       desc: "Path to the runner and error logs"
     exec_options
     def exec(default_profile = nil)
-      parallel_cmd = InspecPlugins::Parallelism::Command.new(options, default_profile)
+      parallel_cmd = InspecPlugins::Parallelism::ExecCommand.new(options, default_profile)
       if options[:dry_run]
         parallel_cmd.dry_run
       else

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
@@ -36,6 +36,8 @@ module InspecPlugins::Parallelism
     desc "list", "Generate a list of targets as an option file for `parallel exec`"
     option :resource, aliases: :r, type: :string, required: true,
       desc: "Plural resource to list. See docs for current list of accepted values."
+    option :target, aliases: :t, type: :string,
+      desc: "Target to connect to for listing resources. If omitted, will be guessed from --resource."
     def list
       require_relative "list_command"
       InspecPlugins::Parallelism::ListCommand.new(options).run

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/cli.rb
@@ -38,6 +38,10 @@ module InspecPlugins::Parallelism
       desc: "Plural resource to list. See docs for current list of accepted values."
     option :target, aliases: :t, type: :string,
       desc: "Target to connect to for listing resources. If omitted, will be guessed from --resource."
+    option :parameters, aliases: :p, type: :string,
+      desc: "String of resource parameters for the resource. See resource docs for details."
+    option :query, aliases: :q, type: :string,
+      desc: "String of 'where' query for the resource. See resource docs for details."
     def list
       require_relative "list_command"
       InspecPlugins::Parallelism::ListCommand.new(options).run

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/exec_command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/exec_command.rb
@@ -83,8 +83,14 @@ module InspecPlugins
 
       def read_options_file
         opts = []
+        content = []
         begin
-          content = content_from_file(cli_options_to_parallel_cmd[:option_file])
+          if cli_options_to_parallel_cmd[:option_file] == "-"
+            content = $stdin.readlines if !$stdin.tty? && $stdin.stat.pipe?
+            @logger.error("Standard input options are empty") if content.empty?
+          else
+            content = content_from_file(cli_options_to_parallel_cmd[:option_file])
+          end
         rescue OptionFileNotReadable => e
           @logger.error "Cannot read options file: #{e.message}"
           Inspec::UI.new.exit(:usage_error)

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/exec_command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/exec_command.rb
@@ -8,7 +8,7 @@ module InspecPlugins
     class OptionFileNotReadable < RuntimeError
     end
 
-    class Command
+    class ExecCommand
       attr_accessor :cli_options_to_parallel_cmd, :default_profile, :sub_cmd, :invocations, :run_in_background
 
       def initialize(cli_options_to_parallel_cmd, default_profile, sub_cmd = "exec")

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/list_command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/list_command.rb
@@ -4,7 +4,7 @@ module InspecPlugins
     class ListCommand
 
       SUPPORTED_RESOURCES = {
-        aws_ecr_images: { property: "image_ids", list_transport: "ecr-image://%s", target_transport: :aws },
+        aws_ecr_images: { property: "digests", list_transport: "ecr-image://%s", target_transport: :aws },
       }.freeze
 
       SUPPORTED_TARGET_TRANSPORTS = {
@@ -13,7 +13,7 @@ module InspecPlugins
         gcp: { dependency_name: "inspec-gcp", dependency_uri: "https://github.com/inspec/inspec-gcp.git" },
       }.freeze
 
-      attr_reader :resource_name, :target_uri, :ui
+      attr_reader :parameters, :query, :resource_name, :target_uri, :ui
       def initialize(options)
         @ui = Inspec::UI.new
 
@@ -35,6 +35,10 @@ module InspecPlugins
           ui.error("Unsupported target transport '#{target_transport}' for resource '#{resource_name}'. Supported transport: '#{SUPPORTED_RESOURCES[resource_name][:target_transport]}'")
           ui.exit(:usage_error)
         end
+
+        # Pass through other options
+        @parameters = options[:parameters]
+        @query = options[:query]
       end
 
       def run
@@ -79,6 +83,24 @@ EOY
         FileUtils.mkdir_p File.join(profile_path, "controls")
         #   add plural resource lookup with provided query
         #   add describe block in each loop
+        control_template = <<EOC
+control "the-control" do
+  %s(%s).where(%s).%s.each do |id|
+    describe id do
+      # It took some funbling to find something that would always match.
+      it { should match //  }
+    end
+  end
+end
+EOC
+        content = format(
+          control_template,
+          resource_name,
+          parameters,
+          query,
+          SUPPORTED_RESOURCES[resource_name][:property]
+        )
+        File.write(File.join(profile_path, "controls", "list.rb"), content)
       end
 
       def execute_profile(profile_path)

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/list_command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/list_command.rb
@@ -1,0 +1,33 @@
+module InspecPlugins
+  module Parallelism
+    class ListCommand
+
+      SUPPORTED_RESOURCES = {
+        aws_ecr_images: { property: "image_ids", transport: "ecr-image://%s" },
+      }
+
+      attr_reader :resource_name, :ui
+      def initialize(options)
+        @ui = Inspec::UI.new
+
+        # Make sure resource is supported
+        @resource_name = options[:resource].to_sym
+        unless SUPPORTED_RESOURCES.key?(@resource_name)
+          ui.error("Unsupported resource '#{resource_name}'. Currently supported resources: #{SUPPORTED_RESOURCES.keys.join(', ')}")
+          ui.exit(:usage_error)
+        end
+
+        # TODO: Make sure transport schema is supported
+      end
+
+      def run
+        # TODO: Generate profile in cache
+        #  Add dep based on transport in inspec.yml
+        #  create control file
+        #   add plural resource lookup with provided query
+        #   add describe block in each loop
+        # TODO: Execute with custom reporter
+      end
+    end
+  end
+end

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/list_command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/list_command.rb
@@ -1,23 +1,40 @@
+require "uri" unless defined?(URI)
 module InspecPlugins
   module Parallelism
     class ListCommand
 
       SUPPORTED_RESOURCES = {
-        aws_ecr_images: { property: "image_ids", transport: "ecr-image://%s" },
-      }
+        aws_ecr_images: { property: "image_ids", list_transport: "ecr-image://%s", target_transport: :aws },
+      }.freeze
 
-      attr_reader :resource_name, :ui
+      SUPPORTED_TARGET_TRANSPORTS = {
+        aws: { dependency_name: "inspec-aws", dependency_uri: "https://github.com/inspec/inspec-aws.git" },
+        azure: { dependency_name: "inspec-azure", dependency_uri: "https://github.com/inspec/inspec-azure.git" },
+        gcp: { dependency_name: "inspec-gcp", dependency_uri: "https://github.com/inspec/inspec-gcp.git" },
+      }.freeze
+
+      attr_reader :resource_name, :target_uri, :ui
       def initialize(options)
         @ui = Inspec::UI.new
 
         # Make sure resource is supported
         @resource_name = options[:resource].to_sym
         unless SUPPORTED_RESOURCES.key?(@resource_name)
-          ui.error("Unsupported resource '#{resource_name}'. Currently supported resources: #{SUPPORTED_RESOURCES.keys.join(', ')}")
+          ui.error("Unsupported resource '#{resource_name}'. Currently supported resources: #{SUPPORTED_RESOURCES.keys.join(", ")}")
           ui.exit(:usage_error)
         end
 
-        # TODO: Make sure transport schema is supported
+        # Make sure transport schema is supported
+        @target_uri = options[:target] || "#{SUPPORTED_RESOURCES[resource_name][:target_transport]}://"
+        target_transport = URI(target_uri).scheme.to_sym
+        unless SUPPORTED_TARGET_TRANSPORTS.key?(target_transport)
+          ui.error("Unsupported target transport '#{target_transport}'. Supported transports: #{SUPPORTED_TARGET_TRANSPORTS.keys.join(", ")}")
+          ui.exit(:usage_error)
+        end
+        unless target_transport == SUPPORTED_RESOURCES[resource_name][:target_transport]
+          ui.error("Unsupported target transport '#{target_transport}' for resource '#{resource_name}'. Supported transport: '#{SUPPORTED_RESOURCES[resource_name][:target_transport]}'")
+          ui.exit(:usage_error)
+        end
       end
 
       def run

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/list_reporter.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/list_reporter.rb
@@ -20,7 +20,7 @@ module InspecPlugins::Parallelism
         @resource_formatter = InspecPlugins::Parallelism::ListReporter::ResourceFormatter::Base.formatter_for(resource_name, parameters: parameters, query: query)
       end
 
-      puts "-t " + resource_formatter.format_id_for_list(raw_id)
+      puts "-t " + resource_formatter.format_id_for_list(raw_id) + " --reporter json:#{raw_id}.json"
     end
 
     def example_failed(notification)

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/list_reporter.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/list_reporter.rb
@@ -1,0 +1,31 @@
+require_relative "list_reporter/resource_formatter"
+module InspecPlugins::Parallelism
+  class ListReporter < Inspec.plugin(2, :streaming_reporter)
+    # Registering these methods with RSpec::Core::Formatters class is mandatory
+    RSpec::Core::Formatters.register self, :example_passed, :example_failed
+
+    attr_reader :resource_formatter
+    def initialize(output); end
+
+    def example_passed(notification)
+      # Encoded as describe block subject
+      raw_id = notification.example.metadata[:example_group][:description]
+
+      # Extra data passed through via descriptions
+      unless @resource_formatter
+        resource_name = notification.example.metadata[:descriptions][:resource_name]
+        parameters = notification.example.metadata[:descriptions][:parameters]
+        query = notification.example.metadata[:descriptions][:query]
+
+        @resource_formatter = InspecPlugins::Parallelism::ListReporter::ResourceFormatter::Base.formatter_for(resource_name, parameters: parameters, query: query)
+      end
+
+      puts "-t " + resource_formatter.format_id_for_list(raw_id)
+    end
+
+    def example_failed(notification)
+      # TODO - pick apart notification and print an exception to stderr
+      # require "byebug"; byebug
+    end
+  end
+end

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/list_reporter/resource_formatter.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/list_reporter/resource_formatter.rb
@@ -1,0 +1,47 @@
+module InspecPlugins::Parallelism
+  class ListReporter < Inspec.plugin(2, :streaming_reporter)
+    class ResourceFormatter
+
+      class Base
+
+        @@formatter_class_by_name = {}
+
+        def self.list_formatter_name(name)
+          @@formatter_class_by_name[name] = self
+        end
+
+        def self.formatter_for(name, opts)
+          @@formatter_class_by_name[name].new(opts)
+        end
+
+        attr_reader :raw_parameters, :raw_query
+        def initialize(opts)
+          @raw_parameters = opts[:parameters]
+          @raw_query = opts[:query]
+          interpret_parameters!
+        end
+      end
+
+      # TODO: figure out a way to move this logic into inspec-aws
+      class AwsEcrImages < Base
+
+        list_formatter_name "aws_ecr_images"
+
+        attr_reader :repository_name
+        def interpret_parameters!
+          @raw_parameters = "{#{raw_parameters}}" unless raw_parameters.match?(/^\{.+\}$/)
+          cooked_params = eval raw_parameters # rubocop:disable Security/Eval
+          # Should include respository name
+          # TODO - handle errors here?
+          @repository_name = cooked_params[:repository_name]
+        end
+
+        def format_id_for_list(raw_id)
+          # Trim off sha256: prefix
+          id = raw_id.sub("sha256:", "")
+          "ecr-image://#{repository_name}/#{id}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provides a command which iterates over a plural resource and enumerates the IDs of the child resources, with the goal of generating a list of targets to scan.

Limitations:
 * Currently only supports the resource aws_ecr_images.
 * Based on a crude implementation that generates a temporary profile and executes it with a custom reporter. This requires several hacks and is inefficient. It feels like we have one hammer, and everything is a nail.
 * At the current moment, if there is an error in the parameters to the resource, the error is silently ignored and nothing happens. This need to be implemented. See example_failed in list_reporter.rb
 * No docs
 * No tests
 * I'm guessing at the format of the ecr-image URL needed. It may need more than just the repo name and the digest ID.

Example invocation:
```
inspec parallel list -r aws_ecr_images -p "repository_name: 'dev-aws-ecr-sign-bot'" -t aws://
-t ecr-image://dev-aws-ecr-sign-bot/f99f3d427b0b422be75dfe59015f43c784a04181538635adaaf6a1eab404608c
-t ecr-image://dev-aws-ecr-sign-bot/6757f680e09fe98dd5fe97ea669edc7f2a8e8b0f18c36ffcb6084dd8f678ae64
```

 