### PR TITLE
Fix main pipeline issue on JSON gem update

### DIFF
--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -98,11 +98,7 @@ describe "Inspec::Config" do
       let(:fixture_name) { "malformed_json" }
       it "should throw an exception" do
         ex = _ { cfg }.must_raise(Inspec::ConfigError::MalformedJson)
-        # Failed to load JSON configuration: 765: unexpected token at '{ "hot_garbage": "a", "version": "1.1",
-        # '
-        # Config was: "{ \"hot_garbage\": \"a\", \"version\": \"1.1\", \n"
         _(ex.message).must_include "Failed to load JSON config" # The message
-        _(ex.message).must_include "unexpected token" # The specific parser error
         _(ex.message).must_include "hot_garbage" # A sample of the unacceptable contents
       end
     end

--- a/test/unit/plugin/v2/plugin_conf_test.rb
+++ b/test/unit/plugin/v2/plugin_conf_test.rb
@@ -72,7 +72,6 @@ describe "Inspec::Plugin::V2::ConfigFile" do
         ex = assert_raises(Inspec::Plugin::V2::ConfigError) { config_file_obj }
         _(ex.message).must_include("Failed to load")
         _(ex.message).must_include("JSON")
-        _(ex.message).must_include("unexpected token")
       end
     end
 


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix main pipeline issue on JSON gem update, by removing the `specific` error check. It is making the tests too dependent on the specific message which can change more often.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
