### PR TITLE
CHEF-18030- Fix GitFetcher to Clear Empty Cache Directory on Fetch

### DIFF
--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -73,7 +73,9 @@ module Inspec::Fetcher
             # this means the git repository did not contain any files (or the checkout failed).
             # In this case, remove the destination directory to avoid
             # leaving an empty or invalid profile directory.
-            FileUtils.rm_r(destination_path)
+            if Dir.exist?(destination_path)
+              FileUtils.rm_rf(destination_path)
+            end
             raise Inspec::FetcherFailure, "Profile git dependency failed for #{@remote_url} - no files found in the repository."
           end
           if @relative_path

--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -75,12 +75,14 @@ module Inspec::Fetcher
                                 "Moving checkout to #{destination_path}")
             FileUtils.cp_r(working_dir + "/.", destination_path)
           end
-          # If the temporary working directory is empty after checkout,
-          # this means the git repository did not contain any files (or the checkout failed).
-          # In this case, remove the destination directory to avoid
-          # leaving an empty or invalid profile directory.
-          Inspec::Log.debug("Remove #{destination_path} directory because temp directory #{working_dir} it is empty")
-          FileUtils.rm_r(destination_path) unless Dir.empty?(working_dir) || Dir.empty?(destination_path)
+          if Dir.exist?(destination_path) && Dir.empty?(destination_path)
+            # If the temporary working directory is empty after checkout,
+            # this means the git repository did not contain any files (or the checkout failed).
+            # In this case, remove the destination directory to avoid
+            # leaving an empty or invalid profile directory.
+            Inspec::Log.debug("Remove #{destination_path} directory because temp directory #{working_dir} it is empty")
+            FileUtils.rm_r(destination_path)
+          end
         end
       end
       @repo_directory

--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -69,7 +69,11 @@ module Inspec::Fetcher
         Dir.mktmpdir do |working_dir|
           checkout(working_dir)
           if Dir.empty?(working_dir)
-            Inspec::Log.debug("Remove #{destination_path} directory because it is empty")
+            # If the temporary working directory is empty after checkout,
+            # this means the git repository did not contain any files (or the checkout failed).
+            # In this case, remove the destination directory to avoid
+            # leaving an empty or invalid profile directory.
+            Inspec::Log.debug("Remove #{destination_path} directory because temp directory {working_dir} it is empty")
             FileUtils.rm_r(destination_path)
           elsif @relative_path
             perform_relative_path_fetch(destination_path, working_dir)

--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -80,7 +80,7 @@ module Inspec::Fetcher
           # In this case, remove the destination directory to avoid
           # leaving an empty or invalid profile directory.
           Inspec::Log.debug("Remove #{destination_path} directory because temp directory #{working_dir} it is empty")
-          FileUtils.rm_r(destination_path) unless Dir.empty?(working_dir) || Dir.empty?(working_dir)
+          FileUtils.rm_r(destination_path) unless Dir.empty?(working_dir) || Dir.empty?(destination_path)
         end
       end
       @repo_directory

--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -80,7 +80,7 @@ module Inspec::Fetcher
             # this means the git repository did not contain any files (or the checkout failed).
             # In this case, remove the destination directory to avoid
             # leaving an empty or invalid profile directory.
-            Inspec::Log.debug("Remove #{destination_path} directory because temp directory #{working_dir} it is empty")
+            Inspec::Log.debug("Removing #{destination_path} directory because temp directory #{working_dir} is empty")
             FileUtils.rm_r(destination_path)
           end
         end

--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -68,11 +68,14 @@ module Inspec::Fetcher
       else
         Dir.mktmpdir do |working_dir|
           checkout(working_dir)
-          if @relative_path
+          if Dir.empty?(working_dir)
+            Inspec::Log.debug("Remove #{working_dir} directory because it is empty")
+            FileUtils.rm_r(destination_path)
+          elsif @relative_path
             perform_relative_path_fetch(destination_path, working_dir)
           else
             Inspec::Log.debug("Checkout of #{resolved_ref.nil? ? @remote_url : resolved_ref} successful. " \
-                              "Moving checkout to #{destination_path}")
+                                "Moving checkout to #{destination_path}")
             FileUtils.cp_r(working_dir + "/.", destination_path)
           end
         end

--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -69,7 +69,7 @@ module Inspec::Fetcher
         Dir.mktmpdir do |working_dir|
           checkout(working_dir)
           if Dir.empty?(working_dir)
-            Inspec::Log.debug("Remove #{working_dir} directory because it is empty")
+            Inspec::Log.debug("Remove #{destination_path} directory because it is empty")
             FileUtils.rm_r(destination_path)
           elsif @relative_path
             perform_relative_path_fetch(destination_path, working_dir)

--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -68,20 +68,19 @@ module Inspec::Fetcher
       else
         Dir.mktmpdir do |working_dir|
           checkout(working_dir)
-          if Dir.empty?(working_dir)
-            # If the temporary working directory is empty after checkout,
-            # this means the git repository did not contain any files (or the checkout failed).
-            # In this case, remove the destination directory to avoid
-            # leaving an empty or invalid profile directory.
-            Inspec::Log.debug("Remove #{destination_path} directory because temp directory {working_dir} it is empty")
-            FileUtils.rm_r(destination_path)
-          elsif @relative_path
+          if @relative_path
             perform_relative_path_fetch(destination_path, working_dir)
           else
             Inspec::Log.debug("Checkout of #{resolved_ref.nil? ? @remote_url : resolved_ref} successful. " \
                                 "Moving checkout to #{destination_path}")
             FileUtils.cp_r(working_dir + "/.", destination_path)
           end
