### PR TITLE
CFINSPEC-573: Fix for mongodb_session resource prints debug level of information in profile run result.

### DIFF
--- a/lib/inspec/resources/mongodb_session.rb
+++ b/lib/inspec/resources/mongodb_session.rb
@@ -84,6 +84,11 @@ module Inspec::Resources
       options[:ssl_cert] = @ssl_cert unless @ssl_cert.nil?
       options[:ssl_ca_cert] = @ssl_ca_cert unless @ssl_ca_cert.nil?
 
+      # Setting the logger level to INFO as mongo gem version 2.13.2 is using DEBUG as the log level Ref: https://github.com/mongodb/mongo-ruby-driver/blob/v2.13.2/lib/mongo/logger.rb#L79
+      # Latest version of the mongo gem don't have this issue as it set to INFO level Ref: https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/logger.rb#L82
+      # We pinned the version to 2.13.2 as the latest version of the mongo gem has broken symlink https://jira.mongodb.org/browse/RUBY-2546 which causes omnibus build failure.
+      # Once we get the latest version working we can remove logger level set here.
+      Mongo::Logger.logger.level = Logger::INFO
       @client = Mongo::Client.new([ "#{host}:#{port}" ], options)
 
     rescue => e


### PR DESCRIPTION

Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Following is the output before the change
```
Resolving dependencies...

D, [2023-02-01T11:33:28.171081 #50990] DEBUG -- : MONGODB | Topology type 'unknown' initializing.
D, [2023-02-01T11:33:28.171260 #50990] DEBUG -- : MONGODB | There was a change in the members of the 'Unknown' topology.
D, [2023-02-01T11:33:28.171357 #50990] DEBUG -- : MONGODB | Server 35.86.120.71:27017 initializing.
D, [2023-02-01T11:33:28.171527 #50990] DEBUG -- : MONGODB | Waiting for up to 30.00 seconds for servers to be scanned: #<Cluster topology=Unknown[35.86.120.71:27017] servers=[#<Server address=35.86.120.71:27017 UNKNOWN>]>
D, [2023-02-01T11:33:28.690073 #50990] DEBUG -- : MONGODB | Server description for 35.86.120.71:27017 changed from 'unknown' to 'standalone'.
D, [2023-02-01T11:33:28.690381 #50990] DEBUG -- : MONGODB | Topology type 'Unknown' changed to type 'Single'.
D, [2023-02-01T11:33:29.204761 #50990] DEBUG -- : MONGODB | Server description for 35.86.120.71:27017 changed from 'standalone' to 'standalone'.
D, [2023-02-01T11:33:29.204892 #50990] DEBUG -- : MONGODB | There was a change in the members of the 'Single' topology.
D, [2023-02-01T11:33:29.210588 #50990] DEBUG -- : MONGODB | 35.86.120.71:27017 req:8 conn:1:1 sconn:31 | my_db.saslContinue | STARTED | {}
D, [2023-02-01T11:33:29.468354 #50990] DEBUG -- : MONGODB | 35.86.120.71:27017 req:8 | my_db.saslContinue | SUCCEEDED | 0.258s
D, [2023-02-01T11:33:29.469114 #50990] DEBUG -- : MONGODB | 35.86.120.71:27017 req:9 conn:1:1 sconn:31 | my_db.usersInfo | STARTED | {"usersInfo"=>"inspecuser", "$db"=>"my_db", "lsid"=>{"id"=><BSON::Binary:0x30500 type=uuid data=0xc946f29950fd4b67...>}}
D, [2023-02-01T11:33:29.724625 #50990] DEBUG -- : MONGODB | 35.86.120.71:27017 req:9 | my_db.usersInfo | SUCCEEDED | 0.255s
D, [2023-02-01T11:33:29.725846 #50990] DEBUG -- : MONGODB | Topology type 'unknown' initializing.
D, [2023-02-01T11:33:29.726048 #50990] DEBUG -- : MONGODB | There was a change in the members of the 'Unknown' topology.
D, [2023-02-01T11:33:29.726161 #50990] DEBUG -- : MONGODB | Server 35.86.120.71:27017 initializing.
D, [2023-02-01T11:33:29.726275 #50990] DEBUG -- : MONGODB | Waiting for up to 30.00 seconds for servers to be scanned: #<Cluster topology=Unknown[35.86.120.71:27017] servers=[#<Server address=35.86.120.71:27017 UNKNOWN>]>
D, [2023-02-01T11:33:30.240507 #50990] DEBUG -- : MONGODB | Server description for 35.86.120.71:27017 changed from 'unknown' to 'standalone'.
D, [2023-02-01T11:33:30.241036 #50990] DEBUG -- : MONGODB | Topology type 'Unknown' changed to type 'Single'.
D, [2023-02-01T11:33:31.476679 #50990] DEBUG -- : MONGODB | Server description for 35.86.120.71:27017 changed from 'standalone' to 'standalone'.
D, [2023-02-01T11:33:31.476795 #50990] DEBUG -- : MONGODB | There was a change in the members of the 'Single' topology.
D, [2023-02-01T11:33:31.477172 #50990] DEBUG -- : MONGODB | 35.86.120.71:27017 req:13 conn:1:1 sconn:34 | my_db.saslContinue | STARTED | {}
D, [2023-02-01T11:33:31.731635 #50990] DEBUG -- : MONGODB | 35.86.120.71:27017 req:13 | my_db.saslContinue | SUCCEEDED | 0.254s
D, [2023-02-01T11:33:31.732105 #50990] DEBUG -- : MONGODB | 35.86.120.71:27017 req:14 conn:1:1 sconn:34 | my_db.buildInfo | STARTED | {"buildInfo"=>1, "$db"=>"my_db", "lsid"=>{"id"=><BSON::Binary:0x30620 type=uuid data=0x8fa71f82b1f34db9...>}}
D, [2023-02-01T11:33:31.987204 #50990] DEBUG -- : MONGODB | 35.86.120.71:27017 req:14 | my_db.buildInfo | SUCCEEDED | 0.255s

Profile:   tests from ./test/integration/db/mongodb (tests from ..test.integration.db.mongodb)
Version:   (not specified)
Target:    ssh://ubuntu@ec2-35-86-120-71.us-west-2.compute.amazonaws.com:22
Target ID: 239b0369-c36a-52c8-8ab8-6b93256e7a19

  {"role"=>"readWrite", "db"=>"my_db"}
     ✔  ["role"] is expected to eq "readWrite"
  {"version"=>"4.4.18", "gitVersion"=>"8ed32b5c2c68ebe7f8ae2ebe8d23f36037a17dea", "modules"=>[], "allocator"=>"tcmalloc", "javascriptEngine"=>"mozjs", "sysInfo"=>"deprecated", "versionArray"=>[4, 4, 18, 0], "openssl"=>{"running"=>"OpenSSL 1.1.1f  31 Mar 2020", "compiled"=>"OpenSSL 1.1.1f  31 Mar 2020"}, "buildEnvironment"=>{"distmod"=>"ubuntu2004", "distarch"=>"x86_64", "cc"=>"/opt/mongodbtoolchain/v3/bin/gcc: gcc (GCC) 8.5.0", "ccflags"=>"-ffp-contract=off -fno-omit-frame-pointer -fno-strict-aliasing -fasynchronous-unwind-tables -ggdb -pthread -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -Werror -O2 -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-const-variable -Wno-unused-but-set-variable -Wno-missing-braces -fstack-protector-strong -fno-builtin-memcmp", "cxx"=>"/opt/mongodbtoolchain/v3/bin/g++: g++ (GCC) 8.5.0", "cxxflags"=>"-Woverloaded-virtual -Wno-maybe-uninitialized -fsized-deallocation -std=c++17", "linkflags"=>"-pthread -Wl,-z,now -rdynamic -Wl,--fatal-warnings -fstack-protector-strong -fuse-ld=gold -Wl,--no-threads -Wl,--build-id -Wl,--hash-style=gnu -Wl,-z,noexecstack -Wl,--warn-execstack -Wl,-z,relro -Wl,-z,origin -Wl,--enable-new-dtags", "target_arch"=>"x86_64", "target_os"=>"linux", "cppdefines"=>"SAFEINT_USE_INTRINSICS 0 PCRE_STATIC NDEBUG _XOPEN_SOURCE 700 _GNU_SOURCE _FORTIFY_SOURCE 2 BOOST_THREAD_VERSION 5 BOOST_THREAD_USES_DATETIME BOOST_SYSTEM_NO_DEPRECATED BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS BOOST_ENABLE_ASSERT_DEBUG_HANDLER BOOST_LOG_NO_SHORTHAND_NAMES BOOST_LOG_USE_NATIVE_SYSLOG BOOST_LOG_WITHOUT_THREAD_ATTR ABSL_FORCE_ALIGNED_ACCESS"}, "bits"=>64, "debug"=>false, "maxBsonObjectSize"=>16777216, "storageEngines"=>["biggie", "devnull", "ephemeralForTest", "wiredTiger"], "ok"=>1.0}
     ×  ["version"] is expected to eq "4.4.6"
     
     expected: "4.4.6"
          got: "4.4.18"
     
     (compared using ==)


Test Summary: 1 successful, 1 failure, 0 skipped
```

