### PR TITLE
Update faraday requirement from >= 0.9.0, < 1.5 to >= 0.9.0, < 2.8

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mixlib-log",         "~> 3.0"
   spec.add_dependency "sslshake",           "~> 1.2"
   spec.add_dependency "parallel",           "~> 1.9"
-  spec.add_dependency "faraday",            ">= 0.9.0", "< 1.5"
+  spec.add_dependency "faraday",            ">= 0.9.0", "< 2.8"
   spec.add_dependency "faraday_middleware", "~> 1.0"
   spec.add_dependency "tty-table",          "~> 0.10"
   spec.add_dependency "tty-prompt",         "~> 0.17"


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Recreate PR #6699 to run pipeline against ruby 3.0 & 3.1

Updates the requirements on [faraday](https://github.com/lostisland/faraday) to permit the latest version.
- [Release notes](https://github.com/lostisland/faraday/releases)
- [Changelog](https://github.com/lostisland/faraday/blob/main/CHANGELOG.md)
- [Commits](https://github.com/lostisland/faraday/compare/v0.9.0...v1.10.3)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
