### PR TITLE
CHEF-29019 Adjust ci thread count

### DIFF
--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -9,6 +9,6 @@ bundle config set --local without deploy
 bundle install --jobs=7 --retry=3
 
 echo "+++ bundle exec rake test:parallel"
-bundle exec rake test:parallel K=20
+bundle exec rake test:parallel K=16
 
 exit $LASTEXITCODE

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -19,7 +19,7 @@ steps:
 
   - label: run-tests-ruby-3.1
     command:
-      - /workdir/.expeditor/buildkite/verify.sh
+      - K=16 RAKE_TASK=test:parallel /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:
@@ -27,7 +27,7 @@ steps:
 
   - label: isolated-tests-ruby-3.1
     command:
-      - RAKE_TASK=test:isolated /workdir/.expeditor/buildkite/verify.sh
+      - K=16 RAKE_TASK=test:isolated /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       executor:
         docker:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This pull request updates the test parallelization configuration for Ruby 3.1 in the CI pipeline to use 16 parallel jobs instead of 20, aiming to optimize resource usage and improve stability.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
* Reduced the number of parallel test jobs from 20 to 16 in the `bundle exec rake test:parallel` command within `.expeditor/buildkite/verify.ps1`.
* Updated the `run-tests-ruby-3.1` and `isolated-tests-ruby-3.1` pipeline steps in `.expeditor/verify.pipeline.yml` to explicitly set `K=16` for parallel test execution.


Previous runs used to take **~40 mins** for the job to complete 
examples: 
https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/1004#019addbb-410f-46dd-9e43-efd952249263
https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/1116#019b0713-11b4-4569-9068-363a7ff3379a

Now this PR reduces that to **~4 mins**.
https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/1124#019b07fa-a782-4e42-b1ec-0ddf6ab3fb6c
https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/1127#019b0837-2f23-47a2-a557-a6bb873ad480

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://progresssoftware.atlassian.net/browse/CHEF-29019

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
