### PR TITLE
Fix broken plugin search test

### DIFF
--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/search_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/search_test.rb
@@ -24,7 +24,7 @@ class PluginManagerCliSearch < Minitest::Test
   end
 
   def test_search_for_a_real_gem_with_stub_name_no_options
-    result = run_inspec_process("plugin search --include-test-fixture inspec-test-")
+    result = run_inspec_process("plugin search --include-test-fixture inspec-test-fix")
 
     assert_includes result.stdout, "inspec-test-fixture", "Search result should contain the gem name"
     assert_includes result.stdout, "A simple test plugin gem for InSpec", "Search result should contain the gem description"


### PR DESCRIPTION
Since we published a test gem, it broke one of our over-sensitive plugin search tests. I tightened up the test slightly.

This CI-only change should be backported to inspec-4 and inspec-5.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
