### PR TITLE
Backport 7023: Fix URL fetcher failure to work when current directory is not a Git repository

### DIFF
--- a/test/unit/fetchers/url_test.rb
+++ b/test/unit/fetchers/url_test.rb
@@ -20,7 +20,7 @@ describe Inspec::Fetcher::Url do
 
     let(:git_remote_head_main) do
       out = mock
-      out.stubs(:stdout).returns("HEAD branch: main\n")
+      out.stubs(:stdout).returns("ref: refs/heads/main\tHEAD\n")
       out.stubs(:exitstatus).returns(0)
       out.stubs(:stderr).returns("")
       out.stubs(:error!).returns(false)


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Backports #7023 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
