### PR TITLE
CFINSPEC-554: Update CLI Docs rake task to work with current InSpec docs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ group :test do
   gem "pry-byebug"
   gem "pry", "~> 0.10"
   gem "rake", ">= 10"
-  gem "ruby-progressbar", "~> 1.8"
   gem "simplecov", "~> 0.21"
   gem "simplecov_json_formatter"
   gem "webmock", "~> 3.0"

--- a/Rakefile
+++ b/Rakefile
@@ -5,20 +5,10 @@ require "bundler/gem_helper"
 require "rake/testtask"
 require "train"
 require "fileutils"
+require_relative "tasks/docs"
 
 Bundler::GemHelper.install_tasks name: "inspec-core"
 Bundler::GemHelper.install_tasks name: "inspec"
-
-# The docs tasks rely on ruby-progressbar. If we can't load it, then don't
-# load the docs tasks. This is necessary to allow this Rakefile to work
-# when the "tests" gem group in the Gemfile has been excluded, such as
-# during an appbundle-updater run.
-begin
-  require "ruby-progressbar"
-  require_relative "tasks/docs"
-rescue LoadError
-  puts "docs tasks are unavailable because the ruby-progressbar gem is not available."
-end
 
 task :install do
   inspec_bin_path = ::File.join(::File.dirname(__FILE__), "inspec-bin")

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -33,39 +33,32 @@ This subcommand has the following additional options:
 
 <dl>
 <dt><code>--airgap</code>, <code>--no-airgap</code></dt>
-<dd> Fallback to using local archives if fetching fails.</dd>
-</dl>
-<dl>
+<dd>Fallback to using local archives if fetching fails.</dd>
+
 <dt><code>--auto-install-gems</code>, <code>--no-auto-install-gems</code></dt>
-<dd> Auto installs gem dependencies of the profile or resource pack.</dd>
-</dl>
-<dl>
+<dd>Auto installs gem dependencies of the profile or resource pack.</dd>
+
 <dt><code>--ignore-errors</code>, <code>--no-ignore-errors</code></dt>
-<dd> Ignore profile warnings.</dd>
-</dl>
-<dl>
+<dd>Ignore profile warnings.</dd>
+
 <dt><code>-o</code>, <code>--output=OUTPUT</code></dt>
-<dd> Save the archive to a path.</dd>
-</dl>
-<dl>
+<dd>Save the archive to a path.</dd>
+
 <dt><code>--overwrite</code>, <code>--no-overwrite</code></dt>
-<dd> Overwrite existing archive.</dd>
-</dl>
-<dl>
+<dd>Overwrite existing archive.</dd>
+
 <dt><code>--profiles-path=PROFILES_PATH</code></dt>
-<dd> Folder which contains referenced profiles.</dd>
-</dl>
-<dl>
+<dd>Folder which contains referenced profiles.</dd>
+
 <dt><code>--tar</code>, <code>--no-tar</code></dt>
-<dd> Generates a tar.gz archive.</dd>
-</dl>
-<dl>
+<dd>Generates a tar.gz archive.</dd>
+
 <dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
-<dd> Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
-</dl>
-<dl>
+<dd>Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
+
 <dt><code>--zip</code>, <code>--no-zip</code></dt>
-<dd> Generates a zip archive.</dd>
+<dd>Generates a zip archive.</dd>
+
 </dl>
 
 ## check
@@ -86,23 +79,20 @@ This subcommand has the following additional options:
 
 <dl>
 <dt><code>--auto-install-gems</code>, <code>--no-auto-install-gems</code></dt>
-<dd> Auto installs gem dependencies of the profile or resource pack.</dd>
-</dl>
-<dl>
+<dd>Auto installs gem dependencies of the profile or resource pack.</dd>
+
 <dt><code>--format=FORMAT</code></dt>
-<dd> The output format to use. Valid values: `json` and `doc`. Default value: `doc`.</dd>
-</dl>
-<dl>
+<dd>The output format to use. Valid values: `json` and `doc`. Default value: `doc`.</dd>
+
 <dt><code>--profiles-path=PROFILES_PATH</code></dt>
-<dd> Folder which contains referenced profiles.</dd>
-</dl>
-<dl>
+<dd>Folder which contains referenced profiles.</dd>
+
 <dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
-<dd> Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
-</dl>
-<dl>
+<dd>Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
+
 <dt><code>--with-cookstyle</code>, <code>--no-with-cookstyle</code></dt>
-<dd> Enable or disable cookstyle checks.</dd>
+<dd>Enable or disable cookstyle checks.</dd>
+
 </dl>
 
 ## clear_cache
@@ -123,7 +113,8 @@ This subcommand has the following additional options:
 
 <dl>
 <dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
-<dd> Use the given path for caching dependencies, (default: `~/.inspec/cache`).</dd>
+<dd>Use the given path for caching dependencies, (default: `~/.inspec/cache`).</dd>
+
 </dl>
 
 ## detect
@@ -144,154 +135,117 @@ This subcommand has the following additional options:
 
 <dl>
 <dt><code>-b</code>, <code>--backend=BACKEND</code></dt>
-<dd> Choose a backend: local, ssh, winrm, docker.</dd>
-</dl>
-<dl>
+<dd>Choose a backend: local, ssh, winrm, docker.</dd>
+
 <dt><code>--bastion-host=BASTION_HOST</code></dt>
-<dd> Specifies the bastion host if applicable.</dd>
-</dl>
-<dl>
+<dd>Specifies the bastion host if applicable.</dd>
+
 <dt><code>--bastion-port=BASTION_PORT</code></dt>
-<dd> Specifies the bastion port if applicable.</dd>
-</dl>
-<dl>
+<dd>Specifies the bastion port if applicable.</dd>
+
 <dt><code>--bastion-user=BASTION_USER</code></dt>
-<dd> Specifies the bastion user if applicable.</dd>
-</dl>
-<dl>
+<dd>Specifies the bastion user if applicable.</dd>
+
 <dt><code>--ca-trust-file=CA_TRUST_FILE</code></dt>
-<dd> Specify CA certificate required for SSL authentication (WinRM).</dd>
-</dl>
-<dl>
+<dd>Specify CA certificate required for SSL authentication (WinRM).</dd>
+
 <dt><code>--client-cert=CLIENT_CERT</code></dt>
-<dd> Specify client certificate for SSL authentication</dd>
-</dl>
-<dl>
+<dd>Specify client certificate for SSL authentication</dd>
+
 <dt><code>--client-key=CLIENT_KEY</code></dt>
-<dd> Specify client key required with client cert for SSL authentication</dd>
-</dl>
-<dl>
+<dd>Specify client key required with client cert for SSL authentication</dd>
+
 <dt><code>--client-key-pass=CLIENT_KEY_PASS</code></dt>
-<dd> Specify client cert password, if required for SSL authentication</dd>
-</dl>
-<dl>
+<dd>Specify client cert password, if required for SSL authentication</dd>
+
 <dt><code>--config=CONFIG</code></dt>
-<dd> Read configuration from JSON file (`-` reads from stdin).</dd>
-</dl>
-<dl>
+<dd>Read configuration from JSON file (`-` reads from stdin).</dd>
+
 <dt><code>--docker-url=DOCKER_URL</code></dt>
-<dd> Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.</dd>
-</dl>
-<dl>
+<dd>Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.</dd>
+
 <dt><code>--enable-password=ENABLE_PASSWORD</code></dt>
-<dd> Password for enable mode on Cisco IOS devices.</dd>
-</dl>
-<dl>
+<dd>Password for enable mode on Cisco IOS devices.</dd>
+
 <dt><code>--format=FORMAT</code></dt>
-</dl>
-<dl>
 <dt><code>--host=HOST</code></dt>
-<dd> Specify a remote host which is tested.</dd>
-</dl>
-<dl>
+<dd>Specify a remote host which is tested.</dd>
+
 <dt><code>--insecure</code>, <code>--no-insecure</code></dt>
-<dd> Disable SSL verification on select targets.</dd>
-</dl>
-<dl>
+<dd>Disable SSL verification on select targets.</dd>
+
 <dt><code>-i</code>, <code>--key-files=one two three</code></dt>
-<dd> Login key or certificate file for a remote scan.</dd>
-</dl>
-<dl>
+<dd>Login key or certificate file for a remote scan.</dd>
+
 <dt><code>--password=PASSWORD</code></dt>
-<dd> Login password for a remote scan, if required.</dd>
-</dl>
-<dl>
+<dd>Login password for a remote scan, if required.</dd>
+
 <dt><code>--path=PATH</code></dt>
-<dd> Login path to use when connecting to the target (WinRM).</dd>
-</dl>
-<dl>
+<dd>Login path to use when connecting to the target (WinRM).</dd>
+
 <dt><code>--podman-url=PODMAN_URL</code></dt>
-<dd> Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).</dd>
-</dl>
-<dl>
+<dd>Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).</dd>
+
 <dt><code>-p</code>, <code>--port=N</code></dt>
-<dd> Specify the login port for a remote scan.</dd>
-</dl>
-<dl>
+<dd>Specify the login port for a remote scan.</dd>
+
 <dt><code>--proxy-command=PROXY_COMMAND</code></dt>
-<dd> Specifies the command to use to connect to the server.</dd>
-</dl>
-<dl>
+<dd>Specifies the command to use to connect to the server.</dd>
+
 <dt><code>--self-signed</code>, <code>--no-self-signed</code></dt>
-<dd> Allow remote scans with self-signed certificates (WinRM).</dd>
-</dl>
-<dl>
+<dd>Allow remote scans with self-signed certificates (WinRM).</dd>
+
 <dt><code>--shell</code>, <code>--no-shell</code></dt>
-<dd> Run scans in a subshell. Only activates on Unix.</dd>
-</dl>
-<dl>
+<dd>Run scans in a subshell. Only activates on Unix.</dd>
+
 <dt><code>--shell-command=SHELL_COMMAND</code></dt>
-<dd> Specify a particular shell to use.</dd>
-</dl>
-<dl>
+<dd>Specify a particular shell to use.</dd>
+
 <dt><code>--shell-options=SHELL_OPTIONS</code></dt>
-<dd> Additional shell options.</dd>
-</dl>
-<dl>
+<dd>Additional shell options.</dd>
+
 <dt><code>--ssh-config-file=one two three</code></dt>
-<dd> A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.</dd>
-</dl>
-<dl>
+<dd>A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.</dd>
+
 <dt><code>--ssl</code>, <code>--no-ssl</code></dt>
-<dd> Use SSL for transport layer encryption (WinRM).</dd>
-</dl>
-<dl>
+<dd>Use SSL for transport layer encryption (WinRM).</dd>
+
 <dt><code>--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT</code></dt>
-<dd> Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).</dd>
-</dl>
-<dl>
+<dd>Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).</dd>
+
 <dt><code>--sudo</code>, <code>--no-sudo</code></dt>
-<dd> Run scans with sudo. Only activates on Unix and non-root user.</dd>
-</dl>
-<dl>
+<dd>Run scans with sudo. Only activates on Unix and non-root user.</dd>
+
 <dt><code>--sudo-command=SUDO_COMMAND</code></dt>
-<dd> Alternate command for sudo.</dd>
-</dl>
-<dl>
+<dd>Alternate command for sudo.</dd>
+
 <dt><code>--sudo-options=SUDO_OPTIONS</code></dt>
-<dd> Additional sudo options for a remote scan.</dd>
-</dl>
-<dl>
+<dd>Additional sudo options for a remote scan.</dd>
+
 <dt><code>--sudo-password=SUDO_PASSWORD</code></dt>
-<dd> Specify a sudo password, if it is required.</dd>
-</dl>
-<dl>
+<dd>Specify a sudo password, if it is required.</dd>
+
 <dt><code>-t</code>, <code>--target=TARGET</code></dt>
-<dd> Simple targeting option using URIs, e.g. ssh://user:pass@host:port</dd>
-</dl>
-<dl>
+<dd>Simple targeting option using URIs, e.g. ssh://user:pass@host:port</dd>
+
 <dt><code>--target-id=TARGET_ID</code></dt>
-<dd> Provide an ID which will be included on reports - deprecated</dd>
-</dl>
-<dl>
+<dd>Provide an ID which will be included on reports - deprecated</dd>
+
 <dt><code>--user=USER</code></dt>
-<dd> The login user for a remote scan.</dd>
-</dl>
-<dl>
+<dd>The login user for a remote scan.</dd>
+
 <dt><code>--winrm-basic-auth-only</code>, <code>--no-winrm-basic-auth-only</code></dt>
-<dd> Whether to use basic authentication, defaults to false (WinRM).</dd>
-</dl>
-<dl>
+<dd>Whether to use basic authentication, defaults to false (WinRM).</dd>
+
 <dt><code>--winrm-disable-sspi</code>, <code>--no-winrm-disable-sspi</code></dt>
-<dd> Whether to use disable sspi authentication, defaults to false (WinRM).</dd>
-</dl>
-<dl>
+<dd>Whether to use disable sspi authentication, defaults to false (WinRM).</dd>
+
 <dt><code>--winrm-shell-type=WINRM_SHELL_TYPE</code></dt>
-<dd> Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).</dd>
-</dl>
-<dl>
+<dd>Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).</dd>
+
 <dt><code>--winrm-transport=WINRM_TRANSPORT</code></dt>
-<dd> Specify which transport to use, defaults to negotiate (WinRM).</dd>
+<dd>Specify which transport to use, defaults to negotiate (WinRM).</dd>
+
 </dl>
 
 ## env
@@ -397,255 +351,194 @@ This subcommand has the following additional options:
 
 <dl>
 <dt><code>--attrs=one two three</code></dt>
-<dd> Legacy name for --input-file - deprecated.</dd>
-</dl>
-<dl>
+<dd>Legacy name for --input-file - deprecated.</dd>
+
 <dt><code>--auto-install-gems</code>, <code>--no-auto-install-gems</code></dt>
-<dd> Auto installs gem dependencies of the profile or resource pack.</dd>
-</dl>
-<dl>
+<dd>Auto installs gem dependencies of the profile or resource pack.</dd>
+
 <dt><code>-b</code>, <code>--backend=BACKEND</code></dt>
-<dd> Choose a backend: local, ssh, winrm, docker.</dd>
-</dl>
-<dl>
+<dd>Choose a backend: local, ssh, winrm, docker.</dd>
+
 <dt><code>--backend-cache</code>, <code>--no-backend-cache</code></dt>
-<dd> Allow caching for backend command output. (default: true).</dd>
-</dl>
-<dl>
+<dd>Allow caching for backend command output. (default: true).</dd>
+
 <dt><code>--bastion-host=BASTION_HOST</code></dt>
-<dd> Specifies the bastion host if applicable.</dd>
-</dl>
-<dl>
+<dd>Specifies the bastion host if applicable.</dd>
+
 <dt><code>--bastion-port=BASTION_PORT</code></dt>
-<dd> Specifies the bastion port if applicable.</dd>
-</dl>
-<dl>
+<dd>Specifies the bastion port if applicable.</dd>
+
 <dt><code>--bastion-user=BASTION_USER</code></dt>
-<dd> Specifies the bastion user if applicable.</dd>
-</dl>
-<dl>
+<dd>Specifies the bastion user if applicable.</dd>
+
 <dt><code>--ca-trust-file=CA_TRUST_FILE</code></dt>
-<dd> Specify CA certificate required for SSL authentication (WinRM).</dd>
-</dl>
-<dl>
+<dd>Specify CA certificate required for SSL authentication (WinRM).</dd>
+
 <dt><code>--client-cert=CLIENT_CERT</code></dt>
-<dd> Specify client certificate for SSL authentication</dd>
-</dl>
-<dl>
+<dd>Specify client certificate for SSL authentication</dd>
+
 <dt><code>--client-key=CLIENT_KEY</code></dt>
-<dd> Specify client key required with client cert for SSL authentication</dd>
-</dl>
-<dl>
+<dd>Specify client key required with client cert for SSL authentication</dd>
+
 <dt><code>--client-key-pass=CLIENT_KEY_PASS</code></dt>
-<dd> Specify client cert password, if required for SSL authentication</dd>
-</dl>
-<dl>
+<dd>Specify client cert password, if required for SSL authentication</dd>
+
 <dt><code>--command-timeout=N</code></dt>
-<dd> Maximum seconds to allow commands to run during execution.</dd>
-</dl>
-<dl>
+<dd>Maximum seconds to allow commands to run during execution.</dd>
+
 <dt><code>--config=CONFIG</code></dt>
-<dd> Read configuration from JSON file (`-` reads from stdin).</dd>
-</dl>
-<dl>
+<dd>Read configuration from JSON file (`-` reads from stdin).</dd>
+
 <dt><code>--controls=one two three</code></dt>
-<dd> A list of control names to run, or a list of /regexes/ to match against control names. Ignore all other tests.</dd>
-</dl>
-<dl>
+<dd>A list of control names to run, or a list of /regexes/ to match against control names. Ignore all other tests.</dd>
+
 <dt><code>--create-lockfile</code>, <code>--no-create-lockfile</code></dt>
-<dd> Write out a lockfile based on this execution (unless one already exists)</dd>
-</dl>
-<dl>
+<dd>Write out a lockfile based on this execution (unless one already exists)</dd>
+
 <dt><code>--diff</code>, <code>--no-diff</code></dt>
-<dd> Use --no-diff to suppress 'diff' output of failed textual test results.</dd>
-</dl>
-<dl>
+<dd>Use --no-diff to suppress 'diff' output of failed textual test results.</dd>
+
 <dt><code>--distinct-exit</code>, <code>--no-distinct-exit</code></dt>
-<dd> Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.</dd>
-</dl>
-<dl>
+<dd>Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.</dd>
+
 <dt><code>--docker-url=DOCKER_URL</code></dt>
-<dd> Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.</dd>
-</dl>
-<dl>
+<dd>Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.</dd>
+
 <dt><code>--enable-password=ENABLE_PASSWORD</code></dt>
-<dd> Password for enable mode on Cisco IOS devices.</dd>
-</dl>
-<dl>
+<dd>Password for enable mode on Cisco IOS devices.</dd>
+
 <dt><code>--enhanced-outcomes</code>, <code>--no-enhanced-outcomes</code></dt>
-<dd> Show enhanced outcomes in output</dd>
-</dl>
-<dl>
+<dd>Show enhanced outcomes in output</dd>
+
 <dt><code>--filter-empty-profiles</code>, <code>--no-filter-empty-profiles</code></dt>
