### PR TITLE
Explicitly make verify pipeline private

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -7,6 +7,7 @@ product_key: inspec
 pipelines:
  - verify:
     description: Pull Request validation tests
+    public: false
     env:
      - LANG: "C.UTF-8"
      - SLOW: 1


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Makes verify pipeline private explicitly so that we can use Vault for secrets.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
