### PR TITLE
CFINSPEC-458 Oracle DB session resource compatibility with AIX-C shell

### DIFF
--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -107,7 +107,7 @@ module Inspec::Resources
       else
         sql_postfix = %{ <<'EOC'\n#{format_options}\n#{verified_query}\nEXIT\nEOC}
         # oracle_query_string is echoed to be able to extract the query output clearly
-        oracle_echo_str = %{ echo 'oracle_query_string'; }
+        oracle_echo_str = %{echo 'oracle_query_string';}
       end
 
       # Resetting sql_postfix if system is using AIX OS and C shell installation for oracle

--- a/lib/inspec/resources/oracledb_session.rb
+++ b/lib/inspec/resources/oracledb_session.rb
@@ -101,22 +101,31 @@ module Inspec::Resources
         verified_query = verify_query(escaped_query)
       end
 
-      sql_prefix, sql_postfix = "", ""
+      sql_prefix, sql_postfix, oracle_echo_str = "", "", ""
       if inspec.os.windows?
         sql_prefix = %{@'\n#{format_options}\n#{verified_query}\nEXIT\n'@ | }
       else
         sql_postfix = %{ <<'EOC'\n#{format_options}\n#{verified_query}\nEXIT\nEOC}
+        # oracle_query_string is echoed to be able to extract the query output clearly
+        oracle_echo_str = %{ echo 'oracle_query_string'; }
+      end
+
+      # Resetting sql_postfix if system is using AIX OS and C shell installation for oracle
+      if inspec.os.aix?
+        command_to_fetch_shell = @su_user ? %{su - #{@su_user} -c "env | grep SHELL"} : %{env | grep SHELL}
+        shell_is_csh = inspec.command(command_to_fetch_shell).stdout&.include? "/csh"
+        sql_postfix = %{ <<'EOC'\n#{format_options}\n#{verified_query}\nEXIT\n'EOC'} if shell_is_csh
       end
 
       if @db_role.nil?
-        %{#{sql_prefix}#{bin} #{user}/#{password}@#{host}:#{port}/#{@service}#{sql_postfix}}
+        %{#{oracle_echo_str}#{sql_prefix}#{bin} #{user}/#{password}@#{host}:#{port}/#{@service}#{sql_postfix}}
       elsif @su_user.nil?
-        %{#{sql_prefix}#{bin} #{user}/#{password}@#{host}:#{port}/#{@service} as #{@db_role}#{sql_postfix}}
+        %{#{oracle_echo_str}#{sql_prefix}#{bin} #{user}/#{password}@#{host}:#{port}/#{@service} as #{@db_role}#{sql_postfix}}
       else
         # oracle_query_string is echoed to be able to extract the query output clearly
         # su - su_user in certain versions of oracle returns a message
         # Example of msg with query output: The Oracle base remains unchanged with value /oracle\n\nVALUE\n3\n
-        %{su - #{@su_user} -c "echo 'oracle_query_string'; env ORACLE_SID=#{@service} #{@bin} / as #{@db_role}#{sql_postfix}"}
+        %{su - #{@su_user} -c "#{oracle_echo_str} env ORACLE_SID=#{@service} #{@bin} / as #{@db_role}#{sql_postfix}"}
       end
     end
 

--- a/test/unit/resources/oracledb_session_test.rb
+++ b/test/unit/resources/oracledb_session_test.rb
@@ -7,7 +7,7 @@ describe "Inspec::Resources::OracledbSession" do
     resource = quick_resource(:oracledb_session, :linux, user: "USER", password: "password", host: "localhost", service: "ORCL", port: 1527, sqlplus_bin: "/bin/sqlplus") do |cmd|
       cmd.strip!
       case cmd
-      when "/bin/sqlplus -S USER/password@localhost:1527/ORCL <<'EOC'\nSET PAGESIZE 32000\nSET FEEDBACK OFF\nSET UNDERLINE OFF\nSELECT NAME AS VALUE FROM v$database;\nEXIT\nEOC" then
+      when "echo 'oracle_query_string';/bin/sqlplus -S USER/password@localhost:1527/ORCL <<'EOC'\nSET PAGESIZE 32000\nSET FEEDBACK OFF\nSET UNDERLINE OFF\nSELECT NAME AS VALUE FROM v$database;\nEXIT\nEOC" then
         stdout_file "test/fixtures/cmd/oracle-result"
       else
         raise cmd.inspect
@@ -169,7 +169,7 @@ describe "Inspec::Resources::OracledbSession" do
     resource = quick_resource(:oracledb_session, :linux, user: "USER", password: "wrongpassword", host: "localhost", service: "ORCL", port: 1527, sqlplus_bin: "/bin/sqlplus") do |cmd|
       cmd.strip!
       case cmd
-      when "/bin/sqlplus -S USER/wrongpassword@localhost:1527/ORCL <<'EOC'\nSET PAGESIZE 32000\nSET FEEDBACK OFF\nSET UNDERLINE OFF\nSELECT NAME AS VALUE FROM v$database;\nEXIT\nEOC" then
+      when "echo 'oracle_query_string';/bin/sqlplus -S USER/wrongpassword@localhost:1527/ORCL <<'EOC'\nSET PAGESIZE 32000\nSET FEEDBACK OFF\nSET UNDERLINE OFF\nSELECT NAME AS VALUE FROM v$database;\nEXIT\nEOC" then
         stdout_file "test/fixtures/cmd/oracle-error"
       else
         raise cmd.inspect


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
1. Oracle DB session resource compatibility with AIX-C shell
2. Made changes to print "oracle_query_string" before every query. This makes fetching result from the string simpler and handles edge cases.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
