### PR TITLE
Profile params usage changes - inspec compliance plugin

### DIFF
--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
@@ -182,10 +182,10 @@ module InspecPlugins
           end
 
           # read profile name from inspec.yml
-          profile_name = profile.params[:name]
+          profile_name = profile.name
 
           # read profile version from inspec.yml
-          profile_version = profile.params[:version]
+          profile_version = profile.version
 
           # check that the profile is not uploaded already,
           # confirm upload to the user (overwrite with --force)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Profile params usage changes in inspec compliance plugin, to directly fetch basic params from metadata instead of using params.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
