### PR TITLE
remove mac 11 from inspec-5 as its EOL and update 12 as builder

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -30,11 +30,9 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
-  mac_os_x-11-x86_64:
-    - mac_os_x-11-x86_64
+  mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
-  mac_os_x-11-arm64:
-    - mac_os_x-11-arm64
+  mac_os_x-12-arm64:
     - mac_os_x-12-arm64
   sles-12-x86_64:
     - sles-12-x86_64

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Remote Targets
 | CentOS                       | 6, 7, 8                                          | i386, x86_64  |
 | Debian                       | 9, 10                                            | i386, x86_64  |
 | FreeBSD                      | 9, 10, 11                                        | i386, amd64   |
-| macOS                        | 10.14, 10.15, 11.0 , 12.0                              | x86_64        |
+| macOS                        | 10.14, 10.15, 11.0 , 12.0                        | x86_64,amd64  |
 | Oracle Enterprise Linux      | 6, 7, 8                                          | i386, x86_64  |
 | Red Hat Enterprise Linux     | 6, 7, 8                                          | i386, x86_64  |
 | Solaris                      | 10, 11                                           | sparc, x86    |

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Remote Targets
 | CentOS                       | 6, 7, 8                                          | i386, x86_64  |
 | Debian                       | 9, 10                                            | i386, x86_64  |
 | FreeBSD                      | 9, 10, 11                                        | i386, amd64   |
-| macOS                        | 10.14, 10.15, 11.0                               | x86_64        |
+| macOS                        | 10.14, 10.15, 11.0 , 12.0                              | x86_64        |
 | Oracle Enterprise Linux      | 6, 7, 8                                          | i386, x86_64  |
 | Red Hat Enterprise Linux     | 6, 7, 8                                          | i386, x86_64  |
 | Solaris                      | 10, 11                                           | sparc, x86    |
@@ -339,7 +339,7 @@ In addition, runtime support is provided for:
 
 | Platform | Versions | Arch   |
 | -------- | -------- | ------ |
-| macOS    | 11+      | x86_64, arm64 |
+| macOS    | 11,12      | x86_64, arm64 |
 | Debian   | 9, 10    | x86_64, aarch64 |
 | RHEL     | 7, 8, 9  | x86_64, aarch64 |
 | Fedora   | 29+      | x86_64, aarch64 |

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     awesome_print (1.9.2)
     aws-eventstream (1.3.1)
     aws-partitions (1.1054.0)
-    aws-sdk-core (3.218.1)
+    aws-sdk-core (3.219.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     awesome_print (1.9.2)
     aws-eventstream (1.3.1)
     aws-partitions (1.1054.0)
-    aws-sdk-core (3.219.0)
+    aws-sdk-core (3.218.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Removing mac 11 from inspec-5 as its EOL and updating 12 as builder

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
