### PR TITLE
Update copyright year in README, attempt 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ KITCHEN_YAML=kitchen.dokken.yml bundle exec kitchen test -c 3
 | **Author:**    | Christoph Hartmann (<chartmann@chef.io>)       |
 | **Copyright:** | Copyright (c) 2015 Vulcano Security GmbH.      |
 | **Copyright:** | Copyright (c) 2017-2020 Chef Software Inc.     |
-| **Copyright:** | Copyright (c) 2020-2022 Progress Software Corp.|
+| **Copyright:** | Copyright (c) 2020-2023 Progress Software Corp.|
 | **License:**   | Apache License, Version 2.0                    |
 | **License:**   | Chef End User License Agreement                |
 


### PR DESCRIPTION
Updates the copyright year in the README to 2023.

We need a PR put in to the release to make sure the version bumps to 5.21.28; we had an expeditor failure on the last merge.

This is a re-open of a previous PR, to investigate an expeditor outage.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
