### PR TITLE
Using Typeform action: Git actions workflow to label PR with InSpec major versions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,6 @@
 name: "Pull Request Labeler"
-on:
-  - pull_request_target
-
+pull_request:
+    types: [opened, synchronize]
 permissions:
   contents: read
 
@@ -12,6 +11,32 @@ jobs:
       pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@main
+      - name: Use Git Actions labeler
+        uses: actions/labeler@main
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Fetch pull request base branch
+        id: pr_info
+        run: |
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          if [ "$BASE_BRANCH" == "main" ]; then
+            echo "::set-output name=base_branch_name::inspec-6"
+          elif [ "$BASE_BRANCH" == "inspec-4" ] || [ "$BASE_BRANCH" == "inspec-5" ]; then
+            echo "::set-output name=base_branch_name::${BASE_BRANCH}"
+          else
+            echo "Unknown base branch for labelling : ${BASE_BRANCH}"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Use Typeform labeler action to add labels based on base branch
+        if: startsWith(steps.pr_info.outputs.base_branch_name, 'inspec-')
+        uses: Typeform/labeler@v1.2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          repository-name: "inspec/inspec"
+          label-action: "add"
+          label: "${{ steps.pr_info.outputs.base_branch_name }}"
+          base-branch: "${{ steps.pr_info.outputs.base_branch }}"
+          hard-failure: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -22,8 +22,10 @@ jobs:
         run: |
           BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
           if [ "$BASE_BRANCH" == "main" ]; then
+            echo "::set-output name=base_branch::main"
             echo "::set-output name=base_branch_name::inspec-6"
           elif [ "$BASE_BRANCH" == "inspec-4" ] || [ "$BASE_BRANCH" == "inspec-5" ]; then
+            echo "::set-output name=base_branch::${BASE_BRANCH}"
             echo "::set-output name=base_branch_name::${BASE_BRANCH}"
           else
             echo "Unknown base branch for labelling : ${BASE_BRANCH}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read  # for actions/labeler to determine modified files
       pull-requests: write  # for actions/labeler to add labels to PRs
+      issues: write # for typeform/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
       - name: Use Git Actions labeler

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,6 @@
 name: "Pull Request Labeler"
-pull_request:
+on:
+  pull_request:
     types: [opened, synchronize]
 permissions:
   contents: read


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Git actions workflow to label PR with InSpec major versions using Typeform labeler action.
The only base branches that are allowed are: `main`, `inspec-4` and `inspec-5`

**Caveat of this approach:** 

- [Typeform Labeler](https://github.com/Typeform/labeler) is no longer maintained. 
- Filters all PRs of the same base branch and updates all the PRs with labels.

**Why this looks good?**

But it is a verified action by Git and also was created by [Typeform](https://www.typeform.com/).
And this action has the capability to add labels based on base branch directly.
This capability will be automatically available in [Git labeler version 5](https://github.com/marketplace/actions/labeler) as well, but right now it is on a beta version.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
