### PR TITLE
Fix uninitialized constant Parser::AST::Processor::Mixin

### DIFF
--- a/lib/inspec/utils/profile_ast_helpers.rb
+++ b/lib/inspec/utils/profile_ast_helpers.rb
@@ -3,8 +3,7 @@ require "rubocop-ast"
 module Inspec
   class Profile
     class AstHelper
-      class CollectorBase
-        include Parser::AST::Processor::Mixin
+      class CollectorBase < Parser::AST::Processor
         include RuboCop::AST::Traversal
 
         attr_reader :memo


### PR DESCRIPTION
## Description

parser 3.3.1.0 introduced https://github.com/whitequark/parser/pull/1000, which causes this failure:

```
% bundle exec ruby -Itest test/unit/profiles/profile_test.rb
inspec/lib/inspec/utils/profile_ast_helpers.rb:7:in `<class:CollectorBase>': uninitialized constant Parser::AST::Processor::Mixin (NameError)

        include Parser::AST::Processor::Mixin
                                      ^^^^^^^
```

Fix this by inherting from `Parser::AST::Processor` and requiring the right version of the `parser` gem.

## Related Issue

Closes #7029

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
