### PR TITLE
CHEF-15789 - Improve error handling for `audit_policy` resource

### DIFF
--- a/lib/inspec/resources/audit_policy.rb
+++ b/lib/inspec/resources/audit_policy.rb
@@ -39,11 +39,17 @@ module Inspec::Resources
       # expected result:
       # Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclusion Setting
       # WIN-MB8NINQ388J,System,Kerberos Authentication Service,{0CCE9242-69AE-11D9-BED3-505054503030},No Auditing,
-      result ||= inspec.command("Auditpol /get /subcategory:'#{key}' /r").stdout
+      auditpol_cmd = "Auditpol /get /subcategory:'#{key}' /r"
+      result ||= inspec.command(auditpol_cmd)
+
+      unless result.exit_status == 0
+        error = result.stdout + "\n" + result.stderr
+        raise Inspec::Exceptions::ResourceFailed, "Error while executing #{auditpol_cmd} command: #{error}"
+      end
 
       # find line
       target = nil
-      result.each_line do |s|
+      result.stdout.each_line do |s|
         target = s.strip if s =~ /\b.*#{key}.*\b/
       end
 

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -244,6 +244,7 @@ class MockLoader
       # registry key test using winrm 2.0
       "9417f24311a9dcd90f1b1734080a2d4c6516ec8ff2d452a2328f68eb0ed676cf" => cmd.call("reg_schedule"),
       "Auditpol /get /subcategory:'User Account Management' /r" => cmd.call("auditpol"),
+      "Auditpol /get /subcategory:'Some Invalid Key' /r" => cmd_exit_1.call,
       "/sbin/auditctl -l" => cmd.call("auditctl"),
       "/sbin/auditctl -s" => cmd.call("auditctl-s"),
       "dpkg -s curl" => cmd.call("dpkg-s-curl"),

--- a/test/unit/resources/audit_policy_test.rb
+++ b/test/unit/resources/audit_policy_test.rb
@@ -8,4 +8,11 @@ describe "Inspec::Resources::AuditPolicy" do
     _(resource.resource_id).must_equal "audit_policy"
     _(resource.send("User Account Management")).must_equal "Success"
   end
+
+  it "check audit policy parsing" do
+    resource = MockLoader.new(:windows).load_resource("audit_policy")
+    _(resource.resource_id).must_equal "audit_policy"
+    ex = assert_raises(Inspec::Exceptions::ResourceFailed) { resource.send("Some Invalid Key") }
+    _(ex.message).must_include("Error while executing Auditpol /get /subcategory:'Some Invalid Key'")
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR improves the error handling for audit_policy resource by making the resource fail if the exit status is not zero. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-15789: Inspec Profile throwing "Error 0x00000057 occurred: The parameter is incorrect." on windows client (Server 2019)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
