### PR TITLE
CHEF-14242 Support for Gem-Based Resource Packs

### DIFF
--- a/etc/deprecations.json
+++ b/etc/deprecations.json
@@ -1,5 +1,5 @@
 {
-  "file_version": "1.0.0",
+  "file_version": "2.0.0",
   "unknown_group_action": "ignore",
   "groups": {
     "attrs_value_replaces_default": {
@@ -125,6 +125,12 @@
     "renamed_to_inspec_export":{
       "action": "ignore",
       "prefix": "The `inspec json` command is deprecated in InSpec 5 and replaced with `inspec export` command."
+    }
+  },
+  "fallback_resource_packs":{
+    "internal_fallback_test.+":{
+      "gem":"inspec-test-resources",
+      "message":"The internal_fallback_test resource is a test resource used to exercise InSpec's ability to fallback on gem resource packs."
     }
   }
 }

--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -61,6 +61,7 @@ module Inspec
         rescue SystemExit => e
           exit_code = e.status || 1
           Inspec::Log.error "Error while creating cache for dependency ... #{e.message}"
+          # TODO: in the case of gem profile/resource pack dependency installs gone awry, this is the wrong thing to do!
           FileUtils.rm_rf(cache.base_path_for(fetcher.cache_key))
           exit(exit_code)
         ensure
@@ -72,6 +73,8 @@ module Inspec
     end
 
     def assert_cache_sanity!
+      # TODO: update this to handle gem resource pack dependencies
+      # which are known by a special prefix on their cache key or by having the :gem key
       return unless target.respond_to?(:key?) && target.key?(:sha256)
 
       exception_message = <<~EOF

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -46,9 +46,9 @@ module Inspec
     # profile exists in the Cache.
     #
     # InSpec 7+ Special Magic for Gem-Based Resource Pack Profiles:
-    #   These "profiles" are installed as gems, and so are "cached" 
+    #   These "profiles" are installed as gems, and so are "cached"
     #   by being installed as gems.
-    #     The magic is triggered by a special prefix of 
+    #     The magic is triggered by a special prefix of
     #   the cache_key: gem: or gem_path:
     #
     # @param [String] name
@@ -60,7 +60,7 @@ module Inspec
 
       if key.start_with?("gem:")
         # A gem installation
-        (dummy, gem_name, version) = key.split(":")
+        (_, gem_name, version) = key.split(":")
         loader = Inspec::Plugin::V2::Loader.new
         !loader.find_gem_directory(gem_name, version).nil?
 
@@ -89,18 +89,18 @@ module Inspec
     def base_path_for(key)
       if key.start_with?("gem:")
         # A gem installation
-        (dummy, gem_name, version) = key.split(":")
+        (_, gem_name, version) = key.split(":")
         loader = Inspec::Plugin::V2::Loader.new
         loader.find_gem_directory(gem_name, version)
 
       elsif key.start_with?("gem_path:")
         # Gem installed as explicit path reference, as in testing / development
         entry_point_path = key.sub(/^gem_path:/, "")
-        # We were given an explicit path like 
+        # We were given an explicit path like
         # inspec-test-resources/lib/inspec-test-resources.rb
         # go two directories up
         parts = Pathname(entry_point_path).each_filename.to_a
-        File.join(parts.slice(0,parts.length-2))
+        File.join(parts.slice(0, parts.length - 2))
       else
         # Standard cache entry
         File.join(@path, key)

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -45,6 +45,12 @@ module Inspec
     # For a given name and source_url, return true if the
     # profile exists in the Cache.
     #
+    # InSpec 7+ Special Magic for Gem-Based Resource Pack Profiles:
+    #   These "profiles" are installed as gems, and so are "cached" 
+    #   by being installed as gems.
+    #     The magic is triggered by a special prefix of 
+    #   the cache_key: gem: or gem_path:
+    #
     # @param [String] name
     # @param [String] source_url
     # @return [Boolean]
@@ -52,8 +58,21 @@ module Inspec
     def exists?(key)
       return false if key.nil? || key.empty?
 
-      path = base_path_for(key)
-      File.directory?(path) || File.exist?("#{path}.tar.gz") || File.exist?("#{path}.zip")
+      if key.start_with?("gem:")
+        # A gem installation
+        (dummy, gem_name, version) = key.split(":")
+        loader = Inspec::Plugin::V2::Loader.new
+        !loader.find_gem_directory(gem_name, version).nil?
+
+      elsif key.start_with?("gem_path:")
+        # Gem installed as explicit path reference, as in testing / development
+        entry_point_path = key.sub(/^gem_path:/, "")
+        File.exist?(entry_point_path)
+      else
+        # Standard cache entry
+        path = base_path_for(key)
+        File.directory?(path) || File.exist?("#{path}.tar.gz") || File.exist?("#{path}.zip")
+      end
     end
 
     #
@@ -67,8 +86,25 @@ module Inspec
     # @param [String] source_url
     # @return [String]
     #
-    def base_path_for(cache_key)
-      File.join(@path, cache_key)
+    def base_path_for(key)
+      if key.start_with?("gem:")
+        # A gem installation
+        (dummy, gem_name, version) = key.split(":")
+        loader = Inspec::Plugin::V2::Loader.new
+        loader.find_gem_directory(gem_name, version)
+
+      elsif key.start_with?("gem_path:")
+        # Gem installed as explicit path reference, as in testing / development
+        entry_point_path = key.sub(/^gem_path:/, "")
+        # We were given an explicit path like 
+        # inspec-test-resources/lib/inspec-test-resources.rb
+        # go two directories up
+        parts = Pathname(entry_point_path).each_filename.to_a
+        File.join(parts.slice(0,parts.length-2))
+      else
+        # Standard cache entry
+        File.join(@path, key)
+      end
     end
 
     #

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -62,8 +62,10 @@ module Inspec::DSL
         loader.activate_managed_gems_for_plugin(gem_name)
 
         # 2. Load all libraries from the gem path
-        resources_path = File.join(loader.find_gem_directory(gem_name), "lib", gem_name, "resources")
-        Dir.glob("#{resources_path}/*.rb").each do |resource_lib|
+        gem_path = loader.find_gem_directory(gem_name)
+        resources_path = File.join(gem_path, "lib", gem_name, "resources", "*.rb")
+        legacy_library_path = File.join(gem_path, "libraries", "*.rb")
+        Dir.glob([resources_path,legacy_library_path]).each do |resource_lib|
           require resource_lib
         end
         # Resources now available in Inspec::Resource.registry

--- a/lib/inspec/fetcher.rb
+++ b/lib/inspec/fetcher.rb
@@ -43,4 +43,5 @@ end
 require "inspec/fetcher/local"
 require "inspec/fetcher/url"
 require "inspec/fetcher/git"
+require "inspec/fetcher/gem"
 require "plugins/inspec-compliance/lib/inspec-compliance/api"

--- a/lib/inspec/fetcher/gem.rb
+++ b/lib/inspec/fetcher/gem.rb
@@ -1,11 +1,12 @@
 module Inspec::Fetcher
   class Gem < Inspec.fetcher(1)
     name "gem"
-    priority 100 # TODO: verify value
+    priority 0.5 # TODO: verify value
     # Priority is used for setting precedence of fetchers. And registry plugin(v1) decides which fetcher to use for loading profiles by using this priority
+    # Gem fetcher's priority should be lowest because gem profiles are only executables via inspec metadata
 
     def self.resolve(target)
-      if target.is_a?(Hash) && if target.key?(:gem)
+      if target.is_a?(Hash) && target.key?(:gem)
         resolve_from_hash(target)
       end
     end
@@ -15,7 +16,6 @@ module Inspec::Fetcher
 
       # TODO: implement version
       # TODO: implement source
-      require "byebug"; byebug
       new(target)
     end
 
@@ -25,76 +25,53 @@ module Inspec::Fetcher
       @archive_shasum = nil
     end
 
-  #   def fetch(path)
-  #     # If `inspec exec` is used then we should not vendor/fetch. This makes
-  #     # local development easier and more predictable.
-  #     return @target if Inspec::BaseCLI.inspec_cli_command == :exec
+    def fetch(path)
+      # TODO Logic to perform the installation
+      # If `inspec exec` is used then we should not vendor/fetch. This makes
+      # local development easier and more predictable.
+      return @target if Inspec::BaseCLI.inspec_cli_command == :exec
 
-  #     # Skip vendoring if @backend is not set (example: ad hoc runners)
-  #     return @target unless @backend
+      # Skip vendoring if @backend is not set (example: ad hoc runners)
+      return @target unless @backend
 
-  #     if File.directory?(@target)
-  #       # Create an archive, checksum, and move to the vendor directory
-  #       Dir.mktmpdir do |tmpdir|
-  #         temp_archive = File.join(tmpdir, "#{File.basename(@target)}.tar.gz")
-  #         opts = {
-  #           backend: @backend,
-  #           output: temp_archive,
-  #         }
+      @target
+    end
 
-  #         # Create a temporary archive at `opts[:output]`
-  #         Inspec::Profile.for_target(@target, opts).archive(opts)
+    def archive_path
+      @target
+    end
 
-  #         checksum = perform_shasum(temp_archive)
-  #         final_path = File.join(path, checksum)
-  #         FileUtils.mkdir_p(final_path)
-  #         Inspec::FileProvider.for_path(temp_archive).extract(final_path)
-  #       end
-  #     else
-  #       # Verify profile (archive) is valid and extract to vendor directory
-  #       opts = { backend: @backend }
-  #       Inspec::Profile.for_target(@target, opts).check
-  #       Inspec::FileProvider.for_path(@target).extract(path)
-  #     end
-
-  #     @target
-  #   end
-
-  #   def archive_path
-  #     @target
-  #   end
-
-  #   def writable?
-  #     File.directory?(@target)
-  #   end
+    def writable?
+      # Gem based profile is not writable because it is not cached in lockfile
+      false
+    end
 
     def cache_key
       # Want this to be any unstable value - always changing for now
-      rand()
+      rand().to_s
     end
 
-    # def sha256
-    #   if !@archive_shasum.nil?
-    #     @archive_shasum
-    #   elsif File.directory?(@target)
-    #     nil
-    #   else
-    #     perform_shasum(@target)
-    #   end
-    # end
+    def sha256
+      if !@archive_shasum.nil?
+        @archive_shasum
+      elsif File.directory?(@target)
+        nil
+      else
+        perform_shasum(@target)
+      end
+    end
 
-  #   def perform_shasum(target)
-  #     return @archive_shasum if @archive_shasum
-  #     raise(Inspec::FetcherFailure, "Profile dependency local path '#{target}' does not exist") unless File.exist?(target)
+    def perform_shasum(target)
+      return @archive_shasum if @archive_shasum
+      raise(Inspec::FetcherFailure, "Profile dependency local path '#{target}' does not exist") unless File.exist?(target)
 
-  #     @archive_shasum = OpenSSL::Digest.digest("SHA256", File.read(target)).unpack("H*")[0]
-  #   end
+      @archive_shasum = OpenSSL::Digest.digest("SHA256", File.read(target)).unpack("H*")[0]
+    end
 
-  #   def resolved_source
-  #     h = { path: @target }
-  #     h[:sha256] = sha256 if sha256
-  #     h
-  #   end
+    def resolved_source
+      h = { path: @target }
+      h[:sha256] = sha256 if sha256
+      h
     end
   end
 end

--- a/lib/inspec/fetcher/gem.rb
+++ b/lib/inspec/fetcher/gem.rb
@@ -24,18 +24,17 @@ module Inspec::Fetcher
       @gem_name = target[:gem]
       @version = target[:version] # optional
       @source = target[:source] # optional
-      @gem_path = target[:path] # optional, sets local path installation mode 
+      @gem_path = target[:path] # optional, sets local path installation mode
       @backend = opts[:backend]
       @archive_shasum = nil
     end
 
     def fetch(path)
-
       plugin_installer = Inspec::Plugin::V2::Installer.instance
 
       # Determine if gem is installed
       have_plugin = false
-      Inspec::Log.debug("GemFetcher fetching #{@gem_name} v" + (@version ? @version : "ANY"))
+      Inspec::Log.debug("GemFetcher fetching #{@gem_name} v" + (@version || "ANY"))
 
       if @version
         have_plugin = plugin_installer.plugin_version_installed?(@gem_name, @version)

--- a/lib/inspec/fetcher/gem.rb
+++ b/lib/inspec/fetcher/gem.rb
@@ -71,8 +71,15 @@ module Inspec::Fetcher
     end
 
     def cache_key
-      # Want this to be any unstable value - always changing for now
-      rand().to_s
+      # This special value is interpreted by Inspec::Cache.exists?
+      # gem:gemname:version
+      # gem_path:/filesystem/path/entrypoint.rb
+
+      if @gem_path
+        "gem_path:#{@gem_path}"
+      else
+        "gem:#{@gem_name}:#{@version}"
+      end
     end
 
     def sha256

--- a/lib/inspec/fetcher/gem.rb
+++ b/lib/inspec/fetcher/gem.rb
@@ -81,29 +81,17 @@ module Inspec::Fetcher
       end
     end
 
+    # The intent here is to provide a signature that would change with the content of the profile.
+    # In the case of gems, for released gems,  "name-version" should suffice.
+    # For development gems specified by path, the're ever-changing anyway, so just give the path.
+    # In eith case, that string is in fact just the cache key.
     def sha256
-      # TODO - calculate the sha of the installed rubygem
-      cache_key # WRONG
-      # Left as an exercise
-      # if !@archive_shasum.nil?
-      #   @archive_shasum
-      # elsif File.directory?(@target)
-      #   nil
-      # else
-      #   perform_shasum(@target)
-      # end
+      cache_key
     end
 
-    # def perform_shasum(target)
-    #   return @archive_shasum if @archive_shasum
-    #   raise(Inspec::FetcherFailure, "Profile dependency local path '#{target}' does not exist") unless File.exist?(target)
-
-    #   @archive_shasum = OpenSSL::Digest.digest("SHA256", File.read(target)).unpack("H*")[0]
-    # end
-
     def resolved_source
-      h = { gem: @gem_name, version: @version }
-      h[:sha256] = sha256 if sha256
+      h = { gem: @gem_name, version: @version, gem_path: @gem_path }
+      h[:sha256] = sha256
       h
     end
   end

--- a/lib/inspec/fetcher/gem.rb
+++ b/lib/inspec/fetcher/gem.rb
@@ -24,6 +24,7 @@ module Inspec::Fetcher
       @gem_name = target[:gem]
       @version = target[:version] # optional
       @source = target[:source] # optional
+      @gem_path = target[:path] # optional, sets local path installation mode 
       @backend = opts[:backend]
       @archive_shasum = nil
     end
@@ -46,7 +47,12 @@ module Inspec::Fetcher
         # Install
         # TODO - error handling?
         Inspec::Log.debug("GemFetcher - install request for #{@gem_name}")
-        plugin_installer.install(@gem_name, version: @version, source: @source)
+        if @gem_path
+          # No version permitted
+          plugin_installer.install(@gem_name, path: @gem_path)
+        else
+          plugin_installer.install(@gem_name, version: @version, source: @source )
+        end
       end
 
       # Should the plugin activate? No, it should only be "fetched" (installed)

--- a/lib/inspec/fetcher/gem.rb
+++ b/lib/inspec/fetcher/gem.rb
@@ -1,0 +1,100 @@
+module Inspec::Fetcher
+  class Gem < Inspec.fetcher(1)
+    name "gem"
+    priority 100 # TODO: verify value
+    # Priority is used for setting precedence of fetchers. And registry plugin(v1) decides which fetcher to use for loading profiles by using this priority
+
+    def self.resolve(target)
+      if target.is_a?(Hash) && if target.key?(:gem)
+        resolve_from_hash(target)
+      end
+    end
+
+    def self.resolve_from_hash(target)
+      return unless target.key?(:gem)
+
+      # TODO: implement version
+      # TODO: implement source
+      require "byebug"; byebug
+      new(target)
+    end
+
+    def initialize(target, opts = {})
+      @target = target
+      @backend = opts[:backend]
+      @archive_shasum = nil
+    end
+
+  #   def fetch(path)
+  #     # If `inspec exec` is used then we should not vendor/fetch. This makes
+  #     # local development easier and more predictable.
+  #     return @target if Inspec::BaseCLI.inspec_cli_command == :exec
+
+  #     # Skip vendoring if @backend is not set (example: ad hoc runners)
+  #     return @target unless @backend
+
+  #     if File.directory?(@target)
+  #       # Create an archive, checksum, and move to the vendor directory
+  #       Dir.mktmpdir do |tmpdir|
+  #         temp_archive = File.join(tmpdir, "#{File.basename(@target)}.tar.gz")
+  #         opts = {
+  #           backend: @backend,
+  #           output: temp_archive,
+  #         }
+
+  #         # Create a temporary archive at `opts[:output]`
+  #         Inspec::Profile.for_target(@target, opts).archive(opts)
+
+  #         checksum = perform_shasum(temp_archive)
+  #         final_path = File.join(path, checksum)
+  #         FileUtils.mkdir_p(final_path)
+  #         Inspec::FileProvider.for_path(temp_archive).extract(final_path)
+  #       end
+  #     else
+  #       # Verify profile (archive) is valid and extract to vendor directory
+  #       opts = { backend: @backend }
+  #       Inspec::Profile.for_target(@target, opts).check
+  #       Inspec::FileProvider.for_path(@target).extract(path)
+  #     end
+
+  #     @target
+  #   end
+
+  #   def archive_path
+  #     @target
+  #   end
+
+  #   def writable?
+  #     File.directory?(@target)
+  #   end
+
+    def cache_key
+      # Want this to be any unstable value - always changing for now
+      rand()
+    end
+
+    # def sha256
+    #   if !@archive_shasum.nil?
+    #     @archive_shasum
+    #   elsif File.directory?(@target)
+    #     nil
+    #   else
+    #     perform_shasum(@target)
+    #   end
+    # end
+
+  #   def perform_shasum(target)
+  #     return @archive_shasum if @archive_shasum
+  #     raise(Inspec::FetcherFailure, "Profile dependency local path '#{target}' does not exist") unless File.exist?(target)
+
+  #     @archive_shasum = OpenSSL::Digest.digest("SHA256", File.read(target)).unpack("H*")[0]
+  #   end
+
+  #   def resolved_source
+  #     h = { path: @target }
+  #     h[:sha256] = sha256 if sha256
+  #     h
+  #   end
+    end
+  end
+end

--- a/lib/inspec/fetcher/gem.rb
+++ b/lib/inspec/fetcher/gem.rb
@@ -27,12 +27,6 @@ module Inspec::Fetcher
 
     def fetch(path)
       # TODO Logic to perform the installation
-      # If `inspec exec` is used then we should not vendor/fetch. This makes
-      # local development easier and more predictable.
-      return @target if Inspec::BaseCLI.inspec_cli_command == :exec
-
-      # Skip vendoring if @backend is not set (example: ad hoc runners)
-      return @target unless @backend
 
       @target
     end
@@ -52,21 +46,24 @@ module Inspec::Fetcher
     end
 
     def sha256
-      if !@archive_shasum.nil?
-        @archive_shasum
-      elsif File.directory?(@target)
-        nil
-      else
-        perform_shasum(@target)
-      end
+      # TODO - calculate the sha of the installed rubygem
+      cache_key # WRONG
+      # Left as an exercise
+      # if !@archive_shasum.nil?
+      #   @archive_shasum
+      # elsif File.directory?(@target)
+      #   nil
+      # else
+      #   perform_shasum(@target)
+      # end
     end
 
-    def perform_shasum(target)
-      return @archive_shasum if @archive_shasum
-      raise(Inspec::FetcherFailure, "Profile dependency local path '#{target}' does not exist") unless File.exist?(target)
+    # def perform_shasum(target)
+    #   return @archive_shasum if @archive_shasum
+    #   raise(Inspec::FetcherFailure, "Profile dependency local path '#{target}' does not exist") unless File.exist?(target)
 
-      @archive_shasum = OpenSSL::Digest.digest("SHA256", File.read(target)).unpack("H*")[0]
-    end
+    #   @archive_shasum = OpenSSL::Digest.digest("SHA256", File.read(target)).unpack("H*")[0]
+    # end
 
     def resolved_source
       h = { path: @target }

--- a/lib/inspec/fetcher/local.rb
+++ b/lib/inspec/fetcher/local.rb
@@ -10,7 +10,7 @@ module Inspec::Fetcher
       if target.is_a?(String)
         local_path = resolve_from_string(target)
         new(local_path) if local_path
-      elsif target.is_a?(Hash)
+      elsif target.is_a?(Hash) && !target.key?(:gem)
         local_path = resolve_from_hash(target)
         new(local_path, target) if local_path
       end

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -7,8 +7,10 @@ require "inspec/iaf_file"
 module Inspec
   class FileProvider
     def self.for_path(path)
-      if path.is_a?(Hash)
+      if path.is_a?(Hash) && !path.key?(:gem)
         MockProvider.new(path)
+      elsif path.is_a?(Hash) && path.key?(:gem)
+        GemProvider.new(path)
       elsif File.directory?(path)
         DirProvider.new(path)
       elsif File.exist?(path) && path.end_with?(".tar.gz", "tgz")
@@ -98,6 +100,40 @@ module Inspec
       File.binread(file)
     end
   end # class DirProvider
+
+  class GemProvider < FileProvider
+    attr_reader :files
+    def initialize(gem_info)
+      # Determine a path to the gem installation directory
+      gem_name = gem_info[:gem]
+      bootstrap_file = gem_info[:path]
+      if bootstrap_file
+        # We were given an explicit path - go two directories up
+        parts = Pathname(gem_info[:path]).each_filename.to_a
+        @gem_lib_root = File.join(parts.slice(0,parts.length-2))
+      else
+        # Look up where the gem is installed, respecting version
+        raise NotImplementedError, "TODO: Gem FileProvider when gem is not a local reference"
+      end
+
+      @files = Dir[File.join(Shellwords.shellescape(@gem_lib_root), "**", "*")]
+    end
+
+    def read(file)
+      return nil unless files.include?(file)
+      return nil unless File.file?(file)
+
+      File.read(file)
+    end
+
+    def binread(file)
+      return nil unless files.include?(file)
+      return nil unless File.file?(file)
+
+      File.binread(file)
+    end
+  end # class GemProvider
+
 
   class ZipProvider < FileProvider
     attr_reader :files

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -110,10 +110,10 @@ module Inspec
       if bootstrap_file
         # We were given an explicit path - go two directories up
         parts = Pathname(gem_info[:path]).each_filename.to_a
-        @gem_lib_root = File.join(parts.slice(0,parts.length-2))
+        @gem_lib_root = File.join(parts.slice(0, parts.length - 2))
       else
         # Look up where the gem is installed, respecting version
-        raise NotImplementedError, "TODO: Gem FileProvider when gem is not a local reference"
+        raise NotImplementedError, "TODO: Gem FileProvider when gem #{gem_name} is not a local reference"
       end
 
       @files = Dir[File.join(Shellwords.shellescape(@gem_lib_root), "**", "*")]
@@ -133,7 +133,6 @@ module Inspec
       File.binread(file)
     end
   end # class GemProvider
-
 
   class ZipProvider < FileProvider
     attr_reader :files

--- a/lib/inspec/plugin/v2.rb
+++ b/lib/inspec/plugin/v2.rb
@@ -13,6 +13,7 @@ module Inspec
       end
 
       class InstallError < Inspec::Plugin::V2::GemActionError; end
+      class InstallRequiredError < Inspec::Plugin::V2::InstallError; end
 
       class PluginExcludedError < Inspec::Plugin::V2::InstallError
         attr_accessor :details

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -78,7 +78,6 @@ module Inspec::Plugin::V2
       end
 
       update_plugin_config_file(plugin_name, opts.merge({ action: :install }))
-      register_plugin
     end
 
     # Updates a plugin. Most options same as install, but will not handle path installs.

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -45,6 +45,10 @@ module Inspec::Plugin::V2
       list_installed_plugin_gems.detect { |spec| spec.name == name && spec.version == Gem::Version.new(version) }
     end
 
+    def ensure_installed(name)
+      plugin_installed?(name) || install(name)
+    end
+
     # Installs a plugin. Defaults to assuming the plugin provided is a gem, and will try to install
     # from whatever gemsources `rubygems` thinks it should use.
     # If it's a gem, installs it and its dependencies to the `gem_path`. The gem is not activated.
@@ -74,6 +78,7 @@ module Inspec::Plugin::V2
       end
 
       update_plugin_config_file(plugin_name, opts.merge({ action: :install }))
+      register_plugin
     end
 
     # Updates a plugin. Most options same as install, but will not handle path installs.

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -186,8 +186,6 @@ module Inspec::Plugin::V2
       self.class.list_managed_gems
     end
 
-    private
-
     # 'Activating' a gem adds it to the load path, so 'require "gemname"' will work.
     # Given a gem name, this activates the gem and all of its dependencies, respecting
     # version pinning needs.
@@ -231,6 +229,8 @@ module Inspec::Plugin::V2
         # TODO: If we are under Bundler, inform it that we loaded a gem
       end
     end
+
+    private
 
     def annotate_status_after_loading(plugin_name)
       status = registry[plugin_name]

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -158,11 +158,11 @@ module Inspec::Plugin::V2
     end
 
     def self.find_gem_directory(gem_name, version = nil)
-      matching_gem_versions = list_managed_gems.filter { |g| g.name == gem_name}.sort(&:version)
+      matching_gem_versions = list_managed_gems.filter { |g| g.name == gem_name }.sort(&:version)
       selected_gemspec = nil
       if version
         selected_gemspec = matching_gem_versions.find { |g| g.version == version }
-      else 
+      else
         # Use latest
         selected_gemspec = matching_gem_versions.last
       end

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -157,6 +157,23 @@ module Inspec::Plugin::V2
       self.class.list_managed_gems
     end
 
+    def self.find_gem_directory(gem_name, version = nil)
+      matching_gem_versions = list_managed_gems.filter { |g| g.name == gem_name}.sort(&:version)
+      selected_gemspec = nil
+      if version
+        selected_gemspec = matching_gem_versions.find { |g| g.version == version }
+      else 
+        # Use latest
+        selected_gemspec = matching_gem_versions.last
+      end
+
+      selected_gemspec && selected_gemspec.full_gem_path
+    end
+
+    def find_gem_directory(gem_name, version = nil)
+      self.class.find_gem_directory(gem_name, version)
+    end
+
     # Lists all plugin gems found in the plugin_gem_path.
     # This is simply all gems that begin with train- or inspec-
     # and are not on the exclusion list.

--- a/lib/inspec/plugin/v2/plugin_types/resource_pack.rb
+++ b/lib/inspec/plugin/v2/plugin_types/resource_pack.rb
@@ -1,0 +1,8 @@
+module Inspec::Plugin::V2::PluginType
+  class ResourcePack < Inspec::Plugin::V2::PluginBase
+    register_plugin_type(:resource_pack)
+
+    # Any DSL definitions would go here
+
+  end
+end

--- a/lib/inspec/plugin/v2/plugin_types/resource_pack.rb
+++ b/lib/inspec/plugin/v2/plugin_types/resource_pack.rb
@@ -2,7 +2,7 @@ module Inspec::Plugin::V2::PluginType
   class ResourcePack < Inspec::Plugin::V2::PluginBase
     register_plugin_type(:resource_pack)
 
-    # Any DSL definitions would go here
+    # TODO: Any DSL definitions would go here
 
   end
 end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -391,6 +391,16 @@ module Inspec
       included_tags
     end
 
+    # InSpec 7 introduced gem-based resource packs, so some "profiles" are now gem-based
+    # In this case, they are backed by a gem that contains an inspec.yml and a lib/PATH/plugin.rb
+    # which contains activator code which needs to be fired.
+    def activate_plugin_if_gem_based
+      return unless source_reader.is_a?(SourceReaders::GemReader)
+
+      reg = Inspec::Plugin::V2::Registry.instance
+      reg.find_activator(plugin_name: name.to_sym).activate!
+    end
+
     def load_libraries
       return @runner_context if @libraries_loaded
 

--- a/lib/inspec/profile_context.rb
+++ b/lib/inspec/profile_context.rb
@@ -141,9 +141,9 @@ module Inspec
           no_subdir = File.dirname(path) == "."
 
           autoloads.push(path) if no_subdir
-        elsif source.match(/^lib\/.+\/resources\/.*\.rb/)
+        elsif source.match(%r{^lib/.+/resources/.*\.rb})
           # Gem Resource Pack
-          path = source.sub(/^lib\//, "")
+          path = source.sub(%r{^lib/}, "")
           autoloads.push(path)
         end
 

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -115,7 +115,9 @@ module Inspec
         next unless profile.supports_platform?
 
         write_lockfile(profile) if @create_lockfile
-        profile.locked_dependencies
+        # TODO: InSpec 8: Replace with Profile OnLoad event handling
+        profile.activate_plugin_if_gem_based
+        profile.locked_dependencies # Only need to do this once, this recurses down
         profile.load_gem_dependencies
         profile_context = profile.load_libraries
 
@@ -125,6 +127,10 @@ module Inspec
              " on unsupported platform: '#{@backend.platform.name}/#{@backend.platform.release}'."
             next
           end
+          # TODO: InSpec 8: Replace with Profile OnLoad event handling
+          requirement.profile.activate_plugin_if_gem_based
+          requirement.profile.load_gem_dependencies
+          requirement.profile.load_libraries
           @test_collector.add_profile(requirement.profile)
         end
 

--- a/lib/inspec/source_reader.rb
+++ b/lib/inspec/source_reader.rb
@@ -24,3 +24,5 @@ end
 
 require "source_readers/inspec"
 require "source_readers/flat"
+require "source_readers/gem"
+

--- a/lib/inspec/utils/deprecation/deprecator.rb
+++ b/lib/inspec/utils/deprecation/deprecator.rb
@@ -4,11 +4,12 @@ require "inspec/log"
 module Inspec
   module Deprecation
     class Deprecator
-      attr_reader :config, :groups
+      attr_reader :config, :fallback_resource_packs, :groups
 
       def initialize(opts = {})
         @config = Inspec::Deprecation::ConfigFile.new(opts[:config_io])
         @groups = @config.groups
+        @fallback_resource_packs = @config.fallback_resource_packs
       end
 
       def handle_deprecation(group_name, message, opts = {})

--- a/lib/inspec/utils/deprecation/deprecator.rb
+++ b/lib/inspec/utils/deprecation/deprecator.rb
@@ -22,6 +22,13 @@ module Inspec
         send(action_method, group_name.to_sym, assembled_message, group)
       end
 
+      # Given a resource name, suggest a gem nam to load and or install
+      def match_gem_for_fallback_resource_name(resource_name)
+        fallback = fallback_resource_packs.find { |fb| fb.resource_name_regex.match(resource_name) }
+        # We have a message here but can't pass it back?
+        fallback&.gem_name
+      end
+
       private
 
       def create_group_entry_for_unknown_group(group_name)

--- a/lib/source_readers/gem.rb
+++ b/lib/source_readers/gem.rb
@@ -1,0 +1,67 @@
+require "inspec/fetcher"
+require "inspec/metadata"
+
+module SourceReaders
+  class GemReader < Inspec.source_reader(1)
+    name "gem"
+    priority 20
+
+    def self.resolve(target)
+      return new(target) unless target.files.grep(/gemspec/).empty?
+
+      nil
+    end
+
+    attr_reader :metadata, :metadata_src, :tests, :libraries, :data_files, :target, :readme
+
+    # This creates a new instance of an InSpec Gem-packaged profile source reader
+    # As of July 2024 only resource packs, not controls, may be packaged as gems
+    #
+    # @param [FileProvider] target An instance of a FileProvider object that can list files and read them
+    def initialize(target)
+      @target     = target
+      @metadata   = load_metadata(target.files.grep("inspec.yml").first)
+      @tests      = {} # TODO - one day support controls?
+      @libraries  = load_libs
+      @data_files = {}
+      @readme     = load_readme
+    end
+
+    private
+
+    def load_metadata(metadata_source)
+      @metadata_src = @target.read(metadata_source)
+      Inspec::Metadata.from_ref(
+        metadata_source,
+        @metadata_src,
+        nil
+      )
+    rescue Psych::SyntaxError => e
+      raise "Unable to parse inspec.yml: line #{e.line}, #{e.problem} #{e.context}"
+    rescue => e
+      raise "Unable to parse #{metadata_source}: #{e.class} -- #{e.message}"
+    end
+
+    def find_all(regexp)
+      @target.files.grep(regexp)
+    end
+
+    def load_all(regexp)
+      find_all(regexp)
+        .map { |path| file = @target.read(path); [path, file] if file }
+        .compact
+        .to_h
+    end
+
+    def load_libs      
+      # Legacy resource packs (inspec-gcp, inspec-aws, etc) have resources in old locations
+      load_all(%r{^libraries/.*\.rb$})
+      # New resource packs have them here
+      load_all(%r{^lib/.*/resources/.*\.rb$})
+    end
+
+    def load_readme
+      load_all(/README.md/)
+    end
+  end
+end

--- a/lib/source_readers/gem.rb
+++ b/lib/source_readers/gem.rb
@@ -53,7 +53,7 @@ module SourceReaders
         .to_h
     end
 
-    def load_libs      
+    def load_libs
       # Legacy resource packs (inspec-gcp, inspec-aws, etc) have resources in old locations
       load_all(%r{^libraries/.*\.rb$})
       # New resource packs have them here

--- a/test/fixtures/plugins/inspec-test-resources/Gemfile
+++ b/test/fixtures/plugins/inspec-test-resources/Gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gemspec
+
+group :development do
+  gem "bundler"
+  gem "byebug"
+  gem "minitest"
+  gem "rake"
+  gem "rubocop", "= 0.49.1" # Need to keep in sync with main InSpec project, so config files will work
+end

--- a/test/fixtures/plugins/inspec-test-resources/README.md
+++ b/test/fixtures/plugins/inspec-test-resources/README.md
@@ -1,3 +1,5 @@
 # inspec-test-resources
 
 Resource Pack plugin used to test resource_pack plugin type in test/functional/plugins_test.rb
+
+Defines one resource, demo_resource.

--- a/test/fixtures/plugins/inspec-test-resources/README.md
+++ b/test/fixtures/plugins/inspec-test-resources/README.md
@@ -1,0 +1,3 @@
+# inspec-test-resources
+
+Resource Pack plugin used to test resource_pack plugin type in test/functional/plugins_test.rb

--- a/test/fixtures/plugins/inspec-test-resources/inspec-test-resources.gemspec
+++ b/test/fixtures/plugins/inspec-test-resources/inspec-test-resources.gemspec
@@ -4,7 +4,7 @@
 
 # It is traditional in a gemspec to dynamically load the current version
 # from a file in the source tree.  The next three lines make that happen.
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "inspec-test-resources/version"
 

--- a/test/fixtures/plugins/inspec-test-resources/inspec-test-resources.gemspec
+++ b/test/fixtures/plugins/inspec-test-resources/inspec-test-resources.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # It just filters what will actually be packaged in the gem (leaving
   # out tests, etc)
   spec.files = %w{
-    README.md inspec-test-resources.gemspec Gemfile
+    README.md inspec-test-resources.gemspec Gemfile inspec.yml
   } + Dir.glob(
     "lib/**/*", File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }

--- a/test/fixtures/plugins/inspec-test-resources/inspec-test-resources.gemspec
+++ b/test/fixtures/plugins/inspec-test-resources/inspec-test-resources.gemspec
@@ -1,0 +1,42 @@
+# As plugins are usually packaged and distributed as a RubyGem,
+# we have to provide a .gemspec file, which controls the gembuild
+# and publish process.  This is a fairly generic gemspec.
+
+# It is traditional in a gemspec to dynamically load the current version
+# from a file in the source tree.  The next three lines make that happen.
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "inspec-test-resources/version"
+
+Gem::Specification.new do |spec|
+  # Importantly, all InSpec plugins must be prefixed with `inspec-` (most
+  # plugins) or `train-` (plugins which add new connectivity features).
+  spec.name          = "inspec-test-resources"
+
+  # It is polite to namespace your plugin under InspecPlugins::YourPluginInCamelCase
+  spec.version       = InspecPlugins::TestResources::VERSION
+  spec.authors       = ["InSpec Core Maintainers"]
+  spec.email         = ["inspec@progress.com"]
+  spec.summary       = "A simple resource pack plugin used to test InSpec itelf"
+  spec.description   = "This resource pack plugin is iused for internal testing of InSpec."
+  spec.homepage      = "https://github.com/inspec/inspec"
+  spec.license       = "Apache-2.0"
+
+  # Though complicated-looking, this is pretty standard for a gemspec.
+  # It just filters what will actually be packaged in the gem (leaving
+  # out tests, etc)
+  spec.files = %w{
+    README.md inspec-test-resources.gemspec Gemfile
+  } + Dir.glob(
+    "lib/**/*", File::FNM_DOTMATCH
+  ).reject { |f| File.directory?(f) }
+  spec.require_paths = ["lib"]
+
+  # If you rely on any other gems, list them here with any constraints.
+  # This is how `inspec plugin install` is able to manage your dependencies.
+  # For example, perhaps you are writing a thing that talks to AWS, and you
+  # want to ensure you have `aws-sdk` in a certain version.
+
+  # This plugin uses InSpec 7 Resource Pack Plugins
+  spec.add_dependency "inspec", ">= 7.0"
+end

--- a/test/fixtures/plugins/inspec-test-resources/inspec-test-resources.gemspec
+++ b/test/fixtures/plugins/inspec-test-resources/inspec-test-resources.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |spec|
   # want to ensure you have `aws-sdk` in a certain version.
 
   # This plugin uses InSpec 7 Resource Pack Plugins
-  spec.add_dependency "inspec", ">= 7.0"
+  spec.add_dependency "inspec-core", ">= 7.0"
 end

--- a/test/fixtures/plugins/inspec-test-resources/inspec.yml
+++ b/test/fixtures/plugins/inspec-test-resources/inspec.yml
@@ -1,0 +1,10 @@
+name: inspec-test-resources
+title: InSpec Test Resources 
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Profile that is a Gem Dependency
+version: 0.1.0
+supports:
+  platform: os

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources.rb
@@ -1,0 +1,14 @@
+# This file is known as the "entry point."
+# This is the file InSpec will try to load if it
+# thinks your plugin is installed.
+
+# The *only* thing this file should do is setup the
+# load path, then load the plugin definition file.
+
+# Next two lines simply add the path of the gem to the load path.
+# This is not needed when being loaded as a gem; but when doing
+# plugin development, you may need it.  Either way, it's harmless.
+libdir = File.dirname(__FILE__)
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+
+require "inspec-test-resources/plugin"

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/plugin.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/plugin.rb
@@ -1,0 +1,43 @@
+# Plugin Definition file
+# The purpose of this file is to declare to InSpec what plugin_types (capabilities)
+# are included in this plugin, and provide activator that will load them as needed.
+
+# It is important that this file load successfully and *quickly*.
+# Your plugin's functionality may never be used on this InSpec run; so we keep things
+# fast and light by only loading heavy things when they are needed.
+
+# Presumably this is light
+require "inspec-test-resources/version"
+
+# The InspecPlugins namespace is where all plugins should declare themselves.
+# The "Inspec" capitalization is used throughout the InSpec source code; yes, it's
+# strange.
+module InspecPlugins
+  # Pick a reasonable namespace here for your plugin. A reasonable choice
+  # would be the CamelCase version of your plugin gem name.
+  # inspec-test-resources => TestResources
+  module TestResources
+    # This simple class handles the plugin definition, so calling it simply Plugin is OK.
+    #   Inspec.plugin returns various Classes, intended to be superclasses for various
+    # plugin components. Here, the one-arg form gives you the Plugin Definition superclass,
+    # which mainly gives you access to the activator / plugin_type DSL.
+    #   The number '2' says you are asking for version 2 of the plugin API. If there are
+    # future versions, InSpec promises plugin API v2 will work for at least two more InSpec
+    # major versions.
+    class Plugin < ::Inspec.plugin(2)
+      # Internal machine name of the plugin. InSpec will use this in errors, etc.
+      plugin_name :"inspec-test-resources"
+
+      
+      # Define a new Resource Pack.
+      resource_pack :"inspec-test-resources" do
+        # This file will load the resources implicitly via the superclass
+        require "inspec-test-resources/resource_pack"
+
+        # Having loaded our functionality, return a class that represents the plugin.
+        # Reserved for future use.
+        InspecPlugins::TestResources::ResourcePack
+      end
+    end
+  end
+end

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/plugin.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/plugin.rb
@@ -28,7 +28,6 @@ module InspecPlugins
       # Internal machine name of the plugin. InSpec will use this in errors, etc.
       plugin_name :"inspec-test-resources"
 
-      
       # Define a new Resource Pack.
       resource_pack :"inspec-test-resources" do
         # This file will load the resources implicitly via the superclass

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resource_pack.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resource_pack.rb
@@ -7,10 +7,8 @@ module InspecPlugins::TestResources
   # version 2 of the Plugins API.  The second says we are making a Resource
   # Pack plugin component, so please make available any DSL needed
   # for that.
-    class ResourcePack < Inspec.plugin(2, :resource_pack)
-      # TBD
-      # load_timing :early  <-- isn't that implicit in the rewuire statements
-      # train relationship declarations?  <-- that should be in the gemspec
-    end
+  class ResourcePack < Inspec.plugin(2, :resource_pack)
+    # load_timing :early  <-- isn't that implicit in the rewuire statements
+    # train relationship declarations?  <-- that should be in the gemspec
   end
 end

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resource_pack.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resource_pack.rb
@@ -1,0 +1,16 @@
+require "inspec/resource"
+
+module InspecPlugins::TestResources
+  # This class will provide the actual CLI implementation.
+  # Its superclass is provided by another call to Inspec.plugin,
+  # this time with two args.  The first arg specifies we are requesting
+  # version 2 of the Plugins API.  The second says we are making a Resource
+  # Pack plugin component, so please make available any DSL needed
+  # for that.
+    class ResourcePack < Inspec.plugin(2, :resource_pack)
+      # TBD
+      # load_timing :early  <-- isn't that implicit in the rewuire statements
+      # train relationship declarations?  <-- that should be in the gemspec
+    end
+  end
+end

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/demo_resource.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/demo_resource.rb
@@ -11,7 +11,7 @@ class DemoResourcePackResource < Inspec.resource(1)
 
   example "
     describe demo_resource do
-      its should { deliver_value_and_delight_customers }
+      its('awesomeness') { should cmp 'extreme' }}
     end
   "
 
@@ -19,8 +19,7 @@ class DemoResourcePackResource < Inspec.resource(1)
     # nothing to do
   end
 
-  # Example method called by 'it { should deliver_value_and_delight_customers }'
-  def deliver_value_and_delight_customers?
-    true
+  def awesomeness
+    "extreme"
   end
 end

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/demo_resource.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/demo_resource.rb
@@ -1,0 +1,26 @@
+# Custom resource based on the InSpec resource DSL
+class DemoResourcePackResource < Inspec.resource(1)
+  name 'demo_resource'
+
+  supports platform: 'unix'
+  supports platform: 'windows'
+
+  desc "
+    A test resource used to test the Resource Pack plugin type.
+  "
+
+  example "
+    describe demo_resource do
+      its should { deliver_value_and_delight_customers }
+    end
+  "
+
+  def initialize
+    # nothing to do
+  end
+
+  # Example method called by 'it { should deliver_value_and_delight_customers }'
+  def deliver_value_and_delight_customers?
+    true
+  end
+end

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/demo_resource.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/demo_resource.rb
@@ -1,9 +1,9 @@
 # Custom resource based on the InSpec resource DSL
 class DemoResourcePackResource < Inspec.resource(1)
-  name 'demo_resource'
+  name "demo_resource"
 
-  supports platform: 'unix'
-  supports platform: 'windows'
+  supports platform: "unix"
+  supports platform: "windows"
 
   desc "
     A test resource used to test the Resource Pack plugin type.

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/internal_fallback_test_resource.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/internal_fallback_test_resource.rb
@@ -14,7 +14,7 @@ class InternalFallbackTestResource < Inspec.resource(1)
 
   example "
     describe internal_fallback_test_resource do
-      its('custom_method') { should 'be_available' }
+      its('custom_method') { should cmp 'be_available' }
     end
   "
 

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/internal_fallback_test_resource.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/internal_fallback_test_resource.rb
@@ -1,0 +1,28 @@
+# Custom resource based on the InSpec resource DSL
+class InternalFallbackTestResource < Inspec.resource(1)
+  name "internal_fallback_test_resource"
+
+  supports platform: "unix"
+  supports platform: "windows"
+
+  desc "
+    A test resource used to test fallback loading.
+    Fallback loading is when a resource is mentioned
+    without a profile dependency, yet InSpec core is
+    expected to guess the dependency.
+  "
+
+  example "
+    describe internal_fallback_test_resource do
+      its('custom_method') { should 'be_available' }
+    end
+  "
+
+  def initialize
+    # nothing to do
+  end
+
+  def custom_method
+    "be_available"
+  end
+end

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/version.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/version.rb
@@ -3,6 +3,6 @@
 # to learn the current version.
 module InspecPlugins
   module TestResources
-    VERSION = "0.2.0".freeze
+    VERSION = "0.2.1".freeze
   end
 end

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/version.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/version.rb
@@ -3,6 +3,6 @@
 # to learn the current version.
 module InspecPlugins
   module TestResources
-    VERSION = "0.1.0".freeze
+    VERSION = "0.2.0".freeze
   end
 end

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/version.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/version.rb
@@ -1,0 +1,8 @@
+# This file simply makes it easier for CI engines to update
+# the version stamp, and provide a clean way for the gemspec
+# to learn the current version.
+module InspecPlugins
+  module TestResources
+    VERSION = "0.1.0".freeze
+  end
+end

--- a/test/fixtures/profiles/dependencies/uses-resource-pack-gem/controls/resource_pack_demo.rb
+++ b/test/fixtures/profiles/dependencies/uses-resource-pack-gem/controls/resource_pack_demo.rb
@@ -1,0 +1,5 @@
+control "demo-control" do
+  describe demo_resource do
+    it { should deliver_value_and_delight_customers }
+  end
+end

--- a/test/fixtures/profiles/dependencies/uses-resource-pack-gem/controls/resource_pack_demo.rb
+++ b/test/fixtures/profiles/dependencies/uses-resource-pack-gem/controls/resource_pack_demo.rb
@@ -1,5 +1,5 @@
 control "demo-control" do
   describe demo_resource do
-    it { should deliver_value_and_delight_customers }
+    its("awesomeness") { should cmp "extreme" }
   end
 end

--- a/test/fixtures/profiles/dependencies/uses-resource-pack-gem/inspec.yml
+++ b/test/fixtures/profiles/dependencies/uses-resource-pack-gem/inspec.yml
@@ -12,4 +12,6 @@ depends:
  - name: inspec-test-resources
    gem: inspec-test-resources
    # Note that path makes this a local install, bypassing source
+   # To test with actual gem install, comment out this next line.
+   # (You'll also need to make the inspec-test-resources gem available via your gem sources)
    path: test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources.rb

--- a/test/fixtures/profiles/dependencies/uses-resource-pack-gem/inspec.yml
+++ b/test/fixtures/profiles/dependencies/uses-resource-pack-gem/inspec.yml
@@ -1,0 +1,13 @@
+name: uses-resource-pack-gem
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Profile that uses a Gem Dependency
+version: 0.1.0
+supports:
+  platform: os
+depends:
+ - name: inspec-test-resources
+   gem: inspec-test-resources

--- a/test/fixtures/profiles/dependencies/uses-resource-pack-gem/inspec.yml
+++ b/test/fixtures/profiles/dependencies/uses-resource-pack-gem/inspec.yml
@@ -11,3 +11,5 @@ supports:
 depends:
  - name: inspec-test-resources
    gem: inspec-test-resources
+   # Note that path makes this a local install, bypassing source
+   path: test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources.rb

--- a/test/fixtures/profiles/fallback-resource-packs/controls/fallback_test.rb
+++ b/test/fixtures/profiles/fallback-resource-packs/controls/fallback_test.rb
@@ -1,0 +1,10 @@
+control "fallback-control" do
+  # This must match the pattern in etc/deprecations.json
+
+  # This is defined in test/fixtures/plugins/inspec-test-resources
+  # and should be dynamically installed by the fallback mechanism
+
+  describe internal_fallback_test_resource do
+    its('custom_method') { should 'be_available' }
+  end
+end

--- a/test/fixtures/profiles/fallback-resource-packs/controls/fallback_test.rb
+++ b/test/fixtures/profiles/fallback-resource-packs/controls/fallback_test.rb
@@ -5,6 +5,6 @@ control "fallback-control" do
   # and should be dynamically installed by the fallback mechanism
 
   describe internal_fallback_test_resource do
-    its('custom_method') { should 'be_available' }
+    its('custom_method') { should cmp 'be_available' }
   end
 end

--- a/test/fixtures/profiles/fallback-resource-packs/inspec.yml
+++ b/test/fixtures/profiles/fallback-resource-packs/inspec.yml
@@ -1,0 +1,10 @@
+name: fallback-resource-packs
+title: InSpec Fallback Test Profile
+maintainer: InSpec Core Maintainers
+copyright: Progress Software Corportation
+copyright_email: inspec@progress.com
+license: Apache-2.0
+summary: A profile that uses an apparently non-existant resource that will trigger fallback resource pack loading in the functional tests.
+version: 0.1.0
+supports:
+  platform: os

--- a/test/functional/fallback_test.rb
+++ b/test/functional/fallback_test.rb
@@ -1,0 +1,50 @@
+require "functional/helper"
+
+describe "profiles with missing resources" do
+  include FunctionalHelper
+  let(:config_dir_path) { File.expand_path "test/fixtures/config_dirs" }
+  let(:ruby_abi_version) { RbConfig::CONFIG["ruby_version"] }
+  let(:ruby_dir) { File.join(config_dir_path, "profile_gems", ".inspec/gems/#{ruby_abi_version}/gems") }
+
+  let(:fallback_profile_path) { File.join(profile_path, "fallback-resource-packs") }
+
+  # let(:profile_with_gem_dependency_without_gem_version) { File.join(profile_path, "profile-without-gem-version") }
+  # let(:illformatted_gem_dependency) { File.join(profile_path, "profile-with-illformed-gem-depedency") }
+  # let(:depdent_profile_gem_dependency) { File.join(profile_path, "profile-with-dependent-gem-dependency") }
+
+  def reset_globals
+    ENV["HOME"] = Dir.home
+  end
+
+  before(:each) do
+    reset_globals
+    ENV["HOME"] = File.join(config_dir_path, "profile_gems")
+  end
+
+  after do
+    reset_globals
+
+    if config_dir_path
+      Dir.glob(File.join(config_dir_path, "profile_gems")).each do |path|
+        next if path.end_with? ".gitkeep"
+
+        FileUtils.rm_rf(path)
+      end
+    end
+  end
+
+  it "installs the gem dependencies and load them if --auto-install-gems is provided." do
+    # TODO - this work if you have a private rubygems server and upload inspec-test-resources to it
+    skip 
+    out = inspec_with_env("exec #{fallback_profile_path} --no-create-lockfile --auto-install-gems")
+
+    _(out.stderr).must_equal ""
+
+    # Indicates that at least one ruby install happened
+    # Want better test - check for actual gem
+    _(File.directory?(ruby_dir)).must_equal true
+
+    assert_exit_code 0, out
+  end
+
+end

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -221,11 +221,12 @@ describe "Resource Pack Plugin support" do
 
   describe "loading via profile gem dependency" do
     let(:fixture_path) { File.join(profile_path, "dependencies", "uses-resource-pack-gem") }
-    let(:run_result) { run_inspec_with_plugin("exec #{fixture_path}", plugin_path: resource_pack_plugin_path, do_install: false) }
+    let(:run_result) { run_inspec_process("exec #{fixture_path}", json: true) }
 
     it "runs the resource pack plugin type successfully" do
       _(run_result.stderr).must_be_empty
       _(run_result.exit_status).must_equal 0
+      assert_json_controls_passing
     end
   end
 end

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -201,6 +201,27 @@ describe "Streaming-reporter plugin type support" do
 end
 
 #=========================================================================================#
+#                           Resource Pack Plugin Support
+#=========================================================================================#
+
+describe "Resource Pack Plugin support" do
+  include PluginFunctionalHelper
+
+  let(:resource_pack_plugin_path) { File.join(mock_path, "plugins", "inspec-test-resources", "lib", "inspec-test-resources.rb") }
+
+  describe "just loading the plugin" do
+    let(:fixture_path) { File.join(profile_path, "basic_profile") }
+    let(:run_result) { run_inspec_with_plugin("exec #{fixture_path}", plugin_path: resource_pack_plugin_path) }
+
+    it "runs the resource pack plugin type successfully" do
+      _(run_result.stderr).must_be_empty
+      _(run_result.exit_status).must_equal 0
+    end
+  end
+
+end
+
+#=========================================================================================#
 #                           DSL Plugin Support
 #=========================================================================================#
 

--- a/test/functional/plugins_test.rb
+++ b/test/functional/plugins_test.rb
@@ -219,6 +219,15 @@ describe "Resource Pack Plugin support" do
     end
   end
 
+  describe "loading via profile gem dependency" do
+    let(:fixture_path) { File.join(profile_path, "dependencies", "uses-resource-pack-gem") }
+    let(:run_result) { run_inspec_with_plugin("exec #{fixture_path}", plugin_path: resource_pack_plugin_path, do_install: false) }
+
+    it "runs the resource pack plugin type successfully" do
+      _(run_result.stderr).must_be_empty
+      _(run_result.exit_status).must_equal 0
+    end
+  end
 end
 
 #=========================================================================================#

--- a/test/unit/utils/deprecation_test.rb
+++ b/test/unit/utils/deprecation_test.rb
@@ -204,6 +204,12 @@ describe "The Deprecator object" do
       it "should report two fallbacks" do
         _(dpcr.fallback_resource_packs.count).must_equal 2
       end
+      it "should suggest the stuff gem for somepat resources" do
+        _(dpcr.match_gem_for_fallback_resource_name("somepat_resource")).must_equal "inspec-stuff-resources"
+      end
+      it "should suggest nil for things it does not know about" do
+        _(dpcr.match_gem_for_fallback_resource_name("unknown_resource")).must_be_nil
+      end
     end
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Provides facilities in core to allow Resource Packs (profiles that contain definitions of resources and no controls) to be contained in RubyGem files and managed by the InSpec Plugin V2 system.

There are a lot of moving parts in this.

1. a PluginType definition of ResourcePack so we can install gems and classify them as resource packs.
2. A new Fetcher that fetches gem-based profile dependencies
3. Changes to the Cache to be aware that some entries will be in the gem directory , not the cache directory
4. A new SourceReader that knows how to read Gems and get the library files out of them
5. Changes to the ProfileContext to update library autoload patterns

MANUAL TESTING - you have to make a gem out of the inspec-test-resources gemspec, then upload it to a private gemserver, set your gemsources, then comment out a certain line in the test inspec.yml dependency.





## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
