### PR TITLE
CFINSPEC-517: Fix for habitat buld failure 

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -42,15 +42,15 @@ Write-Host "--- Installing $pkg_ident/$pkg_artifact"
 hab pkg install -b $project_root/results/$pkg_artifact
 
 Write-Host "--- Downloading Ruby + DevKit"
-aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-3.1.2-1-x64.exe c:/rubyinstaller-devkit-3.1.2-1-x64.exe
+aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.6-1-x64.exe c:/rubyinstaller-devkit-2.6.6-1-x64.exe
 
 Write-Host "--- Installing Ruby + DevKit"
-Start-Process c:\rubyinstaller-devkit-3.1.2-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait
+Start-Process c:\rubyinstaller-devkit-2.6.6-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
 
 Write-Host "--- Cleaning up installation"
-Remove-Item c:\rubyinstaller-devkit-3.1.2-1-x64.exe -Force
+Remove-Item c:\rubyinstaller-devkit-2.6.6-1-x64.exe -Force
 
-$Env:Path += ";C:\ruby31\bin;C:\hab\bin"
+$Env:Path += ";C:\ruby26\bin;C:\hab\bin"
 
 Write-Host "+++ Testing $Plan"
 

--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -41,19 +41,19 @@ $env:DO_CHECK=$true; hab pkg build .
 Write-Host "--- Installing $pkg_ident/$pkg_artifact"
 hab pkg install -b $project_root/results/$pkg_artifact
 
-Write-Host "--- Downloading Ruby + DevKit"
-aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.6-1-x64.exe c:/rubyinstaller-devkit-2.6.6-1-x64.exe
+# Remove if habitat build is green without this
+# Write-Host "--- Downloading Ruby + DevKit"
+# aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.6-1-x64.exe c:/rubyinstaller-devkit-2.6.6-1-x64.exe
 
-Write-Host "--- Installing Ruby + DevKit"
-Start-Process c:\rubyinstaller-devkit-2.6.6-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
+# Write-Host "--- Installing Ruby + DevKit"
+# Start-Process c:\rubyinstaller-devkit-2.6.6-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
 
-Write-Host "--- Cleaning up installation"
-Remove-Item c:\rubyinstaller-devkit-2.6.6-1-x64.exe -Force
+# Write-Host "--- Cleaning up installation"
+# Remove-Item c:\rubyinstaller-devkit-2.6.6-1-x64.exe -Force
 
-$Env:Path += ";C:\ruby26\bin;C:\hab\bin"
+$Env:Path += ";C:\ruby31-x64\bin;C:\hab\bin"
 
 Write-Host "+++ Testing $Plan"
-
 Push-Location $project_root/test/artifact
 rake
 If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -42,15 +42,15 @@ Write-Host "--- Installing $pkg_ident/$pkg_artifact"
 hab pkg install -b $project_root/results/$pkg_artifact
 
 Write-Host "--- Downloading Ruby + DevKit"
-aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.6-1-x64.exe c:/rubyinstaller-devkit-2.6.6-1-x64.exe
+aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-3.1.2-1-x64.exe c:/rubyinstaller-devkit-3.1.2-1-x64.exe
 
 Write-Host "--- Installing Ruby + DevKit"
-Start-Process c:\rubyinstaller-devkit-2.6.6-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
+Start-Process c:\rubyinstaller-devkit-3.1.2-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait
 
 Write-Host "--- Cleaning up installation"
-Remove-Item c:\rubyinstaller-devkit-2.6.6-1-x64.exe -Force
+Remove-Item c:\rubyinstaller-devkit-3.1.2-1-x64.exe -Force
 
-$Env:Path += ";C:\ruby26\bin;C:\hab\bin"
+$Env:Path += ";C:\ruby31\bin;C:\hab\bin"
 
 Write-Host "+++ Testing $Plan"
 

--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -41,19 +41,19 @@ $env:DO_CHECK=$true; hab pkg build .
 Write-Host "--- Installing $pkg_ident/$pkg_artifact"
 hab pkg install -b $project_root/results/$pkg_artifact
 
-# Remove if habitat build is green without this
-# Write-Host "--- Downloading Ruby + DevKit"
-# aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.6-1-x64.exe c:/rubyinstaller-devkit-2.6.6-1-x64.exe
+Write-Host "--- Downloading Ruby + DevKit"
+aws s3 cp s3://core-buildkite-cache-chef-prod/rubyinstaller-devkit-2.6.6-1-x64.exe c:/rubyinstaller-devkit-2.6.6-1-x64.exe
 
-# Write-Host "--- Installing Ruby + DevKit"
-# Start-Process c:\rubyinstaller-devkit-2.6.6-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
+Write-Host "--- Installing Ruby + DevKit"
+Start-Process c:\rubyinstaller-devkit-2.6.6-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
 
-# Write-Host "--- Cleaning up installation"
-# Remove-Item c:\rubyinstaller-devkit-2.6.6-1-x64.exe -Force
+Write-Host "--- Cleaning up installation"
+Remove-Item c:\rubyinstaller-devkit-2.6.6-1-x64.exe -Force
 
-$Env:Path += ";C:\ruby31-x64\bin;C:\hab\bin"
+$Env:Path += ";C:\ruby26\bin;C:\hab\bin"
 
 Write-Host "+++ Testing $Plan"
+
 Push-Location $project_root/test/artifact
 rake
 If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -15,7 +15,8 @@ $pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 $pkg_license=('Apache-2.0')
 
 $pkg_deps=@(
-  "chef/ruby30-plus-devkit"
+  "chef/ruby31-plus-devkit"
+  "core/git"
 )
 $pkg_bin_dirs=@("bin"
                 "vendor/bin")
@@ -32,6 +33,7 @@ function Invoke-SetupEnvironment {
 
 function Invoke-Build {
     try {
+        $env:Path += ";c:\\Program Files\\Git\\bin"
         Push-Location $project_root
         $env:GEM_HOME = "$HAB_CACHE_SRC_PATH/$pkg_dirname/vendor"
 


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This fixes the habitat Windows build 
Failure #1 https://buildkite.com/chef/inspec-inspec-main-artifact-habitat/builds/4512#0184e646-bbb7-456a-84af-6eabfcbeade4/156-203 as Chef 18 has dependency of ruby 3.1
and 
Failure #2 https://buildkite.com/chef/inspec-inspec-main-artifact-habitat/builds/4521#0184e6a1-49e8-4906-924f-efc21e2615bd/159-837 as git was not available in the path.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
