### PR TITLE
Fix missing nil check for control variable in formatter's base - Issue 6510

### DIFF
--- a/lib/inspec/formatters/base.rb
+++ b/lib/inspec/formatters/base.rb
@@ -160,7 +160,7 @@ module Inspec::Formatters
           end
 
           # added this additionally because stats summary is also used for determining exit code in runner rspec
-          skipped += 1 if control[:results].any? { |r| r[:status] == "skipped" }
+          skipped += 1 if control[:results] && (control[:results].any? { |r| r[:status] == "skipped" })
 
         end
         total = error + not_applicable + not_reviewed + failed + passed


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR fixes the issue #6510; missing nil check for `control` variable in the `Base` class of `Inspec::Formatters`. This issue is only faced in InSpec 5 (inspec-5 branch).

It was fixed in InSpec 6 (now main branch) with the other work on the base and streaming reporters.

## Related Issue
#6510 - Base InSpec formatter class missing nil check

```
inspec/lib/inspec/formatters/base.rb:163:in `block in statistics': undefined method `any?' for nil:NilClass (NoMethodError)

          skipped += 1 if control[:results].any? { |r| r[:status] == "skipped" }
                                           ^^^^^
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
