### PR TITLE
chore: pin nokogiri to ~> 1.18.0 in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,9 @@ group :test do
   # Adding unconditionally as it's compatible with all Ruby versions
   gem "minitest-mock"
   gem "mocha"
-  gem "nokogiri"
+  # nokogiri >= 1.19.1 patches GHSA-wx95-c6cv-8532 but requires Ruby >= 3.2.
+  # Pinning to ~> 1.18.0 until InSpec drops Ruby 3.1 support.
+  gem "nokogiri", "~> 1.18.0"
   gem "pry-byebug"
   gem "pry"
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    inspec (7.0.110)
+    inspec (7.1.0)
       faraday_middleware (~> 1.2, >= 1.2.1)
-      inspec-core (= 7.0.110)
+      inspec-core (= 7.1.0)
       progress_bar (~> 1.3.3)
       rake
       train (~> 3.16, >= 3.16.1)
@@ -11,7 +11,7 @@ PATH
       train-habitat (~> 0.1)
       train-kubernetes (>= 0.3.1)
       train-winrm (~> 0.4.0)
-    inspec-core (7.0.110)
+    inspec-core (7.1.0)
       addressable (~> 2.9)
       chef-licensing (>= 1.2.0)
       chef-telemetry (~> 1.0, >= 1.0.8)
@@ -43,8 +43,8 @@ PATH
 PATH
   remote: inspec-bin
   specs:
-    inspec-bin (7.0.110)
-      inspec (= 7.0.110)
+    inspec-bin (7.1.0)
+      inspec (= 7.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -878,7 +878,7 @@ DEPENDENCIES
   minitest-mock
   minitest-sprint (~> 1.0)
   mocha
-  nokogiri
+  nokogiri (~> 1.18.0)
   pry
   pry-byebug
   rake
@@ -888,4 +888,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.5.11
+   2.5.23


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Adds an explicit version pin for `nokogiri` (`~> 1.18.0`) in the development group of the `Gemfile`.

Previously `nokogiri` had no version constraint. Newer versions of nokogiri (`>= 1.19.1`) require Ruby `>= 3.2`, which is incompatible with InSpec's current minimum Ruby requirement of `3.1.0`. Pinning to `~> 1.18.0` keeps the development dependency stable and CI-compatible until InSpec drops Ruby 3.1 support.

This work was completed with AI assistance following Progress AI policies.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Dependabot alert: https://github.com/inspec/inspec/security/dependabot/50

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
