### PR TITLE
Fix reading/writing tar profiles issue

### DIFF
--- a/lib/inspec/archive/tar.rb
+++ b/lib/inspec/archive/tar.rb
@@ -1,5 +1,5 @@
 require "rubygems/package" unless defined?(Gem::Package)
-require 'rubygems/package/tar_writer' unless defined?(Gem::Package::TarWriter)
+require "rubygems/package/tar_writer" unless defined?(Gem::Package::TarWriter)
 
 module Inspec::Archive
   class TarArchiveGenerator

--- a/lib/inspec/archive/tar.rb
+++ b/lib/inspec/archive/tar.rb
@@ -1,4 +1,5 @@
 require "rubygems/package" unless defined?(Gem::Package)
+require 'rubygems/package/tar_writer' unless defined?(Gem::Package::TarWriter)
 
 module Inspec::Archive
   class TarArchiveGenerator

--- a/lib/inspec/file_provider.rb
+++ b/lib/inspec/file_provider.rb
@@ -1,4 +1,5 @@
 require "rubygems/package" unless defined?(Gem::Package)
+require "rubygems/package/tar_header" unless defined?(Gem::Package::TarHeader)
 require "pathname" unless defined?(Pathname)
 require "zlib" unless defined?(Zlib)
 require "zip" unless defined?(Zip)


### PR DESCRIPTION
<h2>Summary</h2>
<p>Getting Following error and [[inspec/inspec:inspec-5] coverage](https://buildkite.com/chef/inspec-inspec-inspec-5-coverage) build is failing.

Inspec::Profile::code info#test_0003_gets code on tgz profiles:
NameError: uninitialized constant Gem::Package::TarWriter

          Gem::Package::TarWriter.new(gz) do |tar|</p>

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
