### PR TITLE
chore: CHEF-35033 - Upgrade faraday gem to 1.10.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,7 +415,7 @@ GEM
     ed25519 (1.4.0)
     erubi (1.13.1)
     excon (0.112.0)
-    faraday (1.10.4)
+    faraday (1.10.5)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)


### PR DESCRIPTION
## Description
Upgrades the `faraday` gem from version `1.10.4` to `1.10.5` in `Gemfile.lock` as part of the InSpec 5.x dependency maintenance (CHEF-31832).

## Related Issue
CHEF-35033

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
