### PR TITLE
Revert #6688

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "train-habitat", "~> 0.1"
   spec.add_dependency "train-aws",     "~> 0.2"
   spec.add_dependency "train-winrm",   "~> 0.2"
-  spec.add_dependency "mongo", "= 2.19.1" # 2.14 introduces a broken symlink in mongo-2.14.0/spec/support/ocsp
+  spec.add_dependency "mongo", "= 2.13.2" # 2.14 introduces a broken symlink in mongo-2.14.0/spec/support/ocsp
 
 end


### PR DESCRIPTION
This reverts commit 31f6e2669d91ea488c5db11aa50316a76e6fa1ff.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Reverting  dependabot PR #6688 change as version 2.19.1 is breaking omnibus build on windows. https://buildkite.com/chef/inspec-inspec-inspec-4-omnibus-adhoc/builds/19#018ae5c8-09ac-473c-9d9e-ed440de98173/6-6443
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
