### PR TITLE
CHEF-15083: Update groups resource to use `getent` utility to fetch groups info

### DIFF
--- a/test/fixtures/cmd/group_info
+++ b/test/fixtures/cmd/group_info
@@ -1,0 +1,4 @@
+root:x:0:
+www-data:x:33:www-data,root
+GroupWithCaps:x:999:
+sftpusers:x:1000:sftponly

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -334,6 +334,7 @@ class MockLoader
       "chage -l root" => cmd.call("chage-l-root"),
       "cat ~/.ssh/authorized_keys" => cmd.call("authorized-keys-mock"),
       %{sh -c 'type "getent"'} => empty.call,
+      %{type "getent"} => empty.call,
       "getent shadow root" => cmd.call("getent-shadow-mock"),
       # user information for ldap test
       "id jfolmer" => cmd.call("id-jfolmer"),

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -330,6 +330,7 @@ class MockLoader
       # user information for linux
       "id root" => cmd.call("id-root"),
       "getent passwd root" => cmd.call("getent-passwd-root"),
+      "getent group" => cmd.call("group_info"),
       "chage -l root" => cmd.call("chage-l-root"),
       "cat ~/.ssh/authorized_keys" => cmd.call("authorized-keys-mock"),
       %{sh -c 'type "getent"'} => empty.call,


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR updates the `groups` resource to retrieve group information using the `getent` utility, instead of directly reading it from `/etc/group` file. 

This resolves the limitation where groups added by other methods were not detected, causing failures even if the group existed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-15083: InSpec for group resource using /etc/group instead of using getent

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
