### PR TITLE
CHEF-12879 Test kitchen integration with InSpec 6

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -168,8 +168,10 @@ module Inspec
     end
 
     def run(with = nil)
+      product_dist_name = Inspec::Dist::PRODUCT_NAME
       if Inspec::Dist::EXEC_NAME == "inspec"
         if Inspec::Telemetry::RunContextProbe.guess_run_context == "test-kitchen"
+          product_dist_name = "Chef Workstation"
           configure_licensing_config_for_kitchen(@conf)
           # Persist the license key in file when passed via test-kitchen
           ChefLicensing.fetch_and_persist if @conf[:chef_license_key]
@@ -191,10 +193,10 @@ module Inspec
       load
       run_tests(with)
     rescue ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError
-      Inspec::Log.error "#{Inspec::Dist::PRODUCT_NAME} cannot execute without valid licenses."
+      Inspec::Log.error "#{product_dist_name} cannot execute without valid licenses."
       Inspec::UI.new.exit(:license_not_set)
     rescue ChefLicensing::SoftwareNotEntitled
-      Inspec::Log.error "License is not entitled to use InSpec."
+      Inspec::Log.error "License is not entitled to use #{product_dist_name}."
       Inspec::UI.new.exit(:license_not_entitled)
     rescue ChefLicensing::Error => e
       Inspec::Log.error e.message

--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -168,7 +168,12 @@ module Inspec
     end
 
     def run(with = nil)
-      ChefLicensing.check_software_entitlement! if Inspec::Dist::EXEC_NAME == "inspec"
+      if Inspec::Dist::EXEC_NAME == "inspec"
+        if Inspec::Telemetry::RunContextProbe.guess_run_context == "test-kitchen"
+          configure_licensing_config_for_kitchen(@conf)
+        end
+        ChefLicensing.check_software_entitlement!
+      end
 
       # Validate if profiles are signed and verified
       # Additional check is required to provide error message in case of inspec exec command (exec command can use multiple profiles as well)

--- a/lib/inspec/utils/licensing_config.rb
+++ b/lib/inspec/utils/licensing_config.rb
@@ -15,8 +15,7 @@ def configure_licensing_config_for_kitchen(opts = {})
     # Reset Chef License server via kitchen when passed in kitchen.yml
     opts["chef_license_server"] = opts["chef_license_server"].join(",") if opts["chef_license_server"].is_a? Array
     unless opts["chef_license_server"].nil? || opts["chef_license_server"].empty?
-      config.license_server_url_check_in_file = true
-      config.license_server_url = opts["chef_license_server"]
+      ENV["CHEF_LICENSE_SERVER"] = opts["chef_license_server"]
     end
   end
   # Reset Chef License key via kitchen when passed in kitchen.yml

--- a/lib/inspec/utils/licensing_config.rb
+++ b/lib/inspec/utils/licensing_config.rb
@@ -7,3 +7,18 @@ ChefLicensing.configure do |config|
   config.license_server_url = "https://services.chef.io/licensing"
   config.logger = Inspec::Log
 end
+
+def configure_licensing_config_for_kitchen(opts = {})
+  ChefLicensing.configure do |config|
+    # Reset entitlement ID to the ID of Chef Workstation
+    config.chef_entitlement_id = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
+    # Reset Chef License server via kitchen when passed in kitchen.yml
+    opts["chef_license_server"] = opts["chef_license_server"].join(",") if opts["chef_license_server"].is_a? Array
+    unless opts["chef_license_server"].nil? || opts["chef_license_server"].empty?
+      config.license_server_url_check_in_file = true
+      config.license_server_url = opts["chef_license_server"]
+    end
+  end
+  # Reset Chef License key via kitchen when passed in kitchen.yml
+  ENV["CHEF_LICENSE_KEY"] = opts["chef_license_key"] if opts["chef_license_key"]
+end

--- a/lib/inspec/utils/telemetry.rb
+++ b/lib/inspec/utils/telemetry.rb
@@ -18,10 +18,12 @@ module Inspec
       # Don't perform telemetry action for other InSpec distros
       # Don't perform telemetry action if running under Automate - Automate does LDC tracking for us
       # Don't perform telemetry action if license is a commercial license
+      # Don't perform telemetry action if running under Test Kitchen
 
       if Inspec::Dist::EXEC_NAME != "inspec" ||
           Inspec::Telemetry::RunContextProbe.under_automate? ||
-          license&.license_type&.downcase == "commercial"
+          license&.license_type&.downcase == "commercial" ||
+          Inspec::Telemetry::RunContextProbe.guess_run_context == "test-kitchen"
 
         Inspec::Log.debug "Determined telemetry operation is not applicable and hence aborting it."
         return Inspec::Telemetry::Null


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Disable license usage telemetry when running under Test Kitchen
- Reset chef entitlement ID to the entitlement ID of the Chef workstation when running under Test Kitchen
- Enable the ability to set chef_license_key using Kitchen
- Enable the ability to set chef_license_server using Kitchen

Via Kitchen **kitchen.yaml**
To configure verifier block with `chef_license_key` :
```
verifier:
  name: inspec
  chef_license_key: LICENSE_KEY
```

To configure verifier block with `chef_license_server` :

**Multiple URLS**
```
verifier:
  name: inspec
  chef_license_key: LICENSE_KEY
  chef_license_server:
    - https://test-url-1
    - https://test-url-2
```
Or

**Single URL**
```
verifier:
  name: inspec
  chef_license_key: LICENSE_KEY
  chef_license_server: https://test-url-1
```


**BEFOR RELEASE:**
- Need these changes released https://github.com/chef/chef-licensing/pull/194 for better error messaging.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
