### PR TITLE
CHEF-3849: InSpec should exit quickly and clearly if waiver file is malformed/corrupt

### DIFF
--- a/lib/inspec/exceptions.rb
+++ b/lib/inspec/exceptions.rb
@@ -12,5 +12,6 @@ module Inspec
     class ProfileSigningKeyNotFound < ArgumentError; end
     class WaiversFileNotReadable < ArgumentError; end
     class WaiversFileDoesNotExist < ArgumentError; end
+    class WaiversFileInvalidFormatting < ArgumentError; end
   end
 end

--- a/lib/inspec/secrets/yaml.rb
+++ b/lib/inspec/secrets/yaml.rb
@@ -25,7 +25,7 @@ module Secrets
       end
 
       # In case of empty yaml file raise the warning else raise the parsing error.
-      if @inputs.nil? || @inputs == false
+      if !@inputs || @inputs.empty?
         Inspec::Log.warn("Unable to parse #{target}: YAML file is empty.")
         @inputs = nil if @inputs == false
       elsif !@inputs.is_a?(Hash)

--- a/lib/inspec/secrets/yaml.rb
+++ b/lib/inspec/secrets/yaml.rb
@@ -26,7 +26,7 @@ module Secrets
 
       # In case of empty yaml file raise the warning else raise the parsing error.
       if @inputs.nil? || @inputs == false
-        Inspec::Log.warn("#{self.class} unable to parse #{target}: Yaml file is empty.")
+        Inspec::Log.warn("Unable to parse #{target}: YAML file is empty.")
         @inputs = nil if @inputs == false
       elsif !@inputs.is_a?(Hash)
         # Exits with usage error.

--- a/lib/inspec/secrets/yaml.rb
+++ b/lib/inspec/secrets/yaml.rb
@@ -24,11 +24,17 @@ module Secrets
         @inputs = ::YAML.load_file(target)
       end
 
-      if @inputs == false || !@inputs.is_a?(Hash)
-        Inspec::Log.warn("#{self.class} unable to parse #{target}: invalid YAML or contents is not a Hash")
-        @inputs = nil
+      # In case of empty yaml file raise the warning else raise the parsing error.
+      if @inputs.nil? || @inputs == false
+        Inspec::Log.warn("#{self.class} unable to parse #{target}: Yaml file is empty.")
+        @inputs = nil if @inputs == false
+      elsif !@inputs.is_a?(Hash)
+        # Exits with usage error.
+        Inspec::Log.error("Unable to parse #{target}: invalid YAML or contents is not a Hash")
+        Inspec::UI.new.exit(:usage_error)
       end
     rescue => e
+      # Any other error related to Yaml parsing will be raised here.
       raise "Error reading InSpec inputs: #{e}"
     end
   end

--- a/lib/inspec/secrets/yaml.rb
+++ b/lib/inspec/secrets/yaml.rb
@@ -27,7 +27,7 @@ module Secrets
       # In case of empty yaml file raise the warning else raise the parsing error.
       if !@inputs || @inputs.empty?
         Inspec::Log.warn("Unable to parse #{target}: YAML file is empty.")
-        @inputs = nil if @inputs == false
+        @inputs = nil
       elsif !@inputs.is_a?(Hash)
         # Exits with usage error.
         Inspec::Log.error("Unable to parse #{target}: invalid YAML or contents is not a Hash")
@@ -35,7 +35,7 @@ module Secrets
       end
     rescue => e
       # Any other error related to Yaml parsing will be raised here.
-      raise "Error reading InSpec inputs: #{e}"
+      raise "Error reading YAML file #{target}: #{e}"
     end
   end
 end

--- a/lib/inspec/waiver_file_reader.rb
+++ b/lib/inspec/waiver_file_reader.rb
@@ -61,7 +61,7 @@ module Inspec
         raise Inspec::Exceptions::WaiversFileInvalidFormatting,
             "\n Missing parameters: #{required_fields}.\n Valid parameters are #{all_fields}."
       end
-      Inspec::Log.warn "Invalid parameters: Column can't be nil" if headers.include? nil
+      Inspec::Log.warn "Invalid column headers: Column can't be nil" if headers.include? nil && !json_yaml
       Inspec::Log.warn "Extra parameters: #{(headers - all_fields)}" unless (headers - all_fields).empty?
     end
 

