### PR TITLE
Remove checks for export

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -818,6 +818,9 @@ module Inspec
         offenses: [],
       }
 
+      # memoize `info_from_parse` with tests
+      info_from_parse(include_tests: true)
+
       entry = lambda { |file, line, column, control, msg|
         {
           file: file,

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -516,7 +516,7 @@ module Inspec
     end
 
     # Return data like profile.info(params), but try to do so without evaluating the profile.
-    def info_from_parse
+    def info_from_parse(include_tests: false)
       return @info_from_parse unless @info_from_parse.nil?
 
       @info_from_parse = {
@@ -571,7 +571,8 @@ module Inspec
         source_location_ref = @source_reader.target.abs_path(control_filename)
 
         input_collector = Inspec::Profile::AstHelper::InputCollectorOutsideControlBlock.new(@info_from_parse)
-        ctl_id_collector = Inspec::Profile::AstHelper::ControlIDCollector.new(@info_from_parse, source_location_ref)
+        ctl_id_collector = Inspec::Profile::AstHelper::ControlIDCollector.new(@info_from_parse, source_location_ref,
+                                                                              include_tests: include_tests)
 
         # Collect all metadata defined in the control block and inputs defined inside the control block
         src.ast.each_node { |n|

--- a/lib/inspec/utils/profile_ast_helpers.rb
+++ b/lib/inspec/utils/profile_ast_helpers.rb
@@ -267,11 +267,12 @@ module Inspec
       end
 
       class ControlIDCollector < CollectorBase
-        attr_reader :seen_control_ids, :source_location_ref
-        def initialize(memo, source_location_ref)
+        attr_reader :seen_control_ids, :source_location_ref, :include_tests
+        def initialize(memo, source_location_ref, include_tests: false)
           @memo = memo
           @seen_control_ids = {}
           @source_location_ref = source_location_ref
+          @include_tests = include_tests
         end
 
         def on_block(block_node)
@@ -300,8 +301,8 @@ module Inspec
               impact: 0.5,
               refs: [],
               tags: {},
-              checks: [],
             }
+            control_data[:checks] = [] if include_tests
 
             # Scan the code block for per-control metadata
             collectors = []
@@ -311,7 +312,7 @@ module Inspec
             collectors.push TagCollector.new(control_data)
             collectors.push RefCollector.new(control_data)
             collectors.push InputCollectorWithinControlBlock.new(@memo)
-            collectors.push TestsCollector.new(control_data)
+            collectors.push TestsCollector.new(control_data) if include_tests
 
             begin_block.each_node do |node_within_control|
               collectors.each { |collector| collector.process(node_within_control) }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
The `checks` subfield should not be available part of the `controls` data structure for `inspec export`.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
`check` are basically list of tests per control. This is used to check for availability of tests during `inspec check` where as it is not needed for `export` action. 
In the legacy mode, we [delete the checks ](https://github.com/inspec/inspec/blob/ee490412e811de57023002384089fcb8545dde71/lib/inspec/profile.rb#L462) while running export. With the recent changes, since it is a costly operation to populate these values at first place this change by default does not populate it and provides an option to populate checks when needed. In this case, the only action that needs it are `inspec check`. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
