### PR TITLE
Remove RBS from omnibus

### DIFF
--- a/omnibus/config/software/remove-old-gems.rb
+++ b/omnibus/config/software/remove-old-gems.rb
@@ -30,4 +30,17 @@ build do
     # Note: We do NOT use -x flag to avoid removing executables/binstubs
     command "#{gembin} uninstall net-imap -v \"<0.2.5\" -a -I", env: env
   end
+
+  block "Removing rbs gem - not needed at runtime and contains vulnerable dependencies" do
+    gembin = "#{install_dir}/embedded/bin/gem"
+
+    next unless File.exist?(gembin)
+
+    puts "Removing rbs gem"
+    env = with_standard_compiler_flags(with_embedded_path)
+
+    # RBS is a Ruby default gem for type checking - not needed at runtime
+    # Its bundled Gemfile.lock contains vulnerable versions of rexml, rdoc, activesupport
+    command "#{gembin} uninstall rbs -a -I --force", env: env, returns: [0, 1]
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This pull request adds an additional cleanup step to the build process to improve security by removing unnecessary and potentially vulnerable gems from the runtime environment.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Security and dependency management:

* Added a block in `remove-old-gems.rb` to explicitly uninstall the `rbs` gem, which is not needed at runtime and contains vulnerable dependencies (such as outdated versions of `rexml`, `rdoc`, and `activesupport`). This helps reduce the attack surface of the deployed application.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