--- a/lib/inspec/waiver_file_reader.rb
+++ b/lib/inspec/waiver_file_reader.rb
@@ -68,9 +68,10 @@ module Inspec
     def self.validate_json_yaml(data)
       headers = []
       data.each_value do |value|
+        # In case of yaml or json we need to validate headers/parametes for each value
+        validate_headers(value.keys, true)
         headers.push value.keys
       end
-      validate_headers(headers.flatten.uniq, true)
     end
   end
 end

--- a/lib/inspec/waiver_file_reader.rb
+++ b/lib/inspec/waiver_file_reader.rb
@@ -68,7 +68,6 @@ module Inspec
     def self.validate_headers(headers, json_yaml = false)
       required_fields = json_yaml ? %w{justification} : %w{control_id justification}
       missing_required_field = []
-      extra_headers = []
       # Finds missing required fields
       unless (required_fields - headers).empty?
         missing_required_field = required_fields - headers

--- a/lib/inspec/waiver_file_reader.rb
+++ b/lib/inspec/waiver_file_reader.rb
@@ -24,7 +24,7 @@ module Inspec
               "Check to make sure file has the appropriate extension."
         end
       rescue Inspec::Exceptions::WaiversFileNotReadable, Inspec::Exceptions::WaiversFileInvalidFormatting => e
-        Inspec::Log.error "Error reading waivers file #{file_path}.#{e.message}"
+        Inspec::Log.error "Error reading waivers file #{file_path}. #{e.message}"
         Inspec::UI.new.exit(:usage_error)
       end
 
@@ -41,7 +41,7 @@ module Inspec
       elsif file_extension == ".csv"
         data = Waivers::CSVFileReader.resolve(file_path)
         headers = Waivers::CSVFileReader.headers
-        validate_headers(headers)
+        validate_csv_headers(headers)
       elsif file_extension == ".json"
         data = Waivers::JSONFileReader.resolve(file_path)
         validate_json_yaml(data) unless data.nil?
@@ -53,24 +53,55 @@ module Inspec
       %w{control_id justification expiration_date run}
     end
 
+    def self.validate_csv_headers(headers)
+      missing_required_field, blank_column, extra_headers = validate_headers(headers)
+      # Warn if blank column found in csv file
+      Inspec::Log.warn "Invalid column headers: Column can't be nil" if blank_column
+      # Warn if extra header found in csv file
+      Inspec::Log.warn "Extra header/s #{extra_headers}" unless extra_headers.empty?
+      unless missing_required_field.empty?
+        raise Inspec::Exceptions::WaiversFileInvalidFormatting,
+        "Missing required header/s #{missing_required_field}. Fix headers in file to proceed."
+      end
+    end
+
     def self.validate_headers(headers, json_yaml = false)
       required_fields = json_yaml ? %w{justification} : %w{control_id justification}
-
-      # In case of invalid headers raise error to provide valid waiver file.
+      missing_required_field = []
+      extra_headers = []
+      # Finds missing required fields
       unless (required_fields - headers).empty?
-        raise Inspec::Exceptions::WaiversFileInvalidFormatting,
-            "\n Missing required parameters: #{required_fields}.\n Valid parameters are #{all_fields}."
+        missing_required_field = required_fields - headers
       end
-      Inspec::Log.warn "Invalid column headers: Column can't be nil" if (headers.include? nil) && !json_yaml
-      Inspec::Log.warn "Extra parameters: #{(headers - all_fields)}" unless (headers - all_fields).empty?
+      # If column with no header found set the blank_column flag. Only applicable for csv
+      blank_column = true if headers.include?(nil)
+      # Find extra headers/parameters
+      extra_headers = (headers - all_fields)
+      if json_yaml
+        [missing_required_field, extra_headers]
+      else
+        [missing_required_field, blank_column, extra_headers]
+      end
     end
 
     def self.validate_json_yaml(data)
-      headers = []
-      data.each_value do |value|
+      missing_required_fields = false
+      data.each do |key, value|
         # In case of yaml or json we need to validate headers/parametes for each value
