### PR TITLE
CFINSPEC-542 Bug fix for profiles with dependent profiles

### DIFF
--- a/docs-chef-io/content/inspec/profiles.md
+++ b/docs-chef-io/content/inspec/profiles.md
@@ -404,6 +404,44 @@ As with the prior example, only `baseline-2` and `baseline-4` are executed, but
 if `baseline-2` fails, it will report with an impact of `0.5` instead of the
 originally-intended `1.0` impact.
 
+## Including or Selecting controls from a profile with same name and different version.
+
+When an inspec profile has dependency on another profile to it's specific version, then the controls can be included or selected by using profile name with version separated by `-`.
+
+Here, the Profile - A has following dependency:
+
+```yaml
+name: profile-a
+depends:
+  - name: ssh
+    git: https://github.com/dev-sec/ssh-baseline.git
+    tag: 2.6.0
+```
+
+And Profile - B has following dependency:
+
+```yaml
+name: profile-b
+depends:
+  - name: ssh
+    git: https://github.com/dev-sec/ssh-baseline.git
+    tag: 2.7.0
+```
+
+Controls of these profiles can be included or required in a profile in a following manner:
+
+```ruby
+include_controls "ssh-2.6.0"
+include_controls "ssh-2.7.0"
+```
+
+OR
+
+```ruby
+require_controls "ssh-2.6.0"
+require_controls "ssh-2.7.0"
+```
+
 ## Using Resources from an Included Profile
 
 By default, all of the custom resources from a listed dependency are available

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -93,9 +93,12 @@ module Inspec::DSL
     else
       dependencies.list.keys.each do |key|
         # If dep profile does not contain a source version, key does not contain a version as well. In that case new_profile_id will be always nil and instead profile_id would be used to fetch profile from dependency list.
