### PR TITLE
Replace faraday_middleware with faraday-follow_redirects

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -23,27 +23,27 @@ Gem::Specification.new do |spec|
       .reject { |f| File.directory?(f) }
 
   # Implementation dependencies
-  spec.add_dependency "chef-telemetry",     "~> 1.0", ">= 1.0.8" # 1.0.8+ removes the http dep
-  spec.add_dependency "license-acceptance", ">= 0.2.13", "< 3.0"
-  spec.add_dependency "thor",               ">= 0.20", "< 2.0"
-  spec.add_dependency "method_source",      ">= 0.8", "< 2.0"
-  spec.add_dependency "rubyzip",            ">= 1.2.2", "< 3.0"
-  spec.add_dependency "rspec",              ">= 3.9", "<= 3.11"
-  spec.add_dependency "rspec-its",          "~> 1.2"
-  spec.add_dependency "pry",                "~> 0.13"
-  spec.add_dependency "hashie",             ">= 3.4", "< 5.0"
-  spec.add_dependency "mixlib-log",         "~> 3.0"
-  spec.add_dependency "sslshake",           "~> 1.2"
-  spec.add_dependency "parallel",           "~> 1.9"
-  spec.add_dependency "faraday",            ">= 0.9.0", "< 1.5"
-  spec.add_dependency "faraday_middleware", "~> 1.0"
-  spec.add_dependency "tty-table",          "~> 0.10"
-  spec.add_dependency "tty-prompt",         "~> 0.17"
-  spec.add_dependency "tomlrb",             ">= 1.2", "< 2.1"
-  spec.add_dependency "addressable",        "~> 2.4"
-  spec.add_dependency "parslet",            ">= 1.5", "< 2.0" # Pinned < 2.0, see #5389
-  spec.add_dependency "semverse",           "~> 3.0"
-  spec.add_dependency "multipart-post",     "~> 2.0"
+  spec.add_dependency "chef-telemetry",           "~> 1.0", ">= 1.0.8" # 1.0.8+ removes the http dep
+  spec.add_dependency "license-acceptance",       ">= 0.2.13", "< 3.0"
+  spec.add_dependency "thor",                     ">= 0.20", "< 2.0"
+  spec.add_dependency "method_source",            ">= 0.8", "< 2.0"
+  spec.add_dependency "rubyzip",                  ">= 1.2.2", "< 3.0"
+  spec.add_dependency "rspec",                    ">= 3.9", "<= 3.11"
+  spec.add_dependency "rspec-its",                "~> 1.2"
+  spec.add_dependency "pry",                      "~> 0.13"
+  spec.add_dependency "hashie",                   ">= 3.4", "< 5.0"
+  spec.add_dependency "mixlib-log",               "~> 3.0"
+  spec.add_dependency "sslshake",                 "~> 1.2"
+  spec.add_dependency "parallel",                 "~> 1.9"
+  spec.add_dependency "faraday",                  "~> 1.0", "< 1.5"
+  spec.add_dependency "faraday-follow_redirects", "~> 0.3"
+  spec.add_dependency "tty-table",                "~> 0.10"
+  spec.add_dependency "tty-prompt",               "~> 0.17"
+  spec.add_dependency "tomlrb",                   ">= 1.2", "< 2.1"
+  spec.add_dependency "addressable",              "~> 2.4"
+  spec.add_dependency "parslet",                  ">= 1.5", "< 2.0" # Pinned < 2.0, see #5389
+  spec.add_dependency "semverse",                 "~> 3.0"
+  spec.add_dependency "multipart-post",           "~> 2.0"
 
   spec.add_dependency "train-core", "~> 3.10"
 end

--- a/lib/inspec/resources/http.rb
+++ b/lib/inspec/resources/http.rb
@@ -4,7 +4,7 @@
 
 require "inspec/resources/command"
 require "faraday" unless defined?(Faraday)
-require "faraday_middleware"
+require "faraday/follow_redirects"
 require "hashie"
 
 module Inspec::Resources
@@ -153,7 +153,7 @@ module Inspec::Resources
 
           conn = Faraday.new(url: url, headers: request_headers, params: params, ssl: { verify: ssl_verify? }) do |builder|
             builder.request :url_encoded
-            builder.use FaradayMiddleware::FollowRedirects, limit: max_redirects unless max_redirects.nil?
+            builder.use Faraday::FollowRedirects::Middleware, limit: max_redirects unless max_redirects.nil?
             builder.adapter Faraday.default_adapter
           end
 

--- a/test/unit/resources/http_test.rb
+++ b/test/unit/resources/http_test.rb
@@ -1,7 +1,7 @@
 require "helper"
 require "inspec/resource"
 require "inspec/resources/http"
-require "faraday_middleware/response/follow_redirects"
+require "faraday/follow_redirects/redirect_limit_reached"
 
 describe "Inspec::Resources::Http" do
   describe "InSpec::Resources::Http::Worker::Local" do
@@ -49,7 +49,7 @@ describe "Inspec::Resources::Http" do
         stub_request(:get, "redirect1.com").to_return(status: 302, headers: { location: "http://redirect2.com" } )
         stub_request(:get, "redirect2.com").to_return(status: 200, body: "should not get here")
 
-        _(proc { worker.status }).must_raise FaradayMiddleware::RedirectLimitReached
+        _(proc { worker.status }).must_raise Faraday::FollowRedirects::RedirectLimitReached
       end
     end
 


### PR DESCRIPTION
## Description

`faraday_middleware` gem was already DEPRECATED in 2022-01.
Only `FaradayMiddleware::FollowRedirects` from `faraday_middleware` gem has been used, and so we can replace it with `faraday-follow_redirects` gem.

`faraday-follow_redirects` 0.3.0 requires `faraday ~> 1.0`, which is as same as `faraday_middleware` 1.0.0 or higher (cf. #5391).

This gem was introduced in #3509.

## Related Issue

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)