### PR TITLE
Pin Thor to < 1.3.0 to fix test failures related to aliases

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -33,7 +33,9 @@ Source code obtained from the Chef GitHub repository is made available under Apa
   # Implementation dependencies
   spec.add_dependency "chef-telemetry",           "~> 1.0", ">= 1.0.8" # 1.0.8+ removes the http dep
   spec.add_dependency "license-acceptance",       ">= 0.2.13", "< 3.0"
-  spec.add_dependency "thor",                     ">= 0.20", "< 2.0"
+  # TODO: We should remove the thor pinning in next upcoming releases currently it's breaking our unit test in cli_args_test for aliases due to
+  # recent changes made in thor library REF: https://github.com/rails/thor/releases/tag/v1.3.0 & https://github.com/rails/thor/pull/800
+  spec.add_dependency "thor",                     ">= 0.20", "< 1.3.0"
   spec.add_dependency "method_source",            ">= 0.8", "< 2.0"
   spec.add_dependency "rubyzip",                  ">= 1.2.2", "< 3.0"
   spec.add_dependency "rspec",                    ">= 3.9", "<= 3.12"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
In Thor's recent [release](https://rubygems.org/gems/thor) version 1.3.0 they introduced [changes](https://github.com/rails/thor/releases/tag/v1.3.0) related to aliases here https://github.com/rails/thor/pull/800
that started breaking the inspec test for aliases.  This PR pins the version of Thor to be < 1.3.0 and then we can identify the impact of the Thor changes in InSpec and then remove the pinning.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
