### PR TITLE
FOREPORT: Pin nokogiri to < 1.17.2 for Ruby 3.1.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,9 @@ group :test do
   gem "minitest-sprint", "~> 1.0"
   gem "minitest"
   gem "mocha"
-  gem "nokogiri"
+  # Pinning nokogiri to < 1.17.2 for Ruby 3.1.0 compatibility
+  # nokogiri >= 1.17.2 may have issues with Ruby 3.1.0
+  gem "nokogiri", "< 1.17.2"
   gem "pry-byebug"
   gem "pry"
   gem "rake"


### PR DESCRIPTION
## Summary
Backport nokogiri version pinning from InSpec-5 to InSpec-7 to ensure Ruby 3.1.0 compatibility.

## Issue
`nokogiri >= 1.17.2` may have compatibility issues with Ruby 3.1.0, causing potential build or test failures.

## Solution
Pin nokogiri to `< 1.17.2` in the Gemfile test group to ensure stable operation across:
- Ruby 3.0.x
- Ruby 3.1.x

## Changes
- Added version constraint: `gem "nokogiri", "< 1.17.2"`
- Added explanatory comments in Gemfile

## Testing
- ✅ Compatible with Ruby 3.0.x
- ✅ Compatible with Ruby 3.1.x
- ✅ No breaking changes expected
- ✅ Bundle resolves successfully

## Related
- **JIRA**: Part of CHEF-28142 epic (dependency backporting from InSpec-5 to InSpec-7)
- **InSpec-5 branch**: `bs/encode-spl-char-password`
- **Base branch**: `inspec-7`

## Merge Order
This PR can be merged independently or as the first in a series of dependency backports.

## Notes
- This is a **clean, single-purpose PR** with only the nokogiri pin
- No other dependency changes included
- Part of the larger effort to backport InSpec-5 improvements to InSpec-7