### PR TITLE
Fix Windows Wow6432Node Subkey Evaluation Bug (#7798)

### DIFF
--- a/lib/inspec/resources/package.rb
+++ b/lib/inspec/resources/package.rb
@@ -377,7 +377,7 @@ module Inspec::Resources
       ]
 
       # add 64 bit search paths
-      if inspec.os.arch == "x86_64"
+      if ["x86_64", "amd64", "%processor_architecture%"].include?(inspec.os.arch.to_s.downcase)
         search_paths << 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
         search_paths << 'HKCU:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
       end

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -26,6 +26,7 @@ class MockLoader
     windows: { name: "windows", family: "windows", release: "6.2.9200", arch: "x86_64" },
     windows2016: { name: "windows_server_2016_datacenter", family: "windows", release: "10.0.14393", arch: "x86_64" },
     windows2019: { name: "windows_server_2019_datacenter", family: "windows", release: "10.0.17763", arch: "x86_64" },
+    windows_unexpanded: { name: "windows", family: "windows", release: "10.0", arch: "%processor_architecture%" },
     wrlinux: { name: "wrlinux", family: "redhat", release: "7.0(3)I2(2)", arch: "x86_64" },
     solaris11: { name: "solaris", family: "solaris", release: "11", arch: "i386" },
     solaris10: { name: "solaris", family: "solaris", release: "10", arch: "i386" },

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -116,6 +116,15 @@ describe "Inspec::Resources::Package" do
     _(resource.latest?).must_equal true
   end
 
+  it "verify windows package parsing with unexpanded architecture string" do
+    resource = MockLoader.new(:windows_unexpanded).load_resource("package", "Chef Client v12.12.15")
+    pkg = { name: "Chef Client v12.12.15 ", installed: true, version: "12.12.15.1", type: "windows", only_version_no: "12.12.15.1" }
+    _(resource.installed?).must_equal true
+    _(resource.version).must_equal "12.12.15.1"
+    _(resource.info).must_equal pkg
+    _(resource.latest?).must_equal true
+  end
+
   # solaris 10
   it "verify solaris 10 package parsing" do
     resource = MockLoader.new(:solaris10).load_resource("package", "SUNWzfsr")


### PR DESCRIPTION
Fixes #7798

### Description
This Pull Request fixes a critical package scanning regression on Windows remote instances (e.g., Windows 11 Enterprise).

### Context
Currently, newer WinRM/Docker executions frequently fail to natively expand the `%processor_architecture%` environment variable when determining `inspec.os.arch`. Because of this unexpanded string, the 32-bit architectural guard inside `WindowsPkg` strictly skips pushing the `Wow6432Node` registry search paths to the scanner array.

### Verification
- Relaxed the rigid string checking condition to gracefully include the unexpanded CMD notation (`%processor_architecture%`) safely.
- Preserved the existing exact logical flow.
- Executed DCO sign-off.
