### PR TITLE
Foreport-CHEF-18030- Fix GitFetcher to Clear Empty Cache Directory on Fetch

### DIFF
--- a/lib/inspec/fetcher/git.rb
+++ b/lib/inspec/fetcher/git.rb
@@ -68,16 +68,36 @@ module Inspec::Fetcher
       else
         Dir.mktmpdir do |working_dir|
           checkout(working_dir)
+          if git_only_or_empty?(working_dir)
+            # If the temporary working directory is empty after checkout,
+            # this means the git repository did not contain any files (or the checkout failed).
+            # In this case, remove the destination directory to avoid
+            # leaving an empty or invalid profile directory.
+            if Dir.exist?(destination_path)
+              FileUtils.rm_rf(destination_path)
+            end
+            raise Inspec::FetcherFailure, "Profile git dependency failed for #{@remote_url} - no files found in the repository."
+          end
           if @relative_path
             perform_relative_path_fetch(destination_path, working_dir)
           else
             Inspec::Log.debug("Checkout of #{resolved_ref.nil? ? @remote_url : resolved_ref} successful. " \
-                              "Moving checkout to #{destination_path}")
+                                "Moving checkout to #{destination_path}")
             FileUtils.cp_r(working_dir + "/.", destination_path)
           end
         end
       end
       @repo_directory
+    end
+
+    def git_only_or_empty?(dir)
+      return false unless Dir.exist?(dir)
+
+      children = Dir.children(dir)
+      # Return true if:
+      # - directory is completely empty
+      # - or it contains only one entry: '.git'
+      children.empty? || (children - [".git"]).empty?
     end
 
     def perform_relative_path_fetch(destination_path, working_dir)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
 Foreports (#7398)
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix GitFetcher to Clear Empty Cache Directory on Fetch
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
