### PR TITLE
Temporary turn off pulling of chef-licensing gem from artifactory.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,13 @@
+# TODO: Commentine artifactory source block temporarily
+# to addres JIRA #9390 (Chef InSpec  Verify pipeline is failing due to checksum mismatch of mixlib-shellout gem)
 # For Chef internal builds, allows preview versions of gems if available.
-if ENV["ARTIFACTORY_BASE_URL"]
-  source ENV["ARTIFACTORY_BASE_URL"] + "/artifactory/api/gems/omnibus-gems-local/" do
-    # TODO: either fully populate this list, or revert back to non-block format
-    #       to sweep all Chef gems from Artifactory.
-    gem "chef-licensing"
-  end
-end
+# if ENV["ARTIFACTORY_BASE_URL"]
+#   source ENV["ARTIFACTORY_BASE_URL"] + "/artifactory/api/gems/omnibus-gems-local/" do
+#     # TODO: either fully populate this list, or revert back to non-block format
+#     #       to sweep all Chef gems from Artifactory.
+#     gem "chef-licensing"
+#   end
+# end
 
 source "https://rubygems.org"
 


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR temporarily turns off fetching of chef-licensing gem from artifactory to address the checksum mismatch issue for mixlib-shellout gem.and to make verify pipeline to work on the PR

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
