### PR TITLE
Improved regex to load readme from inspec profiles

### DIFF
--- a/lib/source_readers/inspec.rb
+++ b/lib/source_readers/inspec.rb
@@ -66,7 +66,7 @@ module SourceReaders
     end
 
     def load_readme
-      load_all(/README.md/)
+      load_all(/README(\.md)?$/)
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Improved regex to load readme from inspec profiles. It was unable to load readme files without `.md` extensions in the file.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
