### PR TITLE
Improvements in error handling of plugin installation error

### DIFF
--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -425,8 +425,10 @@ module InspecPlugins
                  "our apologies for the misunderstanding, and open an issue " \
                  "at https://github.com/inspec/inspec/issues/new")
         ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
-      rescue Inspec::Plugin::V2::InstallError
-        raise if Inspec::Log.level == :debug
+      rescue Inspec::Plugin::V2::InstallError => e
+        # This change is required for Ruby 3.3 upgrade
+        # Using Inspec::Log::level breaks with error `undefined method nil` in Ruby log library
+        Inspec::Log.debug e.backtrace
 
         results = installer.search(plugin_name, exact: true)
         source_host = URI(options[:source] || "https://rubygems.org/").host

--- a/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/lib/inspec-plugin-manager-cli/cli_command.rb
@@ -426,7 +426,7 @@ module InspecPlugins
                  "at https://github.com/inspec/inspec/issues/new")
         ui.exit Inspec::UI::EXIT_PLUGIN_ERROR
       rescue Inspec::Plugin::V2::InstallError => e
-        # This change is required for Ruby 3.3 upgrade
+        # This change is compatible with various versions of Ruby, including Ruby 3.3
         # Using Inspec::Log::level breaks with error `undefined method nil` in Ruby log library
         Inspec::Log.debug e.backtrace
 

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
@@ -343,7 +343,7 @@ class PluginManagerCliInstall < Minitest::Test
 
     assert_includes install_result.stdout, "DEBUG"
 
-    assert_includes install_result.stderr, "can't activate rake"
+    assert_includes install_result.stdout, "Unknown error occurred - installation failed"
 
     assert_exit_code 1, install_result
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Improvements in the error handling of plugin installation errors. This will make code compatible with various versions of Ruby.
This issue was encountered during the Ruby version upgrade process for InSpec.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
