### PR TITLE
Removed excel file format support for attestations file

### DIFF
--- a/dev-docs/attestations.md
+++ b/dev-docs/attestations.md
@@ -24,15 +24,15 @@ When used with Enhanced Outcomes, this becomes handling `Not Reviewed` controls.
 
 The new option is named like `--waiver-file` - singular, with `-file`. You may provide multiple arguments for the option.
 
-The file can be any of the following formats: `YAML`, `XLSX`, `CSV`, or `JSON`.
+The file can be any of the following formats: `YAML`, `CSV`, or `JSON`.
 
 #### YAML and JSON
 
 An array of Hashes.
 
-#### XLSX and CSV
+#### CSV
 
-XLSX is the first sheet in the file.
+CSV is the first sheet in the file.
 
 Both formats assume a header row.
 

--- a/docs-chef-io/content/inspec/attestations.md
+++ b/docs-chef-io/content/inspec/attestations.md
@@ -89,7 +89,7 @@ inspec exec path/to/profile --attestation-file attestation.yaml
 
 ## File Format
 
-Attestations files support YAML, JSON, CSV, XLSX, and XLS formats.
+Attestations files support YAML, JSON, and CSV formats.
 
 ```yaml
 control_id:
@@ -153,7 +153,7 @@ example-3.0.2:
 }
 ```
 
-#### Example in CSV/XLSX/XLS
+#### Example in CSV
 
 These file formats support the following fields in a file:
 
@@ -168,7 +168,7 @@ These file formats support the following fields in a file:
 - `expiration_date`
    _Optional_.
 
-![Attestations File Excel Example](/images/inspec/attestations_file_excel.png)
+![Attestations File Example](/images/inspec/attestations_file_excel.png)
 
 {{< note >}}
 

--- a/lib/inspec/attestation_file_reader.rb
+++ b/lib/inspec/attestation_file_reader.rb
@@ -1,7 +1,7 @@
 require "inspec/secrets/yaml"
 require "inspec/utils/waivers/csv_file_reader"
 require "inspec/utils/waivers/json_file_reader"
-require "inspec/utils/waivers/excel_file_reader"
+# require "inspec/utils/waivers/excel_file_reader"
 
 module Inspec
   class AttestationFileReader < WaiverFileReader

--- a/lib/inspec/waiver_file_reader.rb
+++ b/lib/inspec/waiver_file_reader.rb
@@ -44,10 +44,6 @@ module Inspec
       elsif file_extension == ".json"
         data = Waivers::JSONFileReader.resolve(file_path)
         validate_json_yaml(data)
-      elsif [".xls", ".xlsx"].include? file_extension
-        data = Waivers::ExcelFileReader.resolve(file_path)
-        headers = Waivers::ExcelFileReader.headers
-        validate_headers(headers)
       end
       data
     end

--- a/test/functional/attestation_test.rb
+++ b/test/functional/attestation_test.rb
@@ -60,15 +60,6 @@ describe "attestations" do
     end
   end
 
-  describe "with a attestation file that has wrong headers - xlsx format" do
-    let(:attestation_file) { "wrong-headers.xlsx" }
-    it "raise file does not exist standard error" do
-      result = run_result
-      assert_includes result.stdout, "Missing column headers: [\"control_id\", \"status\", \"justification\"]"
-      assert_includes result.stdout, "Extra column headers: [\"control_id_random\", \"justification_random\", \"run_random\", \"expiration_date_random\"]\n"
-    end
-  end
-
   describe "running attestation on a profile - yaml" do
     let(:attestation_file) { "attestations.yaml" }
 
@@ -103,38 +94,6 @@ describe "attestations" do
 
   describe "running attestation on a profile - csv" do
     let(:attestation_file) { "attestations.csv" }
-
-    it "attests N/R controls correctly" do
-      result = run_result
-      assert_includes result.stdout, "tmp-3.0.1: No-op (1 failed)"
-      refute_includes result.stdout, "N/R  tmp-3.0.2: No-op"
-      refute_includes result.stdout, "N/R  tmp-6.0.2: No-op"
-    end
-
-    it "does not attests non N/R controls" do
-      result = run_result
-      assert_includes result.stdout, "tmp-4.0: d.1 (1 failed)"
-    end
-  end
-
-  describe "running attestation on a profile - xlsx" do
-    let(:attestation_file) { "attestations.xlsx" }
-
-    it "attests N/R controls correctly" do
-      result = run_result
-      assert_includes result.stdout, "tmp-3.0.1: No-op (1 failed)"
-      refute_includes result.stdout, "N/R  tmp-3.0.2: No-op"
-      refute_includes result.stdout, "N/R  tmp-6.0.2: No-op"
-    end
-
-    it "does not attests non N/R controls" do
-      result = run_result
-      assert_includes result.stdout, "tmp-4.0: d.1 (1 failed)"
-    end
-  end
-
-  describe "running attestation on a profile - xls" do
-    let(:attestation_file) { "attestations.xls" }
 
     it "attests N/R controls correctly" do
       result = run_result


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Removed attestations support for excel file formats: xlsx and xls because it is using `roo` gem to read excel files and this gem is creating issues with releasing inspec since it has dependency on Nokogiri gem.
Till the time alternative solution is not found, removing excel format support.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
