### PR TITLE
Backport-7030: Fix uninitialized constant Parser::AST::Processor::Mixin (#7030)

### DIFF
--- a/lib/inspec/utils/profile_ast_helpers.rb
+++ b/lib/inspec/utils/profile_ast_helpers.rb
@@ -3,8 +3,7 @@ require "rubocop-ast"
 module Inspec
   class Profile
     class AstHelper
-      class CollectorBase
-        include Parser::AST::Processor::Mixin
+      class CollectorBase < Parser::AST::Processor
         include RuboCop::AST::Traversal
 
         attr_reader :memo


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Backports #7030 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
