### PR TITLE
gemfile: pin securerandom to use below 0.4.0 for ruby 3.1 and below

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,7 @@ end
 # Pinning zeitwerk to ~> 2.6 to avoid Ruby >= 3.2 requirement.
 # Remove this pin when upgrading to Ruby 3.2 or higher.
 gem "zeitwerk", "~> 2.6.0", "< 2.7"
+
+# Pinning securerandom to < 0.4.0 as it is breaking the build because 0.4.0 is incompatible with the current version, ruby 3.0.x on CI
+# Remove this pin when upgrading to Ruby 3.1 or higher on CI.
+gem "securerandom", "< 0.4.0" if RUBY_VERSION < "3.1.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Pin securerandom as it is breaking CI - https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/471
```

Resolving dependencies............................................................................................................................................................................................................................................
--
  | securerandom-0.4.0 requires ruby version >= 3.1.0, which is incompatible with
  | the current version, ruby 3.0.7p220


```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
