### PR TITLE
GHCP -- Walk: 11 PR Hygiene — review focus generator + discipline docs

### DIFF
--- a/.copilot-track/walk/pr-template.md
+++ b/.copilot-track/walk/pr-template.md
@@ -1,13 +1,14 @@
 # Walk Track — PR Template
 
 Copy this block into every Walk PR description.
+See `scripts/pr-review-focus.rb` to auto-generate the Review Focus section from git diff.
 
 ---
 
 **Title: GHCP -- Walk: \<ex#\> \<name\>**
 
 ## Summary
-- What changed and why
+- What changed and why (1–3 lines)
 - Plan: \<link to plan or inline summary\>
 - Files/paths touched
 
@@ -16,13 +17,39 @@ Copy this block into every Walk PR description.
 - Coverage: \<percentage or contract evidence\>
 
 ## Risk & Rollback
-- Risk: low/medium
-- Rollback: revert \<commit SHA\> or toggle \<flag\>
+- Risk: low / medium / high
+- Rollback: `git revert <commit SHA>` (or `toggle <flag>` / `pin back <gem>=<prev_version>`)
 
 ## Review Focus
-- Key areas for reviewer attention
-- Verification steps the reviewer can run
+
+> 3–5 bullets. Each bullet: **what** to look at + **why** it matters + **how** to verify.
+
+- [ ] **\<area 1\>** — \<what changed and why it's the key risk\>
+  - Verify: `<command reviewer can run>`
+- [ ] **\<area 2\>** — \<correctness / edge-case concern\>
+  - Verify: `<command reviewer can run>`
+- [ ] **\<area 3\>** — \<side-effects or coupling to other code\>
+  - Verify: `<command reviewer can run>`
+
+## Verification Steps (reviewer checklist)
+
+```bash
+# 1. Clone branch and install deps
+git checkout <branch>
+gem install minitest -v '~> 6.0'
+
+# 2. Run unit + contract tests
+RUBY_BIN=$(which ruby) bash scripts/crawl-track-test.sh
+ruby -I lib test/contract/impact_contract_test.rb
+
+# 3. Run coverage
+ruby scripts/coverage-impact.rb   # expect ≥ 75%
+
+# 4. Lint
+rubocop lib/inspec/impact.rb test/unit/impact_test.rb --format simple
+```
 
 ## Track
 - Level: Walk
 - Exercise: \<ex#\>
+- Evidence: \<logs / coverage % / diagram link / doc path\>

