### PR TITLE
Upgrades openssl version to 3.0.11

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -5,14 +5,6 @@ train_stable = /^train \((.*)\)/.match(`gem list ^train$ --remote`)[1]
 override "train", version: "v#{train_stable}"
 override "ruby", version: "3.1.2"
 
-# Mac Apple Silicon requires 1.1.1 series instead of 1.0.2 series
-if mac_os_x?
-  override "openssl", version: "1.1.1w"
-else
-  # Hopefully temporary, in October 2023 the default is 1.0.2zg which
-  # has an open high cve, while zi is available. Temporarily pin until
-  # default in omnibus-software has no cves.
-  override "openssl", version: "1.0.2zi"
-end
+override :openssl, version: "3.0.11"
 
 override "ruby-msys2-devkit", version: "3.1.2-1"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR upgrades the openssl version to 3.0.11

Testing adhoc build against PR https://github.com/chef/omnibus-software/pull/1831 as it has the upgraded version of openssl in omnibus software.

The PR in omnibus-software to add new openssl version 3.0.11 is merged https://github.com/chef/omnibus-software/pull/1857/files#diff-05cbe0a6a9b14d404660e58981b5e95f7ec556e4d6673d9a84fad51efd8dc84eR51
so this is good to merge 

This successful adhoc buld after latest omnibus-software upgrade 
https://buildkite.com/chef/inspec-inspec-main-omnibus-adhoc/builds/498

This is ready for merge
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
