### PR TITLE
Update test with updated failure message for GCP authentication

### DIFF
--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -1216,7 +1216,7 @@ describe "inspec exec" do
       let(:args) { "-t gcp:// --input gcp_project_id=fakeproject" }
       let(:env) { { GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS: 1 } }
       it "should fail to connect to gcp due to lack of creds but not stacktrace" do
-        _(run_result.stderr).must_include "Could not load the default credentials."
+        _(run_result.stderr).must_include "Your credentials were not found."
       end
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR updates the error message for an authentication test in InSpec GCP, which was failing due to an outdated error message being used in the test.

The previous error message was: (Ref: https://github.com/googleapis/google-auth-library-ruby/blame/d47a5df79fc3e32bf374eade118319ddaa824e51/lib/googleauth/application_default.rb#L23)
```
Could not load the default credentials. Browse to https://cloud.google.com/docs/authentication/provide-credentials-adc for more information
```
This has been updated to: (Ref: https://github.com/googleapis/google-auth-library-ruby/blame/8f127eee40b0f970706c59cb324f71408dd2fec4/lib/googleauth/application_default.rb#L23)
```
Your credentials were not found. To set up Application Default Credentials for your environment, see https://cloud.google.com/docs/authentication/external/set-up-adc
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
