### PR TITLE
Fixes in ast performance improvement changes

### DIFF
--- a/lib/inspec/utils/profile_ast_helpers.rb
+++ b/lib/inspec/utils/profile_ast_helpers.rb
@@ -10,6 +10,25 @@ module Inspec
         def initialize(memo)
           @memo = memo
         end
+
+        # Helper method to recursively extract values from AST nodes
+        def extract_value(node)
+          return node unless node.is_a?(RuboCop::AST::Node)
+
+          case node.class.to_s
+          when "RuboCop::AST::HashNode"
+            hash_values = {}
+            node.children.each do |pair_node|
+              hash_values[pair_node.key.value] = extract_value(pair_node.value)
+            end
+            hash_values
+          when "RuboCop::AST::ArrayNode"
+            node.children.map { |element| extract_value(element) }
+          else
+            # For simple nodes (string, int, boolean, etc.)
+            node.respond_to?(:value) ? node.value : node
+          end
+        end
       end
 
       class InputCollectorBase < CollectorBase
@@ -41,15 +60,9 @@ module Inspec
                 if VALID_INPUT_OPTIONS.include?(child_node.key.value)
                   if child_node.value.class == RuboCop::AST::Node && REQUIRED_VALUES_MAP.key?(child_node.value.type)
                     opts.merge!(child_node.key.value => REQUIRED_VALUES_MAP[child_node.value.type])
-                  elsif child_node.value.class == RuboCop::AST::HashNode
-                    # Here value will be a hash
-                    values = {}
-                    child_node.value.children.each do |grand_child_node|
-                      values.merge!(grand_child_node.key.value => grand_child_node.value.value)
-                    end
-                    opts.merge!(child_node.key.value => values)
                   else
-                    opts.merge!(child_node.key.value => child_node.value.value)
+                    # Use extract_value helper to handle hash, array, and nested structures
+                    opts.merge!(child_node.key.value => extract_value(child_node.value))
                   end
                 end
               end
@@ -386,7 +399,7 @@ module Inspec
         INPUT_PATTERN = InputCollectorBase::INPUT_PATTERN
         DESCRIBE_PATTERN = TestsCollector::DESCRIBE_PATTERN
         EXPECT_PATTERN = TestsCollector::EXPECT_PATTERN
-        
+
         ACCPETABLE_TAG_TYPE_TO_VALUES = TagCollector::ACCPETABLE_TAG_TYPE_TO_VALUES
 
         def initialize(control_data, memo, include_tests = false)
@@ -513,7 +526,7 @@ module Inspec
 
         def collect_input(node)
           input_name = node.children[2].value
-          
+
           unless @memo[:inputs].any? { |input| input[:name] == input_name }
             opts = {
               value: "Input '#{input_name}' does not have a value. Skipping test.",
@@ -524,14 +537,9 @@ module Inspec
                 if InputCollectorBase::VALID_INPUT_OPTIONS.include?(child_node.key.value)
                   if child_node.value.class == RuboCop::AST::Node && InputCollectorBase::REQUIRED_VALUES_MAP.key?(child_node.value.type)
                     opts[child_node.key.value] = InputCollectorBase::REQUIRED_VALUES_MAP[child_node.value.type]
-                  elsif child_node.value.class == RuboCop::AST::HashNode
-                    values = {}
-                    child_node.value.children.each do |grand_child_node|
-                      values[grand_child_node.key.value] = grand_child_node.value.value
-                    end
-                    opts[child_node.key.value] = values
                   else
-                    opts[child_node.key.value] = child_node.value.value
+                    # Use extract_value helper to handle hash, array, and nested structures
+                    opts[child_node.key.value] = extract_value(child_node.value)
                   end
                 end
               end
@@ -600,14 +608,9 @@ module Inspec
                 if InputCollectorBase::VALID_INPUT_OPTIONS.include?(child_node.key.value)
                   if child_node.value.class == RuboCop::AST::Node && InputCollectorBase::REQUIRED_VALUES_MAP.key?(child_node.value.type)
                     opts[child_node.key.value] = InputCollectorBase::REQUIRED_VALUES_MAP[child_node.value.type]
-                  elsif child_node.value.class == RuboCop::AST::HashNode
-                    values = {}
-                    child_node.value.children.each do |grand_child_node|
-                      values[grand_child_node.key.value] = grand_child_node.value.value
-                    end
-                    opts[child_node.key.value] = values
                   else
-                    opts[child_node.key.value] = child_node.value.value
+                    # Use extract_value helper to handle hash, array, and nested structures
+                    opts[child_node.key.value] = extract_value(child_node.value)
                   end
                 end
               end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request refactors how AST node values are extracted in the `profile_ast_helpers.rb` file to improve consistency and support for nested structures. The main change is the introduction of a new helper method, `extract_value`, which recursively handles hashes, arrays, and simple values. This method replaces previous manual extraction logic in several places, making the code more robust and maintainable.

### AST value extraction improvements

* Added a new `extract_value` helper method to `CollectorBase` that recursively extracts values from AST nodes, supporting hashes, arrays, and simple types.
* Refactored the `collect_input` methods to use the new `extract_value` helper, replacing manual extraction logic for hash and array values, ensuring consistent handling of nested structures. [[1]](diffhunk://#diff-9c68f5a5b2d4203753921aa2958df3a875413bd633beec199e82863beb5a95cdL44-R65) [[2]](diffhunk://#diff-9c68f5a5b2d4203753921aa2958df3a875413bd633beec199e82863beb5a95cdL527-R542) [[3]](diffhunk://#diff-9c68f5a5b2d4203753921aa2958df3a875413bd633beec199e82863beb5a95cdL603-R613)

### Handles few edge cases(CHEF-27810):
- `undefined method value' for s(:array, (NoMethodError)\n s(:str, "rhel-7-server-rpms/7Server/x86_64"),\n s(:str, "rhel-7-server-rt-beta-rpms/x86_64"),\n s(:str, "rhel-7-server-rt-rpms/7Server/x86_64")):RuboCop::AST::ArrayNode\n\n opts.merge!(child_node.key.value => child_node.value.value)\n`
- `undefined method 'value' for s(:hash, (NoMethodError) \n s(:pair, \"health\") \n (:str, \"not found\") ) ) : RuboCop: : AST : : HashNode \n\n{}`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
