### PR TITLE
Update chefstyle from 2.0.x to 2.2.2 to use RuboCop 1.25.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :omnibus do
 end
 
 group :test do
-  gem "chefstyle", "~> 2.0.3"
+  gem "chefstyle", "~> 2.2.2"
   gem "concurrent-ruby", "~> 1.0"
   gem "html-proofer", "~> 3.19.4", platforms: :ruby # do not attempt to run proofer on windows. Pinned to 3.19.4 as test is breaking in updated versions.
   gem "json_schemer", ">= 0.2.1", "< 0.2.19"


### PR DESCRIPTION
## Description
Updates `chefstyle` gem from 2.0.x to 2.2.2 (or higher) to use RuboCop 1.25.1.

## Related Issue

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
