### PR TITLE
Remove resource_id for `service` resource , we do not support in inspec-4

### DIFF
--- a/lib/inspec/resources/service.rb
+++ b/lib/inspec/resources/service.rb
@@ -273,10 +273,6 @@ module Inspec::Resources
       info[:startname]
     end
 
-    def resource_id
-      @service_name || "Service"
-    end
-
     def to_s
       "Service #{@service_name}"
     end

--- a/test/unit/resources/service_test.rb
+++ b/test/unit/resources/service_test.rb
@@ -475,7 +475,6 @@ describe "Inspec::Resources::Service" do
     _(resource.enabled?).must_equal true
     _(resource.running?).must_equal false
     _(resource.params).must_equal params
-    _(resource.resource_id).must_equal "org.example.killed-agent"
   end
 
   # wrlinux


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Revert `resource_id` introduction for `service` resource. We do not support `resource_id` in inspec-4

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