-        profile_id_key = key.split("-")
-        profile_id_key.pop
-        new_profile_id = key if profile_id_key.join("-") == profile_id
+
+        matching_semver = key.match(/(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/).to_s
+        unless matching_semver.nil? || matching_semver.empty?
+          profile_id_key = key.split("-#{matching_semver}")[0]
+          new_profile_id = key if profile_id_key == profile_id
+        end
       end
     end
     dep_entry = new_profile_id ? dependencies.list[new_profile_id] : dependencies.list[profile_id]

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -92,15 +92,16 @@ module Inspec::DSL
       new_profile_id = "#{profile_id}-#{profile_version}"
     else
       dependencies.list.keys.each do |key|
-        # If dep profile does not contain a source version, key does not contain a version as well. In that case new_profile_id will be always nil and instead profile_id would be used to fetch profile from dependency list.
-
-        matching_semver = key.match(/(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/).to_s
-        unless matching_semver.nil? || matching_semver.empty?
-          profile_id_key = key.split("-#{matching_semver}")[0]
+        # 1. Fetching VERSION from a profile dependency name which is in a format NAME-VERSION.
+        # 2. Matching original profile dependency name with profile name used with include or require control DSL.
+        fetching_semver = key.match(/(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/).to_s
+        unless fetching_semver.nil? || fetching_semver.empty?
+          profile_id_key = key.split("-#{fetching_semver}")[0]
           new_profile_id = key if profile_id_key == profile_id
         end
       end
     end
+    # If dep profile does not contain a source version, key does not contain a version as well. In that case new_profile_id will be always nil and instead profile_id would be used to fetch profile from dependency list.
     dep_entry = new_profile_id ? dependencies.list[new_profile_id] : dependencies.list[profile_id]
 
     if dep_entry.nil?

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -91,10 +91,9 @@ module Inspec::DSL
     if profile_version
       new_profile_id = "#{profile_id}-#{profile_version}"
     else
+      # This scary regex is used to match version following semantic Versioning (SemVer). Thanks to https://ihateregex.io/expr/semver/
+      regex_for_semver = /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/
       dependencies.list.keys.each do |key|
-        # This scary regex is used to match version following semantic Versioning (SemVer). Thanks to https://ihateregex.io/expr/semver/
-        regex_for_semver = /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/
-
         # 1. Fetching VERSION from a profile dependency name which is in a format NAME-VERSION.
         # 2. Matching original profile dependency name with profile name used with include or require control DSL.
         fetching_semver = key.match(regex_for_semver).to_s

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -92,9 +92,12 @@ module Inspec::DSL
       new_profile_id = "#{profile_id}-#{profile_version}"
     else
       dependencies.list.keys.each do |key|
+        # This scary regex is used to match version following semantic Versioning (SemVer). Thanks to https://ihateregex.io/expr/semver/
+        regex_for_semver = /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/
+
         # 1. Fetching VERSION from a profile dependency name which is in a format NAME-VERSION.
         # 2. Matching original profile dependency name with profile name used with include or require control DSL.
-        fetching_semver = key.match(/(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/).to_s
+        fetching_semver = key.match(regex_for_semver).to_s
         unless fetching_semver.nil? || fetching_semver.empty?
           profile_id_key = key.split("-#{fetching_semver}")[0]
           new_profile_id = key if profile_id_key == profile_id

--- a/test/fixtures/profiles/git-fetcher/inheritance/child-profile-3/controls/example.rb
+++ b/test/fixtures/profiles/git-fetcher/inheritance/child-profile-3/controls/example.rb
@@ -1,0 +1,3 @@
+require_controls "ssh-2.6.0" do
+  control "sshd-01"
+end

--- a/test/fixtures/profiles/git-fetcher/inheritance/child-profile-3/inspec.yml
+++ b/test/fixtures/profiles/git-fetcher/inheritance/child-profile-3/inspec.yml
@@ -1,0 +1,14 @@
+name: child-profile-3
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  platform: os
+depends:
+  - name: ssh
+    git: https://github.com/dev-sec/ssh-baseline.git
+    tag: 2.6.0

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -1319,6 +1319,17 @@ EOT
         _(run_result.stdout).must_include "sshd-50"
       end
     end
+
+    describe "DSL with version: when profiles are dependent on different versions of same profile" do
+      let(:profile) { "#{profile_path}/git-fetcher/inheritance/child-profile-3" }
+      let(:run_result) { run_inspec_process("exec #{profile}") }
+      it "should evaluate all test controls of all versions correctly" do
+        skip_windows!
+        _(run_result.stderr).must_be_empty
+        _(run_result.stdout).must_include "2.6.0"
+        _(run_result.stdout).must_include "sshd-01"
+      end
+    end
   end
 
   if windows?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This was reported by an Inspec user.

**Following is the excerpt from that:**

I have a new issue with automate compliance that came up recently. As of a few weeks ago, compliance runs all fail due to a dependency error. I have a compliance profile called fedramp-centos7-level1-server that includes a copy of cis-centos7-level1-server that we host on our git server. In overlay.rb:

`include_controls 'cis-centos7-level1-server' do`

and in inspec.yml:

```
depends:
  - name: 'cis-centos7-level1-server'
    git: 'ssh://git@path-to-our-git-server/comply/cis-centos7-level1-server.git'
    branch: 'master'
```

However, recently now whenever Chef runs I get this error:

```
Failed to load profile fedramp-centos7-level1-server: Failed to load source for controls/overlay.rb: Cannot load 'cis-centos7-level1-server' since it is not listed as a dependency of fedramp-centos7-level1-server.

Dependencies available from this context are:
    cis-centos7-level1-server-2.2.0-13

```
It seems to be expecting the version appended to the name? However, if I just try to add that version number to the end of the include_controls line in overlay.rb, inspec archive won't build the archive because the name of the dependency mismatches.How do I solve this dependency issue?We're still running Automate version 2, 20220329091442

**Cause of the issue:**

https://github.com/inspec/inspec/blob/17d7822365e24fdd8d3f1b58c78446d7dff67935/lib/inspec/dsl.rb#L93 This else condition needs a fix.

The above issue is happening because the dependency also has 2.2.0-13" "-" in this

**Possible ways to fix:**

1. Either try catching version and removing it from key on line 96 in dsl.rb, since this could break with versions which does not follow A.B.C pattern # Best solution
2. Or try to put condition that it does not append version when in source_version “-“ is present - Inside dependency_set.rb in line 29 and 45 # This is not a good solution
3. Either document how include controls can work by appending version. # New change documentation.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
