### PR TITLE
CFINSPEC-557: Add ruby-msys2-devkit as omnibus build dependency.

### DIFF
--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -52,6 +52,8 @@ dependency "shebang-cleanup"
 # Ensure our SSL cert files are accessible to ruby.
 dependency "openssl-customization"
 
+dependency "ruby-msys2-devkit" if windows?
+
 package :rpm do
   signing_passphrase ENV["OMNIBUS_RPM_SIGNING_PASSPHRASE"]
   compression_level 1

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -7,3 +7,5 @@ override "ruby", version: "3.1.2"
 
 # Mac m1
 override "openssl", version: "1.1.1m" if mac_os_x?
+
+override "ruby-msys2-devkit", version: "3.1.2-1"


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This resolves the below issue which we encountered after installing Windows package for inspec

```
PS C:\Users\Administrator> inspec version
<internal:C:/opscode/inspec/embedded/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': 126: The specified module could not be found.   - C:/opscode/inspec/embedded/lib/ruby/3.1.0/x64-mingw-ucrt/openssl.so (LoadError)
        from <internal:C:/opscode/inspec/embedded/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from C:/opscode/inspec/embedded/lib/ruby/3.1.0/openssl.rb:15:in `<top (required)>'
        from <internal:C:/opscode/inspec/embedded/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:C:/opscode/inspec/embedded/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from C:/opscode/inspec/bin/inspec:9:in `<main>'
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
