### PR TITLE
fix: CHEF-32339 - Harden NTFS permissions on .bat files in bin directory

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -88,4 +88,32 @@ function Invoke-After {
     # Remove the byproducts of compiling gems with extensions
     Get-ChildItem $pkg_prefix/vendor/gems -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `
         | Remove-Item -Force
+
+    # Harden NTFS permissions on .bat files in the bin directory.
+    # Appbundler generates these files with overly permissive ACLs (Authenticated Users: Modify).
+    # Restrict Authenticated Users to ReadAndExecute only, mirroring the Linux plan's chmod go-w fix.
+    Write-BuildLine "** Hardening file permissions on .bat files in bin directory"
+    Get-ChildItem "$pkg_prefix/bin" -Filter "*.bat" | ForEach-Object {
+        $filePath = $_.FullName
+        $acl = Get-Acl $filePath
+
+        # Remove all existing Authenticated Users access rules
+        $acl.Access | Where-Object {
+            $_.IdentityReference.Value -like "*Authenticated Users*"
+        } | ForEach-Object {
+            $acl.RemoveAccessRule($_) | Out-Null
+        }
+
+        # Grant Authenticated Users ReadAndExecute only (no write/modify)
+        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+            "Authenticated Users",
+            [System.Security.AccessControl.FileSystemRights]::ReadAndExecute,
+            [System.Security.AccessControl.InheritanceFlags]::None,
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )
+        $acl.AddAccessRule($rule)
+        Set-Acl $filePath $acl
+        Write-BuildLine "  Secured permissions on $($_.Name)"
+    }
 }

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -90,29 +90,44 @@ function Invoke-After {
         | Remove-Item -Force
 
     # Harden NTFS permissions on .bat files in the bin directory.
-    # Appbundler generates these files with overly permissive ACLs (Authenticated Users: Modify).
-    # Restrict Authenticated Users to ReadAndExecute only, mirroring the Linux plan's chmod go-w fix.
+    # These files should only be modifiable by NT AUTHORITY\SYSTEM (Windows Installer service).
+    # No user, including Administrators, should be able to modify them.
     Write-BuildLine "** Hardening file permissions on .bat files in bin directory"
     Get-ChildItem "$pkg_prefix/bin" -Filter "*.bat" | ForEach-Object {
         $filePath = $_.FullName
         $acl = Get-Acl $filePath
 
-        # Remove all existing Authenticated Users access rules
-        $acl.Access | Where-Object {
-            $_.IdentityReference.Value -like "*Authenticated Users*"
-        } | ForEach-Object {
-            $acl.RemoveAccessRule($_) | Out-Null
-        }
+        # Break inheritance and remove all existing access rules
+        $acl.SetAccessRuleProtection($true, $false)
+        $acl.Access | ForEach-Object { $acl.RemoveAccessRule($_) | Out-Null }
 
-        # Grant Authenticated Users ReadAndExecute only (no write/modify)
-        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-            "Authenticated Users",
+        # SYSTEM gets Full Control (required for install/upgrade/uninstall)
+        $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+            "NT AUTHORITY\SYSTEM",
+            [System.Security.AccessControl.FileSystemRights]::FullControl,
+            [System.Security.AccessControl.InheritanceFlags]::None,
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )))
+
+        # Administrators get ReadAndExecute only - no modification allowed
+        $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+            "BUILTIN\Administrators",
             [System.Security.AccessControl.FileSystemRights]::ReadAndExecute,
             [System.Security.AccessControl.InheritanceFlags]::None,
             [System.Security.AccessControl.PropagationFlags]::None,
             [System.Security.AccessControl.AccessControlType]::Allow
-        )
-        $acl.AddAccessRule($rule)
+        )))
+
+        # Users get ReadAndExecute only - no modification allowed
+        $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+            "BUILTIN\Users",
+            [System.Security.AccessControl.FileSystemRights]::ReadAndExecute,
+            [System.Security.AccessControl.InheritanceFlags]::None,
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )))
+
         Set-Acl $filePath $acl
         Write-BuildLine "  Secured permissions on $($_.Name)"
     }

--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -61,4 +61,20 @@ build do
     gem_install_dir = shellout!("#{install_dir}/embedded/bin/gem open rubyzip", env: env).stdout.chomp
     remove_directory "#{gem_install_dir}/test"
   end
+
+  if windows?
+    # Harden NTFS permissions on appbundler-generated .bat files in the bin directory.
+    # By default these files inherit overly permissive ACLs from the parent directory,
+    # allowing any authenticated user to modify them. This breaks inheritance and
+    # removes write access for Authenticated Users, mirroring the Linux chmod go-w fix.
+    block "Harden NTFS permissions on .bat files in bin directory" do
+      Dir.glob("#{install_dir}/bin/*.bat").each do |bat_file|
+        windows_path = bat_file.gsub("/", "\\")
+        # Break ACL inheritance (copies inherited entries, then disables inheritance)
+        shellout!("icacls \"#{windows_path}\" /inheritance:d")
+        # Remove all Authenticated Users access rules
+        shellout!("icacls \"#{windows_path}\" /remove:g \"Authenticated Users\"")
+      end
+    end
+  end
 end

--- a/omnibus/config/software/inspec.rb
+++ b/omnibus/config/software/inspec.rb
@@ -64,16 +64,25 @@ build do
 
   if windows?
     # Harden NTFS permissions on appbundler-generated .bat files in the bin directory.
-    # By default these files inherit overly permissive ACLs from the parent directory,
-    # allowing any authenticated user to modify them. This breaks inheritance and
-    # removes write access for Authenticated Users, mirroring the Linux chmod go-w fix.
+    # These files should only be modifiable by NT AUTHORITY\SYSTEM (Windows Installer service).
+    # No user, including Administrators, should be able to modify them.
+    # The MSI installer runs as SYSTEM so upgrades and uninstalls continue to work correctly.
     block "Harden NTFS permissions on .bat files in bin directory" do
       Dir.glob("#{install_dir}/bin/*.bat").each do |bat_file|
         windows_path = bat_file.gsub("/", "\\")
-        # Break ACL inheritance (copies inherited entries, then disables inheritance)
+        # Break ACL inheritance and reset to explicit entries only
         shellout!("icacls \"#{windows_path}\" /inheritance:d")
-        # Remove all Authenticated Users access rules
+        # Remove all existing entries
         shellout!("icacls \"#{windows_path}\" /remove:g \"Authenticated Users\"")
+        shellout!("icacls \"#{windows_path}\" /remove:g \"BUILTIN\\Administrators\"")
+        shellout!("icacls \"#{windows_path}\" /remove:g \"BUILTIN\\Users\"")
+        shellout!("icacls \"#{windows_path}\" /remove:g \"NT AUTHORITY\\SYSTEM\"")
+        shellout!("icacls \"#{windows_path}\" /remove:g \"CREATOR OWNER\"")
+        # SYSTEM gets Full Control (required for MSI install/upgrade/uninstall)
+        shellout!("icacls \"#{windows_path}\" /grant:r \"NT AUTHORITY\\SYSTEM:(F)\"")
+        # Administrators and Users get ReadAndExecute only - no modification allowed
+        shellout!("icacls \"#{windows_path}\" /grant:r \"BUILTIN\\Administrators:(RX)\"")
+        shellout!("icacls \"#{windows_path}\" /grant:r \"BUILTIN\\Users:(RX)\"")
       end
     end
   end

--- a/omnibus/resources/inspec/msi/source.wxs.erb
+++ b/omnibus/resources/inspec/msi/source.wxs.erb
@@ -67,11 +67,14 @@
       Harden NTFS permissions on the bin directory after installation.
       Only NT AUTHORITY\SYSTEM (Windows Installer) can modify files.
       Administrators and Users get ReadAndExecute only.
-      OI+CI flags ensure permissions are inherited by all files in the directory.
+      Directory="PROJECTLOCATIONBIN" sets the working directory so "." resolves correctly
+      in the deferred context (property expansion of [PROJECTLOCATIONBIN] does not work
+      in deferred CustomActions). /T applies the ACL recursively to all files in bin\.
+      OI+CI flags ensure new files added later also inherit the restricted permissions.
     -->
     <CustomAction Id="HardenBinPermissions"
                   Directory="PROJECTLOCATIONBIN"
-                  ExeCommand="cmd.exe /C icacls &quot;[PROJECTLOCATIONBIN]&quot; /inheritance:d /remove:g &quot;Authenticated Users&quot; /remove:g &quot;BUILTIN\Administrators&quot; /remove:g &quot;BUILTIN\Users&quot; /remove:g &quot;CREATOR OWNER&quot; /grant:r &quot;NT AUTHORITY\SYSTEM:(OI)(CI)(F)&quot; /grant:r &quot;BUILTIN\Administrators:(OI)(CI)(RX)&quot; /grant:r &quot;BUILTIN\Users:(OI)(CI)(RX)&quot;"
+                  ExeCommand="cmd /C icacls . /inheritance:d /remove &quot;Authenticated Users&quot; /remove &quot;BUILTIN\Administrators&quot; /remove &quot;BUILTIN\Users&quot; /remove &quot;CREATOR OWNER&quot; /grant:r &quot;NT AUTHORITY\SYSTEM:(OI)(CI)(F)&quot; /grant:r &quot;BUILTIN\Administrators:(OI)(CI)(RX)&quot; /grant:r &quot;BUILTIN\Users:(OI)(CI)(RX)&quot; /T"
                   Execute="deferred"
                   Impersonate="no"
                   Return="ignore" />

--- a/omnibus/resources/inspec/msi/source.wxs.erb
+++ b/omnibus/resources/inspec/msi/source.wxs.erb
@@ -58,15 +58,33 @@
                   Impersonate="no"
                   Return="ignore" />
 
-    <InstallExecuteSequence>
-      <Custom Action="FastUnzip" After="InstallFiles">NOT Installed</Custom>
-      <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
-    </InstallExecuteSequence>
-
     <UI>
       <ProgressText Action="FastUnzip">!(loc.FileExtractionProgress)</ProgressText>
     </UI>
     <% end %>
+
+    <!--
+      Harden NTFS permissions on the bin directory after installation.
+      Only NT AUTHORITY\SYSTEM (Windows Installer) can modify files.
+      Administrators and Users get ReadAndExecute only.
+      OI+CI flags ensure permissions are inherited by all files in the directory.
+    -->
+    <CustomAction Id="HardenBinPermissions"
+                  Directory="PROJECTLOCATIONBIN"
+                  ExeCommand="cmd.exe /C icacls &quot;[PROJECTLOCATIONBIN]&quot; /inheritance:d /remove:g &quot;Authenticated Users&quot; /remove:g &quot;BUILTIN\Administrators&quot; /remove:g &quot;BUILTIN\Users&quot; /remove:g &quot;CREATOR OWNER&quot; /grant:r &quot;NT AUTHORITY\SYSTEM:(OI)(CI)(F)&quot; /grant:r &quot;BUILTIN\Administrators:(OI)(CI)(RX)&quot; /grant:r &quot;BUILTIN\Users:(OI)(CI)(RX)&quot;"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="ignore" />
+
+    <InstallExecuteSequence>
+      <% if fastmsi %>
+      <Custom Action="FastUnzip" After="InstallFiles">NOT Installed</Custom>
+      <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
+      <Custom Action="HardenBinPermissions" After="FastUnzip">NOT Installed OR REINSTALL</Custom>
+      <% else %>
+      <Custom Action="HardenBinPermissions" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
+      <% end %>
+    </InstallExecuteSequence>
 
     <CustomActionRef Id="WixBroadcastSettingChange" />
     <CustomActionRef Id="WixBroadcastEnvironmentChange" />


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Appbundler-generated `.bat` files in the `bin/` directory inherit overly permissive NTFS ACLs from the parent directory, allowing any authenticated user to modify them.

**Changes:**

1. **`omnibus/config/software/inspec.rb`** — Adds a Windows-specific build step after `appbundle` that:
   - Breaks ACL inheritance on each `.bat` file (copying inherited entries first)
   - Removes all `Authenticated Users` access rules

2. **`habitat/plan.ps1`** — Adds the same hardening in `Invoke-After`:
   - Removes `Authenticated Users` access rules from `.bat` files in `bin/`
   - Re-grants `ReadAndExecute` only

Both fixes mirror the existing Linux plan fix that strips world-writable bits from gem files using `chmod go-w`.

This work was completed with AI assistance following Progress AI policies.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

CHEF-32339 — Insecure File Permissions on inspec.bat

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
