### PR TITLE
[W.I.P] Fix: Waived control executes describe block

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -46,12 +46,11 @@ module Inspec
       return unless block_given?
 
       begin
-        instance_eval(&block)
-
-        # By applying waivers *after* the instance eval, we assure that
-        # waivers have higher precedence than only_if.
         __apply_waivers
 
+        unless waiver_is_valid?
+          instance_eval(&block)
+        end
       rescue SystemStackError, StandardError => e
         # We've encountered an exception while trying to eval the code inside the
         # control block. We need to prevent the exception from bubbling up, and
@@ -479,6 +478,16 @@ module Inspec
       { ref: r, line: l }
     rescue MethodSource::SourceNotFoundError
       {}
+    end
+
+    def waiver_is_valid?
+      return false if @__waiver_data.nil? || @__waiver_data.empty?
+
+      if @__waiver_data["run"] == false && !@__waiver_data["message"].match?(/Waiver expired on/)
+        true
+      else
+        false
+      end
     end
   end
 end

--- a/lib/inspec/secrets/yaml.rb
+++ b/lib/inspec/secrets/yaml.rb
@@ -25,8 +25,8 @@ module Secrets
       end
 
       if @inputs == false || !@inputs.is_a?(Hash)
-        raise ("#{self.class} unable to parse #{target}: invalid YAML or contents is not a Hash")
         @inputs = nil
+        raise("#{self.class} unable to parse #{target}: invalid YAML or contents is not a Hash")
       end
     rescue => e
       raise "Error reading InSpec inputs: #{e}"

--- a/lib/inspec/secrets/yaml.rb
+++ b/lib/inspec/secrets/yaml.rb
@@ -25,7 +25,7 @@ module Secrets
       end
 
       if @inputs == false || !@inputs.is_a?(Hash)
-        Inspec::Log.warn("#{self.class} unable to parse #{target}: invalid YAML or contents is not a Hash")
+        raise ("#{self.class} unable to parse #{target}: invalid YAML or contents is not a Hash")
         @inputs = nil
       end
     rescue => e

--- a/lib/inspec/waiver_file_reader.rb
+++ b/lib/inspec/waiver_file_reader.rb
@@ -19,7 +19,7 @@ module Inspec
         data = nil
         if [".yaml", ".yml"].include? file_extension
           data = Secrets::YAML.resolve(file_path)
-          unless data.nil?
+          unless data.nil? || data.inputs.nil?
             data = data.inputs
             validate_json_yaml(data)
           end

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -244,14 +244,10 @@ describe "waivers" do
     describe "when an only_if is used with empty waiver file" do
       let(:waiver_file) { "empty.yaml" }
 
-      it "raise unable to parse empty.yaml file error" do
+      it "raise warnings unable to parse empty.yaml file" do
         result = run_result
-        assert_includes result.stderr, "unable to parse"
-        if windows?
-          assert_equal 1, result.exit_status
-        else
-          assert_equal 102, result.exit_status
-        end
+        assert_includes result.stderr, "WARN: Secrets::YAML unable to parse"
+        assert_skip_message "due to only_if", "waiver"
       end
     end
 

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -246,8 +246,7 @@ describe "waivers" do
 
       it "raise warnings unable to parse empty.yaml file" do
         result = run_result
-        assert_includes result.stderr, "WARN: Secrets::YAML unable to parse"
-        assert_skip_message "due to only_if", "waiver"
+        assert_includes result.stderr, "unable to parse"
       end
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Waived control should not be executed and skipped without execution of describe block.

This change helps in eliminating the efforts to use options `--filter-waived-controls` and `--retain-waiver-data`.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
