### PR TITLE
CHEF-25277 add docs for socks feature

### DIFF
--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -183,6 +183,12 @@ This subcommand has the following additional options:
 `--key-files=one two three`
 : Login key or certificate file for a remote scan.
 
+`--kerberos-realm=KERBEROS_REALM`
+: Kerberos realm used for authentication (WinRM).
+
+`--kerberos-service=KERBEROS_SERVICE`
+: Kerberos service principal name (e.g., HTTP, HOST) (WinRM).
+
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
 
@@ -212,6 +218,15 @@ This subcommand has the following additional options:
 
 `--shell-options=SHELL_OPTIONS`
 : Additional shell options.
+
+`--socks-password=SOCKS_PASSWORD`
+: Password for authenticating with the SOCKS5 proxy (WinRM).
+
+`--socks-proxy=SOCKS_PROXY`
+: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM).
+
+`--socks-user=SOCKS_USER`
+: Username for authenticating with the SOCKS5 proxy (WinRM).
 
 `--ssl`
 `--no-ssl`
@@ -452,6 +467,12 @@ This subcommand has the following additional options:
 `--key-files=one two three`
 : Login key or certificate file for a remote scan.
 
+`--kerberos-realm=KERBEROS_REALM`
+: Kerberos realm used for authentication (WinRM).
+
+`--kerberos-service=KERBEROS_SERVICE`
+: Kerberos service principal name (e.g., HTTP, HOST) (WinRM).
+
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
 
@@ -504,6 +525,15 @@ This subcommand has the following additional options:
 
 `--silence-deprecations=all|GROUP GROUP...`
 : Suppress deprecation warnings. See install_dir/etc/deprecations.json for a list of GROUPs or use 'all'.
+
+`--socks-password=SOCKS_PASSWORD`
+: Password for authenticating with the SOCKS5 proxy (WinRM).
+
+`--socks-proxy=SOCKS_PROXY`
+: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM).
+
+`--socks-user=SOCKS_USER`
+: Username for authenticating with the SOCKS5 proxy (WinRM).
 
 `--ssh-config-file=one two three`
 : A list of paths to the SSH configuration file, for example: `~/.ssh/config` or `/etc/ssh/ssh_config`.
@@ -825,6 +855,12 @@ This subcommand has the following additional options:
 `--key-files=one two three`
 : Login key or certificate file for a remote scan.
 
+`--kerberos-realm=KERBEROS_REALM`
+: Kerberos realm used for authentication (WinRM).
+
+`--kerberos-service=KERBEROS_SERVICE`
+: Kerberos service principal name (e.g., HTTP, HOST) (WinRM).
+
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
 
@@ -901,6 +937,15 @@ This subcommand has the following additional options:
 
 `--winrm-transport=WINRM_TRANSPORT`
 : Specify which transport to use, defaults to negotiate (WinRM).
+
+`--socks-password=SOCKS_PASSWORD`
+: Password for authenticating with the SOCKS5 proxy (WinRM).
+
+`--socks-proxy=SOCKS_PROXY`
+: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM).
+
+`--socks-user=SOCKS_USER`
+: Username for authenticating with the SOCKS5 proxy (WinRM).
 
 `--enhanced-outcomes`
 : Includes enhanced outcome of controls in report data.

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -184,10 +184,10 @@ This subcommand has the following additional options:
 : Login key or certificate file for a remote scan.
 
 `--kerberos-realm=KERBEROS_REALM`
-: Kerberos realm used for authentication (WinRM). Only supported on a linux client.
+: Kerberos realm used for authentication (WinRM). Only supported on Linux clients.
 
 `--kerberos-service=KERBEROS_SERVICE`
-: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on a linux client.
+: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on Linux clients.
 
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
@@ -220,13 +220,13 @@ This subcommand has the following additional options:
 : Additional shell options.
 
 `--socks-password=SOCKS_PASSWORD`
-: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
+: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
 
 `--socks-proxy=SOCKS_PROXY`
-: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on a linux client.
+: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on Linux clients.
 
 `--socks-user=SOCKS_USER`
-: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
+: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
 
 `--ssl`
 `--no-ssl`
@@ -468,10 +468,10 @@ This subcommand has the following additional options:
 : Login key or certificate file for a remote scan.
 
 `--kerberos-realm=KERBEROS_REALM`
-: Kerberos realm used for authentication (WinRM). Only supported on a linux client.
+: Kerberos realm used for authentication (WinRM). Only supported on Linux clients.
 
 `--kerberos-service=KERBEROS_SERVICE`
