### PR TITLE
Backport Fix habitat installation to avoid interfering with parallel CI jobs

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -17,7 +17,35 @@ Write-Host "--- Installing the version of Habitat required"
 
 function Install-Habitat {
   Write-Host "Downloading and installing Habitat..."
+
+  # Suppress errors from the installer script that might try to remove locked files
+  $ErrorActionPreference = 'Continue'
   Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+  $ErrorActionPreference = 'Stop'
+
+  # Add Habitat to PATH for current session
+  $habPath = "C:\ProgramData\Habitat"
+  if (Test-Path $habPath) {
+    $env:Path = "$habPath;$env:Path"
+    Write-Host "Added $habPath to PATH"
+  }
+
+  # Wait for installation to complete and avoid racing conditions
+  Start-Sleep -Seconds 2
+
+  # Verify installation
+  $habVersion = hab --version 2>&1
+  if ($LASTEXITCODE -eq 0) {
+    Write-Host ":habitat: Installed Habitat version: $habVersion"
+  } else {
+    Write-Host "Warning: Could not verify Habitat installation"
+  }
+}
+
+# Ensure Habitat is in PATH before checking
+$habPath = "C:\ProgramData\Habitat"
+if (Test-Path $habPath) {
+  $env:Path = "$habPath;$env:Path"
 }
 
 try {
@@ -32,10 +60,6 @@ catch {
   Write-Host "Installing Habitat ...."
   Set-ExecutionPolicy Bypass -Scope Process -Force
   Install-Habitat
-}
-finally {
-  $habVersion = hab --version 2>&1
-  Write-Host ":habitat: Using Habitat version: $habVersion"
 }
 
 # Set HAB_ORIGIN after Habitat installation

--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -15,43 +15,27 @@ Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table
 
 Write-Host "--- Installing the version of Habitat required"
 
-function Stop-HabProcess {
-  $habProcess = Get-Process hab -ErrorAction SilentlyContinue
-  if ($habProcess) {
-      Write-Host "Stopping hab process..."
-      Stop-Process -Name hab -Force
-  }
-}
-
 function Install-Habitat {
   Write-Host "Downloading and installing Habitat..."
   Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }
 
 try {
-  hab --version
+  $habVersion = hab --version 2>&1
+  if ($LASTEXITCODE -eq 0) {
+    Write-Host "Habitat is already installed: $habVersion"
+  } else {
+    throw "hab command failed"
+  }
 }
 catch {
+  Write-Host "Installing Habitat ...."
   Set-ExecutionPolicy Bypass -Scope Process -Force
-
-  Stop-HabProcess
-
-  # Remove the existing hab.exe if it exists and if you have permissions
-  $habPath = "C:\ProgramData\Habitat\hab.exe"
-  if (Test-Path $habPath) {
-      Write-Host "Attempting to remove existing hab.exe..."
-      Remove-Item $habPath -Force -ErrorAction SilentlyContinue
-      if (Test-Path $habPath) {
-          Write-Host "Failed to remove hab.exe, re-running script with elevated permissions."
-          Start-Process powershell -Verb runAs -ArgumentList "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`""
-          exit
-      }
-  }
-
   Install-Habitat
 }
 finally {
-  Write-Host ":habitat: I think I have the version I need to build."
+  $habVersion = hab --version 2>&1
+  Write-Host ":habitat: Using Habitat version: $habVersion"
 }
 
 # Set HAB_ORIGIN after Habitat installation


### PR DESCRIPTION
- Remove process killing logic that could stop hab processes used by other jobs
- Remove file deletion logic that could break other parallel builds
- Check if hab is already installed and working before attempting installation
- Print habitat version in finally block for better debugging
- Make installation logic safe for concurrent CI execution

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
