### PR TITLE
CI: Increase timeout for buildkite

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -2,7 +2,7 @@
 expeditor:
   defaults:
     buildkite:
-      timeout_in_minutes: 60
+      timeout_in_minutes: 90
       retry:
         automatic:
           limit: 1


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR increases the timeout for buildkite as tests on the CI takes about ~59 minutes or more in some case.
The CI breaks whenever it crosses more than 60 mins. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
