### PR TITLE
CHEF-6493: Support `--legacy-export` option in `inspec archive`

### DIFF
--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -43,6 +43,10 @@ This subcommand has the following additional options:
 `--no-export`
 : Include an inspec.json file in the archive, the results of running `inspec export`.
 
+`--legacy-export`
+`--no-legacy-export`
+: Include an inspec.json file in the archive by utilizing information from the legacy export procedure, the results of running `inspec export --legacy-export`.
+
 `--ignore-errors`
 `--no-ignore-errors`
 : Ignore profile warnings.

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -272,6 +272,8 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "Run profile check before archiving."
   option :export, type: :boolean, default: false,
     desc: "Export the profile to inspec.json and include in archive"
+  option :legacy_export, type: :boolean, default: false,
+    desc: "Export the profile in legacy mode to inspec.json and include in archive"
   def archive(path, log_level = nil)
     Inspec.with_feature("inspec-cli-archive") {
       begin

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -809,9 +809,11 @@ module Inspec
       # TODO ignore all .files, but add the files to debug output
 
       # Generate temporary inspec.json for archive
-      if opts[:export]
+      export_opt_enabled = opts[:export] || opts[:legacy_export]
+      if export_opt_enabled
+        info_for_profile_summary = opts[:export] ? info_from_parse : info
         Inspec::Utils::JsonProfileSummary.produce_json(
-          info: info, # TODO: conditionalize and call info_from_parse
+          info: info_for_profile_summary,
           write_path: "#{root_path}inspec.json",
           suppress_output: true
         )
@@ -820,9 +822,9 @@ module Inspec
       # display all files that will be part of the archive
       @logger.debug "Add the following files to archive:"
       files.each { |f| @logger.debug "    " + f }
-      @logger.debug "    inspec.json" if opts[:export]
+      @logger.debug "    inspec.json" if export_opt_enabled
 
-      archive_files = opts[:export] ? files.push("inspec.json") : files
+      archive_files = export_opt_enabled ? files.push("inspec.json") : files
       if opts[:zip]
         # generate zip archive
         require "inspec/archive/zip"
@@ -836,7 +838,7 @@ module Inspec
       end
 
       # Cleanup
-      FileUtils.rm_f("#{root_path}inspec.json") if opts[:export]
+      FileUtils.rm_f("#{root_path}inspec.json") if export_opt_enabled
 
       @logger.info "Finished archive generation."
       true

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -811,7 +811,7 @@ module Inspec
       # Generate temporary inspec.json for archive
       export_opt_enabled = opts[:export] || opts[:legacy_export]
       if export_opt_enabled
-        info_for_profile_summary = opts[:export] ? info_from_parse : info
+        info_for_profile_summary = opts[:legacy_export] ? info : info_from_parse
         Inspec::Utils::JsonProfileSummary.produce_json(
           info: info_for_profile_summary,
           write_path: "#{root_path}inspec.json",

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -42,13 +42,28 @@ describe "inspec archive" do
     end
   end
 
-  it "archives an inspec.json file utilizing info from legacy export if provided --legacy-export option" do
+  it "archives an inspec.json file utilizing info from legacy export if provided --legacy-export option with a non-marker profile" do
     prepare_examples("profile") do |dir|
       out = inspec("archive " + dir + " --overwrite --legacy-export")
 
       _(out.stderr).must_equal ""
       t = Zlib::GzipReader.open(auto_dst)
       _(Gem::Package::TarReader.new(t).entries.map(&:header).map(&:name)).must_include "inspec.json"
+      assert_exit_code 0, out
+    end
+  end
+
+  it "archives an inspec.json file utilizing info from legacy export if provided --legacy-export option with a marker profile" do
+    prepare_profiles("eval-markers") do |dir|
+      out = inspec("archive " + dir + " --overwrite --legacy-export --output " + dst.path)
+
+      _(out.stderr).must_include "TOP_LEVEL_MARKER"
+      _(out.stderr).must_include "CONTROL_BODY_MARKER"
+      _(out.stderr).must_include "METADATA_MARKER"
+      _(out.stdout).must_include "Generate archive " + dst.path
+      t = Zlib::GzipReader.open(dst.path)
+      files = Gem::Package::TarReader.new(t).entries.map(&:header).map(&:name)
+      _(files).must_include "inspec.json"
       assert_exit_code 0, out
     end
   end

--- a/test/functional/inspec_archive_test.rb
+++ b/test/functional/inspec_archive_test.rb
@@ -42,6 +42,17 @@ describe "inspec archive" do
     end
   end
 
+  it "archives an inspec.json file utilizing info from legacy export if provided --legacy-export option" do
+    prepare_examples("profile") do |dir|
+      out = inspec("archive " + dir + " --overwrite --legacy-export")
+
+      _(out.stderr).must_equal ""
+      t = Zlib::GzipReader.open(auto_dst)
+      _(Gem::Package::TarReader.new(t).entries.map(&:header).map(&:name)).must_include "inspec.json"
+      assert_exit_code 0, out
+    end
+  end
+
   it "does not archive an inspec.json file by default" do
     prepare_examples("profile") do |dir|
       out = inspec("archive " + dir + " --overwrite")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR adds support for `--legacy-export` flag for including the **inspec.json** file as part of the archive using the information from the legacy export procedure i.e. the results of running `inspec export --legacy-export`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-6493: Modify inspec archive to use `--legacy-export` option

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
