### PR TITLE
Update  windows  docker image to fix  verify pipeline issue

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -43,4 +43,4 @@ steps:
             - BUILDKITE
           host_os: windows
           shell: ["powershell", "-Command"]
-          image: rubydistros/windows-2019:3.1
+          image: rubydistros/windows-2019:3.1.7


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR addresses the requirement to upgrade the Ruby version used in our InSpec 5 Windows verify pipeline, 
https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/987#019ad847-91d2-4766-a074-196717052005/59-66
The pipeline utilized Ruby 3.1.1, which is outdated for our testing needs.

Key updates in this PR:

Created and integrated a custom Windows Server 2019 Docker image preinstalled with Ruby 3.1.7.
Adjusted pipeline configuration to utilize the new image for Windows-based tests.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
