### PR TITLE
Allow the negate formating for cmp

### DIFF
--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -299,9 +299,9 @@ RSpec::Matchers.define :cmp do |first_expected| # rubocop:disable Metrics/BlockL
     end
   end
 
-  def format_actual(actual)
+  def format_actual(actual, negate=false)
     actual = "0%o" % actual if octal?(@expected) && !actual.nil?
-    "\n%s\n     got: %s\n\n(compared using `cmp` matcher)\n" % [format_expectation(false), actual]
+    "\n%s\n     got: %s\n\n(compared using `cmp` matcher)\n" % [format_expectation(negate), actual]
   end
 
   def format_expectation(negate)
@@ -316,7 +316,7 @@ RSpec::Matchers.define :cmp do |first_expected| # rubocop:disable Metrics/BlockL
   end
 
   failure_message_when_negated do |actual|
-    format_actual actual
+    format_actual actual, true
   end
 
   description do

--- a/lib/matchers/matchers.rb
+++ b/lib/matchers/matchers.rb
@@ -299,7 +299,7 @@ RSpec::Matchers.define :cmp do |first_expected| # rubocop:disable Metrics/BlockL
     end
   end
 
-  def format_actual(actual, negate=false)
+  def format_actual(actual, negate = false)
     actual = "0%o" % actual if octal?(@expected) && !actual.nil?
     "\n%s\n     got: %s\n\n(compared using `cmp` matcher)\n" % [format_expectation(negate), actual]
   end


### PR DESCRIPTION
## Description
The 'cmp' matcher when used with a negation as 'should_not' has a confusion formating when control fails:
![image](https://github.com/inspec/inspec/assets/12498020/e45ac096-a37d-423e-8ad6-7e61afec8fb3)


This, because the 'format_actual' always pass 'false' to the 'format_expectation'. Thus the 'format_expectation' never reach the 'negate_str'.

When passing the negate value to the 'format_expectation' the output is more intuitive:
![image](https://github.com/inspec/inspec/assets/12498020/e25bc88f-fa9b-4514-b1af-ac46c3d31654)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)
- [x] other 

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
