### PR TITLE
CFINSPEC-374 DSL keyword `only_applicable_if` added

### DIFF
--- a/docs-chef-io/content/inspec/dsl_inspec.md
+++ b/docs-chef-io/content/inspec/dsl_inspec.md
@@ -325,6 +325,56 @@ end
   end
 ```
 
+### Use `only_applicable_if` to test controls for applicability.
+
+The `only_applicable_if` block allows to test if a control is applicable or not. In this example, the control with `only_applicable_if` block will check the condition and mark the control as not applicable (N/A) if the results of the `only_applicable_if` block evaluate to false.
+
+If the gnome-desktop is not installed, following control to test gnome settings will mark control as not applicable.
+
+```ruby
+control 'gnome-destkop-settings' do
+  impact 0.5
+  desc 'some good settings'
+  desc 'check', 'check the settings file for good things'
+  desc 'fix', 'set the good things in the file /etc/gnome/settings'
+  tag nist: 'CM-6'
+
+  only_applicable_if("The Gnome Desktop is not installed, this control is Not Applicable") {
+    package('gnome-desktop').installed?
+  }
+
+  describe gnome_settings do
+    it should_be set_well
+  end
+end
+```
+
+Run output:
+
+```bash
+inspec exec path/to/audit-gnome-settings-profile --enhanced-outcomes
+
+Profile:   InSpec Profile (audit-gnome-settings-profile)
+Version:   0.1.0
+Target:    local://
+Target ID: fa3923b9-f806-4cc2-960d-1ddefb4c7654
+
+  N/A  gnome-destkop-settings: No-op
+     ×  No-op
+     N/A control due to only_applicable_if condition: The Gnome Desktop is not installed, this control is Not Applicable
+
+Profile Summary: 0 successful controls, 0 control failure, 0 controls not reviewed, 1 controls not applicable, 0 controls have error
+Test Summary: 0 successful, 1 failures, 0 skipped
+```
+
+Some notes about `only_applicable_if`:
+
+* `only_applicable_if` applies to the entire `control`. If the results of the `only_applicable_if`
+  block evaluate to false, any Chef InSpec resources mentioned as part of a
+  `describe` block will not be run. Additionally, the contents of the describe
+  blocks will not be run.
+* If the results of the `only_applicable_if` block evaluate to false, it will invoke a failing test which will state the reason for N/A.
+
 ### Additional metadata for controls
 
 The following example illustrates various ways to add tags and references to `control`

--- a/docs-chef-io/content/inspec/dsl_inspec.md
+++ b/docs-chef-io/content/inspec/dsl_inspec.md
@@ -325,11 +325,11 @@ end
   end
 ```
 
-### Use `only_applicable_if` to test controls for applicability.
+### Use **only_applicable_if** to test controls for applicability
 
-The `only_applicable_if` block allows to test if a control is applicable or not. In this example, the control with `only_applicable_if` block will check the condition and mark the control as not applicable (N/A) if the results of the `only_applicable_if` block evaluate to false.
+The `only_applicable_if` block allows to test if a control is applicable or not. In this example, the control with `only_applicable_if` block checks the condition and marks the control as not applicable (N/A) if the results of the `only_applicable_if` block evaluates to `false`.
 
