### PR TITLE
CHEF-7694 (CHEF-8271) : Fix security_policy resource returns array for non comma separated values

### DIFF
--- a/lib/inspec/resources/security_policy.rb
+++ b/lib/inspec/resources/security_policy.rb
@@ -169,9 +169,11 @@ module Inspec::Resources
       # special handling for string values with "
       elsif !(m = /^\"(.*)\"$/.match(val)).nil?
         m[1]
+      # When there is Registry Values value is not seprated with comma we are not spliting the value for backward compatibility
+      elsif !key.include?("\\") && val.match(/,/)
+        val.split(",")
       else
-        # When there is Registry Values we are not spliting the value for backward compatibility
-        key.include?("\\") ? val : val.split(",")
+        val
       end
     end
 

--- a/lib/inspec/resources/security_policy.rb
+++ b/lib/inspec/resources/security_policy.rb
@@ -169,7 +169,10 @@ module Inspec::Resources
       # special handling for string values with "
       elsif !(m = /^\"(.*)\"$/.match(val)).nil?
         m[1]
-      # When there is Registry Values value is not seprated with comma we are not spliting the value for backward compatibility
+      # We get some values of Registry Path as MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Setup\\RecoveryConsole\\SecurityLevel=4,0
+      # which we are not going to split as there are chances that it will break if anyone is using string comparison.
+      # In some cases privilege value which does not have corresponding SID it returns the values in comma seprated which breakes it for some of
+      # the privileges like SeServiceLogonRight as it returns array if previlege values are SID
       elsif !key.include?("\\") && val.match(/,/)
         val.split(",")
       else

--- a/test/fixtures/cmd/secedit-export
+++ b/test/fixtures/cmd/secedit-export
@@ -1,7 +1,13 @@
 [System Access]
 MaximumPasswordAge = 42
+LockoutDuration = -1
+RequireLogonToChangePassword = 0
+NewAdministratorName = "Administrator"
+NewGuestName = "Guest"
 [Registry Values]
 MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Setup\RecoveryConsole\SecurityLevel=4,0
+MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\CachedLogonsCount=1,"10"
+MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0\NTLMMinServerSec=4,536870912
 [Privilege Rights]
 SeUndockPrivilege = *S-1-5-32-544
 SeRemoteInteractiveLogonRight = *S-1-5-32-544,*S-1-5-32-555

--- a/test/unit/resources/security_policy_test.rb
+++ b/test/unit/resources/security_policy_test.rb
@@ -12,6 +12,12 @@ describe "Inspec::Resources::SecurityPolicy" do
     _(resource.SeUndockPrivilege).must_equal ["S-1-5-32-544"]
     _(resource.SeRemoteInteractiveLogonRight).must_equal ["S-1-5-32-544", "S-1-5-32-555"]
     _(resource.SeServiceLogonRight).must_equal %w{ DB2ADMNS db2admin }
+    _(resource.LockoutDuration).must_equal "-1"
+    _(resource.send('MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\CachedLogonsCount')).must_equal "1,\"10\""
+    _(resource.send('MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0\NTLMMinServerSec')).must_equal "4,536870912"
+    _(resource.NewAdministratorName).must_equal "Administrator"
+    _(resource.NewGuestName).must_equal "Guest"
+    _(resource.RequireLogonToChangePassword).must_equal 0
     _(resource.resource_id).must_equal "Security Policy"
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Security Policy which non-comma separated string for example for LockDuration the assigned value is -1 but currently it returns an array ["-1"] which fails the control.  This is a regression introduced in #5629 and this PR fixes that and adds additional data to test.

Example:

```
    describe security_policy do
      its("LockoutDuration") { should be >= "-1" }
    end
  end


Security Policy LockoutDuration is expected to be >= -1
expected: >= "-1"
     got:    ["-1"]
```

Failing Test before fix: https://buildkite.com/chef/inspec-inspec-main-verify-private/builds/377#018b878c-b850-4777-87f2-797bb9a30d7b/1038-1324

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
