### PR TITLE
Ensure inspec-core gem depends on rubocop-ast

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -56,6 +56,7 @@ Source code obtained from the Chef GitHub repository is made available under Apa
   spec.add_dependency "parslet",                  ">= 1.5", "< 2.0" # Pinned < 2.0, see #5389
   spec.add_dependency "semverse",                 "~> 3.0"
   spec.add_dependency "multipart-post",           "~> 2.0"
+  spec.add_dependency "rubocop-ast",              "~> 1.21"
 
   spec.add_dependency "train-core", ">= 3.11.0"
   spec.add_dependency "chef-licensing", ">= 0.7.5"


### PR DESCRIPTION
```
Ensure inspec gem depends on rubocop-ast

- Adds `rubocop-ast` to the gemspec file because it was added as a requirement in commit b5fcc141d2.  Without this addition, the inspec gem will exhibit runtime failures because this gem was not installed.

Obvious fix.
```

## Description

When installing `inspec-core`, the recently introduced dependency on `rubocop-ast` is missed causing runtime failures.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