--- a/ai-track-docs/pr-hygiene.md
+++ b/ai-track-docs/pr-hygiene.md
@@ -1,0 +1,157 @@
+# PR Hygiene — Review Focus Discipline
+
+**Walk Track — Exercise 11**
+**Updated:** 2026-05-21
+
+---
+
+## Overview
+
+A review-ready PR tells the reviewer **what to look at**, **how to verify it**,
+and **how to roll back** — before they ask. This discipline reduces review
+round-trips and surfaces risks that automated checks miss.
+
+Walk track standard: every PR must include:
+1. **3–5 review focus bullets** (what + why + verify command per bullet)
+2. **Runnable verification steps** (copy-paste commands)
+3. **Clear rollback** (a single command, not a description)
+
+---
+
+## Quick Start — Auto-generate Review Focus
+
+```bash
+# From your feature branch, after committing:
+ruby scripts/pr-review-focus.rb                  # diff against HEAD~1
+ruby scripts/pr-review-focus.rb HEAD~3..HEAD     # multi-commit range
+ruby scripts/pr-review-focus.rb --full           # include full PR template sections
+```
+
+The script analyses `git diff` for `lib/inspec/impact.rb` and `test/unit/impact_test.rb`,
+detects change categories, and generates tailored review bullets with verify commands.
+
+**Always review and adjust the output** — the generator is a starting point, not a
+final answer. Add context about *why* this specific change matters in this PR.
+
+---
+
+## Review Focus Bullet Formula
+
+Each bullet follows this structure:
+
+```
+- [ ] **<area>** — <what changed and why it's the key risk>
+  - Verify: `<command the reviewer can run>`
+```
+
+**Good bullet (specific, actionable):**
+```
+- [ ] **Observability hooks (`warn_impact`)** — WARN hooks fire at INFO log level;
+  visible without debug mode. Verify toggle suppresses output and mid-band scores
+  do NOT trigger WARN.
+  - Verify: `ruby -I lib -e "require 'inspec/impact'; Inspec::Impact.string_from_impact(0.75)"`
+```
+
+**Bad bullet (vague, not actionable):**
+```
+- [ ] Check the logging changes
+```
+
+---
+
+## Review Focus Categories for `impact.rb`
+
+| Category | When to include | Verify command |
+|----------|----------------|---------------|
+| **Constants / data** | `IMPACT_SCORES` or `BOUNDARY_SCORES` changed | `ruby -e "require_relative 'lib/inspec/impact'; p Inspec::Impact::IMPACT_SCORES"` |
+| **Public API** | `impact_from_string` / `string_from_impact` changed | Round-trip assertion (see below) |
+| **Type guards** | `assert_type!` / `ImpactError` paths changed | Nil + wrong-type input test |
+| **Observability** | `warn_impact` / `log_impact` / toggle changed | Boundary score + mid-band score |
+| **Private helpers** | `number?` / `json_value` / `elapsed_ms_since` changed | Full test suite |
+| **New tests** | Tests added | Determinism check, AAA structure review |
+| **Coverage delta** | Any code change | `ruby scripts/coverage-impact.rb` |
+| **Contract** | Data constants changed | `ruby -I lib test/contract/impact_contract_test.rb` |
+
+---
+
+## Standard Verification Steps Block
+
+Paste this into every Walk PR (fill in branch name):
+
+```bash
+# 1. Checkout and install minimal deps
+git checkout <branch>
+gem install minitest -v "~> 6.0" --no-document
+
+# 2. Run all track checks (4 checks: ruby version, tests, frozen_string_literal, bare rescue)
+RUBY_BIN=$(which ruby) bash scripts/crawl-track-test.sh
+
+# 3. Contract tests (golden file + API shape)
+ruby -I lib test/contract/impact_contract_test.rb
+
+# 4. Coverage (must be ≥ 75%, baseline 81.71%)
+ruby scripts/coverage-impact.rb
+
+# 5. Lint (RuboCop 1.86.2 pinned)
+rubocop lib/inspec/impact.rb test/unit/impact_test.rb --format simple
+```
+
+---
+
+## Rollback Standard
+
+Every PR must include a single rollback command:
+
+```
+- Rollback: `git revert <commit SHA>`
+```
+
+For feature flags:
+```
+- Rollback: `Inspec::Impact.logging_enabled = false`  (zero-deploy toggle)
+```
+
+For dependency changes:
+```
+- Rollback: pin back `rubocop: 1.86.1` in .github/workflows/crawl-track-impact.yml
+```
+
+**Never write "just revert the PR"** — give the exact command so a reviewer on
+call can act in 30 seconds without context.
+
+---
+
+## Walk Exercise PR Review Focus Examples
+
+### Ex6 — Performance (before/after evidence pattern)
+```
+- [ ] **`number?` regex replacement** — replaces exception-based control flow with
+  `NUMERIC_RE` regex. Verify the true (numeric) path isn't regressed; the hot path
+  (named severity) should be ≥ 4× faster.
+  - Verify: `ruby -I lib -e "require 'inspec/impact'; 10_000.times { Inspec::Impact.impact_from_string('high') }"`
+```
+
+### Ex8 — Security (false positive justification pattern)
+```
+- [ ] **`.gitleaks.toml` allowlist entries** — each allowlist entry must have a
+  documented justification. Review the table in `ai-track-docs/security.md` to
+  confirm no real credentials are suppressed.
+  - Verify: `ruby scripts/secret-scan.rb lib/inspec/ lib/plugins/`
+```
+
+### Ex9 — Observability (WARN level visibility pattern)
+```
+- [ ] **WARN hooks on error paths** — errors now emit WARN (visible at INFO level)
+  before raising ImpactError. Confirm the error is still raised; WARN is additional, not replacement.
+  - Verify: `ruby -I lib -e "require 'inspec/impact'; Inspec::Impact.impact_from_string('bad') rescue puts $!.class"`
+```
+
+---
+
+## Files Added / Changed (Ex11)
+
+| File | Change |
+|------|--------|
+| `.copilot-track/walk/pr-template.md` | Enhanced: added structured review focus section + verification steps block |
+| `scripts/pr-review-focus.rb` (new) | Generator: detects change categories from `git diff`, outputs tailored review bullets |
+| `ai-track-docs/pr-hygiene.md` | This file (new) — discipline doc, examples, rollback standard |

