### PR TITLE
Updating Faraday support to match Chef Infra

### DIFF
--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -39,7 +39,7 @@ Source code obtained from the Chef GitHub repository is made available under Apa
   spec.add_dependency "progress_bar", "~> 1.3.3"
 
   # Used for Azure profile until integrated into train
-  spec.add_dependency "faraday_middleware", ">= 0.12.2", "< 1.1"
+  spec.add_dependency "faraday_middleware", "~> 1.2", ">= 1.2.1"
 
   # Train plugins we ship with InSpec
   spec.add_dependency "train-habitat",    "~> 0.1"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Chef Infra team is starting the work to incorporate inspec 7 into the builds. In updating things, we came across a version conflict where Inspec is using a much older version of Faraday that caused a version collision in Chef. Here we are updating Faraday in Inspec to match the Chef Infra version. I ran the "bundle exec rake:default" and did not note any local errors related to Faraday

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
