### PR TITLE
Backport 7576 to fix windows pipeline failure in inspec 5

### DIFF
--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -5,10 +5,10 @@ ruby -v
 bundle --version
 
 echo "--- bundle install"
-bundle config set --local without deploy kitchen
+bundle config set --local without deploy
 bundle install --jobs=7 --retry=3
 
 echo "+++ bundle exec rake test:parallel"
-bundle exec rake test:parallel K=4
+bundle exec rake test:parallel K=20
 
 exit $LASTEXITCODE


### PR DESCRIPTION
This pull request updates the parallel test execution logic to better utilize available CPU resources and simplify job distribution. The main improvements are in how test files are split among threads and how the number of threads is determined, aiming for more efficient and scalable parallel test runs.

**Parallel Test Execution Improvements:**

* The number of parallel test threads (`K`) now defaults to the number of available CPU cores (`Etc.nprocessors`) instead of a fixed value, making test runs more adaptive to the host machine's capabilities.
* Test files are now divided evenly among threads without padding, which simplifies job allocation and avoids unnecessary empty jobs.
* The command used to run tests in each thread now directly invokes `ruby` with the appropriate load paths, instead of using `minitest`, for more direct control and consistency.

**CI Configuration Update:**

* In the CI script (`.expeditor/buildkite/verify.ps1`), the number of parallel test threads is increased from 4 to 20, and the `kitchen` group is no longer excluded from the bundle install, reflecting the new parallelization strategy.

**Output Formatting:**

* The output section after running tests is streamlined for clarity, condensing the result printing logic.<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
backport #7576 - Fix timeout issues in windows verify pipeline
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
