### PR TITLE
[DO-NOT-MERGE]Add MSDefender exclusions for hab tests

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -15,6 +15,18 @@ Write-Host "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
 
+Write-Host "--- Adding Windows Defender exclusions for Habitat directories"
+try {
+    Add-MpPreference -ExclusionPath "C:\hab"
+    Add-MpPreference -ExclusionPath "C:\ProgramData\hab"
+    Add-MpPreference -ExclusionPath "$env:USERPROFILE\.hab"
+    $project_root = "$(git rev-parse --show-toplevel)"
+    Add-MpPreference -ExclusionPath $project_root
+    Write-Host "Windows Defender exclusions added successfully"
+} catch {
+    Write-Host "Warning: Could not add Windows Defender exclusions (may require admin rights): $($_.Exception.Message)"
+}
+
 Write-Host "--- Installing the version of Habitat required"
 try {
   hab --version

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -51,7 +51,7 @@ function Invoke-Build {
         Write-BuildLine " ** Running the inspec project's 'rake install' to install the path-based gems so they look like any other installed gem."
         bundle exec rake install # this needs to be 'bundle exec'd because a Rakefile makes reference to Bundler
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
-    }finally {
+    } finally {
         Pop-Location
     }
 }

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -35,13 +35,6 @@ function Invoke-SetupEnvironment {
 
 function Invoke-Build {
     try {
-        # Add Windows Defender exclusions for Habitat directories to improve build performance
-        Write-BuildLine " ** Adding Windows Defender exclusions for Habitat directories"
-        Add-MpPreference -ExclusionPath "C:\hab"
-        Add-MpPreference -ExclusionPath "C:\ProgramData\hab"
-        Add-MpPreference -ExclusionPath "$env:USERPROFILE\.hab"
-        Add-MpPreference -ExclusionPath $project_root
-
         $env:Path += ";c:\\Program Files\\Git\\bin"
         Push-Location $project_root
         $env:GEM_HOME = "$HAB_CACHE_SRC_PATH/$pkg_dirname/vendor"
@@ -58,8 +51,7 @@ function Invoke-Build {
         Write-BuildLine " ** Running the inspec project's 'rake install' to install the path-based gems so they look like any other installed gem."
         bundle exec rake install # this needs to be 'bundle exec'd because a Rakefile makes reference to Bundler
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
-    }
-    finally {
+    }finally {
         Pop-Location
     }
 }

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -35,6 +35,13 @@ function Invoke-SetupEnvironment {
 
 function Invoke-Build {
     try {
+        # Add Windows Defender exclusions for Habitat directories to improve build performance
+        Write-BuildLine " ** Adding Windows Defender exclusions for Habitat directories"
+        Add-MpPreference -ExclusionPath "C:\hab"
+        Add-MpPreference -ExclusionPath "C:\ProgramData\hab"
+        Add-MpPreference -ExclusionPath "$env:USERPROFILE\.hab"
+        Add-MpPreference -ExclusionPath $project_root
+
         $env:Path += ";c:\\Program Files\\Git\\bin"
         Push-Location $project_root
         $env:GEM_HOME = "$HAB_CACHE_SRC_PATH/$pkg_dirname/vendor"
@@ -51,7 +58,8 @@ function Invoke-Build {
         Write-BuildLine " ** Running the inspec project's 'rake install' to install the path-based gems so they look like any other installed gem."
         bundle exec rake install # this needs to be 'bundle exec'd because a Rakefile makes reference to Bundler
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
-    } finally {
+    }
+    finally {
         Pop-Location
     }
 }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Added MSDefender exclusions for hab folders
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Error Message:

Copy-Item : Operation did not complete successfully because the file contains a virus or potentially unwanted software.
  | At line:115 char:5
  | +     Copy-Item "$($folder.FullName)\*" $habPath
  | +     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  | + CategoryInfo          : NotSpecified: (:) [Copy-Item], IOException
  | + FullyQualifiedErrorId : System.IO.IOException,Microsoft.PowerShell.Commands.CopyItemCommand
  |  
  | 🚨 Error: The command exited with status 1


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
