### PR TITLE
Updated test and dependency version in fixture to fix pipeline

### DIFF
--- a/test/fixtures/profiles/profile-with-gem-dependency/inspec.yml
+++ b/test/fixtures/profiles/profile-with-gem-dependency/inspec.yml
@@ -10,4 +10,4 @@ supports:
   platform: os
 gem_dependencies:
 - name: money
-  version: ">= 6.16.0"
+  version: "< 7.0"

--- a/test/fixtures/profiles/profile-without-gem-version/controls/example.rb
+++ b/test/fixtures/profiles/profile-without-gem-version/controls/example.rb
@@ -1,11 +1,10 @@
-require "money"
+require "colorize"
 
 control "tmp-1.0" do
-  Money.rounding_mode = BigDecimal::ROUND_HALF_UP
-  m = Money.from_cents(1000, "USD")
-  cents = m.cents
+  colored_text = "InSpec Test".colorize(:green)
 
-  describe cents do
-    it { should eq 1000 }
+  describe colored_text do
+    it { should_not be_nil }
+    it { should be_a(String) }
   end
 end

--- a/test/fixtures/profiles/profile-without-gem-version/inspec.yml
+++ b/test/fixtures/profiles/profile-without-gem-version/inspec.yml
@@ -9,4 +9,4 @@ version: 0.1.0
 supports:
   platform: os
 gem_dependencies:
-- name: money
+- name: colorize


### PR DESCRIPTION
Updated test and dependency version in fixture to fix pipeline
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request updates the test fixture profiles to use the `colorize` gem instead of the `money` gem and adjusts related test code and gem dependency specifications accordingly. The changes fixes the `profile_gem_dependency_test.rb` test failure caused by gem version conflicts with `bigdecimal`

The test was failing with:
`can't activate bigdecimal-4.0.0, already activated bigdecimal-3.3.1 (Gem::LoadError)`

**Breaking Pipeline**: https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/1160#_

Test code updates:

* Replaced the `money` gem with the `colorize` gem in the `gem_dependencies` section of `inspec.yml` for the `profile-without-gem-version` profile.
* Updated the version constraint for the `money` gem in `profile-with-gem-dependency/inspec.yml` to require a version less than 7.0, instead of greater than or equal to 6.16.0.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
