### PR TITLE
CHEF-3759 inspec parallel: Error logging changes to fix renaming file error in windows - Final changes

### DIFF
--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -87,7 +87,10 @@ module InspecPlugins
         child_pid = nil
 
         begin
-          error_log_file = File.open("logs/#{Time.now.nsec}.err", "a+")
+          logs_dir_path = log_path || Dir.pwd
+          log_dir = File.join(logs_dir_path, "logs")
+          FileUtils.mkdir_p(log_dir) unless File.directory?(log_dir)
+          error_log_file = File.open("#{log_dir}/#{Time.now.nsec}.err", "a+")
           cmd = "#{$0} #{sub_cmd} #{invocation}"
           log_msg = "#{Time.now.iso8601} Start Time: #{Time.now}\n#{Time.now.iso8601} Arguments: #{invocation}\n"
           child_pid = Process.spawn(cmd, out: parent_writer, err: error_log_file.path)

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -109,7 +109,7 @@ module InspecPlugins
         begin
           logs_dir_path = log_path || Dir.pwd
           log_dir = File.join(logs_dir_path, "logs")
-          FileUtils.mkdir_p(log_dir) unless File.directory?(log_dir)
+          FileUtils.mkdir_p(log_dir)
           error_log_file = File.open("#{log_dir}/#{Time.now.nsec}.err", "a+")
           cmd = "#{$0} #{sub_cmd} #{invocation}"
           log_msg = "#{Time.now.iso8601} Start Time: #{Time.now}\n#{Time.now.iso8601} Arguments: #{invocation}\n"
@@ -236,7 +236,7 @@ module InspecPlugins
       def create_logs(child_pid, run_log , stderr = nil)
         logs_dir_path = log_path || Dir.pwd
         log_dir = File.join(logs_dir_path, "logs")
-        FileUtils.mkdir_p(log_dir) unless File.directory?(log_dir)
+        FileUtils.mkdir_p(log_dir)
 
         if stderr
           log_file = File.join(log_dir, "#{child_pid}.err") unless File.exist?("#{child_pid}.err")
@@ -250,7 +250,7 @@ module InspecPlugins
       def rename_error_log(error_log_file, child_pid)
         logs_dir_path = log_path || Dir.pwd
         log_dir = File.join(logs_dir_path, "logs")
-        FileUtils.mkdir_p(log_dir) unless File.directory?(log_dir)
+        FileUtils.mkdir_p(log_dir)
 
         if error_log_file.closed? && File.exist?(error_log_file.path)
           begin

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -74,14 +74,11 @@ module InspecPlugins
 
         # Construct command-line invocation
         child_pid = nil
-        error_log_file_name = "#{Time.now.nsec}.err"
 
         begin
           cmd = "#{$0} #{sub_cmd} #{invocation}"
           log_msg = "#{Time.now.iso8601} Start Time: #{Time.now}\n#{Time.now.iso8601} Arguments: #{invocation}\n"
-          child_pid = Process.spawn(cmd, out: parent_writer, err: error_log_file_name)
-          # Rename error log file if exist
-          rename_error_log(error_log_file_name, child_pid) if File.exist?(error_log_file_name)
+          child_pid = Process.spawn(cmd, out: parent_writer, err: $stderr)
           # Logging
           create_logs(child_pid, nil, $stderr)
           create_logs(child_pid, log_msg)
@@ -207,13 +204,6 @@ module InspecPlugins
           log_file = File.join(log_dir, "#{child_pid}.log") unless File.exist?("#{child_pid}.log")
           File.write(log_file, run_log, mode: "a")
         end
-      end
-
-      def rename_error_log(error_log_file_name, child_pid)
-        logs_dir_path = log_path || Dir.pwd
-        log_dir = File.join(logs_dir_path, "logs")
-        FileUtils.mkdir_p(log_dir) unless File.directory?(log_dir)
-        File.rename(error_log_file_name, "#{log_dir}/#{child_pid}.err")
       end
     end
   end

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -93,7 +93,9 @@ module InspecPlugins
           child_pid = Process.spawn(cmd, out: parent_writer, err: error_log_file.path)
 
           # Trap Control-c Interrupts
-          trap('SIGINT') do
+          trap("SIGINT") do
+            # Kill child process instantly
+            Process.kill("SIGINT", child_pid)
           end
 
           # Logging

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -83,9 +83,6 @@ module InspecPlugins
 
         child_reader, parent_writer = IO.pipe
 
