### PR TITLE
CHEF-8416: Fix broken reporter integration for compliance phase

### DIFF
--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -508,19 +508,23 @@ module Inspec
       # Default to cli report for ad-hoc runners
       options["reporter_cli_opts"] = ["cli"] if (options["reporter"].nil? || options["reporter"].empty?) && options["reporter_cli_opts"].nil?
 
+      # Collect all reporters from cli, config file or from compliance mode (in chef-client) into combined_reports
       combined_reports = {}
-      # Parse out reporter_cli_opts to proper report format
+
       if options["reporter_cli_opts"].is_a?(Array)
+        # Collect all reporters from cli (using InSpec cli) into combined_reports
         combined_reports.merge!(parse_array_reporter_to_hash(options["reporter_cli_opts"], options["target_id"]))
       end
 
-      # parse out cli to proper report format
       if options["reporter"].is_a?(Array)
+        # Collect reporter from options["reporter"] when passed from compliance mode (using chef-client) into combined_reports
         combined_reports.merge!(parse_array_reporter_to_hash(options["reporter"], options["target_id"]))
       elsif options["reporter"].is_a?(Hash)
+        # Collect reporter from options["reporter"] when passed in config file (using InSpec cli) into combined_reports
         combined_reports.merge!(options["reporter"])
       end
 
+      # Override the options["reporter"] with combined_reports, handling reporters from all sources (like cli, config file, or compliance mode)
       options["reporter"] = combined_reports
 
       # add in stdout if not specified

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -614,7 +614,7 @@ describe "Inspec::Config" do
     let(:fixture_name) { "basic" }
     let(:fixtures_dir) { File.join(File.dirname(__FILE__), "..", "fixtures") }
     let(:cli_opts) { { "reporter" => ["cli"] } }
-    let(:cli_opts_2) { { :reporter => ["json-automate"] } } # Compliance mode is passes as an array
+    let(:cli_opts_2) { { reporter: ["json-automate"] } } # Compliance mode passes as an array
     let(:seen_reporters) { cfg["reporter"] }
 
     describe "when parsing reporters from CLI" do
@@ -628,7 +628,7 @@ describe "Inspec::Config" do
     describe "when parsing reporters from an IO source (say json file)" do
       let(:cfg) { Inspec::Config.new({}, cfg_io) }
       it "should parse reporters from io correctly" do
-        expected_value = {"automate"=>{"url"=>"http://some.where", "token"=>"YOUR_A2_ADMIN_TOKEN"}}
+        expected_value = { "automate" => { "url" => "http://some.where", "token" => "YOUR_A2_ADMIN_TOKEN" } }
         _(seen_reporters).must_equal expected_value
       end
     end
@@ -636,7 +636,7 @@ describe "Inspec::Config" do
     describe "when parsing reporters from CLI and an IO source (say json file)" do
       let(:cfg) { Inspec::Config.new(cli_opts, cfg_io) }
       it "should parse reporters from both the sources correctly" do
-        expected_value = {"cli"=>{"stdout"=>true}, "automate"=>{"url"=>"http://some.where", "token"=>"YOUR_A2_ADMIN_TOKEN"}}
+        expected_value = { "cli" => { "stdout" => true }, "automate" => { "url" => "http://some.where", "token" => "YOUR_A2_ADMIN_TOKEN" } }
         _(seen_reporters).must_equal expected_value
       end
     end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -604,6 +604,51 @@ describe "Inspec::Config" do
       end
     end
   end
+
+  # ========================================================================== #
+  #               Parsing, Validating & Merging Reporter Options
+  # ========================================================================== #
+
+  describe "when parsing reporters from different sources" do
+    let(:cfg_io) { StringIO.new(ConfigTestHelper.fixture(fixture_name)) }
+    let(:fixture_name) { "basic" }
+    let(:fixtures_dir) { File.join(File.dirname(__FILE__), "..", "fixtures") }
+    let(:cli_opts) { { "reporter" => ["cli"] } }
+    let(:cli_opts_2) { { :reporter => ["json-automate"] } } # Compliance mode is passes as an array
+    let(:seen_reporters) { cfg["reporter"] }
+
+    describe "when parsing reporters from CLI" do
+      let(:cfg) { Inspec::Config.new(cli_opts) }
+      it "should parse reporters from cli correctly" do
+        expected_value = { "cli" => { "stdout" => true } }
+        _(seen_reporters).must_equal expected_value
+      end
+    end
+
+    describe "when parsing reporters from an IO source (say json file)" do
+      let(:cfg) { Inspec::Config.new({}, cfg_io) }
+      it "should parse reporters from io correctly" do
+        expected_value = {"automate"=>{"url"=>"http://some.where", "token"=>"YOUR_A2_ADMIN_TOKEN"}}
+        _(seen_reporters).must_equal expected_value
+      end
+    end
+
+    describe "when parsing reporters from CLI and an IO source (say json file)" do
+      let(:cfg) { Inspec::Config.new(cli_opts, cfg_io) }
+      it "should parse reporters from both the sources correctly" do
+        expected_value = {"cli"=>{"stdout"=>true}, "automate"=>{"url"=>"http://some.where", "token"=>"YOUR_A2_ADMIN_TOKEN"}}
+        _(seen_reporters).must_equal expected_value
+      end
+    end
+
+    describe "when parsing reporters from compliance mode (in chef-client)" do
+      let(:cfg) { Inspec::Config.new(cli_opts_2) }
+      it "should parse reporters from cli correctly" do
+        expected_value = { "json-automate" => { "stdout" => true } }
+        _(seen_reporters).must_equal expected_value
+      end
+    end
+  end
 end
 
 # ========================================================================== #


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR fixes the broken reporter integration for compliance phase.

**Existing Behaviour:**
Running chef-client in compliance phase throws an error `ERROR: undefined method each_value' for ["json-automate"]:Array`.

The reason being reporter passed as `:reporter=>["json-automate"]` by chef-client to InSpec's.
https://github.com/chef/chef/blob/4ce99c419028c169aeb3e68ec954b79f20e654c5/lib/chef/compliance/runner.rb#L167

The existing config class's `finalize_parse_reporters` is unable to handle, when reporter is passed as an array.

**Updated Behaviour:**
InSpec is able to handle the reporter integration with chef-client for compliance phase. 

`finalize_parse_reporters` is improved to handle the scenarios for reporter being passed as an array in the opts: `:reporter=>["json-automate"]`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-8416: Compliance phase reporter integration broken

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
