### PR TITLE
Prep CI system for inspec-prime merge

### DIFF
--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -4,6 +4,67 @@ Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table
 ruby -v
 bundle --version
 
+echo "--- download and install vault"
+# Define the version of Vault to install
+$VaultVersion = "1.13.0"
+
+# Define the installation directory for Vault
+$VaultDirectory = "$env:USERPROFILE\Vault"
+
+# Create the installation directory if it doesn't exist
+if (!(Test-Path $VaultDirectory))
+{
+    New-Item -ItemType Directory -Path $VaultDirectory | Out-Null
+}
+
+$VaultDownloadUrl = "https://releases.hashicorp.com/vault/$VaultVersion/vault_${VaultVersion}_windows_amd64.zip"
+$VaultZipFilePath = Join-Path $VaultDirectory "vault.zip"
+
+Invoke-WebRequest -Uri $VaultDownloadUrl -OutFile $VaultZipFilePath
+
+# Extract the Vault binary from the zip file
+$VaultExtractPath = Join-Path $VaultDirectory "vault"
+Expand-Archive -Path $VaultZipFilePath -DestinationPath $VaultExtractPath
+
+# Add the Vault binary to the system PATH environment variable
+$env:Path += ";$VaultExtractPath"
+
+# Verify the installation
+echo "--- vault version installed is:"
+vault version
+
+echo "--- fetching License serverl url and keys from vault"
+$Env:CHEF_LICENSE_SERVER=vault kv get -field acceptance secret/inspec/licensing/server
+$Env:CHEF_LICENSE_KEY=vault kv get -field acceptance secret/inspec/licensing/license-key
+
+echo "--- verifying if environment variables are set"
+
+function CheckIfEnvVarIsSet {
+  param (
+    [string]$envVarName
+  )
+  if (Test-Path "env:\$envVarName") {
+    Write-Host "  ++ $envVarName set successfully"
+  } else {
+    Write-Host "  !! $envVarName is not set."
+  }
+}
+
+$envVarName = "CHEF_LICENSE_SERVER"
+CheckIfEnvVarIsSet -envVarName $envVarName
+
+$envVarName = "CHEF_LICENSE_SERVER_API_KEY"
+CheckIfEnvVarIsSet -envVarName $envVarName
+
+$envVarName = "CHEF_LICENSE_KEY"
+CheckIfEnvVarIsSet -envVarName $envVarName
+
+if ($Env:CI_ENABLE_COVERAGE)
+{
+    echo "--- fetching Sonar token from vault"
+    $Env:SONAR_TOKEN=vault kv get -field token secret/inspec/sonar
+}
+
 echo "--- bundle install"
 bundle config set --local without deploy kitchen
 bundle install --jobs=7 --retry=3

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -20,14 +20,25 @@ mount
 df /tmp
 echo ${TMPDIR:-unknown}
 
-if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
-  # Fetch token from vault ASAP so that long-running tests don't cause our vault token to expire
-  echo "--- installing vault"
-  export VAULT_VERSION=1.9.3
-  export VAULT_HOME=$HOME/vault
-  curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
-  unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
+# Fetch tokens from vault ASAP so that long-running tests don't cause our vault token to expire
+echo "--- installing vault"
+export VAULT_VERSION=1.13.0
+export VAULT_HOME=$HOME/vault
+curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
+unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
 
+echo "--- fetching License serverl url and keys from vault"
+export CHEF_LICENSE_SERVER=$($VAULT_HOME/vault kv get -field acceptance secret/inspec/licensing/server)
+export CHEF_LICENSE_KEY=$($VAULT_HOME/vault kv get -field acceptance secret/inspec/licensing/license-key)
+if [ -n "${CHEF_LICENSE_KEY:-}" ]; then
+  echo "  ++ License Key set successfully"
+else
+  echo "  !! License Key not set - exiting "
+  exit 1
+fi
+
+
+if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
   echo "--- fetching Sonar token from vault"
   export SONAR_TOKEN=$($VAULT_HOME/vault kv get -field token secret/inspec/sonar)
 fi

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -3,25 +3,18 @@
 
 product_key: inspec
 
-rubygems:
- - inspec
- - inspec-core
- - inspec-bin:
-    gemspec_path: ./inspec-bin/
- - inspec-core-bin:
-    gemspec_path: ./inspec-bin/
 
 pipelines:
- - habitat/build:
+ - verify:
+    description: Pull Request validation tests
+    public: false
     env:
-     - HAB_NONINTERACTIVE: "true"
-     - HAB_NOCOLORING: "true"
-     - HAB_STUDIO_SECRET_HAB_NONINTERACTIVE: "true"
- - docker/build
+     - LANG: "C.UTF-8"
+     - SLOW: 1
+     - NO_AWS: 1
+     - MT_CPU: 5
  - omnibus/release:
     env:
