### PR TITLE
CHEF-21510 Disabled adding chef ruby gem server as source for installation of gems

### DIFF
--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -318,7 +318,8 @@ module Inspec::Plugin::V2
 
     def install_from_remote_gems(requested_plugin_name, opts, source_manager: GemSourceManager.instance)
       plugin_dependency = Gem::Dependency.new(requested_plugin_name, opts[:version] || "> 0")
-      source_manager.add_chef_rubygems_server # ensure CHEF RUBYGEMS server is added to the source
+      ## Disabling logic to add chef rubygems server until licensing is disabled
+      # source_manager.add_chef_rubygems_server # ensure CHEF RUBYGEMS server is added to the source
 
       # This adds custom gem sources to the memoized `Gem.Sources` for this specific run
       # Note: This will not make any change to the environment Gem source list and


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Disabled adding chef ruby gem server as source for installation of gems
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