-        # Construct command-line invocation
-        child_pid = nil
-
         begin
           logs_dir_path = log_path || Dir.pwd
           log_dir = File.join(logs_dir_path, "logs")

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -12,6 +12,7 @@ module InspecPlugins
         @sub_cmd = sub_cmd
         @total_jobs = cli_options["jobs"] || Concurrent.physical_processor_count
         @child_tracker = {}
+        @child_tracker_persisted = {}
         @run_in_background = cli_options["bg"]
         unless run_in_background
           @ui = InspecPlugins::Parallelism::SuperReporter.make(cli_options["ui"], total_jobs, invocations)
@@ -34,6 +35,10 @@ module InspecPlugins
           cleanup_child_processes
           sleep 0.1
         end
+
+        # Requires renaming operations on windows only
+        # Do Rename and delete operations after all child processes have exited successfully
+        rename_error_log_files if Inspec.locally_windows?
         cleanup_empty_error_log_files
         cleanup_daemon_process if run_in_background
       end
@@ -63,6 +68,12 @@ module InspecPlugins
         end
       end
 
+      def rename_error_log_files
+        @child_tracker_persisted.each do |pid, info|
+          rename_error_log(info[:error_log_file], pid)
+        end
+      end
+
       def should_start_more_jobs?
         @child_tracker.length < total_jobs && !invocations.empty?
       end
@@ -76,14 +87,21 @@ module InspecPlugins
         child_pid = nil
 
         begin
+          error_log_file = File.open("logs/#{Time.now.nsec}.err", "a+")
           cmd = "#{$0} #{sub_cmd} #{invocation}"
           log_msg = "#{Time.now.iso8601} Start Time: #{Time.now}\n#{Time.now.iso8601} Arguments: #{invocation}\n"
-          child_pid = Process.spawn(cmd, out: parent_writer, err: $stderr)
+          child_pid = Process.spawn(cmd, out: parent_writer, err: error_log_file.path)
           # Logging
-          create_logs(child_pid, nil, $stderr)
           create_logs(child_pid, log_msg)
           @child_tracker[child_pid] = { io: child_reader }
+
+          # This is used to rename error log files after all child processes are exited
+          @child_tracker_persisted[child_pid] = { error_log_file: error_log_file }
           @ui.child_spawned(child_pid, invocation)
+
+          # Close the stderr and files to unlock the error log files opened by processes
+          error_log_file.close
+          $stderr.close
         rescue StandardError => e
           $stderr.puts "#{Time.now.iso8601} Error Message: #{e.message}"
           $stderr.puts "#{Time.now.iso8601} Error Backtrace: #{e.backtrace}"
@@ -203,6 +221,16 @@ module InspecPlugins
         else
           log_file = File.join(log_dir, "#{child_pid}.log") unless File.exist?("#{child_pid}.log")
           File.write(log_file, run_log, mode: "a")
+        end
+      end
+
+      def rename_error_log(error_log_file, child_pid)
+        logs_dir_path = log_path || Dir.pwd
+        log_dir = File.join(logs_dir_path, "logs")
+        FileUtils.mkdir_p(log_dir) unless File.directory?(log_dir)
+
+        if error_log_file.closed?
+          File.rename("#{error_log_file.path}", "#{log_dir}/#{child_pid}.err")
         end
       end
     end

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -83,6 +83,8 @@ module InspecPlugins
 
         child_reader, parent_writer = IO.pipe
 
+        error_log_file = nil
+        child_pid = nil
         begin
           logs_dir_path = log_path || Dir.pwd
           log_dir = File.join(logs_dir_path, "logs")
@@ -113,8 +115,8 @@ module InspecPlugins
           $stderr.puts "#{Time.now.iso8601} Error Message: #{e.message}"
           $stderr.puts "#{Time.now.iso8601} Error Backtrace: #{e.backtrace}"
         rescue SystemExit, Interrupt
-          # Rename error log files on interrupt
-          rename_error_log_files
+          # Rename error log file on interrupt
+          rename_error_log(error_log_file, child_pid)
         end
       end
 

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/super_reporter/status.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/super_reporter/status.rb
@@ -89,7 +89,8 @@ module InspecPlugins::Parallelism
         # Loop over slots
         slots.each_index do |idx|
           if slots[idx].nil?
-            line += "idle".center(slot_width)
+            # line += "idle".center(slot_width)
+            # Need to improve UI
           elsif slots[idx] == "exited"
             line += "Done".center(slot_width)
           else


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Issue:
Simplifies error log handling under Windows, resolving a critical issue in which inspec parallel jobs would immediately die. 

This covers:
1. Solution to renaming and deletion of error logs
2. Proper logging
3. Renaming error log file with child pid on control-c interrupt.


The PR https://github.com/inspec/inspec/pull/6539 could be closed, after the changes here are verified in code review.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
