### PR TITLE
CHEF-34651 chore: upgrade nokogiri gem to 1.18.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,60 +1,60 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'inspec', path: '.'
+gem "inspec", path: "."
 
 # This dependency is NOT used for normal gem deployment
 # - instead, inspec-bin gemspec-depends on inspec
 #
 # However, AppBundler requires a top-level Gemfile.lock with inspec-bin
 # in it in order to package the executable. Hence the odd backwards dependency.
-gem 'inspec-bin', path: './inspec-bin'
+gem "inspec-bin", path: "./inspec-bin"
 
 # ffi version v1.17.0 is breaking verify pipeline as it requires
 # rubygems version to be upgraded to >= 3.3.22 Ref:https://buildkite.com/chef/inspec-inspec-main-verify-private/builds/812#018fe177-2ccb-45ed-a25e-213c8a6453df/698-707
 
-gem 'ffi', '>= 1.15.5', '< 1.17.0'
+gem "ffi", ">= 1.15.5", "< 1.17.0"
 
 # We have a build issue 2023-11-13 with unf_ext 0.0.9 so we are pinning to 0.0.8.2
 # See https://github.com/knu/ruby-unf_ext/issues/74 https://buildkite.com/chef/inspec-inspec-inspec-5-omnibus-release/builds/22
-gem 'unf_ext', '= 0.0.8.2'
+gem "unf_ext", "= 0.0.8.2"
 
 # inspec tests depend text output that changed in the 3.10 release
 # but our runtime dep is still 3.9+
-gem 'rspec', '>= 3.10'
+gem "rspec", ">= 3.10"
 
 group :omnibus do
-  gem 'appbundler'
-  gem 'bcrypt_pbkdf' # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
-  gem 'ed25519' # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
-  gem 'rb-readline'
+  gem "rb-readline"
+  gem "appbundler"
+  gem "ed25519" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
+  gem "bcrypt_pbkdf" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
   # pinning at < 0.6, 0.6 requires ruby 3.2+, InSpec5 does not support Ruby 3.2
-  gem 'net-imap', '>= 0.5.14', '< 0.6'
+  gem "net-imap", ">= 0.5.14", "< 0.6"
 end
 
 group :test do
-  gem 'chefstyle'
-  gem 'concurrent-ruby'
-  gem 'json_schemer'
-  gem 'm'
+  gem "chefstyle"
+  gem "concurrent-ruby"
+  gem "json_schemer"
+  gem "m"
   # 1.4.0+ requires min ruby 3.2, InSpec5 does not support Ruby 3.2
-  gem 'minitest', '5.15.0'
-  gem 'minitest-sprint', '~> 1.3.0', '< 1.4.0'
-  gem 'mocha'
-  gem 'nokogiri', '~> 1.18.10'
-  gem 'pry'
-  gem 'pry-byebug'
-  gem 'rake'
-  gem 'signet', '< 0.22.0' # 0.20.0+ requires min ruby 3.1
-  gem 'simplecov'
-  gem 'simplecov_json_formatter'
-  gem 'webmock'
+  gem "minitest-sprint", "~> 1.3.0" , "< 1.4.0"
+  gem "minitest", "5.15.0"
+  gem "mocha"
+  gem "nokogiri", "~> 1.18.10"
+  gem "pry-byebug"
+  gem "pry"
+  gem "rake"
+  gem "simplecov"
+  gem "simplecov_json_formatter"
+  gem "webmock"
+  gem "signet", "< 0.22.0" # 0.20.0+ requires min ruby 3.1
   # Pinning to 1.15 as multi_json 1.16 require ruby 3.2 version
   # Ref: https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/647#019808ca-087b-43bc-b1f9-40a36f59c5f4
-  gem 'multi_json', '~> 1.18.0'
+  gem "multi_json", "~> 1.18.0"
 end
 
 group :deploy do
-  gem 'inquirer'
+  gem "inquirer"
 end
 
 # Build is failing - see: https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/442
@@ -63,7 +63,7 @@ end
 # zeitwerk → dry-configurable, dry-struct, dry-types → k8s-ruby → train-kubernetes
 # Pinning zeitwerk to ~> 2.6 to avoid Ruby >= 3.2 requirement.
 # Remove this pin when upgrading to Ruby 3.2 or higher.
-gem 'zeitwerk', '~> 2.6.0', '< 2.7'
+gem "zeitwerk", "~> 2.6.0", "< 2.7"
 
 # Pinning connection_pool to < 3.0.0 as 3.0.0+ requires Ruby >= 3.2.0
