### PR TITLE
Pin net-imap for ruby 3.1 compatability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,8 @@ group :omnibus do
   gem "appbundler"
   gem "ed25519" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
   gem "bcrypt_pbkdf" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
-  gem "net-imap", ">= 0.2.5" # 0.2.5+ required for CVE fix - GHSA-j3g3-5qv5-52mj
+  # pinning at < 0.6, 0.6 requires ruby 3.2+, InSpec5 does not support Ruby 3.2
+  gem "net-imap", "< 0.6" # 0.2.5+ required for CVE fix - GHSA-j3g3-5qv5-52mj
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :omnibus do
   gem "ed25519" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
   gem "bcrypt_pbkdf" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
   # pinning at < 0.6, 0.6 requires ruby 3.2+, InSpec5 does not support Ruby 3.2
-  gem "net-imap", "< 0.6" # 0.2.5+ required for CVE fix - GHSA-j3g3-5qv5-52mj
+  gem "net-imap", "< 0.6"
 end
 
 group :test do


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Pinning net-imap at < 0.6, since 0.6 requires ruby 3.2+, InSpec5 does not support Ruby 3.2
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
