### PR TITLE
CHEF-8416: Patch for broken reporter integration for compliance phase

### DIFF
--- a/lib/inspec/config.rb
+++ b/lib/inspec/config.rb
@@ -470,6 +470,15 @@ module Inspec
       # Reporter options may be defined top-level.
       options.merge!(config_file_reporter_options)
 
+      # when sent reporter from compliance-mode (via chef-client), the reporter is a symbol
+      if @cli_opts.key?(:reporter) && @cli_opts["reporter"].nil?
+        @cli_opts["reporter"] = @cli_opts[:reporter]
+        @cli_opts.delete(:reporter)
+      elsif @cli_opts.key?(:reporter) && @cli_opts.key?("reporter") && @cli_opts["reporter"].is_a?(Array)
+        # combine reporter and "reporter" options into "reporter" option
+        @cli_opts["reporter"] = @cli_opts[:reporter] + @cli_opts["reporter"]
+      end
+
       if @cli_opts["reporter"]
         # Add reporter_cli_opts in options to capture reporter cli opts separately
         options.merge!({ "reporter_cli_opts" => @cli_opts["reporter"] })


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR fixes the broken reporter integration for compliance phase.

Existing Behaviour (which causes the runtime exception):

Running chef-client in compliance phase throws an error ERROR: undefined method each_value' for ["json-automate"]:Array.

The reason being reporter passed as symbol [:reporter=>["json-automate"]](https://github.com/chef/chef/blob/4ce99c419028c169aeb3e68ec954b79f20e654c5/lib/chef/compliance/runner.rb#L167) to InSpec by chef-client.

When the @cli_opts is merged here into the options, the :reporter key is converted to "reporter" and leaving options["reporter"] as array
https://github.com/inspec/inspec/blob/e3708cfa7d57586280824b3b4739cee0c722d87a/lib/inspec/config.rb#L481

**And the options["reporter"] is not converted to hash post this operation.**

This causes a runtime exception when validating the reporters here (options["reporter"] which should be converted to hash by now):
https://github.com/inspec/inspec/blob/e3708cfa7d57586280824b3b4739cee0c722d87a/lib/inspec/config.rb#L543
https://github.com/inspec/inspec/blob/e3708cfa7d57586280824b3b4739cee0c722d87a/lib/inspec/config.rb#L410

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-8416: Compliance phase reporter integration broken

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
