### PR TITLE
CFINSPEC-451 Inspec Parallel options reading using stdin

### DIFF
--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/exec_command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/exec_command.rb
@@ -86,7 +86,8 @@ module InspecPlugins
         content = []
         begin
           if cli_options_to_parallel_cmd[:option_file] == "-"
-            content = $stdin.read&.split("\n") || []
+            content = $stdin.readlines if !$stdin.tty? && $stdin.stat.pipe?
+            @logger.error("Standard input options are empty") if content.empty?
           else
             content = content_from_file(cli_options_to_parallel_cmd[:option_file])
           end

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/exec_command.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/exec_command.rb
@@ -83,8 +83,13 @@ module InspecPlugins
 
       def read_options_file
         opts = []
+        content = []
         begin
-          content = content_from_file(cli_options_to_parallel_cmd[:option_file])
+          if cli_options_to_parallel_cmd[:option_file] == "-"
+            content = $stdin.read&.split("\n") || []
+          else
+            content = content_from_file(cli_options_to_parallel_cmd[:option_file])
+          end
         rescue OptionFileNotReadable => e
           @logger.error "Cannot read options file: #{e.message}"
           Inspec::UI.new.exit(:usage_error)

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/list_reporter.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/list_reporter.rb
@@ -20,7 +20,7 @@ module InspecPlugins::Parallelism
         @resource_formatter = InspecPlugins::Parallelism::ListReporter::ResourceFormatter::Base.formatter_for(resource_name, parameters: parameters, query: query)
       end
 
-      puts "-t " + resource_formatter.format_id_for_list(raw_id)
+      puts "-t " + resource_formatter.format_id_for_list(raw_id) + " --reporter json:<%= pid%>.json"
     end
 
     def example_failed(notification)

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/list_reporter.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/list_reporter.rb
@@ -20,7 +20,7 @@ module InspecPlugins::Parallelism
         @resource_formatter = InspecPlugins::Parallelism::ListReporter::ResourceFormatter::Base.formatter_for(resource_name, parameters: parameters, query: query)
       end
 
-      puts "-t " + resource_formatter.format_id_for_list(raw_id) + " --reporter json:<%= pid%>.json"
+      puts "-t " + resource_formatter.format_id_for_list(raw_id) + " --reporter json:#{raw_id}.json"
     end
 
     def example_failed(notification)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Option to read Inspec Parallel options reading using stdin, to use inspec parallel list.

Command to run:

`inspec parallel list -r aws_ecr_images -p "repository_name: 'test-inspec'" -t aws:// |  inspec parallel exec profiles/test-aws -o -
`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
