### PR TITLE
Require CSV gem to avoid warnings on modern Ruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 3.1 # this should match the required ruby in the gemspec
   Exclude:
     - 'test/kitchen/**/*'
     - 'test/integration/**/controls/**/*.rb'

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -54,6 +54,7 @@ Source code obtained from the Chef GitHub repository is made available under Apa
   spec.add_dependency "parslet",                  ">= 1.5", "< 2.0" # Pinned < 2.0, see #5389
   spec.add_dependency "semverse",                 "~> 3.0"
   spec.add_dependency "multipart-post",           "~> 2.0"
+  spec.add_dependency "csv",                      "~> 3.0"
 
   # cookstyle support for inspec check
   # This was initially included in 'inspec.gemspec' to keep 'chef-client' lightweight.


### PR DESCRIPTION
InSpec is making a lot of warning noise in any project that has it in the dep tree. This avoids that by requiring the csv gem that is used by the project.

Example:

```
 /home/runner/work/kitchen-dokken/kitchen-dokken/vendor/bundle/ruby/3.3.0/gems/inspec-core-6.8.24/lib/inspec/waiver_file_reader.rb:2: warning: csv was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add csv to your Gemfile or gemspec to silence this warning.
```

While I was here I set the ruby version in cookstyle to match the gemspec

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
