### PR TITLE
BACKPORT 6401: Fix for mongodb_session resource prints debug level of information in profile run result

### DIFF
--- a/lib/inspec/resources/mongodb_session.rb
+++ b/lib/inspec/resources/mongodb_session.rb
@@ -80,6 +80,11 @@ module Inspec::Resources
       options[:ssl_cert] = @ssl_cert unless @ssl_cert.nil?
       options[:ssl_ca_cert] = @ssl_ca_cert unless @ssl_ca_cert.nil?
 
+      # Setting the logger level to INFO as mongo gem version 2.13.2 is using DEBUG as the log level Ref: https://github.com/mongodb/mongo-ruby-driver/blob/v2.13.2/lib/mongo/logger.rb#L79
+      # Latest version of the mongo gem don't have this issue as it set to INFO level Ref: https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/logger.rb#L82
+      # We pinned the version to 2.13.2 as the latest version of the mongo gem has broken symlink https://jira.mongodb.org/browse/RUBY-2546 which causes omnibus build failure.
+      # Once we get the latest version working we can remove logger level set here.
+      Mongo::Logger.logger.level = Logger::INFO
       @client = Mongo::Client.new([ "#{host}:#{port}" ], options)
 
     rescue => e


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Backports #6401 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