-     # The git cache is corrupt more often than not. This always purges the cache.
-     # https://chefio.atlassian.net/wiki/spaces/RELENGKB/pages/2204336129/Resolving+git+cache+build+errors+in+Omnibus
      - EXPIRE_CACHE: 1
      - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems like ffi.
  - omnibus/adhoc:
@@ -29,41 +22,7 @@ pipelines:
     env:
      - ADHOC: true
      - EXPIRE_CACHE: 1
- - verify:
-    description: Pull Request validation tests
-    public: true
-    env:
-     - LANG: "C.UTF-8"
-     - SLOW: 1
-     - NO_AWS: 1
-     - MT_CPU: 5
- - coverage:
-    description: Unit test coverage
-    # Private due to use of tokens
-    trigger: pull_request
-    env:
-     - LANG: "C.UTF-8"
-     - SLOW: 1
-     - NO_AWS: 1
-     - MT_CPU: 5
-# This has been disabled because it regularly hits Docker API rate limits and fails
-#  - integration/resources:
-#     description: Test core resources with test-kitchen.
-#     definition: .expeditor/integration.resources.yml
-#     trigger: pull_request
- - artifact/habitat:
-    description: Execute tests against the habitat artifact
-    definition: .expeditor/artifact.habitat.yml
-    env:
-     - HAB_NONINTERACTIVE: "true"
-     - HAB_NOCOLORING: "true"
-     - HAB_STUDIO_SECRET_HAB_NONINTERACTIVE: "true"
-    trigger: pull_request
-
-schedules:
- - name: integration_schedule
-   description: Periodic Integration Testing
-   cronline: "0 8 * * *"
+     - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems like ffi.
 
 slack:
  notify_channel: inspec-notify
@@ -82,8 +41,6 @@ release_branches:
      version_constraint: 6.*
   - main:
       version_constraint: 5.*
-  - inspec-4:
-     version_constraint: 4.*
 
 changelog:
  categories:
@@ -120,56 +77,11 @@ subscriptions:
         ignore_labels:
          - "Expeditor: Skip All"
          - "Expeditor: Skip Changelog"
-     - trigger_pipeline:omnibus/adhoc:
-        not_if: built_in:bump_version
-        ignore_labels:
-         - "Expeditor: Skip Omnibus"
-         - "Expeditor: Skip All"
-     - trigger_pipeline:artifact/habitat:
-        only_if: built_in:bump_version
-        ignore_labels:
-         - "Expeditor: Skip Habitat"
-         - "Expeditor: Skip All"
      - trigger_pipeline:omnibus/release:
         only_if: built_in:bump_version
         ignore_labels:
          - "Expeditor: Skip Omnibus"
          - "Expeditor: Skip All"
-     - trigger_pipeline:habitat/build:
-        only_if: built_in:bump_version
-        ignore_labels:
-         - "Expeditor: Skip Habitat"
-         - "Expeditor: Skip All"
-     - built_in:build_gem:
-        only_if:
-         - built_in:bump_version
-  - workload: artifact_published:unstable:inspec:{{version_constraint}}
-    actions:
-     - trigger_pipeline:docker/build
-     - bash:.expeditor/buildkite/wwwrelease.sh:
-        post_commit: true
-  - workload: artifact_published:current:inspec:{{version_constraint}}
-    actions:
-     - built_in:promote_docker_images
-     - built_in:promote_habitat_packages
-  - workload: project_promoted:{{agent_id}}:*
-    actions:
-      - built_in:promote_artifactory_artifact
-  - workload: artifact_published:stable:inspec:{{version_constraint}}
-    actions:
-     - bash:.expeditor/update_dockerfile.sh
-     - built_in:rollover_changelog
-     - built_in:publish_rubygems
-     - built_in:create_github_release
-     - built_in:promote_docker_images
-     - built_in:promote_habitat_packages
-     - bash:.expeditor/publish-release-notes.sh:
-        post_commit: true
-     - purge_packages_chef_io_fastly:{{target_channel}}/inspec/latest:
-        post_commit: true
-     - bash:.expeditor/announce-release.sh:
-        post_commit: true
-     - built_in:notify_chefio_slack_channels
   - workload: pull_request_opened:{{github_repo}}:{{release_branch}}:*
     actions:
      - post_github_comment:.expeditor/templates/pull_request.mustache:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -7,7 +7,6 @@ product_key: inspec
 pipelines:
  - verify:
     description: Pull Request validation tests
-    public: false
     env:
      - LANG: "C.UTF-8"
      - SLOW: 1


### PR DESCRIPTION
Prepares Expeditor for the upcoming inspec-prime merge.

Strips down the publishing stream temporarily.

Sets up Vault license key fetching.

Make the verify pipeline private, required so that we can access Vault to load license keys.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
