### PR TITLE
CHEF-21893: Add Gemfile.lock for BlackDuck SCA dependency scanning

### DIFF
--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -4,6 +4,12 @@ Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table
 ruby -v
 bundle --version
 
+# Remove Gemfile.lock to allow Windows to generate its own platform-specific lock file
+if (Test-Path "Gemfile.lock") {
+    echo "--- Removing existing Gemfile.lock to generate Windows-specific dependencies"
+    Remove-Item "Gemfile.lock" -Force
+}
+
 echo "--- bundle install"
 bundle config set --local without deploy kitchen
 bundle install --jobs=7 --retry=3

--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -4,12 +4,6 @@ Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table
 ruby -v
 bundle --version
 
-# Remove Gemfile.lock to allow Windows to generate its own platform-specific lock file
-if (Test-Path "Gemfile.lock") {
-    echo "--- Removing existing Gemfile.lock to generate Windows-specific dependencies"
-    Remove-Item "Gemfile.lock" -Force
-}
-
 echo "--- bundle install"
 bundle config set --local without deploy kitchen
 bundle install --jobs=7 --retry=3

--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -4,6 +4,12 @@ Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table
 ruby -v
 bundle --version
 
+# Remove Gemfile.lock to allow each platform to generate its own platform-specific lock file
+if (Test-Path "Gemfile.lock") {
+    echo "--- Removing existing Gemfile.lock to generate platform-specific dependencies"
+    Remove-Item "Gemfile.lock" -Force
+}
+
 echo "--- bundle install"
 bundle config set --local without deploy kitchen
 bundle install --jobs=7 --retry=3

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -35,12 +35,6 @@ fi
 echo "--- pull bundle cache"
 pull_bundle
 
-# Remove Gemfile.lock to allow each platform to generate its own platform-specific lock file
-if [ -f "Gemfile.lock" ]; then
-  echo "--- Removing existing Gemfile.lock to generate platform-specific dependencies"
-  rm -f Gemfile.lock
-fi
-
 echo "--- bundle"
 bundle config --local path vendor/bundle
 bundle config set --local without deploy kitchen

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -35,6 +35,12 @@ fi
 echo "--- pull bundle cache"
 pull_bundle
 
+# Remove Gemfile.lock to allow each platform to generate its own platform-specific lock file
+if [ -f "Gemfile.lock" ]; then
+  echo "--- Removing existing Gemfile.lock to generate platform-specific dependencies"
+  rm -f Gemfile.lock
+fi
+
 echo "--- bundle"
 bundle config --local path vendor/bundle
 bundle config set --local without deploy kitchen


### PR DESCRIPTION
## Description
This PR adds Gemfile.lock to the InSpec repository for BlackDuck SCA scanning.

**Note**: The initial approach of removing Gemfile.lock in CI has been reverted. The committed Gemfile.lock will be used as-is on all platforms.

## Changes
- ✅ Added Gemfile.lock for BlackDuck SCA scanning (commit: cefc16085)
- ❌ Initially added logic to remove Gemfile.lock in CI (commit: 8f77c8e7f) - **REVERTED**
- ✅ Reverted the CI removal logic (commit: 3ca7f5077)

## Current State
The repository now has:
- Gemfile.lock committed for BlackDuck to scan
- No modifications to Gemfile.lock during CI builds
- CI will use the committed Gemfile.lock on all platforms

## Related
- JIRA: CHEF-21893
- BlackDuck SCA integration for dependency scanning

## Types of changes
- [x] New content (non-breaking change)

## Checklist:
- [x] I have read the CONTRIBUTING document.