### PR TITLE
Update host resource to resolve all ipaddresses

### DIFF
--- a/lib/inspec/resources/host.rb
+++ b/lib/inspec/resources/host.rb
@@ -319,15 +319,9 @@ module Inspec::Resources
         return nil
       end
 
-      resolve_ipv4 = resolve_ipv4.inject(:merge) if resolve_ipv4.is_a?(Array)
-
       # Append the ipv4 addresses
-      resolve_ipv4.each_value do |ip|
-        matched = ip.to_s.chomp.match(Resolv::IPv4::Regex)
-        next if matched.nil? || addresses.include?(matched.to_s)
-
-        addresses << matched.to_s
-      end
+      resolve_ipv4 = [resolve_ipv4] unless resolve_ipv4.is_a?(Array)
+      resolve_ipv4.each { |entry| addresses << entry["IPAddress"] }
 
       # -Type AAAA is the DNS query for IPv6 server Address.
       cmd = inspec.command("Resolve-DnsName –Type AAAA #{hostname} | ConvertTo-Json")
@@ -337,15 +331,9 @@ module Inspec::Resources
         return nil
       end
 
-      resolve_ipv6 = resolve_ipv6.inject(:merge) if resolve_ipv6.is_a?(Array)
-
       # Append the ipv6 addresses
-      resolve_ipv6.each_value do |ip|
-        matched = ip.to_s.chomp.match(Resolv::IPv6::Regex)
-        next if matched.nil? || addresses.include?(matched.to_s)
-
-        addresses << matched.to_s
-      end
+      resolve_ipv6 = [resolve_ipv6] unless resolve_ipv6.is_a?(Array)
+      resolve_ipv6.each { |entry| addresses << entry["IPAddress"] }
 
       addresses
     end

--- a/test/unit/resources/host_test.rb
+++ b/test/unit/resources/host_test.rb
@@ -35,7 +35,7 @@ describe "Inspec::Resources::Host" do
     resource = MockLoader.new(:windows).load_resource("host", "microsoft.com")
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal false
-    _(resource.ipaddress).must_equal ["134.170.188.221", "2404:6800:4009:827::200e"]
+    _(resource.ipaddress).must_equal ["134.170.185.46", "134.170.188.221", "2404:6800:4009:827::200e"]
     _(resource.to_s).must_equal "Host microsoft.com"
     _(resource.resource_id).must_equal "microsoft.com"
   end
@@ -107,7 +107,7 @@ describe "Inspec::Resources::Host" do
     resource = MockLoader.new(:windows).load_resource("host", "microsoft.com", port: 1234, protocol: "tcp")
     _(resource.resolvable?).must_equal true
     _(resource.reachable?).must_equal true
-    _(resource.ipaddress).must_equal ["134.170.188.221", "2404:6800:4009:827::200e"]
+    _(resource.ipaddress).must_equal ["134.170.185.46", "134.170.188.221", "2404:6800:4009:827::200e"]
     _(resource.to_s).must_equal "Host microsoft.com port 1234 proto tcp"
     _(resource.resource_id).must_equal "microsoft.com-1234-tcp"
   end
@@ -379,7 +379,7 @@ describe Inspec::Resources::UnixHostProvider do
 
     it "checks ipv4_address and ipv6_address properties on windows" do
       resource = MockLoader.new(:windows).load_resource("host", "microsoft.com")
-      _(resource.ipv4_address).must_equal ["134.170.188.221"]
+      _(resource.ipv4_address).must_equal ["134.170.185.46", "134.170.188.221"]
       _(resource.ipv4_address).must_include "134.170.188.221"
       _(resource.ipv6_address).must_equal ["2404:6800:4009:827::200e"]
       _(resource.ipv6_address).must_include "2404:6800:4009:827::200e"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Aims to fix a regression introduced by https://github.com/inspec/inspec/pull/6045 where resolving DNS may return multiple ipaddresses:

```powershell
PS > Resolve-DnsName -Type A dc1.example.demo.local | Select-Object -first 2 | ConvertTo-Json
[
    {
        "IP4Address":  "10.10.11.5",
        "Name":  "dc1.example.demo.locall",
        "Type":  1,
        "CharacterSet":  1,
        "Section":  0,
        "DataLength":  4,
        "TTL":  1200,
        "Address":  "10.10.11.5",
        "IPAddress":  "10.10.11.5",
        "QueryType":  1
    },
    {
        "IP4Address":  "10.0.2.15",
        "Name":  "dc1.example.demo.local",
        "Type":  1,
        "CharacterSet":  1,
        "Section":  0,
        "DataLength":  4,
        "TTL":  1200,
        "Address":  "10.0.2.15",
        "IPAddress":  "10.0.2.15",
        "QueryType":  1
    }
]
```

After the code change introduced by https://github.com/inspec/inspec/pull/6045 - the call to `resolve_ipv4.inject(:merge)` would evaluate to:

``` ruby                                                                                         
{"IP4Address"=>"10.0.2.15",                                                                           
 "Name"=>"dc1.example.demo.local",                                                                       
 "Type"=>1,                                                                                           
 "CharacterSet"=>1,                                                                                   
 "Section"=>0,
 "DataLength"=>4,
 "TTL"=>1200,
 "Address"=>"10.0.2.15",
 "IPAddress"=>"10.0.2.15",
 "QueryType"=>1}
```

Which causes the the `10.10.11.5` IPAddress to be dropped

## Related Issue

https://github.com/inspec/inspec/pull/6045

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
