### PR TITLE
Fixing typo in user_permissions

### DIFF
--- a/lib/inspec/resources/file.rb
+++ b/lib/inspec/resources/file.rb
@@ -66,7 +66,7 @@ module Inspec::Resources
     def user_permissions
       return {} unless exist?
 
-      return skip_resource"`user_permissions` is not supported on your OS yet." unless inspec.os.windows?
+      return skip_resource "`user_permissions` is not supported on your OS yet." unless inspec.os.windows?
 
       @perms_provider.user_permissions(file)
     end

--- a/lib/inspec/resources/file.rb
+++ b/lib/inspec/resources/file.rb
@@ -66,7 +66,7 @@ module Inspec::Resources
     def user_permissions
       return {} unless exist?
 
-      return skip_reource"`user_permissions` is not supported on your OS yet." unless inspec.os.windows?
+      return skip_resource"`user_permissions` is not supported on your OS yet." unless inspec.os.windows?
 
       @perms_provider.user_permissions(file)
     end


### PR DESCRIPTION


## Description
user_permissions has a typo when calling skip_resource 

## Related Issue
https://github.com/inspec/inspec/issues/6343

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [ x] I have read the **CONTRIBUTING** document.

I have attempted to test locally as outlined in the contributing guide but I am running into bundle error after error. Specific to M1 mac is this current issue which is preventing me from using the latest ruby (https://github.com/chef/ffi-yajl/issues/115) and older versions are all giving me various different issues. I'm hoping the CI tests would reveal any errors for this minor change.
