### PR TITLE
Add trust_server_certificate option to mssql_session

### DIFF
--- a/docs-chef-io/content/inspec/resources/mssql_session.md
+++ b/docs-chef-io/content/inspec/resources/mssql_session.md
@@ -33,9 +33,57 @@ A `mssql_session` resource block declares the username and password to use for t
 
 where
 
-- `mssql_session` declares a username and password with permission to run the query. Omitting the username or password parameters results in the use of Windows authentication as the user Chef InSpec is executing as. You may also optionally pass a host and instance name. If omitted, they will default to host: localhost and the default instance. Set `trust_server_certificate: true` to pass `-C` to `sqlcmd`.
+- `mssql_session` declares credentials and connection settings with permission to run the query.
 - `query('QUERY')` contains the query to be run
 - `its('value') { should eq('') }` compares the results of the query against the expected result in the test
+
+### Optional Parameters
+
+The `mssql_session` resource accepts `user`, `password`, `pass`, `host`, `port`, `instance`, `db_name`, `local_mode`, and `trust_server_certificate`.
+
+#### `user`
+
+The SQL Server user name for SQL authentication.
+
+If `user` or `password` is omitted, `mssql_session` uses Windows authentication as the user running Chef InSpec.
+
+#### `password`
+
+The SQL Server password for SQL authentication.
+
+#### `pass` (deprecated)
+
+Deprecated alias for `password`. Use `password` instead.
+
+#### `host`
+
+The SQL Server host name. Default value: `localhost`.
+
+#### `port`
+
+The SQL Server port. By default, no explicit port is passed.
+
+#### `instance`
+
+The SQL Server instance name. By default, the server's default instance is used.
+
+#### `db_name`
+
+The database name to connect to before running the query.
+
+#### `local_mode`
+
+Set to `true` to run in local mode.
+
+In local mode, the resource does not pass host or port to `sqlcmd`.
+
+#### `trust_server_certificate`
+
+Set `trust_server_certificate: true` to pass `-C` to the underlying `sqlcmd`.
+
+Use this when you need encrypted connectivity, but certificate validation would otherwise fail due to missing certificate-chain configuration (for example, SQL Server uses a self-signed certificate or a private CA that isn't available in the runner trust store).
+
+This option is less secure than full certificate validation because it trusts the server certificate without strict verification. Use it only when necessary, and prefer installing the correct CA/server certificates on the target system when possible.
 
 ## Examples
 

--- a/docs-chef-io/content/inspec/resources/mssql_session.md
+++ b/docs-chef-io/content/inspec/resources/mssql_session.md
@@ -33,7 +33,7 @@ A `mssql_session` resource block declares the username and password to use for t
 
 where
 
-- `mssql_session` declares a username and password with permission to run the query. Omitting the username or password parameters results in the use of Windows authentication as the user Chef InSpec is executing as. You may also optionally pass a host and instance name. If omitted, they will default to host: localhost and the default instance.
+- `mssql_session` declares a username and password with permission to run the query. Omitting the username or password parameters results in the use of Windows authentication as the user Chef InSpec is executing as. You may also optionally pass a host and instance name. If omitted, they will default to host: localhost and the default instance. Set `trust_server_certificate: true` to pass `-C` to `sqlcmd`.
 - `query('QUERY')` contains the query to be run
 - `its('value') { should eq('') }` compares the results of the query against the expected result in the test
 
@@ -71,6 +71,14 @@ The following examples show how to use this Chef InSpec audit resource.
 
     describe sql.query("SELECT Name AS result FROM Product WHERE ProductID == 1").row(0).column('result') do
       its("value") { should eq 'foo' }
+    end
+
+### Trust the SQL Server certificate
+
+    sql = mssql_session(user: 'my_user', password: 'password', trust_server_certificate: true)
+
+    describe sql.query("SELECT SERVERPROPERTY('ProductVersion') as result").row(0).column('result') do
+      its("value") { should_not be_empty }
     end
 
 ## Matchers

--- a/lib/inspec/resources/mssql_session.rb
+++ b/lib/inspec/resources/mssql_session.rb
@@ -30,9 +30,15 @@ module Inspec::Resources
         its('value') { should_not be_empty }
         its('value') { should cmp == 1 }
       end
+
+      # Trust the SQL Server TLS certificate when using sqlcmd
+      sql_tls = mssql_session(user: 'myuser', password: 'mypassword', trust_server_certificate: true)
+      describe sql_tls.query(\"SELECT SERVERPROPERTY('ProductVersion') as \\\"version\\\";\").row(0).column('version') do
+        its('value') { should_not be_empty }
+      end
     EXAMPLE
 
-    attr_reader :user, :password, :host, :port, :instance, :local_mode, :db_name
+    attr_reader :user, :password, :host, :port, :instance, :local_mode, :db_name, :trust_server_certificate
     def initialize(opts = {})
       @user = opts[:user]
       @password = opts[:password] || opts[:pass]
@@ -46,6 +52,7 @@ module Inspec::Resources
       end
       @instance = opts[:instance]
       @db_name = opts[:db_name]
+      @trust_server_certificate = !!opts[:trust_server_certificate] # rubocop:disable Style/DoubleNegation
 
       # check if sqlcmd is available
       raise Inspec::Exceptions::ResourceSkipped, "sqlcmd is missing" unless inspec.command("sqlcmd").exist?
@@ -57,6 +64,7 @@ module Inspec::Resources
       escaped_query = q.gsub(/\\/, "\\\\").gsub(/"/, '""').gsub(/\$/, '\\$')
       # surpress 'x rows affected' in SQLCMD with 'set nocount on;'
       cmd_string = "sqlcmd -Q \"set nocount on; #{escaped_query}\" -W -w 1024 -s ','"
+      cmd_string += " -C" if trust_server_certificate?
       cmd_string += " -U '#{@user}' -P '#{@password}'" unless @user.nil? || @password.nil?
       cmd_string += " -d '#{@db_name}'" unless @db_name.nil?
       unless local_mode?
@@ -92,6 +100,10 @@ module Inspec::Resources
 
     def local_mode?
       !!@local_mode # rubocop:disable Style/DoubleNegation
+    end
+
+    def trust_server_certificate?
+      @trust_server_certificate
     end
 
     def test_connection

--- a/test/unit/resources/mssql_session_test.rb
+++ b/test/unit/resources/mssql_session_test.rb
@@ -9,6 +9,7 @@ describe "Inspec::Resources::MssqlSession" do
     _(resource.user).must_equal "sa"
     _(resource.password).must_equal "yourStrong(!)Password"
     _(resource.host).must_equal "localhost"
+    _(resource.trust_server_certificate).must_equal false
   end
 
   it "verify mssql_session configuration with custom hostname" do
@@ -61,6 +62,11 @@ describe "Inspec::Resources::MssqlSession" do
     _(resource.local_mode).must_equal true
   end
 
+  it "verify mssql_session configuration with trust_server_certificate enabled" do
+    resource = load_resource("mssql_session", user: "sa", password: "yourStrong(!)Password", trust_server_certificate: true)
+    _(resource.trust_server_certificate).must_equal true
+  end
+
   it "run a SQL query" do
     resource = load_resource("mssql_session", user: "sa", password: "yourStrong(!)Password", host: "localhost", port: "1433")
     query = resource.query("SELECT SERVERPROPERTY('ProductVersion') as result")
@@ -81,5 +87,20 @@ describe "Inspec::Resources::MssqlSession" do
 
     query = resource.query("SELECT * FROM example as result")
     _(query.row(1).column("result").value).must_include "multiline"
+  end
+
+  it "run a SQL query with trust_server_certificate enabled" do
+    resource = quick_resource(:mssql_session, :linux, user: "sa", password: "yourStrong(!)Password", host: "localhost", port: "1433", trust_server_certificate: true) do |cmd|
+      cmd.strip!
+      case cmd
+      when "sqlcmd -Q \"set nocount on; SELECT SERVERPROPERTY('ProductVersion') as result\" -W -w 1024 -s ',' -C -U 'sa' -P 'yourStrong(!)Password' -S 'localhost,1433'" then
+        stdout_file "test/fixtures/cmd/mssql-result"
+      else
+        raise cmd.inspect
+      end
+    end
+
+    query = resource.query("SELECT SERVERPROPERTY('ProductVersion') as result")
+    _(query.row(0).column("result").value).must_equal "14.0.600.250"
   end
 end


### PR DESCRIPTION
## Description
Add trust_server_certificate option to mssql_session, to allow the resource to work with newer SQL Server instances ( starting with 2025) that will default to require certificate trust by default.

## Related Issue
#7777 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
