### PR TITLE
CHEF-6412: Fix for virutalization resource undefined method file_read

### DIFF
--- a/lib/inspec/resources/virtualization.rb
+++ b/lib/inspec/resources/virtualization.rb
@@ -223,7 +223,7 @@ module Inspec::Resources
       elsif cgroup_content =~ %r{^\d+:[^:]+:/(kubepods)/.+$}
         @virtualization_data[:system] = $1
         @virtualization_data[:role] = "guest"
-      elsif /container=podman/.match?(file_read("/proc/1/environ"))
+      elsif /container=podman/.match?(inspec.file("/proc/1/environ").content)
         @virtualization_data[:system] = "podman"
         @virtualization_data[:role] = "guest"
       elsif lxc_version_exists? && cgroup_content =~ %r{\d:[^:]+:/$}

--- a/test/unit/resources/virtualization_test.rb
+++ b/test/unit/resources/virtualization_test.rb
@@ -37,4 +37,33 @@ describe "Inspec::Resources::Virtualization" do
       _(mock_resource.role).must_be_nil
     end
   end
+
+  describe "detect_container" do
+    def mock_file_methods(mocked_files)
+      proc do |filename|
+        OpenStruct.new(
+          exist?: mocked_files.keys.include?(filename) ? true : false,
+          content: mocked_files.keys.include?(filename) ? mocked_files[filename] : nil
+        )
+      end
+    end
+
+    let(:mocked_files) {
+      {
+        "/proc/self/cgroup" => "",
+        "/proc/1/environ" => "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/binTERM=xtermcontainer=podmanHOSTNAME=8a97c663f060HOME=/root",
+      }
+    }
+
+    let(:mock_loader) { MockLoader.new(:ubuntu) }
+    let(:backend) { mock_loader.backend }
+
+    it "returns podman if /proc/1/environ file has container=podman entry" do
+      backend.stub :file, mock_file_methods(mocked_files) do
+        resource = mock_loader.load_resource("virtualization")
+        _(resource.system).must_equal "podman"
+        _(resource.role).must_equal "guest"
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR is to fix the error undefined method file_read

When the detect_container method is called  it checks for the condition  if /proc/1/environ file has an entry for Podman container. For reading the contents of the file file_read method is used, which does not exist throughout the code and due to which the virtualization resource sets the platform values as nil and gives the wrong result.

This PR removes file_read command and uses file method of the inspec backend to read the contents. It also adds the unit test for Podman container detection.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
