### PR TITLE
Updated omnibus buildkite plugin version pin

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -24,12 +24,16 @@ pipelines:
      # https://chefio.atlassian.net/wiki/spaces/RELENGKB/pages/2204336129/Resolving+git+cache+build+errors+in+Omnibus
      - EXPIRE_CACHE: 1
      - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems like ffi.
+     - BUNDLE_GITHUB__COM: "x-access-token:$GITHUB_TOKEN" # Required to fetch private GitHub gem sources in omnibus/Gemfile
+     - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 252fb152aa8652505adf404061478ffd70e3747a # Pin plugin version to fix Windows bundler git auth hang
  - omnibus/adhoc:
     definition: .expeditor/release.omnibus.yml
     env:
      - ADHOC: true
      - EXPIRE_CACHE: 1
      - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems like ffi.
+     - BUNDLE_GITHUB__COM: "x-access-token:$GITHUB_TOKEN" # Required to fetch private GitHub gem sources in omnibus/Gemfile
+     - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 252fb152aa8652505adf404061478ffd70e3747a # Pin plugin version to fix Windows bundler git auth hang
  - verify:
     description: Pull Request validation tests
     public: true


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This is required for a private omnibus usage implementation.
This pull request updates the CI pipeline configuration to improve authentication for private GitHub gem sources and address a Windows-specific bundler issue. The changes focus on environment variable management for the `omnibus` and `omnibus/adhoc` pipelines.

**Pipeline authentication and reliability improvements:**

* Added the `BUNDLE_GITHUB__COM` environment variable to both `omnibus` and `omnibus/adhoc` pipelines to enable fetching private GitHub gem sources using a GitHub token.
* Pinned the `OMNIBUS_BUILDKITE_PLUGIN_VERSION` to a specific commit in both pipelines to resolve a Windows bundler git authentication hang.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
