### PR TITLE
CHEF-14246 Implement version handling of resource pack gem via gem fetcher

### DIFF
--- a/lib/inspec/fetcher/gem.rb
+++ b/lib/inspec/fetcher/gem.rb
@@ -50,7 +50,8 @@ module Inspec::Fetcher
           # No version permitted
           plugin_installer.install(@gem_name, path: @gem_path)
         else
-          plugin_installer.install(@gem_name, version: @version, source: @source )
+          # Passing an extra gem argument to enable detecting gem based plugins
+          plugin_installer.install(@gem_name, version: @version, source: @source, gem: @gem_name )
         end
       end
 

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -217,7 +217,7 @@ module Inspec::Plugin::V2
         if opts.key?(:version) && plugin_version_installed?(plugin_name, opts[:version])
           raise InstallError, "#{plugin_name} version #{opts[:version]} is already installed."
         else
-          # Do not redirect to plugin update when using resource packs plugin
+          # Do not redirect to plugin update when using gem based plugin
           unless is_a_gem_based_plugin?(plugin_name)
             raise InstallError, "#{plugin_name} is already installed. Use 'inspec plugin update' to change version."
           end
@@ -346,14 +346,14 @@ module Inspec::Plugin::V2
       # Activate all current plugins before trying to activate the new one
       loader.list_managed_gems.each do |spec|
         # Skip in case of update mode
-        # Skip in case using a resource pack plugin
+        # Skip in case using a gem based plugin
         next if spec.name == new_plugin_dependency.name && (update_mode || is_a_gem_based_plugin?(new_plugin_dependency.name))
         spec.activate
       end
 
       # Make sure we remove any previously loaded gem on update
       # Make sure we remove any previously loaded gem when trying to use resource pack gem
-      # Resource pack gems when updated need to deactivate older version of gem
+      # Gem based plugin when updated need to deactivate older version of gem
       Gem.loaded_specs.delete(new_plugin_dependency.name) if update_mode || is_a_gem_based_plugin?(new_plugin_dependency.name)
 
       # Test activating the solution. This makes sure we do not try to load two different versions

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -218,7 +218,7 @@ module Inspec::Plugin::V2
           raise InstallError, "#{plugin_name} version #{opts[:version]} is already installed."
         else
           # Do not redirect to plugin update when using gem based plugin
-          unless is_a_gem_based_plugin?(plugin_name)
+          unless gem_based_plugin?(opts)
             raise InstallError, "#{plugin_name} is already installed. Use 'inspec plugin update' to change version."
           end
         end
@@ -314,7 +314,7 @@ module Inspec::Plugin::V2
                 end
 
       begin
-        install_gem_to_plugins_dir(plugin_dependency, [sources], opts[:update_mode])
+        install_gem_to_plugins_dir(plugin_dependency, [sources], opts[:update_mode], opts)
       rescue Gem::RemoteFetcher::FetchError => gem_ex
         # TODO: Give a hint if the host was not resolvable or a 404 occured
         ex = Inspec::Plugin::V2::InstallError.new(gem_ex.message)
@@ -325,7 +325,7 @@ module Inspec::Plugin::V2
 
     def install_gem_to_plugins_dir(new_plugin_dependency, # rubocop: disable Metrics/AbcSize
       extra_request_sets = [],
-      update_mode = false)
+      update_mode = false, opts = {})
 
       # Get a list of all the gems available to us.
       gem_to_force_update = update_mode ? new_plugin_dependency.name : nil
@@ -347,7 +347,7 @@ module Inspec::Plugin::V2
       loader.list_managed_gems.each do |spec|
         # Skip in case of update mode
         # Skip in case using a gem based plugin
-        next if spec.name == new_plugin_dependency.name && (update_mode || is_a_gem_based_plugin?(new_plugin_dependency.name))
+        next if spec.name == new_plugin_dependency.name && (update_mode || gem_based_plugin?(opts))
 
         spec.activate
       end
@@ -355,7 +355,7 @@ module Inspec::Plugin::V2
       # Make sure we remove any previously loaded gem on update
       # Make sure we remove any previously loaded gem when trying to use resource pack gem
       # Gem based plugin when updated need to deactivate older version of gem
-      Gem.loaded_specs.delete(new_plugin_dependency.name) if update_mode || is_a_gem_based_plugin?(new_plugin_dependency.name)
+      Gem.loaded_specs.delete(new_plugin_dependency.name) if update_mode || gem_based_plugin?(opts)
 
       # Test activating the solution. This makes sure we do not try to load two different versions
       # of the same gem on the stack or a malformed dependency.
