### PR TITLE
ci: trigger hab pipeline only on version bump

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -132,12 +132,12 @@ subscriptions:
          - "Expeditor: Skip Omnibus"
          - "Expeditor: Skip All"
      - trigger_pipeline:artifact/habitat:
-      #   only_if: built_in:bump_version
+        only_if: built_in:bump_version
         ignore_labels:
          - "Expeditor: Skip Habitat"
          - "Expeditor: Skip All"
      - trigger_pipeline:habitat/build:
-      #   only_if: built_in:bump_version
+        only_if: built_in:bump_version
         ignore_labels:
          - "Expeditor: Skip Habitat"
          - "Expeditor: Skip All"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR introduces a condition in the expeditor config for habitat pipelines to be triggered when version is bumped.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
