### PR TITLE
CHEF-12175: Remove use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/lib/inspec/fetcher/url.rb
+++ b/lib/inspec/fetcher/url.rb
@@ -248,10 +248,30 @@ module Inspec::Fetcher
       @temp_archive_path = archive.path
     end
 
-    def open(target, opts) # overridden so we can control who we're talking to
-      URI.open(target, opts)
-    rescue NoMethodError   # TODO: remove when we drop ruby 2.4
-      super(target, opts)  # Kernel#open
+    # Opens a URI or local file specified by `target` with options `opts`.
+    # If `target` is a valid URI (http://, https://, ftp://), opens it using URI.open.
+    # If `target` is a local file path, opens it using File.open.
+    # Raises ArgumentError for invalid `target` that is neither a valid URI nor a local file path.
+    # Logs or handles exceptions gracefully using `pretty_handle_exception`.
+    def open(target, opts)
+      if valid_uri?(target)
+        URI(target).open(opts)  # Open URI if it's a valid HTTP, HTTPS, or FTP URI
+      elsif File.file?(target)
+        File.open(target, opts)  # Open local file if it exists
+      else
+        raise ArgumentError, "Invalid target: #{target}. Must be a valid URI or a local file path."
+      end
+    rescue StandardError => e
+      pretty_handle_exception(e)
+    end
+
+    # Checks if the given `target` string is a valid URI by attempting to parse it.
+    # Returns true if `target` is a valid HTTP, HTTPS, or FTP URI; false otherwise.
+    def valid_uri?(target)
+      uri = URI.parse(target)
+      uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS) || uri.is_a?(URI::FTP)
+    rescue URI::InvalidURIError
+      false
     end
 
     def open_via_uri(target)

--- a/lib/inspec/fetcher/url.rb
+++ b/lib/inspec/fetcher/url.rb
@@ -262,7 +262,7 @@ module Inspec::Fetcher
         raise ArgumentError, "Invalid target: #{target}. Must be a valid URI or a local file path."
       end
     rescue StandardError => e
-      pretty_handle_exception(e)
+      raise Inspec::FetcherFailure, "Profile could not be fetched: #{e.message}"
     end
 
     # Checks if the given `target` string is a valid URI by attempting to parse it.

--- a/lib/inspec/fetcher/url.rb
+++ b/lib/inspec/fetcher/url.rb
@@ -255,9 +255,9 @@ module Inspec::Fetcher
     # Logs or handles exceptions gracefully using `pretty_handle_exception`.
     def open(target, opts)
       if valid_uri?(target)
-        URI(target).open(opts)  # Open URI if it's a valid HTTP, HTTPS, or FTP URI
+        URI(target).open(opts) # Open URI if it's a valid HTTP, HTTPS, or FTP URI
       elsif File.file?(target)
-        File.open(target, opts)  # Open local file if it exists
+        File.open(target, opts) # Open local file if it exists
       else
         raise ArgumentError, "Invalid target: #{target}. Must be a valid URI or a local file path."
       end

--- a/lib/inspec/fetcher/url.rb
+++ b/lib/inspec/fetcher/url.rb
@@ -262,7 +262,7 @@ module Inspec::Fetcher
         raise ArgumentError, "Invalid target: #{target}. Must be a valid URI or a local file path."
       end
     rescue StandardError => e
-      raise Inspec::FetcherFailure, "Profile could not be fetched: #{e.message}"
+      raise Inspec::FetcherFailure, "Profile URL dependency #{target} could not be fetched: #{e.message}"
     end
 
     # Checks if the given `target` string is a valid URI by attempting to parse it.

--- a/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
+++ b/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
@@ -164,7 +164,7 @@ module InspecPlugins
           ui.exit(:usage_error)
         end
 
-        lines = IO.readlines(p)
+        lines = File.readlines(p)
         lines << "\nprofile_content_id: #{profile_content_id}\n"
 
         File.open("#{p}", "w" ) do |f|

--- a/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
+++ b/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
@@ -39,11 +39,15 @@ module InspecPlugins
         FileUtils.mkdir_p(path)
 
         puts "Generating signing key in #{path}/#{options["keyname"]}.pem.key"
-        open "#{path}/#{options["keyname"]}.pem.key", "w" do |io|
+        # https://github.com/inspec/inspec/security/code-scanning/1
+        # https://github.com/inspec/inspec/security/code-scanning/2
+        # The following line was flagged by GitHub code scanning as a security vulnerability.
+        # Update the code to eliminate the vulnerability.
+        File.open("#{path}/#{options["keyname"]}.pem.key", "w") do |io|
           io.write key.to_pem
         end
         puts "Generating validation key in #{path}/#{options["keyname"]}.pem.pub"
-        open "#{path}/#{options["keyname"]}.pem.pub", "w" do |io|
+        File.open("#{path}/#{options["keyname"]}.pem.pub", "w") do |io|
           io.write key.public_key.to_pem
         end
       end
@@ -70,7 +74,8 @@ module InspecPlugins
         # Generating tar.gz file using archive method of Inspec Cli
         Inspec::InspecCLI.new.archive(profile_path, "error")
         tarfile = "#{filename}.tar.gz"
-        tar_content = IO.binread(tarfile)
+        # Update IO.binread with File.binread because of https://github.com/inspec/inspec/security/code-scanning/3
+        tar_content = File.binread(tarfile)
         FileUtils.rm(tarfile)
 
         # Generate the signature


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixes:
- https://github.com/inspec/inspec/security/code-scanning/1
- https://github.com/inspec/inspec/security/code-scanning/2
- https://github.com/inspec/inspec/security/code-scanning/3
- https://github.com/inspec/inspec/security/code-scanning/4
- https://github.com/inspec/inspec/security/code-scanning/5
- https://github.com/inspec/inspec/security/code-scanning/6


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
