### PR TITLE
Update macOS support documentation for versions 13.x and 14.x

### DIFF
--- a/docs-chef-io/content/inspec/reusable/md/support_commercial_platforms.md
+++ b/docs-chef-io/content/inspec/reusable/md/support_commercial_platforms.md
@@ -2,7 +2,7 @@
 | --- | --- | --- |
 | Amazon Linux | `x86_64`, `aarch64` | `2.x` |
 | Debian | `x86_64`, `aarch64` (10.x only) | `9`, `10`, `11` |
-| macOS | `x86_64`, `aarch64` (M1 processors) | `11.x`, `12.x` |
+| macOS | `x86_64`, `aarch64` (M1 processors) | `11.x`, `12.x`, `13.x`, `14.x` |
 | Oracle Enterprise Linux | `x86_64`, `aarch64` (7.x / 8.x only) | `6.x`, `7.x`, `8.x` |
 | Red Hat Enterprise Linux | `x86_64`, `aarch64` (7.x, 8.x and 9.x only) | `7.x`, `8.x`, `9.x` |
 | SUSE Linux Enterprise Server | `x86_64`, `aarch64` (15.x only) | `12.x`, `15.x` |


### PR DESCRIPTION
## Summary

This PR updates the supported commercial platforms documentation to include macOS 13.x and 14.x versions, reflecting the infrastructure improvements made in PR #7524.

## Changes Made

- Updated 
- Added macOS  and  to the supported versions list
- Maintained existing ARM64 (M1 processors) architecture support note

## Background

PR #7524 added Omnibus build support for macOS 13 and 14 on ARM64 architecture. This documentation update ensures that our supported platform documentation accurately reflects these new capabilities.

## Related Issues/PRs

- Related: https://github.com/inspec/inspec/pull/7524

## Testing

- [x] Documentation builds successfully
- [x] Formatting is consistent with existing content
- [x] All supported platforms are accurately represented