### PR TITLE
Chef 28247 - Support RHEL-10 Amazon-linux-2023  windows 2025 Platforms

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -16,6 +16,10 @@ builder-to-testers-map:
   debian-10-aarch64:
     - debian-10-aarch64
     - debian-11-aarch64
+  amazon-2023-aarch64:
+    - amazon-2023-aarch64
+  amazon-2023-x86_64:
+    - amazon-2023-x86_64
   el-7-aarch64:
     - el-7-aarch64
     - amazon-2-aarch64
@@ -30,6 +34,8 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
+  # el-10-x86_64:
+  #   - el-10-x86_64
   mac_os_x-13-arm64:
     - mac_os_x-13-arm64
     - mac_os_x-14-arm64
@@ -49,5 +55,6 @@ builder-to-testers-map:
     - windows-2019-x86_64
     - windows-2016-x86_64
     - windows-2022-x86_64
+    - windows-2025-x86_64
     - windows-10-x86_64
     - windows-11-x86_64


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR adds support for additional platforms in the `release.omnibus.yml` file to expand the testing and packaging coverage. The following platforms have been added:

- amazon-linux-2023
- windows-2025-x86_64
- RHEL-10

These changes ensure that the InSpec project can be tested and built for these newly added platforms.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
