### PR TITLE
Add 	rust_cert option to mssql_session (#7777)

### DIFF
--- a/lib/inspec/resources/mssql_session.rb
+++ b/lib/inspec/resources/mssql_session.rb
@@ -32,7 +32,7 @@ module Inspec::Resources
       end
     EXAMPLE
 
-    attr_reader :user, :password, :host, :port, :instance, :local_mode, :db_name
+    attr_reader :user, :password, :host, :port, :instance, :local_mode, :db_name, :trust_cert
     def initialize(opts = {})
       @user = opts[:user]
       @password = opts[:password] || opts[:pass]
@@ -46,6 +46,7 @@ module Inspec::Resources
       end
       @instance = opts[:instance]
       @db_name = opts[:db_name]
+      @trust_cert = opts[:trust_cert] || false
 
       # check if sqlcmd is available
       raise Inspec::Exceptions::ResourceSkipped, "sqlcmd is missing" unless inspec.command("sqlcmd").exist?
@@ -59,6 +60,7 @@ module Inspec::Resources
       cmd_string = "sqlcmd -Q \"set nocount on; #{escaped_query}\" -W -w 1024 -s ','"
       cmd_string += " -U '#{@user}' -P '#{@password}'" unless @user.nil? || @password.nil?
       cmd_string += " -d '#{@db_name}'" unless @db_name.nil?
+      cmd_string += " -C" if @trust_cert
       unless local_mode?
         if @port.nil?
           cmd_string += " -S '#{@host}"

--- a/test/unit/resources/mssql_session_test.rb
+++ b/test/unit/resources/mssql_session_test.rb
@@ -82,4 +82,19 @@ describe "Inspec::Resources::MssqlSession" do
     query = resource.query("SELECT * FROM example as result")
     _(query.row(1).column("result").value).must_include "multiline"
   end
+
+  it "verify mssql_session with trust_cert option" do
+    resource = quick_resource(:mssql_session, :linux, user: "sa", password: "yourStrong(!)Password", host: "localhost", port: "1433", trust_cert: true) do |cmd|
+      cmd.strip!
+      case cmd
+      when "sqlcmd -Q \"set nocount on; SELECT * FROM example\" -W -w 1024 -s ',' -U 'sa' -P 'yourStrong(!)Password' -C -S 'localhost,1433'" then
+        stdout "result\n------\n1\n"
+      else
+        raise cmd.inspect
+      end
+    end
+
+    _(resource.trust_cert).must_equal true
+    resource.query("SELECT * FROM example")
+  end
 end


### PR DESCRIPTION
Fixes #7777

### Description
This Pull Request adds a new `trust_cert` option to the `mssql_session` resource. 
When set to `true`, this option appends the `-C` (Trust Server Certificate) flag to the underlying `sqlcmd` utility.

### Context
Newer versions of `sqlcmd` (SQL Server 2025 and later) now default to requiring trusted certificates. This breaks automated tests in many environments where certificates are not yet set up (e.g. Test Kitchen).

### Verification
- Added unit tests in `test/unit/resources/mssql_session_test.rb` to verify the command string construction.
- Formatted and signed-off as per DCO requirements.
