### PR TITLE
CHEF-28672 Remove old rexml bundled gems

### DIFF
--- a/omnibus/config/projects/inspec.rb
+++ b/omnibus/config/projects/inspec.rb
@@ -51,6 +51,8 @@ dependency "gem-permissions"
 dependency "shebang-cleanup"
 # Ensure our SSL cert files are accessible to ruby.
 dependency "openssl-customization"
+# introduced for rexml cleanup
+dependency "remove-old-gems"
 
 dependency "ruby-msys2-devkit" if windows?
 

--- a/omnibus/config/software/remove-old-gems.rb
+++ b/omnibus/config/software/remove-old-gems.rb
@@ -12,7 +12,8 @@ build do
     puts "Removing old versions of rexml < 3.4.2"
     env = with_standard_compiler_flags(with_embedded_path)
 
-    # remove [-a] all rexml < 3.4.2 including [-x] executables and [-I] ignore dependencies
-    command "#{gemfile} uninstall rexml -v \"<3.4.2\" -a -x -I", env: env
+    # remove [-a] all rexml < 3.4.2 and [-I] ignore dependencies
+    # Note: We do NOT use -x flag to avoid removing executables/binstubs
+    command "#{gemfile} uninstall rexml -v \"<3.4.2\" -a -I", env: env
   end
 end

--- a/omnibus/config/software/remove-old-gems.rb
+++ b/omnibus/config/software/remove-old-gems.rb
@@ -1,0 +1,18 @@
+name "remove-old-gems"
+
+license :project_license
+skip_transitive_dependency_licensing true
+
+build do
+  block "Removing old versions of rexml < 3.4.2" do
+    gemfile = "#{install_dir}/embedded/bin/gem"
+
+    next unless File.exist?(gemfile)
+
+    puts "Removing old versions of rexml < 3.4.2"
+    env = with_standard_compiler_flags(with_embedded_path)
+
+    # remove [-a] all rexml < 3.4.2 including [-x] executables and [-I] ignore dependencies
+    command "#{gemfile} uninstall rexml -v \"<3.4.2\" -a -x -I", env: env
+  end
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Dependency management and security improvements:

* Added a new `remove-old-gems` software definition (`omnibus/config/software/remove-old-gems.rb`) that removes all versions of the `rexml` gem older than 3.4.2 during the build, ensuring only safe versions are present.
* Updated the `inspec.rb` project configuration to include the `remove-old-gems` dependency, integrating this cleanup step into the build process.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
