### PR TITLE
CHEF-9848 - Exclude Warning "Unrecognized feature name"  for Custom InSpec plugins.

### DIFF
--- a/lib/inspec/feature/runner.rb
+++ b/lib/inspec/feature/runner.rb
@@ -11,7 +11,10 @@ module Inspec
         # Validate that the feature is recognized
         feature = config[feature_name]
         unless feature
-          logger.warn "Unrecognized feature name '#{feature_name}'"
+          # Avoid warning for custom plugins
+          user_plugins = Inspec::Plugin::V2::Registry.instance.plugin_statuses.select { |status| status.installation_type == :user_gem }
+          user_plugin_names = user_plugins.collect { |a| a.name.to_s }
+          logger.warn "Unrecognized feature name '#{feature_name}'" unless user_plugin_names.include?(feature_name)
         end
 
         # If the feature is not recognized

--- a/test/fixtures/config_dirs/train-test-fixture/plugins.json
+++ b/test/fixtures/config_dirs/train-test-fixture/plugins.json
@@ -4,10 +4,6 @@
     {
       "name": "train-test-fixture",
       "version": ">= 0.1.0"
-    },
-    {
-      "name": "inspec-reporter-custom-plugin",
-      "version": "= 0.5.0"
     }
   ]
 }

--- a/test/fixtures/config_dirs/train-test-fixture/plugins.json
+++ b/test/fixtures/config_dirs/train-test-fixture/plugins.json
@@ -4,6 +4,10 @@
     {
       "name": "train-test-fixture",
       "version": ">= 0.1.0"
+    },
+    {
+      "name": "inspec-reporter-custom-plugin",
+      "version": "= 0.5.0"
     }
   ]
 }

--- a/test/unit/feature_test.rb
+++ b/test/unit/feature_test.rb
@@ -9,6 +9,12 @@ require "stringio"
 
 require "inspec/feature"
 
+require "inspec/plugin/v2"
+
+class Inspec::Plugin::V2::Loader
+  public :detect_system_plugins
+end
+
 describe "Inspec::Feature" do
   let(:fixtures_path) { "test/fixtures" }
   it "should be a class" do
@@ -61,6 +67,17 @@ describe "Inspec::Feature" do
       end
       _(logger_io.string).must_match(/WARN/)
       _(logger_io.string).must_match(/test-feature-nonesuch/)
+    end
+
+    it "should not give warnings for inspec custom plugins" do
+      @config_dir_path = File.expand_path "test/fixtures/config_dirs"
+      ENV["INSPEC_CONFIG_DIR"] = File.join(@config_dir_path, "train-test-fixture")
+      loader = Inspec::Plugin::V2::Loader.new(omit_bundles: true)
+      loader.send(:read_conf_file_into_registry)
+      Inspec::Plugin::V2::Registry.instance
+      Inspec.with_feature("inspec-reporter-custom-plugin", config: cfg, logger: logger) do
+      end
+      _(logger_io.string).wont_match(/WARN/)
     end
   end
 

--- a/test/unit/feature_test.rb
+++ b/test/unit/feature_test.rb
@@ -16,6 +16,17 @@ class Inspec::Plugin::V2::Loader
 end
 
 describe "Inspec::Feature" do
+  after do
+    ENV["HOME"] = Dir.home
+    ENV["INSPEC_CONFIG_DIR"] = nil
+    Inspec::Plugin::V2::Registry.instance.__reset
+    if defined?(::InspecPlugins::TestFixture)
+      InspecPlugins.send :remove_const, :TestFixture
+    end
+    # forget all test fixture files
+    $".reject! { |path| path =~ %r{test/fixtures} }
+  end
+
   let(:fixtures_path) { "test/fixtures" }
   it "should be a class" do
     _(Inspec::Feature).must_be_kind_of Class
@@ -75,7 +86,7 @@ describe "Inspec::Feature" do
       loader = Inspec::Plugin::V2::Loader.new(omit_bundles: true)
       loader.send(:read_conf_file_into_registry)
       Inspec::Plugin::V2::Registry.instance
-      Inspec.with_feature("inspec-reporter-custom-plugin", config: cfg, logger: logger) do
+      Inspec.with_feature("train-test-fixture", config: cfg, logger: logger) do
       end
       _(logger_io.string).wont_match(/WARN/)
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR is raised to exclude warning  "Unrecognized feature name"  for Custom plugins.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
