### PR TITLE
Revert "Update html-proofer requirement from ~> 3.19.4 to ~> 5.0.8"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :test do
 
   if Gem.ruby_version >= Gem::Version.new("3.0.0")
     # html-proofer has a dep on io-event, which is ruby-3 only
-    gem "html-proofer", "~> 5.0.8", platforms: :ruby # do not attempt to run proofer on windows. Pinned to 3.19.4 as test is breaking in updated versions.
+    gem "html-proofer", "~> 3.19.4", platforms: :ruby # do not attempt to run proofer on windows. Pinned to 3.19.4 as test is breaking in updated versions.
   end
 end
 


### PR DESCRIPTION
Reverts inspec/inspec#6697

This breaks ruby 3.0