### PR TITLE
Foreport 6568

### DIFF
--- a/docs-chef-io/content/inspec/reporters.md
+++ b/docs-chef-io/content/inspec/reporters.md
@@ -15,7 +15,7 @@ A `reporter` is a facility for formatting and delivering the results of a Chef I
 
 Chef InSpec allows you to output your test results to one or more reporters.
 
-Configure the reporter(s) using either the `--reporter` option or as part of the general configuration file using the `--config` (or `--json-config`, prior to v3.6) option. While you can configure multiple reporters to write to different files, only one reporter can output to the screen(stdout).
+Configure the reporter(s) using the `--reporter` option or as part of the general configuration file using the `--config` (or `--json-config`, prior to v3.6) option. Both the --reporter and --config options may be used, in which case the options are merged. While you can configure multiple reporters to write to different files, only one reporter can output to the screen(stdout).
 
 ## Syntax
 

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -561,7 +561,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   end
 
   def run_command(opts)
-    runner = Inspec::Runner.new(Inspec::Config.new(opts))
+    runner = Inspec::Runner.new(opts)
     res = runner.eval_with_virtual_profile(opts[:command])
     runner.load
 

--- a/test/fixtures/config_dirs/json-config/reporter-cli-config.json
+++ b/test/fixtures/config_dirs/json-config/reporter-cli-config.json
@@ -1,0 +1,7 @@
+{
+  "reporter": {
+    "cli" : {
+      "stdout" : true
+    }
+  }
+}

--- a/test/functional/inputs_test.rb
+++ b/test/functional/inputs_test.rb
@@ -81,7 +81,7 @@ describe "inputs" do
     let(:common_options) do
       {
         profile: "#{inputs_profiles_path}/via-runner",
-        reporter: ["json"],
+        "reporter" => ["json"],
       }
     end
 

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -1085,6 +1085,34 @@ describe "inspec exec" do
     end
   end
 
+  describe "When specifying a config file and --reporter option to configure reporter in a run in a correct manner" do
+    it "should obey the configurations of both --reporter and config reporter options" do
+      outpath = Dir.tmpdir
+      cli_args = "--no-create-lockfile --reporter json:#{outpath}/foo/bar/test.json --config " + File.join(config_dir_path, "json-config", "reporter-cli-config.json")
+      inspec("exec #{complete_profile} #{cli_args}")
+
+      # File specified with --reporter option - test to see file exists
+      _(File.exist?("#{outpath}/foo/bar/test.json")).must_equal true
+      _(File.stat("#{outpath}/foo/bar/test.json").size).must_be :>, 0
+      # STDOUT true set using config - test to see if this is obeyed
+      _(stdout).must_include "complete example profile (complete)"
+      _(stdout).must_include "1 successful control"
+      _(stdout).must_include "0 control failures"
+      _(stdout).must_include "0 controls skipped"
+      _(stderr).must_be_empty
+      assert_exit_code 0, out
+    end
+  end
+
+  describe "When specifying a config file and --reporter option to configure reporter with stdout true from both the options" do
+    let(:cli_args) { "--config " + File.join(config_dir_path, "json-config", "reporter-cli-config.json") + " --reporter json html2" }
+    let(:run_result) { run_inspec_process("exec " + File.join(profile_path, "basic_profile") + " " + cli_args) }
+    it "should raise error that only single reporter can have output to stdout" do
+      _(run_result.stderr).wont_equal ""
+      _(run_result.stderr).must_include "The option --reporter can only have a single report outputting to stdout."
+    end
+  end
+
   describe "when specifying the execution target" do
     let(:local_plat) do
       json = run_inspec_process("detect --format json", {}).stdout


### PR DESCRIPTION
We could wait to bring this over later, but we need this fix in pre-release testing, so we keep up the habit of foreporting a bit longer.


CHEF-4115 Added ability to merge reporter configurations from both CL……I and config (#6568)

* Added ability to merge cli and config reporter options



* Test cases to validate working of reporter configuration using cli and config



* Documentation change to add information on reporter configurations usage with both



* Added Doc review changes and text fixture for config json



* Verify fix



* Verify pipeline test fixes for reporter options to be read successfully



* Test changes in both cli and config reporter usage scenarios to fix verify pipeline



* Review comments to improvise



* Renamed testing fixture file for reporter cli config file



---------

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
