### PR TITLE
Add inspec-6 branch to Dependabot monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,15 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: bundler
+  target-branch: "inspec-6"
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: bundler
+  target-branch: "inspec-6"
+  directory: "/omnibus"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Add inspec-6 branch to Dependabot dependency monitoring, which causes automated PRs to be opened. We're largely up to date (we had this turned on inspec-6 on inspec-prime) but we're a few behind on Omnibus, which is high-traffic.

This change must be made on main for Dependabot to pick it up.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
