### PR TITLE
CHEF-7281: Remove references to MacOS 10.15 in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Chef InSpec: Inspect Your Infrastructure
-  
+
 * **Project State: Active**
 * **Issues Response SLA: 14 business days**
 * **Pull Request Response SLA: 14 business days**
@@ -314,7 +314,7 @@ Remote Targets
 | CentOS                       | 6, 7, 8                                          | i386, x86_64  |
 | Debian                       | 9, 10                                            | i386, x86_64  |
 | FreeBSD                      | 9, 10, 11                                        | i386, amd64   |
-| macOS                        | 10.14, 10.15, 11.0                               | x86_64        |
+| macOS                        | 11.0                                             | x86_64        |
 | Oracle Enterprise Linux      | 6, 7, 8                                          | i386, x86_64  |
 | Red Hat Enterprise Linux     | 6, 7, 8                                          | i386, x86_64  |
 | Solaris                      | 10, 11                                           | sparc, x86    |

--- a/docs-chef-io/content/inspec/reusable/md/support_commercial_platforms.md
+++ b/docs-chef-io/content/inspec/reusable/md/support_commercial_platforms.md
@@ -2,7 +2,7 @@
 | --- | --- | --- |
 | Amazon Linux | `x86_64`, `aarch64` | `2.x` |
 | Debian | `x86_64`, `aarch64` (10.x only) | `9`, `10`, `11` |
-| macOS | `x86_64`, `aarch64` (M1 processors) | `10.15`, `11.x`, `12.x` |
+| macOS | `x86_64`, `aarch64` (M1 processors) | `11.x`, `12.x` |
 | Oracle Enterprise Linux | `x86_64`, `aarch64` (7.x / 8.x only) | `6.x`, `7.x`, `8.x` |
 | Red Hat Enterprise Linux | `x86_64`, `aarch64` (7.x and 8.x only) | `6.x`, `7.x`, `8.x` |
 | SUSE Linux Enterprise Server | `x86_64`, `aarch64` (15.x only) | `12.x`, `15.x` |


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR, removes MacOS 10.15 references in docs from the codebase.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
**[CHEF-7281: Remove references to MacOS 10.15 in docs](https://chefio.atlassian.net/browse/CHEF-7281)**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [x] Chore (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
