### PR TITLE
fix: CHEF-32339 - Harden NTFS permissions on .bat files in bin directory

### DIFF
--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -121,4 +121,32 @@ function Invoke-After {
     # Remove the byproducts of compiling gems with extensions
     Get-ChildItem $pkg_prefix/vendor/gems -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `
         | Remove-Item -Force
+
+    # Harden NTFS permissions on .bat files in the bin directory to prevent privilege escalation.
+    # Appbundler generates these files with overly permissive ACLs (Authenticated Users: Modify).
+    # Restrict Authenticated Users to ReadAndExecute only, mirroring the Linux plan's chmod go-w fix.
+    Write-BuildLine "** Hardening file permissions on .bat files to prevent privilege escalation"
+    Get-ChildItem "$pkg_prefix/bin" -Filter "*.bat" | ForEach-Object {
+        $filePath = $_.FullName
+        $acl = Get-Acl $filePath
+
+        # Remove all existing Authenticated Users access rules
+        $acl.Access | Where-Object {
+            $_.IdentityReference.Value -like "*Authenticated Users*"
+        } | ForEach-Object {
+            $acl.RemoveAccessRule($_) | Out-Null
+        }
+
+        # Grant Authenticated Users ReadAndExecute only (no write/modify)
+        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+            "Authenticated Users",
+            [System.Security.AccessControl.FileSystemRights]::ReadAndExecute,
+            [System.Security.AccessControl.InheritanceFlags]::None,
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )
+        $acl.AddAccessRule($rule)
+        Set-Acl $filePath $acl
+        Write-BuildLine "  Secured permissions on $($_.Name)"
+    }
 }

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -122,30 +122,45 @@ function Invoke-After {
     Get-ChildItem $pkg_prefix/vendor/gems -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `
         | Remove-Item -Force
 
-    # Harden NTFS permissions on .bat files in the bin directory to prevent privilege escalation.
-    # Appbundler generates these files with overly permissive ACLs (Authenticated Users: Modify).
-    # Restrict Authenticated Users to ReadAndExecute only, mirroring the Linux plan's chmod go-w fix.
-    Write-BuildLine "** Hardening file permissions on .bat files to prevent privilege escalation"
+    # Harden NTFS permissions on .bat files in the bin directory.
+    # These files should only be modifiable by NT AUTHORITY\SYSTEM (Windows Installer service).
+    # No user, including Administrators, should be able to modify them.
+    Write-BuildLine "** Hardening file permissions on .bat files in bin directory"
     Get-ChildItem "$pkg_prefix/bin" -Filter "*.bat" | ForEach-Object {
         $filePath = $_.FullName
         $acl = Get-Acl $filePath
 
-        # Remove all existing Authenticated Users access rules
-        $acl.Access | Where-Object {
-            $_.IdentityReference.Value -like "*Authenticated Users*"
-        } | ForEach-Object {
-            $acl.RemoveAccessRule($_) | Out-Null
-        }
+        # Break inheritance and remove all existing access rules
+        $acl.SetAccessRuleProtection($true, $false)
+        $acl.Access | ForEach-Object { $acl.RemoveAccessRule($_) | Out-Null }
 
-        # Grant Authenticated Users ReadAndExecute only (no write/modify)
-        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-            "Authenticated Users",
+        # SYSTEM gets Full Control (required for install/upgrade/uninstall)
+        $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+            "NT AUTHORITY\SYSTEM",
+            [System.Security.AccessControl.FileSystemRights]::FullControl,
+            [System.Security.AccessControl.InheritanceFlags]::None,
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )))
+
+        # Administrators get ReadAndExecute only - no modification allowed
+        $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+            "BUILTIN\Administrators",
             [System.Security.AccessControl.FileSystemRights]::ReadAndExecute,
             [System.Security.AccessControl.InheritanceFlags]::None,
             [System.Security.AccessControl.PropagationFlags]::None,
             [System.Security.AccessControl.AccessControlType]::Allow
-        )
-        $acl.AddAccessRule($rule)
+        )))
+
+        # Users get ReadAndExecute only - no modification allowed
+        $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+            "BUILTIN\Users",
+            [System.Security.AccessControl.FileSystemRights]::ReadAndExecute,
+            [System.Security.AccessControl.InheritanceFlags]::None,
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )))
+
         Set-Acl $filePath $acl
         Write-BuildLine "  Secured permissions on $($_.Name)"
     }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Appbundler-generated `.bat` files in the `bin/` directory were installed with overly permissive NTFS ACLs granting `Authenticated Users` **Modify** access. This allowed any local user to overwrite `inspec.bat` and other `.bat` wrappers.

**Fix**: Added a permission-hardening step in `Invoke-After` of `habitat/x86_64-windows/plan.ps1` that:
- Removes all `Authenticated Users` access rules from `.bat` files in `bin/`
- Re-grants `ReadAndExecute` only (no write/modify permissions)

This mirrors the existing Linux plan fix that strips world-writable bits from gem files using `chmod go-w`.

This work was completed with AI assistance following Progress AI policies.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

CHEF-32339 — Insecure File Permissions on inspec.bat

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
