### PR TITLE
CHEF-15318 ci: fix the pipeline for windows' habitat build.

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -15,12 +15,41 @@ $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
 
 Write-Host "--- Installing the version of Habitat required"
+
+function Stop-HabProcess {
+  $habProcess = Get-Process hab -ErrorAction SilentlyContinue
+  if ($habProcess) {
+      Write-Host "Stopping hab process..."
+      Stop-Process -Name hab -Force
+  }
+}
+
+function Install-Habitat {
+  Write-Host "Downloading and installing Habitat..."
+  Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+}
+
 try {
   hab --version
 }
 catch {
   Set-ExecutionPolicy Bypass -Scope Process -Force
-  Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+
+  Stop-HabProcess
+
+  # Remove the existing hab.exe if it exists and if you have permissions
+  $habPath = "C:\ProgramData\Habitat\hab.exe"
+  if (Test-Path $habPath) {
+      Write-Host "Attempting to remove existing hab.exe..."
+      Remove-Item $habPath -Force -ErrorAction SilentlyContinue
+      if (Test-Path $habPath) {
+          Write-Host "Failed to remove hab.exe, re-running script with elevated permissions."
+          Start-Process powershell -Verb runAs -ArgumentList "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`""
+          exit
+      }
+  }
+
+  Install-Habitat
 }
 finally {
   Write-Host ":habicat: I think I have the version I need to build."


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Currently the pipeline for windows' habitat build. is failing with:
```

Installing the version of Habitat required | 2s
-- | --
  | Installing Habitat 'hab' program
  | Downloading https://packages.chef.io/files/stable/habitat/latest/hab-x86_64-windows.zip
  | Downloading https://packages.chef.io/files/stable/habitat/latest/hab-x86_64-windows.zip.sha256sum
  | Verifying the shasum digest matches the downloaded archive
  | :habicat: I think I have the version I need to build.
  | Remove-Item : Cannot remove item C:\ProgramData\Habitat\hab.exe: Access to the path 'hab.exe' is denied.
  | At line:112 char:30
  | +     if(Test-Path $habPath) { Remove-Item $habPath -Recurse -Force }
  | +                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  | + CategoryInfo          : PermissionDenied: (hab.exe:FileInfo) [Remove-Item], UnauthorizedAccessException
  | + FullyQualifiedErrorId : RemoveFileSystemItemUnAuthorizedAccess,Microsoft.PowerShell.Commands.RemoveItemCommand
  | 🚨 Error: The command exited with status 1


```

Failure build link: https://buildkite.com/chef/inspec-inspec-inspec-5-artifact-habitat/builds/473

This PR fixes the pipeline for windows' habitat build.

Green build with this changes: https://buildkite.com/chef/inspec-inspec-inspec-5-artifact-habitat/builds/474

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
