### PR TITLE
To Fix OpenSSL 3.2.0 gem issue

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: b97bb4e3e1319ca1c06b1a06f1f6354d3514ff51
+  revision: caad6827c5423bc9df89922b6002c0ab1d390eda
   branch: main
   specs:
     omnibus-software (24.6.323)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The build process for InSpec is failing due to issues related to the OpenSSL-3.2.0 gem on x86-64 RHEL and Ubuntu platforms.

 Build : https://buildkite.com/chef/inspec-inspec-main-omnibus-release/builds/909

```
[Builder: ruby] I | 2025-01-13T08:13:17+00:00 | $ gem install openssl-3.2.0.gem --no-document -- --with-openssl-dir=/opt/inspec/embedded
                          D | 2025-01-13T08:13:35+00:00 | ERROR:  Could not find a valid gem 'openssl-3.2.0.gem' (>= 0) in any repository
          [Builder: ruby] I | 2025-01-13T08:13:43+00:00 | Execute: `gem install openssl-3.2.0.gem --no-document -- --with-openssl-dir=/opt/inspec/embedded': 174.4297s
          [Builder: ruby] I | 2025-01-13T08:13:43+00:00 | Build ruby: 300.8293s
The following shell command exited with status 2:
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
