### PR TITLE
CHEF-65: Create inspec-5 release branch in Expeditor and Dependabot configuration

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -79,9 +79,11 @@ github:
 
 release_branches:
   - main:
+     version_constraint: 99.*
+  - inspec-6:
      version_constraint: 6.*
   - inspec-5:
-      version_constraint: 5.*
+     version_constraint: 5.*
   - inspec-4:
      version_constraint: 4.*
 

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -78,9 +78,9 @@ github:
    - "Expeditor: Bump Major Version"
 
 release_branches:
-  - inspec-6:
-     version_constraint: 6.*
   - main:
+     version_constraint: 6.*
+  - inspec-5:
       version_constraint: 5.*
   - inspec-4:
      version_constraint: 4.*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,16 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: bundler
+  target-branch: "inspec-6"
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: bundler
+  target-branch: "inspec-6"
+  directory: "/omnibus"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,13 +25,13 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
 - package-ecosystem: bundler
-  target-branch: "inspec-6"
+  target-branch: "inspec-5"
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
 - package-ecosystem: bundler
-  target-branch: "inspec-6"
+  target-branch: "inspec-5"
   directory: "/omnibus"
   schedule:
     interval: daily


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This is to update the expeditor and dependabot configuration to get ready for InSpec 6 release.

It creates an inspec-5 release branch in the CI configuration. Cutting a branch is a simple operation after that.

This is the first phase in preparation for merging inspec-6 to main.
Roughly:
1. Branch inspec-5 from main; temporarily freeze main
2. Verify CI health of inspec-5 pipelines
3. Merge inspec-6 to main
4. Verify CI health of main pipelines
5. main thaws; development targets InSpec 6 and some things backport to inspec-5 and inspec-4 pending the release of InSpec 6.




## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
