### PR TITLE
CFINSPEC-555 Ruby 3.1 support: Adds ucrt platform to resolve windows omnibus build.

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -23,6 +23,7 @@ pipelines:
      # The git cache is corrupt more often than not. This always purges the cache.
      # https://chefio.atlassian.net/wiki/spaces/RELENGKB/pages/2204336129/Resolving+git+cache+build+errors+in+Omnibus
      - EXPIRE_CACHE: 1
+     - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems like ffi.
  - omnibus/adhoc:
     definition: .expeditor/release.omnibus.yml
     env:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -7,6 +7,7 @@ fips-platforms:
   - el-*-x86_64
   - windows-*
   - ubuntu-*-x86_64
+windows-64-msystem: UCRT64
 builder-to-testers-map:
   debian-9-x86_64:
     - debian-9-x86_64


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Windows omnibus build fails with `cannot load such file -- 3.1/ffi_c (LoadError)` https://buildkite.com/chef/inspec-inspec-main-omnibus-adhoc/builds/343#01859bcb-7c3c-4851-a0a3-4eb677a5de04/6-6092. The reason is for ruby 3.1 64 bit Windows builds needs to be switched to use `UCRT64` toolchain instead of `MINGW64` which is the default.

Also after adding `UCRT64` it further started breaking where it was unable to download some gems like `ffi-1.15.5-x64-mingw-ucrt.gem` from artifactory. We need to verify whether adding the environment variable `IGNORE_ARTIFACTORY_RUBY_PROXY: true` to the omnibus release pipeline resolves the issue as manually adding this resolved the issue on the ad-hoc build.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
