### PR TITLE
FOREPORT: CHEF-31763 inspec check AST parser fixes

### DIFF
--- a/lib/inspec/utils/profile_ast_helpers.rb
+++ b/lib/inspec/utils/profile_ast_helpers.rb
@@ -24,6 +24,37 @@ module Inspec
           @memo = memo
         end
 
+        def extract_node_value(node)
+          case node.class.to_s
+          when "RuboCop::AST::HashNode"
+            # Handle hash nodes
+            values = {}
+            node.children.each do |pair_node|
+              values.merge!(pair_node.key.value => extract_node_value(pair_node.value))
+            end
+            values
+          when "RuboCop::AST::ArrayNode"
+            # Handle array nodes
+            node.children.map { |element| extract_node_value(element) }
+          else
+            # Handle simple nodes (strings, numbers, symbols, booleans, nil, etc.)
+            if node.respond_to?(:type)
+              case node.type
+              when :true
+                true
+              when :false
+                false
+              when :nil
+                nil
+              else
+                node.respond_to?(:value) ? node.value : node
+              end
+            else
+              node.respond_to?(:value) ? node.value : node
+            end
+          end
+        end
+
         def collect_input(input_children)
           input_name = input_children.children[2].value
 
@@ -39,15 +70,9 @@ module Inspec
                 if VALID_INPUT_OPTIONS.include?(child_node.key.value)
                   if child_node.value.class == RuboCop::AST::Node && REQUIRED_VALUES_MAP.key?(child_node.value.type)
                     opts.merge!(child_node.key.value => REQUIRED_VALUES_MAP[child_node.value.type])
-                  elsif child_node.value.class == RuboCop::AST::HashNode
-                    # Here value will be a hash
-                    values = {}
-                    child_node.value.children.each do |grand_child_node|
-                      values.merge!(grand_child_node.key.value => grand_child_node.value.value)
-                    end
-                    opts.merge!(child_node.key.value => values)
                   else
-                    opts.merge!(child_node.key.value => child_node.value.value)
+                    # Use the helper method to recursively extract values from any node type
+                    opts.merge!(child_node.key.value => extract_node_value(child_node.value))
                   end
                 end
               end

--- a/lib/inspec/utils/profile_ast_helpers.rb
+++ b/lib/inspec/utils/profile_ast_helpers.rb
@@ -338,8 +338,11 @@ module Inspec
             collectors.push InputCollectorWithinControlBlock.new(@memo)
             collectors.push TestsCollector.new(control_data) if include_tests
 
-            begin_block.each_node do |node_within_control|
-              collectors.each { |collector| collector.process(node_within_control) }
+            # Handle empty control blocks (e.g., control "id" do end)
+            if begin_block
+              begin_block.each_node do |node_within_control|
+                collectors.each { |collector| collector.process(node_within_control) }
+              end
             end
 
             memo[:controls].push control_data

