### PR TITLE
CHEF-5136 - Fixes warning which shows up after inspec execution while using winrm transport

### DIFF
--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -9,6 +9,6 @@ bundle config set --local without deploy
 bundle install --jobs=7 --retry=3
 
 echo "+++ bundle exec rake test:parallel"
-bundle exec rake test:parallel K=16
+bundle exec rake test:parallel K=6
 
 exit $LASTEXITCODE

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,15 +347,15 @@ GEM
       concurrent-ruby (~> 1.0)
     chef-utils (18.8.54)
       concurrent-ruby
-    chef-winrm (2.4.4)
+    chef-winrm (2.5.0)
       builder (>= 2.1.2)
       chef-gyoku (~> 1.5)
       erubi (~> 1.8)
       gssapi (~> 1.2)
       httpclient (~> 2.2, >= 2.2.0.2)
       logging (>= 1.6.1, < 3.0)
-      nori (= 2.7.0)
-      rexml (~> 3.3)
+      nori (~> 2.7)
+      rexml (>= 3.4.2, < 4.0)
       rubyntlm (~> 0.6.0, >= 0.6.3)
     chef-winrm-elevated (1.2.5)
       chef-winrm (>= 2.3.11)
@@ -802,10 +802,10 @@ GEM
     train-kubernetes (0.1.7)
       k8s-ruby (~> 0.10)
       train (~> 3.0)
-    train-winrm (0.4.0)
-      chef-winrm (~> 2.4.4)
-      chef-winrm-elevated (~> 1.2.5)
-      chef-winrm-fs (~> 1.4.1)
+    train-winrm (0.4.3)
+      chef-winrm (>= 2.4.4, < 3.0)
+      chef-winrm-elevated (>= 1.2.5, < 2.0)
+      chef-winrm-fs (>= 1.4.1, < 2.0)
       socksify (~> 1.8)
     tty-box (0.7.0)
       pastel (~> 0.8)
@@ -847,6 +847,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-24
   x64-mingw-ucrt
   x86_64-darwin-23
   x86_64-linux


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This fixes the warnings shows up after execution of inspec shell or inspec exec command using winrm transport

```
warning: Exception in finalizer #<Proc:0x000000010b7ba3c0 /opt/inspec/embedded/lib/ruby/gems/3.1.0/gems/chef-winrm-2.4.4/lib/chef-winrm/shells/base.rb:98>
/opt/inspec/embedded/lib/ruby/gems/3.1.0/gems/logging-2.4.0/lib/logging/diagnostic_context.rb:471:in `new': can't alloc thread (ThreadError)
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
