### PR TITLE
Foreport 6240: Update chefstyle from 2.0.x to 2.2.2 to use RuboCop 1.25.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :omnibus do
 end
 
 group :test do
-  gem "chefstyle", "~> 2.0.3"
+  gem "chefstyle", "~> 2.2.2"
   gem "concurrent-ruby", "~> 1.0"
   gem "json_schemer", ">= 0.2.1", "< 0.2.19"
   gem "m"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Foreport change for PR https://github.com/inspec/inspec/pull/6240 to inspec-6 branch.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
