### PR TITLE
Ugraded faraday gem to 1.10.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    inspec (7.0.110)
+    inspec (7.1.0)
       faraday_middleware (~> 1.2, >= 1.2.1)
-      inspec-core (= 7.0.110)
+      inspec-core (= 7.1.0)
       progress_bar (~> 1.3.3)
       rake
       train (~> 3.16, >= 3.16.1)
@@ -11,7 +11,7 @@ PATH
       train-habitat (~> 0.1)
       train-kubernetes (>= 0.3.1)
       train-winrm (~> 0.4.0)
-    inspec-core (7.0.110)
+    inspec-core (7.1.0)
       addressable (~> 2.9)
       chef-licensing (>= 1.2.0)
       chef-telemetry (~> 1.0, >= 1.0.8)
@@ -43,8 +43,8 @@ PATH
 PATH
   remote: inspec-bin
   specs:
-    inspec-bin (7.0.110)
-      inspec (= 7.0.110)
+    inspec-bin (7.1.0)
+      inspec (= 7.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -418,7 +418,7 @@ GEM
       zeitwerk (~> 2.6)
     erubi (1.13.1)
     excon (0.112.0)
-    faraday (1.10.4)
+    faraday (1.10.5)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -447,7 +447,7 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday-retry (1.0.4)
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     ffi (1.16.3)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updates the faraday gem from 1.10.4 to 1.10.5 and faraday-retry from 1.0.3 to 1.0.4 in Gemfile.lock


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
