### PR TITLE
Fix gemspec activation logic to check for alternate spec file

### DIFF
--- a/lib/inspec/plugin/v2/installer.rb
+++ b/lib/inspec/plugin/v2/installer.rb
@@ -391,7 +391,7 @@ module Inspec::Plugin::V2
           # And if the requested_gemspec_file has not been downloaded in this default dir do not activate it
           # Activation will be taken care after the downloads
           requested_gemspec_file = File.join(requested_gemspec.gem_dir, "#{requested_gemspec.name}.gemspec")
-          next unless File.exist?(requested_gemspec_file)
+          next unless File.exist?(requested_gemspec_file) || File.exist?(requested_gemspec.spec_file)
 
           # activate the requested gemspec from the Gem::RequestSet
           requested_gemspec.activate unless loaded_recent_most_version_of?(requested_gemspec)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

```
bundle exec inspec exec ../profiles/profile-mongodb -t docker://8e9c3008e947 --no-create-lockfile
Could not find 'bson' (>= 4.8.2, < 5.0.0) among 320 total gem(s)
```

Inspec plugin installer fails to activate the bson gem as the bson gemspec is not available

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This pull request includes a minor update to the plugin installation logic to improve gemspec file detection. The change ensures that the installer checks for both the default gemspec file location and an alternative `spec_file` location before proceeding with activation.

- Plugin gemspec detection:
  * Updated the check in `install_gem_to_plugins_dir` within `installer.rb` to proceed if either the default gemspec file or the `spec_file` exists, improving compatibility with different gemspec layouts.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
