### PR TITLE
CHEF-16676-Postgres session resource fix for special characters in password(InSpec-5)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,8 +63,9 @@ end
 gem "zeitwerk", "~> 2.6.0", "< 2.7"
 
 # Pinning dry-core,dry-core to < 1.1.0 as it is breaking the build because 1.1.0 is incompatible with the current version, ruby 3.0.x on CI
-gem "dry-core", "> 1.0.0", "< 1.1.0" if RUBY_VERSION < "3.1.0"
-gem "dry-inflector", "<= 1.1.0" if RUBY_VERSION < "3.1.0"
+gem "dry-types", "<= 1.7.2" if RUBY_VERSION < "3.1.0"
+# gem "dry-core", "> 1.0.0", "< 1.1.0" if RUBY_VERSION < "3.1.0"
+# gem "dry-inflector", "<= 1.1.0" if RUBY_VERSION < "3.1.0"
 
 # Pinning securerandom to < 0.4.0 as it is breaking the build because 0.4.0 is incompatible with the current version, ruby 3.0.x on CI
 # Remove this pin when upgrading to Ruby 3.1 or higher on CI.

--- a/Gemfile
+++ b/Gemfile
@@ -62,10 +62,10 @@ end
 # Remove this pin when upgrading to Ruby 3.2 or higher.
 gem "zeitwerk", "~> 2.6.0", "< 2.7"
 
-# Pinning dry-core,dry-core to < 1.1.0 as it is breaking the build because 1.1.0 is incompatible with the current version, ruby 3.0.x on CI
+# Pinning dry-core,dry-core,dry-types to < 1.1.0 as it is breaking the build because 1.1.0 is incompatible with the current version, ruby 3.0.x on CI
 gem "dry-types", "<= 1.7.2" if RUBY_VERSION < "3.1.0"
-# gem "dry-core", "> 1.0.0", "< 1.1.0" if RUBY_VERSION < "3.1.0"
-# gem "dry-inflector", "<= 1.1.0" if RUBY_VERSION < "3.1.0"
+gem "dry-core", "> 1.0.0", "< 1.1.0" if RUBY_VERSION < "3.1.0"
+gem "dry-inflector", "<= 1.1.0" if RUBY_VERSION < "3.1.0"
 
 # Pinning securerandom to < 0.4.0 as it is breaking the build because 0.4.0 is incompatible with the current version, ruby 3.0.x on CI
 # Remove this pin when upgrading to Ruby 3.1 or higher on CI.

--- a/Gemfile
+++ b/Gemfile
@@ -62,9 +62,9 @@ end
 # Remove this pin when upgrading to Ruby 3.2 or higher.
 gem "zeitwerk", "~> 2.6.0", "< 2.7"
 
-# Pinning dry-core to < 1.1.0 as it is breaking the build because 1.1.0 is incompatible with the current version, ruby 3.0.x on CI
+# Pinning dry-core,dry-core to < 1.1.0 as it is breaking the build because 1.1.0 is incompatible with the current version, ruby 3.0.x on CI
 gem "dry-core", "> 1.0.0", "< 1.1.0" if RUBY_VERSION < "3.1.0"
-gem "dry-inflector", "> 1.0.0", "< 1.1.0" if RUBY_VERSION < "3.1.0"
+gem "dry-inflector", "<= 1.1.0" if RUBY_VERSION < "3.1.0"
 
 # Pinning securerandom to < 0.4.0 as it is breaking the build because 0.4.0 is incompatible with the current version, ruby 3.0.x on CI
 # Remove this pin when upgrading to Ruby 3.1 or higher on CI.

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :test do
   gem "minitest", "5.15.0"
   gem "mocha"
   # Pinning this version as it breaking for ruby 3.1.0
-  gem "nokogiri", "< 1.18.2"
+  gem "nokogiri", "< 1.17.2"
   gem "pry-byebug"
   gem "pry"
   gem "rake"
@@ -64,6 +64,7 @@ gem "zeitwerk", "~> 2.6.0", "< 2.7"
 
 # Pinning dry-core to < 1.1.0 as it is breaking the build because 1.1.0 is incompatible with the current version, ruby 3.0.x on CI
 gem "dry-core", "> 1.0.0", "< 1.1.0" if RUBY_VERSION < "3.1.0"
+gem "dry-inflector", "> 1.0.0", "< 1.1.0" if RUBY_VERSION < "3.1.0"
 
 # Pinning securerandom to < 0.4.0 as it is breaking the build because 0.4.0 is incompatible with the current version, ruby 3.0.x on CI
 # Remove this pin when upgrading to Ruby 3.1 or higher on CI.

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,8 @@ group :test do
   gem "minitest-sprint", "~> 1.0"
   gem "minitest", "5.15.0"
   gem "mocha"
-  gem "nokogiri"
+  # Pinning this version as it breaking for ruby 3.1.0
+  gem "nokogiri", "< 1.18.2"
   gem "pry-byebug"
   gem "pry"
   gem "rake"
