### PR TITLE
CHEF-11996: Move cookstyle as a dependency to inspec-core.gemspec

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -57,6 +57,13 @@ Source code obtained from the Chef GitHub repository is made available under Apa
   spec.add_dependency "semverse",                 "~> 3.0"
   spec.add_dependency "multipart-post",           "~> 2.0"
 
+
+  # cookstyle support for inspec check
+  # This was initially included in 'inspec.gemspec' to keep 'chef-client' lightweight.
+  # However, it has been moved to 'inspec-core.gemspec' due to a dependency on the 'ast' gem,
+  # which was causing a LoadError ('cannot load such file -- ast') for users/applications using 'inspec-core'.
+  spec.add_dependency "cookstyle"
+
   spec.add_dependency "train-core", ">= 3.11.0"
   spec.add_dependency "chef-licensing", ">= 0.7.5"
 end

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -57,7 +57,6 @@ Source code obtained from the Chef GitHub repository is made available under Apa
   spec.add_dependency "semverse",                 "~> 3.0"
   spec.add_dependency "multipart-post",           "~> 2.0"
 
-
   # cookstyle support for inspec check
   # This was initially included in 'inspec.gemspec' to keep 'chef-client' lightweight.
   # However, it has been moved to 'inspec-core.gemspec' due to a dependency on the 'ast' gem,

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -35,10 +35,6 @@ Source code obtained from the Chef GitHub repository is made available under Apa
   spec.add_dependency "inspec-core", "= #{Inspec::VERSION}"
 
   spec.add_dependency "train", "~> 3.10"
-
-  # cookstyle support for inspec check
-  # Added here not because they are compiled, but to keep chef-client lightweight
-  spec.add_dependency "cookstyle"
   spec.add_dependency "rake"
 
   # progress bar streaming reporter plugin support


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This PR moves the `cookstyle` gem dependency from `inspec.gemspec` (it was included in `inspec.gemspec` to keep 'chef-client' lightweight) to `inspec-core.gemspec` file. 

This change is necessary due to a dependency on the `ast` gem in https://github.com/inspec/inspec/blob/main/lib/inspec/utils/profile_ast_helpers.rb, which is causing a LoadError ('cannot load such file -- ast') for users and applications using 'inspec-core'. 


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-11996: InSpec core fails with a LoadError: `require': cannot load such file -- ast

https://github.com/chef/chef/issues/14096

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
