### PR TITLE
CHEF-20799 Fixes in json reporter

### DIFF
--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -62,8 +62,13 @@ module Inspec::Reporters
       if resource_obj.is_a?(String)
         orig_str = resource_obj
         # Try to trim off the resource class - eg "File /some/path" => "/some/path"
-        trimmed_str = orig_str.sub(/^#{r[:resource_class]}/i, "").strip
-        trimmed_str.empty? ? orig_str : trimmed_str
+        resource_class = r[:resource_class].to_s
+        trimmed_str = orig_str.sub(/^#{Regexp.escape(resource_class)}/i, "").strip
+
+        # Cap the resource_id to a reasonable length to avoid bloating reports
+        max_length = 256
+        candidate = trimmed_str.empty? ? orig_str : trimmed_str
+        candidate.length > max_length ? candidate[0, max_length] : candidate
       else
         # Boo, InSpec is crazy, and we don't know what it possibly could be.
         # Failsafe for resource_id is empty string.

--- a/lib/inspec/reporters/json.rb
+++ b/lib/inspec/reporters/json.rb
@@ -55,6 +55,11 @@ module Inspec::Reporters
     def extract_resource_id(r)
       # According to the RunData API, this is supposed to be an anonymous
       # class that represents a resource, with embedded instance methods....
+      # Prefer resource object if present and exposes resource_id
+      resource_candidate = r[:resource]
+      return resource_candidate.resource_id if resource_candidate.respond_to?(:resource_id)
+
+      # Fall back to resource_title
       resource_obj = r[:resource_title]
       return resource_obj.resource_id if resource_obj.respond_to?(:resource_id)
 

--- a/test/unit/reporters/json_test.rb
+++ b/test/unit/reporters/json_test.rb
@@ -126,6 +126,13 @@ describe Inspec::Reporters::Json do
       _(result).must_equal "custom-id"
     end
 
+    it "prefers resource.resource_id over resource_title when available" do
+      resource = Struct.new(:resource_id).new("from-resource")
+      title    = Struct.new(:resource_id).new("from-title")
+      result = report.send(:extract_resource_id, { resource: resource, resource_title: title })
+      _(result).must_equal "from-resource"
+    end
+
     it "returns trimmed string when resource_class prefix matches" do
       result = report.send(:extract_resource_id, { resource_title: "File /tmp", resource_class: "File" })
       _(result).must_equal "/tmp"

--- a/test/unit/reporters/json_test.rb
+++ b/test/unit/reporters/json_test.rb
@@ -119,6 +119,31 @@ describe Inspec::Reporters::Json do
     end
   end
 
+  describe "#extract_resource_id" do
+    it "returns resource_id from objects that implement it" do
+      fake_resource = Struct.new(:resource_id).new("custom-id")
+      result = report.send(:extract_resource_id, { resource_title: fake_resource })
+      _(result).must_equal "custom-id"
+    end
+
+    it "returns trimmed string when resource_class prefix matches" do
+      result = report.send(:extract_resource_id, { resource_title: "File /tmp", resource_class: "File" })
+      _(result).must_equal "/tmp"
+    end
+
+    it "falls back to original when trimming empties the string, still capped" do
+      result = report.send(:extract_resource_id, { resource_title: "File", resource_class: "File" })
+      _(result).must_equal "File"
+    end
+
+    it "caps long string resource titles to a reasonable length" do
+      long_title = "a" * 500
+      result = report.send(:extract_resource_id, { resource_title: long_title })
+      _(result.length).must_equal 256
+      _(result).must_equal("a" * 256)
+    end
+  end
+
   describe "#profiles" do
     it "confirm profile_groups output" do
       hash = {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request enhances the extraction and handling of resource IDs in the JSON reporter.

Improvements to resource ID extraction:

* The `extract_resource_id` method in `lib/inspec/reporters/json.rb` now prefers the `resource.resource_id` if available, falling back to `resource_title.resource_id`, and finally to a processed string version. It also escapes the resource class in the regex and caps the length of the resource ID to 256 characters to avoid bloated reports.

Testing enhancements:

* Added a new test suite for `extract_resource_id` in `test/unit/reporters/json_test.rb`, covering scenarios such as preferring `resource.resource_id`, trimming resource class prefixes, handling empty trims, and capping long strings.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
