### PR TITLE
Results empty should return error - fix

### DIFF
--- a/dev-docs/enhanced-outcomes.md
+++ b/dev-docs/enhanced-outcomes.md
@@ -18,8 +18,9 @@ Enhanced Outcomes adds three new control outcomes to the existing `Pass`, `Fail`
 
 In the first iteration of Enhanced Outcomes, the Error outcome is detected:
 
- * if the message of any test includes the text "Control source error" OR
- * the result of any test includes a backtrace
+ * if there are no test results for the control (empty results array) OR
+ * if the result of any test includes both an exception and a backtrace (and the resource class is not "noop") OR
+ * if the message of any test includes the text "Control source error"
 
 Then the entire control should be marked `Error`.
 

--- a/lib/inspec/enhanced_outcomes.rb
+++ b/lib/inspec/enhanced_outcomes.rb
@@ -1,20 +1,19 @@
 module Inspec
   module EnhancedOutcomes
-
     def self.determine_status(results, impact)
       # No-op exception occurs in case of not_applicable_if
-      if results.any? { |r| !r[:exception].nil? && !r[:backtrace].nil? && r[:resource_class] != "noop" }
-        "error"
-      elsif !impact.nil? && impact.to_f == 0.0
-        "not_applicable"
-      elsif results.all? { |r| r[:status] == "skipped" }
-        "not_reviewed"
-      elsif results.any? { |r| r[:status] == "failed" }
-        "failed"
-      else
-        "passed"
-      end
+        return "error" if results.empty?
+        if results.any? { |r| !r[:exception].nil? && !r[:backtrace].nil? && r[:resource_class] != "noop" }
+          "error"
+        elsif !impact.nil? && impact.to_f == 0.0
+          "not_applicable"
+        elsif results.all? { |r| r[:status] == "skipped" }
+          "not_reviewed"
+        elsif results.any? { |r| r[:status] == "failed" }
+          "failed"
+        else
+          "passed"
+        end
     end
-
   end
 end

--- a/test/unit/enhanced_outcomes_test.rb
+++ b/test/unit/enhanced_outcomes_test.rb
@@ -78,6 +78,14 @@ describe "Inspec::EnhancedOutcomes" do
       end
     end
 
+    describe "When there are no results" do
+      let(:results) { [] }
+      it "returns status as error" do
+        status = Inspec::EnhancedOutcomes.determine_status(results, nil)
+        _(status).must_equal "error"
+      end
+    end
+
     describe "When results status are none of the above but have a failed test" do
       let(:results) {
         [


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Results being empty was giving outcome as "passed". Added a condition to check results and return error if it's empty

## Related Issue
https://github.com/inspec/inspec/issues/6890
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
