### PR TITLE
feat: CHEF-34404 - Add aarch64-linux habitat package support

### DIFF
--- a/.expeditor/artifact.habitat.yml
+++ b/.expeditor/artifact.habitat.yml
@@ -23,11 +23,13 @@ steps:
   - label: ":linux: Arm64 Validate Habitat Builds of Chef InSpec"
     commands:
       - .expeditor/buildkite/artifact.habitat.test.sh
-    expeditor:
-      executor:
-        docker:
-          image: ruby:3.4.2-bullseye
+    agents:
+      queue: default-privileged-aarch64
+    plugins:
+      - docker#v3.5.0:
+          image: chefes/omnibus-toolchain-ubuntu-2204:aarch64
           privileged: true
+          propagate-environment: true
           environment:
             - HAB_AUTH_TOKEN
             - BUILD_PKG_TARGET: "aarch64-linux"

--- a/.expeditor/artifact.habitat.yml
+++ b/.expeditor/artifact.habitat.yml
@@ -20,6 +20,18 @@ steps:
           environment:
             - HAB_AUTH_TOKEN
 
+  - label: ":linux: Arm64 Validate Habitat Builds of Chef InSpec"
+    commands:
+      - .expeditor/buildkite/artifact.habitat.test.sh
+    expeditor:
+      executor:
+        docker:
+          image: ruby:3.4.2-bullseye
+          privileged: true
+          environment:
+            - HAB_AUTH_TOKEN
+            - BUILD_PKG_TARGET: "aarch64-linux"
+
   - label: ":windows: Validate Habitat Builds of Chef InSpec"
     commands:
       - .expeditor/buildkite/artifact.habitat.test.ps1

--- a/.expeditor/artifact.habitat.yml
+++ b/.expeditor/artifact.habitat.yml
@@ -27,7 +27,7 @@ steps:
       queue: default-privileged-aarch64
     plugins:
       - docker#v3.5.0:
-          image: chefes/omnibus-toolchain-ubuntu-2204:aarch64
+          image: ruby:3.4.2-bullseye
           privileged: true
           propagate-environment: true
           environment:

--- a/.expeditor/buildkite/artifact.habitat.test.sh
+++ b/.expeditor/buildkite/artifact.habitat.test.sh
@@ -60,7 +60,12 @@ fi
 
 echo "--- Building $PLAN"
 cd "$project_root"
-DO_CHECK=true hab pkg build .
+if [ -n "$BUILD_PKG_TARGET" ]; then
+  echo "--- Building for target: $BUILD_PKG_TARGET"
+  DO_CHECK=true hab pkg build "habitat/$BUILD_PKG_TARGET"
+else
+  DO_CHECK=true hab pkg build .
+fi
 
 echo "--- Sourcing 'results/last_build.sh'"
 if [ -f ./results/last_build.env ]; then

--- a/.github/skills/build-hab-pkg/aarch64-linux/SKILL.md
+++ b/.github/skills/build-hab-pkg/aarch64-linux/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: build-hab-pkg-aarch64-linux
+description: >
+  Sets up aarch64-linux (Linux ARM64) Habitat package support for InSpec.
+  Use this skill when asked to add ARM64 Habitat build support, add the
+  aarch64-linux plan file, or configure the ARM64 pipeline steps in
+  artifact.habitat.yml and artifact.habitat.test.sh.
+---
+
+# Skill: build-hab-pkg-aarch64-linux
+
+When this skill is invoked, check and apply the three changes below **in
+order**. For each change, search the file for the identifying label/string
+first. If it is already present, say `✔ <name> – already in place` and move
+on. Only make an edit when the change is genuinely missing.
+
+---
+
+## Change 1 – `habitat/aarch64-linux/plan.sh`
+
+**Check:** does `habitat/aarch64-linux/plan.sh` exist and contain
+`x86_64-linux/plan.sh`?
+
+- **Already in place** → report `✔ habitat/aarch64-linux/plan.sh – already in place`.
+- **Missing** → create the file with this exact content and report
+  `✅ habitat/aarch64-linux/plan.sh – created`:
+
+  ```bash
+  # Reuse the x86_64-linux plan for Linux ARM builds.
+  source "$(dirname "${BASH_SOURCE[0]}")/../x86_64-linux/plan.sh"
+  ```
+
+---
+
+## Change 2 – `.expeditor/artifact.habitat.yml`
+
+**Check:** search `.expeditor/artifact.habitat.yml` for the label
+`Arm64 Validate Habitat Builds`.
+
+- **Already in place** → report `✔ artifact.habitat.yml ARM64 step – already in place`.
+- **Missing** → insert the block below **immediately before** the line
+  containing `:windows: Validate Habitat Builds`, then report
+  `✅ artifact.habitat.yml ARM64 step – added`:
+
+  ```yaml
+    - label: ":linux: Arm64 Validate Habitat Builds of Chef InSpec"
+      commands:
+        - .expeditor/buildkite/artifact.habitat.test.sh
+      agents:
+        queue: default-privileged-aarch64
+      plugins:
+        - docker#v3.5.0:
+            image: ruby:3.4.2-bullseye
+            privileged: true
+            propagate-environment: true
+            environment:
+              - HAB_AUTH_TOKEN
+              - BUILD_PKG_TARGET: "aarch64-linux"
+  ```
+
+---
+
+## Change 3 – `.expeditor/buildkite/artifact.habitat.test.sh`
+
+**Check:** search `.expeditor/buildkite/artifact.habitat.test.sh` for the
+string `BUILD_PKG_TARGET`.
+
+- **Already in place** → report `✔ artifact.habitat.test.sh BUILD_PKG_TARGET – already in place`.
+- **Missing** → replace the single unconditional line
+  `DO_CHECK=true hab pkg build .` with the conditional block below, then
+  report `✅ artifact.habitat.test.sh BUILD_PKG_TARGET – added`:
+
+  ```bash
+  if [ -n "$BUILD_PKG_TARGET" ]; then
+    echo "--- Building for target: $BUILD_PKG_TARGET"
+    DO_CHECK=true hab pkg build "habitat/$BUILD_PKG_TARGET"
+  else
+    DO_CHECK=true hab pkg build .
+  fi
+  ```
+
+---
+
+## Summary
+
+After all three checks, print:
+
+- `All aarch64-linux Habitat build changes are already in place. Nothing to do.` — if nothing was changed.
+- `N change(s) applied successfully.` — if one or more edits were made.

