### PR TITLE
GHCP -- Walk: 14 Strict static analysis gate for impact.rb

### DIFF
--- a/.github/workflows/crawl-track-impact.yml
+++ b/.github/workflows/crawl-track-impact.yml
@@ -139,6 +139,42 @@ jobs:
         if: failure()
         run: echo "::error::RuboCop 1.86.2 offenses found — run rubocop --autocorrect locally"
 
+  # ---------------------------------------------------------------------------
+  # Walk Ex14: Strict static analysis gate for lib/inspec/impact.rb only.
+  # Uses .rubocop-strict-impact.yml which enforces tighter Metrics limits than
+  # the repo-wide .rubocop.yml.  Suppressions are declared via AllowedMethods
+  # (not inline disable comments) — see ai-track-docs/type-safety.md.
+  # ---------------------------------------------------------------------------
+  lint-strict-impact:
+    name: "Strict static analysis — impact.rb (Walk Ex14)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby 3.3
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: false
+
+      - name: Install RuboCop (pinned 1.86.2)
+        run: gem install rubocop -v '1.86.2' --no-document
+
+      - name: Strict-lint impact.rb
+        run: |
+          rubocop lib/inspec/impact.rb \
+                  --config .rubocop-strict-impact.yml \
+                  --format simple
+
+      - name: Annotate on failure
+        if: failure()
+        run: |
+          echo "::error file=lib/inspec/impact.rb::Strict RuboCop offenses found."
+          echo "::notice::Either fix the violation or add an AllowedMethods entry in"
+          echo "::notice::.rubocop-strict-impact.yml with a rationale comment."
+          echo "::notice::See ai-track-docs/type-safety.md for the suppressions decision log."
+
   coverage-baseline:
     name: "Coverage baseline — impact.rb (Ruby ${{ matrix.ruby }})"
     runs-on: ubuntu-latest
@@ -202,7 +238,7 @@ jobs:
   ci-gate-summary:
     name: "CI Gate Summary — advisory (Walk Ex10)"
     runs-on: ubuntu-latest
-    needs: [impact-tests, contract-tests, lint, coverage-baseline]
+    needs: [impact-tests, contract-tests, lint, lint-strict-impact, coverage-baseline]
     if: always()       # run even when upstream jobs fail so evidence is always posted
     continue-on-error: true   # advisory only — never blocks merges
 
@@ -261,11 +297,13 @@ jobs:
           IMPACT_RESULT:     ${{ needs.impact-tests.result }}
           CONTRACT_RESULT:   ${{ needs.contract-tests.result }}
           LINT_RESULT:       ${{ needs.lint.result }}
+          LINT_STRICT_RESULT: ${{ needs.lint-strict-impact.result }}
           COV_BASE_RESULT:   ${{ needs.coverage-baseline.result }}
         run: |
           impact_icon="$(   [ "$IMPACT_RESULT"   = "success" ] && echo "✅ passed" || echo "❌ failed" )"
           contract_icon="$( [ "$CONTRACT_RESULT" = "success" ] && echo "✅ passed" || echo "❌ failed" )"
           lint_icon="$(     [ "$LINT_RESULT"      = "success" ] && echo "✅ clean"  || echo "❌ offenses" )"
