### PR TITLE
[W.I.P] Fix inspec parallel hangs on windows for certain CIS profile

### DIFF
--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/child_status_reporter.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/child_status_reporter.rb
@@ -1,7 +1,7 @@
 module InspecPlugins::Parallelism
   class StreamingReporter < Inspec.plugin(2, :streaming_reporter)
     # Registering these methods with RSpec::Core::Formatters class is mandatory
-    RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending
+    RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending, :close
 
     def initialize(output)
       @status_mapping = {}
@@ -19,6 +19,11 @@ module InspecPlugins::Parallelism
 
     def example_pending(notification)
       set_example(notification, "skipped")
+    end
+
+    def close(notification)
+      # HACK: if we've reached the end of the execution, send a special marker, to ease EOF detection on Windows
+      puts "EOF_MARKER"
     end
 
     private
@@ -46,10 +51,6 @@ module InspecPlugins::Parallelism
       display_name = control_id.to_s.lstrip.force_encoding(Encoding::UTF_8) unless title
 
       puts "#{@control_counter}/#{stat}/#{controls_count}/#{display_name}"
-      # HACK: if we've reached the end of the execution, send a special marker, to ease EOF detection on Windows
-      if @control_counter == controls_count
-        puts "EOF_MARKER"
-      end
     end
 
     def set_status_mapping(control_id, status)


### PR DESCRIPTION
## Description

This PR provides a fix for an issue in which InSpec parallel would hang on certain profiles. It was eventually traced to the EOF detection code in the child-status reporter, which is used to communicate between the child processes and the master process. On Windows, we need to send an explicit EOF marker, which means detecting when we are done; previously this was done by watching the control count, but it was found that certain profiles (those containing several zero-test controls, which is common in large CIS profiles) cause the control count to never be accurate. While that issue will be resolved another day, in the meantime, this PR fixes the hanging issue by moving the end--of-report detection to a rSpec Formatter close() handler, which is more reliable.

Tested on Windows 2019 and MacOS.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
