### PR TITLE
Remove Windows Ruby 3.0 testing

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -57,18 +57,6 @@ steps:
         docker:
           image: ruby:3.1
 
-  - label: run-tests-ruby-3.0-windows
-    command:
-      - /workdir/.expeditor/buildkite/verify.ps1
-    expeditor:
-      executor:
-        docker:
-          environment:
-            - BUILDKITE
-          host_os: windows
-          shell: ["powershell", "-Command"]
-          image: rubydistros/windows-2019:3.0
-
   - label: run-tests-ruby-3.1-windows
     command:
       - /workdir/.expeditor/buildkite/verify.ps1


### PR DESCRIPTION
We only have proper dependencies for testing on Ruby 3.1.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
