### PR TITLE
CHEF-15651: Introduce `--legacy` flag for compatibility in `inspec automate upload` with legacy checks and export options

### DIFF
--- a/lib/plugins/inspec-compliance/README.md
+++ b/lib/plugins/inspec-compliance/README.md
@@ -14,8 +14,18 @@ To use the CLI, this InSpec add-on adds the following commands:
  * `$ inspec automate profiles` - list all available Compliance profiles
  * `$ inspec exec compliance://profile` - runs a Compliance profile
  * `$ inspec automate upload path/to/local/profile` - uploads a local profile to Chef Automate/Chef Compliance
+ * `$ inspec automate upload path/to/local/profile --legacy` - uploads a local profile to Chef Automate/Chef Compliance using legacy functionalities of inspec check and inspec export
+
+    *Options*:
+    ```
+      [--overwrite], [--no-overwrite]  # Overwrite existing profile on Server.
+      [--owner=OWNER]                  # Owner that should own the profile
+      [--legacy], [--no-legacy]        # Enable legacy functionality, activating both legacy export and legacy check.
+
+    uploads a local profile to Chef Automate
+    ```
  * `$ inspec automate logout` - logout of Chef Automate/Chef Compliance
- 
+
  Similar to these CLI commands are:
 
  * `$ inspec compliance login` - authentication of the API token against Chef Automate/Chef Compliance

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
@@ -136,6 +136,8 @@ module InspecPlugins
         desc: "Overwrite existing profile on Server."
       option :owner, type: :string, required: false,
         desc: "Owner that should own the profile"
+      option :legacy, type: :boolean, default: false,
+        desc: "Enable legacy functionality, activating both legacy export and legacy check."
       def upload(path) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
         Inspec.with_feature("inspec-cli-compliance-upload") {
           config = InspecPlugins::Compliance::Configuration.new
@@ -169,7 +171,7 @@ module InspecPlugins
             puts msg
           }
 
-          result = profile.check
+          result = options["legacy"] ? profile.legacy_check : profile.check
           unless result[:summary][:valid]
             error.call("Profile check failed. Please fix the profile before upload.")
           else
@@ -205,7 +207,7 @@ module InspecPlugins
             generated = true
             archive_path = Dir::Tmpname.create([profile_name, ".tar.gz"]) {}
             puts "Generate temporary profile archive at #{archive_path}"
-            profile.archive({ output: archive_path, ignore_errors: false, overwrite: true })
+            profile.archive({ output: archive_path, ignore_errors: false, overwrite: true, legacy_export: options["legacy"] })
           else
             archive_path = path
           end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR introduces a `--legacy` flag for the `inspec automate upload` command, enabling legacy export and check functions for compatibility with prior (to #6816) behavior during the upload process.

This option is essential for cases where the newer `export` and `check` methods may fail to parse older profiles correctly, particularly due to limitations in AST parsing.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
[CHEF-15651: If inspec profile code includes "=begin =end", inspec check consistently returns error when running "inspec check" command from workstation](https://progresssoftware.atlassian.net/browse/CHEF-15651)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
