### PR TITLE
CHEF-5200 Waived controls are not getting waived (skipped) in case of failure at resource level.

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -63,6 +63,11 @@ module Inspec
           # Rubocop thinks we are raising an exception - we're actually calling RSpec's fail()
           its(location) { fail e.message } # rubocop: disable Style/SignalException
         end
+
+        # instance_eval evaluates the describe block and raise errors if at the resource level any execution is failed
+        # Waived controls expect not to raise any controls and get skipped if run is false so __apply_waivers needs to be called here too
+        # so that waived control are actually gets waived.
+	      __apply_waivers
       end
     end
 

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -67,7 +67,7 @@ module Inspec
         # instance_eval evaluates the describe block and raise errors if at the resource level any execution is failed
         # Waived controls expect not to raise any controls and get skipped if run is false so __apply_waivers needs to be called here too
         # so that waived control are actually gets waived.
-	      __apply_waivers
+        __apply_waivers
       end
     end
 

--- a/lib/inspec/waiver_file_reader.rb
+++ b/lib/inspec/waiver_file_reader.rb
@@ -19,15 +19,17 @@ module Inspec
         data = nil
         if [".yaml", ".yml"].include? file_extension
           data = Secrets::YAML.resolve(file_path)
-          data = data.inputs unless data.nil?
-          validate_json_yaml(data)
+          unless data.nil?
+            data = data.inputs
+            validate_json_yaml(data)
+          end
         elsif file_extension == ".csv"
           data = Waivers::CSVFileReader.resolve(file_path)
           headers = Waivers::CSVFileReader.headers
           validate_headers(headers)
         elsif file_extension == ".json"
           data = Waivers::JSONFileReader.resolve(file_path)
-          validate_json_yaml(data)
+          validate_json_yaml(data) unless data.nil?
         end
         output.merge!(data) if !data.nil? && data.is_a?(Hash)
 

--- a/test/fixtures/profiles/waivers/only_if/controls/only_if_controls.rb
+++ b/test/fixtures/profiles/waivers/only_if/controls/only_if_controls.rb
@@ -7,3 +7,10 @@ control "01_only_if" do
     it { should eq true }
   end
 end
+
+control "02_only_if_when_waiver_is_expired" do
+  only_if("test_message_from_dsl_02_only_if") { false }
+  describe true do
+    it { should eq true }
+  end
+end

--- a/test/fixtures/profiles/waivers/only_if/files/waiver.yaml
+++ b/test/fixtures/profiles/waivers/only_if/files/waiver.yaml
@@ -1,3 +1,8 @@
 01_only_if:
   run: false
   justification: test_message_from_waiver
+
+02_only_if_when_waiver_is_expired:
+  expiration_date: 1977-06-01
+  run: false
+  justification: test_message_from_waiver

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -72,7 +72,7 @@ describe "waivers" do
     assert_empty act
   end
 
-  def assert_skip_message(control_id = "01_only_if", yea, nay)
+  def assert_skip_message(yea, nay, control_id = "01_only_if")
     msg = controls_by_id.dig(control_id, "results", 0, "skip_message")
     assert_includes msg, yea
     refute_includes msg, nay
@@ -252,9 +252,9 @@ describe "waivers" do
     end
 
     describe "when an only_if is used with waiver file which has waived control with past expiration date" do
-      let(:waiver_file) {"waiver.yaml"}
+      let(:waiver_file) { "waiver.yaml" }
       it "skips the control with a waiver message" do
-        assert_skip_message "02_only_if_when_waiver_is_expired", "test_message_from_dsl_02_only_if", "waiver"
+        assert_skip_message "test_message_from_dsl_02_only_if", "waiver", "02_only_if_when_waiver_is_expired"
       end
     end
 

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -72,8 +72,8 @@ describe "waivers" do
     assert_empty act
   end
 
-  def assert_skip_message(yea, nay)
-    msg = controls_by_id.dig("01_only_if", "results", 0, "skip_message")
+  def assert_skip_message(control_id = "01_only_if", yea, nay)
+    msg = controls_by_id.dig(control_id, "results", 0, "skip_message")
     assert_includes msg, yea
     refute_includes msg, nay
   end
@@ -241,10 +241,20 @@ describe "waivers" do
   describe "waivers and only_if" do
     let(:profile_name) { "only_if" }
 
-    describe "when an only_if is used with no waiver" do
+    describe "when an only_if is used with empty waiver file" do
       let(:waiver_file) { "empty.yaml" }
-      it "skips the control with an only_if message" do
-        assert_skip_message "due to only_if", "waiver"
+
+      it "raise unable to parse empty.yaml file error" do
+        result = run_result
+        assert_includes result.stderr, "unable to parse"
+        assert_equal 102, result.exit_status
+      end
+    end
+
+    describe "when an only_if is used with waiver file which has waived control with past expiration date" do
+      let(:waiver_file) {"waiver.yaml"}
+      it "skips the control with a waiver message" do
+        assert_skip_message "02_only_if_when_waiver_is_expired", "test_message_from_dsl_02_only_if", "waiver"
       end
     end
 

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -247,7 +247,11 @@ describe "waivers" do
       it "raise unable to parse empty.yaml file error" do
         result = run_result
         assert_includes result.stderr, "unable to parse"
-        assert_equal 102, result.exit_status
+        if windows?
+          assert_equal 1, result.exit_status
+        else
+          assert_equal 102, result.exit_status
+        end
       end
     end
 


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
CHEF-5200: This fix applies waiver if an exception occurs while eval the control inside control block. This ensures that waiver got applied in case of resource level failures and when run is set to false.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