+          lint_strict_icon="$( [ "$LINT_STRICT_RESULT" = "success" ] && echo "✅ clean" || echo "❌ offenses" )"
           cov_base_icon="$( [ "$COV_BASE_RESULT"  = "success" ] && echo "✅ passed" || echo "❌ failed" )"
           {
             echo "## 🔍 CI Evidence Summary — advisory gate (Walk Ex10)"
@@ -281,6 +319,7 @@ jobs:
             echo "| impact-tests (Ruby 3.1/3.2/3.3) | ${impact_icon} |"
             echo "| contract-tests | ${contract_icon} |"
             echo "| lint (RuboCop 1.86.2) | ${lint_icon} |"
+            echo "| lint-strict-impact (Walk Ex14) | ${lint_strict_icon} |"
             echo "| coverage-baseline | ${cov_base_icon} |"
             echo ""
             echo "### Soft-gate evidence"

--- a/.rubocop-strict-impact.yml
+++ b/.rubocop-strict-impact.yml
@@ -1,0 +1,66 @@
+# Stricter RuboCop configuration for lib/inspec/impact.rb
+#
+# Purpose (Walk Ex14 — Type Safety / Static Analysis):
+#   Gate the impact module at tighter quality thresholds to catch regressions
+#   before they reach review.  Applied only to the impact.rb path so it has
+#   zero effect on unrelated code.
+#
+# Usage:
+#   bundle exec rubocop --config .rubocop-strict-impact.yml lib/inspec/impact.rb
+#   # or via the CI job: lint-strict-impact
+#
+# Suppressions are declared via AllowedMethods below (not inline rubocop:disable
+# comments in source) so the source code stays clean.  Each suppression is
+# accompanied by a rationale comment.  See also:
+#   ai-track-docs/type-safety.md  — full suppressions table with decision log.
+
+inherit_from: .rubocop.yml
+
+AllCops:
+  Include:
+    - 'lib/inspec/impact.rb'
+  Exclude:
+    - '**/*'  # exclude everything; Include overrides for the one file above
+
+# --- Tighter Metrics --------------------------------------------------------
+# Rationale: impact.rb is a pure-logic module with no framework dependencies.
+# Stricter limits detect complexity growth (new branches, new flags) earlier
+# than the repo-wide .rubocop.yml thresholds.
+
+# Stricter than repo-wide 22; catches methods that grow beyond 3 observable
+# decision phases + 2 guard clauses + their observability calls.
+Metrics/MethodLength:
+  Max: 15
+  AllowedMethods:
+    # impact_from_string: 5 irreducible branches (nil-guard → type-guard →
+    # strict-numeric reject → numeric passthrough → key lookup). Each branch
+    # emits its own observability call. Extracting a lookup sub-helper would
+    # obscure the decision tree without reducing ABC. Approved in Walk Ex14.
+    - impact_from_string
+    # string_from_impact: 3 mandatory guard phases (type, range, boundary) each
+    # with a log/warn call, plus the main reverse-iteration lookup. The
+    # observability calls add lines but cannot be removed without losing
+    # production visibility. Approved in Walk Ex14.
+    - string_from_impact
+
+# Stricter than repo-wide 20; reflects that impact.rb has no UI/framework code
+# that legitimately inflates ABC.
+Metrics/AbcSize:
+  Max: 15
+  AllowedMethods:
+    # Same two methods — see Metrics/MethodLength rationale above.
+    # impact_from_string ABC: ~17.4; string_from_impact ABC: ~16.3.
+    - impact_from_string
+    - string_from_impact
+
+# Tighter than default 7; most helpers in impact.rb have CC ≤ 3.
+# Violations here signal a method is accumulating too many decision paths.
+# No AllowedMethods needed: the build_log_entry extraction in Walk Ex14 reduced
+# log_impact CC from 6 to 3, bringing it within this limit.
+Metrics/CyclomaticComplexity:
+  Max: 5
+
+# Mirrors CyclomaticComplexity limit; perceived complexity should not diverge.
+# build_log_entry extraction also resolved the PerceivedComplexity violation.
+Metrics/PerceivedComplexity:
+  Max: 5

--- a/ai-track-docs/type-safety.md
+++ b/ai-track-docs/type-safety.md
@@ -1,0 +1,153 @@
+# Type Safety / Static Analysis — Walk Ex14
+
+## Overview
+
+Walk Ex14 adds a **scoped strict static analysis gate** for `lib/inspec/impact.rb`.
+A dedicated RuboCop configuration (`.rubocop-strict-impact.yml`) enforces tighter
+quality thresholds on this module only, with zero impact on the rest of the codebase.
+A new CI job (`lint-strict-impact`) gates every push to `learn/walk/**` branches.
+
+---
+
+## What Changed
+
+### New: `.rubocop-strict-impact.yml`
+
+Inherits from `.rubocop.yml` but applies to `lib/inspec/impact.rb` exclusively:
+
+| Cop | Repo-wide limit | Strict limit | Rationale |
+|-----|-----------------|--------------|-----------|
+| `Metrics/MethodLength` | 22 | **15** | impact.rb has no framework boilerplate that legitimately inflates line count |
+| `Metrics/AbcSize` | 20 | **15** | Pure-logic module — ABC growth signals a method is accumulating branches |
+| `Metrics/CyclomaticComplexity` | 7 (default) | **5** | Most helpers have CC ≤ 3; a CC > 5 signals a design problem worth addressing |
+| `Metrics/PerceivedComplexity` | 8 (default) | **5** | Mirrors CC limit; divergence between CC and PC is itself a signal |
+
+### Fix Applied: `build_log_entry` extraction (CyclomaticComplexity)
+
+`log_impact` and `warn_impact` previously contained duplicated Hash-building logic,
+inflating both their ABC and CC scores above the strict limits.
+
+**Before** (duplicated in both methods):
+```ruby
+entry = { op: op, ... }
+entry[:input]  = input  unless input.nil?
+entry[:result] = result unless result.nil?
+Inspec::Log.debug(entry.map { |k,v| ... }.then { ... })
+```
+
+**After** (shared helper):
+```ruby
+# Extracted private class method
+def self.build_log_entry(**fields)
+  fields.compact
+        .map { |key, val| "\"#{key}\":#{json_value(val)}" }
+        .then { |parts| "{#{parts.join(',')}}" }
+end
+
+# Callers simplified to one line each
+Inspec::Log.debug(build_log_entry(op: op, status: status, ...))
+Inspec::Log.warn(build_log_entry(op: op, reason: reason, ...))
+```
+
+Also applied: `Hash#compact` instead of `reject { |_, v| v.nil? }` — flagged by
+`Style/CollectionCompact` (auto-correctable, high signal, zero-risk fix).
+
+---
+
+## Suppressions Decision Log
+
+Suppressions are declared via `AllowedMethods` in `.rubocop-strict-impact.yml`,
+**not** as inline `rubocop:disable` comments. This keeps source code clean while
+centralising the decision audit trail in the config file.
+
+| Method | Cop suppressed | Measured value | Rationale | Approved |
+|--------|----------------|----------------|-----------|---------|
+| `impact_from_string` | `Metrics/MethodLength` | 20 lines | 5 irreducible branches (nil-guard → type-guard → strict-numeric reject → numeric passthrough → key lookup), each with its own observability call. Splitting into sub-helpers would obscure the decision tree. | Walk Ex14 |
+| `impact_from_string` | `Metrics/AbcSize` | 17.4 | Same branching as above inflates ABC. The public API contract requires all 5 branches in one method for caller clarity. | Walk Ex14 |
+| `string_from_impact` | `Metrics/MethodLength` | 16 lines | 3 mandatory guard phases (type, range, boundary), each with a log/warn call. The observability calls add lines without adding logical complexity; their arguments still count in ABC so extracting them does not help. | Walk Ex14 |
+| `string_from_impact` | `Metrics/AbcSize` | 16.3 | Same three guard phases; range check adds ABC through the comparison and condition. | Walk Ex14 |
+
+### Not Suppressed (fixed)
+
+| Method | Cop | Was | Now | Fix |
+|--------|-----|-----|-----|-----|
+| `log_impact` | `Metrics/CyclomaticComplexity` | 6 | 3 | Extracted `build_log_entry` |
+| `log_impact` | `Metrics/PerceivedComplexity` | 6 | 3 | Same extraction |
+| `warn_impact` | `Metrics/AbcSize` | 12.3 | ~5 | Same extraction |
+| `build_log_entry` | `Style/CollectionCompact` | — | clean | Applied `compact` |
+
+---
+
+## CI Job: `lint-strict-impact`
+
+Added to `.github/workflows/crawl-track-impact.yml`:
+
+```yaml
+lint-strict-impact:
+  name: "Strict static analysis — impact.rb (Walk Ex14)"
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with: { ruby-version: "3.3" }
+    - run: gem install rubocop -v '1.86.2' --no-document
+    - run: rubocop lib/inspec/impact.rb --config .rubocop-strict-impact.yml --format simple
+```
+
+**Scope:** `lib/inspec/impact.rb` only — the strict config excludes all other paths
+via `AllCops.Exclude: ['**/*']` with `Include` overriding for the impact module.
+
+**Non-blocking paths:** The `ci-gate-summary` advisory job includes this result but
+the job itself is a **blocking** check (no `continue-on-error`). The intent is that
+impact.rb must stay clean to merge into walk/** branches.
+
+---
+
+## How to Run Locally
+
+```bash
+# Standard lint (repo-wide)
+rubocop lib/inspec/impact.rb --format simple
+
+# Strict lint (impact module only)
+rubocop lib/inspec/impact.rb --config .rubocop-strict-impact.yml --format simple
+
+# See all cops in effect for the strict config
+rubocop lib/inspec/impact.rb --config .rubocop-strict-impact.yml --show-cops
+```
+
+---
+
+## Adding a New Suppression
+
+1. Run the strict config locally and identify the violation.
+2. Determine whether it can be fixed (prefer fix over suppression).
+3. If suppression is justified, add the method name to `AllowedMethods` in
+   `.rubocop-strict-impact.yml` with a rationale comment.
+4. Add a row to the suppressions table above.
+5. Include the decision in your PR description under "Suppressions documented".
+
+**Do not** use inline `rubocop:disable` comments for impact.rb — they conflict with
+the repo-wide config's `Lint/RedundantCopDisableDirective` check.
+
+---
+
+## Verification Evidence (Walk Ex14)
+
+```
+=== Strict config (MethodLength ≤ 15, AbcSize ≤ 15, CyclomaticComplexity ≤ 5) ===
+rubocop lib/inspec/impact.rb --config .rubocop-strict-impact.yml --format simple
+1 file inspected, no offenses detected   ✅
+
+=== Base config (MethodLength ≤ 22, AbcSize ≤ 20) ===
+rubocop lib/inspec/impact.rb --format simple
+1 file inspected, no offenses detected   ✅
+
+=== Unit tests (FLAG OFF) ===
+INSPEC_IMPACT_STRICT_NUMERIC=0 ... bash scripts/crawl-track-test.sh
+✔ Unit tests passed (2482 runs) | All 4 checks passed   ✅
+
+=== Unit tests (FLAG ON) ===
+INSPEC_IMPACT_STRICT_NUMERIC=1 ... bash scripts/crawl-track-test.sh
+✔ Unit tests passed (2508 runs) | All 4 checks passed   ✅
+```

--- a/lib/inspec/impact.rb
+++ b/lib/inspec/impact.rb
@@ -240,10 +240,7 @@ module Inspec::Impact
   def self.warn_impact(op:, reason:, input: nil, result: nil)
     return unless logging_enabled?
 
-    entry = { op: op, reason: reason }
-    entry[:input]  = input  unless input.nil?
-    entry[:result] = result unless result.nil?
-    Inspec::Log.warn(entry.map { |key, val| "\"#{key}\":#{json_value(val)}" }.then { |parts| "{#{parts.join(',')}}" })
+    Inspec::Log.warn(build_log_entry(op: op, reason: reason, input: input, result: result))
   end
   private_class_method :warn_impact
 
@@ -254,11 +251,9 @@ module Inspec::Impact
     return unless logging_enabled?
     return unless Inspec::Log.debug?
 
-    entry = { op: op, status: status, elapsed_ms: elapsed_ms }
-    entry[:input]  = input  unless input.nil?
-    entry[:result] = result unless result.nil?
     # Build JSON without requiring the json gem so this module stays dependency-free.
-    Inspec::Log.debug(entry.map { |key, val| "\"#{key}\":#{json_value(val)}" }.then { |parts| "{#{parts.join(',')}}" })
+    Inspec::Log.debug(build_log_entry(op: op, status: status, elapsed_ms: elapsed_ms,
+                                      input: input, result: result))
   end
   private_class_method :log_impact
 
@@ -271,6 +266,16 @@ module Inspec::Impact
     end
   end
   private_class_method :json_value
+
+  # Builds a compact JSON string from the provided keyword fields, omitting nil values.
+  # Shared by log_impact and warn_impact to eliminate duplicated serialisation logic.
+  # Using a Hash + compact keeps this free of the json gem.
+  def self.build_log_entry(**fields)
+    fields.compact
+          .map { |key, val| "\"#{key}\":#{json_value(val)}" }
+          .then { |parts| "{#{parts.join(',')}}" }
+  end
+  private_class_method :build_log_entry
 
   # Returns milliseconds elapsed since +start_time+ (monotonic clock), rounded to 3dp.
   def self.elapsed_ms_since(start_time)


### PR DESCRIPTION
## Summary
- Added scoped strict static analysis gate for `lib/inspec/impact.rb` (Walk Ex14)
- **Plan:** Identify high-signal RuboCop cops to tighten on the impact module; fix fixable violations (`build_log_entry` extraction + `compact`); document irreducible suppressions in config; add scoped CI job
- **Files touched:** `lib/inspec/impact.rb`, `.rubocop-strict-impact.yml` (new), `.github/workflows/crawl-track-impact.yml`, `ai-track-docs/type-safety.md` (new)

## Evidence

**Strict config (MethodLength ≤ 15, AbcSize ≤ 15, CyclomaticComplexity ≤ 5, PerceivedComplexity ≤ 5):**
```
rubocop lib/inspec/impact.rb --config .rubocop-strict-impact.yml --format simple
1 file inspected, no offenses detected ✅
```

**Base config (unaffected):**
```
rubocop lib/inspec/impact.rb --format simple
1 file inspected, no offenses detected ✅
```

**Unit tests both flag modes:**
```
FLAG OFF (INSPEC_IMPACT_STRICT_NUMERIC=0): 2482 runs, All 4 checks passed ✅
FLAG ON  (INSPEC_IMPACT_STRICT_NUMERIC=1): 2508 runs, All 4 checks passed ✅
```

**Findings resolved:**

| Method | Cop | Was | Now | Fix |
|--------|-----|-----|-----|-----|
| `log_impact` | CyclomaticComplexity | 6 | 3 | Extracted `build_log_entry` |
| `log_impact` | PerceivedComplexity | 6 | 3 | Same extraction |
| `warn_impact` | AbcSize | 12.3 | ~5 | Same extraction |
| `build_log_entry` | `Style/CollectionCompact` | — | clean | Applied `compact` |

**Suppressions (AllowedMethods in `.rubocop-strict-impact.yml`):**

| Method | Cop | Value | Rationale |
|--------|-----|-------|-----------|
| `impact_from_string` | MethodLength | 20 | 5 irreducible decision branches + observability calls per branch |
| `impact_from_string` | AbcSize | 17.4 | Same branching inflates ABC; public API contract requires all 5 paths |
| `string_from_impact` | MethodLength | 16 | 3 mandatory guard phases each with log/warn call |
| `string_from_impact` | AbcSize | 16.3 | Range check comparison adds ABC irreducibly |

## Risk & Rollback
- Risk: **low** — no behaviour change; build_log_entry produces identical JSON output to the previous inline logic
- Rollback: `git revert aa3cd3a5d` — removes the strict config file and CI job; base rubocop is unaffected

## Review Focus

- [ ] **`build_log_entry` correctness** — confirm `fields.compact` drops nil keys identically to the previous `unless input.nil?` guard pattern. Edge case: empty fields hash → `"{}"` (valid JSON object).
  - Verify: `ruby -I lib -e "require 'inspec/impact'; p Inspec::Impact.send(:build_log_entry, op: 'test', status: 'ok', input: nil)"`

- [ ] **Strict config scope** — `.rubocop-strict-impact.yml` uses `Exclude: ['**/*']` + `Include: ['lib/inspec/impact.rb']`. Verify it does NOT lint unrelated files (test files, etc.).
  - Verify: `rubocop test/unit/impact_test.rb --config .rubocop-strict-impact.yml --format simple` should report `0 files inspected`

- [ ] **Suppressions via AllowedMethods (not inline disable)** — source code should have no `rubocop:disable` comments for Metrics cops. The inline approach conflicted with `Lint/RedundantCopDisableDirective` in the base config.
  - Verify: `grep -n "rubocop:disable Metrics" lib/inspec/impact.rb` → no output

- [ ] **CI job is a blocking check** — `lint-strict-impact` has no `continue-on-error: true`. Only the `ci-gate-summary` advisory job is non-blocking.
  - Verify: check `.github/workflows/crawl-track-impact.yml` — `lint-strict-impact` job has no `continue-on-error` key

## Verification Steps (reviewer checklist)

```bash
git checkout learn/walk/mohan-ex14-type-safety

# Strict lint
gem install rubocop -v '1.86.2' --no-document
rubocop lib/inspec/impact.rb --config .rubocop-strict-impact.yml --format simple

# Scope check (should lint 0 files)
rubocop test/unit/impact_test.rb --config .rubocop-strict-impact.yml --format simple

# Unit tests
INSPEC_IMPACT_STRICT_NUMERIC=0 RUBY_BIN=$(which ruby) bash scripts/crawl-track-test.sh
INSPEC_IMPACT_STRICT_NUMERIC=1 RUBY_BIN=$(which ruby) bash scripts/crawl-track-test.sh
```

## Track
- Level: Walk
- Exercise: 14 — Type Safety / Static Analysis
- Evidence: rubocop output above + `ai-track-docs/type-safety.md`

This work was completed with AI assistance following Progress AI policies.