@@ -548,8 +548,9 @@ module Inspec::Plugin::V2
       conf_file
     end
 
-    def is_a_gem_based_plugin?(plugin_name)
-      (plugin_name =~ /^(inspec)-/ && plugin_name =~ /-resources/) || (plugin_name =~ /^(train)-/)
+    def gem_based_plugin?(opts)
+      # Param passed by gem fetcher while installing a new gem plugin dependency.
+      !!opts[:gem]
     end
   end
 end

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -348,6 +348,7 @@ module Inspec::Plugin::V2
         # Skip in case of update mode
         # Skip in case using a gem based plugin
         next if spec.name == new_plugin_dependency.name && (update_mode || is_a_gem_based_plugin?(new_plugin_dependency.name))
+
         spec.activate
       end
 

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -218,7 +218,7 @@ module Inspec::Plugin::V2
           raise InstallError, "#{plugin_name} version #{opts[:version]} is already installed."
         else
           # Do not redirect to plugin update when using resource packs plugin
-          unless is_resource_pack_gem?(plugin_name)
+          unless is_a_gem_based_plugin?(plugin_name)
             raise InstallError, "#{plugin_name} is already installed. Use 'inspec plugin update' to change version."
           end
         end
@@ -347,15 +347,14 @@ module Inspec::Plugin::V2
       loader.list_managed_gems.each do |spec|
         # Skip in case of update mode
         # Skip in case using a resource pack plugin
-        next if spec.name == new_plugin_dependency.name && (update_mode || is_resource_pack_gem?(new_plugin_dependency.name))
-
+        next if spec.name == new_plugin_dependency.name && (update_mode || is_a_gem_based_plugin?(new_plugin_dependency.name))
         spec.activate
       end
 
       # Make sure we remove any previously loaded gem on update
       # Make sure we remove any previously loaded gem when trying to use resource pack gem
       # Resource pack gems when updated need to deactivate older version of gem
-      Gem.loaded_specs.delete(new_plugin_dependency.name) if update_mode || is_resource_pack_gem?(new_plugin_dependency.name)
+      Gem.loaded_specs.delete(new_plugin_dependency.name) if update_mode || is_a_gem_based_plugin?(new_plugin_dependency.name)
 
       # Test activating the solution. This makes sure we do not try to load two different versions
       # of the same gem on the stack or a malformed dependency.
@@ -548,8 +547,8 @@ module Inspec::Plugin::V2
       conf_file
     end
 
-    def is_resource_pack_gem?(plugin_name)
-      plugin_name =~ /^(inspec)-/ && plugin_name =~ /-resources/
+    def is_a_gem_based_plugin?(plugin_name)
+      (plugin_name =~ /^(inspec)-/ && plugin_name =~ /-resources/) || (plugin_name =~ /^(train)-/)
     end
   end
 end

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -314,7 +314,7 @@ module Inspec::Plugin::V2
                 end
 
       begin
-        install_gem_to_plugins_dir(plugin_dependency, [sources], opts[:update_mode], opts)
+        install_gem_to_plugins_dir(plugin_dependency, [sources], opts[:update_mode], opts: opts)
       rescue Gem::RemoteFetcher::FetchError => gem_ex
         # TODO: Give a hint if the host was not resolvable or a 404 occured
         ex = Inspec::Plugin::V2::InstallError.new(gem_ex.message)
@@ -325,7 +325,7 @@ module Inspec::Plugin::V2
 
     def install_gem_to_plugins_dir(new_plugin_dependency, # rubocop: disable Metrics/AbcSize
       extra_request_sets = [],
-      update_mode = false, opts = {})
+      update_mode = false, opts: {})
 
       # Get a list of all the gems available to us.
       gem_to_force_update = update_mode ? new_plugin_dependency.name : nil

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -158,7 +158,7 @@ module Inspec::Plugin::V2
     end
 
     def self.find_gem_directory(gem_name, version = nil)
-      matching_gem_versions = list_managed_gems.filter { |g| g.name == gem_name }.sort(&:version)
+      matching_gem_versions = list_managed_gems.filter { |g| g.name == gem_name }.sort_by(&:version)
       selected_gemspec = nil
       if version
         selected_gemspec = matching_gem_versions.find { |g| g.version == version }


### PR DESCRIPTION
Implement version handling of resource pack gem via gem fetcher
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Implemented version handling of resource pack gem by introducing working usage of `version` key in metadata file under dependency section.
```
depends:
  - name: inspec-ibmdb2-resources
    gem: inspec-ibmdb2-resources
    version: 0.1.1
```
When not used the `version` key in the metadata file, it picks the last activated version of the resource pack gem.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
