### PR TITLE
CHEF-1458 Multiple values changes in SimpleConfig library

### DIFF
--- a/lib/inspec/utils/simpleconfig.rb
+++ b/lib/inspec/utils/simpleconfig.rb
@@ -61,8 +61,8 @@ class SimpleConfig
 
     if opts[:multiple_values]
       @vals[m[1]] ||= []
-      value_to_array = values.split(" ")
-      if value_to_array.count > 1
+      if opts[:multiple_value_regex] # can be used only if multiple values is set as true
+        value_to_array = values.split(opts[:multiple_value_regex])
         @vals[m[1]].concat(value_to_array)
       else
         @vals[m[1]].push(values)
@@ -123,6 +123,7 @@ class SimpleConfig
       key_values: 1, # default for key=value, may require for 'key val1 val2 val3'
       standalone_comments: false,
       multiple_values: false,
+      multiple_value_regex: nil,
     }
   end
 end

--- a/lib/inspec/utils/simpleconfig.rb
+++ b/lib/inspec/utils/simpleconfig.rb
@@ -57,11 +57,18 @@ class SimpleConfig
     m = opts[:assignment_regex].match(line)
     return nil if m.nil?
 
+    values = parse_values(m, opts[:key_values])
+
     if opts[:multiple_values]
       @vals[m[1]] ||= []
-      @vals[m[1]].push(parse_values(m, opts[:key_values]))
+      value_to_array = values.split(" ")
+      if value_to_array.count > 1
+        @vals[m[1]].concat(value_to_array)
+      else
+        @vals[m[1]].push(values)
+      end
     else
-      @vals[m[1]] = parse_values(m, opts[:key_values])
+      @vals[m[1]] = values
     end
   end
 

--- a/test/unit/utils/simpleconfig_test.rb
+++ b/test/unit/utils/simpleconfig_test.rb
@@ -101,4 +101,9 @@ describe "SimpleConfig Default Parser" do
     cur = SimpleConfig.new("1:2:3", assignment_regex: /^(.*):(.*):(.*)$/, key_values: 4)
     _(cur.params).must_equal({ "1" => ["2", "3", nil, nil] })
   end
+
+  it "supports :mulitple values and returns array of values" do
+    cur = SimpleConfig.new("foo:  bar\nbiz:  baz boz bop\nbiz:  cdsdcs cdscs csc\nbiz:  ada\nfoz:  foo [!deny] bar", assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/, multiple_values: true)
+    _(cur.params).must_equal({ "foo" => ["bar"], "biz" => %w{baz boz bop cdsdcs cdscs csc ada}, "foz" => ["foo", "[!deny]", "bar"] })
+  end
 end

--- a/test/unit/utils/simpleconfig_test.rb
+++ b/test/unit/utils/simpleconfig_test.rb
@@ -103,7 +103,7 @@ describe "SimpleConfig Default Parser" do
   end
 
   it "supports :mulitple values and returns array of values" do
-    cur = SimpleConfig.new("foo:  bar\nbiz:  baz boz bop\nbiz:  cdsdcs cdscs csc\nbiz:  ada\nfoz:  foo [!deny] bar", assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/, multiple_values: true)
+    cur = SimpleConfig.new("foo:  bar\nbiz:  baz boz bop\nbiz:  cdsdcs cdscs csc\nbiz:  ada\nfoz:  foo [!deny] bar", assignment_regex: /^\s*([^:]*?)\s*:\s*(.*?)\s*$/, multiple_values: true, multiple_value_regex: /\s+/)
     _(cur.params).must_equal({ "foo" => ["bar"], "biz" => %w{baz boz bop cdsdcs cdscs csc ada}, "foz" => ["foo", "[!deny]", "bar"] })
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Multiple values changes in SimpleConfig library.

**Existing behavior:**
Returns `["baz boz bop abc def bhb hbjb"]` for key value `biz`

**New change:**
Returns `["baz", "boz", "bop", "abc", "def", "bhb", "hbjb"]`

**Usage**:

New default option for Simple Config library:
 `multiple_values_regex` which will be helpful in splitting values by any specified delimiter regex.

`SimpleConfig.new(content_from_config, multiple_values: true, multiple_value_regex: /\s+/)`

This will enable testing config with values
```
foo:  bar
biz:  baz boz bop
biz:  abc def bhb hbjb
foz:  foo [!deny] bar
```

With a test like this:

`its('biz') { should cmp %w(baz boz bop abc def bhb hbjb) }`


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
