### PR TITLE
CHEF-10392 load default telemetry url conditionally

### DIFF
--- a/lib/inspec/utils/telemetry/http.rb
+++ b/lib/inspec/utils/telemetry/http.rb
@@ -7,7 +7,7 @@ module Inspec
     class HTTP < Base
       TELEMETRY_JOBS_PATH = "v1/job"
       TELEMETRY_URL = if ChefLicensing::Config.license_server_url&.match?("acceptance")
-                        ENV["TELEMETRY_URL"]
+                        ENV["CHEF_TELEMETRY_URL"]
                       else
                         "https://services.chef.io/telemetry/"
                       end

--- a/lib/inspec/utils/telemetry/http.rb
+++ b/lib/inspec/utils/telemetry/http.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 require_relative "base"
 require "faraday" unless defined?(Faraday)
+require "inspec/utils/licensing_config"
 module Inspec
   class Telemetry
     class HTTP < Base
       TELEMETRY_JOBS_PATH = "v1/job"
-      TELEMETRY_URL = ENV["TELEMETRY_URL"] # TODO Set to production telemetry URL before release
+      TELEMETRY_URL = if ChefLicensing::Config.license_server_url&.match?("acceptance")
+                        ENV["TELEMETRY_URL"]
+                      else
+                        "https://services.chef.io/telemetry/v1/"
+                      end
       def run_ending(opts)
         payload = super
         response = connection.post(TELEMETRY_JOBS_PATH) do |req|

--- a/lib/inspec/utils/telemetry/http.rb
+++ b/lib/inspec/utils/telemetry/http.rb
@@ -9,7 +9,7 @@ module Inspec
       TELEMETRY_URL = if ChefLicensing::Config.license_server_url&.match?("acceptance")
                         ENV["TELEMETRY_URL"]
                       else
-                        "https://services.chef.io/telemetry/v1/"
+                        "https://services.chef.io/telemetry/"
                       end
       def run_ending(opts)
         payload = super


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Load the default telemetry URL 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Loads valid production URL as default URL.
- Allows loading a custom acceptance URL in case the Licensing Server is pointed towards Acceptance.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
