### PR TITLE
Prevent negative status from crashing launchctl service resource

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -646,7 +646,7 @@ module Inspec::Resources
       return nil if srv.nil? || srv[0].nil?
 
       # extract values from service
-      parsed_srv = /^(?<pid>[0-9-]+)\t(?<exit>[0-9]+)\t(?<name>\S*)$/.match(srv[0])
+      parsed_srv = /^(?<pid>[0-9-]+)\t(?<exit>[\-0-9]+)\t(?<name>\S*)$/.match(srv[0])
       enabled = !parsed_srv["name"].nil? # it's in the list
 
       # check if the service is running

--- a/test/fixtures/cmd/launchctl-list
+++ b/test/fixtures/cmd/launchctl-list
@@ -1,3 +1,4 @@
 PID	Status	Label
 2892	0	org.openbsd.ssh-agent
 -	0	com.apple.FilesystemUI
+-	-15	org.example.killed-agent

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -497,6 +497,21 @@ describe "Inspec::Resources::Service" do
     _(resource.resource_id).must_equal "ssh"
   end
 
+  it "verify mac osx service parsing with negative status launchd_service" do
+    resource = MockLoader.new(:macos10_10).load_resource(
+      "launchd_service", "org.example.killed-agent"
+    )
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal "darwin"
+    _(resource.name).must_equal "org.example.killed-agent"
+    _(resource.description).must_be_nil
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal false
+    _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "org.example.killed-agent"
+  end
+
   # wrlinux
   it "verify wrlinux service parsing" do
     resource = MockLoader.new(:wrlinux).load_resource("service", "sshd")


### PR DESCRIPTION
Currently the launchd_service resource crashes with the error `undefined method '[]' for nil:NilClass` whenever it attempts to check the state of a service that was ended via a signal or returned a negative error code.

## Description

The current regex used to match the fields from `launchctl list` does not expect the status column to be a negative number. If the status field is a negative number the regex match does not work as expected and results in the function attempting to index into `nil`.

The launchctl man page states that:

> The second column displays the last exit status of the job. If the number in this column is negative, it represents the negative of the signal which stopped the job. Thus, "-15" would indicate that the job was terminated with SIGTERM.

Since a negative status is a normal case, the regex match should expect and handle it correctly.

## Example:
I created a service on a Mac that is killed via signal 11 (SIGSEGV). I then created and ran an Inspec test that attempts to determine if the service is installed, enabled, and running.

`launchctl list` output is as follows:
```
% sudo launchctl list | grep 'com.example.test'
42061	-11	com.example.test
```

### Before
```
% sudo inspec exec ~/profiles/example           

Profile: Inspec Example profile
Version: 0.1.0
Target:  local://

  ×  Example Service Monitoring: Check that a service is installed, enabled, and running (3 failed)
     ×  Service com.example.test is expected to be installed
     undefined method `[]' for nil:NilClass
     ×  Service com.example.test is expected to be enabled
     undefined method `[]' for nil:NilClass
     ×  Service com.example.test is expected to be running
     undefined method `[]' for nil:NilClass


Profile Summary: 0 successful controls, 1 control failure, 0 controls skipped
Test Summary: 0 successful, 3 failures, 0 skipped
```

## After
```
% sudo inspec exec ~/profiles/example                                                           

Profile: Inspec Example profile
Version: 0.1.0
Target:  local://

  ✔  Example Service Monitoring: Check that a service is installed, enabled, and running
     ✔  Service com.example.test is expected to be installed
     ✔  Service com.example.test is expected to be enabled
     ✔  Service com.example.test is expected to be running


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 3 successful, 0 failures, 0 skipped
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
