### PR TITLE
Potential fix for code scanning alert no. 61: Request without certificate validation

### DIFF
--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/http.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/http.rb
@@ -50,7 +50,7 @@ module InspecPlugins
 
         # set connection flags
         http.use_ssl = (uri.scheme == "https")
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE if insecure
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
         req = Net::HTTP::Post.new(uri.path)
         headers.each do |key, value|
@@ -75,7 +75,7 @@ module InspecPlugins
 
         # set connection flags
         http.use_ssl = (uri.scheme == "https")
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE if insecure
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
         File.open(file_path) do |tar|
           req = Net::HTTP::Post::Multipart.new(uri, "file" => UploadIO.new(tar, "application/x-gzip", File.basename(file_path)))


### PR DESCRIPTION
Potential fix for [https://github.com/inspec/inspec/security/code-scanning/61](https://github.com/inspec/inspec/security/code-scanning/61)

To fix the problem, we should ensure that certificate validation is not disabled by setting `http.verify_mode` to `OpenSSL::SSL::VERIFY_PEER` instead of `OpenSSL::SSL::VERIFY_NONE`. This change will enforce certificate validation, making the connection more secure.

- Update the `post_file` and `post_multipart_file` methods to set `http.verify_mode` to `OpenSSL::SSL::VERIFY_PEER` regardless of the `insecure` flag.
- Ensure that the `send_request` method, which is called by other methods, also enforces certificate validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
