### PR TITLE
add train-kubernetes as a dependency

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "train-aws",     "~> 0.2"
   spec.add_dependency "train-winrm",   "~> 0.2"
   spec.add_dependency "mongo", "= 2.13.2" # 2.14 introduces a broken symlink in mongo-2.14.0/spec/support/ocsp
-
+  spec.add_dependency "train-kubernetes", "~> 0.1.12"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
add `train-kubernetes` as a dependency to inspec

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
installing `train-kubernetes` as plugin has a series of issues and behaves differently for every platform. Hence the most consistent way to load the `train-kubernetes` plugin is to make it available as dependency for inspec so every customer has a seamless experience.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
