### PR TITLE
[W.I.P] Fix: Waived control executes describe block

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -46,12 +46,11 @@ module Inspec
       return unless block_given?
 
       begin
-        instance_eval(&block)
-
-        # By applying waivers *after* the instance eval, we assure that
-        # waivers have higher precedence than only_if.
         __apply_waivers
 
+        unless waiver_is_valid?
+          instance_eval(&block)
+        end
       rescue SystemStackError, StandardError => e
         # We've encountered an exception while trying to eval the code inside the
         # control block. We need to prevent the exception from bubbling up, and
@@ -479,6 +478,16 @@ module Inspec
       { ref: r, line: l }
     rescue MethodSource::SourceNotFoundError
       {}
+    end
+
+    def waiver_is_valid?
+      return false if @__waiver_data.nil? || @__waiver_data.empty?
+
+      if @__waiver_data["run"] == false && !@__waiver_data["message"].match?(/Waiver expired on/)
+        true
+      else
+        false
+      end
     end
   end
 end


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Evaluates the describe block only if the waived control run is set to true or the waiver is expired. This ensures the describe block of the waived control should not be executed.

Waived control should not be executed and skipped without execution of describe block.

This change helps in eliminating the efforts to use options --filter-waived-controls and --retain-waiver-data.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
