### PR TITLE
Adds missing expeditor configuration for inspec 6 release

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -98,8 +98,13 @@ subscriptions:
         ignore_labels:
          - "Expeditor: Skip All"
          - "Expeditor: Skip Changelog"
-    - trigger_pipeline:omnibus/adhoc:
+     - trigger_pipeline:omnibus/adhoc:
         not_if: built_in:bump_version
+        ignore_labels:
+         - "Expeditor: Skip Omnibus"
+         - "Expeditor: Skip All"
+     - trigger_pipeline:omnibus/release:
+        only_if: built_in:bump_version
         ignore_labels:
          - "Expeditor: Skip Omnibus"
          - "Expeditor: Skip All"
@@ -121,11 +126,6 @@ subscriptions:
      - bash:.expeditor/announce-release.sh:
         post_commit: true
      - built_in:notify_chefio_slack_channels
-     - trigger_pipeline:omnibus/release:
-        only_if: built_in:bump_version
-        ignore_labels:
-         - "Expeditor: Skip Omnibus"
-         - "Expeditor: Skip All"
   - workload: pull_request_opened:{{github_repo}}:{{release_branch}}:*
     actions:
      - post_github_comment:.expeditor/templates/pull_request.mustache:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -98,6 +98,29 @@ subscriptions:
         ignore_labels:
          - "Expeditor: Skip All"
          - "Expeditor: Skip Changelog"
+    - trigger_pipeline:omnibus/adhoc:
+        not_if: built_in:bump_version
+        ignore_labels:
+         - "Expeditor: Skip Omnibus"
+         - "Expeditor: Skip All"
+     - built_in:build_gem:
+        only_if:
+         - built_in:bump_version
+  - workload: project_promoted:{{agent_id}}:*
+    actions:
+      - built_in:promote_artifactory_artifact
+  - workload: artifact_published:stable:inspec:{{version_constraint}}
+    actions:
+     - built_in:rollover_changelog
+     - built_in:publish_rubygems
+     - built_in:create_github_release
+     - bash:.expeditor/publish-release-notes.sh:
+        post_commit: true
+     - purge_packages_chef_io_fastly:{{target_channel}}/inspec/latest:
+        post_commit: true
+     - bash:.expeditor/announce-release.sh:
+        post_commit: true
+     - built_in:notify_chefio_slack_channels
      - trigger_pipeline:omnibus/release:
         only_if: built_in:bump_version
         ignore_labels:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -3,6 +3,13 @@
 
 product_key: inspec
 
+rubygems:
+ - inspec
+ - inspec-core
+ - inspec-bin:
+    gemspec_path: ./inspec-bin/
+ - inspec-core-bin:
+    gemspec_path: ./inspec-bin/
 
 pipelines:
  - verify:
@@ -32,6 +39,8 @@ pipelines:
       - ARTIFACTORY_BASE_URL: https://artifactory-internal.ps.chef.co
  - omnibus/release:
     env:
+     # The git cache is corrupt more often than not. This always purges the cache.
+     # https://chefio.atlassian.net/wiki/spaces/RELENGKB/pages/2204336129/Resolving+git+cache+build+errors+in+Omnibus
      - EXPIRE_CACHE: 1
      - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems like ffi.
      - ARTIFACTORY_BASE_URL: https://artifactory-internal.ps.chef.co


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This contains missing configurations that will be required for the inspec 6 release 
 * omnibus ad-hoc build 
 * build gem
 * project promotion
  * publishing artifacts (rollover of changelog, publish rubygems, create github release, publish release notes, purge_packages_chef_io_fastly, announce release, notify_chefio_slack_channels)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
