### PR TITLE
Inspec-6 - Update GitHub Actions CI stub workflow to target inspec-6 branch

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub-1.0.8.yml
+++ b/.github/workflows/ci-main-pull-request-stub-1.0.8.yml
@@ -7,9 +7,9 @@ name: CI Pull Request on Main Branch
 
 on: 
   pull_request:
-    branches: [ main, release/** ]
+    branches: [ inspec-6, release/** ]
   push:
-    branches: [ main, release/** ]
+    branches: [ inspec-6, release/** ]
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Description

Updates the GitHub Actions CI pull request stub workflow to target the `inspec-6` branch instead of `main`.

**Changes made in `.github/workflows/ci-main-pull-request-stub-1.0.8.yml`:**
- Changed `pull_request` branch trigger from `main` to `inspec-6`
- Changed `push` branch trigger from `main` to `inspec-6`

This ensures the stub CI workflow runs on pull requests and pushes targeting the `inspec-6` release branch, enabling proper CI coverage for the InSpec 6 release cycle.