### PR TITLE
Set  IGNORE_ARTIFACTORY_RUBY_PROXY to true on inspec-4 for adhoc build

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -29,6 +29,7 @@ pipelines:
     env:
      - ADHOC: true
      - EXPIRE_CACHE: 1
+     - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems like ffi.
  - verify:
     description: Pull Request validation tests
     public: true


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Build is failing with 500 internal server for artifactory url on  inspec-4 ad-hoc build. Adding this flag to ignore the artifactory ruby proxy.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
