### PR TITLE
dependabot - disabled all target branches but inspec-5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,26 @@
 version: 2
 updates:
+# - package-ecosystem: bundler
+#   target-branch: "main"
+#   directory: "/"
+#   schedule:
+#     interval: daily
+#   open-pull-requests-limit: 10
+# - package-ecosystem: bundler
+#   target-branch: "main"
+#   directory: "/omnibus"
+#   schedule:
+#     interval: daily
+#   open-pull-requests-limit: 10
 - package-ecosystem: bundler
-  target-branch: "main"
+  target-branch: "inspec-5"
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-- package-ecosystem: bundler
-  target-branch: "main"
-  directory: "/omnibus"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: bundler
-  target-branch: "inspec-5"
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: bundler
-  target-branch: "inspec-5"
-  directory: "/omnibus"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+# - package-ecosystem: bundler
+#   target-branch: "inspec-5"
+#   directory: "/omnibus"
+#   schedule:
+#     interval: daily
+#   open-pull-requests-limit: 10


### PR DESCRIPTION
## Description
Even if we have multiple target branches defined, Dependabot still scans only "main". We are disabling all other branches but "inspec-5" to get a proper, one time dependency scan. After the reading is done we will revert the change.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