-        validate_headers(value.keys, true)
-        headers.push value.keys
+        missing_required_field, extra_parameters = validate_headers(value.keys, true)
+        # WARN in case of extra parameters found in each waived control
+        Inspec::Log.warn "Control ID #{key}: extra parameter/s #{extra_parameters}" unless extra_parameters.empty?
+        unless missing_required_field.empty?
+          missing_required_fields = true
+          # Log error for each waived control
+          Inspec::Log.error "Control ID #{key}: missing required parameter/s #{missing_required_field}"
+        end
+      end
+
+      # Raise error if any of the waived control has missing required filed
+      if missing_required_fields
+        raise Inspec::Exceptions::WaiversFileInvalidFormatting,
+             "Missing required parameter [justification]. Fix parameters in file to proceed."
       end
     end
   end

--- a/lib/inspec/waiver_file_reader.rb
+++ b/lib/inspec/waiver_file_reader.rb
@@ -59,7 +59,7 @@ module Inspec
       # In case of invalid headers raise error to provide valid waiver file.
       unless (required_fields - headers).empty?
         raise Inspec::Exceptions::WaiversFileInvalidFormatting,
-            "\n Missing parameters: #{required_fields}.\n Valid parameters are #{all_fields}."
+            "\n Missing required parameters: #{required_fields}.\n Valid parameters are #{all_fields}."
       end
       Inspec::Log.warn "Invalid column headers: Column can't be nil" if (headers.include? nil) && !json_yaml
       Inspec::Log.warn "Extra parameters: #{(headers - all_fields)}" unless (headers - all_fields).empty?

--- a/lib/inspec/waiver_file_reader.rb
+++ b/lib/inspec/waiver_file_reader.rb
@@ -24,7 +24,7 @@ module Inspec
               "Check to make sure file has the appropriate extension."
         end
       rescue Inspec::Exceptions::WaiversFileNotReadable, Inspec::Exceptions::WaiversFileInvalidFormatting => e
-        Inspec::Log.error "Error reading waivers file #{file_path }.#{e.message}"
+        Inspec::Log.error "Error reading waivers file #{file_path}.#{e.message}"
         Inspec::UI.new.exit(:usage_error)
       end
 
@@ -57,11 +57,11 @@ module Inspec
       required_fields = json_yaml ? %w{justification} : %w{control_id justification}
 
       # In case of invalid headers raise error to provide valid waiver file.
-      if !(required_fields - headers).empty?
+      unless (required_fields - headers).empty?
         raise Inspec::Exceptions::WaiversFileInvalidFormatting,
             "\n Missing parameters: #{required_fields}.\n Valid parameters are #{all_fields}."
       end
-      Inspec::Log.warn "Invalid column headers: Column can't be nil" if headers.include? nil && !json_yaml
+      Inspec::Log.warn "Invalid column headers: Column can't be nil" if (headers.include? nil) && !json_yaml
       Inspec::Log.warn "Extra parameters: #{(headers - all_fields)}" unless (headers - all_fields).empty?
     end
 

--- a/test/fixtures/profiles/waivers/basic/files/extra-headers.csv
+++ b/test/fixtures/profiles/waivers/basic/files/extra-headers.csv
@@ -1,8 +1,0 @@
-control_id,justification,run_random,expiration_date_random,,,
-03_waivered_no_expiry_ran_passes,Sound reasoning,TRUE,,,,
-04_waivered_no_expiry_ran_fails,Unassailable thinking,TRUE,2077-11-10T00:00:00Z,,,
-,,,,,,
-05_waivered_no_expiry_not_ran,Sheer cleverness,FALSE,,,,
-06_waivered_expiry_in_past_ran_passes,Necessity,TRUE,,,,
-14_waivered_expiry_in_future_z_not_ran,Lack of imagination,FALSE,2077-11-10T00:00:00Z,,,
-random contorl id with no data,,,,,,random data in csv!

--- a/test/fixtures/profiles/waivers/basic/files/extra-headers.csv
+++ b/test/fixtures/profiles/waivers/basic/files/extra-headers.csv
@@ -1,0 +1,8 @@
+control_id,justification,run_random,expiration_date_random,,,
+03_waivered_no_expiry_ran_passes,Sound reasoning,TRUE,,,,
+04_waivered_no_expiry_ran_fails,Unassailable thinking,TRUE,2077-11-10T00:00:00Z,,,
+,,,,,,
+05_waivered_no_expiry_not_ran,Sheer cleverness,FALSE,,,,
+06_waivered_expiry_in_past_ran_passes,Necessity,TRUE,,,,
+14_waivered_expiry_in_future_z_not_ran,Lack of imagination,FALSE,2077-11-10T00:00:00Z,,,
+random contorl id with no data,,,,,,random data in csv!

