### PR TITLE
CFINSPEC-553: Fix failing verify pipeline builds on ruby 3.0

### DIFF
--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -5,7 +5,7 @@ ruby -v
 bundle --version
 
 echo "--- bundle install"
-bundle config set --local without tools maintenance deploy
+bundle config set --local without deploy
 bundle install --jobs=7 --retry=3
 
 echo "+++ bundle exec rake test:parallel"

--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -5,7 +5,7 @@ ruby -v
 bundle --version
 
 echo "--- bundle install"
-bundle config set --local without deploy
+bundle config set --local without deploy kitchen
 bundle install --jobs=7 --retry=3
 
 echo "+++ bundle exec rake test:parallel"

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -37,7 +37,7 @@ pull_bundle
 
 echo "--- bundle"
 bundle config --local path vendor/bundle
-bundle config set --local without tools maintenance deploy
+bundle config set --local without tools maintenance deploy kitchen
 bundle install --jobs=7 --retry=3
 
 echo "--- push bundle cache"

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -37,7 +37,7 @@ pull_bundle
 
 echo "--- bundle"
 bundle config --local path vendor/bundle
-bundle config set --local without tools maintenance deploy kitchen
+bundle config set --local without deploy kitchen
 bundle install --jobs=7 --retry=3
 
 echo "--- push bundle cache"

--- a/.expeditor/buildkite/wwwrelease.sh
+++ b/.expeditor/buildkite/wwwrelease.sh
@@ -7,7 +7,7 @@ set -ue
 echo "--- bundle install"
 
 cd www
-bundle config set --local without tools maintenance deploy
+bundle config set --local without deploy
 bundle install --jobs=7 --retry=3
 
 echo "+++ bundle exec rake"

--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -35,7 +35,7 @@ build do
 
   # We bundle install to ensure the versions of gems we are going to
   # appbundle-lock to are definitely installed
-  bundle "config set --local without test", env: env
+  bundle "config set --local without test kitchen", env: env
   bundle "install", env: env
 
   gem "build #{name}-core.gemspec", env: env

--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -35,7 +35,7 @@ build do
 
   # We bundle install to ensure the versions of gems we are going to
   # appbundle-lock to are definitely installed
-  bundle "config set --local without test integration tools maintenance", env: env
+  bundle "config set --local without test", env: env
   bundle "install", env: env
 
   gem "build #{name}-core.gemspec", env: env


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
*  Changes included in `verify.sh` to `bundle install` without kitchen group from Gemfile. Reason is verify pipeline is breaking for ruby 3.0 for Chef 18. Chef 18 works with ruby >= 3.1. In the future, we will be removing the support for ruby 3.0 as Chef 18 was never released with ruby 3.0. After discussing with @clintoncwolfe instead of updating the kitchen group currently, we preferred to exclude the kitchen group while bundling the gems.

https://buildkite.com/chef-oss/inspec-inspec-main-verify/builds/5197#01859c63-1d3d-4527-adc8-f6727097a90d/651-658

*  Removes all excluded groups from the bundle config set which was removed from the Gemfile.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
