### PR TITLE
CHEF-8598: Add support for curve25519 key exchange

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :omnibus do
   gem "appbundler"
   gem "ed25519" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
   gem "bcrypt_pbkdf" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
+  gem "x25519" # curve25519-sha256 ssh key support done here as its a native gem we can't put in the gemspec
 end
 
 group :test do

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -57,7 +57,7 @@ do_install() {
 
   # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
   # for omnibus we also install this as part of the package
-  gem install ed25519 bcrypt_pbkdf --no-document
+  gem install ed25519 bcrypt_pbkdf x25519 --no-document
 
   # Certain gems (timeliness) are getting installed with world writable files
   # This is removing write bits for group and other.


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixes #6660 

This pull request introduces support for the curve25519 key exchange to address an error associated with key exchange algorithm negotiation.

Here is the issue encountered when attempting to SSH into a machine (an Ubuntu EC2 instance in my case) which is configured to exclusively support curve25519 for key exchange.
```
Transport error, can't connect to 'ssh' backend: SSH command failed (could not settle on kex algorithm
Server kex preferences: curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com
Client kex preferences: ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1)
```     

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-8598: Cannot SSH to modern ed25519-only linux hosts with InSpec 5


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
