### PR TITLE
Add --legacy-export option to inspec export

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -94,6 +94,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "For --what=profile, a list of controls to include. Ignore all other tests."
   option :tags, type: :array,
     desc: "For --what=profile, a list of tags to filter controls and include only those. Ignore all other tests."
+  option :"legacy-export", type: :boolean, default: false,
+         desc: "Run with legacy export."
   profile_options
   def export(target, as_json = false)
     Inspec.with_feature("inspec-cli-export") {

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -133,16 +133,17 @@ class Inspec::InspecCLI < Inspec::BaseCLI
 
         case what
         when "profile"
+          profile_info = o[:"legacy-export"] ? profile.info : profile.info_from_parse
           if format == "json"
             require "json" unless defined?(JSON)
             # Write JSON
             Inspec::Utils::JsonProfileSummary.produce_json(
-              info: profile.info_from_parse,
+              info: profile_info,
               write_path: dst
             )
           elsif format == "yaml"
             Inspec::Utils::YamlProfileSummary.produce_yaml(
-              info: profile.info_from_parse,
+              info: profile_info,
               write_path: dst
             )
           end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Ability to run export in the legacy way.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR allows a new option `--legacy-export` to allow users to choose between the new export and old export options. Default is the new export.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [X] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
