### PR TITLE
Pin gem `train` and `train-core` to version below 3.12 for inspec and inspec-core respectively

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -57,6 +57,6 @@ Source code obtained from the Chef GitHub repository is made available under Apa
   spec.add_dependency "semverse",                 "~> 3.0"
   spec.add_dependency "multipart-post",           "~> 2.0"
 
-  spec.add_dependency "train-core", ">= 3.11.0"
+  spec.add_dependency "train-core", ">= 3.11.0", "< 3.12"
   spec.add_dependency "chef-licensing", ">= 0.7.5"
 end

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -34,7 +34,7 @@ Source code obtained from the Chef GitHub repository is made available under Apa
 
   spec.add_dependency "inspec-core", "= #{Inspec::VERSION}"
 
-  spec.add_dependency "train", "~> 3.10"
+  spec.add_dependency "train", ">= 3.11.0", "< 3.12"
 
   # cookstyle support for inspec check
   # Added here not because they are compiled, but to keep chef-client lightweight


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
`train` 3.12 released recently is breaking the CI: https://buildkite.com/chef/inspec-inspec-main-verify-private/builds/704

This pin is a temporary fix until the root cause analysis is done for the issue.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
