### PR TITLE
For #6493 : Add postgres_session support for custom port with a socket connection

### DIFF
--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -81,7 +81,8 @@ module Inspec::Resources
         # Socket path and empty host in the connection string establishes socket connection
         # Socket connection only enabled for non-windows platforms
         # Windows does not support unix domain sockets
-        "psql -d postgresql://#{@user}:#{@pass}@/#{dbs}?host=#{@socket_path} -A -t -w -c #{escaped_query(query)}"
+        option_port = "-p #{@port} " if @port else "" # add explicit port if specified
+        "psql -d postgresql://#{@user}:#{@pass}@/#{dbs}?host=#{@socket_path} #{option_port} -A -t -w -c #{escaped_query(query)}"
       else
         # Host in connection string establishes tcp/ip connection
         if inspec.os.windows?

--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -81,7 +81,7 @@ module Inspec::Resources
         # Socket path and empty host in the connection string establishes socket connection
         # Socket connection only enabled for non-windows platforms
         # Windows does not support unix domain sockets
-        option_port = "-p #{@port} " if @port else "" # add explicit port if specified
+        option_port = @port.nil? ? "" : "-p #{@port}" # add explicit port if specified
         "psql -d postgresql://#{@user}:#{@pass}@/#{dbs}?host=#{@socket_path} #{option_port} -A -t -w -c #{escaped_query(query)}"
       else
         # Host in connection string establishes tcp/ip connection

--- a/test/unit/resources/postgres_session_test.rb
+++ b/test/unit/resources/postgres_session_test.rb
@@ -39,7 +39,11 @@ describe "Inspec::Resources::PostgresSession" do
   end
   it "verify postgres_session create_psql_cmd in socket connection" do
     resource = load_resource("postgres_session", "myuser", "mypass", "127.0.0.1", 5432, "/var/run/postgresql")
-    _(resource.send(:create_psql_cmd, "SELECT * FROM STUDENTS;", ["testdb"])).must_equal "psql -d postgresql://myuser:mypass@/testdb?host=/var/run/postgresql -A -t -w -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;"
+    _(resource.send(:create_psql_cmd, "SELECT * FROM STUDENTS;", ["testdb"])).must_equal "psql -d postgresql://myuser:mypass@/testdb?host=/var/run/postgresql -p 5432 -A -t -w -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;"
+  end
+  it "verify postgres_session create_psql_cmd in socket connection" do
+    resource = load_resource("postgres_session", "myuser", "mypass", "127.0.0.1", 1234, "/var/run/postgresql")
+    _(resource.send(:create_psql_cmd, "SELECT * FROM STUDENTS;", ["testdb"])).must_equal "psql -d postgresql://myuser:mypass@/testdb?host=/var/run/postgresql -p 1234 -A -t -w -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;"
   end
 
   it "fails when no connection established in linux" do


### PR DESCRIPTION
Currently the inspec ressource postgres_session.rb does not support the connection to a postgresql server with a socket and a custom port.

## Related Issue
#6493

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