@@ -60,6 +61,9 @@ end
 # Pinning zeitwerk to ~> 2.6 to avoid Ruby >= 3.2 requirement.
 # Remove this pin when upgrading to Ruby 3.2 or higher.
 gem "zeitwerk", "~> 2.6.0", "< 2.7"
+
+# Pinning dry-core to < 1.1.0 as it is breaking the build because 1.1.0 is incompatible with the current version, ruby 3.0.x on CI
+gem "dry-core", "> 1.0.0", "< 1.1.0" if RUBY_VERSION < "3.1.0"
 
 # Pinning securerandom to < 0.4.0 as it is breaking the build because 0.4.0 is incompatible with the current version, ruby 3.0.x on CI
 # Remove this pin when upgrading to Ruby 3.1 or higher on CI.

--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -1,7 +1,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require "shellwords" unless defined?(Shellwords)
-require "cgi"
+require "cgi" unless defined?(CGI)
 module Inspec::Resources
   class Lines
     attr_reader :output, :exit_status

--- a/lib/inspec/resources/postgres_session.rb
+++ b/lib/inspec/resources/postgres_session.rb
@@ -1,7 +1,7 @@
 # copyright: 2015, Vulcano Security GmbH
 
 require "shellwords" unless defined?(Shellwords)
-
+require "cgi"
 module Inspec::Resources
   class Lines
     attr_reader :output, :exit_status
@@ -42,7 +42,7 @@ module Inspec::Resources
 
     def initialize(user, pass, host = nil, port = nil, socket_path = nil)
       @user = user || "postgres"
-      @pass = pass
+      @pass = CGI.escape(pass)
       @host = host || "localhost"
       @port = port || 5432
       @socket_path = socket_path

--- a/test/unit/resources/postgres_session_test.rb
+++ b/test/unit/resources/postgres_session_test.rb
@@ -8,9 +8,10 @@ describe "Inspec::Resources::PostgresSession" do
     resource = load_resource("postgres_session", "myuser", "mypass", "127.0.0.1", 5432)
     _(resource.resource_id).must_equal "postgress_session:User:myuser:Host:127.0.0.1"
   end
-  it "generates the resource_id for passwords with special characters" do
+  it "generates the resource_id and verifies create_psql_cmd for passwords with special characters" do
     resource = load_resource("postgres_session", "myuser", "my@pa$ss", "127.0.0.1", 5432)
     _(resource.resource_id).must_equal "postgress_session:User:myuser:Host:127.0.0.1"
+    _(resource.send(:create_psql_cmd, "SELECT * FROM STUDENTS;", ["testdb"])).must_equal "psql -d postgresql://myuser:my%40pa%24ss@127.0.0.1:5432/testdb -A -t -w -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;"
   end
   it "verify postgres_session create_psql_cmd with a basic query" do
     resource = load_resource("postgres_session", "myuser", "mypass", "127.0.0.1", 5432)
@@ -48,6 +49,11 @@ describe "Inspec::Resources::PostgresSession" do
   it "verify postgres_session create_psql_cmd in socket connection" do
     resource = load_resource("postgres_session", "myuser", "mypass", "127.0.0.1", 1234, "/var/run/postgresql")
     _(resource.send(:create_psql_cmd, "SELECT * FROM STUDENTS;", ["testdb"])).must_equal "psql -d postgresql://myuser:mypass@/testdb?host=/var/run/postgresql -p 1234 -A -t -w -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;"
+  end
+
+  it "encodes the password correctly" do
+    resource = load_resource("postgres_session", "myuser", "my@pa$ss", "127.0.0.1", 5432)
+    _(resource.send(:encoded_password, "my@pa$ss")).must_equal "my%40pa%24ss"
   end
 
   it "fails when no connection established in linux" do

--- a/test/unit/resources/postgres_session_test.rb
+++ b/test/unit/resources/postgres_session_test.rb
@@ -8,6 +8,10 @@ describe "Inspec::Resources::PostgresSession" do
     resource = load_resource("postgres_session", "myuser", "mypass", "127.0.0.1", 5432)
     _(resource.resource_id).must_equal "postgress_session:User:myuser:Host:127.0.0.1"
   end
+  it "generates the resource_id for passwords with special characters" do
+    resource = load_resource("postgres_session", "myuser", "my@pa$ss", "127.0.0.1", 5432)
+    _(resource.resource_id).must_equal "postgress_session:User:myuser:Host:127.0.0.1"
+  end
   it "verify postgres_session create_psql_cmd with a basic query" do
     resource = load_resource("postgres_session", "myuser", "mypass", "127.0.0.1", 5432)
     _(resource.send(:create_psql_cmd, "SELECT * FROM STUDENTS;", ["testdb"])).must_equal "psql -d postgresql://myuser:mypass@127.0.0.1:5432/testdb -A -t -w -c SELECT\\ \\*\\ FROM\\ STUDENTS\\;"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Postgres session resource does not function correctly when the password contains special characters.
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Encoded the password variable to ensure it is properly formatted 
and does not break when included in the connection string.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
