### PR TITLE
Add Stable channel to artifact Channels

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -75,10 +75,12 @@ changelog:
   - "Type: Enhancement": "Enhancements"
   - "Type: Bug": "Bug Fixes"
 
-
+# Channel promotion flow for InSpec 7 (base-2025) will be:
+# unstable → base-2025-current → base-2025 & stable
 artifact_channels:
   - base-2025-current
   - base-2025
+  - stable
 
 subscriptions:
   - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Add Stable channel to artifact Channels
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Channel promotion flow for InSpec 7 (base-2025) will be:
 unstable → base-2025-current → base-2025 & stable
 
 Added Stable to artifact channels

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
