### PR TITLE
CHEF-4010 make a clean exit for License list command

### DIFF
--- a/lib/plugins/inspec-license/lib/inspec-license/cli.rb
+++ b/lib/plugins/inspec-license/lib/inspec-license/cli.rb
@@ -7,6 +7,9 @@ module InspecPlugins::License
     desc "list", "List licenses (not applicable to local licensing service)"
     def list
       ChefLicensing.list_license_keys_info
+    rescue ChefLicensing::Error => e
+      Inspec::Log.error e.message
+      Inspec::UI::EXIT_LICENSE_NOT_SET
     end
 
     desc "add", "Add a new license (not applicable to local licensing service)"

--- a/lib/plugins/inspec-license/lib/inspec-license/cli.rb
+++ b/lib/plugins/inspec-license/lib/inspec-license/cli.rb
@@ -9,7 +9,7 @@ module InspecPlugins::License
       ChefLicensing.list_license_keys_info
     rescue ChefLicensing::Error => e
       Inspec::Log.error e.message
-      Inspec::UI::EXIT_LICENSE_NOT_SET
+      Inspec::UI.new.exit(Inspec::UI::EXIT_LICENSE_NOT_SET)
     end
 
     desc "add", "Add a new license (not applicable to local licensing service)"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
`inspec license list` throws stacktrace when it is not able to connect to the License Server

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Better error handling on the license list command. Specific error to handle HTTP error is done in https://github.com/chef/chef-licensing/pull/136 . Now it responds with below error in case of issues around license server

```
╰─ bundle exec inspec license list                                                                                                                                                         ─╯
[2023-07-07T17:40:01+05:30] ERROR: Unable to connect to the licensing server at https://liensing-acceptance.chef.co/License.
Please check if the server is reachable and try again. InSpec requires server communication to operate.
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef-licensing/pull/136

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
