### PR TITLE
CHEF-18510 resolve gem conflicts installed plugins

### DIFF
--- a/lib/inspec/plugin/v2/concerns/gem_spec_helper.rb
+++ b/lib/inspec/plugin/v2/concerns/gem_spec_helper.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Inspec
+  module Plugin
+    module V2
+      # holds all GemSpec related helper functions
+      module GemSpecHelper
+
+        def loaded_recent_most_version_of?(gemspec)
+          # Check if the gem is already loaded via bundler
+          # In most cases this is true since all Plugins/Resource Packs inherit from inspec-core
+          gem_name = gemspec.name
+          loaded_gem = Gem.loaded_specs[gem_name]
+          return false unless loaded_gem
+
+          # follow bundler's original philosophy i.e load gems that are recent most
+          # This logic works unless there is a pinned version which we don't expect to have since these are managed by us
+          if gemspec.version > loaded_gem.version
+            # deactivate the lower version specs that are loaded via bundler
+            Gem.loaded_specs.delete(gem_name)
+            false # so it can re-activate the requested spec
+          else
+            # don't activate requested gemspec when the already loaded gem is the most recent version
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -373,9 +373,14 @@ module Inspec::Plugin::V2
 
           gem_name = requested_gemspec.name
           loaded_gem = Gem.loaded_specs[gem_name]
-          # TODO: give priority to more recent version
-          Gem.loaded_specs.delete(gem_name) if loaded_gem && loaded_gem.version != requested_gemspec.version
-          activation_request.full_spec.activate
+          if loaded_gem
+            if requested_gemspec.version > loaded_gem.version
+              Gem.loaded_specs.delete(gem_name)
+            else
+              next # don't activate requested gemspec
+            end
+          end
+          requested_gemspec.activate
         end
       rescue Gem::LoadError => gem_ex
         ex = Inspec::Plugin::V2::InstallError.new(gem_ex.message)

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -12,6 +12,7 @@ require "rubygems/uninstaller"
 require "rubygems/remote_fetcher"
 
 require "inspec/plugin/v2/filter"
+require "inspec/plugin/v2/concerns/gem_spec_helper"
 
 module Inspec::Plugin::V2
   # Handles all actions modifying the user's plugin set:
@@ -23,6 +24,7 @@ module Inspec::Plugin::V2
   class Installer
     include Singleton
     extend Forwardable
+    include Inspec::Plugin::V2::GemSpecHelper
 
     Gem.configuration["verbose"] = false
 

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -355,9 +355,16 @@ module Inspec::Plugin::V2
         # Skip in case of update mode
         # Skip in case using a gem based plugin
         next if spec.name == new_plugin_dependency.name && (update_mode || gem_based_plugin?(opts))
-        # give priority to already loaded gems
-        next if Gem.loaded_specs[spec.name]
 
+        # give priority to already loaded gems
+        loaded_gem = Gem.loaded_specs[spec.name]
+        if loaded_gem
+          if spec.version > loaded_gem.version
+            Gem.loaded_specs.delete(gem_name)
+          else
+            next # don't activate requested gemspec
+          end
+        end
         spec.activate
       end
 

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -358,16 +358,8 @@ module Inspec::Plugin::V2
         # Skip in case using a gem based plugin
         next if spec.name == new_plugin_dependency.name && (update_mode || gem_based_plugin?(opts))
 
-        # give priority to already loaded gems
-        loaded_gem = Gem.loaded_specs[spec.name]
-        if loaded_gem
-          if spec.version > loaded_gem.version
-            Gem.loaded_specs.delete(gem_name)
-          else
-            next # don't activate requested gemspec
-          end
-        end
-        spec.activate
+        # activate the requested gemspec from the Gem::RequestSet
+        spec.activate unless loaded_recent_most_version_of?(spec)
       end
 
       # Make sure we remove any previously loaded gem on update
@@ -382,16 +374,8 @@ module Inspec::Plugin::V2
           requested_gemspec = activation_request.full_spec
           next if requested_gemspec.activated?
 