-: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on a linux client.
+: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on Linux clients.
 
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
@@ -527,13 +527,13 @@ This subcommand has the following additional options:
 : Suppress deprecation warnings. See install_dir/etc/deprecations.json for a list of GROUPs or use 'all'.
 
 `--socks-password=SOCKS_PASSWORD`
-: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
+: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
 
 `--socks-proxy=SOCKS_PROXY`
-: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on a linux client.
+: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on Linux clients.
 
 `--socks-user=SOCKS_USER`
-: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
+: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
 
 `--ssh-config-file=one two three`
 : A list of paths to the SSH configuration file, for example: `~/.ssh/config` or `/etc/ssh/ssh_config`.
@@ -856,10 +856,10 @@ This subcommand has the following additional options:
 : Login key or certificate file for a remote scan.
 
 `--kerberos-realm=KERBEROS_REALM`
-: Kerberos realm used for authentication (WinRM). Only supported on a linux client.
+: Kerberos realm used for authentication (WinRM). Only supported on Linux clients.
 
 `--kerberos-service=KERBEROS_SERVICE`
-: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on a linux client.
+: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on Linux clients.
 
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
@@ -939,13 +939,13 @@ This subcommand has the following additional options:
 : Specify which transport to use, defaults to negotiate (WinRM).
 
 `--socks-password=SOCKS_PASSWORD`
-: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
+: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
 
 `--socks-proxy=SOCKS_PROXY`
-: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on a linux client.
+: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on Linux clients.
 
 `--socks-user=SOCKS_USER`
-: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
+: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
 
 `--enhanced-outcomes`
 : Includes enhanced outcome of controls in report data.

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -184,10 +184,10 @@ This subcommand has the following additional options:
 : Login key or certificate file for a remote scan.
 
 `--kerberos-realm=KERBEROS_REALM`
-: Kerberos realm used for authentication (WinRM). Only supported on Linux clients.
+: The Kerberos realm used for authentication (WinRM). This option can only be run from Linux workstations.
 
 `--kerberos-service=KERBEROS_SERVICE`
-: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on Linux clients.
+: The Kerberos service principal name (such as HTTP or HOST) (WinRM). This option can only be run from Linux workstations.
 
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
@@ -220,13 +220,13 @@ This subcommand has the following additional options:
 : Additional shell options.
 
 `--socks-password=SOCKS_PASSWORD`
-: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
+: The password for authenticating with a SOCKS5 proxy (WinRM). This option can only be run from Linux workstations.
 
 `--socks-proxy=SOCKS_PROXY`
-: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on Linux clients.
+: The SOCKS5H proxy URL to tunnel the WinRM connection (for example, `<URL_OR_IP_ADDRESS>:1080`) (WinRM). This option can only be run from Linux workstations.
 
 `--socks-user=SOCKS_USER`
-: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
+: The username for authenticating with a SOCKS5 proxy (WinRM). This option can only be run from Linux workstations.
 
 `--ssl`
 `--no-ssl`
@@ -468,10 +468,10 @@ This subcommand has the following additional options:
 : Login key or certificate file for a remote scan.
 
 `--kerberos-realm=KERBEROS_REALM`
-: Kerberos realm used for authentication (WinRM). Only supported on Linux clients.
+: The Kerberos realm used for authentication (WinRM). This option can only be run from Linux workstations.
 
 `--kerberos-service=KERBEROS_SERVICE`
-: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on Linux clients.
+: The Kerberos service principal name (such as HTTP or HOST) (WinRM). This option can only be run from Linux workstations.
 
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
@@ -527,13 +527,13 @@ This subcommand has the following additional options:
 : Suppress deprecation warnings. See install_dir/etc/deprecations.json for a list of GROUPs or use 'all'.
 
 `--socks-password=SOCKS_PASSWORD`
-: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
+: The password for authenticating with a SOCKS5 proxy (WinRM). This option can only be run from Linux workstations.
 
 `--socks-proxy=SOCKS_PROXY`
-: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on Linux clients.
+: The SOCKS5H proxy URL to tunnel the WinRM connection (for example, `<URL_OR_IP_ADDRESS>:1080`) (WinRM). This option can only be run from Linux workstations.
 
 `--socks-user=SOCKS_USER`
-: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
+: The username for authenticating with a SOCKS5 proxy (WinRM). This option can only be run from Linux workstations.
 
 `--ssh-config-file=one two three`
 : A list of paths to the SSH configuration file, for example: `~/.ssh/config` or `/etc/ssh/ssh_config`.
@@ -840,6 +840,9 @@ This subcommand has the following additional options:
 `--enable-password=ENABLE_PASSWORD`
 : Password for enable mode on Cisco IOS devices.
 
