### PR TITLE
CHEF-13122 Pin the ffi version < 1.17.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem "inspec", path: "."
 # in it in order to package the executable. Hence the odd backwards dependency.
 gem "inspec-bin", path: "./inspec-bin"
 
+# ffi version v1.17.0 is breaking verify pipeline as it requires
+# rubygems version to be upgraded to >= 3.3.22 Ref:https://buildkite.com/chef/inspec-inspec-main-verify-private/builds/812#018fe177-2ccb-45ed-a25e-213c8a6453df/698-707
+
 gem "ffi", ">= 1.15.5", "< 1.17.0"
 
 # inspec tests depend text output that changed in the 3.10 release

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "inspec", path: "."
 # in it in order to package the executable. Hence the odd backwards dependency.
 gem "inspec-bin", path: "./inspec-bin"
 
-gem "ffi", ">= 1.9.14", "!= 1.13.0", "!= 1.14.2"
+gem "ffi", ">= 1.15.5", "< 1.17.0"
 
 # inspec tests depend text output that changed in the 3.10 release
 # but our runtime dep is still 3.9+


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR pins the ffi version to he < 1.17.0 as version 1.17.0 is breaking pipeline as it needs upgrade to rubygem version to be >= 3.3.22
https://buildkite.com/chef/inspec-inspec-main-verify-private/builds/812#018fe177-2cd7-42c1-8e51-174567c21ea2/634-643
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
