### PR TITLE
CHEF-26478 Add Omnibus build support for macOS 13 and 14 on ARM64 architecture.

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -32,15 +32,9 @@ builder-to-testers-map:
     - el-9-x86_64
   mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
-  mac_os_x-13-x86_64:
-    - mac_os_x-13-x86_64
-  mac_os_x-14-x86_64:
-    - mac_os_x-14-x86_64
   mac_os_x-12-arm64:
     - mac_os_x-12-arm64
-  mac_os_x-13-arm64:
     - mac_os_x-13-arm64
-  mac_os_x-14-arm64:
     - mac_os_x-14-arm64
   sles-12-x86_64:
     - sles-12-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -32,11 +32,15 @@ builder-to-testers-map:
     - el-9-x86_64
   mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
+  mac_os_x-13-x86_64:
     - mac_os_x-13-x86_64
+  mac_os_x-14-x86_64:
     - mac_os_x-14-x86_64
   mac_os_x-12-arm64:
     - mac_os_x-12-arm64
+  mac_os_x-13-arm64:
     - mac_os_x-13-arm64
+  mac_os_x-14-arm64:
     - mac_os_x-14-arm64
   sles-12-x86_64:
     - sles-12-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -32,8 +32,12 @@ builder-to-testers-map:
     - el-9-x86_64
   mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
+    - mac_os_x-13-x86_64
+    - mac_os_x-14-x86_64
   mac_os_x-12-arm64:
     - mac_os_x-12-arm64
+    - mac_os_x-13-arm64
+    - mac_os_x-14-arm64
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Add Omnibus build support for macOS 13 and 14 on ARM64 architecture.
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Omnibus build support for macOS versions 13 and 14 targeting ARM64 architecture.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
