### PR TITLE
Revert "Backport 6989: Add support for curve25519 key exchange"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ group :omnibus do
   gem "appbundler"
   gem "ed25519" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
   gem "bcrypt_pbkdf" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
-  gem "x25519" # curve25519-sha256 ssh key support done here as its a native gem we can't put in the gemspec
 end
 
 group :test do

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -57,7 +57,7 @@ do_install() {
 
   # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
   # for omnibus we also install this as part of the package
-  gem install ed25519 bcrypt_pbkdf x25519 --no-document
+  gem install ed25519 bcrypt_pbkdf --no-document
 
   # Certain gems (timeliness) are getting installed with world writable files
   # This is removing write bits for group and other.


### PR DESCRIPTION
Reverts inspec/inspec#6990

Build on rhel7 is failing with this change so reverting this change for now till we find the solution https://buildkite.com/chef/inspec-inspec-inspec-5-omnibus-release/builds/35