### PR TITLE
Fix for omnibus build failure on Windows due to ffi-yajl error

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -6,6 +6,11 @@ gem "artifactory"
 
 gem "ffi", ">= 1.9.14", "!= 1.13.0"
 
+# Pinning to 2.4.0 as 2.6.0 version breaks the Windows build
+# Ref: https://buildkite.com/chef/inspec-inspec-main-omnibus-release/builds/815#018a1db4-2971-4e77-8bca-32d058fe8c12/173-340
+# We can try reverting this change once it gets fixed in the omnibus-toolchain as per slack conversation
+gem 'ffi-yajl', "= 2.4.0"
+
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need
 # the Test Kitchen-based build lab. You can skip these unnecessary dependencies

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi
-    ffi-yajl (2.6.0)
+    ffi-yajl (2.4.0)
       libyajl2 (>= 1.2)
     fuzzyurl (0.9.0)
     gssapi (1.3.1)
@@ -458,7 +458,7 @@ GEM
     vault (0.17.0)
       aws-sigv4
     webrick (1.8.1)
-    win32-api (1.10.1-universal-mingw32)
+    win32-api (1.10.1)
     win32-certstore (0.6.15)
       chef-powershell (>= 1.0.12)
       ffi
@@ -513,6 +513,7 @@ DEPENDENCIES
   artifactory
   berkshelf (>= 7.0)
   ffi (>= 1.9.14, != 1.13.0)
+  ffi-yajl (= 2.4.0)
   kitchen-vagrant (>= 1.3.1)
   omnibus!
   omnibus-software!


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Currently, omnibus build is failing as it unables to resolve the `ffi-yajl` dependency Ref: https://buildkite.com/chef/inspec-inspec-main-omnibus-release/builds/815#018a1db4-2971-4e77-8bca-32d058fe8c12/173-336

Pinning `ffi-yajl` currently helps to fix the build (Adhoc passing build with this change https://buildkite.com/chef/inspec-inspec-main-omnibus-adhoc/builds/406). This can be reverted once this gets fixed in omnibus.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