-<dd> Filter empty profiles (profiles without controls) from the report.</dd>
-</dl>
-<dl>
+<dd>Filter empty profiles (profiles without controls) from the report.</dd>
+
 <dt><code>--filter-waived-controls</code>, <code>--no-filter-waived-controls</code></dt>
-<dd> Do not execute waived controls in InSpec at all. Must use with --waiver-file. Ignores the `run` setting of the waiver file.</dd>
-</dl>
-<dl>
+<dd>Do not execute waived controls in InSpec at all. Must use with --waiver-file. Ignores the `run` setting of the waiver file.</dd>
+
 <dt><code>--host=HOST</code></dt>
-<dd> Specify a remote host which is tested.</dd>
-</dl>
-<dl>
+<dd>Specify a remote host which is tested.</dd>
+
 <dt><code>--input=name1=value1 name2=value2</code></dt>
-<dd> Specify one or more inputs directly on the command line, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.</dd>
-</dl>
-<dl>
+<dd>Specify one or more inputs directly on the command line, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.</dd>
+
 <dt><code>--input-file=one two three</code></dt>
-<dd> Load one or more input files, a YAML file with values for the profile to use.</dd>
-</dl>
-<dl>
+<dd>Load one or more input files, a YAML file with values for the profile to use.</dd>
+
 <dt><code>--insecure</code>, <code>--no-insecure</code></dt>
-<dd> Disable SSL verification on select targets.</dd>
-</dl>
-<dl>
+<dd>Disable SSL verification on select targets.</dd>
+
 <dt><code>-i</code>, <code>--key-files=one two three</code></dt>
-<dd> Login key or certificate file for a remote scan.</dd>
-</dl>
-<dl>
+<dd>Login key or certificate file for a remote scan.</dd>
+
 <dt><code>--password=PASSWORD</code></dt>
-<dd> Login password for a remote scan, if required.</dd>
-</dl>
-<dl>
+<dd>Login password for a remote scan, if required.</dd>
+
 <dt><code>--path=PATH</code></dt>
-<dd> Login path to use when connecting to the target (WinRM).</dd>
-</dl>
-<dl>
+<dd>Login path to use when connecting to the target (WinRM).</dd>
+
 <dt><code>--podman-url=PODMAN_URL</code></dt>
-<dd> Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).</dd>
-</dl>
-<dl>
+<dd>Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).</dd>
+
 <dt><code>-p</code>, <code>--port=N</code></dt>
-<dd> Specify the login port for a remote scan.</dd>
-</dl>
-<dl>
+<dd>Specify the login port for a remote scan.</dd>
+
 <dt><code>--profiles-path=PROFILES_PATH</code></dt>
-<dd> Folder which contains referenced profiles.</dd>
-</dl>
-<dl>
+<dd>Folder which contains referenced profiles.</dd>
+
 <dt><code>--proxy-command=PROXY_COMMAND</code></dt>
-<dd> Specifies the command to use to connect to the server.</dd>
-</dl>
-<dl>
+<dd>Specifies the command to use to connect to the server.</dd>
+
 <dt><code>--reporter=one two:/output/file/path</code></dt>
-<dd> Enable one or more output reporters: cli, documentation, html, progress, progress-bar, json, json-min, json-rspec, junit, yaml</dd>
-</dl>
-<dl>
+<dd>Enable one or more output reporters: cli, documentation, html, progress, progress-bar, json, json-min, json-rspec, junit, yaml</dd>
+
 <dt><code>--reporter-backtrace-inclusion</code>, <code>--no-reporter-backtrace-inclusion</code></dt>
-<dd> Include a code backtrace in report data (default: true)</dd>
-</dl>
-<dl>
+<dd>Include a code backtrace in report data (default: true)</dd>
+
 <dt><code>--reporter-include-source</code>, <code>--no-reporter-include-source</code></dt>
-<dd> Include full source code of controls in the CLI report</dd>
-</dl>
-<dl>
+<dd>Include full source code of controls in the CLI report</dd>
+
 <dt><code>--reporter-message-truncation=REPORTER_MESSAGE_TRUNCATION</code></dt>
-<dd> Number of characters to truncate failure messages and code_desc in report data to (default: no truncation)</dd>
-</dl>
-<dl>
+<dd>Number of characters to truncate failure messages and code_desc in report data to (default: no truncation)</dd>
+
 <dt><code>--retain-waiver-data</code>, <code>--no-retain-waiver-data</code></dt>
-<dd> EXPERIMENTAL: Only works in conjunction with --filter-waived-controls, retains waiver data about controls that were skipped</dd>
-</dl>
-<dl>
+<dd>EXPERIMENTAL: Only works in conjunction with --filter-waived-controls, retains waiver data about controls that were skipped</dd>
+
 <dt><code>--self-signed</code>, <code>--no-self-signed</code></dt>
-<dd> Allow remote scans with self-signed certificates (WinRM).</dd>
-</dl>
-<dl>
+<dd>Allow remote scans with self-signed certificates (WinRM).</dd>
+
 <dt><code>--shell</code>, <code>--no-shell</code></dt>
-<dd> Run scans in a subshell. Only activates on Unix.</dd>
-</dl>
-<dl>
+<dd>Run scans in a subshell. Only activates on Unix.</dd>
+
 <dt><code>--shell-command=SHELL_COMMAND</code></dt>
-<dd> Specify a particular shell to use.</dd>
-</dl>
-<dl>
+<dd>Specify a particular shell to use.</dd>
+
 <dt><code>--shell-options=SHELL_OPTIONS</code></dt>
-<dd> Additional shell options.</dd>
-</dl>
-<dl>
+<dd>Additional shell options.</dd>
+
 <dt><code>--show-progress</code>, <code>--no-show-progress</code></dt>
-<dd> Show progress while executing tests.</dd>
-</dl>
-<dl>
+<dd>Show progress while executing tests.</dd>
+
 <dt><code>--silence-deprecations=all|GROUP GROUP...</code></dt>
-<dd> Suppress deprecation warnings. See install_dir/etc/deprecations.json for a list of GROUPs or use 'all'.</dd>
-</dl>
-<dl>
+<dd>Suppress deprecation warnings. See install_dir/etc/deprecations.json for a list of GROUPs or use 'all'.</dd>
+
 <dt><code>--sort-results-by=--sort-results-by=none|control|file|random</code></dt>
-<dd> After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode.</dd>
-</dl>
-<dl>
+<dd>After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode.</dd>
+
 <dt><code>--ssh-config-file=one two three</code></dt>
-<dd> A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.</dd>
-</dl>
-<dl>
+<dd>A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.</dd>
+
 <dt><code>--ssl</code>, <code>--no-ssl</code></dt>
-<dd> Use SSL for transport layer encryption (WinRM).</dd>
-</dl>
-<dl>
+<dd>Use SSL for transport layer encryption (WinRM).</dd>
+
 <dt><code>--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT</code></dt>
-<dd> Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).</dd>
-</dl>
-<dl>
+<dd>Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).</dd>
+
 <dt><code>--sudo</code>, <code>--no-sudo</code></dt>
-<dd> Run scans with sudo. Only activates on Unix and non-root user.</dd>
-</dl>
-<dl>
+<dd>Run scans with sudo. Only activates on Unix and non-root user.</dd>
+
 <dt><code>--sudo-command=SUDO_COMMAND</code></dt>
-<dd> Alternate command for sudo.</dd>
-</dl>
-<dl>
+<dd>Alternate command for sudo.</dd>
+
 <dt><code>--sudo-options=SUDO_OPTIONS</code></dt>
-<dd> Additional sudo options for a remote scan.</dd>
-</dl>
-<dl>
+<dd>Additional sudo options for a remote scan.</dd>
+
 <dt><code>--sudo-password=SUDO_PASSWORD</code></dt>
-<dd> Specify a sudo password, if it is required.</dd>
-</dl>
-<dl>
+<dd>Specify a sudo password, if it is required.</dd>
+
 <dt><code>--supermarket-url=SUPERMARKET_URL</code></dt>
-<dd> Specify the URL of a private Chef Supermarket.</dd>
-</dl>
-<dl>
+<dd>Specify the URL of a private Chef Supermarket.</dd>
+
 <dt><code>--tags=one two three</code></dt>
-<dd> A list of tags names that are part of controls to filter and run controls, or a list of /regexes/ to match against tags names of controls. Ignore all other tests.</dd>
-</dl>
-<dl>
+<dd>A list of tags names that are part of controls to filter and run controls, or a list of /regexes/ to match against tags names of controls. Ignore all other tests.</dd>
+
 <dt><code>-t</code>, <code>--target=TARGET</code></dt>
-<dd> Simple targeting option using URIs, e.g. ssh://user:pass@host:port</dd>
-</dl>
-<dl>
+<dd>Simple targeting option using URIs, e.g. ssh://user:pass@host:port</dd>
+
 <dt><code>--target-id=TARGET_ID</code></dt>
-<dd> Provide an ID which will be included on reports - deprecated</dd>
-</dl>
-<dl>
+<dd>Provide an ID which will be included on reports - deprecated</dd>
+
 <dt><code>--user=USER</code></dt>
-<dd> The login user for a remote scan.</dd>
-</dl>
-<dl>
+<dd>The login user for a remote scan.</dd>
+
 <dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
-<dd> Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
-</dl>
-<dl>
+<dd>Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
+
 <dt><code>--waiver-file=one two three</code></dt>
-<dd> Load one or more waiver files.</dd>
-</dl>
-<dl>
+<dd>Load one or more waiver files.</dd>
+
 <dt><code>--winrm-basic-auth-only</code>, <code>--no-winrm-basic-auth-only</code></dt>
-<dd> Whether to use basic authentication, defaults to false (WinRM).</dd>
-</dl>
-<dl>
+<dd>Whether to use basic authentication, defaults to false (WinRM).</dd>
+
 <dt><code>--winrm-disable-sspi</code>, <code>--no-winrm-disable-sspi</code></dt>
-<dd> Whether to use disable sspi authentication, defaults to false (WinRM).</dd>
-</dl>
-<dl>
+<dd>Whether to use disable sspi authentication, defaults to false (WinRM).</dd>
+
 <dt><code>--winrm-shell-type=WINRM_SHELL_TYPE</code></dt>
-<dd> Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).</dd>
-</dl>
-<dl>
+<dd>Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).</dd>
+
 <dt><code>--winrm-transport=WINRM_TRANSPORT</code></dt>
-<dd> Specify which transport to use, defaults to negotiate (WinRM).</dd>
+<dd>Specify which transport to use, defaults to negotiate (WinRM).</dd>
+
 </dl>
 
 ## export
@@ -666,35 +559,29 @@ This subcommand has the following additional options:
 
 <dl>
 <dt><code>--auto-install-gems</code>, <code>--no-auto-install-gems</code></dt>
-<dd> Auto installs gem dependencies of the profile or resource pack.</dd>
-</dl>
-<dl>
+<dd>Auto installs gem dependencies of the profile or resource pack.</dd>
+
 <dt><code>--controls=one two three</code></dt>
-<dd> For --what=profile, a list of controls to include. Ignore all other tests.</dd>
-</dl>
-<dl>
+<dd>For --what=profile, a list of controls to include. Ignore all other tests.</dd>
+
 <dt><code>--format=FORMAT</code></dt>
-<dd> The output format to use: json, raw, yaml. If valid format is not provided then it will use the default for the given 'what'.</dd>
-</dl>
-<dl>
+<dd>The output format to use: json, raw, yaml. If valid format is not provided then it will use the default for the given 'what'.</dd>
+
 <dt><code>-o</code>, <code>--output=OUTPUT</code></dt>
-<dd> Save the created output to a path.</dd>
-</dl>
-<dl>
+<dd>Save the created output to a path.</dd>
+
 <dt><code>--profiles-path=PROFILES_PATH</code></dt>
-<dd> Folder which contains referenced profiles.</dd>
-</dl>
-<dl>
+<dd>Folder which contains referenced profiles.</dd>
+
 <dt><code>--tags=one two three</code></dt>
-<dd> For --what=profile, a list of tags to filter controls and include only those. Ignore all other tests.</dd>
-</dl>
-<dl>
+<dd>For --what=profile, a list of tags to filter controls and include only those. Ignore all other tests.</dd>
+
 <dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
-<dd> Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
-</dl>
-<dl>
+<dd>Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
+
 <dt><code>--what=WHAT</code></dt>
-<dd> What to export: profile (default), readme, metadata.</dd>
+<dd>What to export: profile (default), readme, metadata.</dd>
+
 </dl>
 
 ## help
@@ -727,27 +614,23 @@ This subcommand has the following additional options:
 
 <dl>
 <dt><code>--auto-install-gems</code>, <code>--no-auto-install-gems</code></dt>
-<dd> Auto installs gem dependencies of the profile or resource pack.</dd>
-</dl>
-<dl>
+<dd>Auto installs gem dependencies of the profile or resource pack.</dd>
+
 <dt><code>--controls=one two three</code></dt>
-<dd> A list of controls to include. Ignore all other tests.</dd>
-</dl>
-<dl>
+<dd>A list of controls to include. Ignore all other tests.</dd>
+
 <dt><code>-o</code>, <code>--output=OUTPUT</code></dt>
-<dd> Save the created profile to a path.</dd>
-</dl>
-<dl>
+<dd>Save the created profile to a path.</dd>
+
 <dt><code>--profiles-path=PROFILES_PATH</code></dt>
-<dd> Folder which contains referenced profiles.</dd>
-</dl>
-<dl>
+<dd>Folder which contains referenced profiles.</dd>
+
 <dt><code>--tags=one two three</code></dt>
-<dd> A list of tags to filter controls and include only those. Ignore all other tests.</dd>
-</dl>
-<dl>
+<dd>A list of tags to filter controls and include only those. Ignore all other tests.</dd>
+
 <dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
-<dd> Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
+<dd>Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
+
 </dl>
 
 ## run_context
@@ -780,7 +663,8 @@ This subcommand has the following additional options:
 
 <dl>
 <dt><code>--enhanced-outcomes</code>, <code>--no-enhanced-outcomes</code></dt>
-<dd> Show enhanced outcomes output</dd>
+<dd>Show enhanced outcomes output</dd>
+
 </dl>
 
 ## shell
@@ -801,187 +685,143 @@ This subcommand has the following additional options:
 
 <dl>
 <dt><code>-b</code>, <code>--backend=BACKEND</code></dt>
-<dd> Choose a backend: local, ssh, winrm, docker.</dd>
-</dl>
-<dl>
+<dd>Choose a backend: local, ssh, winrm, docker.</dd>
+
 <dt><code>--bastion-host=BASTION_HOST</code></dt>
-<dd> Specifies the bastion host if applicable.</dd>
-</dl>
-<dl>
+<dd>Specifies the bastion host if applicable.</dd>
+
 <dt><code>--bastion-port=BASTION_PORT</code></dt>
-<dd> Specifies the bastion port if applicable.</dd>
-</dl>
-<dl>
+<dd>Specifies the bastion port if applicable.</dd>
+
 <dt><code>--bastion-user=BASTION_USER</code></dt>
-<dd> Specifies the bastion user if applicable.</dd>
-</dl>
-<dl>
+<dd>Specifies the bastion user if applicable.</dd>
+
 <dt><code>--ca-trust-file=CA_TRUST_FILE</code></dt>
-<dd> Specify CA certificate required for SSL authentication (WinRM).</dd>
-</dl>
-<dl>
+<dd>Specify CA certificate required for SSL authentication (WinRM).</dd>
+
 <dt><code>--client-cert=CLIENT_CERT</code></dt>
-<dd> Specify client certificate for SSL authentication</dd>
-</dl>
-<dl>
+<dd>Specify client certificate for SSL authentication</dd>
+
 <dt><code>--client-key=CLIENT_KEY</code></dt>
-<dd> Specify client key required with client cert for SSL authentication</dd>
-</dl>
-<dl>
+<dd>Specify client key required with client cert for SSL authentication</dd>
+
 <dt><code>--client-key-pass=CLIENT_KEY_PASS</code></dt>
-<dd> Specify client cert password, if required for SSL authentication</dd>
-</dl>
-<dl>
+<dd>Specify client cert password, if required for SSL authentication</dd>
+
 <dt><code>-c</code>, <code>--command=COMMAND</code></dt>
-<dd> A single command string to run instead of launching the shell</dd>
-</dl>
-<dl>
+<dd>A single command string to run instead of launching the shell</dd>
+
 <dt><code>--command-timeout=N</code></dt>
-<dd> Maximum seconds to allow a command to run.</dd>
-</dl>
-<dl>
+<dd>Maximum seconds to allow a command to run.</dd>
+
 <dt><code>--config=CONFIG</code></dt>
-<dd> Read configuration from JSON file (`-` reads from stdin).</dd>
-</dl>
-<dl>
+<dd>Read configuration from JSON file (`-` reads from stdin).</dd>
+
 <dt><code>--depends=one two three</code></dt>
-<dd> A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell</dd>
-</dl>
-<dl>
+<dd>A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell</dd>
+
 <dt><code>--distinct-exit</code>, <code>--no-distinct-exit</code></dt>
-<dd> Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures.</dd>
-</dl>
-<dl>
+<dd>Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures.</dd>
+
 <dt><code>--docker-url=DOCKER_URL</code></dt>
-<dd> Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.</dd>
-</dl>
-<dl>
+<dd>Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.</dd>
+
 <dt><code>--enable-password=ENABLE_PASSWORD</code></dt>
-<dd> Password for enable mode on Cisco IOS devices.</dd>
-</dl>
-<dl>
+<dd>Password for enable mode on Cisco IOS devices.</dd>
+
 <dt><code>--enhanced-outcomes</code>, <code>--no-enhanced-outcomes</code></dt>
-<dd> Show enhanced outcomes in output</dd>
-</dl>
-<dl>
+<dd>Show enhanced outcomes in output</dd>
+
 <dt><code>--host=HOST</code></dt>
-<dd> Specify a remote host which is tested.</dd>
-</dl>
-<dl>
+<dd>Specify a remote host which is tested.</dd>
+
 <dt><code>--input=name1=value1 name2=value2</code></dt>
-<dd> Specify one or more inputs directly on the command line to the shell, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.</dd>
-</dl>
-<dl>
+<dd>Specify one or more inputs directly on the command line to the shell, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.</dd>
+
 <dt><code>--input-file=one two three</code></dt>
