### PR TITLE
remove mac11 as its EOL and upadte 12 as builder

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -30,11 +30,9 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
-  mac_os_x-11-x86_64:
-    - mac_os_x-11-x86_64
+  mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
-  mac_os_x-11-arm64:
-    - mac_os_x-11-arm64
+  mac_os_x-12-arm64:
     - mac_os_x-12-arm64
   sles-12-x86_64:
     - sles-12-x86_64

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ In addition, runtime support is provided for:
 
 | Platform | Versions | Arch   |
 | -------- | -------- | ------ |
-| macOS    | 11+      | x86_64, arm64 |
+| macOS    | 12      | x86_64, arm64 |
 | Debian   | 9, 10    | x86_64, aarch64 |
 | RHEL     | 7, 8, 9  | x86_64, aarch64 |
 | Fedora   | 29+      | x86_64, aarch64 |

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Remote Targets
 | CentOS                       | 6, 7, 8                                          | i386, x86_64  |
 | Debian                       | 9, 10                                            | i386, x86_64  |
 | FreeBSD                      | 9, 10, 11                                        | i386, amd64   |
-| macOS                        | 11.0                                             | x86_64        |
+| macOS                        | 12.0                                             | x86_64, amd64       |
 | Oracle Enterprise Linux      | 6, 7, 8                                          | i386, x86_64  |
 | Red Hat Enterprise Linux     | 7, 8, 9                                          | i386, x86_64  |
 | Solaris                      | 10, 11                                           | sparc, x86    |


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Removing mac 11 from pipeline as its EOL and updating 12 as builder

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
