### PR TITLE
CHEF-14322 private rubygem server integ

### DIFF
--- a/lib/inspec/plugin/v2/gem_source_manager.rb
+++ b/lib/inspec/plugin/v2/gem_source_manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require "singleton" unless defined?(Singleton)
-require 'forwardable' unless defined?(Forwardable)
+require "forwardable" unless defined?(Forwardable)
 require "chef-licensing"
 
 module Inspec::Plugin::V2
@@ -32,7 +32,7 @@ module Inspec::Plugin::V2
     end
 
     def licenses_string
-      ChefLicensing.license_keys.join(',')
+      ChefLicensing.license_keys.join(",")
     end
   end
 end

--- a/lib/inspec/plugin/v2/gem_source_manager.rb
+++ b/lib/inspec/plugin/v2/gem_source_manager.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require "singleton" unless defined?(Singleton)
+require 'forwardable' unless defined?(Forwardable)
+require "chef-licensing"
+
+module Inspec::Plugin::V2
+  class GemSourceManager
+    include Singleton
+    extend Forwardable
+
+    DEFAULT_CHEF_RUBY_GEMS_SERVER = "rubygems.chef.io"
+    DEFAULT_USERNAME = "v1"
+
+    def add_chef_rubygems_server
+      register_source(chef_rubygems_server)
+    end
+
+    def add(sources)
+      Array(sources).each { |source| register_source(source) }
+    end
+
+    private
+
+    def chef_rubygems_server
+      "https://#{DEFAULT_USERNAME}:#{licenses_string}@#{DEFAULT_CHEF_RUBY_GEMS_SERVER}"
+    end
+
+    def register_source(source)
+      sources = Gem.sources.sources
+      gem_source = Gem::Source.new(source)
+      sources << gem_source unless sources.include?(gem_source)
+    end
+
+    def licenses_string
+      ChefLicensing.license_keys.join(',')
+    end
+  end
+end

--- a/lib/inspec/plugin/v2/gem_source_manager.rb
+++ b/lib/inspec/plugin/v2/gem_source_manager.rb
@@ -11,6 +11,12 @@ module Inspec::Plugin::V2
     DEFAULT_CHEF_RUBY_GEMS_SERVER = "rubygems.chef.io"
     DEFAULT_USERNAME = "v1"
 
+    def initialize
+      @sources = Gem.sources
+    end
+
+    def_delegator :@sources, :sources
+
     def add_chef_rubygems_server
       register_source(chef_rubygems_server)
     end
@@ -26,7 +32,6 @@ module Inspec::Plugin::V2
     end
 
     def register_source(source)
-      sources = Gem.sources.sources
       gem_source = Gem::Source.new(source)
       sources << gem_source unless sources.include?(gem_source)
     end

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -309,6 +309,7 @@ module Inspec::Plugin::V2
 
     def install_from_remote_gems(requested_plugin_name, opts, source_manager: GemSourceManager.instance)
       plugin_dependency = Gem::Dependency.new(requested_plugin_name, opts[:version] || "> 0")
+      source_manager.add_chef_rubygems_server # ensure CHEF RUBYGEMS server is added to the source
 
       # This adds custom gem sources to the memoized `Gem.Sources` for this specific run
       # Note: This will not make any change to the environment Gem source list and

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -314,12 +314,7 @@ module Inspec::Plugin::V2
       # This adds custom gem sources to the memoized `Gem.Sources` for this specific run
       # Note: This will not make any change to the environment Gem source list and
       # in fact will consider all of the environment Gem sources and custom gem sources to resolve deps
-      if opts[:source]
-        sources = [opts[:source]].flatten
-        sources.each do |source|
-          Gem.sources.sources << Gem::Source.new(source)
-        end
-      end
+      source_manager.add(opts[:source])
 
       # BestSet is rubygems.org API + indexing by default
       # `Gem.sources` is injected as a dependency implicitly while BestSet is initialized

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -14,6 +14,8 @@ require "rubygems/remote_fetcher"
 require "inspec/plugin/v2/filter"
 require "inspec/plugin/v2/concerns/gem_spec_helper"
 
+require "inspec/plugin/v2/gem_source_manager"
+
 module Inspec::Plugin::V2
   # Handles all actions modifying the user's plugin set:
   # * Modifying the plugins.json file
@@ -305,7 +307,7 @@ module Inspec::Plugin::V2
       install_gem_to_plugins_dir(plugin_dependency, [requested_local_gem_set])
     end
 
-    def install_from_remote_gems(requested_plugin_name, opts)
+    def install_from_remote_gems(requested_plugin_name, opts, source_manager: GemSourceManager.instance)
       plugin_dependency = Gem::Dependency.new(requested_plugin_name, opts[:version] || "> 0")
 
       # This adds custom gem sources to the memoized `Gem.Sources` for this specific run

--- a/test/unit/plugin/v2/gem_source_manager_test.rb
+++ b/test/unit/plugin/v2/gem_source_manager_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require "helper"
+
+require "inspec/plugin/v2/gem_source_manager"
+
+class TestGemSourceManager < Minitest::Test
+  def setup
+    Gem.sources.clear
+    @gem_source_manager = Inspec::Plugin::V2::GemSourceManager.instance
+  end
+
+  def test_add_chef_rubygems_server
+    ChefLicensing.stub(:license_keys, ["test-license"]) do
+      expected_server = "https://v1:test-license@rubygems.chef.io"
+      @gem_source_manager.add_chef_rubygems_server
+      assert_includes mapped_uri_string, expected_server
+    end
+  end
+
+  def test_add_single_source
+    source = "https://custom.source.com"
+    @gem_source_manager.add(source)
+    assert_includes mapped_uri_string, source
+  end
+
+  def test_add_multiple_sources
+    sources = ["https://source1.com", "https://source2.com"]
+    @gem_source_manager.add(sources)
+    sources.each do |source|
+      assert_includes mapped_uri_string, source
+    end
+  end
+
+  def test_chef_rubygems_server_url_format
+    ChefLicensing.stub(:license_keys, %w{test-license-1 test-license-2}) do
+      expected_url = "https://v1:test-license-1,test-license-2@rubygems.chef.io"
+      assert_equal expected_url, @gem_source_manager.send(:chef_rubygems_server)
+    end
+  end
+
+  def test_no_duplicate_sources
+    source = "https://unique.source.com"
+    @gem_source_manager.add(source)
+    @gem_source_manager.add(source)
+    sources = mapped_uri_string
+    assert_equal sources.count(source), 1
+  end
+
+  def mapped_uri_string
+    Gem.sources.sources.map { _1.uri.to_s }
+  end
+end
+
+


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
All private resource packs will now be hosted in private Chef rubygems server. The plugin system will look into it to fetch the private resource packs.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Introduced a new singleton Source Manager object ( Plugin Installer is already a singleton instance )
- check for duplicates 
- Construct Chef rubygems server using available license keys
- custom method to add chef rubygems server 
- refactor the add custom sources 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