+`--enhanced-outcomes`
+: Includes enhanced outcome of controls in report data.
+
 `--host=HOST`
 : Specify a remote host which is tested.
 
@@ -856,10 +859,10 @@ This subcommand has the following additional options:
 : Login key or certificate file for a remote scan.
 
 `--kerberos-realm=KERBEROS_REALM`
-: Kerberos realm used for authentication (WinRM). Only supported on Linux clients.
+: Kerberos realm used for authentication (WinRM). This option can only be run from Linux workstations.
 
 `--kerberos-service=KERBEROS_SERVICE`
-: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on Linux clients.
+: Kerberos service principal name (for example, HTTP, HOST) (WinRM). This option can only be run from Linux workstations.
 
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
@@ -893,6 +896,15 @@ This subcommand has the following additional options:
 
 `--shell-options=SHELL_OPTIONS`
 : Additional shell options.
+
+`--socks-password=SOCKS_PASSWORD`
+: The password for authenticating with a SOCKS5 proxy (WinRM). This option can only be run from Linux workstations.
+
+`--socks-proxy=SOCKS_PROXY`
+: The SOCKS5H proxy URL to tunnel the WinRM connection (for example, `<URL_OR_IP_ADDRESS>:1080`) (WinRM). This option can only be run from Linux workstations.
+
+`--socks-user=SOCKS_USER`
+: The username for authenticating with a SOCKS5 proxy (WinRM). This option can only be run from Linux workstations.
 
 `--ssh-config-file=one two three`
 : A list of paths to the SSH configuration file, for example: `~/.ssh/config` or `/etc/ssh/ssh_config`.
@@ -937,18 +949,6 @@ This subcommand has the following additional options:
 
 `--winrm-transport=WINRM_TRANSPORT`
 : Specify which transport to use, defaults to negotiate (WinRM).
-
-`--socks-password=SOCKS_PASSWORD`
-: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
-
-`--socks-proxy=SOCKS_PROXY`
-: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on Linux clients.
-
-`--socks-user=SOCKS_USER`
-: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on Linux clients.
-
-`--enhanced-outcomes`
-: Includes enhanced outcome of controls in report data.
 
 ## supermarket
 

--- a/docs-chef-io/content/inspec/cli.md
+++ b/docs-chef-io/content/inspec/cli.md
@@ -184,10 +184,10 @@ This subcommand has the following additional options:
 : Login key or certificate file for a remote scan.
 
 `--kerberos-realm=KERBEROS_REALM`
-: Kerberos realm used for authentication (WinRM).
+: Kerberos realm used for authentication (WinRM). Only supported on a linux client.
 
 `--kerberos-service=KERBEROS_SERVICE`
-: Kerberos service principal name (e.g., HTTP, HOST) (WinRM).
+: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on a linux client.
 
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
@@ -220,13 +220,13 @@ This subcommand has the following additional options:
 : Additional shell options.
 
 `--socks-password=SOCKS_PASSWORD`
-: Password for authenticating with the SOCKS5 proxy (WinRM).
+: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
 
 `--socks-proxy=SOCKS_PROXY`
-: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM).
+: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on a linux client.
 
 `--socks-user=SOCKS_USER`
-: Username for authenticating with the SOCKS5 proxy (WinRM).
+: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
 
 `--ssl`
 `--no-ssl`
@@ -468,10 +468,10 @@ This subcommand has the following additional options:
 : Login key or certificate file for a remote scan.
 
 `--kerberos-realm=KERBEROS_REALM`
-: Kerberos realm used for authentication (WinRM).
+: Kerberos realm used for authentication (WinRM). Only supported on a linux client.
 
 `--kerberos-service=KERBEROS_SERVICE`
-: Kerberos service principal name (e.g., HTTP, HOST) (WinRM).
+: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on a linux client.
 
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
@@ -527,13 +527,13 @@ This subcommand has the following additional options:
 : Suppress deprecation warnings. See install_dir/etc/deprecations.json for a list of GROUPs or use 'all'.
 
 `--socks-password=SOCKS_PASSWORD`
-: Password for authenticating with the SOCKS5 proxy (WinRM).
+: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
 
 `--socks-proxy=SOCKS_PROXY`
-: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM).
+: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on a linux client.
 
 `--socks-user=SOCKS_USER`
-: Username for authenticating with the SOCKS5 proxy (WinRM).
+: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
 
 `--ssh-config-file=one two three`
 : A list of paths to the SSH configuration file, for example: `~/.ssh/config` or `/etc/ssh/ssh_config`.
