### PR TITLE
Allow dev/CI to override the telemetry URL to a staging service

### DIFF
--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -36,6 +36,8 @@ vault version
 echo "--- fetching License serverl url and keys from vault"
 # Note: Currently, the value for the local license server is a static IP address. Please update this to a DNS name when available.
 $Env:CHEF_LICENSE_SERVER=vault kv get -field ci secret/inspec/licensing/server
+# Note: Currently, this returns blank response
+$Env:CHEF_TELEMETRY_URL=vault kv get -field ci secret/inspec/telemetry/server
 
 echo "--- verifying if environment variables are set"
 

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -30,6 +30,8 @@ unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
 echo "--- fetching License serverl url and keys from vault"
 # Note: Currently, the value for the local license server is a static IP address. Please update this to a DNS name when available.
 export CHEF_LICENSE_SERVER=$($VAULT_HOME/vault kv get -field ci secret/inspec/licensing/server)
+# Note: Currently, this returns blank response
+export CHEF_TELEMETRY_URL=$($VAULT_HOME/vault kv get -field ci secret/inspec/telemetry/server)
 
 if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
   echo "--- fetching Sonar token from vault"

--- a/lib/inspec/utils/telemetry/http.rb
+++ b/lib/inspec/utils/telemetry/http.rb
@@ -6,11 +6,8 @@ module Inspec
   class Telemetry
     class HTTP < Base
       TELEMETRY_JOBS_PATH = "v1/job"
-      TELEMETRY_URL = if ChefLicensing::Config.license_server_url&.match?("acceptance")
-                        ENV["CHEF_TELEMETRY_URL"]
-                      else
-                        "https://services.chef.io/telemetry/"
-                      end
+      # Allow dev/CI to override the telemetry URL to a staging service
+      TELEMETRY_URL = ENV["CHEF_TELEMETRY_URL"] || "https://services.chef.io/telemetry/"
       def run_ending(opts)
         payload = super
         response = connection.post(TELEMETRY_JOBS_PATH) do |req|


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Do not hit prod telemetry URL from CI in case of non acceptance environment.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Ability to allow overriding the telemetry URL 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
