### PR TITLE
CHEF-3928 Fix in HTML2 reporter - unique ID usage for control HTML divisions

### DIFF
--- a/lib/plugins/inspec-reporter-html2/templates/control.html.erb
+++ b/lib/plugins/inspec-reporter-html2/templates/control.html.erb
@@ -1,4 +1,5 @@
-<% slugged_id = control.id.tr(" ", "_") %>
+<% slugged_control_id = control.id.tr(" ", "_") %>
+<% slugged_profile_id = profile.name.gsub(/\W/, "_") %>
 <%
     if enhanced_outcomes
       status = control.status
@@ -13,7 +14,7 @@
     end
 %>
 
-<div class="control control-status-<%= status %>" id="control-<%= slugged_id %>">
+<div class="control control-status-<%= status %>" id="profile-<%= slugged_profile_id %>-control-<%= slugged_control_id %>">
 
   <%
     # Determine range of impact
@@ -29,7 +30,7 @@
   %>
 
   <h3 class="control-title">Control <code><%= control.id %></code></h3>
-  <table class="control-metadata info" id="control-metadata-<%= slugged_id %>">
+  <table class="control-metadata info" id="profile-<%= slugged_profile_id %>-control-metadata-<%= slugged_control_id %>">
   <caption>Control Table</caption>
     <tr class="status status-<%= status %>"><th>Status:</th><td><div><%= status.capitalize %></div></td></tr>
     <% if control.title %><tr class="title"><th>Title:</th><td><%= control.title %></td></tr> <% end %>
@@ -64,9 +65,9 @@
     <tr class="code">
       <th>Source Code:</th>
       <td>
-        <input type="button" class="show-source-code" id="show-code-<%= slugged_id %>" value="Show Source"/>
-        <input type="button" class="hide-source-code hidden" id="hide-code-<%= slugged_id %>" value="Hide Source"/>
-        <pre class="source-code hidden" id="source-code-<%= slugged_id %>">
+        <input type="button" class="show-source-code" id="show-code-<%= slugged_profile_id %>-<%= slugged_control_id %>" value="Show Source"/>
+        <input type="button" class="hide-source-code hidden" id="hide-code-<%= slugged_profile_id %>-<%= slugged_control_id %>" value="Hide Source"/>
+        <pre class="source-code hidden" id="source-code-<%= slugged_profile_id %>-<%= slugged_control_id %>">
           <code>
 <%= control.code %>
           </code>

--- a/lib/plugins/inspec-reporter-html2/templates/default.js
+++ b/lib/plugins/inspec-reporter-html2/templates/default.js
@@ -11,17 +11,17 @@ function removeCssClass(id, cls) {
 }
 
 function handleShowSource(evt) {
-  var control_id = evt.srcElement.id.replace("show-code-", "")
+  var slugged_id = evt.srcElement.id.replace("show-code-", "")
   addCssClass(evt.srcElement.id, "hidden")
-  removeCssClass("hide-code-" + control_id, "hidden")
-  removeCssClass("source-code-" + control_id, "hidden")
+  removeCssClass("hide-code-" + slugged_id, "hidden")
+  removeCssClass("source-code-" + slugged_id, "hidden")
 }
 
 function handleHideSource(evt) {
-  var control_id = evt.srcElement.id.replace("hide-code-", "")
+  var slugged_id = evt.srcElement.id.replace("hide-code-", "")
   addCssClass(evt.srcElement.id, "hidden")
-  addCssClass("source-code-" + control_id, "hidden")
-  removeCssClass("show-code-" + control_id, "hidden")
+  addCssClass("source-code-" + slugged_id, "hidden")
+  removeCssClass("show-code-" + slugged_id, "hidden")
 }
 
 function handleSelectorChange(evt) {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix in HTML2 reporter - unique ID usage for control HTML divisions.

Because the same control ID was used in different dependent profiles for different controls, the checkboxes on HTML report were not working as expected. So a unique ID is created by adding a prefix of the profile name.

`profile-<%= slugged_profile_id %>-control-<%= slugged_control_id %>`
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
