### PR TITLE
Use Ruby 3.1.2 in Omnibus build

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -3,7 +3,7 @@
 # grab the current train release from rubygems.org
 train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
 override "train", version: "v#{train_stable}"
-override "ruby", version: "2.7.4"
+override "ruby", version: "3.1.2"
 
 # Mac m1
 override "openssl", version: "1.1.1m" if mac_os_x?


### PR DESCRIPTION
This does two things:
* Moves us onto Ruby 3 for InSpec 5, which we have been on for a while
* Fixes two CVEs present in the CGI gem included with Ruby (#6215)

The smoke tests also detected a minor issue which we'll need to merge in (#6342) before we can merge this. 

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
