### PR TITLE
Remove Undocumented Dependency on ActiveSupport

### DIFF
--- a/lib/inspec/dependencies/dependency_set.rb
+++ b/lib/inspec/dependencies/dependency_set.rb
@@ -26,7 +26,7 @@ module Inspec
       dep_list = {}
       dependencies.each do |d|
         # if depedent profile does not have a source version then only name is used in dependency hash
-        key_name = (d.source_version.blank? ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
+        key_name = (d.source_version.empty? ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
         dep_list[key_name] = d
       end
       new(cwd, cache, dep_list, backend)
@@ -42,7 +42,7 @@ module Inspec
       dep_list = {}
       dep_tree.each do |d|
         # if depedent profile does not have a source version then only name is used in dependency hash
-        key_name = (d.source_version.blank? ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
+        key_name = (d.source_version.empty? ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
         dep_list[key_name] = d
         dep_list.merge!(flatten_dep_tree(d.dependencies))
       end

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -95,7 +95,7 @@ module Inspec::DSL
         # 1. Fetching VERSION from a profile dependency name which is in a format NAME-VERSION.
         # 2. Matching original profile dependency name with profile name used with include or require control DSL.
         source_version = value.source_version
-        unless source_version.blank?
+        unless source_version.empty?
           profile_id_key = key.split("-#{source_version}")[0]
           new_profile_id = key if profile_id_key == profile_id
         end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -247,7 +247,7 @@ module Inspec
       ## Find the waivers file
       # - TODO: cli_opts and instance_variable_get could be exposed
       waiver_paths = cfg.instance_variable_get(:@cli_opts)["waiver_file"]
-      if waiver_paths.blank?
+      if waiver_paths.empty?
         Inspec::Log.error "Must use --waiver-file with --filter-waived-controls"
         Inspec::UI.new.exit(:usage_error)
       end
@@ -275,7 +275,7 @@ module Inspec
         # be processed and rendered
         tests.each do |control_filename, source_code|
           cleared_tests = source_code.scan(/control\s+['"].+?['"].+?(?=(?:control\s+['"].+?['"])|\z)/m).collect do |element|
-            next if element.blank?
+            next if element.empty?
 
             if element&.match?(waived_control_id_regex)
               splitlines = element.split("\n")

--- a/lib/inspec/utils/waivers/csv_file_reader.rb
+++ b/lib/inspec/utils/waivers/csv_file_reader.rb
@@ -19,7 +19,7 @@ module Waivers
         row_hash.delete("control_id")
         row_hash.delete_if { |k, v| k.nil? || v.nil? }
 
-        waiver_data_hash[control_id] = row_hash if control_id && !row_hash.blank?
+        waiver_data_hash[control_id] = row_hash if control_id && !row_hash.empty?
       end
 
       waiver_data_hash

--- a/lib/inspec/utils/waivers/excel_file_reader.rb
+++ b/lib/inspec/utils/waivers/excel_file_reader.rb
@@ -25,7 +25,7 @@ module Waivers
           row_hash.delete_if { |k, v| k.nil? || v.nil? }
         end
 
-        waiver_data_hash[control_id] = row_hash if control_id && !row_hash.blank?
+        waiver_data_hash[control_id] = row_hash if control_id && !row_hash.empty?
       end
       waiver_data_hash
     rescue Exception => e


### PR DESCRIPTION
Resolves https://github.com/inspec/inspec/issues/6527 

https://github.com/inspec/inspec/pull/6410 introduced an undocumented dependency on ActiveSupport due to its usage of the .blank? method on string values. This function is provided by ActiveSupport

I consume inspec-core-bin in some custom tooling and #6410 introduced a stack trace.