### PR TITLE
CFINSPEC-533: Fix undefined method 'summary' for Gem::SourceFetchProblem (NoMethodError) when airgapped 

### DIFF
--- a/test/artifact/inspec_plugin_test.rb
+++ b/test/artifact/inspec_plugin_test.rb
@@ -5,7 +5,6 @@ class TestInspecPlugin < ArtifactTest
     # This one is custom because it emits a special warning to stderr
     inspec_command = "plugin list"
     stdout, stderr, status = run_cmd "inspec #{inspec_command} #{TEST_CLI_OPTS}"
-
     assert_empty stderr.sub(/#< CLIXML\n/, "").sub(/The table size exceeds the currently set width\.Defaulting to vertical orientation\.\n/, "")
     assert stdout
     assert status

--- a/test/fixtures/config_dirs/train-test-fixture/plugins.json
+++ b/test/fixtures/config_dirs/train-test-fixture/plugins.json
@@ -3,7 +3,7 @@
   "plugins": [
     {
       "name": "train-test-fixture",
-      "version": "0.1.0"
+      "version": ">= 0.1.0"
     }
   ]
 }

--- a/test/unit/plugin/v2/loader_test.rb
+++ b/test/unit/plugin/v2/loader_test.rb
@@ -333,4 +333,14 @@ class PluginLoaderTests < Minitest::Test
       end
     end
   end
+
+  def test_read_conf_file_into_registry
+    ENV["INSPEC_CONFIG_DIR"] = File.join(@config_dir_path, "train-test-fixture")
+    loader = Inspec::Plugin::V2::Loader.new(omit_bundles: true)
+    registry = loader.send(:read_conf_file_into_registry)
+    assert_includes registry, { :name => :"train-test-fixture", :version => ">= 0.1.0" }
+    reg = Inspec::Plugin::V2::Registry.instance
+    status = reg[registry.first[:name]]
+    assert_equal("Test train plugin. Not intended for use as an example.", status.description, "Reads the description of the plugin from local gemspec file.")
+  end
 end


### PR DESCRIPTION


Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
This fixes the undefined method 'summary' for #<Gem::SourceFetchProblem:0x000000000139dc70> (NoMethodError) while invoking any inspec command if the custom plugin is installed and if inspec commands are run in an air gap environment.
This fix removes an earlier call for getting gem specification from rubygems.org which is the cause for the above error and replaces it with fetching the summary from a locally saved gemspec file. This will work in both airgap and non-airgap environments. 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
