### PR TITLE
Fix license server URL override issue by prioritizing environment-set value

### DIFF
--- a/lib/inspec/utils/licensing_config.rb
+++ b/lib/inspec/utils/licensing_config.rb
@@ -4,7 +4,7 @@ ChefLicensing.configure do |config|
   config.chef_product_name = "InSpec"
   config.chef_entitlement_id = "3ff52c37-e41f-4f6c-ad4d-365192205968"
   config.chef_executable_name = "inspec"
-  config.license_server_url = "https://services.chef.io/licensing"
+  config.license_server_url = ENV["CHEF_LICENSE_SERVER"] || "https://services.chef.io/licensing"
   config.logger = Inspec::Log
 end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR modifies the licensing configuration to prioritize the license server URL set in the CHEF_LICENSE_SERVER environment variable over the default. 

This ensures compatibility with setups that define a specific licensing server, addressing issues where lazy loading or other internal processes were resetting licensing configuration to default values.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
[CHEF-16786: Upgrade Infra 19 to use InSpec 6 and resolve build or pipeline issues, if any](https://progresssoftware.atlassian.net/browse/CHEF-16786) — Encountered this issue during the Infra 19 upgrade to InSpec 6.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
