### PR TITLE
BACKPORT: CHEF-12175: Remove use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value (#7079)

### DIFF
--- a/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
+++ b/lib/plugins/inspec-sign/lib/inspec-sign/base.rb
@@ -36,11 +36,15 @@ module InspecPlugins
         FileUtils.mkdir_p(path)
 
         puts "Generating signing key in #{path}/#{options["keyname"]}.pem.key"
-        open "#{path}/#{options["keyname"]}.pem.key", "w" do |io|
+        # https://github.com/inspec/inspec/security/code-scanning/1
+        # https://github.com/inspec/inspec/security/code-scanning/2
+        # The following line was flagged by GitHub code scanning as a security vulnerability.
+        # Update the code to eliminate the vulnerability.
+        File.open("#{path}/#{options["keyname"]}.pem.key", "w") do |io|
           io.write key.to_pem
         end
         puts "Generating validation key in #{path}/#{options["keyname"]}.pem.pub"
-        open "#{path}/#{options["keyname"]}.pem.pub", "w" do |io|
+        File.open("#{path}/#{options["keyname"]}.pem.pub", "w") do |io|
           io.write key.public_key.to_pem
         end
       end
@@ -67,7 +71,8 @@ module InspecPlugins
         # Generating tar.gz file using archive method of Inspec Cli
         Inspec::InspecCLI.new.archive(profile_path, "error")
         tarfile = "#{filename}.tar.gz"
-        tar_content = IO.binread(tarfile)
+        # Update IO.binread with File.binread because of https://github.com/inspec/inspec/security/code-scanning/3
+        tar_content = File.binread(tarfile)
         FileUtils.rm(tarfile)
 
         # Generate the signature
@@ -152,7 +157,7 @@ module InspecPlugins
           ui.exit(:usage_error)
         end
 
-        lines = IO.readlines(p)
+        lines = File.readlines(p)
         lines << "\nprofile_content_id: #{profile_content_id}\n"
 
         File.open("#{p}", "w" ) do |f|


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Backports #7079 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
