### PR TITLE
Pin hab version for CI - Expeditor

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -8,6 +8,7 @@ $ErrorActionPreference = 'Stop'
 $env:CHEF_LICENSE = 'accept-no-persist'
 $env:HAB_LICENSE = 'accept-no-persist'
 $Plan = 'inspec'
+$HabitatVersion = if ($env:HAB_VERSION) { $env:HAB_VERSION } else { '1.6.1245' }
 
 Write-Host "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
@@ -24,8 +25,20 @@ function Stop-HabProcess {
 }
 
 function Install-Habitat {
-  Write-Host "Downloading and installing Habitat..."
-  Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+    Write-Host "Downloading and installing Habitat version $Version..."
+    $installScriptUrl = 'https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'
+    $installScriptPath = Join-Path $env:TEMP "hab-install-$Version.ps1"
+    Invoke-WebRequest -Uri $installScriptUrl -OutFile $installScriptPath
+    try {
+        & $installScriptPath -Version $Version
+    }
+    finally {
+        Remove-Item $installScriptPath -Force -ErrorAction SilentlyContinue
+    }
 }
 
 try {
@@ -48,7 +61,7 @@ catch {
       }
   }
 
-  Install-Habitat
+  Install-Habitat -Version $HabitatVersion
 }
 finally {
   Write-Host ":habitat: I think I have the version I need to build."

--- a/.expeditor/buildkite/artifact.habitat.test.sh
+++ b/.expeditor/buildkite/artifact.habitat.test.sh
@@ -30,13 +30,26 @@ echo "The value for project_root is: $project_root"
 export HAB_NONINTERACTIVE=true
 export HAB_NOCOLORING=true
 export HAB_STUDIO_SECRET_HAB_NONINTERACTIVE=true
+export HAB_VERSION="1.6.1245"
 
 echo "--- system details"
 uname -a
 
 echo "--- Installing Habitat"
 id -a
-curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+
+# Download Habitat install script to a file to avoid pipe errors
+echo "--- Downloading Habitat install script"
+curl -sSLf -o /tmp/hab_install.sh https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh
+
+# Make it executable
+chmod +x /tmp/hab_install.sh
+
+# Execute the install script
+bash /tmp/hab_install.sh -v "$HAB_VERSION" -t "x86_64-linux"
+
+# Clean up
+rm -f /tmp/hab_install.sh
 
 # Set HAB_ORIGIN after Habitat installation
 echo "--- Setting HAB_ORIGIN to 'ci' after installation"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Pin hab version for CI - Expeditor
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request updates the installation process for Habitat in both Windows (`.ps1`) and Linux (`.sh`) build scripts to ensure a consistent and explicit version (`1.6.1245`) is used.

Habitat installation improvements:

* The Habitat version is now explicitly set to `1.6.1245` for both Windows and Linux build scripts, ensuring consistency across environments. 
* The Windows installation function `Install-Habitat` is refactored to accept a version parameter, download the install script, execute it with the specified version, and clean up the script file afterward, making the process more robust and maintainable.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
