### PR TITLE
Fix: Update ruby base image to bullseye in CI tests

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -16,7 +16,7 @@ steps:
       secrets: true
       executor:
         docker:
-          image: ruby:3.0
+          image: ruby:3.0-bullseye
 
   - label: run-tests-ruby-3.0
     command:
@@ -25,7 +25,7 @@ steps:
       secrets: true
       executor:
         docker:
-          image: ruby:3.0
+          image: ruby:3.0-bullseye
 
   - label: run-tests-ruby-3.1
     command:
@@ -34,7 +34,7 @@ steps:
       secrets: true
       executor:
         docker:
-          image: ruby:3.1
+          image: ruby:3.1-bullseye
 
   - label: isolated-tests-ruby-3.0
     command:
@@ -43,7 +43,7 @@ steps:
       secrets: true
       executor:
         docker:
-          image: ruby:3.0
+          image: ruby:3.0-bullseye
 
   - label: isolated-tests-ruby-3.1
     command:
@@ -52,7 +52,7 @@ steps:
       secrets: true
       executor:
         docker:
-          image: ruby:3.1
+          image: ruby:3.1-bullseye
 
   - label: run-tests-ruby-3.1-windows
     command:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The current Docker image version (ruby:3.1) with libseccomp is blocking a newer syscall used in Debian Bookworm packages/libs, leading to errors during APT update post-invoke script execution.

```
E: Problem executing scripts APT::Update::Post-Invoke 'rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true'
E: Sub-process returned an error code
```

This PR addresses the issue encountered in the current Docker image setup by updating the Docker image version from ruby:3.1 to ruby:3.1-bullseye.

_Note: This is a workaround_

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-11234: CI is breaking for inspec, inspec-gcp, and train due to issue with docker image used for the tests

## Related Conversation
https://github.com/docker-library/python/issues/837#issuecomment-1599640563
https://github.com/docker-library/redmine/discussions/307#discussioncomment-7711691

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
