### PR TITLE
Pin connection_pool to < 3.0.0 in Gemfile to support ruby >=3.1.0 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,7 @@ gem "dry-inflector", "<= 1.1.0" if RUBY_VERSION < "3.1.0"
 # Pinning securerandom to < 0.4.0 as it is breaking the build because 0.4.0 is incompatible with the current version, ruby 3.0.x on CI
 # Remove this pin when upgrading to Ruby 3.1 or higher on CI.
 gem "securerandom", "< 0.4.0" if RUBY_VERSION < "3.1.0"
+
+# Pinning connection_pool to < 3.0.0 as 3.0.1 requires Ruby >= 3.2.0
+# Remove this pin when upgrading to Ruby 3.2 or higher.
+gem "connection_pool", "< 3.0.0" if RUBY_VERSION < "3.2.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
# Pinning connection_pool to < 3.0.0 as 3.0.1 requires Ruby >= 3.2.0
# Remove this pin when upgrading to Ruby 3.2 or higher.
   gem "connection_pool", "< 3.0.0" if RUBY_VERSION < "3.2.0"

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
