### PR TITLE
Added more test in inspec_plugin_test file to catch gem conflict issue

### DIFF
--- a/test/artifact/inspec_plugin_test.rb
+++ b/test/artifact/inspec_plugin_test.rb
@@ -6,11 +6,9 @@ class TestInspecPlugin < ArtifactTest
     inspec_command = "plugin list"
     stdout, stderr, status = run_cmd "inspec #{inspec_command} #{TEST_CLI_OPTS}"
     
-    # Check for plugin loading errors in stdout (InSpec logs errors to stdout, not stderr)
-    refute_match(/ERROR: Could not load plugin/, stdout, 
-      "Plugin loading error detected in stdout")
-    refute_match(/Unable to activate/, stdout,
-      "Gem activation failure detected in stdout")
+    # This catches dependency conflicts, plugin loading failures, and any other errors
+    refute_match(/\[.*\] ERROR:/i, stdout, 
+      "Error detected in stdout - check for plugin loading or dependency issues")
     
     # Check stderr only for cosmetic warnings
     assert_empty stderr.sub(/#< CLIXML\n/, "").sub(/The table size exceeds the currently set width\.Defaulting to vertical orientation\.\n/, "")

--- a/test/artifact/inspec_plugin_test.rb
+++ b/test/artifact/inspec_plugin_test.rb
@@ -5,8 +5,17 @@ class TestInspecPlugin < ArtifactTest
     # This one is custom because it emits a special warning to stderr
     inspec_command = "plugin list"
     stdout, stderr, status = run_cmd "inspec #{inspec_command} #{TEST_CLI_OPTS}"
+    
+    # Check for plugin loading errors in stdout (InSpec logs errors to stdout, not stderr)
+    refute_match(/ERROR: Could not load plugin/, stdout, 
+      "Plugin loading error detected in stdout")
+    refute_match(/Unable to activate/, stdout,
+      "Gem activation failure detected in stdout")
+    
+    # Check stderr only for cosmetic warnings
     assert_empty stderr.sub(/#< CLIXML\n/, "").sub(/The table size exceeds the currently set width\.Defaulting to vertical orientation\.\n/, "")
+    
     assert stdout
-    assert status
+    assert status.success?, "Command failed with exit code #{status.exitstatus}"
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
**Currently CI pipelines passes with no error but later at runtime gives an error like below..**
# inspec -v
[2026-02-03T06:41:14+00:00] ERROR: Could not load plugin train-kubernetes: Unable to activate ms_rest_azure-0.12.0, because faraday-2.14.0 conflicts with faraday (>= 0.9, < 2.0.0)
[2026-02-03T06:41:14+00:00] ERROR: Errors were encountered while loading plugins...
[2026-02-03T06:41:14+00:00] ERROR: Plugin name: train-kubernetes
[2026-02-03T06:41:14+00:00] ERROR: Error: Unable to activate ms_rest_azure-0.12.0, because faraday-2.14.0 conflicts with faraday (>= 0.9, < 2.0.0)
[2026-02-03T06:41:14+00:00] ERROR: Run again with --debug for a stacktrace.

Above error needs to catch while building the hab package.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