--- a/test/fixtures/profiles/waivers/basic/files/malformed-waiver.yaml
+++ b/test/fixtures/profiles/waivers/basic/files/malformed-waiver.yaml
@@ -1,0 +1,3 @@
+"03_waivered_no_expiry_ran_passes"
+  justification: "Justification of 03"
+  run: false

--- a/test/fixtures/profiles/waivers/basic/files/wrong-headers.json
+++ b/test/fixtures/profiles/waivers/basic/files/wrong-headers.json
@@ -1,9 +1,11 @@
 {
   "03_waivered_no_expiry_ran_passes": {
-    "justification_random": "Sound reasoning",
+    "justification": "Sound reasoning",
     "run_random": true,
     "expiration_date_random": "1977-06-01T00:00:00.000Z"
   },
   "04_waivered_no_expiry_ran_fails": {
+    "justification_random": "Sound reasoning",
+    "run_random": true
   }
 }

--- a/test/fixtures/profiles/waivers/basic/files/wrong-headers.yaml
+++ b/test/fixtures/profiles/waivers/basic/files/wrong-headers.yaml
@@ -1,4 +1,8 @@
 03_waivered_no_expiry_ran_passes:
-  justification_random: Sound reasoning
+  justification: Sound reasoning
   run_random: true
   expiration_date_random: 2077-11-10T00:00:00Z
+
+04_waivered_no_expiry_ran_fails:
+  justification_random: Sound reasoning
+  run_random: true

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -325,7 +325,7 @@ describe "waivers" do
     end
   end
 
-  describe "with a waiver file with wrong headers" do
+  describe "with a waiver file with malformed data" do
     let(:profile_name) { "basic" }
     let(:waiver_file) { "malformed-waiver.yaml" }
 

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -246,7 +246,7 @@ describe "waivers" do
 
       it "raise unable to parse empty.yaml file error" do
         result = run_result
-        assert_includes result.stderr, "unable to parse"
+        assert_includes result.stderr, "ERROR: Secrets::YAML unable to parse"
         if windows?
           assert_equal 1, result.exit_status
         else
@@ -309,6 +309,16 @@ describe "waivers" do
         assert_includes result.stderr, "Missing column headers: [\"justification\"]"
         assert_includes result.stderr, "Extra column headers: [\"justification_random\", \"run_random\", \"expiration_date_random\"]"
       end
+    end
+  end
+
+  describe "with a waiver file with wrong headers" do
+    let(:profile_name) { "basic" }
+    let(:waiver_file) { "malformed-waiver.yaml" }
+
+    it "raise error" do
+      result = run_result
+      assert_includes result.stderr, "ERROR: Secrets::YAML unable to parse"
     end
   end
 end

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -289,8 +289,8 @@ describe "waivers" do
       it "raise errors" do
         result = run_result
         assert_includes result.stderr, "ERROR: Error reading waivers file"
-        assert_includes result.stderr, "Missing required parameters: [\"control_id\", \"justification\"]"
-        assert_includes result.stderr, "Valid parameters are [\"control_id\", \"justification\", \"expiration_date\", \"run\"]"
+        assert_includes result.stderr, "Missing required header/s [\"control_id\", \"justification\"]"
+        assert_includes result.stderr, "Fix headers in file to proceed."
       end
     end
 
@@ -299,9 +299,9 @@ describe "waivers" do
       it "raise errors" do
         result = run_result
         assert_includes result.stderr, "ERROR: Error reading waivers file"
-        assert_includes result.stderr, "Missing required parameters: [\"justification\"]"
-        assert_includes result.stderr, "Valid parameters are [\"control_id\", \"justification\", \"expiration_date\", \"run\"]"
-        assert_includes result.stderr, "WARN: Extra parameters:"
+        assert_includes result.stderr, "ERROR: Control ID 04_waivered_no_expiry_ran_fails: missing required parameter/s [\"justification\"]"
+        assert_includes result.stderr, "Fix parameters in file to proceed."
+        assert_includes result.stderr, "WARN: Control ID 03_waivered_no_expiry_ran_passes: extra parameter/s [\"run_random\", \"expiration_date_random\"]"
       end
     end
 
