### PR TITLE
CHEF-26987 Prevent adding CHEF RUBYGEMS server if license key is empty

### DIFF
--- a/lib/inspec/plugin/v2/gem_source_manager.rb
+++ b/lib/inspec/plugin/v2/gem_source_manager.rb
@@ -28,16 +28,20 @@ module Inspec::Plugin::V2
     private
 
     def chef_rubygems_server
-      "https://#{DEFAULT_USERNAME}:#{licenses_string}@#{DEFAULT_CHEF_RUBY_GEMS_SERVER}"
+      # If there are no license keys, return nil to avoid adding an invalid source
+      "https://#{DEFAULT_USERNAME}:#{licenses_string}@#{DEFAULT_CHEF_RUBY_GEMS_SERVER}" unless licenses_string.empty?
     end
 
     def register_source(source)
+      return if source.nil? # If the source is nil, we don't want to add it
       gem_source = Gem::Source.new(source)
       sources << gem_source unless sources.include?(gem_source)
     end
 
     def licenses_string
       ChefLicensing.license_keys.join(",")
+    rescue
+      ""
     end
   end
 end

--- a/lib/inspec/plugin/v2/gem_source_manager.rb
+++ b/lib/inspec/plugin/v2/gem_source_manager.rb
@@ -37,11 +37,13 @@ module Inspec::Plugin::V2
 
       gem_source = Gem::Source.new(source)
       sources << gem_source unless sources.include?(gem_source)
+    rescue StandardError => e
+      raise StandardError, "Unable to add gem source #{source}: #{e.message}"
     end
 
     def licenses_string
       ChefLicensing.license_keys.join(",")
-    rescue
+    rescue StandardError
       ""
     end
   end

--- a/lib/inspec/plugin/v2/gem_source_manager.rb
+++ b/lib/inspec/plugin/v2/gem_source_manager.rb
@@ -34,6 +34,7 @@ module Inspec::Plugin::V2
 
     def register_source(source)
       return if source.nil? # If the source is nil, we don't want to add it
+
       gem_source = Gem::Source.new(source)
       sources << gem_source unless sources.include?(gem_source)
     end

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -318,7 +318,7 @@ module Inspec::Plugin::V2
 
     def install_from_remote_gems(requested_plugin_name, opts, source_manager: GemSourceManager.instance)
       plugin_dependency = Gem::Dependency.new(requested_plugin_name, opts[:version] || "> 0")
-      source_manager.add_chef_rubygems_server unless ChefLicensing::Config.make_licensing_optional # ensure CHEF RUBYGEMS server is added to the source
+      source_manager.add_chef_rubygems_server
 
       # This adds custom gem sources to the memoized `Gem.Sources` for this specific run
       # Note: This will not make any change to the environment Gem source list and

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -318,7 +318,7 @@ module Inspec::Plugin::V2
 
     def install_from_remote_gems(requested_plugin_name, opts, source_manager: GemSourceManager.instance)
       plugin_dependency = Gem::Dependency.new(requested_plugin_name, opts[:version] || "> 0")
-      source_manager.add_chef_rubygems_server
+      source_manager.add_chef_rubygems_server # ensure CHEF RUBYGEMS server is added to the source
 
       # This adds custom gem sources to the memoized `Gem.Sources` for this specific run
       # Note: This will not make any change to the environment Gem source list and

--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -318,7 +318,7 @@ module Inspec::Plugin::V2
 
     def install_from_remote_gems(requested_plugin_name, opts, source_manager: GemSourceManager.instance)
       plugin_dependency = Gem::Dependency.new(requested_plugin_name, opts[:version] || "> 0")
-      source_manager.add_chef_rubygems_server # ensure CHEF RUBYGEMS server is added to the source
+      source_manager.add_chef_rubygems_server unless ChefLicensing::Config.make_licensing_optional # ensure CHEF RUBYGEMS server is added to the source
 
       # This adds custom gem sources to the memoized `Gem.Sources` for this specific run
       # Note: This will not make any change to the environment Gem source list and


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This pull request introduces a conditional check when adding the Chef Rubygems server as a gem source during plugin installation, if the license key is empty. An empty license key will form an invalid source URL for establishing a connection.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://progresssoftware.atlassian.net/browse/CHEF-26987

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [X] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
