### PR TITLE
CHEF-16631 Implement fallback logic when gem caching is manually deleted

### DIFF
--- a/lib/inspec/base_cli.rb
+++ b/lib/inspec/base_cli.rb
@@ -389,6 +389,9 @@ module Inspec
       when Inspec::InvalidProfileSignature
         $stderr.puts exception.message
         Inspec::UI.new.exit(:bad_signature)
+      when Inspec::Exceptions::GemDependencyNotFound
+        $stderr.puts exception.message
+        Inspec::UI.new.exit(:gem_dependency_not_found)
       when Inspec::Error
         $stderr.puts exception.message
         exit(1)

--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -57,12 +57,12 @@ module Inspec
           [cache_value, false]
         else
           Inspec::Log.debug "Dependency does not exist in the cache for target #{target}"
-          cache_key_name = fetcher.cache_key
+          cache_key_name = cache_key
           if cache_key_name.start_with?("gem:")
             # When cache for gem - meaning gemspec exists but gem does not exists then clearing up gemspec is required
             # This logic enables the gem fetcher logic to work step by step again
             Inspec::Log.debug "Clearing cached gemspec to fix dependency issue and enable fresh download."
-            FileUtils.rm_rf(cache.gemspec_path_for(fetcher.cache_key))
+            FileUtils.rm_rf(cache.gemspec_path_for(cache_key))
           end
         end
       else

--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -57,6 +57,13 @@ module Inspec
           [cache_value, false]
         else
           Inspec::Log.debug "Dependency does not exist in the cache for target #{target}"
+          cache_key_name = fetcher.cache_key
+          if cache_key_name.start_with?("gem:")
+            # When cache for gem - meaning gemspec exists but gem does not exists then clearing up gemspec is required
+            # This logic enables the gem fetcher logic to work step by step again
+            Inspec::Log.debug "Clearing cached gemspec to fix dependency issue and enable fresh download."
+            FileUtils.rm_rf(cache.gemspec_path_for(fetcher.cache_key))
+          end
         end
       else
         begin

--- a/lib/inspec/cached_fetcher.rb
+++ b/lib/inspec/cached_fetcher.rb
@@ -52,7 +52,12 @@ module Inspec
         fetch
       elsif cache.exists?(cache_key) && !cache.locked?(cache_key)
         Inspec::Log.debug "Using cached dependency for #{target}"
-        [cache.prefered_entry_for(cache_key), false]
+        cache_value = cache.prefered_entry_for(cache_key)
+        if cache_value
+          [cache_value, false]
+        else
+          Inspec::Log.debug "Dependency does not exist in the cache for target #{target}"
+        end
       else
         begin
           Inspec::Log.debug "Dependency does not exist in the cache #{target}"

--- a/lib/inspec/dependencies/cache.rb
+++ b/lib/inspec/dependencies/cache.rb
@@ -107,6 +107,14 @@ module Inspec
       end
     end
 
+    def gemspec_path_for(key)
+      if key.start_with?("gem:")
+        (_, gem_name, version) = key.split(":")
+        loader = Inspec::Plugin::V2::Loader.new
+        loader.find_gemspec_directory(gem_name, version)
+      end
+    end
+
     #
     # For given cache key, return true if the
     # cache path is locked

--- a/lib/inspec/exceptions.rb
+++ b/lib/inspec/exceptions.rb
@@ -7,6 +7,7 @@ module Inspec
     class ProfileLoadFailed < StandardError; end
     class ResourceFailed < StandardError; end
     class ResourceSkipped < StandardError; end
+    class GemDependencyNotFound < StandardError; end
     class SecretsBackendNotFound < ArgumentError; end
     class ProfileValidationKeyNotFound < ArgumentError; end
     class ProfileSigningKeyNotFound < ArgumentError; end

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -119,12 +119,12 @@ module Inspec
         # Look up where the gem is installed, respecting version
         loader = Inspec::Plugin::V2::Loader.new
         gem_path = loader.find_gem_directory(gem_name, gem_version)
-        if File.exist?(gem_path)
+        if gem_path && File.exist?(gem_path)
           gem = DirProvider.new(gem_path)
           @files = gem.files
           gem
         else
