### PR TITLE
CHEF-14729 Habitat LTS channel support 

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -8,6 +8,7 @@ $ErrorActionPreference = 'Stop'
 $env:HAB_ORIGIN = 'ci'
 $env:CHEF_LICENSE = 'accept-no-persist'
 $env:HAB_LICENSE = 'accept-no-persist'
+$env:HAB_BLDR_CHANNEL = 'LTS-2024'
 $Plan = 'inspec'
 
 Write-Host "--- system details"

--- a/.expeditor/buildkite/artifact.habitat.test.sh
+++ b/.expeditor/buildkite/artifact.habitat.test.sh
@@ -31,6 +31,7 @@ echo "The value for project_root is: $project_root"
 export HAB_NONINTERACTIVE=true
 export HAB_NOCOLORING=true
 export HAB_STUDIO_SECRET_HAB_NONINTERACTIVE=true
+export HAB_BLDR_CHANNEL='LTS-2024'
 
 echo "--- system details"
 uname -a

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -12,6 +12,7 @@ pkg_deps=(
   core/git
   core/ruby3_1
   core/bash
+  core/cacerts
 )
 pkg_build_deps=(
   core/gcc
@@ -27,6 +28,9 @@ do_setup_environment() {
 
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
+
+  build_line "Setting SSL_CA_CERT_FILE path=$(pkg_path_for cacerts)/ssl/cert.pem"
+  export SSL_CERT_FILE="$(pkg_path_for cacerts)/ssl/cert.pem"
 }
 
 do_unpack() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -10,7 +10,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/coreutils
   core/git
-  core/ruby31
+  core/ruby3_1
   core/bash
 )
 pkg_build_deps=(
@@ -80,7 +80,7 @@ export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
 
-exec $(pkg_path_for core/ruby31)/bin/ruby $real_bin \$@
+exec $(pkg_path_for core/ruby3_1)/bin/ruby $real_bin \$@
 EOF
   chmod -v 755 "$bin"
 }

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -12,7 +12,6 @@ pkg_deps=(
   core/git
   core/ruby3_1
   core/bash
-  core/cacerts
 )
 pkg_build_deps=(
   core/gcc
@@ -28,9 +27,6 @@ do_setup_environment() {
 
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
-
-  build_line "Setting SSL_CA_CERT_FILE path=$(pkg_path_for cacerts)/ssl/cert.pem"
-  export SSL_CERT_FILE="$(pkg_path_for cacerts)/ssl/cert.pem"
 }
 
 do_unpack() {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Habitat LTS channel support 
- To start using the LTS channel for hab packages. Requires updating channel name in the plan file.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
