### PR TITLE
CHEF-14245 - Fallback Resource Pack Support when a Resource is Not Found

### DIFF
--- a/etc/deprecations.json
+++ b/etc/deprecations.json
@@ -1,5 +1,5 @@
 {
-  "file_version": "1.0.0",
+  "file_version": "2.0.0",
   "unknown_group_action": "ignore",
   "groups": {
     "attrs_value_replaces_default": {
@@ -125,6 +125,12 @@
     "renamed_to_inspec_export":{
       "action": "ignore",
       "prefix": "The `inspec json` command is deprecated in InSpec 5 and replaced with `inspec export` command."
+    }
+  },
+  "fallback_resource_packs":{
+    "internal_fallback_test.+":{
+      "gem":"inspec-test-resources",
+      "message":"The internal_fallback_test resource is a test resource used to exercise InSpec's ability to fallback on gem resource packs."
     }
   }
 }

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -62,8 +62,10 @@ module Inspec::DSL
         loader.activate_managed_gems_for_plugin(gem_name)
 
         # 2. Load all libraries from the gem path
-        resources_path = File.join(loader.find_gem_directory(gem_name), "lib", gem_name, "resources")
-        Dir.glob("#{resources_path}/*.rb").each do |resource_lib|
+        gem_path = loader.find_gem_directory(gem_name)
+        resources_path = File.join(gem_path, "lib", gem_name, "resources", "*.rb")
+        legacy_library_path = File.join(gem_path, "libraries", "*.rb")
+        Dir.glob([resources_path,legacy_library_path]).each do |resource_lib|
           require resource_lib
         end
         # Resources now available in Inspec::Resource.registry

--- a/lib/inspec/plugin/v2.rb
+++ b/lib/inspec/plugin/v2.rb
@@ -13,6 +13,7 @@ module Inspec
       end
 
       class InstallError < Inspec::Plugin::V2::GemActionError; end
+      class InstallRequiredError < Inspec::Plugin::V2::InstallError; end
 
       class PluginExcludedError < Inspec::Plugin::V2::InstallError
         attr_accessor :details

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -78,7 +78,6 @@ module Inspec::Plugin::V2
       end
 
       update_plugin_config_file(plugin_name, opts.merge({ action: :install }))
-      register_plugin
     end
 
     # Updates a plugin. Most options same as install, but will not handle path installs.

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -45,6 +45,10 @@ module Inspec::Plugin::V2
       list_installed_plugin_gems.detect { |spec| spec.name == name && spec.version == Gem::Version.new(version) }
     end
 
+    def ensure_installed(name)
+      plugin_installed?(name) || install(name)
+    end
+
     # Installs a plugin. Defaults to assuming the plugin provided is a gem, and will try to install
     # from whatever gemsources `rubygems` thinks it should use.
     # If it's a gem, installs it and its dependencies to the `gem_path`. The gem is not activated.
@@ -74,6 +78,7 @@ module Inspec::Plugin::V2
       end
 
       update_plugin_config_file(plugin_name, opts.merge({ action: :install }))
+      register_plugin
     end
 
     # Updates a plugin. Most options same as install, but will not handle path installs.

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -186,8 +186,6 @@ module Inspec::Plugin::V2
       self.class.list_managed_gems
     end
 
-    private
-
     # 'Activating' a gem adds it to the load path, so 'require "gemname"' will work.
     # Given a gem name, this activates the gem and all of its dependencies, respecting
     # version pinning needs.
@@ -231,6 +229,8 @@ module Inspec::Plugin::V2
         # TODO: If we are under Bundler, inform it that we loaded a gem
       end
     end
+
+    private
 
     def annotate_status_after_loading(plugin_name)
       status = registry[plugin_name]

--- a/lib/inspec/plugin/v2/plugin_types/resource_pack.rb
+++ b/lib/inspec/plugin/v2/plugin_types/resource_pack.rb
@@ -2,7 +2,7 @@ module Inspec::Plugin::V2::PluginType
   class ResourcePack < Inspec::Plugin::V2::PluginBase
     register_plugin_type(:resource_pack)
 
-    # Any DSL definitions would go here
+    # TODO: Any DSL definitions would go here
 
   end
 end

--- a/lib/inspec/utils/deprecation/deprecator.rb
+++ b/lib/inspec/utils/deprecation/deprecator.rb
@@ -4,11 +4,12 @@ require "inspec/log"
 module Inspec
   module Deprecation
     class Deprecator
-      attr_reader :config, :groups
+      attr_reader :config, :fallback_resource_packs, :groups
 
       def initialize(opts = {})
         @config = Inspec::Deprecation::ConfigFile.new(opts[:config_io])
         @groups = @config.groups
+        @fallback_resource_packs = @config.fallback_resource_packs
       end
 
       def handle_deprecation(group_name, message, opts = {})

--- a/lib/inspec/utils/deprecation/deprecator.rb
+++ b/lib/inspec/utils/deprecation/deprecator.rb
@@ -22,6 +22,13 @@ module Inspec
         send(action_method, group_name.to_sym, assembled_message, group)
       end
 
+      # Given a resource name, suggest a gem nam to load and or install
+      def match_gem_for_fallback_resource_name(resource_name)
+        fallback = fallback_resource_packs.find { |fb| fb.resource_name_regex.match(resource_name) }
+        # We have a message here but can't pass it back?
+        fallback&.gem_name
+      end
+
       private
 
       def create_group_entry_for_unknown_group(group_name)

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/internal_fallback_test_resource.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/internal_fallback_test_resource.rb
@@ -14,7 +14,7 @@ class InternalFallbackTestResource < Inspec.resource(1)
 
   example "
     describe internal_fallback_test_resource do
-      its('custom_method') { should 'be_available' }
+      its('custom_method') { should cmp 'be_available' }
     end
   "
 

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/internal_fallback_test_resource.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/resources/internal_fallback_test_resource.rb
@@ -1,0 +1,28 @@
+# Custom resource based on the InSpec resource DSL
+class InternalFallbackTestResource < Inspec.resource(1)
+  name "internal_fallback_test_resource"
+
+  supports platform: "unix"
+  supports platform: "windows"
+
+  desc "
+    A test resource used to test fallback loading.
+    Fallback loading is when a resource is mentioned
+    without a profile dependency, yet InSpec core is
+    expected to guess the dependency.
+  "
+
+  example "
+    describe internal_fallback_test_resource do
+      its('custom_method') { should 'be_available' }
+    end
+  "
+
+  def initialize
+    # nothing to do
+  end
+
+  def custom_method
+    "be_available"
+  end
+end

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/version.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/version.rb
@@ -3,6 +3,6 @@
 # to learn the current version.
 module InspecPlugins
   module TestResources
-    VERSION = "0.2.0".freeze
+    VERSION = "0.2.1".freeze
   end
 end

--- a/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/version.rb
+++ b/test/fixtures/plugins/inspec-test-resources/lib/inspec-test-resources/version.rb
@@ -3,6 +3,6 @@
 # to learn the current version.
 module InspecPlugins
   module TestResources
-    VERSION = "0.1.0".freeze
+    VERSION = "0.2.0".freeze
   end
 end

--- a/test/fixtures/profiles/fallback-resource-packs/controls/fallback_test.rb
+++ b/test/fixtures/profiles/fallback-resource-packs/controls/fallback_test.rb
@@ -1,0 +1,10 @@
+control "fallback-control" do
+  # This must match the pattern in etc/deprecations.json
+
+  # This is defined in test/fixtures/plugins/inspec-test-resources
+  # and should be dynamically installed by the fallback mechanism
+
+  describe internal_fallback_test_resource do
+    its('custom_method') { should 'be_available' }
+  end
+end

--- a/test/fixtures/profiles/fallback-resource-packs/controls/fallback_test.rb
+++ b/test/fixtures/profiles/fallback-resource-packs/controls/fallback_test.rb
@@ -5,6 +5,6 @@ control "fallback-control" do
   # and should be dynamically installed by the fallback mechanism
 
   describe internal_fallback_test_resource do
-    its('custom_method') { should 'be_available' }
+    its('custom_method') { should cmp 'be_available' }
   end
 end

--- a/test/fixtures/profiles/fallback-resource-packs/inspec.yml
+++ b/test/fixtures/profiles/fallback-resource-packs/inspec.yml
@@ -1,0 +1,10 @@
+name: fallback-resource-packs
+title: InSpec Fallback Test Profile
+maintainer: InSpec Core Maintainers
+copyright: Progress Software Corportation
+copyright_email: inspec@progress.com
+license: Apache-2.0
+summary: A profile that uses an apparently non-existant resource that will trigger fallback resource pack loading in the functional tests.
+version: 0.1.0
+supports:
+  platform: os

--- a/test/functional/fallback_test.rb
+++ b/test/functional/fallback_test.rb
@@ -1,0 +1,50 @@
+require "functional/helper"
+
+describe "profiles with missing resources" do
+  include FunctionalHelper
+  let(:config_dir_path) { File.expand_path "test/fixtures/config_dirs" }
+  let(:ruby_abi_version) { RbConfig::CONFIG["ruby_version"] }
+  let(:ruby_dir) { File.join(config_dir_path, "profile_gems", ".inspec/gems/#{ruby_abi_version}/gems") }
+
+  let(:fallback_profile_path) { File.join(profile_path, "fallback-resource-packs") }
+
+  # let(:profile_with_gem_dependency_without_gem_version) { File.join(profile_path, "profile-without-gem-version") }
+  # let(:illformatted_gem_dependency) { File.join(profile_path, "profile-with-illformed-gem-depedency") }
+  # let(:depdent_profile_gem_dependency) { File.join(profile_path, "profile-with-dependent-gem-dependency") }
+
+  def reset_globals
+    ENV["HOME"] = Dir.home
+  end
+
+  before(:each) do
+    reset_globals
+    ENV["HOME"] = File.join(config_dir_path, "profile_gems")
+  end
+
+  after do
+    reset_globals
+
+    if config_dir_path
+      Dir.glob(File.join(config_dir_path, "profile_gems")).each do |path|
+        next if path.end_with? ".gitkeep"
+
+        FileUtils.rm_rf(path)
+      end
+    end
+  end
+
+  it "installs the gem dependencies and load them if --auto-install-gems is provided." do
+    # TODO - this work if you have a private rubygems server and upload inspec-test-resources to it
+    skip 
+    out = inspec_with_env("exec #{fallback_profile_path} --no-create-lockfile --auto-install-gems")
+
+    _(out.stderr).must_equal ""
+
+    # Indicates that at least one ruby install happened
+    # Want better test - check for actual gem
+    _(File.directory?(ruby_dir)).must_equal true
+
+    assert_exit_code 0, out
+  end
+
+end

--- a/test/unit/utils/deprecation_test.rb
+++ b/test/unit/utils/deprecation_test.rb
@@ -204,6 +204,12 @@ describe "The Deprecator object" do
       it "should report two fallbacks" do
         _(dpcr.fallback_resource_packs.count).must_equal 2
       end
+      it "should suggest the stuff gem for somepat resources" do
+        _(dpcr.match_gem_for_fallback_resource_name("somepat_resource")).must_equal "inspec-stuff-resources"
+      end
+      it "should suggest nil for things it does not know about" do
+        _(dpcr.match_gem_for_fallback_resource_name("unknown_resource")).must_be_nil
+      end
     end
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

When a resource is not found in core, could we do something more to try to obtain the resource?
1. We know how to dynamically install gems.
2. Resource packs are now available as gems
3. If we had a way of mapping resource name patterns to gem names, we could dynamically install resource packs.

This PR uses the Deprecation system to implement a registry of such "fallback" definitions. It then uses the DSL method_missing_resource hook to intercept when resources are detected as missing, and install and load the gem.

**MANUAL TESTING** The included functional test, test/functional/fallback_test.rb, has a skip built in - you need to run a private rubygem server to test it.

**WORK IN PROGRESS** The registry works! The hook works! Installation works! Loading works! Something falls apart in profile evaluation and I can't trace a TypeError.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
