### PR TITLE
chore: disable habitat package promotion in config

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -163,7 +163,7 @@ subscriptions:
      - built_in:rollover_changelog
      - built_in:publish_rubygems
      - built_in:create_github_release
-     - built_in:promote_habitat_packages
+     # - built_in:promote_habitat_packages # disable habitat package promotion
      - bash:.expeditor/publish-release-notes.sh:
         post_commit: true
      - purge_packages_chef_io_fastly:{{target_channel}}/inspec/latest:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR comments out the `promote_habitat_packages` configuration to disable promotion of Habitat packages temporarily.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
