### PR TITLE
fix: pin bigdecimal < 4.0 for Ruby 3.1 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ PATH
       train-winrm (~> 0.4.0)
     inspec-core (5.24.15)
       addressable (~> 2.9)
+      bigdecimal (< 4.0)
       chef-telemetry (~> 1.0, >= 1.0.8)
       cookstyle
       faraday (>= 1, < 3)
@@ -329,7 +330,7 @@ GEM
     bcrypt_pbkdf (1.1.2-x64-mingw-ucrt)
     bcrypt_pbkdf (1.1.2-x86_64-darwin)
     benchmark (0.5.0)
-    bigdecimal (4.1.2)
+    bigdecimal (3.3.1)
     bson (5.2.0)
     builder (3.3.0)
     byebug (12.0.0)

--- a/inspec-core.gemspec
+++ b/inspec-core.gemspec
@@ -55,4 +55,9 @@ Gem::Specification.new do |spec|
   # which was causing a LoadError ('cannot load such file -- ast') for users/applications using 'inspec-core'.
   spec.add_dependency "cookstyle"
   spec.add_dependency "train-core", "~> 3.16", ">= 3.16.1"
+
+  # bigdecimal 4.x changed native extension internals that fail to compile
+  # against the embedded Ruby 3.1 environment. Pin to 3.x until InSpec
+  # upgrades to Ruby 3.2+. Applies to all consumers (gem install + omnibus).
+  spec.add_dependency "bigdecimal", "< 4.0"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Pin `bigdecimal` to `< 4.0` as an explicit runtime dependency in `inspec-core.gemspec`.

`bigdecimal` 4.x changed its native extension internals and fails to compile against the embedded Ruby 3.1 environment used by InSpec omnibus packages (`/opt/inspec/embedded`). Adding the constraint directly in the gemspec ensures it applies to all consumers — `bundle install` (local dev + omnibus builds) and direct `gem install inspec` users alike.

## Related Issue
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
