### PR TITLE
GEMFILE: Remove kitchen group from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,20 +47,3 @@ end
 group :deploy do
   gem "inquirer"
 end
-
-group :kitchen do
-  gem "berkshelf"
-
-  # Chef 18 requires ruby 3
-  if Gem.ruby_version >= Gem::Version.new("3.0.0")
-    gem "chef", ">= 17.0"
-  else
-    # Ruby 2.7 presumably - TODO remove this when 2.7 is sunsetted
-    gem "chef", "~> 16.0"
-  end
-
-  gem "test-kitchen", ">= 2.8"
-  gem "kitchen-inspec", ">= 2.0"
-  gem "kitchen-dokken", ">= 2.11"
-  gem "git"
-end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR removes the kitchen group from Gemfile as we no longer do kitchen testing due to certain API limitations. Additionally, removing this group solves a stacktrace issue when closing winrm connection.

### Existing Behavior
![image](https://github.com/inspec/inspec/assets/98935583/0b310a38-6859-4b37-a217-aefe77e6ef34)

### Updated Behavior 
![image](https://github.com/inspec/inspec/assets/98935583/8e13467b-0b82-4558-ba2e-ab87d5bfe532)

![image](https://github.com/inspec/inspec/assets/98935583/1bd126e7-08d1-45be-a175-7d436bb36691)


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
[CHEF-5136: Closing a winrm connection via InSpec 5 and Ruby 3.1 throws stack trace due to ThreadError](https://chefio.atlassian.net/browse/CHEF-5136)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
