### PR TITLE
BACKPORT 6262: Prevent negative status from crashing launchd service resource 

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -273,6 +273,10 @@ module Inspec::Resources
       info[:startname]
     end
 
+    def resource_id
+      @service_name || "Service"
+    end
+
     def to_s
       "Service #{@service_name}"
     end

--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -605,7 +605,7 @@ module Inspec::Resources
       return nil if srv.nil? || srv[0].nil?
 
       # extract values from service
-      parsed_srv = /^(?<pid>[0-9-]+)\t(?<exit>[0-9]+)\t(?<name>\S*)$/.match(srv[0])
+      parsed_srv = /^(?<pid>[0-9-]+)\t(?<exit>[\-0-9]+)\t(?<name>\S*)$/.match(srv[0])
       enabled = !parsed_srv["name"].nil? # it's in the list
 
       # check if the service is running

--- a/test/fixtures/cmd/launchctl-list
+++ b/test/fixtures/cmd/launchctl-list
@@ -1,3 +1,4 @@
 PID	Status	Label
 2892	0	org.openbsd.ssh-agent
 -	0	com.apple.FilesystemUI
+-	-15	org.example.killed-agent

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -463,6 +463,21 @@ describe "Inspec::Resources::Service" do
     _(resource.params).must_equal params
   end
 
+  it "verify mac osx service parsing with negative status launchd_service" do
+    resource = MockLoader.new(:macos10_10).load_resource(
+      "launchd_service", "org.example.killed-agent"
+    )
+    params = Hashie::Mash.new({})
+    _(resource.type).must_equal "darwin"
+    _(resource.name).must_equal "org.example.killed-agent"
+    _(resource.description).must_be_nil
+    _(resource.installed?).must_equal true
+    _(resource.enabled?).must_equal true
+    _(resource.running?).must_equal false
+    _(resource.params).must_equal params
+    _(resource.resource_id).must_equal "org.example.killed-agent"
+  end
+
   # wrlinux
   it "verify wrlinux service parsing" do
     resource = MockLoader.new(:wrlinux).load_resource("service", "sshd")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Backports #6262 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