--- a/test/unit/utils/profile_ast_helpers_test.rb
+++ b/test/unit/utils/profile_ast_helpers_test.rb
@@ -1,0 +1,195 @@
+require "helper"
+require "inspec/utils/profile_ast_helpers"
+
+describe Inspec::Profile::AstHelper::InputCollectorBase do
+  let(:memo) { { inputs: [] } }
+  let(:collector) { Inspec::Profile::AstHelper::InputCollectorWithinControlBlock.new(memo) }
+
+  describe "#extract_node_value" do
+    it "extracts simple string values" do
+      # Create a simple string node
+      code = "'simple string'"
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      result = collector.extract_node_value(ast)
+      _(result).must_equal "simple string"
+    end
+
+    it "extracts numeric values" do
+      code = "42"
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      result = collector.extract_node_value(ast)
+      _(result).must_equal 42
+    end
+
+    it "extracts array of strings" do
+      code = <<~RUBY
+        ["rhel-7-server-rpms/7Server/x86_64",#{" "}
+         "rhel-7-server-rt-beta-rpms/x86_64",#{" "}
+         "rhel-7-server-rt-rpms/7Server/x86_64"]
+      RUBY
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      result = collector.extract_node_value(ast)
+      _(result).must_equal [
+        "rhel-7-server-rpms/7Server/x86_64",
+        "rhel-7-server-rt-beta-rpms/x86_64",
+        "rhel-7-server-rt-rpms/7Server/x86_64",
+      ]
+    end
+
+    it "extracts hash values" do
+      code = '{ "key1" => "value1", "key2" => "value2" }'
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      result = collector.extract_node_value(ast)
+      _(result).must_equal({ "key1" => "value1", "key2" => "value2" })
+    end
+
+    it "extracts array containing hashes" do
+      code = '[{ "health" => "not found" }, { "status" => "ok" }]'
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      result = collector.extract_node_value(ast)
+      _(result).must_equal [
+        { "health" => "not found" },
+        { "status" => "ok" },
+      ]
+    end
+
+    it "extracts nested hash containing arrays" do
+      code = '{ "repos" => ["repo1", "repo2"], "enabled" => true }'
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      result = collector.extract_node_value(ast)
+      _(result).must_equal({ "repos" => %w{repo1 repo2}, "enabled" => true })
+    end
+
+    it "extracts deeply nested structures" do
+      code = <<~RUBY
+        {#{" "}
+          "array_of_hashes" => [
+            { "name" => "item1", "values" => [1, 2, 3] },
+            { "name" => "item2", "values" => [4, 5, 6] }
+          ],
+          "simple_key" => "simple_value"
+        }
+      RUBY
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      result = collector.extract_node_value(ast)
+      _(result).must_equal({
+        "array_of_hashes" => [
+          { "name" => "item1", "values" => [1, 2, 3] },
+          { "name" => "item2", "values" => [4, 5, 6] },
+        ],
+        "simple_key" => "simple_value",
+      })
+    end
+
+    it "handles boolean values" do
+      code = "true"
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      result = collector.extract_node_value(ast)
+      _(result).must_equal true
+    end
+
+    it "handles nil values" do
+      code = "nil"
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      result = collector.extract_node_value(ast)
+      _(result).must_be_nil
+    end
+
+    it "handles symbol values" do
+      code = ":my_symbol"
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      result = collector.extract_node_value(ast)
+      _(result).must_equal :my_symbol
+    end
+
+    it "handles arrays with mixed types" do
+      code = '["string", 42, true, nil, :symbol]'
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      result = collector.extract_node_value(ast)
+      _(result).must_equal ["string", 42, true, nil, :symbol]
+    end
+  end
+
+  describe "#collect_input integration" do
+    it "collects input with array value" do
+      code = <<~RUBY
+        input('excluded_repos',#{" "}
+          value: ["rhel-7-server-rpms/7Server/x86_64",#{" "}
+                  "rhel-7-server-rt-beta-rpms/x86_64"])
+      RUBY
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      collector.check_and_collect_input(ast)
+
+      _(memo[:inputs].length).must_equal 1
+      _(memo[:inputs][0][:name]).must_equal "excluded_repos"
+      _(memo[:inputs][0][:options][:value]).must_equal [
+        "rhel-7-server-rpms/7Server/x86_64",
+        "rhel-7-server-rt-beta-rpms/x86_64",
+      ]
+    end
+
+    it "collects input with hash value" do
+      code = <<~RUBY
+        input('config',#{" "}
+          value: { "host" => "localhost", "port" => 8080 })
+      RUBY
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      collector.check_and_collect_input(ast)
+
+      _(memo[:inputs].length).must_equal 1
+      _(memo[:inputs][0][:name]).must_equal "config"
+      _(memo[:inputs][0][:options][:value]).must_equal({ "host" => "localhost", "port" => 8080 })
+    end
+
+    it "collects input with array of hashes" do
+      code = <<~RUBY
+        input('checks',#{" "}
+          value: [{ "health" => "not found" }, { "status" => "ok" }])
+      RUBY
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      collector.check_and_collect_input(ast)
+
+      _(memo[:inputs].length).must_equal 1
+      _(memo[:inputs][0][:name]).must_equal "checks"
+      _(memo[:inputs][0][:options][:value]).must_equal [
+        { "health" => "not found" },
+        { "status" => "ok" },
+      ]
+    end
+
+    it "collects input with complex nested structure" do
+      code = <<~RUBY
+        input('complex_config',#{" "}
+          value: {
+            "repos" => ["repo1", "repo2"],
+            "settings" => { "enabled" => true, "count" => 5 }
+          })
+      RUBY
+      ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+
+      collector.check_and_collect_input(ast)
+
+      _(memo[:inputs].length).must_equal 1
+      _(memo[:inputs][0][:name]).must_equal "complex_config"
+      expected_value = {
+        "repos" => %w{repo1 repo2},
+        "settings" => { "enabled" => true, "count" => 5 },
+      }
+      _(memo[:inputs][0][:options][:value]).must_equal expected_value
+    end
+  end
+end

