### PR TITLE
CHEF-3832: Fix for InSpec Parallel fails to fetch remote profiles due to cache contention.

### DIFF
--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -39,7 +39,8 @@ module Inspec
     end
 
     def fetch
-      if cache.exists?(cache_key)
+      # In case of parallel execution we need to lock the cache folder, here we only read from cache if it's unlocked.
+      if cache.exists?(cache_key) && !cache.locked?(cache_key)
         Inspec::Log.debug "Using cached dependency for #{target}"
         [cache.prefered_entry_for(cache_key), false]
       else

--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -56,7 +56,7 @@ module Inspec
       else
         begin
           Inspec::Log.debug "Dependency does not exist in the cache #{target}"
-          cache.lock(cache_key) if fetcher.requires_locking?
+          cache.lock(cache.base_path_for(fetcher.cache_key)) if fetcher.requires_locking?
           fetcher.fetch(cache.base_path_for(fetcher.cache_key))
         rescue SystemExit => e
           exit_code = e.status || 1
@@ -64,7 +64,7 @@ module Inspec
           FileUtils.rm_rf(cache.base_path_for(fetcher.cache_key))
           exit(exit_code)
         ensure
-          cache.unlock(cache_key) if fetcher.requires_locking?
+          cache.unlock(cache.base_path_for(fetcher.cache_key)) if fetcher.requires_locking?
         end
         assert_cache_sanity!
         [fetcher.archive_path, fetcher.writable?]

--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -58,6 +58,10 @@ module Inspec
           Inspec::Log.debug "Dependency does not exist in the cache #{target}"
           cache.lock(cache_key) if fetcher.requires_locking?
           fetcher.fetch(cache.base_path_for(fetcher.cache_key))
+        rescue Interrupt => e
+          Inspec::Log.debug "Error while creating cache for dependency ... #{e.message}"
+          FileUtils.rm_rf(cache.base_path_for(fetcher.cache_key))
+          exit Inspec::UI::EXIT_TERMINATED_BY_CTL_C
         ensure
          cache.unlock(cache_key) if fetcher.requires_locking?
         end

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -87,21 +87,22 @@ module Inspec
     def lock(key)
       path = base_path_for(key)
       lock_file_path = File.join(path, '.lock')
-      FileUtils.mkdir_p(path)
-      Inspec::Log.debug("Locking cache ..... #{path}")
-      FileUtils.touch(lock_file_path)
+      begin
+        FileUtils.mkdir_p(path)
+        Inspec::Log.debug("Locking cache ..... #{path}")
+        FileUtils.touch(lock_file_path)
+      rescue Errno::EACCES
+        raise "Permission denied while creating cache lock #{path}/.lock."
+      end
     end
 
     def unlock(key)
       path = base_path_for(key)
-      puts "Unlocking cache ....."
       Inspec::Log.debug("Unlocking cache..... #{path}")
       begin
         FileUtils.rm("#{path}/.lock") if File.exist?("#{path}/.lock")
       rescue Errno::EACCES
-        puts "Permission denied while removing cache lock #{path}/.lock."
-      rescue => e
-        puts "An error occurred while removing cache lock #{path}/.lock: #{e.message}"
+        raise "Permission denied while removing cache lock #{path}/.lock"
       end
     end
   end

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -77,13 +77,25 @@ module Inspec
     def locked?(key)
       locked = false
       path = base_path_for(key)
-      # On Windows cache directories are in archive format. This check is just to make sure we skip this for Windows here.
+      # For archive there is no need to lock the directory so we skip those and return false for archive formatted cache
       if File.directory?(path)
-        f = File.open(base_path_for(key), File::RDONLY)
-        locked = f.flock(File::LOCK_EX | File::LOCK_NB) && File.exist?("#{path}/.lock")
-        f.close
+        locked = File.exist?("#{path}/.lock")
       end
       locked
+    end
+
+    def lock(key)
+      path = base_path_for(key)
+      lock_file_path = File.join(path, '.lock')
+      FileUtils.mkdir_p(path) unless Dir.exist?(path)
+      Inspec::Log.debug("Locking ..... #{path}")
+      FileUtils.touch(lock_file_path)
+    end
+
+    def unlock(key)
+      path = base_path_for(key)
+      Inspec::Log.debug("Unlocking ..... #{path}")
+      FileUtils.rm_f("#{path}/.lock") if File.exist?("#{path}/.lock")
     end
   end
 end

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -87,15 +87,22 @@ module Inspec
     def lock(key)
       path = base_path_for(key)
       lock_file_path = File.join(path, '.lock')
