### PR TITLE
ci: update digi cert token for windows platforms

### DIFF
--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -75,7 +75,7 @@ package :msi do
   fast_msi true
   upgrade_code "DFCD452F-31E5-4236-ACD1-253F4720250B"
   wix_light_extension "WixUtilExtension"
-  signing_identity "769E6AF679126F184850AAC7C5C823A80DB3ADAA", machine_store: false, keypair_alias: "key_495941360"
+  signing_identity "7D16AE73AB249D473362E9332D029089DBBB89B2", machine_store: false, keypair_alias: "key_875762014"
 end
 
 exclude "**/.git"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR updates the digi cert token for windows platform. Without the updated token the windows build is currently failing with the below issue:

```

Checking that C:\builds\pkg/inspec-6.8.9-20240927112801-1-x64.msi has been signed. | 1s
-- | --
  | Exiting with an error because C:\builds\pkg/inspec-6.8.9-20240927112801-1-x64.msi has not been signed. Check your omnibus project config.
  | 1
  | At C:\builds\.omnibus-buildkite-plugin\test.ps1:42 char:3
  | +   Throw 1
  | +   ~~~~~~~
  | + CategoryInfo          : OperationStopped: (1:Int32) [], RuntimeException
  | + FullyQualifiedErrorId : 1
  |  
  | 🚨 Error: The command exited with status 1

```

Build failure link: [omnibus-adhoc-622](https://buildkite.com/chef/inspec-inspec-main-omnibus-adhoc/builds/622#0192333c-e456-4f79-9193-0e91891bf6cf)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
