### PR TITLE
Chef 26425 add notices text

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -73,6 +73,15 @@ function Invoke-Install {
                      "*/latest", "latest",
                      "*/JSON-Schema-Test-Suite", "JSON-Schema-Test-Suite")
 
+    # Copy NOTICE.TXT to the package directory
+    $NoticeFile = "$project_root/NOTICE.TXT"
+    if (Test-Path $NoticeFile) {
+        Write-BuildLine "** Copying NOTICE.TXT to package directory"
+        Copy-Item -Path $NoticeFile -Destination $pkg_prefix -Force
+    } else {
+        Write-BuildLine "** Warning: NOTICE.TXT not found at $NoticeFile"
+    }
+
     try {
         Push-Location $pkg_prefix
         bundle config --local gemfile $project_root/Gemfile

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -66,6 +66,14 @@ do_install() {
 
   wrap_inspec_bin
 
+  # Copy NOTICE.TXT to the package directory
+  if [[ -f "$PLAN_CONTEXT/../NOTICE.TXT" ]]; then
+    build_line "Copying NOTICE.TXT to package directory"
+    cp "$PLAN_CONTEXT/../NOTICE.TXT" "$pkg_prefix/"
+  else
+    build_line "Warning: NOTICE.TXT not found at $PLAN_CONTEXT/../NOTICE.TXT"
+  fi
+
   # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
   # for omnibus we also install this as part of the package
   gem install ed25519 bcrypt_pbkdf --no-document


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This pull request adds logic to both the Windows (`plan.ps1`) and Unix (`plan.sh`) Habitat build scripts to ensure that the `NOTICE.TXT` file is copied into the package directory during installation. This helps maintain compliance with license and notice requirements across all build environments.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

**Build process improvements:**

* Added code to `plan.ps1` to copy `NOTICE.TXT` from the project root to the package directory if it exists, with a warning if not found.
* Added similar logic to `plan.sh` to copy `NOTICE.TXT` to the package directory, also warning if the file is missing.
* Added blank NOTICE.TXT for testing purpose.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

https://progresssoftware.atlassian.net/browse/CHEF-26425

**Linux Build:** 
<img width="705" height="57" alt="Screenshot 2025-10-09 at 1 57 24 PM" src="https://github.com/user-attachments/assets/543fc26e-82e8-429d-b450-0994d6914213" />


**Windows Build:**
<img width="1077" height="433" alt="Screenshot 2025-10-09 at 2 18 09 PM" src="https://github.com/user-attachments/assets/47e3d673-3aa0-435e-b9af-6ad119bb61b5" />



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