-      FileUtils.mkdir_p(path) unless Dir.exist?(path)
-      Inspec::Log.debug("Locking ..... #{path}")
+      FileUtils.mkdir_p(path)
+      Inspec::Log.debug("Locking cache ..... #{path}")
       FileUtils.touch(lock_file_path)
     end
 
     def unlock(key)
       path = base_path_for(key)
-      Inspec::Log.debug("Unlocking ..... #{path}")
-      FileUtils.rm_f("#{path}/.lock") if File.exist?("#{path}/.lock")
+      puts "Unlocking cache ....."
+      Inspec::Log.debug("Unlocking cache..... #{path}")
+      begin
+        FileUtils.rm("#{path}/.lock") if File.exist?("#{path}/.lock")
+      rescue Errno::EACCES
+        puts "Permission denied while removing cache lock #{path}/.lock."
+      rescue => e
+        puts "An error occurred while removing cache lock #{path}/.lock: #{e.message}"
+      end
     end
   end
 end

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -84,25 +84,23 @@ module Inspec
       locked
     end
 
-    def lock(key)
-      path = base_path_for(key)
-      lock_file_path = File.join(path, ".lock")
+    def lock(cache_path)
+      lock_file_path = File.join(cache_path, ".lock")
       begin
-        FileUtils.mkdir_p(path)
-        Inspec::Log.debug("Locking cache ..... #{path}")
+        FileUtils.mkdir_p(cache_path)
+        Inspec::Log.debug("Locking cache ..... #{cache_path}")
         FileUtils.touch(lock_file_path)
       rescue Errno::EACCES
-        raise "Permission denied while creating cache lock #{path}/.lock."
+        raise "Permission denied while creating cache lock #{cache_path}/.lock."
       end
     end
 
-    def unlock(key)
-      path = base_path_for(key)
-      Inspec::Log.debug("Unlocking cache..... #{path}")
+    def unlock(cache_path)
+      Inspec::Log.debug("Unlocking cache..... #{cache_path}")
       begin
-        FileUtils.rm("#{path}/.lock") if File.exist?("#{path}/.lock")
+        FileUtils.rm("#{cache_path}/.lock") if File.exist?("#{cache_path}/.lock")
       rescue Errno::EACCES
-        raise "Permission denied while removing cache lock #{path}/.lock"
+        raise "Permission denied while removing cache lock #{cache_path}/.lock"
       end
     end
   end

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -71,9 +71,9 @@ module Inspec
       File.join(@path, cache_key)
     end
 
-   #
-   # For given cache key, return true if the
-   # cache path is locked
+    #
+    # For given cache key, return true if the
+    # cache path is locked
     def locked?(key)
       locked = false
       path = base_path_for(key)
@@ -86,7 +86,7 @@ module Inspec
 
     def lock(key)
       path = base_path_for(key)
-      lock_file_path = File.join(path, '.lock')
+      lock_file_path = File.join(path, ".lock")
       begin
         FileUtils.mkdir_p(path)
         Inspec::Log.debug("Locking cache ..... #{path}")

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -70,5 +70,20 @@ module Inspec
     def base_path_for(cache_key)
       File.join(@path, cache_key)
     end
+
+   #
+   # For given cache key, return true if the
+   # cache path is locked
+    def locked?(key)
+      locked = false
+      path = base_path_for(key)
+      # On Windows cache directories are in archive format. This check is just to make sure we skip this for Windows here.
+      if File.directory?(path)
+        f = File.open(base_path_for(key), File::RDONLY)
+        locked = f.flock(File::LOCK_EX | File::LOCK_NB) && File.exist?("#{path}/.lock")
+        f.close
+      end
+      locked
+    end
   end
 end

--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -115,6 +115,11 @@ module Inspec::Fetcher
       %i{branch tag ref}.map { |opt_name| update_ivar_from_opt(opt_name, opts) }.any?
     end
 
+    # Git fetcher is sensitive to cache contention so it needs cache locking mechanism.
+    def requires_locking?
+      true
+    end
+
     private
 
     def resolved_ref

--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -62,32 +62,19 @@ module Inspec::Fetcher
     def fetch(destination_path)
       @repo_directory = destination_path # Might be the cache, or vendoring, or something else
       FileUtils.mkdir_p(destination_path) unless Dir.exist?(destination_path)
