### PR TITLE
Habitat-Based Native RPM Installer

### DIFF
--- a/.expeditor/scripts/build-inspec-rpm.sh
+++ b/.expeditor/scripts/build-inspec-rpm.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 <version> <release>"
+  exit 1
+fi
+
+arch=$(uname -m)
+if [ "$arch" != "x86_64" ]; then
+  echo "Architecture '$arch' is not supported. Only x86_64 is supported."
+  exit 1
+fi
+
+# Read the version and release from the command-line arguments
+VERSION="$1"
+RELEASE="$2"
+
+# Define the base directory for the RPM build environment
+TEMP_DIR=$(mktemp -d)
+
+export HAB_LICENSE="accept-no-persist"
+sudo -E hab pkg export tar chef/inspec/$VERSION/$RELEASE
+
+# Copy build source files to the BUILD directory or untar the tarball
+TARBALL="chef-inspec-$VERSION-$RELEASE.tar.gz"
+
+# Check if tarball exists
+if [ ! -f "$TARBALL" ]; then
+  echo "Tarball $TARBALL not found. Exiting."
+  exit 1
+fi
+
+# Create the directory structure
+BASE_DIR=$TEMP_DIR/rpmbuild
+mkdir -p "$BASE_DIR"/{BUILD,RPMS/x86_64,SOURCES,SPECS,SRPMS}
+
+echo "RPM build directory structure created under $BASE_DIR"
+
+echo "Untarring $TARBALL into $BASE_DIR/BUILD"
+tar -xzf "$TARBALL" -C "$BASE_DIR/BUILD"
+
+.expeditor/scripts/hab-contents.sh "$BASE_DIR/BUILD/hab"
+
+# Concatenate spec and contents into a single spec file
+cat .expeditor/scripts/inspec-hab.spec hab-contents.txt > "$BASE_DIR/SPECS/inspec.spec"
+
+# Replace the VERSION placeholder with the combined $VERSION and $RELEASE
+sed -i "s/%{VERSION}/$VERSION~$RELEASE/" "$BASE_DIR/SPECS/inspec.spec"
+
+# Run the rpmbuild command
+rpmbuild -bb --target $arch --buildroot "$BASE_DIR/BUILD" --define "_topdir $BASE_DIR" "$BASE_DIR/SPECS/inspec.spec"
+
+RPM_PATH=$(find "$BASE_DIR/RPMS/$arch" -type f -name "inspec-${VERSION}~${RELEASE}-*.${arch}.rpm" | head -n 1)
+
+echo $RPM_PATH
+
+# Check if the RPM was created
+if [ -f "$RPM_PATH" ]; then
+  echo "RPM created successfully: $RPM_PATH"
+  cp "$RPM_PATH" .  # Copy the RPM to the current directory
+  echo "RPM copied to current directory."
+else
+  echo "RPM creation failed or the RPM is not located in the expected directory."
+fi
+
+# Delete the temporary directory after build
+rm -rf "$TEMP_DIR"

