### PR TITLE
CFINSPEC-576 : Fix profile gem dependency loading issue when dependent gem is required inside profile libraries.

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -383,24 +383,22 @@ module Inspec
       @runner_context
     end
 
-    def collect_gem_dependencies(profile_context)
+    def collect_gem_dependencies
       gem_dependencies = []
-      all_profiles = []
-      profile_context.dependencies.list.values.each do |requirement|
-        all_profiles << requirement.profile
-      end
-      all_profiles << self
-      all_profiles.each do |profile|
+      locked_dependencies.dep_list.each do |_name, dep|
+        profile = dep.profile
         gem_dependencies << profile.metadata.gem_dependencies unless profile.metadata.gem_dependencies.empty?
       end
+      gem_dependencies << metadata.gem_dependencies
       gem_dependencies.flatten.uniq
     end
 
     # Loads the required gems specified in the Profile's metadata file from default inspec gems path i.e. ~/.inspec/gems
     # else installs and loads them.
     def load_gem_dependencies
-      gem_dependencies = collect_gem_dependencies(load_libraries)
+      gem_dependencies = collect_gem_dependencies
       gem_dependencies.each do |gem_data|
+
         dependency_loader = DependencyLoader.new
         if dependency_loader.gem_version_installed?(gem_data[:name], gem_data[:version]) ||
             dependency_loader.gem_installed?(gem_data[:name])

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -383,13 +383,16 @@ module Inspec
       @runner_context
     end
 
+    # This collects the gem dependencies data from parent and its dependent profiles
     def collect_gem_dependencies
       gem_dependencies = []
+      # This collects the dependent profiles gem dependencies if any
       locked_dependencies.dep_list.each do |_name, dep|
         profile = dep.profile
         gem_dependencies << profile.metadata.gem_dependencies unless profile.metadata.gem_dependencies.empty?
       end
-      gem_dependencies << metadata.gem_dependencies
+      # Appends the parent profile gem dependencies which are available through metadata
+      gem_dependencies << metadata.gem_dependencies unless metadata.gem_dependencies.empty?
       gem_dependencies.flatten.uniq
     end
 

--- a/test/fixtures/profiles/profile-with-gem-dependency/controls/example.rb
+++ b/test/fixtures/profiles/profile-with-gem-dependency/controls/example.rb
@@ -1,11 +1,5 @@
-require "money"
-
 control "tmp-1.0" do
-  Money.rounding_mode = BigDecimal::ROUND_HALF_UP
-  m = Money.from_cents(1000, "USD")
-  cents = m.cents
-
-  describe cents do
+  describe money_converter.cents do
     it { should eq 1000 }
   end
 end

--- a/test/fixtures/profiles/profile-with-gem-dependency/libraries/money_converter.rb
+++ b/test/fixtures/profiles/profile-with-gem-dependency/libraries/money_converter.rb
@@ -4,6 +4,7 @@ class MoneyConverter < Inspec.resource(1)
   name "money_converter"
 
   supports platform: "unix"
+  supports platform: "windows"
 
   desc "money_converter"
     example <<~EXAMPLE

--- a/test/fixtures/profiles/profile-with-gem-dependency/libraries/money_converter.rb
+++ b/test/fixtures/profiles/profile-with-gem-dependency/libraries/money_converter.rb
@@ -1,0 +1,30 @@
+require "money"
+
+class MoneyConverter < Inspec.resource(1)
+  name "money_converter"
+
+  supports platform: "unix"
+
+  desc "money_converter"
+    example <<~EXAMPLE
+      describe money_converter.cents do
+        it { should eq 1000 }
+      end
+    EXAMPLE
+
+    def initialize
+      # select permissions style
+      Money.locale_backend = nil
+      Money.default_currency = "USD"
+      Money.rounding_mode = BigDecimal::ROUND_HALF_UP
+    end
+
+    def cents
+      m = Money.from_cents(1000, "USD")
+      m.cents
+    end
+
+    def to_s
+      "MoneyConverter"
+    end
+end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This fixes the profile gem dependency loading issue when the gem is required inside profile libraries.
An earlier call to load_libraries to get the gem dependencies was resulting in actually loading the libraries before installing the gem due to which it was unable to find the required gem. Found that we can fetch the gem dependencies using locked_dependencies without calling the method load_libraries
 Here is the failing test https://buildkite.com/chef-oss/inspec-inspec-main-verify/builds/5273#01862a94-0632-4bc7-9e6e-9094102e73f7/1212-1215



## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
