### PR TITLE
Update connection_pool dependency to be compatible with Ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,5 @@ end
 # Remove this pin when upgrading to Ruby 3.2 or higher.
 gem "zeitwerk", "~> 2.6.0", "< 2.7"
 
-# Pinning connection_pool to < 3.0.0 as 3.0.1 requires Ruby >= 3.2.0
-# Remove this pin when upgrading to Ruby 3.2 or higher.
-gem "connection_pool", "< 3.0.0" if RUBY_VERSION < "3.2.0"
+# Pinning connection_pool to < 3.0.0 as 3.0.0+ requires Ruby >= 3.2.0
+gem "connection_pool", ">= 2.5", "< 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,6 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     ffi (1.16.3)
-    ffi (1.16.3-x64-mingw-ucrt)
     ffi-win32-extensions (1.0.4)
       ffi
     fuzzyurl (0.9.0)
@@ -533,6 +532,7 @@ GEM
       rake
     method_source (1.1.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (5.15.0)
     minitest-sprint (1.3.0)
       path_expander (~> 1.1)
@@ -829,7 +829,6 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unf_ext (0.0.8.2)
-    unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
     webmock (3.26.1)
@@ -856,7 +855,7 @@ DEPENDENCIES
   bcrypt_pbkdf
   chefstyle
   concurrent-ruby
-  connection_pool (< 3.0.0)
+  connection_pool (>= 2.5, < 3.0)
   ed25519
   ffi (>= 1.15.5, < 1.17.0)
   inquirer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,6 +446,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     ffi (1.16.3)
+    ffi (1.16.3-x64-mingw-ucrt)
     ffi-win32-extensions (1.0.4)
       ffi
     fuzzyurl (0.9.0)
@@ -532,7 +533,6 @@ GEM
       rake
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (5.15.0)
     minitest-sprint (1.3.0)
       path_expander (~> 1.1)
@@ -829,6 +829,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unf_ext (0.0.8.2)
+    unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
     webmock (3.26.1)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This pull request updates the version pinning for the `connection_pool` gem in the `Gemfile` to allow compatibility with newer patch versions while still restricting to Ruby versions below 3.2.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Dependency management:

* Updated the `connection_pool` gem constraint to allow all versions from `2.5` up to (but not including) `3.0`, ensuring compatibility with Ruby versions below 3.2 and enabling use of newer patch releases.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://progresssoftware.atlassian.net/browse/CHEF-29497

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
