### PR TITLE
Fix Ruby 2.7 Bundle Installs on CI Verify Pipeline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,20 +45,11 @@ group :deploy do
   gem "inquirer"
 end
 
-# Only include Test Kitchen support if we are on Ruby 2.7 or higher
-# as chef-zero support requires Ruby 2.6
-# See https://github.com/inspec/inspec/pull/5341
-if Gem.ruby_version >= Gem::Version.new("2.7.0")
-  group :kitchen do
-    gem "berkshelf"
-    gem "chef", ">= 16.0" # Required to allow net-ssh > 6
-    gem "test-kitchen", ">= 2.8"
-    gem "kitchen-inspec", ">= 2.0"
-    gem "kitchen-dokken", ">= 2.11"
-    gem "git"
-  end
-end
-
-if Gem.ruby_version < Gem::Version.new("2.7.0")
-  gem "activesupport", "6.1.4.4"
+group :kitchen do
+  gem "berkshelf"
+  gem "chef", ">= 16.0" # Required to allow net-ssh > 6
+  gem "test-kitchen", ">= 2.8"
+  gem "kitchen-inspec", ">= 2.0"
+  gem "kitchen-dokken", ">= 2.11"
+  gem "git"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ end
 group :test do
   gem "chefstyle", "~> 2.0.3"
   gem "concurrent-ruby", "~> 1.0"
-  gem "html-proofer", "~> 3.19.4", platforms: :ruby # do not attempt to run proofer on windows. Pinned to 3.19.4 as test is breaking in updated versions.
   gem "json_schemer", ">= 0.2.1", "< 0.2.19"
   gem "m"
   gem "minitest-sprint", "~> 1.0"
@@ -39,6 +38,12 @@ group :test do
   gem "simplecov", "~> 0.21"
   gem "simplecov_json_formatter"
   gem "webmock", "~> 3.0"
+
+  if Gem.ruby_version >= Gem::Version.new("3.0.0")
+    # html-proofer has a dep on io-event, which is ruby-3 only
+    gem "html-proofer", "~> 3.19.4", platforms: :ruby # do not attempt to run proofer on windows. Pinned to 3.19.4 as test is breaking in updated versions.
+  end
+
 end
 
 group :deploy do

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :test do
     # html-proofer has a dep on io-event, which is ruby-3 only
     gem "html-proofer", "~> 3.19.4", platforms: :ruby # do not attempt to run proofer on windows. Pinned to 3.19.4 as test is breaking in updated versions.
   end
-
 end
 
 group :deploy do
@@ -52,7 +51,15 @@ end
 
 group :kitchen do
   gem "berkshelf"
-  gem "chef", ">= 16.0" # Required to allow net-ssh > 6
+
+  # Chef 18 requires ruby 3
+  if Gem.ruby_version >= Gem::Version.new("3.0.0")
+    gem "chef", ">= 17.0"
+  else
+    # Ruby 2.7 presumably - TODO remove this when 2.7 is sunsetted
+    gem "chef", "~> 16.0"
+  end
+
   gem "test-kitchen", ">= 2.8"
   gem "kitchen-inspec", ">= 2.0"
   gem "kitchen-dokken", ">= 2.11"

--- a/lib/plugins/inspec-reporter-html2/test/functional/inspec_reporter_html2_test.rb
+++ b/lib/plugins/inspec-reporter-html2/test/functional/inspec_reporter_html2_test.rb
@@ -24,6 +24,9 @@ describe "inspec-reporter-html2" do
       # and we really only need to verify this on one platform
       return if is_windows?
 
+      # html-proofer relies on io-event, which is ruby-3 only
+      skip unless Gem.ruby_version >= Gem::Version.new("3.0.0")
+
       require "html-proofer"
 
       proofer_opts = {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

Attempt to fix Ruby 2.7 bundle install.
* Only run HTML proofer on Ruby 3 (it's only supported there anyway, as io-event is only supported on Ruby 3)
* Run Chef 16 on Ruby 2.7 and Chef 17+ on Ruby 3. 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
