### PR TITLE
Adding gem 'mixlib-shellout', '~> 3.3' for windows support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,7 @@ gem "securerandom", "< 0.4.0" if RUBY_VERSION < "3.1.0"
 # Pinning connection_pool to < 3.0.0 as 3.0.1 requires Ruby >= 3.2.0
 # Remove this pin when upgrading to Ruby 3.2 or higher.
 gem "connection_pool", "< 3.0.0" if RUBY_VERSION < "3.2.0"
+
+# mixlib-shellout < 3.3 uses fork() which is not available on Windows
+# Pin to 3.3.x for proper Windows support
+gem "mixlib-shellout", "~> 3.3"


### PR DESCRIPTION
<h2>Summary</h2>
<p>Adding gem 'mixlib-shellout', '~> 3.3' to the Gemfile.

mixlib-shellout < 3.3 uses fork() which is not available on Windows
+# Pin to 3.3.x for proper Windows support
 </p>

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
