### PR TITLE
Ignore dependencies flag usage for external gems

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -60,7 +60,7 @@ function Invoke-Install {
     Write-BuildLine "** Installing chef-official-distribution gem from artifactory"
     $ArtifactoryUrl = "https://artifactory-internal.ps.chef.co/artifactory/omnibus-gems-local/"
     gem sources --add $ArtifactoryUrl
-    gem install chef-official-distribution
+    gem install chef-official-distribution --ignore-dependencies --no-document
     gem sources --remove $ArtifactoryUrl
 
     # Verify chef-official-distribution installation

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -53,7 +53,7 @@ do_build() {
 do_install() {
   export ARTIFACTORY_URL="https://artifactory-internal.ps.chef.co/artifactory/omnibus-gems-local/"
   gem sources --add "$ARTIFACTORY_URL"
-  gem install chef-official-distribution
+  gem install chef-official-distribution --ignore-dependencies --no-document
   gem sources --remove "$ARTIFACTORY_URL"
 
   # MUST install inspec first because inspec-bin depends on it via gemspec


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request makes a small but important change to the installation process for the external gem in both Windows (`plan.ps1`) and Linux (`plan.sh`) build scripts. The gem is now installed without its dependencies and documentation, which can help speed up builds and avoid unnecessary installations.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
