### PR TITLE
Pin to unf_ext 0.0.8.2 in top-level Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,10 @@ gem "inspec-bin", path: "./inspec-bin"
 
 gem "ffi", ">= 1.9.14", "!= 1.13.0", "!= 1.14.2"
 
+# We have a build issue 2023-11-13 with unf_ext 0.0.9 so we are pinning to 0.0.8.2
+# See https://github.com/knu/ruby-unf_ext/issues/74 https://buildkite.com/chef/inspec-inspec-inspec-5-omnibus-release/builds/22
+gem "unf_ext", "= 0.0.8.2"
+
 # inspec tests depend text output that changed in the 3.10 release
 # but our runtime dep is still 3.9+
 gem "rspec", ">= 3.10"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Green adhoc build here https://buildkite.com/chef/inspec-inspec-inspec-5-omnibus-adhoc/builds/32

Temporarily pin unf_ext to 0.0.8.2 in the top-level Gemfile to fix a build issue in the omnibus builds. Note that we need to fix it in the top-level Gemfile, which defines dependencies for the InSpec project, not in the omnibus/Gemfile, which defines deps for use when running Omnibus.

Links in comments in the gemfile.

Need to bump patch version to get a new release candidate.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
