### PR TITLE
CHEF-12024 Adds C Shell support to sybase_session resource

### DIFF
--- a/lib/inspec/resources/sybase_session.rb
+++ b/lib/inspec/resources/sybase_session.rb
@@ -44,10 +44,18 @@ module Inspec::Resources
       # try to get a temp path
       sql_file_path = upload_sql_file(sql)
 
-      # isql reuires that we have a matching locale set, but does not support C.UTF-8. en_US.UTF-8 is the least evil.
-      command = "LANG=en_US.UTF-8 SYBASE=#{sybase_home} #{bin} -s\"#{col_sep}\" -w80000 -S #{server} -U #{username} -D #{database} -P \"#{password}\" < #{sql_file_path}"
-      isql_cmd = inspec.command(command)
+      current_shell = inspec.command("echo $SHELL")
 
+      res = current_shell.exit_status
+
+      # isql reuires that we have a matching locale set, but does not support C.UTF-8. en_US.UTF-8 is the least evil.
+      if res == 0 && ( current_shell.stdout&.include?("/csh") || current_shell.stdout&.include?("/tcsh") )
+        command = "source #{sybase_home}/SYBASE.csh; setenv LANG en_US.UTF-8; #{bin} -s\"#{col_sep}\" -w80000 -S #{server} -U #{username} -D #{database} -P \"#{password}\" < #{sql_file_path}"
+      else
+        command = "LANG=en_US.UTF-8 SYBASE=#{sybase_home} #{bin} -s\"#{col_sep}\" -w80000 -S #{server} -U #{username} -D #{database} -P \"#{password}\" < #{sql_file_path}"
+      end
+
+      isql_cmd = inspec.command(command)
       # Check for isql errors
       res = isql_cmd.exit_status
       raise Inspec::Exceptions::ResourceFailed.new("isql exited with code #{res} and stderr '#{isql_cmd.stderr}', stdout '#{isql_cmd.stdout}'") unless res == 0

--- a/lib/inspec/resources/sybase_session.rb
+++ b/lib/inspec/resources/sybase_session.rb
@@ -44,6 +44,7 @@ module Inspec::Resources
       # try to get a temp path
       sql_file_path = upload_sql_file(sql)
 
+      # TODO: Find if there is better way to get the current shell
       current_shell = inspec.command("echo $SHELL")
 
       res = current_shell.exit_status


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR fixes the `sybase_session` InSpec resource, which when the user's default shell was set to `/bin/csh`, would lead to the error:
 
```
isql exited with code 1 and stderr 'LANG=en_US.UTF-8: Command not found.\n', stdout ''","exception":"RuntimeError"
```

Changes include identifying the current shell and using the right syntax for setting env variables as per current shell.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