--- a/scripts/pr-review-focus.rb
+++ b/scripts/pr-review-focus.rb
@@ -1,0 +1,218 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# scripts/pr-review-focus.rb
+#
+# Generates review focus bullets and verification steps for a Walk track PR
+# by analysing the git diff for lib/inspec/impact.rb.
+#
+# Usage:
+#   ruby scripts/pr-review-focus.rb                  # diff against HEAD~1
+#   ruby scripts/pr-review-focus.rb HEAD~3..HEAD      # custom range
+#   ruby scripts/pr-review-focus.rb --full            # include full PR template
+#
+# Output is printed to stdout; paste into your PR description.
+
+IMPACT_FILE = 'lib/inspec/impact.rb'
+TEST_FILE   = 'test/unit/impact_test.rb'
+
+CATEGORY_PATTERNS = [
+  { category: :constants,    pattern: /^\+.*[A-Z_]{3,}\s*=/, label: 'constant/data change' },
+  { category: :public_api,   pattern: /^\+.*def self\.(impact_from_string|string_from_impact|number\?)/, label: 'public API change' },
+  { category: :guard,        pattern: /^\+.*assert_type!|ImpactError/, label: 'type guard / error path' },
+  { category: :logging,      pattern: /^\+.*(log_impact|warn_impact|BOUNDARY_SCORES|logging_enabled)/, label: 'observability / logging hook' },
+  { category: :private_api,  pattern: /^\+.*private_class_method|def self\.[a-z]/, label: 'private helper change' },
+  { category: :tests_added,  pattern: /^\+.*it ['"]/, label: 'new test cases' },
+  { category: :frozen,       pattern: /^\+.*frozen_string_literal/, label: 'string literal freeze' },
+].freeze
+
+VERIFY_COMMANDS = {
+  constants:   'ruby -e "require_relative \'lib/inspec/impact\'; p Inspec::Impact::IMPACT_SCORES"',
+  public_api:  'RUBY_BIN=$(which ruby) bash scripts/crawl-track-test.sh',
+  guard:       'ruby -I lib -e "require \'inspec/impact\'; Inspec::Impact.impact_from_string(nil) rescue puts $!.class"',
+  logging:     'ruby -I lib -e "require \'inspec/log\'; require \'inspec/impact\'; Inspec::Log.level = :warn; Inspec::Impact.string_from_impact(0.7)" 2>&1',
+  private_api: 'RUBY_BIN=$(which ruby) bash scripts/crawl-track-test.sh',
+  tests_added: 'RUBY_BIN=$(which ruby) bash scripts/crawl-track-test.sh',
+  frozen:      'ruby -c lib/inspec/impact.rb',
+}.freeze
+
+def run_git_diff(range)
+  `git diff #{range} -- #{IMPACT_FILE} #{TEST_FILE} 2>/dev/null`
+end
+
+def detect_categories(diff)
+  added_lines = diff.lines.select { |l| l.start_with?('+') && !l.start_with?('+++') }
+  CATEGORY_PATTERNS.filter_map do |entry|
+    matching = added_lines.select { |l| l.match?(entry[:pattern]) }
+    next if matching.empty?
+
+    { **entry, matches: matching.first(3) }
+  end
+end
+
+def commit_sha
+  `git log --format=%H -1`.strip[0, 12]
+end
+
+def branch_name
+  `git branch --show-current`.strip
+end
+
+def changed_files(range)
+  `git diff --name-only #{range} 2>/dev/null`.split
+end
+
+def generate_review_bullets(categories, diff_stat)
+  bullets = []
+
+  categories.each do |cat|
+    case cat[:category]
+    when :constants
+      bullets << {
+        area: 'IMPACT_SCORES / constant values',
+        concern: 'Any change to IMPACT_SCORES or BOUNDARY_SCORES affects contract tests and '\
+                 'all severity lookups — the most critical data in this module.',
+        verify: VERIFY_COMMANDS[:constants]
+      }
+    when :public_api
+      bullets << {
+        area: 'Public API behaviour (`impact_from_string` / `string_from_impact`)',
+        concern: 'Public method changes can silently break callers. Check round-trip '\
+                 'invariants: `impact_from_string(string_from_impact(0.5)) == 0.5`.',
+        verify: 'ruby -I lib -e "require \'inspec/impact\'; p Inspec::Impact.string_from_impact(Inspec::Impact.impact_from_string(\'high\'))"'
+      }
+    when :guard
+      bullets << {
+        area: 'Error handling / type guards (`assert_type!` / `ImpactError`)',
+        concern: 'Guard changes control what input is accepted. Verify nil, wrong type, and '\
+                 'boundary inputs still raise `Inspec::ImpactError` (never raw Ruby errors).',
+        verify: VERIFY_COMMANDS[:guard]
+      }
+    when :logging
+      bullets << {
+        area: 'Observability hooks (`warn_impact` / `log_impact` / `BOUNDARY_SCORES`)',
+        concern: 'WARN hooks fire at INFO log level — visible without debug mode. Verify '\
+                 'the toggle suppresses output and mid-band scores do NOT trigger WARN.',
+        verify: VERIFY_COMMANDS[:logging]
+      }
+    when :private_api
+      bullets << {
+        area: 'Private helpers (`assert_type!` / `number?` / `json_value` etc.)',
+        concern: 'Private method changes should be behaviour-preserving. Run full suite '\
+                 'to confirm no unit test regressions.',
+        verify: VERIFY_COMMANDS[:private_api]
+      }
+    when :tests_added
+      bullets << {
+        area: 'New test cases',
+        concern: 'Ensure tests are deterministic (no random data, no time-dependent assertions). '\
+                 'Check that each test has a clear Arrange-Act-Assert structure.',
+        verify: 'RUBY_BIN=$(which ruby) bash scripts/crawl-track-test.sh 2>&1 | grep "runs\|checks passed"'
+      }
+    end
+  end
+
+  # Always include coverage and contract bullets
+  bullets << {
+    area: 'Coverage delta',
+    concern: "Confirm coverage for `impact.rb` stays ≥ 75% (baseline 81.71%). "\
+             "Any new branch added without a test will show as a gap.",
+    verify: 'ruby scripts/coverage-impact.rb 2>&1 | grep "impact.rb line coverage"'
+  }
+
+  bullets << {
+    area: 'Contract golden file',
+    concern: 'If `IMPACT_SCORES` changed, the golden file must be regenerated. '\
+             'Contract tests will fail otherwise.',
+    verify: 'ruby -I lib test/contract/impact_contract_test.rb'
+  }
+
+  bullets.first(5) # cap at 5 per Walk discipline
+end
+
+def format_output(bullets, categories, range, full_template)
+  sha      = commit_sha
+  branch   = branch_name
+  files    = changed_files(range)
+  n_cats   = categories.map { |c| c[:label] }.join(', ')
+
+  lines = []
+  lines << "<!-- Generated by scripts/pr-review-focus.rb | #{Time.now.strftime('%Y-%m-%dT%H:%M:%S')} -->"
+  lines << ''
+
+  if full_template
+    lines << '## Summary'
+    lines << "- **Branch:** `#{branch}`"
+    lines << "- **What changed:** #{n_cats.empty? ? '(describe here)' : n_cats}"
+    lines << "- **Files touched:** #{files.map { |f| "`#{f}`" }.join(', ')}"
+    lines << ''
+    lines << '## Evidence'
+    lines << '```'
+    lines << 'RUBY_BIN=$(which ruby) bash scripts/crawl-track-test.sh'
+    lines << 'ruby scripts/coverage-impact.rb'
+    lines << '```'
+    lines << '> Paste actual output here before submitting.'
+    lines << ''
+    lines << '## Risk & Rollback'
+    lines << '- Risk: low'
+    lines << "- Rollback: `git revert #{sha}`"
+    lines << ''
+  end
+
+  lines << '## Review Focus'
+  lines << ''
+  lines << '> Auto-generated from `git diff`. Review and adjust before submitting.'
+  lines << ''
+
+  bullets.each_with_index do |b, i|
+    lines << "- [ ] **#{b[:area]}** — #{b[:concern]}"
+    lines << "  - Verify: `#{b[:verify]}`"
+    lines << '' if i < bullets.size - 1
+  end
+
+  lines << ''
+  lines << '## Verification Steps (reviewer checklist)'
+  lines << ''
+  lines << '```bash'
+  lines << "git checkout #{branch}"
+  lines << 'gem install minitest -v "~> 6.0" --no-document'
+  lines << ''
+  lines << '# Run all track checks'
+  lines << 'RUBY_BIN=$(which ruby) bash scripts/crawl-track-test.sh'
+  lines << ''
+  lines << '# Run contract tests'
+  lines << 'ruby -I lib test/contract/impact_contract_test.rb'
+  lines << ''
+  lines << '# Check coverage'
+  lines << 'ruby scripts/coverage-impact.rb'
+  lines << ''
+  lines << '# Lint'
+  lines << 'rubocop lib/inspec/impact.rb test/unit/impact_test.rb --format simple'
+  lines << '```'
+
+  unless full_template
+    lines << ''
+    lines << '## Risk & Rollback'
+    lines << "- Rollback: `git revert #{sha}`"
+  end
+
+  lines.join("\n")
+end
+
+# --- main ---
+
+range       = ARGV.reject { |a| a.start_with?('--') }.first || 'HEAD~1..HEAD'
+full_mode   = ARGV.include?('--full')
+
+diff = run_git_diff(range)
+
+if diff.empty?
+  warn "No diff found for range '#{range}' on #{IMPACT_FILE} / #{TEST_FILE}."
+  warn 'Make sure you have committed your changes, or provide a custom range.'
+  exit 1
+end
+
+categories = detect_categories(diff)
+bullets    = generate_review_bullets(categories, diff)
+
+puts format_output(bullets, categories, range, full_mode)


### PR DESCRIPTION
## Summary
- Added PR hygiene tooling and discipline documentation (Walk Ex11)
- **Plan:** Identify gap in current minimal PR template → create generator script that auto-drafts review focus bullets from `git diff` → document the discipline with examples
- **Files touched:** `.copilot-track/walk/pr-template.md`, `scripts/pr-review-focus.rb` (new), `ai-track-docs/pr-hygiene.md` (new)

## Evidence

**Generator output (self-referential demo — run against ex9 changes):**
```
$ ruby scripts/pr-review-focus.rb learn/walk/mohan-ex8-security..HEAD --full

✅ Generated 5 review focus bullets detecting:
   constant/data change, type guard / error path, observability / logging hook,
   private helper change, new test cases
```

**Template validation:** Generator exits 1 with clear message when no impact.rb diff is found (non-impact.rb-only PRs print a usage hint).

## Risk & Rollback
- Risk: **low** — no production code changed; script and docs only
- Rollback: `git revert b3963bf7a739`

## Review Focus

> Generated by `ruby scripts/pr-review-focus.rb HEAD~2..HEAD --full` and adjusted.

- [ ] **`scripts/pr-review-focus.rb` category detection** — CATEGORY_PATTERNS regex array must not produce false positives (e.g. matching comment lines that start with `+#`). The `+` prefix filter only applies to added lines, not `+++` file headers.
  - Verify: `ruby scripts/pr-review-focus.rb learn/walk/mohan-ex8-security..HEAD 2>&1 | grep "Review Focus" -A 20`

- [ ] **Bullet cap at 5** — `bullets.first(5)` ensures output stays within Walk discipline limit. Coverage and contract bullets always append last (highest signal for any impact.rb PR).
  - Verify: `ruby scripts/pr-review-focus.rb learn/walk/mohan-ex8-security..HEAD 2>&1 | grep -c "^\- \[ \]"`

- [ ] **`--full` flag completeness** — Summary, Evidence, Risk & Rollback sections must include branch name, commit SHA, and placeholder evidence block.
  - Verify: `ruby scripts/pr-review-focus.rb --full learn/walk/mohan-ex8-security..HEAD 2>&1 | grep "Branch\|Rollback\|Evidence"`

- [ ] **PR template structure** — Updated `.copilot-track/walk/pr-template.md` must include both review focus bullets AND a separate verification steps bash block.
  - Verify: `grep -c "Verify:" .copilot-track/walk/pr-template.md && grep "bash" .copilot-track/walk/pr-template.md`

- [ ] **Coverage delta** — No impact.rb changes in this PR; coverage stays at 81.71%.
  - Verify: `ruby scripts/coverage-impact.rb 2>&1 | grep "impact.rb line coverage"`

## Verification Steps (reviewer checklist)

```bash
git checkout learn/walk/mohan-ex11-pr-hygiene
gem install minitest -v "~> 6.0" --no-document

# Run generator on a real impact.rb diff range
ruby scripts/pr-review-focus.rb learn/walk/mohan-ex8-security..HEAD

# Run with --full to see complete template
ruby scripts/pr-review-focus.rb learn/walk/mohan-ex8-security..HEAD --full

# Confirm tests still pass (no regressions from script addition)
RUBY_BIN=$(which ruby) bash scripts/crawl-track-test.sh

# Check coverage unchanged
ruby scripts/coverage-impact.rb 2>&1 | grep "impact.rb"
```

## Track
- Level: Walk
- Exercise: 11 — PR Hygiene and Review
- Evidence: generator output above + `ai-track-docs/pr-hygiene.md` with examples

This work was completed with AI assistance following Progress AI policies.
