### PR TITLE
Main branch coverage pipeline fix

### DIFF
--- a/lib/inspec/iaf_file.rb
+++ b/lib/inspec/iaf_file.rb
@@ -45,7 +45,7 @@ module Inspec
 
     def self.fetch_validation_key_from_github(keyname)
       URI.open("https://raw.githubusercontent.com/inspec/inspec/main/etc/keys/#{keyname}.pem.pub") do |r|
-        puts "Fetching validation key '#{keyname}' from github"
+        Inspec::Log.debug "Fetching validation key '#{keyname}' from github"
         dir = File.join(Inspec.config_dir, "keys")
         FileUtils.mkdir_p dir
         key_file = File.join(dir, "#{keyname}.pem.pub")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Coverage pipeline fix by replacing `puts` with `debug` log. This was a potential fix, which made the pipeline green. The assumption is that `puts` might be interfering with the IO stream and breaking it. 

It could be any of the following scenarios:
- If `$stdout` has been closed or redirected, `puts` might trigger an IOError, causing the Rake task to abort.
- If `puts` is inside a thread or forked process, it might be trying to write to a stream that is no longer available.

Failing pipeline: https://buildkite.com/chef/inspec-inspec-main-coverage/builds/1238#_
Successful pipeline: https://buildkite.com/chef/inspec-inspec-main-coverage/builds/1255
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
