### PR TITLE
ci: change license server to point to local licensing server

### DIFF
--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -34,6 +34,7 @@ echo "--- vault version installed is:"
 vault version
 
 echo "--- fetching License serverl url and keys from vault"
+# Note: Currently, the value for the local license server is a static IP address. Please update this to a DNS name when available.
 $Env:CHEF_LICENSE_SERVER=vault kv get -field ci secret/inspec/licensing/server
 
 echo "--- verifying if environment variables are set"

--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -34,8 +34,7 @@ echo "--- vault version installed is:"
 vault version
 
 echo "--- fetching License serverl url and keys from vault"
-$Env:CHEF_LICENSE_SERVER=vault kv get -field acceptance secret/inspec/licensing/server
-$Env:CHEF_LICENSE_KEY=vault kv get -field commercial secret/inspec/licensing/license-key
+$Env:CHEF_LICENSE_SERVER=vault kv get -field ci secret/inspec/licensing/server
 
 echo "--- verifying if environment variables are set"
 
@@ -51,12 +50,6 @@ function CheckIfEnvVarIsSet {
 }
 
 $envVarName = "CHEF_LICENSE_SERVER"
-CheckIfEnvVarIsSet -envVarName $envVarName
-
-$envVarName = "CHEF_LICENSE_SERVER_API_KEY"
-CheckIfEnvVarIsSet -envVarName $envVarName
-
-$envVarName = "CHEF_LICENSE_KEY"
 CheckIfEnvVarIsSet -envVarName $envVarName
 
 if ($Env:CI_ENABLE_COVERAGE)

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -28,15 +28,7 @@ curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/va
 unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
 
 echo "--- fetching License serverl url and keys from vault"
-export CHEF_LICENSE_SERVER=$($VAULT_HOME/vault kv get -field acceptance secret/inspec/licensing/server)
-export CHEF_LICENSE_KEY=$($VAULT_HOME/vault kv get -field commercial secret/inspec/licensing/license-key)
-if [ -n "${CHEF_LICENSE_KEY:-}" ]; then
-  echo "  ++ License Key set successfully"
-else
-  echo "  !! License Key not set - exiting "
-  exit 1
-fi
-
+export CHEF_LICENSE_SERVER=$($VAULT_HOME/vault kv get -field ci secret/inspec/licensing/server)
 
 if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
   echo "--- fetching Sonar token from vault"

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -28,6 +28,7 @@ curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/va
 unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
 
 echo "--- fetching License serverl url and keys from vault"
+# Note: Currently, the value for the local license server is a static IP address. Please update this to a DNS name when available.
 export CHEF_LICENSE_SERVER=$($VAULT_HOME/vault kv get -field ci secret/inspec/licensing/server)
 
 if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR updates the licensing server used in our CI pipelines. Instead of using the acceptance environment, it now points to a locally designated server specifically for CI purposes.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
