### PR TITLE
CHEF-3916 Add section on inspec license subcommand to online docs

### DIFF
--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -635,23 +635,28 @@ This subcommand has the following additional options:
 
 ## license
 
-Subcommands for interacting with the licensing system.
+Subcommands for interacting with the Chef licensing system.
 
 ### Syntax
 
-`inspec license` currently supports two sub-commands, `list` and `add`.
+`inspec license` supports two subcommands, `add` and `list`.
 
+#### Add
 
-All users. To run license diagnostics and output the details of your current license configuration, run `inspec license list`.
+Add a Chef license.
 
-```bash
-inspec license list
-```
-
-Global license service users only - local license service users not applicable - To add a license, for example when your current license has expired, use `inspec license add`:
+Not applicable for users running the local licensing service.
 
 ```bash
 inspec license add
+```
+
+#### List
+
+Run license diagnostics and output the details of your current Chef license configuration.
+
+```bash
+inspec license list
 ```
 
 ## run_context

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -633,6 +633,27 @@ This subcommand has the following additional options:
 
 </dl>
 
+## license
+
+Subcommands for interacting with the licensing system.
+
+### Syntax
+
+`inspec license` currently supports two sub-commands, `list` and `add`.
+
+
+All users. To run license diagnostics and output the details of your current license configuration, run `inspec license list`.
+
+```bash
+inspec license list
+```
+
+Global license service users only - local license service users not applicable - To add a license, for example when your current license has expired, use `inspec license add`:
+
+```bash
+inspec license add
+```
+
 ## run_context
 
 Used to test run-context detection


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Adds a section on inspec license to the CLI help page. Need some editng to reword the applicability of the license add command.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-3916: Create "license" subcommand section in CLI help text docs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