@@ -310,20 +310,10 @@ describe "waivers" do
       it "raise errors" do
         result = run_result
         assert_includes result.stderr, "ERROR: Error reading waivers file"
-        assert_includes result.stderr, "Missing required parameters: [\"justification\"]"
-        assert_includes result.stderr, "Valid parameters are [\"control_id\", \"justification\", \"expiration_date\", \"run\"]"
-        assert_includes result.stderr, "WARN: Extra parameters:"
+        assert_includes result.stderr, "ERROR: Control ID 04_waivered_no_expiry_ran_fails: missing required parameter/s [\"justification\"]"
+        assert_includes result.stderr, "Fix parameters in file to proceed."
+        assert_includes result.stderr, "WARN: Control ID 03_waivered_no_expiry_ran_passes: extra parameter/s [\"run_random\", \"expiration_date_random\"]"
       end
-    end
-  end
-
-  describe "with a waiver file with extra headers" do
-    let(:profile_name) { "basic" }
-    let(:waiver_file) { "extra-headers.csv" }
-    it "raise warnings" do
-      result = run_result
-      assert_includes result.stderr, "WARN: Invalid column headers: Column can't be nil"
-      assert_includes result.stderr, "WARN: Extra parameters: [\"run_random\", \"expiration_date_random\", nil]"
     end
   end
 

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -246,7 +246,8 @@ describe "waivers" do
 
       it "raise warning unable to parse empty.yaml file error" do
         result = run_result
-        assert_includes result.stderr, "WARN: Secrets::YAML unable to parse"
+        assert_includes result.stderr, "WARN: Unable to parse"
+        assert_includes result.stderr, "YAML file is empty."
         if windows?
           assert_equal 1, result.exit_status
         else
@@ -288,7 +289,7 @@ describe "waivers" do
       it "raise errors" do
         result = run_result
         assert_includes result.stderr, "ERROR: Error reading waivers file"
-        assert_includes result.stderr, "Missing parameters: [\"control_id\", \"justification\"]"
+        assert_includes result.stderr, "Missing required parameters: [\"control_id\", \"justification\"]"
         assert_includes result.stderr, "Valid parameters are [\"control_id\", \"justification\", \"expiration_date\", \"run\"]"
       end
     end
@@ -298,7 +299,7 @@ describe "waivers" do
       it "raise errors" do
         result = run_result
         assert_includes result.stderr, "ERROR: Error reading waivers file"
-        assert_includes result.stderr, "Missing parameters: [\"justification\"]"
+        assert_includes result.stderr, "Missing required parameters: [\"justification\"]"
         assert_includes result.stderr, "Valid parameters are [\"control_id\", \"justification\", \"expiration_date\", \"run\"]"
       end
     end
@@ -308,7 +309,7 @@ describe "waivers" do
       it "raise errors" do
         result = run_result
         assert_includes result.stderr, "ERROR: Error reading waivers file"
-        assert_includes result.stderr, "Missing parameters: [\"justification\"]"
+        assert_includes result.stderr, "Missing required parameters: [\"justification\"]"
         assert_includes result.stderr, "Valid parameters are [\"control_id\", \"justification\", \"expiration_date\", \"run\"]"
       end
     end

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -301,6 +301,7 @@ describe "waivers" do
         assert_includes result.stderr, "ERROR: Error reading waivers file"
         assert_includes result.stderr, "Missing required parameters: [\"justification\"]"
         assert_includes result.stderr, "Valid parameters are [\"control_id\", \"justification\", \"expiration_date\", \"run\"]"
+        assert_includes result.stderr, "WARN: Extra parameters:"
       end
     end
 
@@ -311,6 +312,7 @@ describe "waivers" do
         assert_includes result.stderr, "ERROR: Error reading waivers file"
         assert_includes result.stderr, "Missing required parameters: [\"justification\"]"
         assert_includes result.stderr, "Valid parameters are [\"control_id\", \"justification\", \"expiration_date\", \"run\"]"
+        assert_includes result.stderr, "WARN: Extra parameters:"
       end
     end
   end

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -285,30 +285,42 @@ describe "waivers" do
 
     describe "using csv file" do
       let(:waiver_file) { "wrong-headers.csv" }
-      it "raise warnings" do
+      it "raise errors" do
         result = run_result
