### PR TITLE
CHEF-34651 Remove test dependencies during hab build 

### DIFF
--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -40,7 +40,7 @@ function Invoke-Build {
         $env:GEM_HOME = "$HAB_CACHE_SRC_PATH/$pkg_dirname/vendor"
 
         Write-BuildLine " ** Configuring bundler for this build environment"
-        bundle config --local without integration deploy maintenance
+        bundle config --local without integration deploy maintenance test
         bundle config --local jobs 4
         bundle config --local retry 5
         bundle config --local silence_root_warning 1


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request makes a minor update to the bundler configuration in the `Invoke-Build` function. The change ensures that the `test` group is excluded when installing gems, in addition to the previously excluded groups.

- Bundler configuration:
  * Updated the `bundle config --local without` setting to exclude the `test` group along with `integration`, `deploy`, and `maintenance` groups. This prevents gems in the `test` group from being installed during the build.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