--- a/.github/skills/setup-hab-studio/SKILL.md
+++ b/.github/skills/setup-hab-studio/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: setup-hab-studio
+description: Check if Chef Habitat (hab) is installed and set up. If not installed, install it for the current platform and configure required environment variables by prompting the user for any that are missing.
+---
+
+You are a tool that helps the user install and configure Chef Habitat (`hab`) and prepare their environment for working with Habitat Studio on this InSpec project.
+
+Follow each step in order. Be thorough but only ask for information that is actually needed.
+
+## 1. Detect the Operating System
+
+Determine whether the user is on:
+- **macOS** (Darwin)
+- **Linux**
+- **Windows** — check if they are using WSL (Windows Subsystem for Linux); if so, treat as Linux for installation purposes
+
+Use `uname -s` on macOS/Linux. On Windows, check for WSL via `/proc/version` or `uname -r`.
+
+## 2. Check if `hab` is Already Installed
+
+Run `hab --version`.
+
+- If it succeeds, report the installed version and skip to **Step 5** (env var check). Do not reinstall.
+- If it fails or the command is not found, proceed to **Step 3**.
+
+## 3. Install `hab`
+
+Install based on the detected platform:
+
+### macOS
+First try Homebrew:
+```
+brew install hab
+```
+If Homebrew is not available, fall back to the curl installer:
+```
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+```
+
+### Linux
+Use the official curl installer:
+```
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+```
+
+### Windows (WSL)
+Run inside the WSL bash shell:
+```
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+```
+
+After installation, verify with `hab --version` and report the installed version. If installation failed, report the error and stop.
+
+## 4. Ensure `hab` is on PATH
+
+After installation, if `hab --version` still fails, check common install paths:
+- `/bin/hab`
+- `/usr/local/bin/hab`
+- `$HOME/.hab/bin/hab`
+
+If found, inform the user to add the directory to their `PATH` and provide the exact export command.
+
+## 5. Check Required Environment Variables
+
+Check each of the following environment variables. For any that are not set or empty, prompt the user:
+
+### `HAB_ORIGIN`
+- **Required.** This is the Habitat origin name used for building packages.
+- Check: `echo $HAB_ORIGIN`
+- If not set: Ask the user — *"What is your HAB_ORIGIN (your Habitat origin name)? This is typically your username or your organization's origin (e.g., 'myorg')."*
+- Set it: `export HAB_ORIGIN=<value>`
+
+### `HAB_LICENSE`
+- **Required.** Controls license acceptance for Chef products.
+- Check: `echo $HAB_LICENSE`
+- If not set: Ask the user — *"How would you like to accept the Chef license? Options: `accept` (permanent), `accept-no-persist` (for this session only, recommended for local dev)."*
+- Default recommendation: `accept-no-persist`
+- Set it: `export HAB_LICENSE=<value>`
+
+### `HAB_REFRESH_CHANNEL`
+- **Optional but recommended.** Controls which channel to pull base packages from.
+- Check: `echo $HAB_REFRESH_CHANNEL`
+- If not set: Inform the user the default used in this project is `base-2025` and ask — *"Should I set HAB_REFRESH_CHANNEL to `base-2025` (project default), or do you want a different channel?"*
+- Set it: `export HAB_REFRESH_CHANNEL=<value>`
+
+### `HAB_NONINTERACTIVE` and `HAB_NOCOLORING`
+- **Optional but helpful for automation and clean output.**
+- If either is not set, automatically set both to `true` without prompting.
+- Set them: `export HAB_NONINTERACTIVE=true && export HAB_NOCOLORING=true`
+
+### `GITHUB_TOKEN`
+- **Optional.** Only needed if accessing private Habitat origins or packages on Builder.
+- Check: `echo $GITHUB_TOKEN`
+- If not set: Ask — *"Do you need to access private packages on Habitat Builder? If yes, please provide your GitHub token (or press Enter to skip)."*
+- If provided, set: `export GITHUB_TOKEN=<value>`
+
+## 6. Generate Origin Key if Missing
+
+After `HAB_ORIGIN` is confirmed, check whether an origin key already exists:
+```
+ls ~/.hab/cache/keys/${HAB_ORIGIN}*.pub 2>/dev/null || ls /hab/cache/keys/${HAB_ORIGIN}*.pub 2>/dev/null
+```
+
+- If a key is found, report it and skip key generation.
+- If no key is found, generate one:
+  ```
+  hab origin key generate $HAB_ORIGIN
+  ```
+  Report the key path after generation.
+
+## 7. Output Summary and Persistence Commands
+
+After all steps are complete, output a clear summary:
+
+1. **Installation status** — whether `hab` was already installed or was just installed, and the version.
+2. **Environment variables set** — list each one and its value (mask any token values).
+3. **Origin key** — whether it existed or was just generated, and the key file path.
+4. **Shell export commands to persist** — provide a copy-pasteable block of `export` commands the user can add to their shell profile (`.zshrc`, `.bashrc`, etc.):
+
+```sh
+export HAB_ORIGIN="chef"
+export HAB_LICENSE="accept-no-persist"
+export HAB_REFRESH_CHANNEL="base-2025"
+export HAB_NONINTERACTIVE=true
+export HAB_NOCOLORING=true
+# export GITHUB_TOKEN="<value>"  # uncomment if needed
+```
+
+5. **Next step** — Remind the user they can now enter the Habitat Studio with:
+   ```
+   hab studio enter
+   ```
+   Or build the InSpec Habitat package with:
+   ```
+   DO_CHECK=true hab pkg build .
+   ```