@@ -856,10 +856,10 @@ This subcommand has the following additional options:
 : Login key or certificate file for a remote scan.
 
 `--kerberos-realm=KERBEROS_REALM`
-: Kerberos realm used for authentication (WinRM).
+: Kerberos realm used for authentication (WinRM). Only supported on a linux client.
 
 `--kerberos-service=KERBEROS_SERVICE`
-: Kerberos service principal name (e.g., HTTP, HOST) (WinRM).
+: Kerberos service principal name (e.g., HTTP, HOST) (WinRM). Only supported on a linux client.
 
 `--password=PASSWORD`
 : Login password for a remote scan, if required.
@@ -939,13 +939,13 @@ This subcommand has the following additional options:
 : Specify which transport to use, defaults to negotiate (WinRM).
 
 `--socks-password=SOCKS_PASSWORD`
-: Password for authenticating with the SOCKS5 proxy (WinRM).
+: Password for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
 
 `--socks-proxy=SOCKS_PROXY`
-: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM).
+: SOCKS5H proxy URL to tunnel the WinRM connection (e.g., proxy-host:1080) (WinRM). Only supported on a linux client.
 
 `--socks-user=SOCKS_USER`
-: Username for authenticating with the SOCKS5 proxy (WinRM).
+: Username for authenticating with the SOCKS5 proxy (WinRM). Only supported on a linux client.
 
 `--enhanced-outcomes`
 : Includes enhanced outcome of controls in report data.

--- a/docs-chef-io/content/inspec/shell.md
+++ b/docs-chef-io/content/inspec/shell.md
@@ -281,7 +281,7 @@ inspec shell --input-file=<path>
 ## Use the InSpec Shell with a SOCKS5 proxy
 
 You can use the InSpec Shell to target Windows nodes using WinRM through a SOCKS5 proxy.
-This is supported on Linux clients.
+These connections options can be run from Linux workstations.
 
 To start an InSpec Shell session with a basic SOCKS5 proxy connection:
 

--- a/docs-chef-io/content/inspec/shell.md
+++ b/docs-chef-io/content/inspec/shell.md
@@ -282,6 +282,8 @@ inspec shell --input-file=<path>
 
 For Windows targets behind a SOCKS5 proxy, you can use the shell with SOCKS proxy parameters:
 
+##### SOCKS5 proxy support is currently available only on Linux clients.
+
 ```bash
 # Basic SOCKS5 proxy connection
 inspec shell -t winrm://windows-host --socks-proxy socks5h://proxy-host:1080
@@ -290,7 +292,7 @@ inspec shell -t winrm://windows-host --socks-proxy socks5h://proxy-host:1080
 inspec shell -t winrm://windows-host \
   --socks-proxy socks5h://proxy-host:1080 \
   --socks-user proxy_username \
-  --socks-password proxy_password \
+  --socks-password proxy_password
 
 # Combined with Kerberos authentication
 inspec shell -t winrm://windows-host \
@@ -299,7 +301,7 @@ inspec shell -t winrm://windows-host \
   --socks-password proxy_password \
   --kerberos-realm CORP.EXAMPLE.COM \
   --kerberos-service HTTP \
-  --winrm_transport kerberos 
+  --winrm_transport kerberos
 ```
 
 Once connected through the SOCKS proxy, you can interact with Windows resources normally:

--- a/docs-chef-io/content/inspec/shell.md
+++ b/docs-chef-io/content/inspec/shell.md
@@ -278,33 +278,39 @@ another_input: another_value
 inspec shell --input-file=<path>
 ```
 
-### Using Shell with SOCKS5 Proxy
+## Use the InSpec Shell with a SOCKS5 proxy
 
-For Windows targets behind a SOCKS5 proxy, you can use the shell with SOCKS proxy parameters:
+You can use the InSpec Shell to target Windows nodes using WinRM through a SOCKS5 proxy.
+This is supported on Linux clients.
 
-##### SOCKS5 proxy support is currently available only on Linux clients.
+To start an InSpec Shell session with a basic SOCKS5 proxy connection:
 
 ```bash
