### PR TITLE
[W.I.P] CHEF-3759 inspec parallel: Error logging changes to fix renaming file error in windows

### DIFF
--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -74,14 +74,11 @@ module InspecPlugins
 
         # Construct command-line invocation
         child_pid = nil
-        error_log_file_name = "#{Time.now.nsec}.err"
 
         begin
           cmd = "#{$0} #{sub_cmd} #{invocation}"
           log_msg = "#{Time.now.iso8601} Start Time: #{Time.now}\n#{Time.now.iso8601} Arguments: #{invocation}\n"
-          child_pid = Process.spawn(cmd, out: parent_writer, err: error_log_file_name)
-          # Rename error log file if exist
-          rename_error_log(error_log_file_name, child_pid) if File.exist?(error_log_file_name)
+          child_pid = Process.spawn(cmd, out: parent_writer, err: $stderr)
           # Logging
           create_logs(child_pid, nil, $stderr)
           create_logs(child_pid, log_msg)
@@ -207,13 +204,6 @@ module InspecPlugins
           log_file = File.join(log_dir, "#{child_pid}.log") unless File.exist?("#{child_pid}.log")
           File.write(log_file, run_log, mode: "a")
         end
-      end
-
-      def rename_error_log(error_log_file_name, child_pid)
-        logs_dir_path = log_path || Dir.pwd
-        log_dir = File.join(logs_dir_path, "logs")
-        FileUtils.mkdir_p(log_dir) unless File.directory?(log_dir)
-        File.rename(error_log_file_name, "#{log_dir}/#{child_pid}.err")
       end
     end
   end

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -34,7 +34,7 @@ module InspecPlugins
           cleanup_child_processes
           sleep 0.1
         end
-        cleanup_empty_error_log_files
+        cleanup_empty_error_log_files unless Inspec.locally_windows?
         cleanup_daemon_process if run_in_background
       end
 

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -73,8 +73,6 @@ module InspecPlugins
         child_reader, parent_writer = IO.pipe
 
         # Construct command-line invocation
-        child_pid = nil
-
         begin
           cmd = "#{$0} #{sub_cmd} #{invocation}"
           log_msg = "#{Time.now.iso8601} Start Time: #{Time.now}\n#{Time.now.iso8601} Arguments: #{invocation}\n"


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Simplifies error log handling under Windows, resolving a critical issue in which inspec parallel jobs would immediately die. Jobs now work on this branch, but we are currently looking at an issue regarding the cleanup of empty error log files.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
