### PR TITLE
chore: upgrade rake gem minimum version to 12.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :test do
   gem "nokogiri"
   gem "pry-byebug"
   gem "pry"
-  gem "rake"
+  gem "rake", ">= 12.3.3"
   gem "simplecov"
   gem "simplecov_json_formatter"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 PATH
   remote: .
   specs:
-    inspec (7.1.0)
+    inspec (7.1.1)
       faraday_middleware (~> 1.2, >= 1.2.1)
-      inspec-core (= 7.1.0)
+      inspec-core (= 7.1.1)
       progress_bar (~> 1.3.3)
-      rake
+      rake (>= 12.3.3)
       train (~> 3.16, >= 3.16.1)
       train-aws (~> 0.2)
       train-habitat (~> 0.1)
       train-kubernetes (>= 0.3.1)
       train-winrm (~> 0.4.0)
-    inspec-core (7.1.0)
+    inspec-core (7.1.1)
       addressable (~> 2.9)
       chef-licensing (>= 1.2.0)
       chef-telemetry (~> 1.0, >= 1.0.8)
@@ -43,8 +43,8 @@ PATH
 PATH
   remote: inspec-bin
   specs:
-    inspec-bin (7.1.0)
-      inspec (= 7.1.0)
+    inspec-bin (7.1.1)
+      inspec (= 7.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -881,7 +881,7 @@ DEPENDENCIES
   nokogiri
   pry
   pry-byebug
-  rake
+  rake (>= 12.3.3)
   rspec (>= 3.10)
   simplecov
   simplecov_json_formatter

--- a/inspec-bin/inspec-bin.gemspec
+++ b/inspec-bin/inspec-bin.gemspec
@@ -24,7 +24,7 @@ Source code obtained from the Chef GitHub repository is made available under Apa
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "inspec", "= #{InspecBin::VERSION}"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", ">= 12.3.3"
 
   spec.files = %w{README.md LICENSE Gemfile} + Dir.glob("*.gemspec") +
     Dir.glob("{lib,bin}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -33,7 +33,7 @@ Source code obtained from the Chef GitHub repository is made available under Apa
   spec.add_dependency "inspec-core", "= #{Inspec::VERSION}"
 
   spec.add_dependency "train", "~> 3.16", ">= 3.16.1"
-  spec.add_dependency "rake"
+  spec.add_dependency "rake", ">= 12.3.3"
   # progress bar streaming reporter plugin support
   spec.add_dependency "progress_bar", "~> 1.3.3"
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Upgraded the `rake` gem minimum version to `>= 12.3.3` across the project.

The following files were updated to enforce the minimum version constraint:
- `Gemfile` (test group)
- `inspec.gemspec` (runtime dependency)
- `inspec-bin/inspec-bin.gemspec` (development dependency)

This work was completed with AI assistance following Progress AI policies.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
