### PR TITLE
chore: CHEF-35017 - Upgrade rake gem minimum version to 12.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ group :test do
   gem "nokogiri", "< 1.17.2"
   gem "pry-byebug"
   gem "pry"
-  gem "rake"
+  gem "rake", ">= 12.3.3"
   gem "simplecov"
   gem "simplecov_json_formatter"
   gem "webmock"

--- a/habitat/x86_64-linux/hooks/install
+++ b/habitat/x86_64-linux/hooks/install
@@ -9,7 +9,7 @@ export GEM_HOME="$pkg_prefix/lib"
 export GEM_PATH="$GEM_HOME"
 
 # Gems whose Gemfile.lock should be removed (not needed at runtime)
-GEMFILE_LOCK_GEMS="lint_roller rbs"
+GEMFILE_LOCK_GEMS="lint_roller rbs os"
 
 # Gems to replace with updated versions: "name:version"
 GEMS_TO_UPDATE="rexml:3.4.4"

--- a/habitat/x86_64-windows/hooks/install
+++ b/habitat/x86_64-windows/hooks/install
@@ -8,7 +8,7 @@ $env:GEM_HOME = "$pkg_prefix\vendor"
 $env:GEM_PATH = $env:GEM_HOME
 
 # Gems whose Gemfile.lock should be removed (not needed at runtime)
-$gemfileLockGems = @("lint_roller", "rbs")
+$gemfileLockGems = @("lint_roller", "rbs", "os")
 
 # Gems to replace with updated versions: name = minimum version
 $gemsToUpdate = @{

--- a/inspec-bin/inspec-bin.gemspec
+++ b/inspec-bin/inspec-bin.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "inspec", "= #{InspecBin::VERSION}"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", ">= 12.3.3"
 
   spec.files = %w{README.md LICENSE Gemfile} + Dir.glob("*.gemspec") +
     Dir.glob("{lib,bin}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }

--- a/inspec-bin/inspec-core-bin.gemspec
+++ b/inspec-bin/inspec-core-bin.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "inspec-core", "= #{InspecBin::VERSION}"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", ">= 12.3.3"
 
   spec.files = %w{README.md LICENSE Gemfile} + ["inspec-core-bin.gemspec"] +
     Dir.glob("{lib,bin}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }

--- a/inspec.gemspec
+++ b/inspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "inspec-core", "= #{Inspec::VERSION}"
 
   spec.add_dependency "train", "~> 3.16", ">= 3.16.1"
-  spec.add_dependency "rake"
+  spec.add_dependency "rake", ">= 12.3.3"
 
   # progress bar streaming reporter plugin support
   spec.add_dependency "progress_bar", "~> 1.3.3"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Upgrade the minimum version of the `rake` dependency to `>= 12.3.3` across the project. This change pins rake in `Gemfile`, `inspec.gemspec`, `inspec-bin/inspec-bin.gemspec`, and `inspec-bin/inspec-core-bin.gemspec` to ensure a safe and up-to-date version of rake is resolved during dependency resolution.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-35017

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
