### PR TITLE
InSpec 6: Drop testing on EOL Ruby 2.7, and run linter on Ruby 3.1

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -9,21 +9,13 @@ expeditor:
 
 steps:
 
-  - label: lint-ruby-3.0
+  - label: lint-ruby-3.1
     command:
       - RAKE_TASK=test:lint /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:
-          image: ruby:3.0
-
-  - label: run-tests-ruby-2.7
-    command:
-      - /workdir/.expeditor/buildkite/verify.sh
-    expeditor:
-      executor:
-        docker:
-          image: ruby:2.7
+          image: ruby:3.1
 
   - label: run-tests-ruby-3.0
     command:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

InSpec 6 will not support EOL Ruby 2.7, so we're dropping it from the test matrix. 
The linter has been running on 3.0.x, should be on 3.1.x.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
