### PR TITLE
Revert "Update html-proofer requirement from ~> 3.19.4 to ~> 5.0.8"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :test do
 
   if Gem.ruby_version >= Gem::Version.new("3.0.0")
     # html-proofer has a dep on io-event, which is ruby-3 only
-    gem "html-proofer", "~> 5.0.8", platforms: :ruby # do not attempt to run proofer on windows. Pinned to 3.19.4 as test is breaking in updated versions.
+    gem "html-proofer", "~> 3.19.4", platforms: :ruby # do not attempt to run proofer on windows. Pinned to 3.19.4 as test is breaking in updated versions.
   end
 end
 


### PR DESCRIPTION
Breaks Ruby 3.0 tests. Need to conditionalize the Gemfile.


This reverts commit 89d625e1ddbf670bbb1d9ab3f9f4042c46ae476e.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
