### PR TITLE
Backports: CHEF-3849: InSpec should exit quickly and clearly if waiver file is malformed/corrupt

### DIFF
--- a/lib/inspec/exceptions.rb
+++ b/lib/inspec/exceptions.rb
@@ -12,5 +12,6 @@ module Inspec
     class ProfileSigningKeyNotFound < ArgumentError; end
     class WaiversFileNotReadable < ArgumentError; end
     class WaiversFileDoesNotExist < ArgumentError; end
+    class WaiversFileInvalidFormatting < ArgumentError; end
   end
 end

--- a/lib/inspec/secrets/yaml.rb
+++ b/lib/inspec/secrets/yaml.rb
@@ -24,12 +24,18 @@ module Secrets
         @inputs = ::YAML.load_file(target)
       end
 
-      if @inputs == false || !@inputs.is_a?(Hash)
-        Inspec::Log.warn("#{self.class} unable to parse #{target}: invalid YAML or contents is not a Hash")
+      # In case of empty yaml file raise the warning else raise the parsing error.
+      if !@inputs || @inputs.empty?
+        Inspec::Log.warn("Unable to parse #{target}: YAML file is empty.")
         @inputs = nil
+      elsif !@inputs.is_a?(Hash)
+        # Exits with usage error.
+        Inspec::Log.error("Unable to parse #{target}: invalid YAML or contents is not a Hash")
+        Inspec::UI.new.exit(:usage_error)
       end
     rescue => e
-      raise "Error reading InSpec inputs: #{e}"
+      # Any other error related to Yaml parsing will be raised here.
+      raise "Error reading YAML file #{target}: #{e}"
     end
   end
 end

--- a/lib/inspec/waiver_file_reader.rb
+++ b/lib/inspec/waiver_file_reader.rb
@@ -21,6 +21,9 @@ module Inspec
 
         data = parse_waiver_file(file_path)
         output.merge!(data) if data.is_a?(Hash)
+      rescue Inspec::Exceptions::WaiversFileNotReadable, Inspec::Exceptions::WaiversFileInvalidFormatting => e
+        Inspec::Log.error "Error reading waivers file #{file_path}. #{e.message}"
+        Inspec::UI.new.exit(:usage_error)
       end
 
       @waivers_data[profile_id] = output
@@ -52,7 +55,7 @@ module Inspec
         validate_json_yaml(data)
       when ".csv"
         data = Waivers::CSVFileReader.resolve(file_path)
-        validate_headers(Waivers::CSVFileReader.headers)
+        validate_csv_headers(Waivers::CSVFileReader.headers)
       when ".json"
         data = Waivers::JSONFileReader.resolve(file_path)
         validate_json_yaml(data)
@@ -61,23 +64,58 @@ module Inspec
       data
     end
 
-    def self.validate_headers(headers, json_yaml = false)
-      required_fields = json_yaml ? %w{justification} : %w{control_id justification}
-      all_fields = %w{control_id justification expiration_date run}
+    def self.all_fields
+      %w{control_id justification expiration_date run}
+    end
 
-      Inspec::Log.warn "Missing column headers: #{(required_fields - headers)}" unless (required_fields - headers).empty?
-      Inspec::Log.warn "Invalid column header: Column can't be nil" if headers.include? nil
-      Inspec::Log.warn "Extra column headers: #{(headers - all_fields)}" unless (headers - all_fields).empty?
+    def self.validate_csv_headers(headers)
+      invalid_headers_info = fetch_invalid_headers_info(headers)
+      # Warn if blank column found in csv file
+      Inspec::Log.warn "Invalid column headers: Column can't be nil" if invalid_headers_info[:blank_column]
+      # Warn if extra header found in csv file
+      Inspec::Log.warn "Extra header/s #{invalid_headers_info[:extra_headers]}" unless invalid_headers_info[:extra_headers].empty?
+      unless invalid_headers_info[:missing_required_fields].empty?
+        raise Inspec::Exceptions::WaiversFileInvalidFormatting,
+        "Missing required header/s #{invalid_headers_info[:missing_required_fields]}. Fix headers in file to proceed."
+      end
+    end
+
+    def self.fetch_invalid_headers_info(headers, json_yaml = false)
+      required_fields = json_yaml ? %w{justification} : %w{control_id justification}
+      data = {}
+      data[:missing_required_fields] = []
+      # Finds missing required fields
+      unless (required_fields - headers).empty?
+        data[:missing_required_fields] = required_fields - headers
+      end
+      # If column with no header found set the blank_column flag. Only applicable for csv
+      data[:blank_column] = headers.include?(nil) ? true : false
+      # Find extra headers/parameters
+      data[:extra_headers] = (headers - all_fields)
+      data
     end
 
     def self.validate_json_yaml(data)
       return if data.nil?
 
-      headers = []
-      data.each_value do |value|
-        headers.push value.keys
+      missing_required_field = false
+      data.each do |key, value|
+        # In case of yaml or json we need to validate headers/parametes for each value
+        invalid_headers_info = fetch_invalid_headers_info(value.keys, true)
+        # WARN in case of extra parameters found in each waived control
+        Inspec::Log.warn "Control ID #{key}: extra parameter/s #{invalid_headers_info[:extra_headers]}" unless invalid_headers_info[:extra_headers].empty?
+        unless invalid_headers_info[:missing_required_fields].empty?
+          missing_required_field = true
+          # Log error for each waived control
+          Inspec::Log.error "Control ID #{key}: missing required parameter/s #{invalid_headers_info[:missing_required_fields]}"
+        end
       end