--- a/.github/skills/setup-hab-studio/SKILL.md
+++ b/.github/skills/setup-hab-studio/SKILL.md
@@ -88,11 +88,11 @@ Check each of the following environment variables. For any that are not set or e
 - If either is not set, automatically set both to `true` without prompting.
 - Set them: `export HAB_NONINTERACTIVE=true && export HAB_NOCOLORING=true`
 
-### `GITHUB_TOKEN`
-- **Optional.** Only needed if accessing private Habitat origins or packages on Builder.
-- Check: `echo $GITHUB_TOKEN`
-- If not set: Ask — *"Do you need to access private packages on Habitat Builder? If yes, please provide your GitHub token (or press Enter to skip)."*
-- If provided, set: `export GITHUB_TOKEN=<value>`
+### `HAB_AUTH_TOKEN`
+- **Required** for authenticating with Habitat Builder to push/pull packages.
+- Check: `echo $HAB_AUTH_TOKEN`
+- If not set: Ask — *"Please provide your Habitat Builder auth token (HAB_AUTH_TOKEN)."*
+- If provided, set: `export HAB_AUTH_TOKEN=<value>`
 
 ## 6. Generate Origin Key if Missing
 
@@ -123,7 +123,7 @@ export HAB_LICENSE="accept-no-persist"
 export HAB_REFRESH_CHANNEL="base-2025"
 export HAB_NONINTERACTIVE=true
 export HAB_NOCOLORING=true
-# export GITHUB_TOKEN="<value>"  # uncomment if needed
+# export HAB_AUTH_TOKEN="<value>"  # uncomment if needed
 ```
 
 5. **Next step** — Remind the user they can now enter the Habitat Studio with:

--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -1,0 +1,2 @@
+# Reuse the x86_64-linux plan for Linux ARM builds.
+source "$(dirname "${BASH_SOURCE[0]}")/../x86_64-linux/plan.sh"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Add support for building a Habitat package for Linux ARM (`aarch64-linux`) by reusing the existing `x86_64-linux` plan file. The new `habitat/aarch64-linux/plan.sh` sources `habitat/x86_64-linux/plan.sh` directly, ensuring full consistency across platforms without duplicating any logic.

- Created `habitat/aarch64-linux/plan.sh` which sources the shared x86_64-linux plan

The `aarch64-linux` package has been successfully built and installed on an Ubuntu ARM VM (AWS Graviton), and `inspec version` was verified to work correctly.

This work was completed with AI assistance following Progress AI policies.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

CHEF-34404

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
