### PR TITLE
Move chef-licensing gem dependency to inspec gemspec file

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -18,6 +18,7 @@ pipelines:
       - SLOW: 1
       - NO_AWS: 1
       - MT_CPU: 5
+      - ARTIFACTORY_BASE_URL: https://artifactory-internal.ps.chef.co
  - coverage:
       description: Unit test coverage
       public: false
@@ -28,16 +29,19 @@ pipelines:
       - SLOW: 1
       - NO_AWS: 1
       - MT_CPU: 5
+      - ARTIFACTORY_BASE_URL: https://artifactory-internal.ps.chef.co
  - omnibus/release:
     env:
      - EXPIRE_CACHE: 1
      - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems like ffi.
+     - ARTIFACTORY_BASE_URL: https://artifactory-internal.ps.chef.co
  - omnibus/adhoc:
     definition: .expeditor/release.omnibus.yml
     env:
      - ADHOC: true
      - EXPIRE_CACHE: 1
      - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems like ffi.
+     - ARTIFACTORY_BASE_URL: https://artifactory-internal.ps.chef.co
 
 slack:
  notify_channel: inspec-notify

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
+# For Chef internal builds, allows preview versions of gems if available.
+if ENV["ARTIFACTORY_BASE_URL"]
+  source ENV["ARTIFACTORY_BASE_URL"] + "/artifactory/api/gems/omnibus-gems-local/"
+end
+
 source "https://rubygems.org"
 
 gem "inspec", path: "."

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,3 @@ end
 group :deploy do
   gem "inquirer"
 end
-
-source "https://artifactory-internal.ps.chef.co/artifactory/api/gems/omnibus-gems-local/" do
-  gem "chef-licensing"
-end

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -46,4 +46,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "multipart-post",           "~> 2.0"
 
   spec.add_dependency "train-core", "~> 3.10"
+  spec.add_dependency "chef-licensing", ">= 0.4.44"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Moves chef-licensing gem dependency to the inspec gemspec file .

Continues and formalizes the practice of fetching Chef-owned gems, like chef-licensing, from internal Chef artifactory.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
