### PR TITLE
CHEF-4191 Waivers backward compatibility support with Chef Client

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -379,12 +379,7 @@ module Inspec
       control_id = @__rule_id # TODO: control ID slugging
 
       waiver_files = Inspec::Config.cached.final_options["waiver_file"] if Inspec::Config.cached.respond_to?(:final_options)
-      unless waiver_files.nil? || waiver_files.empty?
-        waiver_data_by_profile = Inspec::WaiverFileReader.fetch_waivers_by_profile(__profile_id, waiver_files)
-        return unless waiver_data_by_profile && waiver_data_by_profile[control_id] && waiver_data_by_profile[control_id].is_a?(Hash)
-
-        @__waiver_data = waiver_data_by_profile[control_id]
-      else
+      if waiver_files.nil? || waiver_files.empty?
         # Support for input registry is provided for backward compatibilty with compliance phase of chef-client
         # Chef-client sends waiver information in inputs hash
         input_registry = Inspec::InputRegistry.instance
@@ -392,6 +387,11 @@ module Inspec
         return unless waiver_data_via_input && waiver_data_via_input.has_value? && waiver_data_via_input.value.is_a?(Hash)
 
         @__waiver_data = waiver_data_via_input.value
+      else
+        waiver_data_by_profile = Inspec::WaiverFileReader.fetch_waivers_by_profile(__profile_id, waiver_files)
+        return unless waiver_data_by_profile && waiver_data_by_profile[control_id] && waiver_data_by_profile[control_id].is_a?(Hash)
+
+        @__waiver_data = waiver_data_by_profile[control_id]
       end
 
       __waiver_data["skipped_due_to_waiver"] = false


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Waivers backward compatibility support with Chef Client
Chef Client passes waiver information to InSpec via inputs and hence there needs to be a support to read inputs for waivers.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