-          raise "Dependency does not exist #{gem_name}"
+          raise Inspec::Exceptions::GemDependencyNotFound, "Dependency does not exist #{gem_name}"
         end
       end
     end

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -7,31 +7,28 @@ require "inspec/iaf_file"
 module Inspec
   class FileProvider
     def self.for_path(path)
-      if path
-        if path.is_a?(Hash) && !path.key?(:gem)
-          MockProvider.new(path)
-        elsif path.is_a?(Hash) && path.key?(:gem)
-          GemProvider.new(path)
-        elsif File.directory?(path)
-          DirProvider.new(path)
-        elsif File.exist?(path) && path.end_with?(".tar.gz", "tgz")
-          TarProvider.new(path)
-        elsif File.exist?(path) && path.end_with?(".zip")
-          ZipProvider.new(path)
-        elsif File.exist?(path) && path.end_with?(".iaf")
-          iaf_file = IafFile.new(path)
-          if iaf_file.valid?
-            IafProvider.new(path)
-          else
-            raise Inspec::InvalidProfileSignature, "Profile signature is invalid."
-          end
-        elsif File.exist?(path)
-          DirProvider.new(path)
+      raise "Profile or dependency path not resolved." if path.nil?
+      if path.is_a?(Hash) && !path.key?(:gem)
+        MockProvider.new(path)
+      elsif path.is_a?(Hash) && path.key?(:gem)
+        GemProvider.new(path)
+      elsif File.directory?(path)
+        DirProvider.new(path)
+      elsif File.exist?(path) && path.end_with?(".tar.gz", "tgz")
+        TarProvider.new(path)
+      elsif File.exist?(path) && path.end_with?(".zip")
+        ZipProvider.new(path)
+      elsif File.exist?(path) && path.end_with?(".iaf")
+        iaf_file = IafFile.new(path)
+        if iaf_file.valid?
+          IafProvider.new(path)
         else
-          raise "No file provider for the provided path: #{path}"
+          raise Inspec::InvalidProfileSignature, "Profile signature is invalid."
         end
+      elsif File.exist?(path)
+        DirProvider.new(path)
       else
-        raise "Profile or dependency path not resolved."
+        raise "No file provider for the provided path: #{path}"
       end
     end
 

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -8,6 +8,7 @@ module Inspec
   class FileProvider
     def self.for_path(path)
       raise "Profile or dependency path not resolved." if path.nil?
+
       if path.is_a?(Hash) && !path.key?(:gem)
         MockProvider.new(path)
       elsif path.is_a?(Hash) && path.key?(:gem)

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -7,27 +7,31 @@ require "inspec/iaf_file"
 module Inspec
   class FileProvider
     def self.for_path(path)
-      if path.is_a?(Hash) && !path.key?(:gem)
-        MockProvider.new(path)
-      elsif path.is_a?(Hash) && path.key?(:gem)
-        GemProvider.new(path)
-      elsif File.directory?(path)
-        DirProvider.new(path)
-      elsif File.exist?(path) && path.end_with?(".tar.gz", "tgz")
-        TarProvider.new(path)
-      elsif File.exist?(path) && path.end_with?(".zip")
-        ZipProvider.new(path)
-      elsif File.exist?(path) && path.end_with?(".iaf")
-        iaf_file = IafFile.new(path)
-        if iaf_file.valid?
-          IafProvider.new(path)
+      if path
+        if path.is_a?(Hash) && !path.key?(:gem)
+          MockProvider.new(path)
+        elsif path.is_a?(Hash) && path.key?(:gem)
+          GemProvider.new(path)
+        elsif File.directory?(path)
+          DirProvider.new(path)
+        elsif File.exist?(path) && path.end_with?(".tar.gz", "tgz")
+          TarProvider.new(path)
+        elsif File.exist?(path) && path.end_with?(".zip")
+          ZipProvider.new(path)
+        elsif File.exist?(path) && path.end_with?(".iaf")
+          iaf_file = IafFile.new(path)
+          if iaf_file.valid?
+            IafProvider.new(path)
+          else
+            raise Inspec::InvalidProfileSignature, "Profile signature is invalid."
+          end
+        elsif File.exist?(path)
+          DirProvider.new(path)
         else