--- a/.expeditor/scripts/hab-contents.sh
+++ b/.expeditor/scripts/hab-contents.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <hab-content-dir>"
+  exit 1
+fi
+
+# Base directory to iterate over
+base_dir="$1"
+
+# Expand user directory if present
+base_dir=$(eval echo "$base_dir")
+
+# Convert relative paths to absolute paths
+base_dir=$(realpath "$base_dir")
+parent_dir=$(dirname "$base_dir")
+
+# Output file to store the RPM %files entries
+output_file="hab-contents.txt"
+
+# Clear the output file
+> "$output_file"
+
+content=""
+
+# Function to iterate over the directory recursively
+iterate_directory() {
+    local dir_path="$1"
+    # Check if we are at the top-level directory
+    if [ "$dir_path" != "$base_dir" ]; then
+	local hab_path="${dir_path#"$parent_dir"}"
+        content+="%dir ${hab_path}\n"
+    fi
+
+    for entry in "$dir_path"/.* "$dir_path"/*; do
+        # Skip current and parent directory entries
+        if [ "$entry" == "$dir_path/." ] || [ "$entry" == "$dir_path/.." ]; then
+            continue
+        fi
+        if [ -L "$entry" ]; then
+            # Handle symbolic links
+	    local hab_path="${entry#"$parent_dir"}"
+            content+="${hab_path}\n"
+        elif [ -d "$entry" ]; then
+            # Recursively process directories
+            iterate_directory "$entry"
+        elif [ -f "$entry" ]; then
+            # Record regular files
+	    local hab_path="${entry#"$parent_dir"}"
+            content+="${hab_path}\n"
+        fi
+    done
+}
+
+# Start the recursion from the base directory
+iterate_directory "$base_dir"
+
+# Write accumulated content to the output file
+echo -e "$content" | sudo tee -a "$output_file" > /dev/null
+

--- a/.expeditor/scripts/inspec-hab.spec
+++ b/.expeditor/scripts/inspec-hab.spec
@@ -1,0 +1,183 @@
+# Disable any shell actions, replace them with simply 'true'
+%define __spec_prep_post true
+%define __spec_prep_pre true
+%define __spec_build_post true
+%define __spec_build_pre true
+%define __spec_install_post true
+%define __spec_install_pre true
+%define __spec_clean_post true
+%define __spec_clean_pre true
+
+# Use SHA256 checksums for all files
+%define _binary_filedigest_algorithm 8
+
+%define _binary_payload w1.xzdio
+
+# Disable creation of build-id links
+%define _build_id_links none
+
+# Metadata
+Name: inspec
+Version: %{VERSION}
+Release: 1%{?dist}
+Summary:  The full stack of inspec
+AutoReqProv: no
+BuildRoot: %buildroot
+Prefix: /
+Group: default
+License: Chef EULA
+Vendor: Omnibus <omnibus@getchef.com>
+URL: https://www.chef.io
+Packager: Chef Software, Inc. <maintainers@chef.io>
+%description
+The full stack of inspec
+
+%prep
+# noop
+
+%build
+# noop
+
+%install
+# noop
+
+%clean
+# noop
+
+%pre
+#!/bin/sh
+#
+# Perform necessary inspec setup steps
+# before package is installed.
+#
+
+echo "You're about to install InSpec!"
+
+%post
+#!/bin/sh
+#
+# Perform necessary inspec setup steps
+# after package is installed.
+#
+
+# Create wrapper binaries into /hab/chef directory
+mkdir -p /hab/inspec/bin
+
+binaries=("inspec")
+for binary in "${binaries[@]}"; do
+  cat << EOF > /hab/inspec/bin/$binary
+#!/bin/sh
+hab pkg exec chef/inspec $binary -- "\$@"
+EOF
+  chmod +x /hab/inspec/bin/$binary
+done
+
+PROGNAME=`basename $0`
+INSTALLER_DIR=/hab/inspec
+CONFIG_DIR=/etc/inspec
+USAGE="usage: $0"
+
+error_exit()
+{
+  echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
+  exit 1
+}
+
+is_darwin()
+{
+  uname -a | grep "^Darwin" 2>&1 >/dev/null
+}
+
+if is_darwin; then
+    PREFIX="/usr/local"
+    mkdir -p "$PREFIX/bin"
+else
+    PREFIX="/usr"
+fi
+
+binaries="inspec"
+for binary in $binaries; do
+  rm -f $PREFIX/bin/$binary
+done
+
+for binary in $binaries; do
+  ln -sf $INSTALLER_DIR/bin/$binary $PREFIX/bin || error_exit "Cannot link $binary to $PREFIX/bin"
+done
+
+# Ensure all files/directories in $INSTALLER_DIR are owned by root. This
+# has been fixed on new installs but upgrades from old installs need to
+# be manually fixed.
+chown -Rh 0:0 $INSTALLER_DIR
+
+echo "Thank you for installing Chef InSpec!"
+
+exit 0
+
+%preun
+#!/bin/sh
+#
+# Perform necessary inspec setup steps
+# prior to installing package.
+#
+
+PROGNAME=`basename $0`
+
+error_exit()
+{
+  echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
+  exit 1
+}
+
+exit 0
+
+%postun
+#!/bin/sh
+#
+# Perform necessary inspec removal steps
+# after package is uninstalled.
+#
+
+is_darwin()
+{
+  uname -a | grep "^Darwin" 2>&1 >/dev/null
+}
+
+if is_darwin; then
+    PREFIX="/usr/local"
+else
+    PREFIX="/usr"
+fi
+
+cleanup_symlinks() {
+  binaries="inspec"
+  for binary in $binaries; do
+    rm -f $PREFIX/bin/$binary
+  done
+}
+
+# Clean up binary symlinks if they exist
+# see: http://tickets.opscode.com/browse/CHEF-3022
+if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release ]; then
+  # not a redhat-ish RPM-based system
+  cleanup_symlinks
+elif [ "x$1" = "x0" ]; then
+  # RPM-based system and we're deinstalling rather than upgrading
+  cleanup_symlinks
+fi
+
+# Clean the /hab/inspec directory created with wrappers
+rm -rf /hab/inspec || true
+
+# Remove /hab if it is empty after this RPM is uninstalled
+if [ -d /hab ] && [ -z "$(ls -A /hab)" ]; then
+  rmdir /hab
+fi
+
+echo "Chef InSpec has been uninstalled!"
+
+exit 0
+
+
+%files
+%defattr(-,root,root,-)
+%dir %attr(0755,root,root) /hab


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This PR is to open up a discussion about building a Habitat-based native installer for the Chef Inspec.

**Note:** The script used to build the RPM in this PR downloads and builds the RPM for the specified version/release. The Habitat package for Chef Inspec is built and uploaded by the `habitat-buildkite-plugin`. We need to modify this script to capture the Habitat artifact for the Chef Inspec that is built and uploaded, and then prepare the RPM from that artifact.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Before you proceed, ensure that the environment is set up using Amazon Linux 2023, and run the commands below to configure it

**Install RPM Development Tools**
sudo dnf install -y rpmdevtools rpmlint

**Install Chef Habitat**
curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash

Run the command below to prepare the RPM:
`./.expeditor/scripts/build-inspec-rpm.sh 7.0.0 20240905110645`

You can choose a different version/release from the Habitat Builder (https://bldr.habitat.sh/#/pkgs/chef/inspec/latest).

Install the RPM using the following command:
`sudo dnf install inspec-7.0.0~20240905110645-1.amzn2023.x86_64.rpm`

Check the Chef Inspec version using the following command
`inspec --version`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://chefio.atlassian.net/browse/CHEF-15073

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
