### PR TITLE
Configurable backend for Chef Infra in Target Mode

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -32,9 +32,8 @@ module Inspec
   class Runner
     extend Forwardable
 
-    attr_reader :rules
+    attr_reader :backend, :rules
     attr_accessor :target_profiles
-    attr_accessor :backend
 
     attr_accessor :test_collector
 
@@ -90,7 +89,12 @@ module Inspec
     end
 
     def configure_transport
-      @backend = Inspec::Backend.create(@conf)
+      backend = Inspec::Backend.create(@conf)
+      set_backend(backend)
+    end
+
+    def set_backend(new_backend)
+      @backend = new_backend
       @test_collector.backend = @backend
     end
 

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -32,8 +32,9 @@ module Inspec
   class Runner
     extend Forwardable
 
-    attr_reader :backend, :rules
+    attr_reader :rules
     attr_accessor :target_profiles
+    attr_accessor :backend
 
     attr_accessor :test_collector
 

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -112,6 +112,7 @@ describe Inspec::Runner do
 
   describe "when backend gets switched" do
     it "replaces the existing backend with the given one" do
+      opts = { command_runner: :generic, backend_cache: false }
       runner = Inspec::Runner.new(opts)
 
       new_backend_config = Inspec::Config.new(backend_cache: true)

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -105,4 +105,21 @@ describe Inspec::Runner do
       _(backend.backend.cache_enabled?(:command)).must_equal false
     end
   end
+
+  # =============================================================== #
+  #                      Backend Switching
+  # =============================================================== #
+
+  describe "when backend gets switched" do
+    it "replaces the existing backend with the given one" do
+      runner = Inspec::Runner.new(opts)
+
+      new_backend_config = Inspec::Config.new(backend_cache: true)
+      new_backend = Inspec::Backend.create(new_backend_config)
+      runner.set_backend(new_backend)
+
+      active_backend = runner.instance_variable_get(:@backend)
+      _(active_backend.backend).must_be_same_as(new_backend)
+    end
+  end
 end

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -120,7 +120,7 @@ describe Inspec::Runner do
       runner.set_backend(new_backend)
 
       active_backend = runner.instance_variable_get(:@backend)
-      _(active_backend.backend).must_be_same_as(new_backend)
+      _(active_backend.backend).must_be_same_as(new_backend.backend)
     end
   end
 end


### PR DESCRIPTION
## Description
Enables Chef to reconfigure the InSpec backend to a Target Mode enabled connection

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