-          gem_name = requested_gemspec.name
-          loaded_gem = Gem.loaded_specs[gem_name]
-          if loaded_gem
-            if requested_gemspec.version > loaded_gem.version
-              Gem.loaded_specs.delete(gem_name)
-            else
-              next # don't activate requested gemspec
-            end
-          end
-          requested_gemspec.activate
+          # activate the requested gemspec from the Gem::RequestSet
+          requested_gemspec.activate unless loaded_recent_most_version_of?(requested_gemspec)
         end
       rescue Gem::LoadError => gem_ex
         ex = Inspec::Plugin::V2::InstallError.new(gem_ex.message)

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -355,6 +355,8 @@ module Inspec::Plugin::V2
         # Skip in case of update mode
         # Skip in case using a gem based plugin
         next if spec.name == new_plugin_dependency.name && (update_mode || gem_based_plugin?(opts))
+        # give priority to already loaded gems
+        next if Gem.loaded_specs[spec.name]
 
         spec.activate
       end

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -238,16 +238,7 @@ module Inspec::Plugin::V2
         requested_gemspec = activation_request.full_spec
         next if requested_gemspec.activated?
 
-        gem_name = requested_gemspec.name
-        loaded_gem = Gem.loaded_specs[gem_name]
-        if loaded_gem
-          if requested_gemspec.version > loaded_gem.version
-            Gem.loaded_specs.delete(gem_name)
-          else
-            next # don't activate requested gemspec
-          end
-        end
-        requested_gemspec.activate
+        requested_gemspec.activate unless loaded_recent_most_version_of?(requested_gemspec)
       end
     end
 

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -233,9 +233,11 @@ module Inspec::Plugin::V2
         raise ex
       end
       solution.each do |activation_request|
-        next if activation_request.full_spec.activated?
+        requested_gemspec =  activation_request.full_spec
+        # Assumption that dependencies of installed plugins have already been resolved while installing
+        next if requested_gemspec.activated? || Gem.loaded_specs[requested_gemspec.name]
 
-        activation_request.full_spec.activate
+        requested_gemspec.activate
         # TODO: If we are under Bundler, inform it that we loaded a gem
       end
     end

--- a/lib/inspec/plugin/v2/loader.rb
+++ b/lib/inspec/plugin/v2/loader.rb
@@ -2,6 +2,7 @@ require "inspec/log"
 require "inspec/version"
 require "inspec/plugin/v2/config_file"
 require "inspec/plugin/v2/filter"
+require "inspec/plugin/v2/concerns/gem_spec_helper"
 
 module Inspec::Plugin::V2
   class Loader
@@ -10,6 +11,7 @@ module Inspec::Plugin::V2
     # For {inspec|train}_plugin_name?
     include Inspec::Plugin::V2::FilterPredicates
     extend Inspec::Plugin::V2::FilterPredicates
+    include Inspec::Plugin::V2::GemSpecHelper
 
     def initialize(options = {})
       @options = options

--- a/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
+++ b/lib/plugins/inspec-plugin-manager-cli/test/functional/install_test.rb
@@ -343,7 +343,7 @@ class PluginManagerCliInstall < Minitest::Test
 
     assert_includes install_result.stdout, "DEBUG"
 
-    assert_includes install_result.stderr, "can't activate rake"
+    assert_includes install_result.stderr, "Unable to activate inspec-test-fixture-0.1.1"
 
     assert_exit_code 1, install_result
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

We have the following conflicts for installed plugins during the second Inspec run.
```
bundle exec inspec exec /Users/sbabu/workspace/inspec-elasticsearch-resources/test/integration/inspec-profile-with-gem-dependency  --log-level=debug --no-create-lockfile
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository: 'ext/ffi_c/libffi/.git'
fatal: not a git repository: 'ext/ffi_c/libffi/.git'
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
[2025-01-08T21:03:27+05:30] ERROR: Could not load plugin inspec-elasticsearch-resources: can't activate concurrent-ruby-1.1.7, already activated concurrent-ruby-1.3.4
[2025-01-08T21:03:28+05:30] ERROR: Errors were encountered while loading plugins...
[2025-01-08T21:03:28+05:30] ERROR: Plugin name: inspec-elasticsearch-resources
[2025-01-08T21:03:28+05:30] ERROR: Error: can't activate concurrent-ruby-1.1.7, already activated concurrent-ruby-1.3.4
[2025-01-08T21:03:28+05:30] ERROR: Run again with --debug for a stacktrace.
```

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

- make loader to skip activation of already activated plugins
- skips Dependency activation of plugins when different versions are attempted to install

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
