### PR TITLE
Fixes for external plugin testing

### DIFF
--- a/lib/plugins/shared/core_plugin_test_helper.rb
+++ b/lib/plugins/shared/core_plugin_test_helper.rb
@@ -12,7 +12,7 @@ require "tmpdir" unless defined?(Dir.mktmpdir)
 require "pathname" unless defined?(Pathname)
 require "forwardable" unless defined?(Forwardable)
 
-require "functional/helper"
+require_relative "../../../test/functional/helper"
 require "inspec/plugin/v2"
 
 # Configure Minitest to expose things like `let`

--- a/test/functional/helper.rb
+++ b/test/functional/helper.rb
@@ -1,4 +1,4 @@
-require "helper"
+require_relative "../helper"
 require "train"
 
 ENV["CHEF_LICENSE"] = "accept-no-persist"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

When developing plugins outside of the InSpec codebase, we need to be able to test the plugins using test facilities provided by InSpec core. The inspec/lib/plugins/shared/core_plugin_test_helper.rb is intended to assist with this, but has incorrect `require`s.

Human written.

Tested with inspec-reporter-csv.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
