### PR TITLE
CHEF-25164 Update Train deps for InSpec 5: train/train-core 3.13.4+, train-winrm…

### DIFF
--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -54,5 +54,5 @@ Gem::Specification.new do |spec|
   # which was causing a LoadError ('cannot load such file -- ast') for users/applications using 'inspec-core'.
   spec.add_dependency "cookstyle"
 
-  spec.add_dependency "train-core", "~> 3.12.13" # Adding tight version constraint for train as it is compatible with Ruby 3.0.x
+  spec.add_dependency "train-core", "~> 3.13", ">= 3.13.4"
 end

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "inspec-core", "= #{Inspec::VERSION}"
 
-  spec.add_dependency "train", "~> 3.12.13" # Adding tight version constraint for train as it is compatible with Ruby 3.0.x
+  spec.add_dependency "train", "~> 3.13", ">= 3.13.4"
   spec.add_dependency "rake"
 
   # progress bar streaming reporter plugin support
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   # Train plugins we ship with InSpec
   spec.add_dependency "train-habitat",    "~> 0.1"
   spec.add_dependency "train-aws",        "~> 0.2"
-  spec.add_dependency "train-winrm",      "~> 0.2.19"
+  spec.add_dependency "train-winrm",      "~> 0.4"
   spec.add_dependency "train-kubernetes", "< 0.3.1" # 0.3.1+ requires min ruby 3.1
 
   spec.add_dependency "mongo", "= 2.13.2" # 2.14 introduces a broken symlink in mongo-2.14.0/spec/support/ocsp

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   # Train plugins we ship with InSpec
   spec.add_dependency "train-habitat",    "~> 0.1"
   spec.add_dependency "train-aws",        "~> 0.2"
-  spec.add_dependency "train-winrm",      "~> 0.4"
+  spec.add_dependency "train-winrm",      "~> 0.4.0"
   spec.add_dependency "train-kubernetes", "< 0.3.1" # 0.3.1+ requires min ruby 3.1
 
   spec.add_dependency "mongo", "= 2.13.2" # 2.14 introduces a broken symlink in mongo-2.14.0/spec/support/ocsp


### PR DESCRIPTION
chore(deps): bump Train deps for InSpec 5 (train 3.13.4+, train-core 3.13.4+, train-winrm 0.4.x)

<!--- Provide a short summary of your changes in the Title above -->
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Description
Update dependency constraints to pick up latest Train releases for InSpec 5:

inspec-core.gemspec: train-core "~> 3.13", ">= 3.13.4"
inspec.gemspec: train "<del>> 3.13", ">= 3.13.4" and train-winrm "</del>> 0.4"
Brings bug fixes and transport improvements while staying within the 3.x line (non-breaking).


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
