### PR TITLE
FOREPORT: Pin zeitwerk to ~> 2.6 for Ruby 3.0/3.1 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,14 @@ gem "ffi", ">= 1.15.5", "< 1.17.0"
 # but our runtime dep is still 3.9+
 gem "rspec", ">= 3.10"
 
+# Build is failing - see: https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/442
+# Error: zeitwerk-2.7.1 requires Ruby >= 3.2, which is incompatible with the current version (Ruby 3.0.7p220)
+# Dependency chain:
+# zeitwerk → dry-configurable, dry-struct, dry-types → k8s-ruby → train-kubernetes
+# Pinning zeitwerk to ~> 2.6 to avoid Ruby >= 3.2 requirement.
+# Remove this pin when upgrading to Ruby 3.2 or higher.
+gem "zeitwerk", "~> 2.6.0", "< 2.7"
+
 # group :omnibus do
 #   gem "rb-readline"
 #   gem "appbundler"


### PR DESCRIPTION
## Summary
This PR foreports the zeitwerk version pin from InSpec-5 to InSpec-7 to ensure compatibility with Ruby 3.0 and Ruby 3.1.

## Issue
Starting with **zeitwerk 2.7.1** (released June 2024), the gem requires Ruby >= 3.2:

```
ERROR: zeitwerk-2.7.1 requires Ruby >= 3.2, 
which is incompatible with the current version (Ruby 3.0.7 / Ruby 3.1.x)
```

This breaks InSpec-7 installations on Ruby 3.0 and 3.1, which are still widely used.

### Real-World Impact
- ❌ Fresh `bundle install` on Ruby 3.0/3.1 fails
- ❌ `bundle update` breaks existing installations
- ❌ CI/CD pipelines fail on Ruby 3.0/3.1
- ❌ Kubernetes support (train-kubernetes) becomes unavailable

### Example Error from CI
From: https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/442
```
Build is failing
Error: zeitwerk-2.7.1 requires Ruby >= 3.2, which is incompatible 
with the current version (Ruby 3.0.7p220)
```

## Solution
Pin zeitwerk to version **2.6.x** in the Gemfile:

```ruby
gem "zeitwerk", "~> 2.6.0", "< 2.7"
```

This pin:
- ✅ Allows versions 2.6.0 through 2.6.999
- ✅ Prevents installation of 2.7.0 and higher
- ✅ Works on **all** Ruby versions (3.0, 3.1, 3.2, 3.4+)
- ✅ Has all features needed by InSpec's dependencies

## Changes
- **File**: `Gemfile` (+8 lines)
- **Added**: zeitwerk version pin with explanatory comment
- **No Gemfile.lock changes**: Already locked to 2.6.18 (compatible version)

## Why Zeitwerk is Needed
Zeitwerk is a transitive dependency required for Kubernetes support:

```
InSpec
  └── Train
      └── train-kubernetes
          └── k8s-ruby
              └── dry-types, dry-struct, dry-configurable
                  └── zeitwerk (code autoloader)
```

**What is zeitwerk?**
- Code autoloader for Ruby gems
- Used by modern dry-rb gems for fast, thread-safe loading
- Required for InSpec's Kubernetes resource support

## Ruby Version Compatibility Matrix

| Zeitwerk Version | Ruby 3.0 | Ruby 3.1 | Ruby 3.2+ | Ruby 3.4+ |
|-----------------|----------|----------|-----------|-----------|
| **2.6.x (pinned)** | ✅ Works | ✅ Works | ✅ Works | ✅ Works |
| **2.7.x** | ❌ Fails | ❌ Fails | ✅ Works | ✅ Works |
| **2.8.x** | ❌ Fails | ❌ Fails | ✅ Works | ✅ Works |

## Testing
✅ **Verified current state**:
- Gemfile.lock already has zeitwerk 2.6.18
- Pin ensures it stays at 2.6.x
- No dependency resolution changes needed

✅ **Tested compatibility**:
- Ruby 3.0.x ✅
- Ruby 3.1.x ✅
- Ruby 3.2+ ✅
- Ruby 3.4+ ✅

✅ **Dependency chain verified**:
- dry-configurable 1.3.0 → zeitwerk (~> 2.6) ✅
- dry-core 1.1.0 → zeitwerk (~> 2.6) ✅
- dry-logic 1.6.0 → zeitwerk (~> 2.6) ✅
- dry-types 1.7.1 → zeitwerk (~> 2.6) ✅
- dry-struct 1.6.0 → zeitwerk (~> 2.6) ✅

## Related PRs
- InSpec-5: Already has this pin implemented
- #7743 - Minitest/mock fix (should be merged first - blocks testing)

## When Can This Pin Be Removed?
This pin can be removed when **one of these happens**:

1. **InSpec drops Ruby 3.0/3.1 support** (bumps minimum to Ruby 3.2+)
2. **Zeitwerk reverts the Ruby 3.2+ requirement** (unlikely)

Until then, the pin is **necessary** for Ruby 3.0/3.1 compatibility.

## Why This Wasn't in InSpec-7 Before
InSpec-5 added this pin to fix build failures. However, when backporting other changes to InSpec-7, the zeitwerk pin was **not included**. This PR completes that backport.

## Impact
✅ **Positive**:
- Fixes Ruby 3.0 and 3.1 compatibility
- Prevents future breakage from `bundle update`
- Protects fresh checkouts and CI/CD
- Aligns InSpec-7 with InSpec-5 approach

❌ **Negative**: None
- Pin is compatible with all Ruby versions
- No performance impact
- No feature limitations

## Documentation
See `WHY_ZEITWERK_IS_USED.md` for technical deep-dive on:
- What zeitwerk does
- Why InSpec needs it
- Dependency chain explanation
- Version compatibility details

## Checklist
- [x] Single-purpose change (only zeitwerk pin)
- [x] Clean commit with sign-off
- [x] Comprehensive commit message
- [x] Only Gemfile modified (no Gemfile.lock changes needed)
- [x] Tested with current dependencies
- [x] Documented in commit and PR
- [x] Ready for immediate merge