### PR TITLE
fix: hab build pipline

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -17,6 +17,8 @@ pipelines:
      - HAB_NONINTERACTIVE: "true"
      - HAB_NOCOLORING: "true"
      - HAB_STUDIO_SECRET_HAB_NONINTERACTIVE: "true"
+     - HAB_BLDR_CHANNEL: "LTS-2024"
+     - HAB_REFRESH_CHANNEL: "LTS-2024"
  - docker/build
  - omnibus/release:
     env:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The Buildkite habitat build pipeline (`habitat/build`) was not setting
 `HAB_BLDR_CHANNEL`, causing Habitat to resolve runtime dependencies from
 the default `stable` channel. Recent updates to the `stable` channel
 promoted newer packages that are built against a different glibc version
 than `core/ruby3_1`, resulting in a duplicate dependency conflict and
 build failure.
 
 While `core/ruby3_1` on `LTS-2024` uses `glibc/2.36`. Habitat's
 runtime dependency checker detected multiple glibc versions in the
 dependency graph and aborted the build with exit code 31:
 
 **Fix:**
 Pin `HAB_BLDR_CHANNEL` and `HAB_REFRESH_CHANNEL` to `LTS-2024` in
 `.expeditor/config.yml` for the `habitat/build` pipeline. This ensures
 all dependencies (`coreutils`, `bash`, `git`, `ruby3_1`) resolve from
 the same frozen `LTS-2024` channel stack — all consistently built
 against `glibc/2.36`.
 
 This is already how the GitHub Actions habitat workflows
 (`habitat-build-lts-current.yml`, `artifact.habitat.test.yml`) are
 configured and they work correctly.
## Related Issue
(https://buildkite.com/chef/inspec-inspec-inspec-5-habitat-build/builds/145)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
