### PR TITLE
CHEF-4442 Streaming reporter fix to capture progress correctly

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -145,7 +145,7 @@ module Inspec
             get_check_example(m, a, b)
           end.compact
 
-          examples.map { |example| total_checks += example.examples.count }
+          examples.map { |example| total_checks += example.descendant_filtered_examples.count }
 
           unless control_describe_checks.empty?
             # controls with empty tests are avoided


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR includes a fix for the streaming reporter in following scenario:
- Controls that only have `its` blocks. rspec-its was not visible to the streaming reporter formatter interface in the same way.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
