### PR TITLE
CHEF-18371: Test and Verify InSpec 7 Pipelines for Ruby 3.4.x Upgrade

### DIFF
--- a/.expeditor/artifact.habitat.yml
+++ b/.expeditor/artifact.habitat.yml
@@ -15,7 +15,7 @@ steps:
     expeditor:
       executor:
         docker:
-          image: ruby:3.4.2
+          image: ruby:3.4
           privileged: true
 
   - label: ":windows: Validate Habitat Builds of Chef InSpec"

--- a/.expeditor/artifact.habitat.yml
+++ b/.expeditor/artifact.habitat.yml
@@ -15,7 +15,7 @@ steps:
     expeditor:
       executor:
         docker:
-          image: ruby:3.0
+          image: ruby:3.4.2
           privileged: true
 
   - label: ":windows: Validate Habitat Builds of Chef InSpec"

--- a/.expeditor/coverage.pipeline.yml
+++ b/.expeditor/coverage.pipeline.yml
@@ -9,11 +9,11 @@ expeditor:
 
 steps:
 
-  - label: coverage-ruby-3.1
+  - label: coverage-ruby-3.4.2
     command:
       - CI_ENABLE_COVERAGE=1 RAKE_TASK=test:unit /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       secrets: true
       executor:
         docker:
-          image: ruby:3.1-bullseye
+          image: ruby:3.4.2-bullseye

--- a/.expeditor/coverage.pipeline.yml
+++ b/.expeditor/coverage.pipeline.yml
@@ -9,11 +9,11 @@ expeditor:
 
 steps:
 
-  - label: coverage-ruby-3.4.2
+  - label: coverage-ruby-3.4
     command:
       - CI_ENABLE_COVERAGE=1 RAKE_TASK=test:unit /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       secrets: true
       executor:
         docker:
-          image: ruby:3.4.2-bullseye
+          image: ruby:3.4-bullseye

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -9,34 +9,34 @@ expeditor:
 
 steps:
 
-  - label: lint-ruby-3.4.2
+  - label: lint-ruby-3.4
     command:
       - RAKE_TASK=test:lint /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       secrets: true
       executor:
         docker:
-          image: ruby:3.1-bullseye
+          image: ruby:3.4-bullseye
 
-  - label: run-tests-ruby-3.4.2
+  - label: run-tests-ruby-3.4
     command:
       - /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       secrets: true
       executor:
         docker:
-          image: ruby:3.4.2-bullseye
+          image: ruby:3.4-bullseye
 
-  - label: isolated-tests-ruby-3.4.2
+  - label: isolated-tests-ruby-3.4
     command:
       - RAKE_TASK=test:isolated /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       secrets: true
       executor:
         docker:
-          image: ruby:3.1-bullseye
+          image: ruby:3.4-bullseye
 
-  - label: run-tests-ruby-3.4.2-windows
+  - label: run-tests-ruby-3.4-windows
     command:
       - /workdir/.expeditor/buildkite/verify.ps1
     expeditor:
@@ -47,4 +47,4 @@ steps:
             - BUILDKITE
           host_os: windows
           shell: ["powershell", "-Command"]
-          image: rubydistros/windows-2019:3.4.2
+          image: rubydistros/windows-2019:3.4

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -9,7 +9,7 @@ expeditor:
 
 steps:
 
-  - label: lint-ruby-3.1
+  - label: lint-ruby-3.4.2
     command:
       - RAKE_TASK=test:lint /workdir/.expeditor/buildkite/verify.sh
     expeditor:
@@ -18,16 +18,16 @@ steps:
         docker:
           image: ruby:3.1-bullseye
 
-  - label: run-tests-ruby-3.1
+  - label: run-tests-ruby-3.4.2
     command:
       - /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       secrets: true
       executor:
         docker:
-          image: ruby:3.1-bullseye
+          image: ruby:3.4.2-bullseye
 
-  - label: isolated-tests-ruby-3.1
+  - label: isolated-tests-ruby-3.4.2
     command:
       - RAKE_TASK=test:isolated /workdir/.expeditor/buildkite/verify.sh
     expeditor:
@@ -36,7 +36,7 @@ steps:
         docker:
           image: ruby:3.1-bullseye
 
-  - label: run-tests-ruby-3.1-windows
+  - label: run-tests-ruby-3.4.2-windows
     command:
       - /workdir/.expeditor/buildkite/verify.ps1
     expeditor:
@@ -47,4 +47,4 @@ steps:
             - BUILDKITE
           host_os: windows
           shell: ["powershell", "-Command"]
-          image: rubydistros/windows-2019:3.1
+          image: rubydistros/windows-2019:3.4.2


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR is part of the CI testing effort to verify that InSpec 7 is compatible with **Ruby 3.4.x**. The primary goal is to ensure that after upgrading to Ruby 3.4.x, all pipelines continue to function correctly across both **Linux** and **Windows** environments. 

This work focuses on:
- Validating and fixing any compatibility issues introduced by Ruby 3.4.x.
- Ensuring that all CI pipelines pass successfully ("green pipelines") for both platforms.

## Related Issue
Linked to internal ticket **CHEF-18371**: *Test verify pipeline for InSpec - Ruby 3.4.x Upgrade*

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] CI/Test infrastructure update (non-breaking change to support Ruby upgrade)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified pipeline runs are green for Linux.
- [x] I have verified pipeline runs are green for Windows.
- [x] I have tested this locally with Ruby 3.4.x.
- [ ] I have added documentation if necessary.