### PR TITLE
Fix for yaml reporter test failure

### DIFF
--- a/test/fixtures/reporters/run_data.yml
+++ b/test/fixtures/reporters/run_data.yml
@@ -15,8 +15,8 @@
     - "(generated from t.rb:1 0aa70d93be7b0cf41b97a1363bb5e8b8)"
   :controls:
   - :id: "(generated from t.rb:1 0aa70d93be7b0cf41b97a1363bb5e8b8)"
-    :title: 
-    :desc: 
+    :title:
+    :desc:
     :impact: 0.5
     :refs: []
     :tags: {}

--- a/test/unit/reporters/yaml_test.rb
+++ b/test/unit/reporters/yaml_test.rb
@@ -11,13 +11,13 @@ describe Inspec::Reporters::Yaml do
 
   describe "#render" do
     it "confirm render output" do
-      #if ( windows? || darwin? ) && RUBY3_PLUS
+      if RUBY3_PLUS
         # On Ruby 3+, empty scalar values are generated without a trailing space
         # this affects the title: and desc: fields
         output = File.read("test/fixtures/reporters/yaml_output_ruby3plus")
-      #else
-        #output = File.read("test/fixtures/reporters/yaml_output")
-      #end
+      else
+        output = File.read("test/fixtures/reporters/yaml_output")
+      end
 
       report.render
       _(report.rendered_output).must_equal output

--- a/test/unit/reporters/yaml_test.rb
+++ b/test/unit/reporters/yaml_test.rb
@@ -11,13 +11,13 @@ describe Inspec::Reporters::Yaml do
 
   describe "#render" do
     it "confirm render output" do
-      if ( windows? || darwin? ) && RUBY3_PLUS
+      #if ( windows? || darwin? ) && RUBY3_PLUS
         # On Ruby 3+, empty scalar values are generated without a trailing space
         # this affects the title: and desc: fields
         output = File.read("test/fixtures/reporters/yaml_output_ruby3plus")
-      else
-        output = File.read("test/fixtures/reporters/yaml_output")
-      end
+      #else
+        #output = File.read("test/fixtures/reporters/yaml_output")
+      #end
 
       report.render
       _(report.rendered_output).must_equal output


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Fix for an overly sensitive test that fails due to whitespace changes introduced on certain platforms and versions of Ruby with the YAML generator.

<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
