### PR TITLE
CHEF-7265 Telemetry opt-in for CINC users

### DIFF
--- a/lib/inspec/cli.rb
+++ b/lib/inspec/cli.rb
@@ -57,7 +57,7 @@ class Inspec::InspecCLI < Inspec::BaseCLI
     desc: "Disable loading all plugins that the user installed."
 
   class_option :enable_telemetry, type: :boolean,
-    desc: "Allow or disable telemetry", default: false
+    desc: "Allow or disable telemetry", default: true
 
   require "license_acceptance/cli_flags/thor"
   include LicenseAcceptance::CLIFlags::Thor

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -178,7 +178,7 @@ module Inspec
       # Perform telemetry when preview flag CHEF_PREVIEW_TELEMETRY_CLIENT is set
       Inspec.with_feature("inspec-telemetry-client") {
         Inspec::Log.debug "Initiating telemetry for InSpec"
-        Inspec::Telemetry.run_starting(runner: self)
+        Inspec::Telemetry.run_starting(runner: self, conf: @conf)
       }
       load
       run_tests(with)
@@ -230,7 +230,7 @@ module Inspec
       render_output(@run_data) unless @conf["report"]
       # Perform telemetry when preview flag CHEF_PREVIEW_TELEMETRY_CLIENT is set
       Inspec.with_feature("inspec-telemetry-client") {
-        Inspec::Telemetry.run_ending(runner: self, run_data: @run_data)
+        Inspec::Telemetry.run_ending(runner: self, run_data: @run_data, conf: @conf)
         Inspec::Log.debug "Finishing telemetry for InSpec"
       }
       @test_collector.exit_code

--- a/lib/inspec/utils/telemetry.rb
+++ b/lib/inspec/utils/telemetry.rb
@@ -25,7 +25,6 @@ module Inspec
 
       # Telemetry opt-in/out enabled for other Inspec distros
       return Inspec::Telemetry::Null if Inspec::Dist::EXEC_NAME != "inspec" && telemetry_disabled?
-      # TODO: ask chef-telemetry gem if we should be enabled or not
 
       # Don't perform telemetry action if running under Automate - Automate does LDC tracking for us
       return Inspec::Telemetry::Null if Inspec::Telemetry::RunContextProbe.under_automate?

--- a/lib/inspec/utils/telemetry.rb
+++ b/lib/inspec/utils/telemetry.rb
@@ -8,6 +8,7 @@ module Inspec
   class Telemetry
 
     @@instance = nil
+    @@config = nil
 
     def self.instance
       @@instance ||= determine_backend_class.new
@@ -16,6 +17,15 @@ module Inspec
     def self.determine_backend_class
       # Don't perform telemetry call if license is not a free license
       return Inspec::Telemetry::Null unless license&.license_type&.downcase == "free"
+
+      if Inspec::Dist::EXEC_NAME == "inspec" && telemetry_disabled?
+        # Issue a warning if an InSpec user is explicitly trying to opt out of telemetry using cli option
+        Inspec::Log.warn "Telemetry opt-out is not permissible."
+      end
+
+      # Telemetry opt-in/out enabled for other Inspec distros
+      return Inspec::Telemetry::Null if Inspec::Dist::EXEC_NAME != "inspec" && telemetry_disabled?
+      # TODO: ask chef-telemetry gem if we should be enabled or not
 
       # Don't perform telemetry action if running under Automate - Automate does LDC tracking for us
       return Inspec::Telemetry::Null if Inspec::Telemetry::RunContextProbe.under_automate?
@@ -34,15 +44,25 @@ module Inspec
     # These class methods make it convenient to call from anywhere within the InSpec codebase.
     ######
     def self.run_starting(opts)
+      @@config ||= opts[:conf]
       instance.run_starting(opts)
     end
 
     def self.run_ending(opts)
+      @@config ||= opts[:conf]
       instance.run_ending(opts)
     end
 
     def self.note_feature_usage(feature_name)
       instance.note_feature_usage(feature_name)
+    end
+
+    def self.config
+      @@config
+    end
+
+    def self.telemetry_disabled?
+      !config.telemetry_options["enable_telemetry"]
     end
   end
 end

--- a/test/unit/utils/telemetry_test.rb
+++ b/test/unit/utils/telemetry_test.rb
@@ -98,4 +98,21 @@ describe "Telemetry" do
       end
     end
   end
+
+  describe "when telemetry is run for Inspec" do
+    let(:profile) { File.join(profile_path, "dependencies", "profile_a") }
+    let(:tm) { Inspec::Telemetry::Mock.new }
+    let(:conf) { Inspec::Config.new({ "enable_telemetry" => false }) }
+    let(:runner) { Inspec::Runner.new({ command_runner: :generic, reporter: [], conf: conf }) }
+
+    it "Inspec user can not disable telemetry using --no-enable-telemetry option" do
+      Inspec::Telemetry.expects(:instance).returns(tm).at_least_once
+      runner.add_target(profile)
+      runner.run
+      # Inspec user attempted to disable telemetry
+      _(Inspec::Telemetry.telemetry_disabled?).must_equal true
+      # Returns HTTP backend meaning the telemetry call is not disabled and will make an API call
+      _(Inspec::Telemetry.determine_backend_class).must_equal Inspec::Telemetry::HTTP
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
By default, telemetry is opted-in by Inspec.
And most users will not be able to disable telemetry. However, CINC users can.

So using the CLI option --no-enable-telemetry by CINC users will disable telemetry.
But if a user is not a CINC user, we need to issue a warning since it is not permissible to disable telemetry for them.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