-<dd> Load one or more input files, a YAML file with values for the shell to use</dd>
-</dl>
-<dl>
+<dd>Load one or more input files, a YAML file with values for the shell to use</dd>
+
 <dt><code>--insecure</code>, <code>--no-insecure</code></dt>
-<dd> Disable SSL verification on select targets.</dd>
-</dl>
-<dl>
+<dd>Disable SSL verification on select targets.</dd>
+
 <dt><code>--inspect</code>, <code>--no-inspect</code></dt>
-<dd> Use verbose/debugging output for resources.</dd>
-</dl>
-<dl>
+<dd>Use verbose/debugging output for resources.</dd>
+
 <dt><code>-i</code>, <code>--key-files=one two three</code></dt>
-<dd> Login key or certificate file for a remote scan.</dd>
-</dl>
-<dl>
+<dd>Login key or certificate file for a remote scan.</dd>
+
 <dt><code>--password=PASSWORD</code></dt>
-<dd> Login password for a remote scan, if required.</dd>
-</dl>
-<dl>
+<dd>Login password for a remote scan, if required.</dd>
+
 <dt><code>--path=PATH</code></dt>
-<dd> Login path to use when connecting to the target (WinRM).</dd>
-</dl>
-<dl>
+<dd>Login path to use when connecting to the target (WinRM).</dd>
+
 <dt><code>--podman-url=PODMAN_URL</code></dt>
-<dd> Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).</dd>
-</dl>
-<dl>
+<dd>Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).</dd>
+
 <dt><code>-p</code>, <code>--port=N</code></dt>
-<dd> Specify the login port for a remote scan.</dd>
-</dl>
-<dl>
+<dd>Specify the login port for a remote scan.</dd>
+
 <dt><code>--proxy-command=PROXY_COMMAND</code></dt>
-<dd> Specifies the command to use to connect to the server.</dd>
-</dl>
-<dl>
+<dd>Specifies the command to use to connect to the server.</dd>
+
 <dt><code>--reporter=one two:/output/file/path</code></dt>
-<dd> Enable one or more output reporters: cli, documentation, html, progress, json, json-min, json-rspec, junit</dd>
-</dl>
-<dl>
+<dd>Enable one or more output reporters: cli, documentation, html, progress, json, json-min, json-rspec, junit</dd>
+
 <dt><code>--self-signed</code>, <code>--no-self-signed</code></dt>
-<dd> Allow remote scans with self-signed certificates (WinRM).</dd>
-</dl>
-<dl>
+<dd>Allow remote scans with self-signed certificates (WinRM).</dd>
+
 <dt><code>--shell</code>, <code>--no-shell</code></dt>
-<dd> Run scans in a subshell. Only activates on Unix.</dd>
-</dl>
-<dl>
+<dd>Run scans in a subshell. Only activates on Unix.</dd>
+
 <dt><code>--shell-command=SHELL_COMMAND</code></dt>
-<dd> Specify a particular shell to use.</dd>
-</dl>
-<dl>
+<dd>Specify a particular shell to use.</dd>
+
 <dt><code>--shell-options=SHELL_OPTIONS</code></dt>
-<dd> Additional shell options.</dd>
-</dl>
-<dl>
+<dd>Additional shell options.</dd>
+
 <dt><code>--ssh-config-file=one two three</code></dt>
-<dd> A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.</dd>
-</dl>
-<dl>
+<dd>A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.</dd>
+
 <dt><code>--ssl</code>, <code>--no-ssl</code></dt>
-<dd> Use SSL for transport layer encryption (WinRM).</dd>
-</dl>
-<dl>
+<dd>Use SSL for transport layer encryption (WinRM).</dd>
+
 <dt><code>--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT</code></dt>
-<dd> Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).</dd>
-</dl>
-<dl>
+<dd>Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).</dd>
+
 <dt><code>--sudo</code>, <code>--no-sudo</code></dt>
-<dd> Run scans with sudo. Only activates on Unix and non-root user.</dd>
-</dl>
-<dl>
+<dd>Run scans with sudo. Only activates on Unix and non-root user.</dd>
+
 <dt><code>--sudo-command=SUDO_COMMAND</code></dt>
-<dd> Alternate command for sudo.</dd>
-</dl>
-<dl>
+<dd>Alternate command for sudo.</dd>
+
 <dt><code>--sudo-options=SUDO_OPTIONS</code></dt>
-<dd> Additional sudo options for a remote scan.</dd>
-</dl>
-<dl>
+<dd>Additional sudo options for a remote scan.</dd>
+
 <dt><code>--sudo-password=SUDO_PASSWORD</code></dt>
-<dd> Specify a sudo password, if it is required.</dd>
-</dl>
-<dl>
+<dd>Specify a sudo password, if it is required.</dd>
+
 <dt><code>-t</code>, <code>--target=TARGET</code></dt>
-<dd> Simple targeting option using URIs, e.g. ssh://user:pass@host:port</dd>
-</dl>
-<dl>
+<dd>Simple targeting option using URIs, e.g. ssh://user:pass@host:port</dd>
+
 <dt><code>--target-id=TARGET_ID</code></dt>
-<dd> Provide an ID which will be included on reports - deprecated</dd>
-</dl>
-<dl>
+<dd>Provide an ID which will be included on reports - deprecated</dd>
+
 <dt><code>--user=USER</code></dt>
-<dd> The login user for a remote scan.</dd>
-</dl>
-<dl>
+<dd>The login user for a remote scan.</dd>
+
 <dt><code>--winrm-basic-auth-only</code>, <code>--no-winrm-basic-auth-only</code></dt>
-<dd> Whether to use basic authentication, defaults to false (WinRM).</dd>
-</dl>
-<dl>
+<dd>Whether to use basic authentication, defaults to false (WinRM).</dd>
+
 <dt><code>--winrm-disable-sspi</code>, <code>--no-winrm-disable-sspi</code></dt>
-<dd> Whether to use disable sspi authentication, defaults to false (WinRM).</dd>
-</dl>
-<dl>
+<dd>Whether to use disable sspi authentication, defaults to false (WinRM).</dd>
+
 <dt><code>--winrm-shell-type=WINRM_SHELL_TYPE</code></dt>
-<dd> Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).</dd>
-</dl>
-<dl>
+<dd>Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).</dd>
+
 <dt><code>--winrm-transport=WINRM_TRANSPORT</code></dt>
-<dd> Specify which transport to use, defaults to negotiate (WinRM).</dd>
+<dd>Specify which transport to use, defaults to negotiate (WinRM).</dd>
+
 </dl>
 
 ## supermarket
@@ -1014,7 +854,8 @@ This subcommand has the following additional options:
 
 <dl>
 <dt><code>--overwrite</code>, <code>--no-overwrite</code></dt>
-<dd> Overwrite existing vendored dependencies and lockfile.</dd>
+<dd>Overwrite existing vendored dependencies and lockfile.</dd>
+
 </dl>
 
 ## version

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -31,33 +31,42 @@ inspec archive PATH
 
 This subcommand has the following additional options:
 
-`--airgap`, `--no-airgap`
-    : Fallback to using local archives if fetching fails.
-    
-`--auto-install-gems`, `--no-auto-install-gems`
-    : Auto installs gem dependencies of the profile or resource pack.
-    
-`--ignore-errors`, `--no-ignore-errors`
-    : Ignore profile warnings.
-    
-`-o`, `--output=OUTPUT`
-    : Save the archive to a path.
-    
-`--overwrite`, `--no-overwrite`
-    : Overwrite existing archive.
-    
-`--profiles-path=PROFILES_PATH`
-    : Folder which contains referenced profiles.
-    
-`--tar`, `--no-tar`
-    : Generates a tar.gz archive.
-    
-`--vendor-cache=VENDOR_CACHE`
-    : Use the given path for caching dependencies, (default: ~/.inspec/cache).
-    
-`--zip`, `--no-zip`
-    : Generates a zip archive.
-    
+<dl>
+<dt><code>--airgap</code>, <code>--no-airgap</code></dt>
+<dd> Fallback to using local archives if fetching fails.</dd>
+</dl>
+<dl>
+<dt><code>--auto-install-gems</code>, <code>--no-auto-install-gems</code></dt>
+<dd> Auto installs gem dependencies of the profile or resource pack.</dd>
+</dl>
+<dl>
+<dt><code>--ignore-errors</code>, <code>--no-ignore-errors</code></dt>
+<dd> Ignore profile warnings.</dd>
+</dl>
+<dl>
+<dt><code>-o</code>, <code>--output=OUTPUT</code></dt>
+<dd> Save the archive to a path.</dd>
+</dl>
+<dl>
+<dt><code>--overwrite</code>, <code>--no-overwrite</code></dt>
+<dd> Overwrite existing archive.</dd>
+</dl>
+<dl>
+<dt><code>--profiles-path=PROFILES_PATH</code></dt>
+<dd> Folder which contains referenced profiles.</dd>
+</dl>
+<dl>
+<dt><code>--tar</code>, <code>--no-tar</code></dt>
+<dd> Generates a tar.gz archive.</dd>
+</dl>
+<dl>
+<dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
+<dd> Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
+</dl>
+<dl>
+<dt><code>--zip</code>, <code>--no-zip</code></dt>
+<dd> Generates a zip archive.</dd>
+</dl>
 
 ## check
 
@@ -75,21 +84,26 @@ inspec check PATH
 
 This subcommand has the following additional options:
 
-`--auto-install-gems`, `--no-auto-install-gems`
-    : Auto installs gem dependencies of the profile or resource pack.
-    
-`--format=FORMAT`
-    : The output format to use. Valid values: `json` and `doc`. Default value: `doc`.
-    
-`--profiles-path=PROFILES_PATH`
-    : Folder which contains referenced profiles.
-    
-`--vendor-cache=VENDOR_CACHE`
-    : Use the given path for caching dependencies, (default: ~/.inspec/cache).
-    
-`--with-cookstyle`, `--no-with-cookstyle`
-    : Enable or disable cookstyle checks.
-    
+<dl>
+<dt><code>--auto-install-gems</code>, <code>--no-auto-install-gems</code></dt>
+<dd> Auto installs gem dependencies of the profile or resource pack.</dd>
+</dl>
+<dl>
+<dt><code>--format=FORMAT</code></dt>
+<dd> The output format to use. Valid values: `json` and `doc`. Default value: `doc`.</dd>
+</dl>
+<dl>
+<dt><code>--profiles-path=PROFILES_PATH</code></dt>
+<dd> Folder which contains referenced profiles.</dd>
+</dl>
+<dl>
+<dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
+<dd> Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
+</dl>
+<dl>
+<dt><code>--with-cookstyle</code>, <code>--no-with-cookstyle</code></dt>
+<dd> Enable or disable cookstyle checks.</dd>
+</dl>
 
 ## clear_cache
 
@@ -107,9 +121,10 @@ inspec clear_cache
 
 This subcommand has the following additional options:
 
-`--vendor-cache=VENDOR_CACHE`
-    : Use the given path for caching dependencies, (default: `~/.inspec/cache`).
-    
+<dl>
+<dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
+<dd> Use the given path for caching dependencies, (default: `~/.inspec/cache`).</dd>
+</dl>
 
 ## detect
 
@@ -127,119 +142,157 @@ inspec detect
 
 This subcommand has the following additional options:
 
