### PR TITLE
Fix Syntax

### DIFF
--- a/docs-chef-io/content/inspec/resources/file.md
+++ b/docs-chef-io/content/inspec/resources/file.md
@@ -299,13 +299,13 @@ The `size` property tests if a file's size matches, is greater than, or is less 
 Greater than:
 
 ```ruby
-    its('size') { should > 64 }
+    its('size') { should be > 64 }
 ```
 
 Less than:
 
 ```ruby
-    its('size') { should < 10240 }
+    its('size') { should be < 10240 }
 ```
 
 ### type


### PR DESCRIPTION
Proper syntax for `its('size')` is `{ should be <|>|<=|>= <size>}`

<!--- Provide a short summary of your changes in the Title above -->

Updated syntax

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Code written as currently documented fails due to a syntax error.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