--- a/test/unit/utils/profile_ast_helpers_test.rb
+++ b/test/unit/utils/profile_ast_helpers_test.rb
@@ -193,3 +193,45 @@ describe Inspec::Profile::AstHelper::InputCollectorBase do
     end
   end
 end
+
+describe Inspec::Profile::AstHelper::ControlIDCollector do
+  let(:source_location_ref) { "/tmp/controls.rb" }
+  let(:memo) { { controls: [], inputs: [] } }
+
+  def process_controls(code, include_tests: false)
+    ast = RuboCop::AST::ProcessedSource.new(code, RUBY_VERSION.to_f).ast
+    collector = Inspec::Profile::AstHelper::ControlIDCollector.new(memo, source_location_ref,
+                                                                  include_tests: include_tests)
+    ast.each_node { |node| collector.process(node) }
+  end
+
+  it "collects an empty control block" do
+    code = <<~RUBY
+      control "empty-control" do
+      end
+    RUBY
+
+    process_controls(code)
+
+    _(memo[:controls].length).must_equal 1
+    control = memo[:controls].first
+    _(control[:id]).must_equal "empty-control"
+    _(control[:title]).must_be_nil
+    _(control[:desc]).must_be_nil
+    _(control[:descriptions]).must_equal({})
+    _(control[:tags]).must_equal({})
+    _(control[:refs]).must_equal([])
+  end
+
+  it "initializes checks when include_tests is enabled" do
+    code = <<~RUBY
+      control "empty-with-checks" do
+      end
+    RUBY
+
+    process_controls(code, include_tests: true)
+
+    _(memo[:controls].length).must_equal 1
+    _(memo[:controls].first[:checks]).must_equal []
+  end
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR includes ast parser fixes for these cases:
- **Array nodes**
   - `inspec/utils/profile_ast_helpers.rb:50:in block in collect_input': undefined method value' for s(:array, (NoMethodError)\n s(:str, "rhel-7-server-rpms/7Server/x86_64"),\n s(:str, "rhel-7-server-rt-beta-rpms/x86_64"),\n s(:str, "rhel-7-server-rt-rpms/7Server/x86_64")):RuboCop::AST::ArrayNode\n\n opts.merge!(child_node.key.value => child_node.value.value)\n`
- **Nested Hash nodes inside array element**
   - `inspec/utils/profile_ast_helpers.rb: 46:in "block (2 levels) in collect input': undefined method 'value' for s(:hash, (NoMethodError) \n s(:pair, \"health\") \n (:str, \"not found\") ) ) : RuboCop: : AST : : HashNode \n\n{}` 
- **No tests present within control** 
  - `inspec/utils/profile_ast_helpers.rb:341:in 'on_block': undefined method 'each_node' for nil:NilClass (NoMethodError)`

Foreport of #7641 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
