### PR TITLE
Remove gemfilelock from deps

### DIFF
--- a/omnibus/config/software/remove-old-gems.rb
+++ b/omnibus/config/software/remove-old-gems.rb
@@ -31,16 +31,23 @@ build do
     command "#{gembin} uninstall net-imap -v \"<0.2.5\" -a -I", env: env
   end
 
-  block "Removing rbs gem - not needed at runtime and contains vulnerable dependencies" do
-    gembin = "#{install_dir}/embedded/bin/gem"
+  block "Remove Gemfile.lock files from installed gems" do
+    require "fileutils"
 
-    next unless File.exist?(gembin)
+    puts "Removing Gemfile.lock files from installed gems..."
+    puts "These are development artifacts and not actual runtime dependencies."
 
-    puts "Removing rbs gem"
-    env = with_standard_compiler_flags(with_embedded_path)
+    gems_dir = "#{install_dir}/embedded/lib/ruby/gems"
 
-    # RBS is a Ruby default gem for type checking - not needed at runtime
-    # Its bundled Gemfile.lock contains vulnerable versions of rexml, rdoc, activesupport
-    command "#{gembin} uninstall rbs -a -I --force", env: env, returns: [0, 1]
+    # Find and remove all Gemfile.lock files within installed gems
+    # These include: gems/*/Gemfile.lock, gems/**/Gemfile.lock
+    lockfiles = Dir.glob("#{gems_dir}/**/Gemfile.lock")
+
+    lockfiles.each do |lockfile|
+      puts "  Removing: #{lockfile.sub(install_dir, "")}"
+      FileUtils.rm_f(lockfile)
+    end
+
+    puts "Removed #{lockfiles.length} Gemfile.lock file(s)"
   end
 end

--- a/omnibus/config/software/remove-old-gems.rb
+++ b/omnibus/config/software/remove-old-gems.rb
@@ -30,4 +30,17 @@ build do
     # Note: We do NOT use -x flag to avoid removing executables/binstubs
     command "#{gembin} uninstall net-imap -v \"<0.2.5\" -a -I", env: env
   end
+
+  block "Removing rbs gem - not needed at runtime and contains vulnerable dependencies" do
+    gembin = "#{install_dir}/embedded/bin/gem"
+
+    next unless File.exist?(gembin)
+
+    puts "Removing rbs gem"
+    env = with_standard_compiler_flags(with_embedded_path)
+
+    # RBS is a Ruby default gem for type checking - not needed at runtime
+    # Its bundled Gemfile.lock contains vulnerable versions of rexml, rdoc, activesupport
+    command "#{gembin} uninstall rbs -a -I --force", env: env, returns: [0, 1]
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request adds a cleanup step to the build process that removes unnecessary `Gemfile.lock` files from installed gems. This helps ensure that only runtime dependencies are included in the final package, reducing clutter from development artifacts.

Build artifact cleanup:

* Added a block to `remove-old-gems.rb` that finds and deletes all `Gemfile.lock` files from the installed gems directory, as these are development artifacts and not needed for runtime.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
