### PR TITLE
CHEF-18347 Fix gem version comparison type mismatch

### DIFF
--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -178,6 +178,15 @@ module Inspec::Plugin::V2
       selected_gemspec&.loaded_from
     end
 
+    def self.find_gemspec_of(gem_name, version = nil)
+      version = Gem::Version.new(version) if version && !version.is_a?(Gem::Version)
+
+      list_managed_gems
+        .select { |g| g.name == gem_name }
+        .sort_by(&:version)
+        .yield_self { |gems| version ? gems.find { |g| g.version == version } : gems.last }
+    end
+
     def find_gemspec_directory(gem_name, version = nil)
       self.class.find_gemspec_directory(gem_name, version)
     end

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -158,23 +158,12 @@ module Inspec::Plugin::V2
     end
 
     def self.find_gem_directory(gem_name, version = nil)
-      matching_gem_versions = list_managed_gems.filter { |g| g.name == gem_name }.sort_by(&:version)
-      selected_gemspec = nil
-      if version
-        selected_gemspec = matching_gem_versions.find { |g| g.version == version }
-      else
-        # Use latest
-        selected_gemspec = matching_gem_versions.last
-      end
-
-      selected_gemspec && selected_gemspec.full_gem_path
+      selected_gemspec = find_gemspec_of(gem_name, version)
+      selected_gemspec&.full_gem_path
     end
 
     def self.find_gemspec_directory(gem_name, version = nil)
-      selected_gemspec = list_managed_gems
-        .select { |g| g.name == gem_name }
-        .sort_by(&:version)
-        .yield_self { |gems| version ? gems.find { |g| g.version == version } : gems.last }
+      selected_gemspec = find_gemspec_of(gem_name, version)
       selected_gemspec&.loaded_from
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Fix type mismatch comparison

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

In ruby 3.1, we found the gem version comparison against version string doesn't behave well. 

```
(byebug) version
"2.2.3"
(byebug) matching_gem_versions.first.version
#<Gem::Version "2.2.3">
(byebug) matching_gem_versions.first.version == version
false
(byebug) '0.1.2' == Gem::Version.new('0.1.2')
false
``` 

as we see `version` is a string object here. So the best way to handle this is to compare against same object types.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
