### PR TITLE
Changed params usage in `inspec archive` to skip evaluation

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -831,10 +831,12 @@ module Inspec
         return Pathname.new(name)
       end
 
-      name = params[:name] ||
+      # Using metadata to fetch basic info of name and params
+      metadata = @source_reader.metadata.params
+      name = metadata[:name] ||
         raise("Cannot create an archive without a profile name! Please "\
              "specify the name in metadata or use --output to create the archive.")
-      version = params[:version] ||
+      version = metadata[:version] ||
         raise("Cannot create an archive without a profile version! Please "\
              "specify the version in metadata or use --output to create the archive.")
       ext = opts[:zip] ? "zip" : "tar.gz"

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -831,7 +831,7 @@ module Inspec
         return Pathname.new(name)
       end
 
-      # Using metadata to fetch basic info of name and params
+      # Using metadata to fetch basic info of name and version
       metadata = @source_reader.metadata.params
       name = metadata[:name] ||
         raise("Cannot create an archive without a profile name! Please "\

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -147,7 +147,7 @@ describe "inspec archive" do
 
       out = inspec("archive " + tmpdir + " --overwrite")
 
-      _(out.out).wont_include "EVALUATION_MARKER"
+      _(out.stdout).wont_include "EVALUATION_MARKER"
       _(out.stderr).must_equal ""
       assert_exit_code 0, out
     end

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -145,9 +145,9 @@ describe "inspec archive" do
     Dir.mktmpdir do |tmpdir|
       FileUtils.cp_r(eval_marker_path + "/.", tmpdir)
 
-      out = inspec("archive " + tmpdir + " --output " + dst.path)
+      out = inspec("archive " + tmpdir + " --overwrite")
 
-      _(out.stderr).wont_include "EVALUATION_MARKER"
+      _(out.out).wont_include "EVALUATION_MARKER"
       _(out.stderr).must_equal ""
       assert_exit_code 0, out
     end


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Changed params usage in `inspec archive` to skip evaluation
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
