### PR TITLE
CHEF-6422 Modify inspec archive to not check or export by default

### DIFF
--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -39,6 +39,10 @@ This subcommand has the following additional options:
 `--no-check`
 : Before running archive, run `inspec check`. Default: do not check.
 
+`--export`
+`--no-export`
+: Include an inspec.json file in the archive, the results of running `inspec export`.
+
 `--ignore-errors`
 `--no-ignore-errors`
 : Ignore profile warnings.

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -35,6 +35,10 @@ This subcommand has the following additional options:
 `--no-airgap`
 : Fallback to using local archives if fetching fails.
 
+`--check`
+`--no-check`
+: Before running archive, run `inspec check`. Default: do not check.
+
 `--ignore-errors`
 `--no-ignore-errors`
 : Ignore profile warnings.

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -261,6 +261,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "Fallback to using local archives if fetching fails."
   option :ignore_errors, type: :boolean, default: false,
     desc: "Ignore profile warnings."
+  option :check, type: :boolean, default: false,
+    desc: "Run profile check."
   def archive(path, log_level = nil)
     Inspec.with_feature("inspec-cli-archive") {
       begin
@@ -283,7 +285,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
           o[:logger].warn "Archiving a profile that contains gem dependencies, but InSpec cannot package gems with the profile! Please archive your ~/.inspec/gems directory separately."
         end
 
-        result = profile.check
+        result = profile.check if o[:check]
 
         if result && !o[:ignore_errors] == false
           o[:logger].info "Profile check failed. Please fix the profile before generating an archive."

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -262,7 +262,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   option :ignore_errors, type: :boolean, default: false,
     desc: "Ignore profile warnings."
   option :check, type: :boolean, default: false,
-    desc: "Run profile check."
+    desc: "Run profile check before archiving."
   def archive(path, log_level = nil)
     Inspec.with_feature("inspec-cli-archive") {
       begin

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -263,6 +263,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "Ignore profile warnings."
   option :check, type: :boolean, default: false,
     desc: "Run profile check before archiving."
+  option :export, type: :boolean, default: false,
+    desc: "Export the profile to inspec.json and include in archive"
   def archive(path, log_level = nil)
     Inspec.with_feature("inspec-cli-archive") {
       begin

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -682,7 +682,6 @@ module Inspec
     end
 
     # generates a archive of a folder profile
-    # assumes that the profile was checked before
     def archive(opts)
       # check if file exists otherwise overwrite the archive
       dst = archive_name(opts)
@@ -699,31 +698,34 @@ module Inspec
       # TODO ignore all .files, but add the files to debug output
 
       # Generate temporary inspec.json for archive
-      Inspec::Utils::JsonProfileSummary.produce_json(
-        info: info,
-        write_path: "#{root_path}inspec.json",
-        suppress_output: true
-      )
+      if opts[:export]
+        Inspec::Utils::JsonProfileSummary.produce_json(
+          info: info, # TODO: conditionalize and call info_from_parse
+          write_path: "#{root_path}inspec.json",
+          suppress_output: true
+        )
+      end
 
       # display all files that will be part of the archive
       @logger.debug "Add the following files to archive:"
       files.each { |f| @logger.debug "    " + f }
-      @logger.debug "    inspec.json"
+      @logger.debug "    inspec.json" if opts[:export]
 
+      archive_files = opts[:export] ? files.push("inspec.json") : files
       if opts[:zip]
         # generate zip archive
         require "inspec/archive/zip"
         zag = Inspec::Archive::ZipArchiveGenerator.new
-        zag.archive(root_path, files.push("inspec.json"), dst)
+        zag.archive(root_path, archive_files, dst)
       else
         # generate tar archive
         require "inspec/archive/tar"
         tag = Inspec::Archive::TarArchiveGenerator.new
-        tag.archive(root_path, files.push("inspec.json"), dst)
+        tag.archive(root_path, archive_files, dst)
       end
 
       # Cleanup
-      FileUtils.rm_f("#{root_path}inspec.json")
+      FileUtils.rm_f("#{root_path}inspec.json") if opts[:export]
 
       @logger.info "Finished archive generation."
       true

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/search_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/search_test.rb
@@ -24,7 +24,7 @@ class PluginManagerCliSearch < Minitest::Test
   end
 
   def test_search_for_a_real_gem_with_stub_name_no_options
-    result = run_inspec_process("plugin search --include-test-fixture inspec-test-")
+    result = run_inspec_process("plugin search --include-test-fixture inspec-test-fix")
 
     assert_includes result.stdout, "inspec-test-fixture", "Search result should contain the gem name"
     assert_includes result.stdout, "A simple test plugin gem for InSpec", "Search result should contain the gem description"

--- a/test/fixtures/profiles/eval-markers/controls/markers.rb
+++ b/test/fixtures/profiles/eval-markers/controls/markers.rb
@@ -1,0 +1,15 @@
+# This profile emits markers to STDERR at various points to indicate that it was evaluated
+
+$stderr.puts "TOP_LEVEL_MARKER"
+$stderr.puts "EVALUATION_MARKER"
+control "my-dummy-control" do
+  $stderr.puts "CONTROL_BODY_MARKER"
+  title "#{$stderr.puts "METADATA_MARKER"}"
+  describe true do
+    $stderr.puts "DESCRIBE_BODY_MARKER"
+    it do
+      $stderr.puts "IT_BODY_MARKER"
+      should be_truthy
+    end
+  end
+end

--- a/test/fixtures/profiles/eval-markers/inspec.yml
+++ b/test/fixtures/profiles/eval-markers/inspec.yml
@@ -1,0 +1,10 @@
+name: eval-markers
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: A profile that emits to STDERR at various points
+version: 0.1.0
+supports:
+  platform: os

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -138,4 +138,18 @@ describe "inspec archive" do
       assert_exit_code 0, out
     end
   end
+
+  it "does not evaluate a profile by default" do
+    eval_marker_path = File.join(profile_path, "eval-markers")
+
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.cp_r(eval_marker_path + "/.", tmpdir)
+
+      out = inspec("archive " + tmpdir + " --output " + dst.path)
+
+      _(out.stderr).wont_include "EVALUATION_MARKER"
+      _(out.stderr).must_equal ""
+      assert_exit_code 0, out
+    end
+  end
 end

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -31,13 +31,24 @@ describe "inspec archive" do
     end
   end
 
-  it "archives an inspec.json file" do
+  it "archives an inspec.json file if export if provided --export option" do
+    prepare_examples("profile") do |dir|
+      out = inspec("archive " + dir + " --overwrite --export")
+
+      _(out.stderr).must_equal ""
+      t = Zlib::GzipReader.open(auto_dst)
+      _(Gem::Package::TarReader.new(t).entries.map(&:header).map(&:name)).must_include "inspec.json"
+      assert_exit_code 0, out
+    end
+  end
+
+  it "does not archive an inspec.json file by default" do
     prepare_examples("profile") do |dir|
       out = inspec("archive " + dir + " --overwrite")
 
       _(out.stderr).must_equal ""
       t = Zlib::GzipReader.open(auto_dst)
-      _(Gem::Package::TarReader.new(t).entries.map(&:header).map(&:name)).must_include "inspec.json"
+      _(Gem::Package::TarReader.new(t).entries.map(&:header).map(&:name)).wont_include "inspec.json"
       assert_exit_code 0, out
     end
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Modify inspec archive to not check or export by default.

Previously, inspec archive would run inspec check prior to archiving the profile. Now, that check is optional, disabled by default. Controlled by the --check option.

Previously, inspec archive would run `inspec export` to generate an inspec.json file to be included with the archive. Now, that functionality is optional, disabled by default. Controlled by the --export option.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
introduce a new option to allow `inspec archive` as describe below. 
It is a boolean flag that controls profile check. By default it skips profile check.
<img width="1362" alt="Screenshot 2023-09-18 at 7 09 25 PM" src="https://github.com/inspec/inspec/assets/80091550/92f5a389-fefa-454a-af88-7999b7dd8537">


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://chefio.atlassian.net/browse/CHEF-6422

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
