### PR TITLE
CHEF-642 Fix for inspec exec fails with git fetcher if current directory does not have .git directory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 if ENV["ARTIFACTORY_BASE_URL"]
   source ENV["ARTIFACTORY_BASE_URL"] + "/artifactory/api/gems/omnibus-gems-local/" do
     # TODO: either fully populate this list, or revert back to non-block format
-    #       to sweep all Chef gems from Artifactory.e verify test working on this PR. Revert once the work is done for the git fetcher fix)
+    #       to sweep all Chef gems from Artifactory.
     gem "chef-licensing"
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 if ENV["ARTIFACTORY_BASE_URL"]
   source ENV["ARTIFACTORY_BASE_URL"] + "/artifactory/api/gems/omnibus-gems-local/" do
     # TODO: either fully populate this list, or revert back to non-block format
-    #       to sweep all Chef gems from Artifactory.
+    #       to sweep all Chef gems from Artifactory.e verify test working on this PR. Revert once the work is done for the git fetcher fix)
     gem "chef-licensing"
   end
 end

--- a/test/functional/git_fetcher_test.rb
+++ b/test/functional/git_fetcher_test.rb
@@ -174,4 +174,15 @@ describe "running profiles with git-based dependencies" do
       assert_exit_code 0, out
     end
   end
+
+  describe "running a remote GIT profile from directory which does not have .git directory" do
+    it "should use default HEAD branch" do
+      Dir.mktmpdir do |temp_dir_path|
+        Dir.chdir(temp_dir_path) do
+          inspec("exec #{git_default_main_profile_url}")
+          assert_empty stderr
+        end
+      end
+    end
+  end
 end

--- a/test/unit/fetchers/git_test.rb
+++ b/test/unit/fetchers/git_test.rb
@@ -60,25 +60,11 @@ a7729ce65636d6d8b80159dd5dd7a40fdb6f2501\trefs/tags/anothertag^{}\n")
       out
     end
 
-    let(:git_remote_head_master) do
-      out = mock
-      out.stubs(:stdout).returns("HEAD branch: master\n")
-      out.stubs(:exitstatus).returns(0)
-      out.stubs(:stderr).returns("")
-      out.stubs(:error!).returns(false)
-      out.stubs(:run_command).returns(true)
-      out
-    end
-
     before do
       # git fetcher likes to make directories, let's stub that for every test
       Dir.stubs(:mktmpdir).yields("test-tmp-dir")
       File.stubs(:directory?).with("fetchpath/.git").returns(false)
       FileUtils.stubs(:mkdir_p)
-    end
-
-    def expect_git_remote_head_master(remote_url)
-      Mixlib::ShellOut.expects(:new).with("git remote show #{remote_url}", {}).returns(git_remote_head_master)
     end
 
     def expect_ls_remote(ref)
@@ -89,6 +75,10 @@ a7729ce65636d6d8b80159dd5dd7a40fdb6f2501\trefs/tags/anothertag^{}\n")
       Mixlib::ShellOut.expects(:new).with("git checkout #{ref}", { cwd: at }).returns(git_output)
     end
 
+    def expect_checkout_without_ref(at = "test-tmp-dir")
+      Mixlib::ShellOut.expects(:new).with("git checkout", { cwd: at }).returns(git_output)
+    end
+
     def expect_clone
       Mixlib::ShellOut.expects(:new).with("git clone #{git_dep_dir} ./", { cwd: "test-tmp-dir" }).returns(git_output)
     end
@@ -97,11 +87,9 @@ a7729ce65636d6d8b80159dd5dd7a40fdb6f2501\trefs/tags/anothertag^{}\n")
       FileUtils.expects(:cp_r).with("test-tmp-dir/.", "fetchpath")
     end
 
-    it "resolves to the revision of master when head branch master" do
-      expect_git_remote_head_master(git_dep_dir)
-      expect_ls_remote("master")
+    it "it should able to resolve" do
       result = fetcher.resolve({ git: git_dep_dir })
-      _(result.resolved_source).must_equal({ git: git_dep_dir, ref: git_master_ref })
+      _(result.resolved_source).must_equal({ git: git_dep_dir })
     end
 
     it "can resolve a tag" do
