### PR TITLE
Temporarily disabled hab pipeline for windows

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,5 +1,4 @@
 [inspec]
 build_targets = [
-  "x86_64-windows",
   "x86_64-linux"
 ]

--- a/.expeditor/artifact.habitat.yml
+++ b/.expeditor/artifact.habitat.yml
@@ -18,10 +18,10 @@ steps:
           image: ruby:3.0
           privileged: true
 
-  - label: ":windows: Validate Habitat Builds of Chef InSpec"
-    commands:
-      - .expeditor/buildkite/artifact.habitat.test.ps1
-    expeditor:
-      executor:
-        windows:
-          privileged: true
+  # - label: ":windows: Validate Habitat Builds of Chef InSpec"
+  #   commands:
+  #     - .expeditor/buildkite/artifact.habitat.test.ps1
+  #   expeditor:
+  #     executor:
+  #       windows:
+  #         privileged: true


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Temporarily disabled hab pipeline for windows. This will be reverted once the windows pipelines are fixed.
Disabling this to successfully test out hab packages promotion flow with expeditor.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