-      validate_headers(headers.flatten.uniq, true)
+
+      # Raise error if any of the waived control has missing required filed
+      if missing_required_field
+        raise Inspec::Exceptions::WaiversFileInvalidFormatting,
+             "Missing required parameter [justification]. Fix parameters in file to proceed."
+      end
     end
   end
 end

--- a/test/fixtures/profiles/waivers/basic/files/malformed-waiver.yaml
+++ b/test/fixtures/profiles/waivers/basic/files/malformed-waiver.yaml
@@ -1,0 +1,3 @@
+"03_waivered_no_expiry_ran_passes"
+  justification: "Justification of 03"
+  run: false

--- a/test/fixtures/profiles/waivers/basic/files/wrong-headers.json
+++ b/test/fixtures/profiles/waivers/basic/files/wrong-headers.json
@@ -1,9 +1,11 @@
 {
   "03_waivered_no_expiry_ran_passes": {
-    "justification_random": "Sound reasoning",
+    "justification": "Sound reasoning",
     "run_random": true,
     "expiration_date_random": "1977-06-01T00:00:00.000Z"
   },
   "04_waivered_no_expiry_ran_fails": {
+    "justification_random": "Sound reasoning",
+    "run_random": true
   }
 }

--- a/test/fixtures/profiles/waivers/basic/files/wrong-headers.yaml
+++ b/test/fixtures/profiles/waivers/basic/files/wrong-headers.yaml
@@ -1,4 +1,8 @@
 03_waivered_no_expiry_ran_passes:
-  justification_random: Sound reasoning
+  justification: Sound reasoning
   run_random: true
   expiration_date_random: 2077-11-10T00:00:00Z
+
+04_waivered_no_expiry_ran_fails:
+  justification_random: Sound reasoning
+  run_random: true

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -286,29 +286,33 @@ describe "waivers" do
 
     describe "using csv file" do
       let(:waiver_file) { "wrong-headers.csv" }
-      it "raise warnings" do
+      it "raise errors" do
         result = run_result
-        assert_includes result.stderr, "Missing column headers: [\"control_id\", \"justification\"]"
-        assert_includes result.stderr, "Invalid column header: Column can't be nil"
-        assert_includes result.stderr, "Extra column headers: [\"control_id_random\", \"justification_random\", \"run_random\", \"expiration_date_random\", nil]"
+        assert_includes result.stderr, "ERROR: Error reading waivers file"
+        assert_includes result.stderr, "Missing required header/s [\"control_id\", \"justification\"]"
+        assert_includes result.stderr, "Fix headers in file to proceed."
       end
     end
 
     describe "using json file" do
       let(:waiver_file) { "wrong-headers.json" }
-      it "raise warnings" do
+      it "raise errors" do
         result = run_result
-        assert_includes result.stderr, "Missing column headers: [\"justification\"]"
-        assert_includes result.stderr, "Extra column headers: [\"justification_random\", \"run_random\", \"expiration_date_random\"]"
+        assert_includes result.stderr, "ERROR: Error reading waivers file"
+        assert_includes result.stderr, "ERROR: Control ID 04_waivered_no_expiry_ran_fails: missing required parameter/s [\"justification\"]"
+        assert_includes result.stderr, "Fix parameters in file to proceed."
+        assert_includes result.stderr, "WARN: Control ID 03_waivered_no_expiry_ran_passes: extra parameter/s [\"run_random\", \"expiration_date_random\"]"
       end
     end
 
     describe "using yaml file" do
       let(:waiver_file) { "wrong-headers.yaml" }
-      it "raise warnings" do
+      it "raise errors" do
         result = run_result
-        assert_includes result.stderr, "Missing column headers: [\"justification\"]"
-        assert_includes result.stderr, "Extra column headers: [\"justification_random\", \"run_random\", \"expiration_date_random\"]"
+        assert_includes result.stderr, "ERROR: Error reading waivers file"
+        assert_includes result.stderr, "ERROR: Control ID 04_waivered_no_expiry_ran_fails: missing required parameter/s [\"justification\"]"
+        assert_includes result.stderr, "Fix parameters in file to proceed."
+        assert_includes result.stderr, "WARN: Control ID 03_waivered_no_expiry_ran_passes: extra parameter/s [\"run_random\", \"expiration_date_random\"]"
       end
     end
 
@@ -317,12 +321,19 @@ describe "waivers" do
       it "raise error" do
         result = run_result
         assert_includes result.stderr, "Unsupported file extension"
-        if windows?
-          assert_equal 1, result.exit_status
-        else
-          assert_equal 102, result.exit_status
-        end
+        assert_equal 1, result.exit_status
       end
+    end
+  end
+
+  describe "with a waiver file with malformed data" do
+    let(:profile_name) { "basic" }
+    let(:waiver_file) { "malformed-waiver.yaml" }
+
+    it "raise error" do
+      result = run_result
+      assert_includes result.stderr, "ERROR:"
+      assert_includes result.stderr, "invalid YAML or contents is not a Hash"
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Backports #6644 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