+          # If the temporary working directory is empty after checkout,
+          # this means the git repository did not contain any files (or the checkout failed).
+          # In this case, remove the destination directory to avoid
+          # leaving an empty or invalid profile directory.
+          Inspec::Log.debug("Remove #{destination_path} directory because temp directory #{working_dir} it is empty")
+          FileUtils.rm_r(destination_path) unless Dir.empty?(working_dir) || Dir.empty?(working_dir)
         end
       end
       @repo_directory

--- a/test/unit/fetchers/git_test.rb
+++ b/test/unit/fetchers/git_test.rb
@@ -124,9 +124,11 @@ a7729ce65636d6d8b80159dd5dd7a40fdb6f2501\trefs/tags/anothertag^{}\n")
       expect_clone
       expect_checkout_without_ref
       expect_mv_into_place
-      Dir.stubs(:empty?).with("test-tmp-dir").returns(false) # Prevent ENOENT
-      Dir.stubs(:empty?).with("fetchpath").returns(false) # Prevent ENOENT on fetchpath
-      FileUtils.stubs(:rm_r) # Prevent actual deletion and ENOENT
+      Dir.stubs(:exist?).with("test-tmp-dir").returns(true) # Simulate directory existence
+      Dir.stubs(:children).with("test-tmp-dir").returns(["file1"]) # Simulate non-empty directory
+      Dir.stubs(:exist?).with("fetchpath").returns(true) # Simulate directory existence
+      Dir.stubs(:children).with("fetchpath").returns(["file2"]) # Simulate non-empty directory
+      FileUtils.stubs(:rm_rf) # Prevent actual deletion and ENOENT
       result = fetcher.resolve({ git: git_dep_dir })
       result.fetch("fetchpath")
     end
@@ -156,7 +158,7 @@ a7729ce65636d6d8b80159dd5dd7a40fdb6f2501\trefs/tags/anothertag^{}\n")
       Dir.stubs(:children).with("test-tmp-dir").returns([".git"])
       Dir.stubs(:exist?).with("test-tmp-dir").returns(true)
       Dir.stubs(:exist?).with("fetchpath").returns(true)
-      FileUtils.expects(:rm_r).with("fetchpath") # Ensure cleanup happens
+      FileUtils.expects(:rm_rf).with("fetchpath") # Ensure cleanup happens
 
       result = fetcher.resolve({ git: git_dep_dir })
       err = _ { result.fetch("fetchpath") }.must_raise Inspec::FetcherFailure

--- a/test/unit/fetchers/git_test.rb
+++ b/test/unit/fetchers/git_test.rb
@@ -188,16 +188,18 @@ a7729ce65636d6d8b80159dd5dd7a40fdb6f2501\trefs/tags/anothertag^{}\n")
     end
 
     it "removes destination_path if working_dir is empty" do
+      # Simulate the case where the temporary working directory is empty after clone/checkout.
+      # The fetch method should log a debug message and remove the destination_path.
       Dir.stubs(:mktmpdir).yields(working_dir)
       Dir.stubs(:empty?).with(working_dir).returns(true)
 
       FileUtils.expects(:rm_r).with(destination_path)
-      Inspec::Log.expects(:debug).with("Remove #{working_dir} directory because it is empty")
-
       fetcher_instance.fetch(destination_path)
     end
 
     it "calls perform_relative_path_fetch if @relative_path is set and working_dir is not empty" do
+      # Simulate the case where a relative path is specified and the working directory is not empty.
+      # The fetch method should call perform_relative_path_fetch.
       Dir.stubs(:mktmpdir).yields(working_dir)
       Dir.stubs(:empty?).with(working_dir).returns(false)
       fetcher_instance.instance_variable_set(:@relative_path, "some/path")
@@ -207,6 +209,8 @@ a7729ce65636d6d8b80159dd5dd7a40fdb6f2501\trefs/tags/anothertag^{}\n")
     end
 
     it "copies working_dir contents to destination_path if not empty and no @relative_path" do
+      # Simulate the case where the working directory is not empty and no relative path is set.
+      # The fetch method should copy the contents of working_dir to destination_path.
       Dir.stubs(:mktmpdir).yields(working_dir)
       Dir.stubs(:empty?).with(working_dir).returns(false)
       fetcher_instance.instance_variable_set(:@relative_path, nil)

--- a/test/unit/fetchers/git_test.rb
+++ b/test/unit/fetchers/git_test.rb
@@ -196,7 +196,7 @@ a7729ce65636d6d8b80159dd5dd7a40fdb6f2501\trefs/tags/anothertag^{}\n")
       fetcher_instance.stubs(:resolved_ref).returns(nil)
 
       FileUtils.expects(:rm_r).with(destination_path)
-      Inspec::Log.expects(:debug).with("Remove #{destination_path} directory because temp directory #{working_dir} it is empty")
+      Inspec::Log.expects(:debug).with("Removing #{destination_path} directory because temp directory #{working_dir} is empty")
       fetcher_instance.fetch(destination_path)
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
In case of a Git fetch failure, the created cache directory remains empty, causing the Test Kitchen suite to fail in subsequent executions across multiple platforms.


## Description
<!--- Describe your changes in detail, what problems does it solve? -->
FIXES
- [x] Added logic to detect and remove empty cache directories when a Git fetch fails.
- [x] Ensured cleanup is performed before retrying or exiting the fetch process.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
