### PR TITLE
CHEF-1631 Clarify that command timeout default was withdrawn

### DIFF
--- a/docs-chef-io/content/inspec/resources/command.md
+++ b/docs-chef-io/content/inspec/resources/command.md
@@ -147,7 +147,7 @@ end
 ```
 
 This example would run the `find` command for up to 300 seconds, then give up and fail the control if it exceeded that time.
-On supported target platforms, the default timeout is 3600 seconds (one hour).
+On supported target platforms, briefly from versions 4.31.0 to when it was withdrawn in 4.33.1, a default of 3600 seconds was provided, but this proved problematic and was removed.
 
 Aside from setting the value on a per-resource basis, you may also use the `--command-timeout` CLI option to globally set a command timeout. The CLI option takes precedence over any per-resource `timeout:` options.
 

--- a/docs-chef-io/content/inspec/resources/command.md
+++ b/docs-chef-io/content/inspec/resources/command.md
@@ -147,7 +147,6 @@ end
 ```
 
 This example would run the `find` command for up to 300 seconds, then give up and fail the control if it exceeded that time.
-On supported target platforms, briefly from versions 4.31.0 to when it was withdrawn in 4.33.1, a default of 3600 seconds was provided, but this proved problematic and was removed.
 
 Aside from setting the value on a per-resource basis, you may also use the `--command-timeout` CLI option to globally set a command timeout. The CLI option takes precedence over any per-resource `timeout:` options.
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

When we withdrew the command timeout default on #5472 we forgot to update the docs on the command resource page. A customer found those docs and was misled.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
