### PR TITLE
Update readme for usage via Docker (CFINSPEC-516)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For Linux:
 
 ```
 docker pull chef/inspec
-function inspec { docker run -it --rm -v $(pwd):/share -v /var/run/docker.sock:/var/run/docker.sock chef/inspec "$@"; }
+function inspec { docker run -it --rm -v $(pwd):/share chef/inspec "$@"; }
 ```
 
 For Windows (PowerShell):
@@ -133,6 +133,14 @@ $ inspec exec test.rb -t ssh://root@192.168.64.2:11022 -i vagrant
 Finished in 0.04321 seconds (files took 0.54917 seconds to load)
 2 examples, 0 failures
 ```
+
+To scan the docker containers running on the host using the containerized InSpec, we need to bind-mount the Unix socket `/var/run/docker.sock` from the host machine to the InSpec Container.
+
+```
+docker pull chef/inspec
+function inspec { docker run -it --rm -v $(pwd):/share -v /var/run/docker.sock:/var/run/docker.sock chef/inspec "$@"; }
+```
+`/var/run/docker.sock` is the Unix socket the Docker daemon listens on by default.
 
 
 ### Install it from source

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For Linux:
 
 ```
 docker pull chef/inspec
-function inspec { docker run -it --rm -v $(pwd):/share chef/inspec "$@"; }
+function inspec { docker run -it --rm -v $(pwd):/share -v /var/run/docker.sock:/var/run/docker.sock chef/inspec "$@"; }
 ```
 
 For Windows (PowerShell):


### PR DESCRIPTION
Signed-off-by: Sonu Saha <sonu.saha@progress.com>

## Description
The readme on inspec is updated for usage via Docker so that the containerised InSpec can be used to scan other containers.

## Related Issue
**CFINSPEC-516: Update InSpec Documentation for Usage via Docker**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Update documentation (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