-          raise Inspec::InvalidProfileSignature, "Profile signature is invalid."
+          raise "No file provider for the provided path: #{path}"
         end
-      elsif File.exist?(path)
-        DirProvider.new(path)
       else
-        raise "No file provider for the provided path: #{path}"
+        raise "Profile or dependency path not resolved."
       end
     end
 

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -171,16 +171,11 @@ module Inspec::Plugin::V2
     end
 
     def self.find_gemspec_directory(gem_name, version = nil)
-      matching_gem_versions = list_managed_gems.filter { |g| g.name == gem_name }.sort(&:version)
-      selected_gemspec = nil
-      if version
-        selected_gemspec = matching_gem_versions.find { |g| g.version == version }
-      else
-        # Use latest
-        selected_gemspec = matching_gem_versions.last
-      end
-
-      selected_gemspec && selected_gemspec.loaded_from
+      selected_gemspec = list_managed_gems
+                          .select { |g| g.name == gem_name }
+                          .sort_by(&:version)
+                          .yield_self { |gems| version ? gems.find { |g| g.version == version } : gems.last }
+      selected_gemspec&.loaded_from
     end
 
     def find_gemspec_directory(gem_name, version = nil)

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -170,6 +170,23 @@ module Inspec::Plugin::V2
       selected_gemspec && selected_gemspec.full_gem_path
     end
 
+    def self.find_gemspec_directory(gem_name, version = nil)
+      matching_gem_versions = list_managed_gems.filter { |g| g.name == gem_name }.sort(&:version)
+      selected_gemspec = nil
+      if version
+        selected_gemspec = matching_gem_versions.find { |g| g.version == version }
+      else
+        # Use latest
+        selected_gemspec = matching_gem_versions.last
+      end
+
+      selected_gemspec && selected_gemspec.loaded_from
+    end
+
+    def find_gemspec_directory(gem_name, version = nil)
+      self.class.find_gemspec_directory(gem_name, version)
+    end
+
     def find_gem_directory(gem_name, version = nil)
       self.class.find_gem_directory(gem_name, version)
     end

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -172,9 +172,9 @@ module Inspec::Plugin::V2
 
     def self.find_gemspec_directory(gem_name, version = nil)
       selected_gemspec = list_managed_gems
-                          .select { |g| g.name == gem_name }
-                          .sort_by(&:version)
-                          .yield_self { |gems| version ? gems.find { |g| g.version == version } : gems.last }
+        .select { |g| g.name == gem_name }
+        .sort_by(&:version)
+        .yield_self { |gems| version ? gems.find { |g| g.version == version } : gems.last }
       selected_gemspec&.loaded_from
     end
 

--- a/lib/inspec/ui.rb
+++ b/lib/inspec/ui.rb
@@ -39,6 +39,7 @@ module Inspec
     EXIT_FAILED_TESTS = 100
     EXIT_SKIPPED_TESTS = 101
     EXIT_TERMINATED_BY_CTL_C = 130
+    EXIT_GEM_DEPENDENCY_NOT_FOUND = 201
 
     attr_reader :io
 

--- a/test/unit/file_provider_test.rb
+++ b/test/unit/file_provider_test.rb
@@ -295,3 +295,14 @@ describe Inspec::RelativeFileProvider do
   end
 
 end
+
+describe Inspec::GemProvider do
+  let(:gem_info) { { gem: "test-dummy-gem" } }
+  let(:subject) { Inspec::GemProvider.new(gem_info) }
+
+  describe "when gem does not exists" do
+    it "throws gem dependency exception" do
+      assert_raises(Inspec::Exceptions::GemDependencyNotFound) { subject.files }
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The following changes are covered:
- A fallback logic when the gem cache is manually deleted or is deleted due to some unknown misconfiguration. Since this was breaking `inspec exec` a fallback logic to clear gem's specification and enable gem fetcher logic to run step by step again is implemented.
- The unimplemented Gemprovider logic is extended now. Scenario when the gem is not locally referenced and it uses gem provider then it loads gem from the path and returns it.
- Null values error handling

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
