### PR TITLE
Fixed `inspec json` ability to use cli options successfully

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -78,6 +78,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   def json(target)
     Inspec.with_feature("inspec-cli-json") {
       # This deprecation warning is ignored currently.
+      config
       Inspec.deprecate(:renamed_to_inspec_export)
       export(target, true)
     }

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -77,6 +77,9 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   profile_options
   def json(target)
     Inspec.with_feature("inspec-cli-json") {
+      # Config initialisation is needed before deprecation warning can be issued
+      # Deprecator calls config get method to fetch the config value
+      # Without config initialisation, the config value is not set and hence calling config get through deprecator will set the value of config as blank, making options of json command inaccessible.
       config
       # This deprecation warning is ignored currently.
       Inspec.deprecate(:renamed_to_inspec_export)

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -77,8 +77,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
   profile_options
   def json(target)
     Inspec.with_feature("inspec-cli-json") {
-      # This deprecation warning is ignored currently.
       config
+      # This deprecation warning is ignored currently.
       Inspec.deprecate(:renamed_to_inspec_export)
       export(target, true)
     }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixed `inspec json` command's ability to access CLI options successfully. Otherwise, the CLI options used with the `json` command become blank.

**More information**:
The deprecator called in `inspec json` command before initialising the config breaks it. 
This is where the deprecator is called from CLI for `inspec json` command https://github.com/inspec/inspec/blob/main/lib/inspec/cli.rb#L81

The deprecator calls the config getter directly before the config value has been set and hence, the config value never gets set.
https://github.com/inspec/inspec/blob/main/lib/inspec/utils/deprecation/config_file.rb#L52

With the current fix, calling config will set the config value before it has been called by the getter.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
