### PR TITLE
Pin zeitwerk gem to ~> 2.6 to avoid Ruby >= 3.2 requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,3 +49,14 @@ end
 group :deploy do
   gem "inquirer"
 end
+
+# Build is failing - see: https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/442
+# Error:
+# zeitwerk-2.7.1 requires Ruby >= 3.2, which is incompatible with the current version (Ruby 3.0.7p220)
+
+# Dependency chain:
+# zeitwerk → dry-configurable, dry-struct, dry-types → k8s-ruby → train-kubernetes
+
+# Pinning zeitwerk to ~> 2.6 to avoid Ruby >= 3.2 requirement.
+# Remove this pin when upgrading to Ruby 3.2 or higher.
+gem "zeitwerk", "~> 2.6.0", "< 2.7"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR pins the zeitwerk gem to version ~> 2.6, as zeitwerk versions >= 2.7 require Ruby 3.2 or higher.

The pin will be removed once the project is upgraded to Ruby 3.2 or higher.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/442

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
