### PR TITLE
CHEF-28137 add support for windows 2025

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -53,6 +53,7 @@ builder-to-testers-map:
     - windows-2019-x86_64
     - windows-2016-x86_64
     - windows-2022-x86_64
-    - windows-2025-x86_64
     - windows-10-x86_64
     - windows-11-x86_64
+  windows-2025-x86_64:
+    - windows-2025-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -53,5 +53,6 @@ builder-to-testers-map:
     - windows-2019-x86_64
     - windows-2016-x86_64
     - windows-2022-x86_64
+    - windows-2025-x86_64
     - windows-10-x86_64
     - windows-11-x86_64

--- a/docs-chef-io/content/inspec/profiles.md
+++ b/docs-chef-io/content/inspec/profiles.md
@@ -170,6 +170,14 @@ supports:
   - platform-name: windows_server_2019*
 ```
 
+To target the entire Windows 2025 platform family, including Datacenter and Core Servers, use:
+
+```yaml
+name: ssh
+supports:
+  - platform-name: windows_server_2025*
+```
+
 To target anything running on Amazon AWS, use:
 
 ```yaml

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -26,6 +26,7 @@ class MockLoader
     windows: { name: "windows", family: "windows", release: "6.2.9200", arch: "x86_64" },
     windows2016: { name: "windows_server_2016_datacenter", family: "windows", release: "10.0.14393", arch: "x86_64" },
     windows2019: { name: "windows_server_2019_datacenter", family: "windows", release: "10.0.17763", arch: "x86_64" },
+    windows2025: { name: "windows_server_2025_datacenter", family: "windows", release: "10.0.26100", arch: "x86_64" },
     wrlinux: { name: "wrlinux", family: "redhat", release: "7.0(3)I2(2)", arch: "x86_64" },
     solaris11: { name: "solaris", family: "solaris", release: "11", arch: "i386" },
     solaris10: { name: "solaris", family: "solaris", release: "10", arch: "i386" },

--- a/test/unit/resources/platform_test.rb
+++ b/test/unit/resources/platform_test.rb
@@ -125,4 +125,32 @@ describe "Inspec::Resources::Platform" do
     _(resource2).wont_be :supported?, supports
   end
 
+  let(:resource3) { MockLoader.new(:windows2025).load_resource("platform") }
+  it "loads a profile which supports platform-name windows_server_2025*" do
+    supports = [
+      { 'platform-name': "windows_server_2025*" },
+    ]
+    _(resource3).must_be :supported?, supports
+  end
+
+  it "loads a profile which supports platform-name windows_server_2025* with wildcard" do
+    supports = [
+      { 'platform-name': "*2025*" },
+    ]
+    _(resource3).must_be :supported?, supports
+  end
+
+  it "reject a profile which supports platform-name not matching regex windows_server_2025*" do
+    supports = [
+      { 'platform-name': "*2022*" },
+    ]
+    _(resource3).wont_be :supported?, supports
+  end
+
+  it "verifies windows2025 platform properties" do
+    _(resource3.name).must_equal "windows_server_2025_datacenter"
+    _(resource3.family).must_equal "windows"
+    _(resource3.release).must_equal "10.0.26100"
+  end
+
 end

--- a/test/unit/resources/platform_test.rb
+++ b/test/unit/resources/platform_test.rb
@@ -140,7 +140,7 @@ describe "Inspec::Resources::Platform" do
     _(resource3).must_be :supported?, supports
   end
 
-  it "reject a profile which supports platform-name not matching regex windows_server_2025*" do
+  it "rejects a profile which supports platform-name not matching regex windows_server_2025*" do
     supports = [
       { 'platform-name': "*2022*" },
     ]
@@ -152,5 +152,4 @@ describe "Inspec::Resources::Platform" do
     _(resource3.family).must_equal "windows"
     _(resource3.release).must_equal "10.0.26100"
   end
-
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This pull request adds support for the Windows Server 2025 platform across the codebase, including documentation, testing, and platform mapping. The changes ensure that Windows Server 2025 is recognized and handled properly in platform detection, documentation, and automated tests.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
**Platform support and mapping:**

* Added `windows-2025-x86_64` to the list of builder/tester platforms in `.expeditor/release.omnibus.yml`, ensuring builds and tests run for Windows Server 2025.
* Added a `windows2025` entry to the `MockLoader` in `test/helpers/mock_loader.rb` to simulate the new platform in tests.

**Documentation updates:**

* Updated `docs-chef-io/content/inspec/profiles.md` to document how to target the Windows Server 2025 platform family in InSpec profiles.

**Testing enhancements:**

* Added multiple tests in `test/unit/resources/platform_test.rb` to verify support for Windows Server 2025, including wildcard and negative matching, and to check platform properties.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://progresssoftware.atlassian.net/browse/CHEF-28137
Omnibus adhoc build https://buildkite.com/chef/inspec-inspec-inspec-5-omnibus-adhoc/builds/229#_

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
