### PR TITLE
CFINSPEC-462: Fixes inspec sign breaks when there is period n the profile name

### DIFF
--- a/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
+++ b/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
@@ -59,11 +59,14 @@ module InspecPlugins
         # Read name and version from metadata and use them to form the filename
         profile_md = artifact.read_profile_metadata(profile_path)
 
-        artifact_filename = "#{profile_md["name"]}-#{profile_md["version"]}.#{SIGNED_PROFILE_SUFFIX}"
+        # Behave same as archive filename for iaf filename
+        slug = profile_md["name"].downcase.strip.tr(" ", "-").gsub(/[^\w-]/, "_")
+        filename = "#{slug}-#{profile_md["version"]}"
+        artifact_filename = "#{filename}.#{SIGNED_PROFILE_SUFFIX}"
 
         # Generating tar.gz file using archive method of Inspec Cli
         Inspec::InspecCLI.new.archive(profile_path, "error")
-        tarfile = "#{profile_md["name"]}-#{profile_md["version"]}.tar.gz"
+        tarfile = "#{filename}.tar.gz"
         tar_content = IO.binread(tarfile)
         FileUtils.rm(tarfile)
 

--- a/lib/plugins/inspec-sign/test/functional/inspec_sign_test.rb
+++ b/lib/plugins/inspec-sign/test/functional/inspec_sign_test.rb
@@ -46,6 +46,31 @@ class SignCli < Minitest::Test
     end
   end
 
+  def test_sign_profile_for_profile_name_with_period
+    prepare_examples do |dir|
+      skip_windows! # Breakage confirmed, only on CI: https://buildkite.com/chef-oss/inspec-inspec-master-verify/builds/2355#2c9d032e-4a24-4e7c-aef2-1c9e2317d9e2
+
+      unique_key_name = SecureRandom.uuid
+
+      # create profile
+      profile = File.join(dir, "artifact-profile-5.3")
+      run_inspec_process("init profile artifact-profile-5.3", prefix: "cd #{dir};")
+
+      out = run_inspec_process("sign generate-keys --keyname #{unique_key_name}", prefix: "cd #{dir};")
+      assert_exit_code 0, out
+
+      out = run_inspec_process("sign profile #{profile} --keyname #{unique_key_name}", prefix: "cd #{dir};")
+      assert_exit_code 0, out
+
+      out = run_inspec_process("sign verify artifact-profile-5_3-0.1.0.iaf", prefix: "cd #{dir};")
+      assert_exit_code 0, out
+
+      assert_includes out.stdout.force_encoding(Encoding::UTF_8), "Verifying artifact-profile-5_3-0.1.0.iaf"
+      assert_exit_code 0, out
+      delete_keys(unique_key_name)
+    end
+  end
+
   def delete_keys(unique_key_name)
     File.delete("#{Inspec.config_dir}/keys/#{unique_key_name}.pem.key") if File.exist?("#{Inspec.config_dir}/keys/#{unique_key_name}.pem.key")
     File.delete("#{Inspec.config_dir}/keys/#{unique_key_name}.pem.pub") if File.exist?("#{Inspec.config_dir}/keys/#{unique_key_name}.pem.pub")


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This fixes the error which is coming while signing profile with names like "cis-aix-5.3-6.1-level1-v1.1.0"

It replaces spaces and periods with "_" same as it done while archiving the profile.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