-        assert_includes result.stderr, "Missing column headers: [\"control_id\", \"justification\"]"
-        assert_includes result.stderr, "Invalid column header: Column can't be nil"
-        assert_includes result.stderr, "Extra column headers: [\"control_id_random\", \"justification_random\", \"run_random\", \"expiration_date_random\", nil]"
+        assert_includes result.stderr, "ERROR: Error reading waivers file"
+        assert_includes result.stderr, "Missing parameters: [\"control_id\", \"justification\"]"
+        assert_includes result.stderr, "Valid parameters are [\"control_id\", \"justification\", \"expiration_date\", \"run\"]"
       end
     end
 
     describe "using json file" do
       let(:waiver_file) { "wrong-headers.json" }
-      it "raise warnings" do
+      it "raise errors" do
         result = run_result
-        assert_includes result.stderr, "Missing column headers: [\"justification\"]"
-        assert_includes result.stderr, "Extra column headers: [\"justification_random\", \"run_random\", \"expiration_date_random\"]"
+        assert_includes result.stderr, "ERROR: Error reading waivers file"
+        assert_includes result.stderr, "Missing parameters: [\"justification\"]"
+        assert_includes result.stderr, "Valid parameters are [\"control_id\", \"justification\", \"expiration_date\", \"run\"]"
       end
     end
 
     describe "using yaml file" do
       let(:waiver_file) { "wrong-headers.yaml" }
-      it "raise warnings" do
+      it "raise errors" do
         result = run_result
-        assert_includes result.stderr, "Missing column headers: [\"justification\"]"
-        assert_includes result.stderr, "Extra column headers: [\"justification_random\", \"run_random\", \"expiration_date_random\"]"
+        assert_includes result.stderr, "ERROR: Error reading waivers file"
+        assert_includes result.stderr, "Missing parameters: [\"justification\"]"
+        assert_includes result.stderr, "Valid parameters are [\"control_id\", \"justification\", \"expiration_date\", \"run\"]"
       end
+    end
+  end
+
+  describe "with a waiver file with extra headers" do
+    let(:profile_name) { "basic" }
+    let(:waiver_file) { "extra-headers.csv" }
+    it "raise warnings" do
+      result = run_result
+      assert_includes result.stderr, "WARN: Invalid column headers: Column can't be nil"
+      assert_includes result.stderr, "WARN: Extra parameters: [\"run_random\", \"expiration_date_random\", nil]"
     end
   end
 

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -244,9 +244,9 @@ describe "waivers" do
     describe "when an only_if is used with empty waiver file" do
       let(:waiver_file) { "empty.yaml" }
 
-      it "raise unable to parse empty.yaml file error" do
+      it "raise warning unable to parse empty.yaml file error" do
         result = run_result
-        assert_includes result.stderr, "ERROR: Secrets::YAML unable to parse"
+        assert_includes result.stderr, "WARN: Secrets::YAML unable to parse"
         if windows?
           assert_equal 1, result.exit_status
         else
@@ -318,7 +318,8 @@ describe "waivers" do
 
     it "raise error" do
       result = run_result
-      assert_includes result.stderr, "ERROR: Secrets::YAML unable to parse"
+      assert_includes result.stderr, "ERROR:"
+      assert_includes result.stderr, "invalid YAML or contents is not a Hash"
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
1) If you provide a malformed waiver file - one that fails YAML lint, in other words - inspec will continue to run, showing an error as the first control failing with a control source code error.
This buries the error message(Warning) deeply in the InSpec reporting output, which on a large profile may be hundred of kilobytes of text.
It also wastes the user’s time, since on a large profile, we know waiver file is bad immediately, but we doggedly execute the whole profile (which may take hours) before finally returning unusable (incorrect, unwaivered) results.

2) In case of invalid parameters in the waiver file currently it shows a warning message whereas it should raise the error in case of required parameters are not present in the waiver file.

This fix includes
 * Detect a malformed waiver file and exit immediately. 
 * Raise error in case of required parameter is not present in the waiver file.
 * Introduced a new exception class to handle invalid formatting of waiver file.
 * Updated code to validate the required parameter for yaml and json file for each waived control.
 
In case of an empty waiver file, extra parameters, or nil header (in CSV formatted) waiver file it will show a warning message that there will not be any behavioral changes.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
