### PR TITLE
CHEF-29564 - standardize - remove_sla_from_readme  

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Chef InSpec: Inspect Your Infrastructure
 
-* **Project State: Active**
-* **Issues Response SLA: 14 business days**
-* **Pull Request Response SLA: 14 business days**
-
 For more information on project states and SLAs, see [this documentation](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md).
 
 [![Slack](https://community-slack.chef.io/badge.svg)](https://community-slack.chef.io/)


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.

This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 
As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).