### PR TITLE
Updated Git actions workflow to label PR with InSpec major versions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -24,13 +24,16 @@ jobs:
           BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
           if [ "$BASE_BRANCH" == "main" ]; then
             echo "::set-output name=base_branch_name::inspec-6"
-          else
+          elif [ "$BASE_BRANCH" == "inspec-4" ] || [ "$BASE_BRANCH" == "inspec-5" ]; then
             echo "::set-output name=base_branch_name::${BASE_BRANCH}"
+          else
+            echo "Unknown base branch for labelling : ${BASE_BRANCH}"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use Git API to update labels based on base branch
+        if: startsWith(steps.pr_info.outputs.base_branch_name, 'inspec-')
         run: |
           curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -d '{"labels":["${{ steps.pr_info.outputs.base_branch_name }}"]}' "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels"
         env:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # Current logic uses main branch to use label of inspec-6
+      # Will need to update this everytime on a new major version release
+      # Will need to update the elif condition to allow inspec-6 in case next major version is released
+      # TODO: Update logic to add label on main based on major version defined in VERSION file
       - name: Fetch pull request base branch
         id: pr_info
         run: |

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,7 @@
 name: "Pull Request Labeler"
 on:
-  - pull_request_target
+  pull_request:
+    types: [opened, synchronize]
 
 permissions:
   contents: read
@@ -12,6 +13,25 @@ jobs:
       pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@main
+      - name: Use Git Actions labeler
+        uses: actions/labeler@main
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Fetch pull request base branch
+        id: pr_info
+        run: |
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          if [ "$BASE_BRANCH" == "main" ]; then
+            echo "::set-output name=base_branch_name::inspec-6"
+          else
+            echo "::set-output name=base_branch_name::${BASE_BRANCH}"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Use Git API to update labels based on base branch
+        run: |
+          curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -d '{"labels":["${{ steps.pr_info.outputs.base_branch_name }}"]}' "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Updated Git actions workflow to label PR based on the base branch. 
The only base branches that are allowed are: `main`, `inspec-4` and `inspec-5`
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
