### PR TITLE
chore: remove mongo dependency from gemspec as it is moved to mongodb resource pack

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -47,6 +47,4 @@ Source code obtained from the Chef GitHub repository is made available under Apa
   spec.add_dependency "train-winrm",      "~> 0.2"
   spec.add_dependency "train-kubernetes", "~> 0.1"
 
-  spec.add_dependency "mongo", "= 2.13.2" # 2.14 introduces a broken symlink in mongo-2.14.0/spec/support/ocsp
-
 end


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR removes the mongo gem dependency from inspec as the gem is moved as a dependency in the inspec-mongodb-resources resource pack

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