-      Inspec::Log.debug("Locking ..... #{destination_path}")
-      lock_file_path = "#{destination_path}/.lock"
-      lock_file = File.open(lock_file_path, File::RDWR|File::CREAT)
-      lock_file.flock(File::LOCK_EX)
-
-      begin
-        if cloned?
-          checkout
-        else
-          Dir.mktmpdir do |working_dir|
-            #require 'byebug'; byebug
-            checkout(working_dir)
-            if @relative_path
-              perform_relative_path_fetch(destination_path, working_dir)
-            else
-              Inspec::Log.debug("Checkout of #{resolved_ref} successful. " \
-                                "Moving checkout to #{destination_path}")
-              FileUtils.cp_r(working_dir + "/.", destination_path)
-            end
+      if cloned?
+        checkout
+      else
+        Dir.mktmpdir do |working_dir|
+          checkout(working_dir)
+          if @relative_path
+            perform_relative_path_fetch(destination_path, working_dir)
+          else
+            Inspec::Log.debug("Checkout of #{resolved_ref} successful. " \
+                              "Moving checkout to #{destination_path}")
+            FileUtils.cp_r(working_dir + "/.", destination_path)
           end
         end
-      ensure
-        Inspec::Log.debug("Locking ..... #{destination_path}")
-        lock_file.flock(File::LOCK_UN)
-        lock_file.close
-        FileUtils.rm_f("#{destination_path}/.lock")
       end
       @repo_directory
     end

--- a/lib/inspec/plugin/v1/plugin_types/fetcher.rb
+++ b/lib/inspec/plugin/v1/plugin_types/fetcher.rb
@@ -105,6 +105,13 @@ module Inspec
         file_provider = Inspec::FileProvider.for_path(archive_path)
         file_provider.relative_provider
       end
+
+      # Returns false by default
+      # This is used to regulate cache contention.
+      # Fetchers that are sensitive to cache contention should return true.
+      def requires_locking?
+        false
+      end
     end
   end
 end

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -144,7 +144,7 @@ module InspecPlugins
           # In child
           child_reader.close
           # replace stdout with writer
-          $stdout = parent_writer
+          #$stdout = parent_writer
           create_logs(Process.pid, nil, $stderr)
 
           begin

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -144,7 +144,7 @@ module InspecPlugins
           # In child
           child_reader.close
           # replace stdout with writer
-          #$stdout = parent_writer
+          $stdout = parent_writer
           create_logs(Process.pid, nil, $stderr)
 
           begin


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This fix creates the write exclusive lock on the cache directory of the profile till the write operation is finished for the git fetcher

Tested this fix with the following runs

1. running dependent profile from the supermarket
Create a wrapper profile

add in inspec.yml
```
depends:
- name: ssh-baseline
  supermarket: dev-sec/ssh-baseline
```

add in controls/example.rb
```
include_controls 'ssh-baseline'
```
```
inspec parallel exec ~/workspace/profiles/test-supermarket-profile/ -o ~/workspace/opts/simple.txt -j 6
```

2. running profile from the Supermarket

```
inspec parallel exec supermarket://dev-sec/ssh-baseline -o ~/workspace/opts/simple.txt -j 6
```

3. Running profile from local path

```
inspec parallel exec ~/workspace/profiles/ssh-baseline-2.8.0.tar.gz -o ~/workspace/opts/simple.txt -j 5
```

4. Running profile from git https URL

```
inspec parallel exec https://github.com/dev-sec/ssh-baseline.git -o ~/workspace/opts/simple.txt -j 3
```

5. Running profile using git ssh URL
```
inspec parallel exec git@github.com:dev-sec/linux-baseline.git -o ~/workspace/opts/simple.txt -j 3
```

6. Running profile using compliance URL

```
inspec parallel exec compliance://admin/ssh-baseline -o ~/workspace/opts/simple.txt -j 3
```

```
inspec exec compliance://admin/ssh-baseline
```

7. Running profile which has a dependent profile with git url

add inspec.yml

```
depends:
- name: ssh-baseline
  git: https://github.com/dev-sec/ssh-baseline
```

```
inspec parallel exec ~/workspace/profiles/test-git-profile/ -o ~/workspace/opts/simple.txt -j 3
```


8. Running profile from local path

```
inspec parallel exec ~/workspace/profiles/ssh-baseline -o ~/workspace/opts/simple.txt -j 3
```

9. Running profile from compliance URL

```
iinspec parallel exec compliance://admin/ssh-baseline -o ~/workspace/opts/simple.txt -j 3
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
