### PR TITLE
Remove mac 12  and update Mac builder

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -30,10 +30,7 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
-  mac_os_x-12-x86_64:
-    - mac_os_x-12-x86_64
-  mac_os_x-12-arm64:
-    - mac_os_x-12-arm64
+  mac_os_x-13-arm64:
     - mac_os_x-13-arm64
     - mac_os_x-14-arm64
   sles-12-x86_64:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
MacOS 12 has reached End-of-Life (EOL) .
Continuing to support EOL platforms presents unnecessary maintenance overhead and security risks.
Hence deprecationing mac12.
Modified the builder as mac-13  .
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