@@ -122,10 +110,8 @@ a7729ce65636d6d8b80159dd5dd7a40fdb6f2501\trefs/tags/anothertag^{}\n")
     end
 
     it "fetches to the given location" do
-      expect_git_remote_head_master(git_dep_dir)
-      expect_ls_remote("master")
       expect_clone
-      expect_checkout(git_master_ref)
+      expect_checkout_without_ref
       expect_mv_into_place
       result = fetcher.resolve({ git: git_dep_dir })
       result.fetch("fetchpath")
@@ -133,61 +119,17 @@ a7729ce65636d6d8b80159dd5dd7a40fdb6f2501\trefs/tags/anothertag^{}\n")
 
     it "doesn't refetch an already cloned repo" do
       File.expects(:directory?).with("fetchpath/.git").at_least_once.returns(true)
-      expect_git_remote_head_master(git_dep_dir)
-      expect_ls_remote("master")
-      expect_checkout(git_master_ref, "fetchpath")
+      expect_checkout_without_ref("fetchpath")
       result = fetcher.resolve({ git: git_dep_dir })
       result.fetch("fetchpath")
     end
 
     it "returns the repo_path that we fetched to as the archive_path" do
       File.expects(:directory?).with("fetchpath/.git").at_least_once.returns(true)
-      expect_git_remote_head_master(git_dep_dir)
-      expect_ls_remote("master")
-      expect_checkout(git_master_ref, "fetchpath")
+      expect_checkout_without_ref("fetchpath")
       result = fetcher.resolve({ git: git_dep_dir })
       result.fetch("fetchpath")
       _(result.archive_path).must_equal "fetchpath"
-    end
-  end
-
-  describe "when given a repository with default branch main" do
-    let(:git_default_main) { "inspec-test-profile-default-main" }
-    let(:git_main_ref) { "69220a2ba6a3b276184f328e69a953e83e283323" }
-
-    let(:git_remote_head_main) do
-      out = mock
-      out.stubs(:stdout).returns("HEAD branch: main\n")
-      out.stubs(:exitstatus).returns(0)
-      out.stubs(:stderr).returns("")
-      out.stubs(:error!).returns(false)
-      out.stubs(:run_command).returns(true)
-      out
-    end
-
-    let(:git_ls_remote_output_for_main) do
-      out = mock
-      out.stubs(:stdout).returns("69220a2ba6a3b276184f328e69a953e83e283323\trefs/heads/main")
-      out.stubs(:exitstatus).returns(0)
-      out.stubs(:stderr).returns("")
-      out.stubs(:error!).returns(false)
-      out.stubs(:run_command).returns(true)
-      out
-    end
-
-    def expect_git_remote_head_main(remote_url)
-      Mixlib::ShellOut.expects(:new).with("git remote show #{remote_url}", {}).returns(git_remote_head_main)
-    end
-
-    def expect_ls_remote(ref)
-      Mixlib::ShellOut.expects(:new).with("git ls-remote \"#{git_default_main}\" \"#{ref}*\"", {}).returns(git_ls_remote_output_for_main)
-    end
-
-    it "resolves to the revision of main when head branch main" do
-      expect_git_remote_head_main(git_default_main)
-      expect_ls_remote("main")
-      result = fetcher.resolve({ git: git_default_main })
-      _(result.resolved_source).must_equal({ git: git_default_main, ref: git_main_ref })
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This fixes #6064 for git fetcher (inspec git fetcher requires the $pwd to be a git repo)
This PR includes a bug fix in the git fetcher

* Enables to fetch git profile irrespective of whether the current directory executing inspec has the .git or not.
* It clones the git profile and git checkout it to the default HEAD branch and does not require resolving reference
* Removes the logic from the git fetcher to get the default branch, it was using `git remote show` command that requires the current directory to be git repo and was causing the git fetch to fail in case the current directory does not have .git directory.
* Tested with a profile that has a dependent profile with a GIT URL.
* Tested with the relative path.
* Updated unit and functional test as per new changes.

Test covering the failure https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/16#018a265e-c1fd-49b5-9562-c2575be5ee8d/710-731 (surprisingly currently this is only failing on ruby 3.1) Note: this reference is from my earlier PR which I opened against the inspec-5 branch.

Passing Test after fix:
https://buildkite.com/chef/inspec-inspec-main-verify-private/builds/66
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
