### PR TITLE
CHEF-3833 Added delay for InSpec parallel status reporter

### DIFF
--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -22,6 +22,7 @@ module InspecPlugins
 
       def run
         initiate_background_run if run_in_background # running a process as daemon changes parent process pid
+        original_stdout_stream = ChefLicensing::Config.output
         until invocations.empty? && @child_tracker.empty?
           # Changing output to STDERR to avoid the output interruption between runs
           ChefLicensing::Config.output = STDERR
@@ -37,6 +38,8 @@ module InspecPlugins
           cleanup_child_processes
           sleep 0.1
         end
+        # Reset output to the original STDOUT stream as a safe measure.
+        ChefLicensing::Config.output = original_stdout_stream
 
         # Requires renaming operations on windows only
         # Do Rename and delete operations after all child processes have exited successfully

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -23,9 +23,9 @@ module InspecPlugins
       def run
         initiate_background_run if run_in_background # running a process as daemon changes parent process pid
         until invocations.empty? && @child_tracker.empty?
+          # Changing output to STDERR to avoid the output interruption between runs
+          ChefLicensing::Config.output = STDERR
           while should_start_more_jobs?
-            # Changing output to STDERR to avoid the output interruption between runs
-            ChefLicensing::Config.output = STDERR
             if Inspec.locally_windows?
               spawn_another_process
             else

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/runner.rb
@@ -24,6 +24,8 @@ module InspecPlugins
         initiate_background_run if run_in_background # running a process as daemon changes parent process pid
         until invocations.empty? && @child_tracker.empty?
           while should_start_more_jobs?
+            # Changing output to STDERR to avoid the output interruption between runs
+            ChefLicensing::Config.output = STDERR
             if Inspec.locally_windows?
               spawn_another_process
             else

--- a/lib/plugins/inspec-parallel/lib/inspec-parallel/super_reporter/status.rb
+++ b/lib/plugins/inspec-parallel/lib/inspec-parallel/super_reporter/status.rb
@@ -44,6 +44,7 @@ module InspecPlugins::Parallelism
         status_by_pid[pid][:last_control] = title
         status_by_pid[pid][:last_status] = status
 
+        sleep 0.5
         paint
       end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added delay for InSpec parallel status reporter for clear reporting.
Additionally, the output of chef licensing is redirected to STDERR in between parallel runs.

**Why this approach?**
- The recurring STDOUT from chef-licensing was creating a blinking effect for `inspec parallel` status reporter.
- **Con** of this approach:  If the license is expired by the end of the 50th invocation of a long-running list in `inspec parallel` then the output will be redirected to STDERR.

**Effect of silencing chef-licensing output in between parallel runs**
Chef licensing output is only printed after the `inspec parallel` command invocation and not between parallel runs.

<img width="1784" alt="parallel-licensing" src="https://github.com/inspec/inspec/assets/10988296/1acbcd47-ab21-4fc8-b4a0-c3ae4d5d5489">


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
