### PR TITLE
CHEF-22822 Fixes unspecified class error while running waiver file with --filter-waived-controls flag

### DIFF
--- a/lib/inspec/profile.rb
+++ b/lib/inspec/profile.rb
@@ -256,7 +256,14 @@ module Inspec
       # # Pull together waiver
       waived_control_ids = []
       waiver_paths.each do |waiver_path|
-        waiver_content = YAML.load_file(waiver_path)
+        # Ruby 3.1 treats YAML load as a dangerous operation by default, requiring us to declare date and time classes as permitted
+        # It's not a valid option in 3.0.x
+        if Gem.ruby_version >= Gem::Version.new("3.1.0")
+          waiver_content = ::YAML.load_file(waiver_path, permitted_classes: [Date, Time])
+        else
+          waiver_content = YAML.load_file(waiver_path)
+        end
+
         unless waiver_content
           # Note that we will have already issued a detailed warning
           Inspec::Log.error "YAML parsing error in #{waiver_path}"

--- a/test/fixtures/profiles/waivers/purely-broken-controls/files/waivers.yml
+++ b/test/fixtures/profiles/waivers/purely-broken-controls/files/waivers.yml
@@ -5,8 +5,4 @@
 02_my_working_but_waived_control:
   justification: Sound reasoning
   run: false
-
-03_my_working_control:
-  justification: Sound reasoning
-  run: false
   expiration_date: 2077-06-01

--- a/test/fixtures/profiles/waivers/purely-broken-controls/files/waivers.yml
+++ b/test/fixtures/profiles/waivers/purely-broken-controls/files/waivers.yml
@@ -5,3 +5,8 @@
 02_my_working_but_waived_control:
   justification: Sound reasoning
   run: false
+
+03_my_working_control:
+  justification: Sound reasoning
+  run: false
+  expiration_date: 2077-06-01


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
While running profile with waiver file and with `--filter-waived-controls flag`, if waiver file has expiration_date, it is throwing exception `Tried to load unspecified class: Date`
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
