### PR TITLE
CHEF-16514 remove redundant plugin activation

### DIFF
--- a/lib/inspec/runner.rb
+++ b/lib/inspec/runner.rb
@@ -116,7 +116,6 @@ module Inspec
 
         write_lockfile(profile) if @create_lockfile
         # TODO: InSpec 8: Replace with Profile OnLoad event handling
-        profile.activate_plugin_if_gem_based
         profile.locked_dependencies # Only need to do this once, this recurses down
         profile.load_gem_dependencies
         profile_context = profile.load_libraries
@@ -128,7 +127,6 @@ module Inspec
             next
           end
           # TODO: InSpec 8: Replace with Profile OnLoad event handling
-          requirement.profile.activate_plugin_if_gem_based
           requirement.profile.load_gem_dependencies
           requirement.profile.load_libraries
           @test_collector.add_profile(requirement.profile)


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

With new plugin activation hook changes, we get the following error
`Plugin hooks search returned zero results for filter {:plugin_name=>:"inspec-elasticsearch-resources"}`

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Removing this redundant hook activation to avoid this error.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
