### PR TITLE
Attempt to avoid dependency of io-event for async gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ end
 group :test do
   gem "chefstyle", "~> 2.0.3"
   gem "concurrent-ruby", "~> 1.0"
+  gem 'async', '~> 2.2.0', platforms: :ruby # Install async prior to version 2.3.0 which doesn't have dependencies on io-event gem
   gem "html-proofer", platforms: :ruby # do not attempt to run proofer on windows
   gem "json_schemer", ">= 0.2.1", "< 0.2.19"
   gem "m"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The `async` gem version 2.3.1 depends on io-event, which requires Ruby version 3.0 or higher. This PR is to avoid this dependency, by using an earlier version of async that doesn't have this requirement. The `async` version 2.2.0 was released before io-event was added as a dependency to it.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
