### PR TITLE
chore: pin gems version which are unable to install for ruby 3.0/3.1 on CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "inspec-bin", path: "./inspec-bin"
 # ffi version v1.17.0 is breaking verify pipeline as it requires
 # rubygems version to be upgraded to >= 3.3.22 Ref:https://buildkite.com/chef/inspec-inspec-main-verify-private/builds/812#018fe177-2ccb-45ed-a25e-213c8a6453df/698-707
 
-gem "ffi", ">= 1.15.5", "< 1.18.0"
+gem "ffi", ">= 1.15.5", "< 1.17.0"
 
 # We have a build issue 2023-11-13 with unf_ext 0.0.9 so we are pinning to 0.0.8.2
 # See https://github.com/knu/ruby-unf_ext/issues/74 https://buildkite.com/chef/inspec-inspec-inspec-5-omnibus-release/builds/22

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rspec-its",                "~> 1.2"
   spec.add_dependency "pry",                      "~> 0.13"
   spec.add_dependency "hashie",                   ">= 3.4", "< 6.0"
-  spec.add_dependency "mixlib-log",               "~> 3.0"
+  spec.add_dependency "mixlib-log",               "~> 3.0", "< 3.2"
   spec.add_dependency "sslshake",                 "~> 1.2"
   spec.add_dependency "parallel",                 "~> 1.9"
   spec.add_dependency "faraday",                  ">= 1", "< 3"


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Pin down gems to get the CI green

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
