### PR TITLE
[W.I.P] CHEF-442 Fix for inspec exec fails with git fetcher if current directory does not have .git directory.

### DIFF
--- a/test/functional/git_fetcher_test.rb
+++ b/test/functional/git_fetcher_test.rb
@@ -174,4 +174,15 @@ describe "running profiles with git-based dependencies" do
       assert_exit_code 0, out
     end
   end
+
+  describe "running a remote GIT profile from directory which does not have .git directory" do
+    it "should use default HEAD branch" do
+      Dir.mktmpdir do |temp_dir_path|
+        Dir.chdir(temp_dir_path) do
+          inspec("exec #{git_default_main_profile_url}")
+          assert_empty stderr
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This is a Work in progress

This will address the issue where inspec execution fails with an error `not a git repository (or any of the parent directories): .git `when inspec is run with the profile which is on git.

Test covering the failure https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/16#018a265e-c1fd-49b5-9562-c2575be5ee8d/710-731 (surprisingly currently this is only failing on ruby 3.1)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
