### PR TITLE
CHEF-7265 Telemetry opt-in for CINC users

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -57,7 +57,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "Disable loading all plugins that the user installed."
 
   class_option :enable_telemetry, type: :boolean,
-    desc: "Allow or disable telemetry", default: false
+    desc: "Allow or disable telemetry", default: true
 
   require "license_acceptance/cli_flags/thor"
   include LicenseAcceptance::CLIFlags::Thor

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -177,7 +177,7 @@ module Inspec
       Inspec::Log.debug "Starting run with targets: #{@target_profiles.map(&:to_s)}"
       # Perform license data collection when preview flag CHEF_PREVIEW_LDC_CLIENT is set
       Inspec.with_feature("inspec-ldc-client") {
-        Inspec::LicenseDataCollector.scan_starting(runner: self)
+        Inspec::LicenseDataCollector.scan_starting(runner: self, conf: @conf)
       }
       load
       run_tests(with)
@@ -227,7 +227,7 @@ module Inspec
       @run_data = @test_collector.run(with)
       # Perform license data collection when preview flag CHEF_PREVIEW_LDC_CLIENT is set
       Inspec.with_feature("inspec-ldc-client") {
-        th = Inspec::LicenseDataCollector.scan_finishing(run_data: @run_data)
+        th = Inspec::LicenseDataCollector.scan_finishing(run_data: @run_data, conf: @conf)
         th.join if th.respond_to? :join
       }
       # dont output anything if we want a report

--- a/lib/inspec/utils/license_data_collector.rb
+++ b/lib/inspec/utils/license_data_collector.rb
@@ -33,15 +33,18 @@ module Inspec
       @@config
     end
 
+    def self.telemetry_disabled?
+      !config.telemetry_options["enable_telemetry"]
+    end
+
     def self.determine_backend_class
-      if Inspec::Dist::EXEC_NAME == "inspec" && !config.telemetry_options["enable_telemetry"]
-        # Issue a warning if a user is explicitly trying to opt out of telemetry using cli option
+      if Inspec::Dist::EXEC_NAME == "inspec" && telemetry_disabled?
+        # Issue a warning if an InSpec user is explicitly trying to opt out of telemetry using cli option
         Inspec::Log.warn "Telemetry opt-out is not permissible."
       end
 
-      # TBD Should this condition be modified now, since we want to allow opt-in and opt-in for non-inspec distros?
-      # Don't perform license data collection if we are not the official Progress Chef InSpec distro
-      return Inspec::LicenseDataCollector::Null if Inspec::Dist::EXEC_NAME != "inspec"
+      # Telemetry opt-in/out enabled for other Inspec distros
+      return Inspec::LicenseDataCollector::Null if Inspec::Dist::EXEC_NAME != "inspec" && telemetry_disabled?
 
       # Don't perform license data collection if license is not a free license
       return Inspec::LicenseDataCollector::Null unless license&.license_type == "free"

--- a/lib/inspec/utils/license_data_collector.rb
+++ b/lib/inspec/utils/license_data_collector.rb
@@ -13,12 +13,15 @@ module Inspec
   class LicenseDataCollector
 
     @@instance = nil
+    @@config = nil
 
     def self.scan_starting(opts)
+      @@config ||= opts[:conf]
       instance.scan_starting(opts)
     end
 
     def self.scan_finishing(opts)
+      @@config ||= opts[:conf]
       instance.scan_finishing(opts)
     end
 
@@ -26,7 +29,17 @@ module Inspec
       @@instance ||= determine_backend_class.new
     end
 
+    def self.config
+      @@config
+    end
+
     def self.determine_backend_class
+      if Inspec::Dist::EXEC_NAME == "inspec" && !config.telemetry_options["enable_telemetry"]
+        # Issue a warning if a user is explicitly trying to opt out of telemetry using cli option
+        Inspec::Log.warn "Telemetry opt-out is not permissible."
+      end
+
+      # TBD Should this condition be modified now, since we want to allow opt-in and opt-in for non-inspec distros?
       # Don't perform license data collection if we are not the official Progress Chef InSpec distro
       return Inspec::LicenseDataCollector::Null if Inspec::Dist::EXEC_NAME != "inspec"
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

By default, telemetry is opted-in by Inspec.
And most users will not be able to disable telemetry. However, CINC users can.

So using the CLI option `--no-enable-telemetry` by CINC users will disable telemetry. 
But if a user is not a CINC user, we need to issue a warning since it is not permissible to disable telemetry for them.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
