### PR TITLE
CHEF-16379 auto-resolve gem conflicts

### DIFF
--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -373,9 +373,14 @@ module Inspec::Plugin::V2
 
           gem_name = requested_gemspec.name
           loaded_gem = Gem.loaded_specs[gem_name]
-          # TODO: give priority to more recent version
-          Gem.loaded_specs.delete(gem_name) if loaded_gem && loaded_gem.version != requested_gemspec.version
-          activation_request.full_spec.activate
+          if loaded_gem
+            if requested_gemspec.version > loaded_gem.version
+              Gem.loaded_specs.delete(gem_name)
+            else
+              next # don't activate requested gemspec
+            end
+          end
+          requested_gemspec.activate
         end
       rescue Gem::LoadError => gem_ex
         ex = Inspec::Plugin::V2::InstallError.new(gem_ex.message)

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
@@ -343,7 +343,7 @@ class PluginManagerCliInstall < Minitest::Test
 
     assert_includes install_result.stdout, "DEBUG"
 
-    assert_includes install_result.stderr, "can't activate rake"
+    assert_includes install_result.stderr, "Unable to activate inspec-test-fixture-0.1.1"
 
     assert_exit_code 1, install_result
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Transitive dependencies fail with conflicts when pointed to rubygems.org source

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Override the required dependencies by choosing the most recent version of already loaded gem vs requested gem and deactivating already older gem version and activating the recent most version from resource packs.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://progresssoftware.atlassian.net/browse/CHEF-16379

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
