### PR TITLE
Chef 19153 resolve inspec config dir in hab

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -34,8 +34,8 @@ do_setup_environment() {
   build_line 'Setting GEM_HOME="$pkg_prefix/lib"'
   export GEM_HOME="$pkg_prefix/lib"
 
-  build_line "Setting GEM_PATH=$GEM_HOME"
-  export GEM_PATH="$GEM_HOME"
+  build_line "Setting GEM_PATH=$GEM_HOME:${INSPEC_CONFIG_DIR:-~/.inspec}"
+  export GEM_PATH="$GEM_HOME:${INSPEC_CONFIG_DIR:-~/.inspec}"
 }
 
 do_unpack() {

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -391,6 +391,9 @@ module Inspec::Plugin::V2
       # So, after each install, run a scan for all gem(specs) we manage, and copy in their gemspec file
       # into the exploded gem source area if absent.
       loader.list_managed_gems.each do |spec|
+        lib_dir = File.join(spec.gem_dir, "lib")
+        # add freshly downloaded gems to the load path
+        $LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
         path_inside_source = File.join(spec.gem_dir, "#{spec.name}.gemspec")
         unless File.exist?(path_inside_source)
           File.write(path_inside_source, spec.to_ruby)

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -400,9 +400,6 @@ module Inspec::Plugin::V2
       # So, after each install, run a scan for all gem(specs) we manage, and copy in their gemspec file
       # into the exploded gem source area if absent.
       loader.list_managed_gems.each do |spec|
-        lib_dir = File.join(spec.gem_dir, "lib")
-        # add freshly downloaded gems to the load path
-        $LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
         path_inside_source = File.join(spec.gem_dir, "#{spec.name}.gemspec")
         unless File.exist?(path_inside_source)
           File.write(path_inside_source, spec.to_ruby)

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -339,6 +339,9 @@ module Inspec::Plugin::V2
       set_available_for_resolution = build_gem_request_universe(extra_request_sets, gem_to_force_update)
 
       # Solve the dependency (that is, find a way to install the new plugin and anything it needs)
+      # [WARN]: Gem::RequestSet cannot resolve from multiple directories
+      # So all dependent gems will be resolved to the GEM_HOME/Gem.default_dir directory
+      # assuming everything will be installed in the same dir
       request_set = Gem::RequestSet.new(new_plugin_dependency)
 
       begin

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -372,6 +372,15 @@ module Inspec::Plugin::V2
           requested_gemspec = activation_request.full_spec
           next if requested_gemspec.activated?
 
+          # The specs at this point are pointed to GEM_HOME/Gem.default_dir directory
+          # because of the resolved set's assumption that we will install Gems in the same directory
+          # In many cases, RubyGems has already loaded gems from default dir
+          # Hence at this point it is really only a sanity check
+          # And if the requested_gemspec_file has not been downloaded in this default dir do not activate it
+          # Activation will be taken care after the downloads
+          requested_gemspec_file = File.join(requested_gemspec.gem_dir, "#{requested_gemspec.name}.gemspec")
+          next unless File.exist?(requested_gemspec_file)
+
           # activate the requested gemspec from the Gem::RequestSet
           requested_gemspec.activate unless loaded_recent_most_version_of?(requested_gemspec)
         end

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -405,7 +405,7 @@ module Inspec::Plugin::V2
           File.write(path_inside_source, spec.to_ruby)
         end
       end
-
+      loader.activate_managed_gems_for_plugin(new_plugin_dependency.name)
       # Locate the GemVersion for the new dependency and return it
       solution.detect { |g| g.name == new_plugin_dependency.name }.version
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
When running Inspec exec for mongo DB profiles that depend on `inspec-mongodb-resources` fails with below error 
```
Fetching inspec-mongodb-resources-0.1.7.gem
<internal:/hab/pkgs/core/ruby3_1/3.1.6/20250115100930/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:160:in `require': cannot load such file -- mongo (LoadError)
```

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The Gem::RequestSet resolver resolves dependent gems in default Gem dir and hence activating the `mongo` gem works by the assumption that it will be installed in the same dir marks this as an activated gem. 
While in reality, we install the gems in Inspec's config dir which is different from default Gem dir. Hence when we attempt to activate the `mongo` gem after it is downloaded in Inspec config dir, it is not activated since it is already marked as activated but in wrong dir ( in this case default gem dir ) 

The fix explicitly checks at the resolver's activation to see if the gemspec of the gem( which is ideally needed to activate) is already present in the spec.gem_dir there by making sure we don't activate the new gems that will be installed part of plugin. After the download, we do activate all the dependant gems needed for plugin to work.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
