### PR TITLE
CHEF-31158 Setup common config to block PR merges if trufflehog fails

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -53,6 +53,7 @@ jobs:
 
       # trufflehog secret scanning
       perform-trufflehog-scan: true
+      fail-trufflehog-on-secrets-found: true
       
       # trivy dependency and container scanning
       perform-trivy-scan: true


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request introduces a configuration change to the CI workflow to strengthen secret detection during pull request validation.

* CI workflow enhancement:
  * [`.github/workflows/ci-main-pull-request-stub.yml`](diffhunk://#diff-794021b939d6ec3846baa92cc46b0ef827740843434c57c71333b593e54d3908R56): Added `fail-trufflehog-on-secrets-found: true` to ensure the workflow fails if TruffleHog detects any secrets, improving security enforcement in the pipeline.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
