### PR TITLE
CHEF-8990 Remove dependency on active-support function `blank?`

### DIFF
--- a/lib/inspec/dependencies/dependency_set.rb
+++ b/lib/inspec/dependencies/dependency_set.rb
@@ -26,7 +26,7 @@ module Inspec
       dep_list = {}
       dependencies.each do |d|
         # if depedent profile does not have a source version then only name is used in dependency hash
-        key_name = (d.source_version.blank? ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
+        key_name = ((d.source_version.nil? || d.source_version.empty?) ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
         dep_list[key_name] = d
       end
       new(cwd, cache, dep_list, backend)
@@ -42,7 +42,7 @@ module Inspec
       dep_list = {}
       dep_tree.each do |d|
         # if depedent profile does not have a source version then only name is used in dependency hash
-        key_name = (d.source_version.blank? ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
+        key_name = ((d.source_version.nil? || d.source_version.empty?) ? "#{d.name}" : "#{d.name}-#{d.source_version}") rescue "#{d.name}"
         dep_list[key_name] = d
         dep_list.merge!(flatten_dep_tree(d.dependencies))
       end

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -86,7 +86,7 @@ module Inspec::DSL
         # 1. Fetching VERSION from a profile dependency name which is in a format NAME-VERSION.
         # 2. Matching original profile dependency name with profile name used with include or require control DSL.
         source_version = value.source_version
-        unless source_version.blank?
+        unless (source_version.nil? || source_version.empty?)
           profile_id_key = key.split("-#{source_version}")[0]
           new_profile_id = key if profile_id_key == profile_id
         end

--- a/lib/inspec/dsl.rb
+++ b/lib/inspec/dsl.rb
@@ -86,7 +86,7 @@ module Inspec::DSL
         # 1. Fetching VERSION from a profile dependency name which is in a format NAME-VERSION.
         # 2. Matching original profile dependency name with profile name used with include or require control DSL.
         source_version = value.source_version
-        unless (source_version.nil? || source_version.empty?)
+        unless source_version.nil? || source_version.empty?
           profile_id_key = key.split("-#{source_version}")[0]
           new_profile_id = key if profile_id_key == profile_id
         end

--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -245,7 +245,7 @@ module Inspec
       ## Find the waivers file
       # - TODO: cli_opts and instance_variable_get could be exposed
       waiver_paths = cfg.instance_variable_get(:@cli_opts)["waiver_file"]
-      if waiver_paths.blank?
+      if waiver_paths.nil? || waiver_paths.empty?
         Inspec::Log.error "Must use --waiver-file with --filter-waived-controls"
         Inspec::UI.new.exit(:usage_error)
       end
@@ -273,7 +273,7 @@ module Inspec
         # be processed and rendered
         tests.each do |control_filename, source_code|
           cleared_tests = source_code.scan(/control\s+['"].+?['"].+?(?=(?:control\s+['"].+?['"])|\z)/m).collect do |element|
-            next if element.blank?
+            next if element.nil? || element.empty?
 
             if element&.match?(waived_control_id_regex)
               splitlines = element.split("\n")

--- a/test/functional/inspec_exec_test.rb
+++ b/test/functional/inspec_exec_test.rb
@@ -1194,7 +1194,7 @@ Test Summary: 2 successful, 0 failures, 0 skipped\n"
       let(:args) { "-t gcp:// --input gcp_project_id=fakeproject" }
       let(:env) { { GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS: 1 } }
       it "should fail to connect to gcp due to lack of creds but not stacktrace" do
-        _(run_result.stderr).must_include "Could not load the default credentials."
+        _(run_result.stderr).must_include "Your credentials were not found."
       end
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -47,6 +47,7 @@ end
 # a clue that something was up--windows is just NOT THAT FAST).
 
 require "minitest/autorun"
+require "ostruct" unless defined?(OpenStruct)
 
 require "rspec/core/dsl"
 module RSpec::Core::DSL


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Remove dependency on active-support function `blank?`
Since active-support is not declared as a dependency for `inspec-core` it breaks the usage of inspec.



## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
