### PR TITLE
Upgrades addresabel gem to < 2.8.8 and mintest-sprint to < 1.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,8 @@ group :test do
   gem "concurrent-ruby"
   gem "json_schemer"
   gem "m"
-  gem "minitest-sprint", "~> 1.0"
+  # 1.4.1+ requires min ruby 3.2, InSpec5 does not support Ruby 3.2
+  gem "minitest-sprint", "< 1.4.1"
   gem "minitest", "5.15.0"
   gem "mocha"
   # Pinning this version as it breaking for ruby 3.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :test do
   gem "json_schemer"
   gem "m"
   # 1.4.0+ requires min ruby 3.2, InSpec5 does not support Ruby 3.2
-  gem "minitest-sprint", "~> 1.3.0"
+  gem "minitest-sprint", "~> 1.3.0" , "< 1.4.0"
   gem "minitest", "5.15.0"
   gem "mocha"
   # Pinning this version as it breaking for ruby 3.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,8 @@ group :test do
   gem "concurrent-ruby"
   gem "json_schemer"
   gem "m"
-  # 1.4.1+ requires min ruby 3.2, InSpec5 does not support Ruby 3.2
-  gem "minitest-sprint", "< 1.4.1"
+  # 1.4.0+ requires min ruby 3.2 (uses Data.define), InSpec5 does not support Ruby 3.2
+  gem "minitest-sprint", "~> 1.3.0"
   gem "minitest", "5.15.0"
   gem "mocha"
   # Pinning this version as it breaking for ruby 3.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :test do
   gem "concurrent-ruby"
   gem "json_schemer"
   gem "m"
-  # 1.4.0+ requires min ruby 3.2 (uses Data.define), InSpec5 does not support Ruby 3.2
+  # 1.4.0+ requires min ruby 3.2, InSpec5 does not support Ruby 3.2
   gem "minitest-sprint", "~> 1.3.0"
   gem "minitest", "5.15.0"
   gem "mocha"

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -43,7 +43,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tty-table",                "~> 0.10"
   spec.add_dependency "tty-prompt",               "~> 0.17"
   spec.add_dependency "tomlrb",                   ">= 1.2", "< 2.1"
-  spec.add_dependency "addressable",              "~> 2.4"
+  # Pinning to < 2.8.8 because public_suffix 7.0 requires Ruby 3.2 or higher
+  spec.add_dependency "addressable",              "< 2.8.8"
   spec.add_dependency "parslet",                  ">= 1.5", "< 3.0" # Pinned < 2.0, see #5389
   spec.add_dependency "semverse",                 "~> 3.0"
   spec.add_dependency "multipart-post",           "~> 2.0"

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tty-table",                "~> 0.10"
   spec.add_dependency "tty-prompt",               "~> 0.17"
   spec.add_dependency "tomlrb",                   ">= 1.2", "< 2.1"
-  # Pinning to < 2.8.8 because public_suffix 7.0 requires Ruby 3.2 or higher
+  # Pinning to < 2.8.8 because public_suffix 7.0 requires Ruby 3.2 or higher, InSpec5 does not support Ruby 3.2
   spec.add_dependency "addressable",              "< 2.8.8"
   spec.add_dependency "parslet",                  ">= 1.5", "< 3.0" # Pinned < 2.0, see #5389
   spec.add_dependency "semverse",                 "~> 3.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This PR pins specific gem versions to ensure compatibility with Ruby versions supported by InSpec-5, which does not support Ruby 3.2 or higher.
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Pin addressable to < 2.8.8 because addressable 2.8.8+ depends on public_suffix 7.0 which requires Ruby 3.2 or higher.

Pin minitest-sprint  to < 1.4.1 because version 1.4.1+ requires minimum Ruby 3.2.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
