### PR TITLE
fix: CHEF-32686 - Pre-check waivers before control block evaluation

### DIFF
--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -48,11 +48,19 @@ module Inspec
       return unless block_given?
 
       begin
-        instance_eval(&block)
-
-        # By applying waivers *after* the instance eval, we assure that
-        # waivers have higher precedence than only_if.
+        # Pre-check: apply waivers before evaluating the control block.
+        # If the control is waived with run: false, skip the block entirely
+        # to avoid eager resource evaluation (e.g., `command('find /').stdout`
+        # executing expensive commands for waived controls).
         __apply_waivers
+
+        unless @__skip_rule[:result] && @__skip_rule[:type] == :waiver
+          instance_eval(&block)
+
+          # Re-apply waivers after instance eval to ensure waivers have
+          # higher precedence than only_if.
+          __apply_waivers
+        end
 
       rescue SystemStackError, StandardError => e
         # We've encountered an exception while trying to eval the code inside the

--- a/lib/inspec/rule.rb
+++ b/lib/inspec/rule.rb
@@ -57,8 +57,11 @@ module Inspec
         unless @__skip_rule[:result] && @__skip_rule[:type] == :waiver
           instance_eval(&block)
 
-          # Re-apply waivers after instance eval to ensure waivers have
-          # higher precedence than only_if.
+          # Re-apply waivers after instance eval. This is a no-op in practice:
+          # run:false waivers are already handled by the pre-check above (the
+          # unless guard prevents instance_eval from running at all), and
+          # run:true / no-run-key waivers do not set a skip flag. Kept for
+          # defensive correctness in case waiver state changes during eval.
           __apply_waivers
         end
 

--- a/test/fixtures/profiles/waivers/eager-eval/controls/eager_eval.rb
+++ b/test/fixtures/profiles/waivers/eager-eval/controls/eager_eval.rb
@@ -1,0 +1,31 @@
+# This control uses eager evaluation pattern found in CIS profiles.
+# When waived with run: false, the command should NOT be executed.
+control "01_eager_waived_not_ran" do
+  result = command("echo eager_eval_marker_01").stdout.strip
+  describe result do
+    it { should eq "eager_eval_marker_01" }
+  end
+end
+
+# This control is NOT waived; eager evaluation should proceed normally.
+control "02_eager_not_waived" do
+  result = command("echo eager_eval_marker_02").stdout.strip
+  describe result do
+    it { should eq "eager_eval_marker_02" }
+  end
+end
+
+# This control is waived with run: true; eager evaluation should proceed normally.
+control "03_eager_waived_ran" do
+  result = command("echo eager_eval_marker_03").stdout.strip
+  describe result do
+    it { should eq "eager_eval_marker_03" }
+  end
+end
+
+# This control uses lazy evaluation (standard pattern) and is waived with run: false.
+control "04_lazy_waived_not_ran" do
+  describe command("echo lazy_eval_marker_04") do
+    its("stdout") { should match /lazy_eval_marker_04/ }
+  end
+end

--- a/test/fixtures/profiles/waivers/eager-eval/files/waivers.yaml
+++ b/test/fixtures/profiles/waivers/eager-eval/files/waivers.yaml
@@ -1,0 +1,11 @@
+01_eager_waived_not_ran:
+  justification: Heavy control should not run
+  run: false
+
+03_eager_waived_ran:
+  justification: This waiver allows running
+  run: true
+
+04_lazy_waived_not_ran:
+  justification: Lazy eval control should not run
+  run: false

--- a/test/fixtures/profiles/waivers/eager-eval/inspec.yml
+++ b/test/fixtures/profiles/waivers/eager-eval/inspec.yml
@@ -1,0 +1,6 @@
+name: eager-eval
+license: Apache-2.0
+summary: A profile to verify that waived controls with run false skip eager resource evaluation
+version: 0.1.0
+supports:
+  platform: os

--- a/test/functional/waivers_test.rb
+++ b/test/functional/waivers_test.rb
@@ -336,4 +336,25 @@ describe "waivers" do
       assert_includes result.stderr, "invalid YAML or contents is not a Hash"
     end
   end
+
+  describe "eager evaluation controls with waivers" do
+    let(:profile_name) { "eager-eval" }
+    let(:waiver_file) { "waivers.yaml" }
+
+    it "skips eagerly-evaluated controls when waived with run false" do
+      assert_test_outcome "skipped", "01_eager_waived_not_ran"
+    end
+
+    it "runs eagerly-evaluated controls that are not waived" do
+      assert_test_outcome "passed", "02_eager_not_waived"
+    end
+
+    it "runs eagerly-evaluated controls when waived with run true" do
+      assert_test_outcome "passed", "03_eager_waived_ran"
+    end
+
+    it "skips lazily-evaluated controls when waived with run false" do
+      assert_test_outcome "skipped", "04_lazy_waived_not_ran"
+    end
+  end
 end


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
CIS Automate profiles use eager resource evaluation where commands like 'find /' are executed directly in the control block. Previously, waivers were only applied after instance_eval, meaning expensive commands ran even for controls waived with run: false.

Move waiver check before instance_eval so controls waived with run: false skip block evaluation entirely. Re-apply waivers after instance_eval for non-waived controls to maintain precedence over only_if.

Foreport #7832 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
