### PR TITLE
CHEF-8990 Remove dependency on active-support function `blank?`

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -47,7 +47,7 @@ module Inspec
           license_keys = ChefLicensing.fetch_and_persist
 
           # Only if EULA acceptance or license key args are present. And licenses are successfully persisted, do clean exit.
-          if ARGV.select { |arg| !(arg.include? "--chef-license") }.empty? && !license_keys.blank?
+          if ARGV.select { |arg| !(arg.include? "--chef-license") }.empty? && !(license_keys.nil? || license_keys.empty?)
             Inspec::UI.new.exit
           end
         end

--- a/lib/inspec/dependencies/dependency_set.rb
+++ b/lib/inspec/dependencies/dependency_set.rb
@@ -26,7 +26,7 @@ module Inspec
       dep_list = {}
       dependencies.each do |d|
         # if depedent profile does not have a source version then only name is used in dependency hash
-        key_name = (d.source_version.blank? ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
+        key_name = ((d.source_version.nil? || d.source_version.empty?) ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
         dep_list[key_name] = d
       end
       new(cwd, cache, dep_list, backend)
@@ -42,7 +42,7 @@ module Inspec
       dep_list = {}
       dep_tree.each do |d|
         # if depedent profile does not have a source version then only name is used in dependency hash
-        key_name = (d.source_version.blank? ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
+        key_name = ((d.source_version.nil? || d.source_version.empty?) ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
         dep_list[key_name] = d
         dep_list.merge!(flatten_dep_tree(d.dependencies))
       end

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -95,7 +95,7 @@ module Inspec::DSL
         # 1. Fetching VERSION from a profile dependency name which is in a format NAME-VERSION.
         # 2. Matching original profile dependency name with profile name used with include or require control DSL.
         source_version = value.source_version
-        unless (source_version.nil? || source_version.empty?)
+        unless source_version.nil? || source_version.empty?
           profile_id_key = key.split("-#{source_version}")[0]
           new_profile_id = key if profile_id_key == profile_id
         end

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -95,7 +95,7 @@ module Inspec::DSL
         # 1. Fetching VERSION from a profile dependency name which is in a format NAME-VERSION.
         # 2. Matching original profile dependency name with profile name used with include or require control DSL.
         source_version = value.source_version
-        unless source_version.blank?
+        unless (source_version.nil? || source_version.empty?)
           profile_id_key = key.split("-#{source_version}")[0]
           new_profile_id = key if profile_id_key == profile_id
         end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -291,7 +291,7 @@ module Inspec
       ## Find the waivers file
       # - TODO: cli_opts and instance_variable_get could be exposed
       waiver_paths = cfg.instance_variable_get(:@cli_opts)["waiver_file"]
-      if waiver_paths.blank?
+      if waiver_paths.nil? || waiver_paths.empty?
         Inspec::Log.error "Must use --waiver-file with --filter-waived-controls"
         Inspec::UI.new.exit(:usage_error)
       end
@@ -319,7 +319,7 @@ module Inspec
         # be processed and rendered
         tests.each do |control_filename, source_code|
           cleared_tests = source_code.scan(/control\s+['"].+?['"].+?(?=(?:control\s+['"].+?['"])|\z)/m).collect do |element|
-            next if element.blank?
+            next if element.nil? || element.empty?
 
             if element&.match?(waived_control_id_regex)
               splitlines = element.split("\n")

--- a/lib/inspec/reporters/cli.rb
+++ b/lib/inspec/reporters/cli.rb
@@ -317,7 +317,7 @@ module Inspec::Reporters
       not_applicable = 0
 
       all_unique_controls.each do |control|
-        next if control[:status].blank?
+        next if control[:status].nil? || control[:status].empty?
 
         if control[:status] == "failed"
           failed += 1

--- a/lib/inspec/utils/waivers/csv_file_reader.rb
+++ b/lib/inspec/utils/waivers/csv_file_reader.rb
@@ -19,7 +19,7 @@ module Waivers
         row_hash.delete("control_id")
         row_hash.delete_if { |k, v| k.nil? || v.nil? }
 
-        waiver_data_hash[control_id] = row_hash if control_id && !row_hash.blank?
+        waiver_data_hash[control_id] = row_hash if control_id && !(row_hash.nil? || row_hash.empty?)
       end
 
       waiver_data_hash

--- a/lib/inspec/utils/waivers/excel_file_reader.rb
+++ b/lib/inspec/utils/waivers/excel_file_reader.rb
@@ -25,7 +25,7 @@ module Waivers
           row_hash.delete_if { |k, v| k.nil? || v.nil? }
         end
 
-        waiver_data_hash[control_id] = row_hash if control_id && !row_hash.blank?
+        waiver_data_hash[control_id] = row_hash if control_id && !(row_hash.nil? || row_hash.empty?)
       end
       waiver_data_hash
     rescue Exception => e


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Remove dependency on active-support function `blank?`
Since active-support is not declared as a dependency for `inspec-core` it breaks the usage of inspec.

Fixes #6527 


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
