### PR TITLE
foreport: CHEF-33393 - Include WOW6432Node registry paths when os.arch is unknown

### DIFF
--- a/lib/inspec/resources/package.rb
+++ b/lib/inspec/resources/package.rb
@@ -376,8 +376,15 @@ module Inspec::Resources
         'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
       ]
 
-      # add 64 bit search paths
-      if inspec.os.arch == "x86_64"
+      # Add WOW6432Node paths for 32-bit apps on 64-bit Windows.
+      # Include these unless the system is explicitly 32-bit (i386) — on 32-bit
+      # Windows, WOW6432Node does not exist since all apps register under the
+      # main Uninstall key.
+      # When os.arch is nil (e.g., train falls back to read_cmd_os in a PowerShell
+      # WinRM session where %PROCESSOR_ARCHITECTURE% is not expanded), we still
+      # include the WOW6432Node paths since virtually all modern Windows systems
+      # are 64-bit.
+      unless inspec.os.arch == "i386"
         search_paths << 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
         search_paths << 'HKCU:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
       end

--- a/test/fixtures/cmd/get-item-property-package-i386
+++ b/test/fixtures/cmd/get-item-property-package-i386
@@ -1,0 +1,4 @@
+{
+    "DisplayName":  "Chef Client v12.12.15 ",
+    "DisplayVersion":  "12.12.15.1"
+}

--- a/test/helpers/mock_loader.rb
+++ b/test/helpers/mock_loader.rb
@@ -26,6 +26,9 @@ class MockLoader
     windows: { name: "windows", family: "windows", release: "6.2.9200", arch: "x86_64" },
     windows2016: { name: "windows_server_2016_datacenter", family: "windows", release: "10.0.14393", arch: "x86_64" },
     windows2019: { name: "windows_server_2019_datacenter", family: "windows", release: "10.0.17763", arch: "x86_64" },
+    windows2025: { name: "windows_server_2025_datacenter", family: "windows", release: "10.0.26100", arch: "x86_64" },
+    windows_nil_arch: { name: "windows", family: "windows", release: "10.0.26100", arch: nil },
+    windows_i386: { name: "windows", family: "windows", release: "6.2.9200", arch: "i386" },
     wrlinux: { name: "wrlinux", family: "redhat", release: "7.0(3)I2(2)", arch: "x86_64" },
     solaris11: { name: "solaris", family: "solaris", release: "11", arch: "i386" },
     solaris10: { name: "solaris", family: "solaris", release: "10", arch: "i386" },
@@ -302,6 +305,8 @@ class MockLoader
       "rmsock f0000000000000002 tcpcb" => cmd.call("rmsock-f0002"),
       # packages on windows
       "6785190b3df7291a7622b0b75b0217a9a78bd04690bc978df51ae17ec852a282" => cmd.call("get-item-property-package"),
+      # packages on windows i386 (no WOW6432Node paths — 32-bit Windows)
+      "9b8d347a9771d5bc5aa6b3ee0b9153f037d3008c76884fb22ef28060c088eba6" => cmd.call("get-item-property-package-i386"),
       # service status upstart on ubuntu
       "initctl status ssh" => cmd.call("initctl-status-ssh"),
       # upstart version on ubuntu

--- a/test/unit/resources/package_test.rb
+++ b/test/unit/resources/package_test.rb
@@ -116,6 +116,25 @@ describe "Inspec::Resources::Package" do
     _(resource.latest?).must_equal true
   end
 
+  # windows with nil arch (e.g., Windows 2025 via WinRM where PROCESSOR_ARCHITECTURE
+  # is not expanded by CMD — train bug workaround)
+  it "verify windows package parsing when os.arch is nil (WOW6432Node still queried)" do
+    resource = MockLoader.new(:windows_nil_arch).load_resource("package", "Chef Client v12.12.15")
+    pkg = { name: "Chef Client v12.12.15 ", installed: true, version: "12.12.15.1", type: "windows", only_version_no: "12.12.15.1" }
+    _(resource.installed?).must_equal true
+    _(resource.version).must_equal "12.12.15.1"
+    _(resource.info).must_equal pkg
+  end
+
+  # windows i386 (32-bit) — WOW6432Node paths must NOT be included
+  it "verify windows package parsing on 32-bit (i386) skips WOW6432Node paths" do
+    resource = MockLoader.new(:windows_i386).load_resource("package", "Chef Client v12.12.15")
+    pkg = { name: "Chef Client v12.12.15 ", installed: true, version: "12.12.15.1", type: "windows", only_version_no: "12.12.15.1" }
+    _(resource.installed?).must_equal true
+    _(resource.version).must_equal "12.12.15.1"
+    _(resource.info).must_equal pkg
+  end
+
   # solaris 10
   it "verify solaris 10 package parsing" do
     resource = MockLoader.new(:solaris10).load_resource("package", "SUNWzfsr")


### PR DESCRIPTION
## Description
On Windows Server 2025 via WinRM (Test Kitchen default), train's `read_cmd_os` fallback returns `nil`/`unknown` for `os.arch` because `echo %PROCESSOR_ARCHITECTURE%` (CMD syntax) is not expanded in PowerShell sessions.

The `WindowsPkg#info` method previously only added `WOW6432Node` registry paths when `os.arch == "x86_64"`. With an unknown arch, 32-bit apps registered exclusively in `WOW6432Node` (e.g. .NET Framework SDK, VC++ x86 redistributables) appeared as "not installed", causing `kitchen verify` to fail while the Compliance Phase passed.

**Fix:** Changed `if inspec.os.arch == "x86_64"` → `unless inspec.os.arch == "i386"` so that `WOW6432Node` paths are always queried except on explicit 32-bit (i386) Windows, where `WOW6432Node` does not exist.

A companion fix in the train gem (inspec/train#832) addresses the root cause by falling back to `$env:PROCESSOR_ARCHITECTURE` (PowerShell syntax) when the CMD expansion fails.

## Related Issue
CHEF-33393 — InSpec Package Resource Fails in Kitchen Verify on Windows

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

**Foreports** [#7935](https://github.com/inspec/inspec/pull/7935)