-If the gnome-desktop is not installed, following control to test gnome settings will mark control as not applicable.
+If **gnome-desktop** is not installed, the following control to test gnome settings marks control as **not applicable**.
 
 ```ruby
 control 'gnome-destkop-settings' do
@@ -369,11 +369,8 @@ Test Summary: 0 successful, 1 failures, 0 skipped
 
 Some notes about `only_applicable_if`:
 
-* `only_applicable_if` applies to the entire `control`. If the results of the `only_applicable_if`
-  block evaluate to false, any Chef InSpec resources mentioned as part of a
-  `describe` block will not be run. Additionally, the contents of the describe
-  blocks will not be run.
-* If the results of the `only_applicable_if` block evaluate to false, it will invoke a failing test which will state the reason for N/A.
+* `only_applicable_if` applies to the entire `control`. If the results of the `only_applicable_if` block evaluates to `false`, any Chef InSpec resources mentioned as part of a `describe` block will not be run. Additionally, the contents of the describe blocks will not be run.
+* If the results of the `only_applicable_if` block evaluates to `false`, it will invoke a failing test which will state the reason for N/A.
 
 ### Additional metadata for controls
 

--- a/lib/inspec/enhanced_outcomes.rb
+++ b/lib/inspec/enhanced_outcomes.rb
@@ -2,7 +2,8 @@ module Inspec
   module EnhancedOutcomes
 
     def self.determine_status(results, impact)
-      if results.any? { |r| !r[:exception].nil? && !r[:backtrace].nil? }
+      # No-op exception occurs in case of not_applicable_if
+      if results.any? { |r| !r[:exception].nil? && !r[:backtrace].nil? && r[:resource_class] != "noop" }
         "error"
       elsif !impact.nil? && impact.to_f == 0.0
         "not_applicable"

--- a/lib/inspec/plugin/v2/plugin_types/streaming_reporter.rb
+++ b/lib/inspec/plugin/v2/plugin_types/streaming_reporter.rb
@@ -72,7 +72,7 @@ module Inspec::Plugin::V2::PluginType
     def control_has_error(notifications)
       notifications.any? do |notification_data|
         notification, _status = notification_data
-        !notification.example.exception.nil? && !(notification.example.exception.is_a? RSpec::Expectations::ExpectationNotMetError) && !notification.example.exception.backtrace.nil?
+        !notification.example.exception.nil? && !(notification.example.exception.is_a? RSpec::Expectations::ExpectationNotMetError) && !notification.example.exception.backtrace.nil? && (!notification.description.include? "No-op") # No-op exception occurs in case of not_applicable_if
       end
     end
 

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -145,6 +145,25 @@ module Inspec
       @__skip_rule[:message] = message
     end
 
+    def not_applicable_if(message = nil)
+      return unless block_given?
+      return unless yield
+
+      self.impact = 0.0
+      if message
+        message = "N/A control due to not_applicable_if condition: #{message}"
+      else
+        message = "N/A control due to not_applicable_if condition."
+      end
+      resource = noop
+
+      resource.fail_resource(message)
+
+      describe resource do
+        nil
+      end
+    end
+
     # Describe will add one or more tests to this control. There is 2 ways
     # of calling it:
     #

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -16,7 +16,7 @@ module Inspec
     include ::RSpec::Matchers
 
     attr_reader :__waiver_data
-    attr_accessor :resource_dsl
+    attr_accessor :resource_dsl, :na_impact_freeze
     attr_reader :__profile_id
 
     def initialize(id, profile_id, resource_dsl, opts, &block)
@@ -40,6 +40,7 @@ module Inspec
       @__merge_count = 0
       @__merge_changes = []
       @__skip_only_if_eval = opts[:skip_only_if_eval]
+      @__na_rule = {}
 
       # evaluate the given definition
       return unless block_given?
@@ -75,10 +76,13 @@ module Inspec
     end
 
     def impact(v = nil)
-      if v.is_a?(String)
-        @impact = Inspec::Impact.impact_from_string(v)
-      elsif !v.nil?
-        @impact = v
+      # N/A impact freeze is required when only_applicable_if block has reset impact value to zero"
+      unless na_impact_freeze
+        if v.is_a?(String)
+          @impact = Inspec::Impact.impact_from_string(v)
+        elsif !v.nil?
+          @impact = v
+        end
       end
 
       @impact
@@ -150,18 +154,11 @@ module Inspec
       return if yield
 
       impact(0.0)
-      if message
-        message = "N/A control due to not_applicable_if condition: #{message}"
-      else
-        message = "N/A control due to not_applicable_if condition."
-      end
-      resource = noop
+      self.na_impact_freeze = true # this flag prevents impact value to reset to any other value
 
-      resource.fail_resource(message)
-
-      describe resource do
-        nil
-      end
+      @__na_rule[:result] ||= !yield
+      @__na_rule[:type] = :only_applicable_if
+      @__na_rule[:message] = message
     end
 
     # Describe will add one or more tests to this control. There is 2 ways
@@ -274,6 +271,10 @@ module Inspec
       rule.instance_variable_get(:@__skip_rule)
     end
 
+    def self.na_status(rule)
+      rule.instance_variable_get(:@__na_rule)
+    end
+
     def self.set_skip_rule(rule, value, message = nil, type = :only_if)
       rule.instance_variable_set(:@__skip_rule,
                                  {
@@ -295,16 +296,26 @@ module Inspec
     # creates a dummay array of "checks" with a skip outcome
     def self.prepare_checks(rule)
       skip_check = skip_status(rule)
-      return checks(rule) unless skip_check[:result].eql?(true)
-
-      if skip_check[:message]
-        msg = "Skipped control due to #{skip_check[:type]} condition: #{skip_check[:message]}"
-      else
-        msg = "Skipped control due to #{skip_check[:type]} condition."
-      end
+      na_check = na_status(rule)
+      return checks(rule) unless skip_check[:result].eql?(true) || na_check[:result].eql?(true)
 
       resource = rule.noop
-      resource.skip_resource(msg)
+      if skip_check[:result].eql?(true)
+        if skip_check[:message]
+          msg = "Skipped control due to #{skip_check[:type]} condition: #{skip_check[:message]}"
+        else
+          msg = "Skipped control due to #{skip_check[:type]} condition."
+        end
+        resource.skip_resource(msg)
+      else
+        if na_check[:message]
+          msg = "N/A control due to #{na_check[:type]} condition: #{na_check[:message]}"
+        else
+          msg = "N/A control due to #{na_check[:type]} condition."
+        end
+        resource.fail_resource(msg)
+      end
+
       [["describe", [resource], nil]]
     end
 

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -145,11 +145,11 @@ module Inspec
       @__skip_rule[:message] = message
     end
 
-    def not_applicable_if(message = nil)
+    def only_applicable_if(message = nil)
       return unless block_given?
-      return unless yield
+      return if yield
 
-      self.impact = 0.0
+      impact(0.0)
       if message
         message = "N/A control due to not_applicable_if condition: #{message}"
       else

--- a/lib/plugins/inspec-streaming-reporter-progress-bar/lib/inspec-streaming-reporter-progress-bar/streaming_reporter.rb
+++ b/lib/plugins/inspec-streaming-reporter-progress-bar/lib/inspec-streaming-reporter-progress-bar/streaming_reporter.rb
@@ -83,6 +83,12 @@ module InspecPlugins::StreamingReporterProgressBar
       control_id = notification.example.metadata[:id]
       title = notification.example.metadata[:title]
       full_description = notification.example.metadata[:full_description]
+
+      # No-op exception occurs in case of not_applicable_if
+      if (full_description.include? "No-op") && notification.example.exception
+        full_description += notification.example.exception.message
+      end
+
       set_status_mapping(control_id, status)
       collect_notifications(notification, control_id, status)
       control_ended = control_ended?(control_id)

--- a/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
+++ b/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
@@ -77,3 +77,22 @@ control "tmp-6.0.2" do
     it { should be_directory }
   end
 end
+
+# Example of setting impact using code and marking it N/A
+control "tmp-7.0.1" do
+  impact 0.5
+  describe file("/tmp") do
+    it { should be_directory }
+    it { exist }
+  end
+  not_applicable_if("Some reason for N/A") { true }
+end
+
+# Example of setting impact using code and not marking it N/A
+control "tmp-7.0.2" do
+  impact 0.5
+  describe file("/tmp") do
+    it { should be_directory }
+  end
+  not_applicable_if("Some reason for N/A") { false }
+end

--- a/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
+++ b/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
@@ -85,7 +85,7 @@ control "tmp-7.0.1" do
     it { should be_directory }
     it { exist }
   end
-  not_applicable_if("Some reason for N/A") { true }
+  only_applicable_if("Some reason for N/A") { false }
 end
 
 # Example of setting impact using code and not marking it N/A
@@ -94,5 +94,5 @@ control "tmp-7.0.2" do
   describe file("/tmp") do
     it { should be_directory }
   end
-  not_applicable_if("Some reason for N/A") { false }
+  only_applicable_if("Some reason for N/A") { true }
 end

--- a/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
+++ b/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
@@ -65,16 +65,16 @@ end
 control "tmp-6.0.1" do
   impact 0.5
   only_if("Some reason for N/A", impact: 0.0) { false }
-  describe file("/tmp") do
-    it { should be_directory }
+  describe "f.1" do
+    it { should cmp "f.1" }
   end
 end
 
 # Example of setting impact using code and not marked as N/A
 control "tmp-6.0.2" do
   only_if(impact: 0.5) { false }
-  describe file("/tmp") do
-    it { should be_directory }
+  describe "f.2" do
+    it { should cmp "f.2" }
   end
 end
 
@@ -82,9 +82,8 @@ end
 control "tmp-7.0.1" do
   only_applicable_if("Some reason for N/A") { false }
   impact 0.5
-  describe file("/tmp") do
-    it { should be_directory }
-    it { exist }
+  describe "g.1" do
+    it { should cmp "g.1" }
   end
 end
 
@@ -92,7 +91,7 @@ end
 control "tmp-7.0.2" do
   only_applicable_if("Some reason for N/A") { true }
   impact 0.5
-  describe file("/tmp") do
-    it { should be_directory }
+  describe "g.2" do
+    it { should cmp "g.2" }
   end
 end

--- a/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
+++ b/test/fixtures/profiles/enhanced-outcomes-test/controls/example.rb
@@ -80,19 +80,19 @@ end
 
 # Example of setting impact using code and marking it N/A
 control "tmp-7.0.1" do
+  only_applicable_if("Some reason for N/A") { false }
   impact 0.5
   describe file("/tmp") do
     it { should be_directory }
     it { exist }
   end
-  only_applicable_if("Some reason for N/A") { false }
 end
 
 # Example of setting impact using code and not marking it N/A
 control "tmp-7.0.2" do
+  only_applicable_if("Some reason for N/A") { true }
   impact 0.5
   describe file("/tmp") do
     it { should be_directory }
   end
-  only_applicable_if("Some reason for N/A") { true }
 end

--- a/test/functional/inspec_exec_streaming_progress_bar_test.rb
+++ b/test/functional/inspec_exec_streaming_progress_bar_test.rb
@@ -88,6 +88,8 @@ describe "inspec exec with streaming progress bar reporter" do
     _(out.stderr).must_include "[N/R]      tmp-3.0.2"
     _(out.stderr).must_include "[FAILED]   tmp-4.0"
     _(out.stderr).must_include "[PASSED]   tmp-5.0"
+    _(out.stderr).must_include "[N/A]      tmp-7.0.1  No-op N/A control due to only_applicable_if condition: Some reason for N/A"
+    _(out.stderr).must_include "[PASSED]   tmp-7.0.2  File /tmp is expected to be directory"
     assert_exit_code 100, out
   end
 

--- a/test/functional/inspec_exec_streaming_progress_bar_test.rb
+++ b/test/functional/inspec_exec_streaming_progress_bar_test.rb
@@ -89,7 +89,7 @@ describe "inspec exec with streaming progress bar reporter" do
     _(out.stderr).must_include "[FAILED]   tmp-4.0"
     _(out.stderr).must_include "[PASSED]   tmp-5.0"
     _(out.stderr).must_include "[N/A]      tmp-7.0.1  No-op N/A control due to only_applicable_if condition: Some reason for N/A"
-    _(out.stderr).must_include "[PASSED]   tmp-7.0.2  File /tmp is expected to be directory"
+    _(out.stderr).must_include "[PASSED]   tmp-7.0.2"
     assert_exit_code 100, out
   end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -1347,12 +1347,12 @@ EOT
 
     it "should show enhanced_outcomes for controls with impact 0" do
       _(run_result.stdout).must_include "5 skipped"
-      _(run_result.stdout).must_include "3 controls not applicable"
+      _(run_result.stdout).must_include "4 controls not applicable"
       _(run_result.stdout).must_include "N/A"
     end
 
     it "should show enhanced_outcomes for controls with errors" do
-      _(run_result.stdout).must_include "3 failures"
+      _(run_result.stdout).must_include "4 failures"
       _(run_result.stdout).must_include "2 controls have error"
       _(run_result.stdout).must_include "ERR"
     end
@@ -1362,7 +1362,7 @@ EOT
     end
 
     it "should show enhanced_outcomes for passed controls" do
-      _(run_result.stdout).must_include "1 successful control"
+      _(run_result.stdout).must_include "2 successful control"
     end
 
     it "should mark control as N/A using zero impact from only_if" do
@@ -1379,6 +1379,23 @@ EOT
         _(run_result.stdout).must_include "[N/R]  tmp-6.0.2"
       else
         _(run_result.stdout).must_include "N/R  tmp-6.0.2"
+      end
+    end
+
+    it "should mark control as N/A using only_applicable_if when false" do
+      if windows?
+        _(run_result.stdout).must_include "[N/A]  tmp-7.0.1"
+      else
+        _(run_result.stdout).must_include "N/A  tmp-7.0.1"
+      end
+      _(run_result.stdout).must_include "Some reason for N/A"
+    end
+
+    it "should not mark control as N/A using only_applicable_if when true" do
+      if windows?
+        _(run_result.stdout).wont_include "[N/A]  tmp-6.0.2"
+      else
+        _(run_result.stdout).wont_include "N/A  tmp-6.0.2"
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
DSL keyword `only_applicable_if` will help set the impact value to zero conditionally when the condition inside the block is not true. It also invokes a failure test in the result containing the reason for why it is not applicable.

**Usage:**

```
control "test-1" do
  only_applicable_if ("Some reason for N/A") { false }
  impact 1.0
  describe ...
end
```
**Output:**

```
×  test-1: No-op
     ×  No-op 
     N/A control due to only_applicable_if condition: Some reason for N/A
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
