### PR TITLE
CHEF-33010 Added config for grype scan on habitat package

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -44,7 +44,7 @@ jobs:
 
   call-ci-inspec-5-pr-check-pipeline:
     needs: read-version
-    uses: chef/common-github-actions/.github/workflows/ci-main-pull-request.yml@fix/grype-hab-token-fallback
+    uses: chef/common-github-actions/.github/workflows/ci-main-pull-request.yml@main
     secrets: inherit
     permissions: 
       id-token: write

--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -17,9 +17,23 @@ permissions:
   contents: read
   
 env:
-  STUB_VERSION: "1.0.5" 
+  STUB_VERSION: "1.0.5"
 
 jobs: 
+  read-version:
+    name: 'Read VERSION file'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.read-version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read VERSION file
+        id: read-version
+        run: |
+          echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+
   echo_version:
     name: 'Echo stub version'
     runs-on: ubuntu-latest
@@ -29,7 +43,8 @@ jobs:
           echo "CI main pull request stub version $STUB_VERSION"
 
   call-ci-inspec-5-pr-check-pipeline:
-    uses: chef/common-github-actions/.github/workflows/ci-main-pull-request.yml@main
+    needs: read-version
+    uses: chef/common-github-actions/.github/workflows/ci-main-pull-request.yml@fix/grype-hab-token-fallback
     secrets: inherit
     permissions: 
       id-token: write
@@ -40,7 +55,7 @@ jobs:
       # go-private-modules: GOPRIVATE for Go private modules, default is 'github.com/progress-platform-services/*
 
       # if version specified, it takes precedence; can be a semver like 1.0.2-xyz or a tag like "latest"
-      version: '5.23.26' # ${{ github.event.repository.version }}
+      version: ${{ needs.read-version.outputs.version }} # ${{ github.event.repository.version }}
       detect-version-source-type: 'none' # options include "none" (do not detect), "file", "github-tag" or "github-release"
       detect-version-source-parameter: '' # use for file name
       language: 'ruby'  # options include "autodetect", "ruby", "go", "node", "python", "java", "dotnet", "c/c++", "other"
@@ -95,6 +110,17 @@ jobs:
       package-binaries: false     # Package binaries (e.g., RPM, DEB, MSI, dpkg + signing + SHA)
       habitat-build: false        # Create Habitat packages
       publish-packages: false     # Publish packages (e.g., container from Dockerfile to ECR, go-releaser binary to releases page, omnibus to artifactory, gems, choco, homebrew, other app stores)
+
+      # Perform grype scan on hab packages
+      perform-grype-hab-scan: true      # Enable/disable Habitat package scan
+      grype-hab-build-package: false    # Build package before scanning (default: false)
+      grype-hab-origin: 'chef' # Habitat package origin (REQUIRED)
+      grype-hab-package: 'inspec' # Habitat package name (REQUIRED)
+      grype-hab-version: ${{ needs.read-version.outputs.version }}       # Package version (REQUIRED)
+      grype-hab-channel: 'unstable'     # Habitat channel: stable, unstable (default: 'unstable')
+      grype-hab-scan-linux: true        # Scan Linux packages (default: true)
+      grype-hab-scan-windows: true      # Scan Windows packages (default: false)
+      grype-hab-scan-macos: false       # Scan macOS packages (default: false)
 
       # generate and export Software Bill of Materials (SBOM) in various formats
       generate-sbom: true


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request updates the GitHub Actions workflow to improve version management and add security scanning for Habitat packages. The main changes involve dynamically reading the package version from the `VERSION` file and configuring Grype scans for Habitat packages across multiple platforms.

**Version Management Improvements:**
- Added a new job (`read-version`) that reads the package version from the `VERSION` file and makes it available as an output for other jobs.
- Updated the `call-ci-inspec-7-pr-check-pipeline` job to depend on the `read-version` job and use the dynamically read version instead of a hardcoded value. [[1]](diffhunk://#diff-794021b939d6ec3846baa92cc46b0ef827740843434c57c71333b593e54d3908R47) [[2]](diffhunk://#diff-794021b939d6ec3846baa92cc46b0ef827740843434c57c71333b593e54d3908L44-R59)

**Security Scanning Enhancements:**
- Enabled Grype scanning for Habitat packages, with configuration options for package origin, name, version (now dynamically set), channel, and target platforms (Linux, Windows, macOS).
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