-`-b`, `--backend=BACKEND`
-    : Choose a backend: local, ssh, winrm, docker.
-    
-`--bastion-host=BASTION_HOST`
-    : Specifies the bastion host if applicable.
-    
-`--bastion-port=BASTION_PORT`
-    : Specifies the bastion port if applicable.
-    
-`--bastion-user=BASTION_USER`
-    : Specifies the bastion user if applicable.
-    
-`--ca-trust-file=CA_TRUST_FILE`
-    : Specify CA certificate required for SSL authentication (WinRM).
-    
-`--client-cert=CLIENT_CERT`
-    : Specify client certificate for SSL authentication
-    
-`--client-key=CLIENT_KEY`
-    : Specify client key required with client cert for SSL authentication
-    
-`--client-key-pass=CLIENT_KEY_PASS`
-    : Specify client cert password, if required for SSL authentication
-    
-`--config=CONFIG`
-    : Read configuration from JSON file (`-` reads from stdin).
-    
-`--docker-url=DOCKER_URL`
-    : Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.
-    
-`--enable-password=ENABLE_PASSWORD`
-    : Password for enable mode on Cisco IOS devices.
-    
-`--format=FORMAT`
-    
-`--host=HOST`
-    : Specify a remote host which is tested.
-    
-`--insecure`, `--no-insecure`
-    : Disable SSL verification on select targets.
-    
-`-i`, `--key-files=one two three`
-    : Login key or certificate file for a remote scan.
-    
-`--password=PASSWORD`
-    : Login password for a remote scan, if required.
-    
-`--path=PATH`
-    : Login path to use when connecting to the target (WinRM).
-    
-`--podman-url=PODMAN_URL`
-    : Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).
-    
-`-p`, `--port=N`
-    : Specify the login port for a remote scan.
-    
-`--proxy-command=PROXY_COMMAND`
-    : Specifies the command to use to connect to the server.
-    
-`--self-signed`, `--no-self-signed`
-    : Allow remote scans with self-signed certificates (WinRM).
-    
-`--shell`, `--no-shell`
-    : Run scans in a subshell. Only activates on Unix.
-    
-`--shell-command=SHELL_COMMAND`
-    : Specify a particular shell to use.
-    
-`--shell-options=SHELL_OPTIONS`
-    : Additional shell options.
-    
-`--ssh-config-file=one two three`
-    : A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.
-    
-`--ssl`, `--no-ssl`
-    : Use SSL for transport layer encryption (WinRM).
-    
-`--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT`
-    : Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).
-    
-`--sudo`, `--no-sudo`
-    : Run scans with sudo. Only activates on Unix and non-root user.
-    
-`--sudo-command=SUDO_COMMAND`
-    : Alternate command for sudo.
-    
-`--sudo-options=SUDO_OPTIONS`
-    : Additional sudo options for a remote scan.
-    
-`--sudo-password=SUDO_PASSWORD`
-    : Specify a sudo password, if it is required.
-    
-`-t`, `--target=TARGET`
-    : Simple targeting option using URIs, e.g. ssh://user:pass@host:port
-    
-`--target-id=TARGET_ID`
-    : Provide an ID which will be included on reports - deprecated
-    
-`--user=USER`
-    : The login user for a remote scan.
-    
-`--winrm-basic-auth-only`, `--no-winrm-basic-auth-only`
-    : Whether to use basic authentication, defaults to false (WinRM).
-    
-`--winrm-disable-sspi`, `--no-winrm-disable-sspi`
-    : Whether to use disable sspi authentication, defaults to false (WinRM).
-    
-`--winrm-shell-type=WINRM_SHELL_TYPE`
-    : Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).
-    
-`--winrm-transport=WINRM_TRANSPORT`
-    : Specify which transport to use, defaults to negotiate (WinRM).
-    
+<dl>
+<dt><code>-b</code>, <code>--backend=BACKEND</code></dt>
+<dd> Choose a backend: local, ssh, winrm, docker.</dd>
+</dl>
+<dl>
+<dt><code>--bastion-host=BASTION_HOST</code></dt>
+<dd> Specifies the bastion host if applicable.</dd>
+</dl>
+<dl>
+<dt><code>--bastion-port=BASTION_PORT</code></dt>
+<dd> Specifies the bastion port if applicable.</dd>
+</dl>
+<dl>
+<dt><code>--bastion-user=BASTION_USER</code></dt>
+<dd> Specifies the bastion user if applicable.</dd>
+</dl>
+<dl>
+<dt><code>--ca-trust-file=CA_TRUST_FILE</code></dt>
+<dd> Specify CA certificate required for SSL authentication (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--client-cert=CLIENT_CERT</code></dt>
+<dd> Specify client certificate for SSL authentication</dd>
+</dl>
+<dl>
+<dt><code>--client-key=CLIENT_KEY</code></dt>
+<dd> Specify client key required with client cert for SSL authentication</dd>
+</dl>
+<dl>
+<dt><code>--client-key-pass=CLIENT_KEY_PASS</code></dt>
+<dd> Specify client cert password, if required for SSL authentication</dd>
+</dl>
+<dl>
+<dt><code>--config=CONFIG</code></dt>
+<dd> Read configuration from JSON file (`-` reads from stdin).</dd>
+</dl>
+<dl>
+<dt><code>--docker-url=DOCKER_URL</code></dt>
+<dd> Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.</dd>
+</dl>
+<dl>
+<dt><code>--enable-password=ENABLE_PASSWORD</code></dt>
+<dd> Password for enable mode on Cisco IOS devices.</dd>
+</dl>
+<dl>
+<dt><code>--format=FORMAT</code></dt>
+</dl>
+<dl>
+<dt><code>--host=HOST</code></dt>
+<dd> Specify a remote host which is tested.</dd>
+</dl>
+<dl>
+<dt><code>--insecure</code>, <code>--no-insecure</code></dt>
+<dd> Disable SSL verification on select targets.</dd>
+</dl>
+<dl>
+<dt><code>-i</code>, <code>--key-files=one two three</code></dt>
+<dd> Login key or certificate file for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--password=PASSWORD</code></dt>
+<dd> Login password for a remote scan, if required.</dd>
+</dl>
+<dl>
+<dt><code>--path=PATH</code></dt>
+<dd> Login path to use when connecting to the target (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--podman-url=PODMAN_URL</code></dt>
+<dd> Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).</dd>
+</dl>
+<dl>
+<dt><code>-p</code>, <code>--port=N</code></dt>
+<dd> Specify the login port for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--proxy-command=PROXY_COMMAND</code></dt>
+<dd> Specifies the command to use to connect to the server.</dd>
+</dl>
+<dl>
+<dt><code>--self-signed</code>, <code>--no-self-signed</code></dt>
+<dd> Allow remote scans with self-signed certificates (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--shell</code>, <code>--no-shell</code></dt>
+<dd> Run scans in a subshell. Only activates on Unix.</dd>
+</dl>
+<dl>
+<dt><code>--shell-command=SHELL_COMMAND</code></dt>
+<dd> Specify a particular shell to use.</dd>
+</dl>
+<dl>
+<dt><code>--shell-options=SHELL_OPTIONS</code></dt>
+<dd> Additional shell options.</dd>
+</dl>
+<dl>
+<dt><code>--ssh-config-file=one two three</code></dt>
+<dd> A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.</dd>
+</dl>
+<dl>
+<dt><code>--ssl</code>, <code>--no-ssl</code></dt>
+<dd> Use SSL for transport layer encryption (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT</code></dt>
+<dd> Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--sudo</code>, <code>--no-sudo</code></dt>
+<dd> Run scans with sudo. Only activates on Unix and non-root user.</dd>
+</dl>
+<dl>
+<dt><code>--sudo-command=SUDO_COMMAND</code></dt>
+<dd> Alternate command for sudo.</dd>
+</dl>
+<dl>
+<dt><code>--sudo-options=SUDO_OPTIONS</code></dt>
+<dd> Additional sudo options for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--sudo-password=SUDO_PASSWORD</code></dt>
+<dd> Specify a sudo password, if it is required.</dd>
+</dl>
+<dl>
+<dt><code>-t</code>, <code>--target=TARGET</code></dt>
+<dd> Simple targeting option using URIs, e.g. ssh://user:pass@host:port</dd>
+</dl>
+<dl>
+<dt><code>--target-id=TARGET_ID</code></dt>
+<dd> Provide an ID which will be included on reports - deprecated</dd>
+</dl>
+<dl>
+<dt><code>--user=USER</code></dt>
+<dd> The login user for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--winrm-basic-auth-only</code>, <code>--no-winrm-basic-auth-only</code></dt>
+<dd> Whether to use basic authentication, defaults to false (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--winrm-disable-sspi</code>, <code>--no-winrm-disable-sspi</code></dt>
+<dd> Whether to use disable sspi authentication, defaults to false (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--winrm-shell-type=WINRM_SHELL_TYPE</code></dt>
+<dd> Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--winrm-transport=WINRM_TRANSPORT</code></dt>
+<dd> Specify which transport to use, defaults to negotiate (WinRM).</dd>
+</dl>
 
 ## env
 
@@ -342,195 +395,258 @@ inspec exec LOCATIONS
 
 This subcommand has the following additional options:
 
-`--attrs=one two three`
-    : Legacy name for --input-file - deprecated.
-    
-`--auto-install-gems`, `--no-auto-install-gems`
-    : Auto installs gem dependencies of the profile or resource pack.
-    
-`-b`, `--backend=BACKEND`
-    : Choose a backend: local, ssh, winrm, docker.
-    
-`--backend-cache`, `--no-backend-cache`
-    : Allow caching for backend command output. (default: true).
-    
-`--bastion-host=BASTION_HOST`
-    : Specifies the bastion host if applicable.
-    
-`--bastion-port=BASTION_PORT`
-    : Specifies the bastion port if applicable.
-    
-`--bastion-user=BASTION_USER`
-    : Specifies the bastion user if applicable.
-    
-`--ca-trust-file=CA_TRUST_FILE`
-    : Specify CA certificate required for SSL authentication (WinRM).
-    
-`--client-cert=CLIENT_CERT`
-    : Specify client certificate for SSL authentication
-    
-`--client-key=CLIENT_KEY`
-    : Specify client key required with client cert for SSL authentication
-    
-`--client-key-pass=CLIENT_KEY_PASS`
-    : Specify client cert password, if required for SSL authentication
-    
-`--command-timeout=N`
-    : Maximum seconds to allow commands to run during execution.
-    
-`--config=CONFIG`
-    : Read configuration from JSON file (`-` reads from stdin).
-    
-`--controls=one two three`
-    : A list of control names to run, or a list of /regexes/ to match against control names. Ignore all other tests.
-    
-`--create-lockfile`, `--no-create-lockfile`
-    : Write out a lockfile based on this execution (unless one already exists)
-    
-`--diff`, `--no-diff`
-    : Use --no-diff to suppress 'diff' output of failed textual test results.
-    
-`--distinct-exit`, `--no-distinct-exit`
-    : Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.
-    
-`--docker-url=DOCKER_URL`
-    : Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.
-    
-`--enable-password=ENABLE_PASSWORD`
-    : Password for enable mode on Cisco IOS devices.
-    
-`--enhanced-outcomes`, `--no-enhanced-outcomes`
-    : Show enhanced outcomes in output
-    
-`--filter-empty-profiles`, `--no-filter-empty-profiles`
-    : Filter empty profiles (profiles without controls) from the report.
-    
-`--filter-waived-controls`, `--no-filter-waived-controls`
-    : Do not execute waived controls in InSpec at all. Must use with --waiver-file. Ignores the `run` setting of the waiver file.
-    
-`--host=HOST`
-    : Specify a remote host which is tested.
-    
-`--input=name1=value1 name2=value2`
-    : Specify one or more inputs directly on the command line, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.
-    
-`--input-file=one two three`
-    : Load one or more input files, a YAML file with values for the profile to use.
-    
-`--insecure`, `--no-insecure`
-    : Disable SSL verification on select targets.
-    
-`-i`, `--key-files=one two three`
-    : Login key or certificate file for a remote scan.
-    
-`--password=PASSWORD`
-    : Login password for a remote scan, if required.
-    
-`--path=PATH`
-    : Login path to use when connecting to the target (WinRM).
-    
-`--podman-url=PODMAN_URL`
-    : Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).
-    
-`-p`, `--port=N`
-    : Specify the login port for a remote scan.
-    
-`--profiles-path=PROFILES_PATH`
-    : Folder which contains referenced profiles.
-    
-`--proxy-command=PROXY_COMMAND`
-    : Specifies the command to use to connect to the server.
-    
-`--reporter=one two:/output/file/path`
-    : Enable one or more output reporters: cli, documentation, html, progress, progress-bar, json, json-min, json-rspec, junit, yaml
-    
-`--reporter-backtrace-inclusion`, `--no-reporter-backtrace-inclusion`
-    : Include a code backtrace in report data (default: true)
-    
-`--reporter-include-source`, `--no-reporter-include-source`
-    : Include full source code of controls in the CLI report
-    
-`--reporter-message-truncation=REPORTER_MESSAGE_TRUNCATION`
-    : Number of characters to truncate failure messages and code_desc in report data to (default: no truncation)
-    
-`--retain-waiver-data`, `--no-retain-waiver-data`
-    : EXPERIMENTAL: Only works in conjunction with --filter-waived-controls, retains waiver data about controls that were skipped
-    
-`--self-signed`, `--no-self-signed`
-    : Allow remote scans with self-signed certificates (WinRM).
-    
-`--shell`, `--no-shell`
-    : Run scans in a subshell. Only activates on Unix.
-    
-`--shell-command=SHELL_COMMAND`
-    : Specify a particular shell to use.
-    
-`--shell-options=SHELL_OPTIONS`
-    : Additional shell options.
-    
-`--show-progress`, `--no-show-progress`
-    : Show progress while executing tests.
-    
-`--silence-deprecations=all|GROUP GROUP...`
-    : Suppress deprecation warnings. See install_dir/etc/deprecations.json for a list of GROUPs or use 'all'.
-    
-`--sort-results-by=--sort-results-by=none|control|file|random`
-    : After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode.
-    
-`--ssh-config-file=one two three`
-    : A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.
-    
-`--ssl`, `--no-ssl`
-    : Use SSL for transport layer encryption (WinRM).
-    
-`--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT`
-    : Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).
-    
-`--sudo`, `--no-sudo`
-    : Run scans with sudo. Only activates on Unix and non-root user.
-    
-`--sudo-command=SUDO_COMMAND`
-    : Alternate command for sudo.
-    
-`--sudo-options=SUDO_OPTIONS`
-    : Additional sudo options for a remote scan.
-    
-`--sudo-password=SUDO_PASSWORD`
-    : Specify a sudo password, if it is required.
-    
-`--supermarket-url=SUPERMARKET_URL`
-    : Specify the URL of a private Chef Supermarket.
-    
-`--tags=one two three`
-    : A list of tags names that are part of controls to filter and run controls, or a list of /regexes/ to match against tags names of controls. Ignore all other tests.
-    
-`-t`, `--target=TARGET`
-    : Simple targeting option using URIs, e.g. ssh://user:pass@host:port
-    
-`--target-id=TARGET_ID`
-    : Provide an ID which will be included on reports - deprecated
-    
-`--user=USER`
-    : The login user for a remote scan.
-    
-`--vendor-cache=VENDOR_CACHE`
-    : Use the given path for caching dependencies, (default: ~/.inspec/cache).
-    
-`--waiver-file=one two three`
-    : Load one or more waiver files.
-    
-`--winrm-basic-auth-only`, `--no-winrm-basic-auth-only`
-    : Whether to use basic authentication, defaults to false (WinRM).
-    
-`--winrm-disable-sspi`, `--no-winrm-disable-sspi`
-    : Whether to use disable sspi authentication, defaults to false (WinRM).
-    
-`--winrm-shell-type=WINRM_SHELL_TYPE`
-    : Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).
-    
-`--winrm-transport=WINRM_TRANSPORT`
-    : Specify which transport to use, defaults to negotiate (WinRM).
-    
+<dl>
+<dt><code>--attrs=one two three</code></dt>
+<dd> Legacy name for --input-file - deprecated.</dd>
+</dl>
+<dl>
+<dt><code>--auto-install-gems</code>, <code>--no-auto-install-gems</code></dt>
+<dd> Auto installs gem dependencies of the profile or resource pack.</dd>
+</dl>
+<dl>
+<dt><code>-b</code>, <code>--backend=BACKEND</code></dt>
+<dd> Choose a backend: local, ssh, winrm, docker.</dd>
+</dl>
+<dl>
+<dt><code>--backend-cache</code>, <code>--no-backend-cache</code></dt>
+<dd> Allow caching for backend command output. (default: true).</dd>
+</dl>
+<dl>
+<dt><code>--bastion-host=BASTION_HOST</code></dt>
+<dd> Specifies the bastion host if applicable.</dd>
+</dl>
+<dl>
+<dt><code>--bastion-port=BASTION_PORT</code></dt>
+<dd> Specifies the bastion port if applicable.</dd>
+</dl>
+<dl>
+<dt><code>--bastion-user=BASTION_USER</code></dt>
+<dd> Specifies the bastion user if applicable.</dd>
+</dl>
+<dl>
+<dt><code>--ca-trust-file=CA_TRUST_FILE</code></dt>
+<dd> Specify CA certificate required for SSL authentication (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--client-cert=CLIENT_CERT</code></dt>
+<dd> Specify client certificate for SSL authentication</dd>
+</dl>
+<dl>
+<dt><code>--client-key=CLIENT_KEY</code></dt>
+<dd> Specify client key required with client cert for SSL authentication</dd>
+</dl>
+<dl>
+<dt><code>--client-key-pass=CLIENT_KEY_PASS</code></dt>
+<dd> Specify client cert password, if required for SSL authentication</dd>
+</dl>
+<dl>
+<dt><code>--command-timeout=N</code></dt>
+<dd> Maximum seconds to allow commands to run during execution.</dd>
+</dl>
+<dl>
+<dt><code>--config=CONFIG</code></dt>
+<dd> Read configuration from JSON file (`-` reads from stdin).</dd>
+</dl>
+<dl>
+<dt><code>--controls=one two three</code></dt>
+<dd> A list of control names to run, or a list of /regexes/ to match against control names. Ignore all other tests.</dd>
+</dl>
+<dl>
+<dt><code>--create-lockfile</code>, <code>--no-create-lockfile</code></dt>
+<dd> Write out a lockfile based on this execution (unless one already exists)</dd>
+</dl>
+<dl>
+<dt><code>--diff</code>, <code>--no-diff</code></dt>
+<dd> Use --no-diff to suppress 'diff' output of failed textual test results.</dd>
+</dl>
+<dl>
+<dt><code>--distinct-exit</code>, <code>--no-distinct-exit</code></dt>
+<dd> Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.</dd>
+</dl>
+<dl>
+<dt><code>--docker-url=DOCKER_URL</code></dt>
+<dd> Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.</dd>
+</dl>
+<dl>
+<dt><code>--enable-password=ENABLE_PASSWORD</code></dt>
+<dd> Password for enable mode on Cisco IOS devices.</dd>
+</dl>
+<dl>
+<dt><code>--enhanced-outcomes</code>, <code>--no-enhanced-outcomes</code></dt>
+<dd> Show enhanced outcomes in output</dd>
+</dl>
+<dl>
+<dt><code>--filter-empty-profiles</code>, <code>--no-filter-empty-profiles</code></dt>
+<dd> Filter empty profiles (profiles without controls) from the report.</dd>
+</dl>
+<dl>
+<dt><code>--filter-waived-controls</code>, <code>--no-filter-waived-controls</code></dt>
+<dd> Do not execute waived controls in InSpec at all. Must use with --waiver-file. Ignores the `run` setting of the waiver file.</dd>
+</dl>
+<dl>
+<dt><code>--host=HOST</code></dt>
+<dd> Specify a remote host which is tested.</dd>
+</dl>
+<dl>
+<dt><code>--input=name1=value1 name2=value2</code></dt>
+<dd> Specify one or more inputs directly on the command line, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.</dd>
+</dl>
+<dl>
+<dt><code>--input-file=one two three</code></dt>
+<dd> Load one or more input files, a YAML file with values for the profile to use.</dd>
+</dl>
+<dl>
+<dt><code>--insecure</code>, <code>--no-insecure</code></dt>
+<dd> Disable SSL verification on select targets.</dd>
+</dl>
+<dl>
+<dt><code>-i</code>, <code>--key-files=one two three</code></dt>
+<dd> Login key or certificate file for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--password=PASSWORD</code></dt>
+<dd> Login password for a remote scan, if required.</dd>
+</dl>
+<dl>
+<dt><code>--path=PATH</code></dt>
+<dd> Login path to use when connecting to the target (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--podman-url=PODMAN_URL</code></dt>
+<dd> Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).</dd>
+</dl>
+<dl>
+<dt><code>-p</code>, <code>--port=N</code></dt>
+<dd> Specify the login port for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--profiles-path=PROFILES_PATH</code></dt>
+<dd> Folder which contains referenced profiles.</dd>
+</dl>
+<dl>
+<dt><code>--proxy-command=PROXY_COMMAND</code></dt>
+<dd> Specifies the command to use to connect to the server.</dd>
+</dl>
+<dl>
+<dt><code>--reporter=one two:/output/file/path</code></dt>
+<dd> Enable one or more output reporters: cli, documentation, html, progress, progress-bar, json, json-min, json-rspec, junit, yaml</dd>
+</dl>
+<dl>
+<dt><code>--reporter-backtrace-inclusion</code>, <code>--no-reporter-backtrace-inclusion</code></dt>
+<dd> Include a code backtrace in report data (default: true)</dd>
+</dl>
+<dl>
+<dt><code>--reporter-include-source</code>, <code>--no-reporter-include-source</code></dt>
+<dd> Include full source code of controls in the CLI report</dd>
+</dl>
+<dl>
+<dt><code>--reporter-message-truncation=REPORTER_MESSAGE_TRUNCATION</code></dt>
+<dd> Number of characters to truncate failure messages and code_desc in report data to (default: no truncation)</dd>
+</dl>
+<dl>
+<dt><code>--retain-waiver-data</code>, <code>--no-retain-waiver-data</code></dt>
+<dd> EXPERIMENTAL: Only works in conjunction with --filter-waived-controls, retains waiver data about controls that were skipped</dd>
+</dl>
+<dl>
+<dt><code>--self-signed</code>, <code>--no-self-signed</code></dt>
+<dd> Allow remote scans with self-signed certificates (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--shell</code>, <code>--no-shell</code></dt>
+<dd> Run scans in a subshell. Only activates on Unix.</dd>
+</dl>
+<dl>
+<dt><code>--shell-command=SHELL_COMMAND</code></dt>
+<dd> Specify a particular shell to use.</dd>
+</dl>
+<dl>
+<dt><code>--shell-options=SHELL_OPTIONS</code></dt>
+<dd> Additional shell options.</dd>
+</dl>
+<dl>
+<dt><code>--show-progress</code>, <code>--no-show-progress</code></dt>
+<dd> Show progress while executing tests.</dd>
+</dl>
+<dl>
+<dt><code>--silence-deprecations=all|GROUP GROUP...</code></dt>
+<dd> Suppress deprecation warnings. See install_dir/etc/deprecations.json for a list of GROUPs or use 'all'.</dd>
+</dl>
+<dl>
+<dt><code>--sort-results-by=--sort-results-by=none|control|file|random</code></dt>
+<dd> After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode.</dd>
+</dl>
+<dl>
+<dt><code>--ssh-config-file=one two three</code></dt>
+<dd> A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.</dd>
+</dl>
+<dl>
+<dt><code>--ssl</code>, <code>--no-ssl</code></dt>
+<dd> Use SSL for transport layer encryption (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT</code></dt>
+<dd> Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--sudo</code>, <code>--no-sudo</code></dt>
+<dd> Run scans with sudo. Only activates on Unix and non-root user.</dd>
+</dl>
+<dl>
+<dt><code>--sudo-command=SUDO_COMMAND</code></dt>
+<dd> Alternate command for sudo.</dd>
+</dl>
+<dl>
+<dt><code>--sudo-options=SUDO_OPTIONS</code></dt>
+<dd> Additional sudo options for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--sudo-password=SUDO_PASSWORD</code></dt>
+<dd> Specify a sudo password, if it is required.</dd>
+</dl>
+<dl>
+<dt><code>--supermarket-url=SUPERMARKET_URL</code></dt>
+<dd> Specify the URL of a private Chef Supermarket.</dd>
+</dl>
+<dl>
+<dt><code>--tags=one two three</code></dt>
+<dd> A list of tags names that are part of controls to filter and run controls, or a list of /regexes/ to match against tags names of controls. Ignore all other tests.</dd>
+</dl>
+<dl>
+<dt><code>-t</code>, <code>--target=TARGET</code></dt>
+<dd> Simple targeting option using URIs, e.g. ssh://user:pass@host:port</dd>
+</dl>
+<dl>
+<dt><code>--target-id=TARGET_ID</code></dt>
+<dd> Provide an ID which will be included on reports - deprecated</dd>
+</dl>
+<dl>
+<dt><code>--user=USER</code></dt>
+<dd> The login user for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
+<dd> Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
+</dl>
+<dl>
+<dt><code>--waiver-file=one two three</code></dt>
+<dd> Load one or more waiver files.</dd>
+</dl>
+<dl>
+<dt><code>--winrm-basic-auth-only</code>, <code>--no-winrm-basic-auth-only</code></dt>
+<dd> Whether to use basic authentication, defaults to false (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--winrm-disable-sspi</code>, <code>--no-winrm-disable-sspi</code></dt>
+<dd> Whether to use disable sspi authentication, defaults to false (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--winrm-shell-type=WINRM_SHELL_TYPE</code></dt>
+<dd> Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--winrm-transport=WINRM_TRANSPORT</code></dt>
+<dd> Specify which transport to use, defaults to negotiate (WinRM).</dd>
+</dl>
 
 ## export
 
@@ -548,30 +664,38 @@ inspec export PATH
 
 This subcommand has the following additional options:
 
-`--auto-install-gems`, `--no-auto-install-gems`
-    : Auto installs gem dependencies of the profile or resource pack.
-    
-`--controls=one two three`
-    : For --what=profile, a list of controls to include. Ignore all other tests.
-    
-`--format=FORMAT`
-    : The output format to use: json, raw, yaml. If valid format is not provided then it will use the default for the given 'what'.
-    
-`-o`, `--output=OUTPUT`
-    : Save the created output to a path.
-    
-`--profiles-path=PROFILES_PATH`
-    : Folder which contains referenced profiles.
-    
-`--tags=one two three`
-    : For --what=profile, a list of tags to filter controls and include only those. Ignore all other tests.
-    
-`--vendor-cache=VENDOR_CACHE`
-    : Use the given path for caching dependencies, (default: ~/.inspec/cache).
-    
-`--what=WHAT`
-    : What to export: profile (default), readme, metadata.
-    
+<dl>
+<dt><code>--auto-install-gems</code>, <code>--no-auto-install-gems</code></dt>
+<dd> Auto installs gem dependencies of the profile or resource pack.</dd>
+</dl>
+<dl>
+<dt><code>--controls=one two three</code></dt>
+<dd> For --what=profile, a list of controls to include. Ignore all other tests.</dd>
+</dl>
+<dl>
+<dt><code>--format=FORMAT</code></dt>
+<dd> The output format to use: json, raw, yaml. If valid format is not provided then it will use the default for the given 'what'.</dd>
+</dl>
+<dl>
+<dt><code>-o</code>, <code>--output=OUTPUT</code></dt>
+<dd> Save the created output to a path.</dd>
+</dl>
+<dl>
+<dt><code>--profiles-path=PROFILES_PATH</code></dt>
+<dd> Folder which contains referenced profiles.</dd>
+</dl>
+<dl>
+<dt><code>--tags=one two three</code></dt>
+<dd> For --what=profile, a list of tags to filter controls and include only those. Ignore all other tests.</dd>
+</dl>
+<dl>
+<dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
+<dd> Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
+</dl>
+<dl>
+<dt><code>--what=WHAT</code></dt>
+<dd> What to export: profile (default), readme, metadata.</dd>
+</dl>
 
 ## help
 
@@ -601,24 +725,30 @@ inspec json PATH
 
 This subcommand has the following additional options:
 
-`--auto-install-gems`, `--no-auto-install-gems`
-    : Auto installs gem dependencies of the profile or resource pack.
-    
-`--controls=one two three`
-    : A list of controls to include. Ignore all other tests.
-    
-`-o`, `--output=OUTPUT`
-    : Save the created profile to a path.
-    
-`--profiles-path=PROFILES_PATH`
-    : Folder which contains referenced profiles.
-    
-`--tags=one two three`
-    : A list of tags to filter controls and include only those. Ignore all other tests.
-    
-`--vendor-cache=VENDOR_CACHE`
-    : Use the given path for caching dependencies, (default: ~/.inspec/cache).
-    
+<dl>
+<dt><code>--auto-install-gems</code>, <code>--no-auto-install-gems</code></dt>
+<dd> Auto installs gem dependencies of the profile or resource pack.</dd>
+</dl>
+<dl>
+<dt><code>--controls=one two three</code></dt>
+<dd> A list of controls to include. Ignore all other tests.</dd>
+</dl>
+<dl>
+<dt><code>-o</code>, <code>--output=OUTPUT</code></dt>
+<dd> Save the created profile to a path.</dd>
+</dl>
+<dl>
+<dt><code>--profiles-path=PROFILES_PATH</code></dt>
+<dd> Folder which contains referenced profiles.</dd>
+</dl>
+<dl>
+<dt><code>--tags=one two three</code></dt>
+<dd> A list of tags to filter controls and include only those. Ignore all other tests.</dd>
+</dl>
+<dl>
+<dt><code>--vendor-cache=VENDOR_CACHE</code></dt>
+<dd> Use the given path for caching dependencies, (default: ~/.inspec/cache).</dd>
+</dl>
 
 ## run_context
 
@@ -648,9 +778,10 @@ inspec schema NAME
 
 This subcommand has the following additional options:
 
-`--enhanced-outcomes`, `--no-enhanced-outcomes`
-    : Show enhanced outcomes output
-    
+<dl>
+<dt><code>--enhanced-outcomes</code>, <code>--no-enhanced-outcomes</code></dt>
+<dd> Show enhanced outcomes output</dd>
+</dl>
 
 ## shell
 
@@ -668,144 +799,190 @@ inspec shell
 
 This subcommand has the following additional options:
 
-`-b`, `--backend=BACKEND`
-    : Choose a backend: local, ssh, winrm, docker.
-    
-`--bastion-host=BASTION_HOST`
-    : Specifies the bastion host if applicable.
-    
-`--bastion-port=BASTION_PORT`
-    : Specifies the bastion port if applicable.
-    
-`--bastion-user=BASTION_USER`
-    : Specifies the bastion user if applicable.
-    
-`--ca-trust-file=CA_TRUST_FILE`
-    : Specify CA certificate required for SSL authentication (WinRM).
-    
-`--client-cert=CLIENT_CERT`
-    : Specify client certificate for SSL authentication
-    
-`--client-key=CLIENT_KEY`
-    : Specify client key required with client cert for SSL authentication
-    
-`--client-key-pass=CLIENT_KEY_PASS`
-    : Specify client cert password, if required for SSL authentication
-    
-`-c`, `--command=COMMAND`
-    : A single command string to run instead of launching the shell
-    
-`--command-timeout=N`
-    : Maximum seconds to allow a command to run.
-    
-`--config=CONFIG`
-    : Read configuration from JSON file (`-` reads from stdin).
-    
-`--depends=one two three`
-    : A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell
-    
-`--distinct-exit`, `--no-distinct-exit`
-    : Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures.
-    
-`--docker-url=DOCKER_URL`
-    : Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.
-    
-`--enable-password=ENABLE_PASSWORD`
-    : Password for enable mode on Cisco IOS devices.
-    
-`--enhanced-outcomes`, `--no-enhanced-outcomes`
-    : Show enhanced outcomes in output
-    
-`--host=HOST`
-    : Specify a remote host which is tested.
-    
-`--input=name1=value1 name2=value2`
-    : Specify one or more inputs directly on the command line to the shell, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.
-    
-`--input-file=one two three`
-    : Load one or more input files, a YAML file with values for the shell to use
-    
-`--insecure`, `--no-insecure`
-    : Disable SSL verification on select targets.
-    
-`--inspect`, `--no-inspect`
-    : Use verbose/debugging output for resources.
-    
-`-i`, `--key-files=one two three`
-    : Login key or certificate file for a remote scan.
-    
-`--password=PASSWORD`
-    : Login password for a remote scan, if required.
-    
-`--path=PATH`
-    : Login path to use when connecting to the target (WinRM).
-    
-`--podman-url=PODMAN_URL`
-    : Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).
-    
-`-p`, `--port=N`
-    : Specify the login port for a remote scan.
-    
-`--proxy-command=PROXY_COMMAND`
-    : Specifies the command to use to connect to the server.
-    
-`--reporter=one two:/output/file/path`
-    : Enable one or more output reporters: cli, documentation, html, progress, json, json-min, json-rspec, junit
-    
-`--self-signed`, `--no-self-signed`
-    : Allow remote scans with self-signed certificates (WinRM).
-    
-`--shell`, `--no-shell`
-    : Run scans in a subshell. Only activates on Unix.
-    
-`--shell-command=SHELL_COMMAND`
-    : Specify a particular shell to use.
-    
-`--shell-options=SHELL_OPTIONS`
-    : Additional shell options.
-    
-`--ssh-config-file=one two three`
-    : A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.
-    
-`--ssl`, `--no-ssl`
-    : Use SSL for transport layer encryption (WinRM).
-    
-`--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT`
-    : Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).
-    
-`--sudo`, `--no-sudo`
-    : Run scans with sudo. Only activates on Unix and non-root user.
-    
-`--sudo-command=SUDO_COMMAND`
-    : Alternate command for sudo.
-    
-`--sudo-options=SUDO_OPTIONS`
-    : Additional sudo options for a remote scan.
-    
-`--sudo-password=SUDO_PASSWORD`
-    : Specify a sudo password, if it is required.
-    
-`-t`, `--target=TARGET`
-    : Simple targeting option using URIs, e.g. ssh://user:pass@host:port
-    
-`--target-id=TARGET_ID`
-    : Provide an ID which will be included on reports - deprecated
-    
-`--user=USER`
-    : The login user for a remote scan.
-    
-`--winrm-basic-auth-only`, `--no-winrm-basic-auth-only`
-    : Whether to use basic authentication, defaults to false (WinRM).
-    
-`--winrm-disable-sspi`, `--no-winrm-disable-sspi`
-    : Whether to use disable sspi authentication, defaults to false (WinRM).
-    
-`--winrm-shell-type=WINRM_SHELL_TYPE`
-    : Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).
-    
-`--winrm-transport=WINRM_TRANSPORT`
-    : Specify which transport to use, defaults to negotiate (WinRM).
-    
+<dl>
+<dt><code>-b</code>, <code>--backend=BACKEND</code></dt>
+<dd> Choose a backend: local, ssh, winrm, docker.</dd>
+</dl>
+<dl>
+<dt><code>--bastion-host=BASTION_HOST</code></dt>
+<dd> Specifies the bastion host if applicable.</dd>
+</dl>
+<dl>
+<dt><code>--bastion-port=BASTION_PORT</code></dt>
+<dd> Specifies the bastion port if applicable.</dd>
+</dl>
+<dl>
+<dt><code>--bastion-user=BASTION_USER</code></dt>
+<dd> Specifies the bastion user if applicable.</dd>
+</dl>
+<dl>
+<dt><code>--ca-trust-file=CA_TRUST_FILE</code></dt>
+<dd> Specify CA certificate required for SSL authentication (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--client-cert=CLIENT_CERT</code></dt>
+<dd> Specify client certificate for SSL authentication</dd>
+</dl>
+<dl>
+<dt><code>--client-key=CLIENT_KEY</code></dt>
+<dd> Specify client key required with client cert for SSL authentication</dd>
+</dl>
+<dl>
+<dt><code>--client-key-pass=CLIENT_KEY_PASS</code></dt>
+<dd> Specify client cert password, if required for SSL authentication</dd>
+</dl>
+<dl>
+<dt><code>-c</code>, <code>--command=COMMAND</code></dt>
+<dd> A single command string to run instead of launching the shell</dd>
+</dl>
+<dl>
+<dt><code>--command-timeout=N</code></dt>
+<dd> Maximum seconds to allow a command to run.</dd>
+</dl>
+<dl>
+<dt><code>--config=CONFIG</code></dt>
+<dd> Read configuration from JSON file (`-` reads from stdin).</dd>
+</dl>
+<dl>
+<dt><code>--depends=one two three</code></dt>
+<dd> A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell</dd>
+</dl>
+<dl>
+<dt><code>--distinct-exit</code>, <code>--no-distinct-exit</code></dt>
+<dd> Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures.</dd>
+</dl>
+<dl>
+<dt><code>--docker-url=DOCKER_URL</code></dt>
+<dd> Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.</dd>
+</dl>
+<dl>
+<dt><code>--enable-password=ENABLE_PASSWORD</code></dt>
+<dd> Password for enable mode on Cisco IOS devices.</dd>
+</dl>
+<dl>
+<dt><code>--enhanced-outcomes</code>, <code>--no-enhanced-outcomes</code></dt>
+<dd> Show enhanced outcomes in output</dd>
+</dl>
+<dl>
+<dt><code>--host=HOST</code></dt>
+<dd> Specify a remote host which is tested.</dd>
+</dl>
+<dl>
+<dt><code>--input=name1=value1 name2=value2</code></dt>
+<dd> Specify one or more inputs directly on the command line to the shell, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.</dd>
+</dl>
+<dl>
+<dt><code>--input-file=one two three</code></dt>
+<dd> Load one or more input files, a YAML file with values for the shell to use</dd>
+</dl>
+<dl>
+<dt><code>--insecure</code>, <code>--no-insecure</code></dt>
+<dd> Disable SSL verification on select targets.</dd>
+</dl>
+<dl>
+<dt><code>--inspect</code>, <code>--no-inspect</code></dt>
+<dd> Use verbose/debugging output for resources.</dd>
+</dl>
+<dl>
+<dt><code>-i</code>, <code>--key-files=one two three</code></dt>
+<dd> Login key or certificate file for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--password=PASSWORD</code></dt>
+<dd> Login password for a remote scan, if required.</dd>
+</dl>
+<dl>
+<dt><code>--path=PATH</code></dt>
+<dd> Login path to use when connecting to the target (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--podman-url=PODMAN_URL</code></dt>
+<dd> Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).</dd>
+</dl>
+<dl>
+<dt><code>-p</code>, <code>--port=N</code></dt>
+<dd> Specify the login port for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--proxy-command=PROXY_COMMAND</code></dt>
+<dd> Specifies the command to use to connect to the server.</dd>
+</dl>
+<dl>
+<dt><code>--reporter=one two:/output/file/path</code></dt>
+<dd> Enable one or more output reporters: cli, documentation, html, progress, json, json-min, json-rspec, junit</dd>
+</dl>
+<dl>
+<dt><code>--self-signed</code>, <code>--no-self-signed</code></dt>
+<dd> Allow remote scans with self-signed certificates (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--shell</code>, <code>--no-shell</code></dt>
+<dd> Run scans in a subshell. Only activates on Unix.</dd>
+</dl>
+<dl>
+<dt><code>--shell-command=SHELL_COMMAND</code></dt>
+<dd> Specify a particular shell to use.</dd>
+</dl>
+<dl>
+<dt><code>--shell-options=SHELL_OPTIONS</code></dt>
+<dd> Additional shell options.</dd>
+</dl>
+<dl>
+<dt><code>--ssh-config-file=one two three</code></dt>
+<dd> A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.</dd>
+</dl>
+<dl>
+<dt><code>--ssl</code>, <code>--no-ssl</code></dt>
+<dd> Use SSL for transport layer encryption (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT</code></dt>
+<dd> Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--sudo</code>, <code>--no-sudo</code></dt>
+<dd> Run scans with sudo. Only activates on Unix and non-root user.</dd>
+</dl>
+<dl>
+<dt><code>--sudo-command=SUDO_COMMAND</code></dt>
+<dd> Alternate command for sudo.</dd>
+</dl>
+<dl>
+<dt><code>--sudo-options=SUDO_OPTIONS</code></dt>
+<dd> Additional sudo options for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--sudo-password=SUDO_PASSWORD</code></dt>
+<dd> Specify a sudo password, if it is required.</dd>
+</dl>
+<dl>
+<dt><code>-t</code>, <code>--target=TARGET</code></dt>
+<dd> Simple targeting option using URIs, e.g. ssh://user:pass@host:port</dd>
+</dl>
+<dl>
+<dt><code>--target-id=TARGET_ID</code></dt>
+<dd> Provide an ID which will be included on reports - deprecated</dd>
+</dl>
+<dl>
+<dt><code>--user=USER</code></dt>
+<dd> The login user for a remote scan.</dd>
+</dl>
+<dl>
+<dt><code>--winrm-basic-auth-only</code>, <code>--no-winrm-basic-auth-only</code></dt>
+<dd> Whether to use basic authentication, defaults to false (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--winrm-disable-sspi</code>, <code>--no-winrm-disable-sspi</code></dt>
+<dd> Whether to use disable sspi authentication, defaults to false (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--winrm-shell-type=WINRM_SHELL_TYPE</code></dt>
+<dd> Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).</dd>
+</dl>
+<dl>
+<dt><code>--winrm-transport=WINRM_TRANSPORT</code></dt>
+<dd> Specify which transport to use, defaults to negotiate (WinRM).</dd>
+</dl>
 
 ## supermarket
 
@@ -835,9 +1012,10 @@ inspec vendor PATH
 
 This subcommand has the following additional options:
 
-`--overwrite`, `--no-overwrite`
-    : Overwrite existing vendored dependencies and lockfile.
-    
+<dl>
+<dt><code>--overwrite</code>, <code>--no-overwrite</code></dt>
+<dd> Overwrite existing vendored dependencies and lockfile.</dd>
+</dl>
 
 ## version
 
@@ -855,6 +1033,7 @@ inspec version
 
 This subcommand has the following additional options:
 
-`--format=FORMAT`
-    
+<dl>
+<dt><code>--format=FORMAT</code></dt>
+</dl>
 

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -31,38 +31,37 @@ inspec archive PATH
 
 This subcommand has the following additional options:
 
-* `--airgap`, `--no-airgap`
-    Fallback to using local archives if fetching fails.
-* `--ignore-errors`, `--no-ignore-errors`
-    Ignore profile warnings.
-* `-o`, `--output=OUTPUT`
-    Save the archive to a path.
-* `--overwrite`, `--no-overwrite`
-    Overwrite existing archive.
-* `--profiles-path=PROFILES_PATH`
-    Folder which contains referenced profiles.
-* `--tar`, `--no-tar`
-    Generates a tar.gz archive.
-* `--vendor-cache=VENDOR_CACHE`
-    Use the given path for caching dependencies, (default: `~/.inspec/cache`).
-* `--zip`, `--no-zip`
-    Generates a zip archive.
-
-## automate
-
-Communicates with Chef Automate.
-
-### Syntax
-
-This subcommand has the following syntax:
-
-```bash
-inspec automate SUBCOMMAND
-```
+`--airgap`, `--no-airgap`
+    : Fallback to using local archives if fetching fails.
+    
+`--auto-install-gems`, `--no-auto-install-gems`
+    : Auto installs gem dependencies of the profile or resource pack.
+    
+`--ignore-errors`, `--no-ignore-errors`
+    : Ignore profile warnings.
+    
+`-o`, `--output=OUTPUT`
+    : Save the archive to a path.
+    
+`--overwrite`, `--no-overwrite`
+    : Overwrite existing archive.
+    
+`--profiles-path=PROFILES_PATH`
+    : Folder which contains referenced profiles.
+    
+`--tar`, `--no-tar`
+    : Generates a tar.gz archive.
+    
+`--vendor-cache=VENDOR_CACHE`
+    : Use the given path for caching dependencies, (default: ~/.inspec/cache).
+    
+`--zip`, `--no-zip`
+    : Generates a zip archive.
+    
 
 ## check
 
-Verify the metadata in the `inspec.yml` file, verify that control blocks have the correct fields (title, description, impact), and define that all controls have visible tests and the controls are not using deprecated InSpec DSL code.
+Verify the metadata in the `inspec.yml` file,  verify that control blocks have the correct fields (title, description, impact),  and define that all controls have visible tests and the controls are not using deprecated inspec dsl code
 
 ### Syntax
 
@@ -76,18 +75,45 @@ inspec check PATH
 
 This subcommand has the following additional options:
 
-* `--format=FORMAT`
-    The output format to use. Valid values: `json` and `doc`. Default value: `doc`.
-* `--profiles-path=PROFILES_PATH`
-    Folder which contains referenced profiles.
-* `--vendor-cache=VENDOR_CACHE`
-    Use the given path for caching dependencies, (default: `~/.inspec/cache`).
-* `--with-cookstyle`, `--no-with-cookstyle`
-    Enable or disable cookstyle checks.
+`--auto-install-gems`, `--no-auto-install-gems`
+    : Auto installs gem dependencies of the profile or resource pack.
+    
+`--format=FORMAT`
+    : The output format to use. Valid values: `json` and `doc`. Default value: `doc`.
+    
+`--profiles-path=PROFILES_PATH`
+    : Folder which contains referenced profiles.
+    
+`--vendor-cache=VENDOR_CACHE`
+    : Use the given path for caching dependencies, (default: ~/.inspec/cache).
+    
+`--with-cookstyle`, `--no-with-cookstyle`
+    : Enable or disable cookstyle checks.
+    
+
+## clear_cache
+
+Clears the inspec cache. useful for debugging.
+
+### Syntax
+
+This subcommand has the following syntax:
+
+```bash
+inspec clear_cache
+```
+
+### Options
+
+This subcommand has the following additional options:
+
+`--vendor-cache=VENDOR_CACHE`
+    : Use the given path for caching dependencies, (default: `~/.inspec/cache`).
+    
 
 ## detect
 
-Detects the target OS.
+Detects the target os.
 
 ### Syntax
 
@@ -101,80 +127,119 @@ inspec detect
 
 This subcommand has the following additional options:
 
-* `-b`, `--backend=BACKEND`
-    Choose a backend: local, ssh, winrm, docker.
-* `--bastion-host=BASTION_HOST`
-    Specifies the bastion host if applicable.
-* `--bastion-port=BASTION_PORT`
-    Specifies the bastion port if applicable.
-* `--bastion-user=BASTION_USER`
-    Specifies the bastion user if applicable.
-* `--ca-trust-file=PATH_TO_CA_TRUST_FILE`
-    Specify CA certificate required for SSL authentication (WinRM).
-* `--client-cert=PATH_TO_CLIENT_CERTIFICATE`
-    Specify client certificate required for SSL authentication (WinRM).
-* `--client-key=PATH_TO_CLIENT_KEY`
-    Specify client key required with client certificate for SSL authentication (WinRM).
-* `--client-key-pass=CLIENT_CERT_PASSWORD`
-    Specify client certificate password, if required for SSL authentication (WinRM).
-* `--config=CONFIG`
-    Read configuration from the JSON file (`-` reads from stdin).
-* `--docker-url`
-    Provides a path to the Docker API endpoint (Docker).
-* `--enable-password=ENABLE_PASSWORD`
-    Password for enable mode on Cisco IOS devices.
-* `--format=FORMAT`
-
-* `--host=HOST`
-    Specify a remote host which is tested.
-* `--insecure`, `--no-insecure`
-    Disable SSL verification on select targets.
-* `-i`, `--key-files=one two three`
-    Login key or certificate file for a remote scan.
-* `--password=PASSWORD`
-    Login password for a remote scan, if required.
-* `--path=PATH`
-    Login path to use when connecting to the target (WinRM).
-* `-p`, `--port=N`
-    Specify the login port for a remote scan.
-* `--podman-url`
-    Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).
-* `--proxy-command=PROXY_COMMAND`
-    Specifies the command to use to connect to the server.
-* `--self-signed`, `--no-self-signed`
-    Allow remote scans with self-signed certificates (WinRM).
-* `--shell`, `--no-shell`
-    Run scans in a subshell. Only activates on Unix.
-* `--shell-command=SHELL_COMMAND`
-    Specify a particular shell to use.
-* `--shell-options=SHELL_OPTIONS`
-    Additional shell options.
-* `--ssl`, `--no-ssl`
-    Use SSL for transport layer encryption (WinRM).
-* `--ssl-peer-fingerprint`
-    Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).
-* `--sudo`, `--no-sudo`
-    Run scans with sudo. Only activates on Unix and non-root user.
-* `--sudo-command=SUDO_COMMAND`
-    Alternate command for sudo.
-* `--sudo-options=SUDO_OPTIONS`
-    Additional sudo options for a remote scan.
-* `--sudo-password=SUDO_PASSWORD`
-    Specify a sudo password, if it is required.
-* `-t`, `--target=TARGET`
-    Simple targeting option using URIs, e.g. ssh://user:pass@host:port.
-* `--target-id=TARGET_ID`
-    Provide a ID which will be included on reports.
-* `--user=USER`
-    The login user for a remote scan.
-* `--winrm-basic-auth-only`, `--no-winrm-basic-auth-only`
-    Whether to use basic authentication, defaults to false (WinRM).
-* `--winrm-disable-sspi`, `--no-winrm-disable-sspi`
-    Whether to use disable sspi authentication, defaults to false (WinRM).
-* `--winrm-transport=WINRM_TRANSPORT`
-    Specify which transport to use, defaults to negotiate (WinRM).
-* `--winrm-shell-type=WINRM_SHELL_TYPE`
-    Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).
+`-b`, `--backend=BACKEND`
+    : Choose a backend: local, ssh, winrm, docker.
+    
+`--bastion-host=BASTION_HOST`
+    : Specifies the bastion host if applicable.
+    
+`--bastion-port=BASTION_PORT`
+    : Specifies the bastion port if applicable.
+    
+`--bastion-user=BASTION_USER`
+    : Specifies the bastion user if applicable.
+    
+`--ca-trust-file=CA_TRUST_FILE`
+    : Specify CA certificate required for SSL authentication (WinRM).
+    
+`--client-cert=CLIENT_CERT`
+    : Specify client certificate for SSL authentication
+    
+`--client-key=CLIENT_KEY`
+    : Specify client key required with client cert for SSL authentication
+    
+`--client-key-pass=CLIENT_KEY_PASS`
+    : Specify client cert password, if required for SSL authentication
+    
+`--config=CONFIG`
+    : Read configuration from JSON file (`-` reads from stdin).
+    
+`--docker-url=DOCKER_URL`
+    : Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.
+    
+`--enable-password=ENABLE_PASSWORD`
+    : Password for enable mode on Cisco IOS devices.
+    
+`--format=FORMAT`
+    
+`--host=HOST`
+    : Specify a remote host which is tested.
+    
+`--insecure`, `--no-insecure`
+    : Disable SSL verification on select targets.
+    
+`-i`, `--key-files=one two three`
+    : Login key or certificate file for a remote scan.
+    
+`--password=PASSWORD`
+    : Login password for a remote scan, if required.
+    
+`--path=PATH`
+    : Login path to use when connecting to the target (WinRM).
+    
+`--podman-url=PODMAN_URL`
+    : Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).
+    
+`-p`, `--port=N`
+    : Specify the login port for a remote scan.
+    
+`--proxy-command=PROXY_COMMAND`
+    : Specifies the command to use to connect to the server.
+    
+`--self-signed`, `--no-self-signed`
+    : Allow remote scans with self-signed certificates (WinRM).
+    
+`--shell`, `--no-shell`
+    : Run scans in a subshell. Only activates on Unix.
+    
+`--shell-command=SHELL_COMMAND`
+    : Specify a particular shell to use.
+    
+`--shell-options=SHELL_OPTIONS`
+    : Additional shell options.
+    
+`--ssh-config-file=one two three`
+    : A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.
+    
+`--ssl`, `--no-ssl`
+    : Use SSL for transport layer encryption (WinRM).
+    
+`--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT`
+    : Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).
+    
+`--sudo`, `--no-sudo`
+    : Run scans with sudo. Only activates on Unix and non-root user.
+    
+`--sudo-command=SUDO_COMMAND`
+    : Alternate command for sudo.
+    
+`--sudo-options=SUDO_OPTIONS`
+    : Additional sudo options for a remote scan.
+    
+`--sudo-password=SUDO_PASSWORD`
+    : Specify a sudo password, if it is required.
+    
+`-t`, `--target=TARGET`
+    : Simple targeting option using URIs, e.g. ssh://user:pass@host:port
+    
+`--target-id=TARGET_ID`
+    : Provide an ID which will be included on reports - deprecated
+    
+`--user=USER`
+    : The login user for a remote scan.
+    
+`--winrm-basic-auth-only`, `--no-winrm-basic-auth-only`
+    : Whether to use basic authentication, defaults to false (WinRM).
+    
+`--winrm-disable-sspi`, `--no-winrm-disable-sspi`
+    : Whether to use disable sspi authentication, defaults to false (WinRM).
+    
+`--winrm-shell-type=WINRM_SHELL_TYPE`
+    : Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).
+    
+`--winrm-transport=WINRM_TRANSPORT`
+    : Specify which transport to use, defaults to negotiate (WinRM).
+    
 
 ## env
 
@@ -192,90 +257,78 @@ inspec env
 
 Run all test files at the specified locations.
 
-The subcommand loads the given profiles, fetches their dependencies if needed, then connects to the target and executes any controls in the profiles. One or more reporters are used to generate the output.
-
-```ruby
-exit codes:
-    0  normal exit, all tests passed
-    1  usage or general error
-    2  error in plugin system
-    3  fatal deprecation encountered
-  100  normal exit, at least one test failed
-  101  normal exit, at least one test skipped but none failed
-  172  chef license not accepted
+The subcommand loads the given profiles, fetches their dependencies if needed, then connects to the target and executes any controls in the profiles.
+One or more reporters are used to generate the output.
+```
+Exit codes:
+    0  Normal exit, all tests passed
+    1  Usage or general error
+    2  Error in plugin system
+    3  Fatal deprecation encountered
+  100  Normal exit, at least one test failed
+  101  Normal exit, at least one test skipped but none failed
+  172  Chef License not accepted
 ```
 
-Below are some examples of using `exec` with different test locations:
+Below are some examples of using `exec` with different test LOCATIONS:
 
 Chef Automate:
-
-```ruby
-inspec automate login
-inspec exec compliance://username/linux-baseline
-```
-
-`inspec compliance` is a backwards compatible alias for `inspec automate` and works the same way:
-
-```ruby
-inspec compliance login
-```
+  ```
+  inspec automate login
+  inspec exec compliance://username/linux-baseline
+  ```
+  `inspec compliance` is a backwards compatible alias for `inspec automate` and works the same way:
+  ```
+  inspec compliance login
+  ```
 
 Chef Supermarket:
-
-```ruby
-inspec exec supermarket://username/linux-baseline
-inspec exec supermarket://username/linux-baseline --supermarket_url="https://privatesupermarket.example.com"
-```
+  ```
+  inspec exec supermarket://username/linux-baseline
+  ```
 
 Local profile (executes all tests in `controls/`):
+  ```
+  inspec exec /path/to/profile
+  ```
 
-```ruby
-inspec exec /path/to/profile
-```
+Local single test (doesn't allow inputs or custom resources)
+  ```
+  inspec exec /path/to/a_test.rb
+  ```
 
-Local single test (doesn't allow inputs or custom resources):
-
-```ruby
-inspec exec /path/to/a_test.rb
-```
-
-Git via SSH:
-
-```ruby
-inspec exec git@github.com:dev-sec/linux-baseline.git
-```
+Git via SSH
+  ```
+  inspec exec git@github.com:dev-sec/linux-baseline.git
+  ```
 
 Git via HTTPS (.git suffix is required):
-
-```ruby
-inspec exec https://github.com/dev-sec/linux-baseline.git
-```
+  ```
+  inspec exec https://github.com/dev-sec/linux-baseline.git
+  ```
 
 Private Git via HTTPS (.git suffix is required):
-
-```ruby
-inspec exec https://api_token@github.com/dev-sec/linux-baseline.git
-```
+  ```
+  inspec exec https://API_TOKEN@github.com/dev-sec/linux-baseline.git
+  ```
 
 Private Git via HTTPS and cached credentials (.git suffix is required):
+  ```
+  git config credential.helper cache
+  git ls-remote https://github.com/dev-sec/linux-baseline.git
+  inspec exec https://github.com/dev-sec/linux-baseline.git
+  ```
 
-```bash
-git config credential.helper cache
-git ls-remote https://github.com/dev-sec/linux-baseline.git
-inspec exec https://github.com/dev-sec/linux-baseline.git
-```
+Web hosted file (also supports .zip):
+  ```
+  inspec exec https://webserver/linux-baseline.tar.gz
+  ```
 
-Web-hosted file (also supports .zip):
+Web hosted file with basic authentication (supports .zip):
+  ```
+  inspec exec https://username:password@webserver/linux-baseline.tar.gz
+  ```
 
-```bash
-inspec exec https://webserver/linux-baseline.tar.gz
-```
-
-Web-hosted file with basic authentication (supports .zip):
-
-```bash
-inspec exec https://username:password@webserver/linux-baseline.tar.gz
-```
 
 ### Syntax
 
@@ -289,138 +342,240 @@ inspec exec LOCATIONS
 
 This subcommand has the following additional options:
 
-* `--attrs=one two three`
-    Legacy name for --input-file - deprecated.
-* `--auto-install-gems`
-    Auto installs gem dependencies of the profile or resource pack.
-* `-b`, `--backend=BACKEND`
-    Choose a backend: local, ssh, winrm, docker.
-* `--backend-cache`, `--no-backend-cache`
-    Allow caching for backend command output. (default: true).
-* `--bastion-host=BASTION_HOST`
-    Specifies the bastion host if applicable.
-* `--bastion-port=BASTION_PORT`
-    Specifies the bastion port if applicable.
-* `--bastion-user=BASTION_USER`
-    Specifies the bastion user if applicable.
-* `--ca-trust-file=PATH_TO_CA_TRUST_FILE`
-    Specify CA certificate required for SSL authentication (WinRM).
-* `--client-cert=PATH_TO_CLIENT_CERTIFICATE`
-    Specify client certificate required for SSL authentication (WinRM).
-* `--client-key=PATH_TO_CLIENT_KEY`
-    Specify client key required with client certificate for SSL authentication (WinRM).
-* `--client-key-pass=CLIENT_CERT_PASSWORD`
-    Specify client certificate password, if required for SSL authentication (WinRM).
-* `--command-timeout=SECONDS`
-    Maximum seconds to allow a command to run.
-* `--config=CONFIG`
-    Read configuration from the JSON file (`-` reads from stdin).
-* `--controls=one two three`
-    A list of control names to run or a list of /regexes/ to match against control names. Ignore all other tests.
-* `--create-lockfile`, `--no-create-lockfile`
-    Write out a lockfile based on this execution (unless one already exists).
-* `--distinct-exit`, `--no-distinct-exit`
-    Exit with code 101 if any tests fail and 100 if any are skipped (default). If disabled, exit 0 on skips and 1 for failures.
-* `--docker-url`
-    Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.
-* `--enable-password=ENABLE_PASSWORD`
-    Password for enable mode on Cisco IOS devices.
-* `--filter-empty-profiles`, `--no-filter-empty-profiles`
-    Filter empty profiles (profiles without controls) from the report.
-* `--filter-waived-controls`
-    Do not execute waived controls in InSpec at all. Must use with --waiver-file. Ignores the `run` setting of the waiver file.
-* `--host=HOST`
-    Specify a remote host which is tested.
-* `--input=name1=value1 name2=value2`
-    Specify one or more inputs directly on the command line, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.
-* `--input-file=one two three`
-    Load one or more input files, a YAML file with values for the profile to use.
-* `--insecure`, `--no-insecure`
-    Disable SSL verification on select targets.
-* `-i`, `--key-files=one two three`
-    Login key or certificate file for a remote scan.
-* `--password=PASSWORD`
-    Login password for a remote scan, if required.
-* `--path=PATH`
-    Login path to use when connecting to the target (WinRM).
-* `-p`, `--port=N`
-    Specify the login port for a remote scan.
-* `--podman-url`
-    Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).
-* `--profiles-path=PROFILES_PATH`
-    Folder which contains referenced profiles.
-* `--proxy-command=PROXY_COMMAND`
-    Specifies the command to use to connect to the server.
-* `--reporter=one two:/output/file/path`
-    Enable one or more output reporters: cli, documentation, html2, progress, progress-bar, json, json-min, json-rspec, junit2, yaml.
-* `--reporter-backtrace-inclusion`, `--no-reporter-backtrace-inclusion`
-    Include a code backtrace in report data (default: true).
-* `--reporter-include-source`
-    Include full source code of controls in the CLI report.
-* `--reporter-message-truncation=REPORTER_MESSAGE_TRUNCATION`
-    Number of characters to truncate failure messages in report data (default: no truncation).
-* `--self-signed`, `--no-self-signed`
-    Allow remote scans with self-signed certificates (WinRM).
-* `--shell`, `--no-shell`
-    Run scans in a subshell. Only activates on Unix.
-* `--shell-command=SHELL_COMMAND`
-    Specify a particular shell to use.
-* `--shell-options=SHELL_OPTIONS`
-    Additional shell options.
-* `--show-progress`, `--no-show-progress`
-    Show progress while executing tests.
-* `--silence-deprecations=all|GROUP GROUP...`
-    Suppress deprecation warnings. See install_dir/etc/deprecations.json for a list of GROUPs or use 'all'.
-* `--ssh-config-file=one two three`
-    A list of paths to the SSH configuration file, for example: `~/.ssh/config` or `/etc/ssh/ssh_config`.
-* `--ssl`, `--no-ssl`
-    Use SSL for transport layer encryption (WinRM).
-* `--ssl-peer-fingerprint`
-    Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).
-* `--sudo`, `--no-sudo`
-    Run scans with sudo. Only activates on Unix and non-root user.
-* `--sudo-command=SUDO_COMMAND`
-    Alternate command for sudo.
-* `--sudo-options=SUDO_OPTIONS`
-    Additional sudo options for a remote scan.
-* `--sudo-password=SUDO_PASSWORD`
-    Specify a sudo password, if it is required.
-* `-t`, `--target=TARGET`
-    Simple targeting option using URIs, e.g. ssh://user:pass@host:port.
-* `--target-id=TARGET_ID`
-    Provide an ID that is included on reports - deprecated.
-* `--tags=one two three`
-    A list of tags or regular expressions that match tags. `exec` will run controls referenced by the listed or matching tags.
-* `--user=USER`
-    The login user for a remote scan.
-* `--vendor-cache=VENDOR_CACHE`
-    Use the given path for caching dependencies. (default: `~/.inspec/cache`).
-* `--waiver-file=one two three`
-    Load one or more waiver files.
-* `--winrm-basic-auth-only`, `--no-winrm-basic-auth-only`
-    Whether to use basic authentication, defaults to false (WinRM).
-* `--winrm-disable-sspi`, `--no-winrm-disable-sspi`
-    Whether to use disable sspi authentication, defaults to false (WinRM).
-* `--winrm-transport=WINRM_TRANSPORT`
-    Specify which transport to use, defaults to negotiate (WinRM).
-* `--enhanced-outcomes`
-    Includes enhanced outcome of controls in report data.
+`--attrs=one two three`
+    : Legacy name for --input-file - deprecated.
+    
+`--auto-install-gems`, `--no-auto-install-gems`
+    : Auto installs gem dependencies of the profile or resource pack.
+    
+`-b`, `--backend=BACKEND`
+    : Choose a backend: local, ssh, winrm, docker.
+    
+`--backend-cache`, `--no-backend-cache`
+    : Allow caching for backend command output. (default: true).
+    
+`--bastion-host=BASTION_HOST`
+    : Specifies the bastion host if applicable.
+    
+`--bastion-port=BASTION_PORT`
+    : Specifies the bastion port if applicable.
+    
+`--bastion-user=BASTION_USER`
+    : Specifies the bastion user if applicable.
+    
+`--ca-trust-file=CA_TRUST_FILE`
+    : Specify CA certificate required for SSL authentication (WinRM).
+    
+`--client-cert=CLIENT_CERT`
+    : Specify client certificate for SSL authentication
+    
+`--client-key=CLIENT_KEY`
+    : Specify client key required with client cert for SSL authentication
+    
+`--client-key-pass=CLIENT_KEY_PASS`
+    : Specify client cert password, if required for SSL authentication
+    
+`--command-timeout=N`
+    : Maximum seconds to allow commands to run during execution.
+    
+`--config=CONFIG`
+    : Read configuration from JSON file (`-` reads from stdin).
+    
+`--controls=one two three`
+    : A list of control names to run, or a list of /regexes/ to match against control names. Ignore all other tests.
+    
+`--create-lockfile`, `--no-create-lockfile`
+    : Write out a lockfile based on this execution (unless one already exists)
+    
+`--diff`, `--no-diff`
+    : Use --no-diff to suppress 'diff' output of failed textual test results.
+    
+`--distinct-exit`, `--no-distinct-exit`
+    : Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures.
+    
+`--docker-url=DOCKER_URL`
+    : Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.
+    
+`--enable-password=ENABLE_PASSWORD`
+    : Password for enable mode on Cisco IOS devices.
+    
+`--enhanced-outcomes`, `--no-enhanced-outcomes`
+    : Show enhanced outcomes in output
+    
+`--filter-empty-profiles`, `--no-filter-empty-profiles`
+    : Filter empty profiles (profiles without controls) from the report.
+    
+`--filter-waived-controls`, `--no-filter-waived-controls`
+    : Do not execute waived controls in InSpec at all. Must use with --waiver-file. Ignores the `run` setting of the waiver file.
+    
+`--host=HOST`
+    : Specify a remote host which is tested.
+    
+`--input=name1=value1 name2=value2`
+    : Specify one or more inputs directly on the command line, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.
+    
+`--input-file=one two three`
+    : Load one or more input files, a YAML file with values for the profile to use.
+    
+`--insecure`, `--no-insecure`
+    : Disable SSL verification on select targets.
+    
+`-i`, `--key-files=one two three`
+    : Login key or certificate file for a remote scan.
+    
+`--password=PASSWORD`
+    : Login password for a remote scan, if required.
+    
+`--path=PATH`
+    : Login path to use when connecting to the target (WinRM).
+    
+`--podman-url=PODMAN_URL`
+    : Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).
+    
+`-p`, `--port=N`
+    : Specify the login port for a remote scan.
+    
+`--profiles-path=PROFILES_PATH`
+    : Folder which contains referenced profiles.
+    
+`--proxy-command=PROXY_COMMAND`
+    : Specifies the command to use to connect to the server.
+    
+`--reporter=one two:/output/file/path`
+    : Enable one or more output reporters: cli, documentation, html, progress, progress-bar, json, json-min, json-rspec, junit, yaml
+    
+`--reporter-backtrace-inclusion`, `--no-reporter-backtrace-inclusion`
+    : Include a code backtrace in report data (default: true)
+    
+`--reporter-include-source`, `--no-reporter-include-source`
+    : Include full source code of controls in the CLI report
+    
+`--reporter-message-truncation=REPORTER_MESSAGE_TRUNCATION`
+    : Number of characters to truncate failure messages and code_desc in report data to (default: no truncation)
+    
+`--retain-waiver-data`, `--no-retain-waiver-data`
+    : EXPERIMENTAL: Only works in conjunction with --filter-waived-controls, retains waiver data about controls that were skipped
+    
+`--self-signed`, `--no-self-signed`
+    : Allow remote scans with self-signed certificates (WinRM).
+    
+`--shell`, `--no-shell`
+    : Run scans in a subshell. Only activates on Unix.
+    
+`--shell-command=SHELL_COMMAND`
+    : Specify a particular shell to use.
+    
+`--shell-options=SHELL_OPTIONS`
+    : Additional shell options.
+    
+`--show-progress`, `--no-show-progress`
+    : Show progress while executing tests.
+    
+`--silence-deprecations=all|GROUP GROUP...`
+    : Suppress deprecation warnings. See install_dir/etc/deprecations.json for a list of GROUPs or use 'all'.
+    
+`--sort-results-by=--sort-results-by=none|control|file|random`
+    : After normal execution order, results are sorted by control ID, or by file (default), or randomly. None uses legacy unsorted mode.
+    
+`--ssh-config-file=one two three`
+    : A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.
+    
+`--ssl`, `--no-ssl`
+    : Use SSL for transport layer encryption (WinRM).
+    
+`--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT`
+    : Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).
+    
+`--sudo`, `--no-sudo`
+    : Run scans with sudo. Only activates on Unix and non-root user.
+    
+`--sudo-command=SUDO_COMMAND`
+    : Alternate command for sudo.
+    
+`--sudo-options=SUDO_OPTIONS`
+    : Additional sudo options for a remote scan.
+    
+`--sudo-password=SUDO_PASSWORD`
+    : Specify a sudo password, if it is required.
+    
+`--supermarket-url=SUPERMARKET_URL`
+    : Specify the URL of a private Chef Supermarket.
+    
+`--tags=one two three`
+    : A list of tags names that are part of controls to filter and run controls, or a list of /regexes/ to match against tags names of controls. Ignore all other tests.
+    
+`-t`, `--target=TARGET`
+    : Simple targeting option using URIs, e.g. ssh://user:pass@host:port
+    
+`--target-id=TARGET_ID`
+    : Provide an ID which will be included on reports - deprecated
+    
+`--user=USER`
+    : The login user for a remote scan.
+    
+`--vendor-cache=VENDOR_CACHE`
+    : Use the given path for caching dependencies, (default: ~/.inspec/cache).
+    
+`--waiver-file=one two three`
+    : Load one or more waiver files.
+    
+`--winrm-basic-auth-only`, `--no-winrm-basic-auth-only`
+    : Whether to use basic authentication, defaults to false (WinRM).
+    
+`--winrm-disable-sspi`, `--no-winrm-disable-sspi`
+    : Whether to use disable sspi authentication, defaults to false (WinRM).
+    
+`--winrm-shell-type=WINRM_SHELL_TYPE`
+    : Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).
+    
+`--winrm-transport=WINRM_TRANSPORT`
+    : Specify which transport to use, defaults to negotiate (WinRM).
+    
 
-## habitat
+## export
 
-Create a Chef Habitat package.
+Read the profile in path and generate a summary in the given format.
 
 ### Syntax
 
 This subcommand has the following syntax:
 
 ```bash
-inspec habitat SUBCOMMAND
+inspec export PATH
 ```
+
+### Options
+
+This subcommand has the following additional options:
+
+`--auto-install-gems`, `--no-auto-install-gems`
+    : Auto installs gem dependencies of the profile or resource pack.
+    
+`--controls=one two three`
+    : For --what=profile, a list of controls to include. Ignore all other tests.
+    
+`--format=FORMAT`
+    : The output format to use: json, raw, yaml. If valid format is not provided then it will use the default for the given 'what'.
+    
+`-o`, `--output=OUTPUT`
+    : Save the created output to a path.
+    
+`--profiles-path=PROFILES_PATH`
+    : Folder which contains referenced profiles.
+    
+`--tags=one two three`
+    : For --what=profile, a list of tags to filter controls and include only those. Ignore all other tests.
+    
+`--vendor-cache=VENDOR_CACHE`
+    : Use the given path for caching dependencies, (default: ~/.inspec/cache).
+    
+`--what=WHAT`
+    : What to export: profile (default), readme, metadata.
+    
 
 ## help
 
-Describe available commands or one specific command.
+Describe available commands or one specific command
 
 ### Syntax
 
@@ -428,18 +583,6 @@ This subcommand has the following syntax:
 
 ```bash
 inspec help [COMMAND]
-```
-
-## init
-
-Scaffold a new project.
-
-### Syntax
-
-This subcommand has the following syntax:
-
-```bash
-inspec init TEMPLATE
 ```
 
 ## json
@@ -458,44 +601,40 @@ inspec json PATH
 
 This subcommand has the following additional options:
 
-* `--controls=one two three`
-    A list of controls to include. Ignore all other tests.
-* `-o`, `--output=OUTPUT`
-    Save the created profile to a path.
-* `--profiles-path=PROFILES_PATH`
-    Folder which contains referenced profiles.
-* `--tags=one two three`
-    A list of tags that reference specific controls. Other controls are ignored.
-* `--vendor-cache=VENDOR_CACHE`
-    Use the given path for caching dependencies. (default: `~/.inspec/cache`).
+`--auto-install-gems`, `--no-auto-install-gems`
+    : Auto installs gem dependencies of the profile or resource pack.
+    
+`--controls=one two three`
+    : A list of controls to include. Ignore all other tests.
+    
+`-o`, `--output=OUTPUT`
+    : Save the created profile to a path.
+    
+`--profiles-path=PROFILES_PATH`
+    : Folder which contains referenced profiles.
+    
+`--tags=one two three`
+    : A list of tags to filter controls and include only those. Ignore all other tests.
+    
+`--vendor-cache=VENDOR_CACHE`
+    : Use the given path for caching dependencies, (default: ~/.inspec/cache).
+    
 
-## nothing
+## run_context
 
-Does nothing.
-
-### Syntax
-
-This subcommand has the following syntax:
-
-```bash
-inspec nothing
-```
-
-## plugin
-
-Install and manage [Chef InSpec plugins](/inspec/plugins/).
+Used to test run-context detection
 
 ### Syntax
 
 This subcommand has the following syntax:
 
 ```bash
-inspec plugin SUBCOMMAND
+inspec run_context
 ```
 
 ## schema
 
-Print the json schema.
+Print the json schema
 
 ### Syntax
 
@@ -507,10 +646,11 @@ inspec schema NAME
 
 ### Options
 
-This subcommand has the following additional option:
+This subcommand has the following additional options:
 
-* `--enhanced-outcomes`
-    Includes enhanced outcome of controls in report data.
+`--enhanced-outcomes`, `--no-enhanced-outcomes`
+    : Show enhanced outcomes output
+    
 
 ## shell
 
@@ -528,96 +668,148 @@ inspec shell
 
 This subcommand has the following additional options:
 
-* `-b`, `--backend=BACKEND`
-    Choose a backend: local, ssh, winrm, docker.
-* `--bastion-host=BASTION_HOST`
-    Specifies the bastion host if applicable.
-* `--bastion-port=BASTION_PORT`
-    Specifies the bastion port if applicable.
-* `--bastion-user=BASTION_USER`
-    Specifies the bastion user if applicable.
-* `-c`, `--command=COMMAND`
-    A single command string to run instead of launching the shell.
-* `--command-timeout=SECONDS`
-    Maximum seconds to allow a command to run.
-* `--ca-trust-file=PATH_TO_CA_TRUST_FILE`
-    Specify CA certificate required for SSL authentication (WinRM).
-* `--client-cert=PATH_TO_CLIENT_CERTIFICATE`
-    Specify client certificate required for SSL authentication (WinRM).
-* `--client-key=PATH_TO_CLIENT_KEY`
-    Specify client key required with client certificate for SSL authentication (WinRM).
-* `--client-key-pass=CLIENT_CERT_PASSWORD`
-    Specify client certificate password, if required for SSL authentication (WinRM).
-* `--config=CONFIG`
-    Read configuration from the JSON file (`-` reads from stdin).
-* `--depends=one two three`
-    A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell.
-* `--distinct-exit`, `--no-distinct-exit`
-    Exit with code 100 if any tests fail and 101 if any are skipped, but none failed (default).  If disabled, exit 0 on skips and 1 for failures.
-* `--docker-url`
-    Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.
-* `--enable-password=ENABLE_PASSWORD`
-    Password for enable mode on Cisco IOS devices.
-* `--host=HOST`
-    Specify a remote host which is tested.
-* `--insecure`, `--no-insecure`
-    Disable SSL verification on select targets.
-* `--inspect`, `--no-inspect`
-    Use verbose/debugging output for resources.
-* `-i`, `--key-files=one two three`
-    Login key or certificate file for a remote scan.
-* `--password=PASSWORD`
-    Login password for a remote scan, if required.
-* `--path=PATH`
-    Login path to use when connecting to the target (WinRM).
-* `-p`, `--port=N`
-    Specify the login port for a remote scan.
-* `--podman-url`
-    Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).
-* `--proxy-command=PROXY_COMMAND`
-    Specifies the command to use to connect to the server.
-* `--reporter=one two:/output/file/path`
-    Enable one or more output reporters: cli, documentation, html2, progress, json, json-min, json-rspec, junit2.
-* `--self-signed`, `--no-self-signed`
-    Allow remote scans with self-signed certificates (WinRM).
-* `--shell`, `--no-shell`
-    Run scans in a subshell. Only activates on Unix.
-* `--shell-command=SHELL_COMMAND`
-    Specify a particular shell to use.
-* `--shell-options=SHELL_OPTIONS`
-    Additional shell options.
-* `--ssh-config-file=one two three`
-    A list of paths to the SSH configuration file, for example: `~/.ssh/config` or `/etc/ssh/ssh_config`.
-* `--ssl`, `--no-ssl`
-    Use SSL for transport layer encryption (WinRM).
-* `--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT`
-    Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).
-* `--sudo`, `--no-sudo`
-    Run scans with sudo. Only activates on Unix and non-root user.
-* `--sudo-command=SUDO_COMMAND`
-    Alternate command for sudo.
-* `--sudo-options=SUDO_OPTIONS`
-    Additional sudo options for a remote scan.
-* `--sudo-password=SUDO_PASSWORD`
-    Specify a sudo password, if it is required.
-* `-t`, `--target=TARGET`
-    Simple targeting option using URIs, e.g. ssh://user:pass@host:port.
-* `--target-id=TARGET_ID`
-    Provide a ID which will be included on reports.
-* `--user=USER`
-    The login user for a remote scan.
-* `--winrm-basic-auth-only`, `--no-winrm-basic-auth-only`
-    Whether to use basic authentication, defaults to false (WinRM).
-* `--winrm-disable-sspi`, `--no-winrm-disable-sspi`
-    Whether to use disable sspi authentication, defaults to false (WinRM).
-* `--winrm-transport=WINRM_TRANSPORT`
-    Specify which transport to use, defaults to negotiate (WinRM).
-* `--enhanced-outcomes`
-    Includes enhanced outcome of controls in report data.
+`-b`, `--backend=BACKEND`
+    : Choose a backend: local, ssh, winrm, docker.
+    
+`--bastion-host=BASTION_HOST`
+    : Specifies the bastion host if applicable.
+    
+`--bastion-port=BASTION_PORT`
+    : Specifies the bastion port if applicable.
+    
+`--bastion-user=BASTION_USER`
+    : Specifies the bastion user if applicable.
+    
+`--ca-trust-file=CA_TRUST_FILE`
+    : Specify CA certificate required for SSL authentication (WinRM).
+    
+`--client-cert=CLIENT_CERT`
+    : Specify client certificate for SSL authentication
+    
+`--client-key=CLIENT_KEY`
+    : Specify client key required with client cert for SSL authentication
+    
+`--client-key-pass=CLIENT_KEY_PASS`
+    : Specify client cert password, if required for SSL authentication
+    
+`-c`, `--command=COMMAND`
+    : A single command string to run instead of launching the shell
+    
+`--command-timeout=N`
+    : Maximum seconds to allow a command to run.
+    
+`--config=CONFIG`
+    : Read configuration from JSON file (`-` reads from stdin).
+    
+`--depends=one two three`
+    : A space-delimited list of local folders containing profiles whose libraries and resources will be loaded into the new shell
+    
+`--distinct-exit`, `--no-distinct-exit`
+    : Exit with code 100 if any tests fail, and 101 if any are skipped but none failed (default).  If disabled, exit 0 on skips and 1 for failures.
+    
+`--docker-url=DOCKER_URL`
+    : Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows.
+    
+`--enable-password=ENABLE_PASSWORD`
+    : Password for enable mode on Cisco IOS devices.
+    
+`--enhanced-outcomes`, `--no-enhanced-outcomes`
+    : Show enhanced outcomes in output
+    
+`--host=HOST`
+    : Specify a remote host which is tested.
+    
+`--input=name1=value1 name2=value2`
+    : Specify one or more inputs directly on the command line to the shell, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures.
+    
+`--input-file=one two three`
+    : Load one or more input files, a YAML file with values for the shell to use
+    
+`--insecure`, `--no-insecure`
+    : Disable SSL verification on select targets.
+    
+`--inspect`, `--no-inspect`
+    : Use verbose/debugging output for resources.
+    
+`-i`, `--key-files=one two three`
+    : Login key or certificate file for a remote scan.
+    
+`--password=PASSWORD`
+    : Login password for a remote scan, if required.
+    
+`--path=PATH`
+    : Login path to use when connecting to the target (WinRM).
+    
+`--podman-url=PODMAN_URL`
+    : Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user).
+    
+`-p`, `--port=N`
+    : Specify the login port for a remote scan.
+    
+`--proxy-command=PROXY_COMMAND`
+    : Specifies the command to use to connect to the server.
+    
+`--reporter=one two:/output/file/path`
+    : Enable one or more output reporters: cli, documentation, html, progress, json, json-min, json-rspec, junit
+    
+`--self-signed`, `--no-self-signed`
+    : Allow remote scans with self-signed certificates (WinRM).
+    
+`--shell`, `--no-shell`
+    : Run scans in a subshell. Only activates on Unix.
+    
+`--shell-command=SHELL_COMMAND`
+    : Specify a particular shell to use.
+    
+`--shell-options=SHELL_OPTIONS`
+    : Additional shell options.
+    
+`--ssh-config-file=one two three`
+    : A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config.
+    
+`--ssl`, `--no-ssl`
+    : Use SSL for transport layer encryption (WinRM).
+    
+`--ssl-peer-fingerprint=SSL_PEER_FINGERPRINT`
+    : Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM).
+    
+`--sudo`, `--no-sudo`
+    : Run scans with sudo. Only activates on Unix and non-root user.
+    
+`--sudo-command=SUDO_COMMAND`
+    : Alternate command for sudo.
+    
+`--sudo-options=SUDO_OPTIONS`
+    : Additional sudo options for a remote scan.
+    
+`--sudo-password=SUDO_PASSWORD`
+    : Specify a sudo password, if it is required.
+    
+`-t`, `--target=TARGET`
+    : Simple targeting option using URIs, e.g. ssh://user:pass@host:port
+    
+`--target-id=TARGET_ID`
+    : Provide an ID which will be included on reports - deprecated
+    
+`--user=USER`
+    : The login user for a remote scan.
+    
+`--winrm-basic-auth-only`, `--no-winrm-basic-auth-only`
+    : Whether to use basic authentication, defaults to false (WinRM).
+    
+`--winrm-disable-sspi`, `--no-winrm-disable-sspi`
+    : Whether to use disable sspi authentication, defaults to false (WinRM).
+    
+`--winrm-shell-type=WINRM_SHELL_TYPE`
+    : Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM).
+    
+`--winrm-transport=WINRM_TRANSPORT`
+    : Specify which transport to use, defaults to negotiate (WinRM).
+    
 
 ## supermarket
 
-Supermarket commands.
+Supermarket commands
 
 ### Syntax
 
@@ -627,16 +819,9 @@ This subcommand has the following syntax:
 inspec supermarket SUBCOMMAND ...
 ```
 
-### Options
-
-This subcommand has additional options:
-
-* `--supermarket_url`
-    Specify the URL of a private Chef Supermarket.
-
 ## vendor
 
-Download all dependencies and generate a lockfile in a `vendor` directory.
+Download all dependencies and generate a lockfile in a `vendor` directory
 
 ### Syntax
 
@@ -648,10 +833,11 @@ inspec vendor PATH
 
 ### Options
 
-This subcommand has additional options:
+This subcommand has the following additional options:
 
-* `--overwrite`, `--no-overwrite`
-    Overwrite existing vendored dependencies and lockfiles.
+`--overwrite`, `--no-overwrite`
+    : Overwrite existing vendored dependencies and lockfile.
+    
 
 ## version
 
@@ -669,4 +855,6 @@ inspec version
 
 This subcommand has the following additional options:
 
-* `--format=FORMAT`
+`--format=FORMAT`
+    
+

--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -100,11 +100,11 @@ module Inspec
       option :ssl, type: :boolean,
         desc: "Use SSL for transport layer encryption (WinRM)."
       option :ssl_peer_fingerprint, type: :string,
-        desc: "Specify peer fingerprint for SSL authentication, used in lieu of certificates"
+        desc: "Specify SSL peer fingerprint in place of certificates for SSL authentication (WinRM)."
       option :self_signed, type: :boolean,
         desc: "Allow remote scans with self-signed certificates (WinRM)."
       option :ca_trust_file, type: :string,
-        desc: "Specify CA trust file for SSL authentication"
+        desc: "Specify CA certificate required for SSL authentication (WinRM)."
       option :client_cert, type: :string,
         desc: "Specify client certificate for SSL authentication"
       option :client_key, type: :string,
@@ -121,32 +121,32 @@ module Inspec
         desc: "Read configuration from JSON file (`-` reads from stdin)."
       option :json_config, type: :string, hide: true
       option :proxy_command, type: :string,
-        desc: "Specifies the command to use to connect to the server"
+        desc: "Specifies the command to use to connect to the server."
       option :bastion_host, type: :string,
-        desc: "Specifies the bastion host if applicable"
+        desc: "Specifies the bastion host if applicable."
       option :bastion_user, type: :string,
-        desc: "Specifies the bastion user if applicable"
+        desc: "Specifies the bastion user if applicable."
       option :bastion_port, type: :string,
-        desc: "Specifies the bastion port if applicable"
+        desc: "Specifies the bastion port if applicable."
       option :insecure, type: :boolean, default: false,
-        desc: "Disable SSL verification on select targets"
+        desc: "Disable SSL verification on select targets."
       option :target_id, type: :string,
-        desc: "Provide a ID which will be included on reports - deprecated"
+        desc: "Provide an ID which will be included on reports - deprecated"
       option :winrm_shell_type, type: :string, default: "powershell",
-        desc: "Specify a shell type for winrm (eg. 'elevated' or 'powershell')"
+        desc: "Specify which shell type to use (powershell, elevated, or cmd), which defaults to powershell (WinRM)."
       option :docker_url, type: :string,
-        desc: "Provides path to Docker API endpoint (Docker)"
+        desc: "Provides path to Docker API endpoint (Docker). Defaults to unix:///var/run/docker.sock on Unix systems and tcp://localhost:2375 on Windows."
       option :ssh_config_file, type: :array,
-        desc: "A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config"
+        desc: "A list of paths to the ssh config file, e.g ~/.ssh/config or /etc/ssh/ssh_config."
       option :podman_url, type: :string,
-        desc: "Provides path to Podman API endpoint"
+        desc: "Provides the path to the Podman API endpoint. Defaults to unix:///run/user/$UID/podman/podman.sock for rootless container, unix:///run/podman/podman.sock for rootful container (for this you need to execute inspec as root user)."
     end
 
     def self.profile_options
       option :profiles_path, type: :string,
         desc: "Folder which contains referenced profiles."
       option :vendor_cache, type: :string,
-        desc: "Use the given path for caching dependencies. (default: ~/.inspec/cache)"
+        desc: "Use the given path for caching dependencies, (default: ~/.inspec/cache)."
       option :auto_install_gems, type: :boolean, default: false,
         desc: "Auto installs gem dependencies of the profile or resource pack."
     end
@@ -174,7 +174,7 @@ module Inspec
       option :input, type: :array, banner: "name1=value1 name2=value2",
         desc: "Specify one or more inputs directly on the command line, as --input NAME=VALUE. Accepts single-quoted YAML and JSON structures."
       option :input_file, type: :array,
-        desc: "Load one or more input files, a YAML file with values for the profile to use"
+        desc: "Load one or more input files, a YAML file with values for the profile to use."
       option :waiver_file, type: :array,
         desc: "Load one or more waiver files."
       option :attrs, type: :array,
@@ -182,14 +182,14 @@ module Inspec
       option :create_lockfile, type: :boolean,
         desc: "Write out a lockfile based on this execution (unless one already exists)"
       option :backend_cache, type: :boolean,
-        desc: "Allow caching for backend command output. (default: true)"
+        desc: "Allow caching for backend command output. (default: true)."
       option :show_progress, type: :boolean,
         desc: "Show progress while executing tests."
       option :distinct_exit, type: :boolean, default: true,
         desc: "Exit with code 101 if any tests fail, and 100 if any are skipped (default).  If disabled, exit 0 on skips and 1 for failures."
       option :silence_deprecations, type: :array,
         banner: "[all]|[GROUP GROUP...]",
-        desc: "Suppress deprecation warnings. See install_dir/etc/deprecations.json for list of GROUPs or use 'all'."
+        desc: "Suppress deprecation warnings. See install_dir/etc/deprecations.json for a list of GROUPs or use 'all'."
       option :diff, type: :boolean, default: true,
         desc: "Use --no-diff to suppress 'diff' output of failed textual test results."
       option :sort_results_by, type: :string, default: "file", banner: "--sort-results-by=none|control|file|random",
@@ -197,7 +197,7 @@ module Inspec
       option :filter_empty_profiles, type: :boolean, default: false,
         desc: "Filter empty profiles (profiles without controls) from the report."
       option :filter_waived_controls, type: :boolean,
-        desc: "Do not execute waived controls in InSpec at all. Must use with --waiver-file. Ignores `run` setting of waiver file."
+        desc: "Do not execute waived controls in InSpec at all. Must use with --waiver-file. Ignores the `run` setting of the waiver file."
       option :retain_waiver_data, type: :boolean,
         desc: "EXPERIMENTAL: Only works in conjunction with --filter-waived-controls, retains waiver data about controls that were skipped"
       option :command_timeout, type: :numeric,

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -61,9 +61,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   require "license_acceptance/cli_flags/thor"
   include LicenseAcceptance::CLIFlags::Thor
 
-  desc "json PATH", "read all tests in PATH and generate a JSON summary"
+  desc "json PATH", "read all tests in the PATH and generate a JSON summary."
   option :output, aliases: :o, type: :string,
-    desc: "Save the created profile to a path"
+    desc: "Save the created profile to a path."
   option :controls, type: :array,
     desc: "A list of controls to include. Ignore all other tests."
   option :tags, type: :array,
@@ -81,7 +81,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :format, type: :string,
     desc: "The output format to use: json, raw, yaml. If valid format is not provided then it will use the default for the given 'what'."
   option :output, aliases: :o, type: :string,
-    desc: "Save the created output to a path"
+    desc: "Save the created output to a path."
   option :controls, type: :array,
     desc: "For --what=profile, a list of controls to include. Ignore all other tests."
   option :tags, type: :array,
@@ -145,9 +145,11 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     pretty_handle_exception(e)
   end
 
-  desc "check PATH", "verify all tests at the specified PATH"
+  desc "check PATH", "Verify the metadata in the `inspec.yml` file,\
+  verify that control blocks have the correct fields (title, description, impact),\
+  and define that all controls have visible tests and the controls are not using deprecated InSpec DSL code"
   option :format, type: :string,
-    desc: "The output format to use doc (default), json. If valid format is not provided then it will use the default."
+    desc: "The output format to use. Valid values: `json` and `doc`. Default value: `doc`."
   option :with_cookstyle, type: :boolean,
     desc: "Enable or disable cookstyle checks.", default: false
   profile_options
@@ -228,10 +230,10 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     vendor_deps(path, o)
   end
 
-  desc "archive PATH", "archive a profile to tar.gz (default) or zip"
+  desc "archive PATH", "Archive a profile to a tar file (default) or zip file."
   profile_options
   option :output, aliases: :o, type: :string,
-    desc: "Save the archive to a path"
+    desc: "Save the archive to a path."
   option :zip, type: :boolean, default: false,
     desc: "Generates a zip archive."
   option :tar, type: :boolean, default: false,
@@ -275,14 +277,10 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     pretty_handle_exception(e)
   end
 
-  desc "exec LOCATIONS", "Run all tests at LOCATIONS."
+  desc "exec LOCATIONS", "Run all test files at the specified locations."
   long_desc <<~EOT
-    Run all test files at the specified LOCATIONS.
-
-    Loads the given profile(s) and fetches their dependencies if needed. Then
-    connects to the target and executes any controls contained in the profiles.
-    One or more reporters are used to generate output.
-
+    The subcommand loads the given profiles, fetches their dependencies if needed, then connects to the target and executes any controls in the profiles.
+    One or more reporters are used to generate the output.
     ```
     Exit codes:
         0  Normal exit, all tests passed
@@ -296,7 +294,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 
     Below are some examples of using `exec` with different test LOCATIONS:
 
-    Automate:
+    Chef Automate:
       ```
       #{Inspec::Dist::EXEC_NAME} automate login
       #{Inspec::Dist::EXEC_NAME} exec compliance://username/linux-baseline
@@ -306,7 +304,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       #{Inspec::Dist::EXEC_NAME} compliance login
       ```
 
-    Supermarket:
+    Chef Supermarket:
       ```
       #{Inspec::Dist::EXEC_NAME} exec supermarket://username/linux-baseline
       ```
@@ -343,12 +341,12 @@ class Inspec::InspecCLI < Inspec::BaseCLI
       #{Inspec::Dist::EXEC_NAME} exec https://github.com/dev-sec/linux-baseline.git
       ```
 
-    Web hosted fileshare (also supports .zip):
+    Web hosted file (also supports .zip):
       ```
       #{Inspec::Dist::EXEC_NAME} exec https://webserver/linux-baseline.tar.gz
       ```
 
-    Web hosted fileshare with basic authentication (supports .zip):
+    Web hosted file with basic authentication (supports .zip):
       ```
       #{Inspec::Dist::EXEC_NAME} exec https://username:password@webserver/linux-baseline.tar.gz
       ```
@@ -371,7 +369,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     pretty_handle_exception(e)
   end
 
-  desc "detect", "detect the target OS"
+  desc "detect", "detects the target OS."
   target_options
   option :format, type: :string
   def detect
@@ -396,7 +394,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     pretty_handle_exception(e)
   end
 
-  desc "shell", "open an interactive debugging shell"
+  desc "shell", "open an interactive debugging shell."
   target_options
   option :command, aliases: :c,
     desc: "A single command string to run instead of launching the shell"
@@ -455,7 +453,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     pretty_handle_exception(e)
   end
 
-  desc "env", "Output shell-appropriate completion configuration"
+  desc "env", "Outputs shell-appropriate completion configuration."
   def env(shell = nil)
     p = Inspec::EnvPrinter.new(self.class, shell)
     p.print_and_exit!
@@ -481,7 +479,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     puts Inspec::Telemetry::RunContextProbe.guess_run_context
   end
 
-  desc "version", "prints the version of this tool"
+  desc "version", "prints the version of this tool."
   option :format, type: :string
   def version
     if config["format"] == "json"
@@ -495,7 +493,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 
   desc "clear_cache", "clears the InSpec cache. Useful for debugging."
   option :vendor_cache, type: :string,
-    desc: "Use the given path for caching dependencies. (default: ~/.inspec/cache)"
+    desc: "Use the given path for caching dependencies, (default: `~/.inspec/cache`)."
   def clear_cache
     o = config
     configure_logger(o)

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -59,7 +59,7 @@ class Markdown
     end
 
     def dl(msg)
-      "<dl>\n#{msg}</dl>\n"
+      "<dl>\n#{msg}</dl>\n\n"
     end
 
     def ul(msg)
@@ -179,10 +179,10 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
             .map { |x| x.start_with?("-") ? x : "-" + x }
             .map { |x| "<code>" + x + "</code>" }
           msg = "<dt>#{usage.join(", ")}</dt>\n"
-          msg << "<dd> #{opt.description}</dd>\n" if opt.description && !opt.description.empty?
-          list << f.dl(msg)
+          msg << "<dd>#{opt.description}</dd>\n\n" if opt.description && !opt.description.empty?
+          list << msg
         end.join
-        res << f.ul(list)
+        res << f.dl(list)
       end
 
       # FIXME: for some reason we have extra lines in our RST; needs investigation

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -14,10 +14,7 @@
 # limitations under the License.
 #
 
-require "erb"
 require "fileutils"
-require "yaml"
-require "git"
 
 DOCS_DIR = "docs-chef-io/content/inspec".freeze
 

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -59,7 +59,7 @@ class Markdown
     end
 
     def dl(msg)
-      "#{msg.gsub("\n", "\n    ")}\n"
+      "<dl>\n#{msg}</dl>\n"
     end
 
     def ul(msg)
@@ -177,9 +177,9 @@ namespace :docs do # rubocop:disable Metrics/BlockLength
           usage = opt.usage.split(", ")
             .map { |x| x.tr("[]", "") }
             .map { |x| x.start_with?("-") ? x : "-" + x }
-            .map { |x| "`" + x + "`" }
-          msg = "#{usage.join(", ")}\n"
-          msg << ": #{opt.description}\n" if opt.description && !opt.description.empty?
+            .map { |x| "<code>" + x + "</code>" }
+          msg = "<dt>#{usage.join(", ")}</dt>\n"
+          msg << "<dd> #{opt.description}</dd>\n" if opt.description && !opt.description.empty?
           list << f.dl(msg)
         end.join
         res << f.ul(list)


### PR DESCRIPTION
Signed-off-by: Sonu Saha <sonu.saha@progress.com>

## Description
- Modify the existing `docs:cli` rake task to generate [current CLI docs page](https://github.com/inspec/inspec/blob/main/docs-chef-io/content/inspec/cli.md)
- Modify few description of commands in the base_cli and cli file.
- Generate a fresh copy of cli docs using the rake task

## Related Issue
**CFINSPEC-554: Update CLI Docs rake task to work with current InSpec docs.**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