output after change:
```
Resolving dependencies...
bundle exec inspec exec ./test/integration/db/mongodb --input-file mongo_terraform/.vjagdale-attributes.yml --reporter cli --no-distinct-exit -t ssh://ubuntu@ec2-35-86-120-71.us-west-2.compute.amazonaws.com -i mongo_terraform/inspec-db-test.pem --chef-license accept-silent

Profile:   tests from ./test/integration/db/mongodb (tests from ..test.integration.db.mongodb)
Version:   (not specified)
Target:    ssh://ubuntu@ec2-35-86-120-71.us-west-2.compute.amazonaws.com:22
Target ID: 239b0369-c36a-52c8-8ab8-6b93256e7a19

  {"role"=>"readWrite", "db"=>"my_db"}
     ✔  ["role"] is expected to eq "readWrite"
  {"version"=>"4.4.18", "gitVersion"=>"8ed32b5c2c68ebe7f8ae2ebe8d23f36037a17dea", "modules"=>[], "allocator"=>"tcmalloc", "javascriptEngine"=>"mozjs", "sysInfo"=>"deprecated", "versionArray"=>[4, 4, 18, 0], "openssl"=>{"running"=>"OpenSSL 1.1.1f  31 Mar 2020", "compiled"=>"OpenSSL 1.1.1f  31 Mar 2020"}, "buildEnvironment"=>{"distmod"=>"ubuntu2004", "distarch"=>"x86_64", "cc"=>"/opt/mongodbtoolchain/v3/bin/gcc: gcc (GCC) 8.5.0", "ccflags"=>"-ffp-contract=off -fno-omit-frame-pointer -fno-strict-aliasing -fasynchronous-unwind-tables -ggdb -pthread -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -Werror -O2 -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-const-variable -Wno-unused-but-set-variable -Wno-missing-braces -fstack-protector-strong -fno-builtin-memcmp", "cxx"=>"/opt/mongodbtoolchain/v3/bin/g++: g++ (GCC) 8.5.0", "cxxflags"=>"-Woverloaded-virtual -Wno-maybe-uninitialized -fsized-deallocation -std=c++17", "linkflags"=>"-pthread -Wl,-z,now -rdynamic -Wl,--fatal-warnings -fstack-protector-strong -fuse-ld=gold -Wl,--no-threads -Wl,--build-id -Wl,--hash-style=gnu -Wl,-z,noexecstack -Wl,--warn-execstack -Wl,-z,relro -Wl,-z,origin -Wl,--enable-new-dtags", "target_arch"=>"x86_64", "target_os"=>"linux", "cppdefines"=>"SAFEINT_USE_INTRINSICS 0 PCRE_STATIC NDEBUG _XOPEN_SOURCE 700 _GNU_SOURCE _FORTIFY_SOURCE 2 BOOST_THREAD_VERSION 5 BOOST_THREAD_USES_DATETIME BOOST_SYSTEM_NO_DEPRECATED BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS BOOST_ENABLE_ASSERT_DEBUG_HANDLER BOOST_LOG_NO_SHORTHAND_NAMES BOOST_LOG_USE_NATIVE_SYSLOG BOOST_LOG_WITHOUT_THREAD_ATTR ABSL_FORCE_ALIGNED_ACCESS"}, "bits"=>64, "debug"=>false, "maxBsonObjectSize"=>16777216, "storageEngines"=>["biggie", "devnull", "ephemeralForTest", "wiredTiger"], "ok"=>1.0}
     ×  ["version"] is expected to eq "4.4.6"
     
     expected: "4.4.6"
          got: "4.4.18"
     
     (compared using ==)


Test Summary: 1 successful, 1 failure, 0 skipped
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
