### PR TITLE
Move InSpec docs menu from chef-web-docs

### DIFF
--- a/docs-chef-io/config.toml
+++ b/docs-chef-io/config.toml
@@ -1,2 +1,68 @@
 [params.inspec]
 gh_path = "https://github.com/inspec/inspec/tree/main/docs-chef-io/content/"
+
+####
+# Chef InSpec Menu
+####
+
+[[menu.inspec]]
+title = "Chef InSpec"
+identifier = "inspec"
+
+  [[menu.inspec]]
+  title = "Chef InSpec Reference"
+  identifier = "inspec/reference"
+  parent = "inspec"
+  weight = 500
+
+  [[menu.inspec]]
+  title = "Chef InSpec Resources"
+  identifier = "inspec/resources"
+  parent = "inspec"
+  weight = 999
+
+    [[menu.inspec]]
+    title = "OS Resources"
+    identifier = "inspec/resources/os"
+    parent = "inspec/resources"
+    weight = 20
+
+    [[menu.inspec]]
+    title = "Alibaba Resources"
+    identifier = "inspec/resources/alicloud"
+    parent = "inspec/resources"
+    weight = 25
+
+    [[menu.inspec]]
+    title = "AWS Resources"
+    identifier = "inspec/resources/aws"
+    parent = "inspec/resources"
+    weight = 30
+
+    [[menu.inspec]]
+    title = "Azure Resources"
+    identifier = "inspec/resources/azure"
+    parent = "inspec/resources"
+    weight = 40
+
+    [[menu.inspec]]
+    title = "GCP Resources"
+    identifier = "inspec/resources/gcp"
+    parent = "inspec/resources"
+    weight = 50
+
+    [[menu.inspec]]
+    title = "Habitat Resources"
+    identifier = "inspec/resources/habitat"
+    parent = "inspec/resources"
+    weight = 60
+
+    [[menu.inspec]]
+    title = "Kubernetes Resources"
+    identifier = "inspec/resources/k8s"
+    parent = "inspec/resources"
+    weight = 70
+
+####
+# End Chef InSpec Menu
+####

--- a/docs-chef-io/go.mod
+++ b/docs-chef-io/go.mod
@@ -1,3 +1,3 @@
 module github.com/inspec/inspec/docs-chef-io
 
-go 1.14
+go 1.18


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
It's time to move the [InSpec menu config](https://github.com/chef/chef-web-docs/blob/main/config/_default/menu.toml#L652-L716) out of chef-web-docs.
This will make it easier to reorganize pages in the nav menu.

Note that the existing menu config in chef-web-docs will override any changes made here until it's deleted.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
