### PR TITLE
Fix env smoke test by updating ERB.new in `inspec env`; add additional test

### DIFF
--- a/lib/inspec/env_printer.rb
+++ b/lib/inspec/env_printer.rb
@@ -35,7 +35,7 @@ module Inspec
     private
 
     def print_completion_for_shell
-      erb = ERB.new(File.read(completion_template_path), nil, "-")
+      erb = ERB.new(File.read(completion_template_path), trim_mode: "-")
       puts erb.result(TemplateContext.new(@command_class).get_bindings)
     end
 

--- a/test/functional/inspec_env_test.rb
+++ b/test/functional/inspec_env_test.rb
@@ -6,7 +6,7 @@ describe "inspec env" do
   parallelize_me!
 
   describe "inspec env with no args" do
-    # env is a command only supported for 
+    # env is a command only supported for
     # bash, zsh, and fish shells - so mac and linux
     unless windows?
       it "runs without warnings" do

--- a/test/functional/inspec_env_test.rb
+++ b/test/functional/inspec_env_test.rb
@@ -1,0 +1,19 @@
+require "functional/helper"
+
+describe "inspec env" do
+  include FunctionalHelper
+
+  parallelize_me!
+
+  describe "inspec env with no args" do
+    it "runs without warnings" do
+      result = run_inspec_process("env")
+
+      assert_empty result.stderr
+      assert_exit_code 0, result
+      
+      # Part of the successful help usage message at the end, not likely to change
+      _(result.stdout).must_include "inspec env SHELLNAME"
+    end
+  end
+end

--- a/test/functional/inspec_env_test.rb
+++ b/test/functional/inspec_env_test.rb
@@ -6,14 +6,18 @@ describe "inspec env" do
   parallelize_me!
 
   describe "inspec env with no args" do
-    it "runs without warnings" do
-      result = run_inspec_process("env")
+    # env is a command only supported for 
+    # bash, zsh, and fish shells - so mac and linux
+    unless windows?
+      it "runs without warnings" do
+        result = run_inspec_process("env")
 
-      assert_empty result.stderr
-      assert_exit_code 0, result
-      
-      # Part of the successful help usage message at the end, not likely to change
-      _(result.stdout).must_include "inspec env SHELLNAME"
+        assert_empty result.stderr
+        assert_exit_code 0, result
+
+        # Part of the successful help usage message at the end, not likely to change
+        _(result.stdout).must_include "inspec env SHELLNAME"
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

Under Ruby 3.x, the calling pattern for ERB.new now insists you use named params, and issues warnings to stderr if you don't. The `env` command uses ERB to template the shell completion functions based on the current list of inspec commands. We test for warnings to stderr in our post-install smoke tests for env, but strangely had no pre-install tests for env.

So, shift that test left, and check for env to work correctly at CI verify time, like we do with all the other commands.

Also, make the simple change needed to fix the call to ERB new, fixing the smoke test.
Verified the fix works on 3.1.2 and 2.7.7 .

This PR blocks #6341 .

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