-gem 'connection_pool', '>= 2.5', '< 3.0'
+gem "connection_pool", ">= 2.5", "< 3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,60 +1,60 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "inspec", path: "."
+gem 'inspec', path: '.'
 
 # This dependency is NOT used for normal gem deployment
 # - instead, inspec-bin gemspec-depends on inspec
 #
 # However, AppBundler requires a top-level Gemfile.lock with inspec-bin
 # in it in order to package the executable. Hence the odd backwards dependency.
-gem "inspec-bin", path: "./inspec-bin"
+gem 'inspec-bin', path: './inspec-bin'
 
 # ffi version v1.17.0 is breaking verify pipeline as it requires
 # rubygems version to be upgraded to >= 3.3.22 Ref:https://buildkite.com/chef/inspec-inspec-main-verify-private/builds/812#018fe177-2ccb-45ed-a25e-213c8a6453df/698-707
 
-gem "ffi", ">= 1.15.5", "< 1.17.0"
+gem 'ffi', '>= 1.15.5', '< 1.17.0'
 
 # We have a build issue 2023-11-13 with unf_ext 0.0.9 so we are pinning to 0.0.8.2
 # See https://github.com/knu/ruby-unf_ext/issues/74 https://buildkite.com/chef/inspec-inspec-inspec-5-omnibus-release/builds/22
-gem "unf_ext", "= 0.0.8.2"
+gem 'unf_ext', '= 0.0.8.2'
 
 # inspec tests depend text output that changed in the 3.10 release
 # but our runtime dep is still 3.9+
-gem "rspec", ">= 3.10"
+gem 'rspec', '>= 3.10'
 
 group :omnibus do
-  gem "rb-readline"
-  gem "appbundler"
-  gem "ed25519" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
-  gem "bcrypt_pbkdf" # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
+  gem 'appbundler'
+  gem 'bcrypt_pbkdf' # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
+  gem 'ed25519' # ed25519 ssh key support done here as its a native gem we can't put in the gemspec
+  gem 'rb-readline'
   # pinning at < 0.6, 0.6 requires ruby 3.2+, InSpec5 does not support Ruby 3.2
-  gem "net-imap", ">= 0.5.14", "< 0.6"
+  gem 'net-imap', '>= 0.5.14', '< 0.6'
 end
 
 group :test do
-  gem "chefstyle"
-  gem "concurrent-ruby"
-  gem "json_schemer"
-  gem "m"
+  gem 'chefstyle'
+  gem 'concurrent-ruby'
+  gem 'json_schemer'
+  gem 'm'
   # 1.4.0+ requires min ruby 3.2, InSpec5 does not support Ruby 3.2
-  gem "minitest-sprint", "~> 1.3.0" , "< 1.4.0"
-  gem "minitest", "5.15.0"
-  gem "mocha"
-  gem "nokogiri", "< 1.17.2"
-  gem "pry-byebug"
-  gem "pry"
-  gem "rake"
-  gem "simplecov"
-  gem "simplecov_json_formatter"
-  gem "webmock"
-  gem "signet", "< 0.22.0" # 0.20.0+ requires min ruby 3.1
+  gem 'minitest', '5.15.0'
+  gem 'minitest-sprint', '~> 1.3.0', '< 1.4.0'
+  gem 'mocha'
+  gem 'nokogiri', '~> 1.18.10'
+  gem 'pry'
+  gem 'pry-byebug'
+  gem 'rake'
+  gem 'signet', '< 0.22.0' # 0.20.0+ requires min ruby 3.1
+  gem 'simplecov'
+  gem 'simplecov_json_formatter'
+  gem 'webmock'
   # Pinning to 1.15 as multi_json 1.16 require ruby 3.2 version
   # Ref: https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/647#019808ca-087b-43bc-b1f9-40a36f59c5f4
-  gem "multi_json", "~> 1.18.0"
+  gem 'multi_json', '~> 1.18.0'
 end
 
 group :deploy do
-  gem "inquirer"
+  gem 'inquirer'
 end
 
 # Build is failing - see: https://buildkite.com/chef-oss/inspec-inspec-inspec-5-verify/builds/442
@@ -63,7 +63,7 @@ end
 # zeitwerk → dry-configurable, dry-struct, dry-types → k8s-ruby → train-kubernetes
 # Pinning zeitwerk to ~> 2.6 to avoid Ruby >= 3.2 requirement.
 # Remove this pin when upgrading to Ruby 3.2 or higher.
