### PR TITLE
CHEF-6285: Move the audit log enablement from exec/shell to runner

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -430,25 +430,5 @@ module Inspec
       end
       o[:logger].level = get_log_level(o["log_level"])
     end
-
-    # This method is currenlty under feature preview flag and audit log will only be enabeld when CHEF_PREVIEW_AUDIT_LOGGING is set in the env variable
-    def set_and_validate_audit_log_options(opts)
-      err = []
-      opts[:enable_audit_log] ||= true
-      if opts[:audit_log_location].nil?
-        opts[:audit_log_location] = "#{Inspec.log_dir}/inspec-audit-#{Time.now.strftime("%Y%m%dT%H%M%S")}-#{Process.pid}.log"
-      elsif File.directory?(File.dirname(opts[:audit_log_location]))
-        file_path = opts[:audit_log_location]
-        # suffix the timestamp and pid to the audit log file name if log location is set through cli option
-        filename  = "#{File.basename(file_path, ".*")}-#{Time.now.strftime("%Y%m%dT%H%M%S")}-#{Process.pid}"
-        opts[:audit_log_location] = File.join( File.dirname(file_path), "#{filename}#{File.extname(file_path)}" )
-      else
-        err << "Audit log location directory #{opts[:audit_log_location]} does not exist."
-      end
-      opts[:audit_log_app_name] = Inspec::Dist::EXEC_NAME
-      unless err.empty?
-        raise Inspec::Exceptions::InvalidAuditLogOption, err.join("\n")
-      end
-    end
   end
 end

--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -390,11 +390,6 @@ class Inspec::InspecCLI < Inspec::BaseCLI
         deprecate_target_id(config)
         configure_logger(o)
 
-        # Only runs this block when preview flag CHEF_PREVIEW_AUDIT_LOGGING is set
-        Inspec.with_feature("inspec-audit-logging") {
-          set_and_validate_audit_log_options(o)
-        }
-
         runner = Inspec::Runner.new(o)
         targets.each { |target| runner.add_target(target) }
 
@@ -466,9 +461,6 @@ class Inspec::InspecCLI < Inspec::BaseCLI
         deprecate_target_id(config)
         diagnose(o)
         o[:debug_shell] = true
-        Inspec.with_feature("inspec-audit-logging") {
-          set_and_validate_audit_log_options(o)
-        }
 
         Inspec::Resource.toggle_inspect unless o[:inspect]
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Currently all option processing and enablement happens in a block in the exec and shell CLI commands.

This PR moves the audit log enablement from exec/shell to runner which will enhance the scope.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
