### PR TITLE
chore: CHEF-34867 - Upgrade addressable gem from < 2.8.8 to ~> 2.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,6 @@ gem "zeitwerk", "~> 2.6.0", "< 2.7"
 
 # Pinning connection_pool to < 3.0.0 as 3.0.0+ requires Ruby >= 3.2.0
 gem "connection_pool", ">= 2.5", "< 3.0"
+
+# Pin to prevent bundler pulling in public_suffix 7.x (which requires Ruby 3.2) when addressable 2.9.0 is resolved
+gem "public_suffix", ">= 2.0.2", "< 7.0"

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,3 @@ gem "zeitwerk", "~> 2.6.0", "< 2.7"
 
 # Pinning connection_pool to < 3.0.0 as 3.0.0+ requires Ruby >= 3.2.0
 gem "connection_pool", ">= 2.5", "< 3.0"
-
-# Pin to prevent bundler pulling in public_suffix 7.x (which requires Ruby 3.2) when addressable 2.9.0 is resolved
-gem "public_suffix", ">= 2.0.2", "< 7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       train-habitat (~> 0.1)
       train-kubernetes (< 0.3.1)
       train-winrm (~> 0.4.0)
-    inspec-core (5.24.10)
+    inspec-core (5.24.13)
       addressable (~> 2.9)
       chef-telemetry (~> 1.0, >= 1.0.8)
       cookstyle
@@ -26,6 +26,7 @@ PATH
       parallel (~> 1.9)
       parslet (>= 1.5, < 3.0)
       pry (~> 0.13)
+      public_suffix (>= 2.0.2, < 7.0)
       rspec (>= 3.9, <= 3.14)
       rspec-its (>= 1.2, < 3.0)
       rubyzip (>= 1.2.2, < 4.0)
@@ -873,7 +874,6 @@ DEPENDENCIES
   nokogiri (< 1.17.2)
   pry
   pry-byebug
-  public_suffix (>= 2.0.2, < 7.0)
   rake
   rb-readline
   rspec (>= 3.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ PATH
       train-habitat (~> 0.1)
       train-kubernetes (< 0.3.1)
       train-winrm (~> 0.4.0)
-    inspec-core (5.24.13)
-      addressable (< 2.8.8)
+    inspec-core (5.24.10)
+      addressable (~> 2.9)
       chef-telemetry (~> 1.0, >= 1.0.8)
       cookstyle
       faraday (>= 1, < 3)
@@ -58,8 +58,8 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     appbundler (0.13.4)
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -873,6 +873,7 @@ DEPENDENCIES
   nokogiri (< 1.17.2)
   pry
   pry-byebug
+  public_suffix (>= 2.0.2, < 7.0)
   rake
   rb-readline
   rspec (>= 3.10)

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -43,8 +43,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tty-table",                "~> 0.10"
   spec.add_dependency "tty-prompt",               "~> 0.17"
   spec.add_dependency "tomlrb",                   ">= 1.2", "< 2.1"
-  # Upgraded to ~> 2.9; public_suffix is pinned in Gemfile to < 7.0 to avoid Ruby 3.2+ requirement
   spec.add_dependency "addressable",              "~> 2.9"
+  spec.add_dependency "public_suffix",            ">= 2.0.2", "< 7.0" # public_suffix 7.x requires Ruby 3.2+
   spec.add_dependency "parslet",                  ">= 1.5", "< 3.0" # Pinned < 2.0, see #5389
   spec.add_dependency "semverse",                 "~> 3.0"
   spec.add_dependency "multipart-post",           "~> 2.0"

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tty-table",                "~> 0.10"
   spec.add_dependency "tty-prompt",               "~> 0.17"
   spec.add_dependency "tomlrb",                   ">= 1.2", "< 2.1"
-  # Upgraded from < 2.8.8 to ~> 2.9 for security fixes; public_suffix is pinned in Gemfile to < 7.0 to avoid Ruby 3.2+ requirement
+  # Upgraded to ~> 2.9; public_suffix is pinned in Gemfile to < 7.0 to avoid Ruby 3.2+ requirement
   spec.add_dependency "addressable",              "~> 2.9"
   spec.add_dependency "parslet",                  ">= 1.5", "< 3.0" # Pinned < 2.0, see #5389
   spec.add_dependency "semverse",                 "~> 3.0"

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tty-table",                "~> 0.10"
   spec.add_dependency "tty-prompt",               "~> 0.17"
   spec.add_dependency "tomlrb",                   ">= 1.2", "< 2.1"
-  # Pinning to < 2.8.8 because public_suffix 7.0 requires Ruby 3.2 or higher, InSpec5 does not support Ruby 3.2
+  # Upgraded from < 2.8.8 to ~> 2.9 for security fixes; public_suffix is pinned in Gemfile to < 7.0 to avoid Ruby 3.2+ requirement
   spec.add_dependency "addressable",              "~> 2.9"
   spec.add_dependency "parslet",                  ">= 1.5", "< 3.0" # Pinned < 2.0, see #5389
   spec.add_dependency "semverse",                 "~> 3.0"

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tty-prompt",               "~> 0.17"
   spec.add_dependency "tomlrb",                   ">= 1.2", "< 2.1"
   # Pinning to < 2.8.8 because public_suffix 7.0 requires Ruby 3.2 or higher, InSpec5 does not support Ruby 3.2
-  spec.add_dependency "addressable",              "< 2.8.8"
+  spec.add_dependency "addressable",              "~> 2.9"
   spec.add_dependency "parslet",                  ">= 1.5", "< 3.0" # Pinned < 2.0, see #5389
   spec.add_dependency "semverse",                 "~> 3.0"
   spec.add_dependency "multipart-post",           "~> 2.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Upgrades the `addressable` gem dependency in `inspec-core.gemspec` from the overly permissive constraint `< 2.8.8` to `~> 2.9`, bringing in security and compatibility improvements while staying within the 2.x series.

A `public_suffix` pin (`>= 2.0.2, < 7.0`) is added to the `Gemfile` to prevent bundler from pulling in `public_suffix 7.x`, which requires Ruby 3.2 — a version not yet supported by InSpec 5.

Also updates the stale inline comment in `inspec-core.gemspec` to accurately reflect the new constraint and rationale.

## Related Issue
CHEF-34867 — Upgrade addressable gem from `< 2.8.8` to `~> 2.9`
Parent: CHEF-31832 — InSpec 5.x dependency scan

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