-gem "zeitwerk", "~> 2.6.0", "< 2.7"
+gem 'zeitwerk', '~> 2.6.0', '< 2.7'
 
 # Pinning connection_pool to < 3.0.0 as 3.0.0+ requires Ruby >= 3.2.0
-gem "connection_pool", ">= 2.5", "< 3.0"
+gem 'connection_pool', '>= 2.5', '< 3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :test do
   gem "minitest-sprint", "~> 1.3.0" , "< 1.4.0"
   gem "minitest", "5.15.0"
   gem "mocha"
-  gem "nokogiri", "~> 1.18.10"
+  gem "nokogiri", "~> 1.18", "< 1.18.10"
   gem "pry-byebug"
   gem "pry"
   gem "rake"

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :test do
   gem "minitest-sprint", "~> 1.3.0" , "< 1.4.0"
   gem "minitest", "5.15.0"
   gem "mocha"
-  gem "nokogiri", "~> 1.18", "< 1.18.10"
+  gem "nokogiri", "~> 1.18.10"
   gem "pry-byebug"
   gem "pry"
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -887,4 +887,4 @@ DEPENDENCIES
   zeitwerk (~> 2.6.0, < 2.7)
 
 BUNDLED WITH
-   2.3.3
+   2.6.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -887,4 +887,4 @@ DEPENDENCIES
   zeitwerk (~> 2.6.0, < 2.7)
 
 BUNDLED WITH
-   2.6.9
+   2.3.27

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -583,8 +583,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-linux-musl)
-      racc (~> 1.4)
     nori (2.7.1)
       bigdecimal
     options (2.3.2)
@@ -856,7 +854,6 @@ PLATFORMS
   x86_64-darwin-23
   x86_64-linux
   x86_64-linux-gnu
-  x86_64-linux-musl
 
 DEPENDENCIES
   appbundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -575,13 +575,13 @@ GEM
     net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-ssh (7.3.2)
-    nokogiri (1.17.1-arm64-darwin)
+    nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.17.1-x64-mingw-ucrt)
+    nokogiri (1.18.10-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.17.1-x86_64-darwin)
+    nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.17.1-x86_64-linux)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     nori (2.7.1)
       bigdecimal
@@ -872,7 +872,7 @@ DEPENDENCIES
   mocha
   multi_json (~> 1.18.0)
   net-imap (>= 0.5.14, < 0.6)
-  nokogiri (< 1.17.2)
+  nokogiri (~> 1.18.10)
   pry
   pry-byebug
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -575,15 +575,15 @@ GEM
     net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-ssh (7.3.2)
-    nokogiri (1.18.10-arm64-darwin)
+    nokogiri (1.18.9-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x64-mingw-ucrt)
+    nokogiri (1.18.9-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-darwin)
+    nokogiri (1.18.9-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-gnu)
+    nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-musl)
+    nokogiri (1.18.9-x86_64-linux-musl)
       racc (~> 1.4)
     nori (2.7.1)
       bigdecimal
@@ -876,7 +876,7 @@ DEPENDENCIES
   mocha
   multi_json (~> 1.18.0)
   net-imap (>= 0.5.14, < 0.6)
-  nokogiri (~> 1.18.10)
+  nokogiri (~> 1.18, < 1.18.10)
   pry
   pry-byebug
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -575,13 +575,13 @@ GEM
     net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-ssh (7.3.2)
-    nokogiri (1.18.9-arm64-darwin)
+    nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.9-x64-mingw-ucrt)
+    nokogiri (1.18.10-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-darwin)
+    nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-linux-gnu)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     nori (2.7.1)
       bigdecimal
@@ -873,7 +873,7 @@ DEPENDENCIES
   mocha
   multi_json (~> 1.18.0)
   net-imap (>= 0.5.14, < 0.6)
-  nokogiri (~> 1.18, < 1.18.10)
+  nokogiri (~> 1.18.10)
   pry
   pry-byebug
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -583,6 +583,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-musl)
+      racc (~> 1.4)
     nori (2.7.1)
       bigdecimal
     options (2.3.2)
@@ -853,6 +855,8 @@ PLATFORMS
   x64-mingw-ucrt
   x86_64-darwin-23
   x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   appbundler


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Bumps the `nokogiri` gem constraint from `< 1.17.1` to `~> 1.18.10` and updates `Gemfile.lock` to resolve to version `1.18.10`. This pins to the latest patch release in the 1.18.x series, picking up any security and bug fixes since 1.17.1.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
