### PR TITLE
Explicitly pin openssl to 1.0.2zi to avoid a CVE - inspec-4

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -5,7 +5,14 @@ train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
 override "train", version: "v#{train_stable}"
 override "ruby", version: "3.1.2"
 
-# Mac m1
-override "openssl", version: "1.1.1w" if mac_os_x?
+# Mac Apple Silicon requires 1.1.1 series instead of 1.0.2 series
+if mac_os_x?
+  override "openssl", version: "1.1.1w"
+else
+  # Hopefully temporary, in October 2023 the default is 1.0.2zg which 
+  # has an open high cve, while zi is available. Temporarily pin until
+  # default in omnibus-software has no cves.
+  override "openssl", version: "1.0.2zi"
+end
 
 override "ruby-msys2-devkit", version: "3.1.2-1"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Avoids CVE-2023-0464 among others, upgrading from 1.0.2zg the default in omnibus software.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
