### PR TITLE
CHEF-2438 Add train-kubernetes to inspec gemspec

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -38,9 +38,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday_middleware", ">= 0.12.2", "< 1.1"
 
   # Train plugins we ship with InSpec
-  spec.add_dependency "train-habitat", "~> 0.1"
-  spec.add_dependency "train-aws",     "~> 0.2"
-  spec.add_dependency "train-winrm",   "~> 0.2"
+  spec.add_dependency "train-habitat",    "~> 0.1"
+  spec.add_dependency "train-aws",        "~> 0.2"
+  spec.add_dependency "train-winrm",      "~> 0.2"
+  spec.add_dependency "train-kubernetes", "~> 0.1"
+
   spec.add_dependency "mongo", "= 2.13.2" # 2.14 introduces a broken symlink in mongo-2.14.0/spec/support/ocsp
 
 end

--- a/test/unit/plugin/v2/loader_test.rb
+++ b/test/unit/plugin/v2/loader_test.rb
@@ -323,7 +323,7 @@ class PluginLoaderTests < Minitest::Test
     skip "not valid in this env" unless using_bundler?
 
     with_empty_registry do
-      exp = %i{ train-aws train-habitat train-winrm }
+      exp = %i{ train-aws train-habitat train-kubernetes train-winrm }
       exp_err = ""
 
       assert_detect_system_plugins exp, exp_err do |loader|


### PR DESCRIPTION

Bundles train-kubernetes and its support libraries k8s-ruby with InSpec, supporting the CSPM effort and significantly reducing the effort to get started with kubernetes compliance scanning.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
