### PR TITLE
CHEF-18596 Fix code scanning alert no. 62: Request without certificate validation

### DIFF
--- a/lib/inspec/reporters/automate.rb
+++ b/lib/inspec/reporters/automate.rb
@@ -41,11 +41,7 @@ module Inspec::Reporters
         Inspec::Log.debug "Posting report to Chef Automate: #{uri.path}"
         http = Net::HTTP.new(uri.hostname, uri.port)
         http.use_ssl = uri.scheme == "https"
-        if @config["verify_ssl"] == true
-          http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        else
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        end
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
         res = http.request(req)
         if res.is_a?(Net::HTTPSuccess)


### PR DESCRIPTION
Fixes [https://github.com/inspec/inspec/security/code-scanning/62](https://github.com/inspec/inspec/security/code-scanning/62)

To fix the problem, we need to ensure that SSL certificate validation is enabled by default. We should remove the code that sets `http.verify_mode` to `OpenSSL::SSL::VERIFY_NONE`. Instead, we should always set `http.verify_mode` to `OpenSSL::SSL::VERIFY_PEER`. If there is a need to disable SSL verification for specific cases (e.g., testing), it should be done explicitly and with caution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