-# Basic SOCKS5 proxy connection
-inspec shell -t winrm://windows-host --socks-proxy socks5h://proxy-host:1080
+inspec shell -t winrm://<WINDOWS_HOST> --socks-proxy socks5h://<PROXY_HOST>:1080
+```
 
-# SOCKS5 proxy with authentication
-inspec shell -t winrm://windows-host \
-  --socks-proxy socks5h://proxy-host:1080 \
-  --socks-user proxy_username \
-  --socks-password proxy_password
+To start an InSpec Shell session with a SOCKS5 proxy and authentication:
 
-# Combined with Kerberos authentication
-inspec shell -t winrm://windows-host \
-  --socks-proxy socks5h://proxy-host:1080 \
-  --socks-user proxy_username \
-  --socks-password proxy_password \
-  --kerberos-realm CORP.EXAMPLE.COM \
+```bash
+inspec shell -t winrm://<WINDOWS_HOST> \
+  --socks-proxy socks5h://<PROXY_HOST>:1080 \
+  --socks-user <PROXY_USERNAME> \
+  --socks-password <PROXY_PASSWORD>
+```
+
+To start an InSpec Shell session with a SOCKS5 proxy using SOCKS and Kerberos authentication:
+
+```bash
+inspec shell -t winrm://<WINDOWS_HOST> \
+  --socks-proxy socks5h://<PROXY_HOST>:1080 \
+  --socks-user <PROXY_USERNAME> \
+  --socks-password <PROXY_PASSWORD> \
+  --kerberos-realm <KERBEROS_REALM> \
   --kerberos-service HTTP \
   --winrm_transport kerberos
 ```
 
-Once connected through the SOCKS proxy, you can interact with Windows resources normally:
+Once you're connected through the SOCKS proxy, you can interact with Windows resources normally. For example:
 
 ```ruby
 inspec> os.family

--- a/docs-chef-io/content/inspec/shell.md
+++ b/docs-chef-io/content/inspec/shell.md
@@ -277,3 +277,38 @@ another_input: another_value
 ```bash
 inspec shell --input-file=<path>
 ```
+
+### Using Shell with SOCKS5 Proxy
+
+For Windows targets behind a SOCKS5 proxy, you can use the shell with SOCKS proxy parameters:
+
+```bash
+# Basic SOCKS5 proxy connection
+inspec shell -t winrm://windows-host --socks-proxy socks5h://proxy-host:1080
+
+# SOCKS5 proxy with authentication
+inspec shell -t winrm://windows-host \
+  --socks-proxy socks5h://proxy-host:1080 \
+  --socks-user proxy_username \
+  --socks-password proxy_password \
+
+# Combined with Kerberos authentication
+inspec shell -t winrm://windows-host \
+  --socks-proxy socks5h://proxy-host:1080 \
+  --socks-user proxy_username \
+  --socks-password proxy_password \
+  --kerberos-realm CORP.EXAMPLE.COM \
+  --kerberos-service HTTP \
+  --winrm_transport kerberos 
+```
+
+Once connected through the SOCKS proxy, you can interact with Windows resources normally:
+
+```ruby
+inspec> os.family
+=> "windows"
+inspec> file('C:\Windows\System32').exist?
+=> true
+inspec> service('wuauserv').installed?
+=> true
+```


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This pull request updates the InSpec CLI documentation to add support for SOCKS5 proxy and Kerberos authentication options, specifically for WinRM connections. It also provides new usage examples for connecting to Windows targets behind a SOCKS5 proxy, including combinations with Kerberos authentication.


## Description
<!--- Describe your changes in detail, what problems does it solve? -->
**Documentation updates for new WinRM connection options:**

* Added `--kerberos-realm` and `--kerberos-service` options to specify Kerberos authentication details for WinRM in multiple CLI command sections. [[1]](diffhunk://#diff-d630cb6548e46d87416a15a5672542b80771df5cd2757d6fbaef1b84d83ff089R186-R191) [[2]](diffhunk://#diff-d630cb6548e46d87416a15a5672542b80771df5cd2757d6fbaef1b84d83ff089R470-R475) [[3]](diffhunk://#diff-d630cb6548e46d87416a15a5672542b80771df5cd2757d6fbaef1b84d83ff089R858-R863)
* Added `--socks-proxy`, `--socks-user`, and `--socks-password` options for authenticating and tunneling WinRM connections through a SOCKS5 proxy in multiple CLI command sections. [[1]](diffhunk://#diff-d630cb6548e46d87416a15a5672542b80771df5cd2757d6fbaef1b84d83ff089R222-R230) [[2]](diffhunk://#diff-d630cb6548e46d87416a15a5672542b80771df5cd2757d6fbaef1b84d83ff089R529-R537) [[3]](diffhunk://#diff-d630cb6548e46d87416a15a5672542b80771df5cd2757d6fbaef1b84d83ff089R941-R949)

**Usage example enhancements:**

* Added a new section to `inspec/shell.md` demonstrating how to use the shell with SOCKS5 proxy parameters, including authentication and Kerberos integration, with example commands and expected shell outputs.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
