### PR TITLE
activesupport minimum version to 7.2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    inspec (7.1.1)
+    inspec (7.1.2)
       faraday_middleware (~> 1.2, >= 1.2.1)
-      inspec-core (= 7.1.1)
+      inspec-core (= 7.1.2)
       progress_bar (~> 1.3.3)
       rake (>= 12.3.3)
       train (~> 3.16, >= 3.16.1)
@@ -11,7 +11,7 @@ PATH
       train-habitat (~> 0.1)
       train-kubernetes (>= 0.3.1)
       train-winrm (~> 0.4.0)
-    inspec-core (7.1.1)
+    inspec-core (7.1.2)
       addressable (~> 2.9)
       chef-licensing (>= 1.2.0)
       chef-telemetry (~> 1.0, >= 1.0.8)
@@ -43,13 +43,13 @@ PATH
 PATH
   remote: inspec-bin
   specs:
-    inspec-bin (7.1.1)
-      inspec (= 7.1.1)
+    inspec-bin (7.1.2)
+      inspec (= 7.1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.3)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -58,7 +58,7 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.9.0)


### PR DESCRIPTION
Bumps the minimum required version of activesupport from >= 7.2.2.1 to >= 7.2.3.1 to align with the latest stable patch release in the 7.2.x series. The upper bound constraint (~> 7.2) is unchanged.