### PR TITLE
fix(source_reader): only claim profile as gem if gemspec is at the root

### DIFF
--- a/lib/source_readers/gem.rb
+++ b/lib/source_readers/gem.rb
@@ -7,7 +7,7 @@ module SourceReaders
     priority 20
 
     def self.resolve(target)
-      return new(target) unless target.files.grep(/gemspec/).empty?
+      return new(target) unless target.files.grep(%r{^[^/\\]+\.gemspec$}).empty?
 
       nil
     end

--- a/test/unit/source_readers/gem_test.rb
+++ b/test/unit/source_readers/gem_test.rb
@@ -1,0 +1,48 @@
+require "helper"
+require "inspec/source_reader"
+require "source_readers/gem"
+
+describe SourceReaders::GemReader do
+  let(:reader) { SourceReaders::GemReader }
+
+  it "registers with the source readers registry" do
+    reg = Inspec::SourceReader.registry
+    _(reg["gem"]).must_equal reader
+  end
+
+  describe "resolve" do
+    class MockTarget
+      attr_reader :files
+      def initialize(files)
+        @files = files
+      end
+
+      def read(file)
+        if file == "inspec.yml"
+          "name: my_gem\nversion: 0.1.0\n"
+        else
+          "dummy content"
+        end
+      end
+    end
+
+    it "resolves the target when gemspec is in root" do
+      target = MockTarget.new(["inspec.yml", "my_gem.gemspec", "lib/my_gem.rb"])
+      res = SourceReaders::GemReader.resolve(target)
+      _(res).wont_be_nil
+      _(res).must_be_kind_of reader
+    end
+
+    it "does not resolve the target when gemspec is in a subfolder" do
+      target = MockTarget.new(["inspec.yml", "vendor/bundle/ruby/3.1.0/specifications/other.gemspec"])
+      res = SourceReaders::GemReader.resolve(target)
+      _(res).must_be_nil
+    end
+
+    it "does not resolve the target when there is no gemspec" do
+      target = MockTarget.new(["inspec.yml", "controls/example.rb"])
+      res = SourceReaders::GemReader.resolve(target)
+      _(res).must_be_nil
+    end
+  end
+end


### PR DESCRIPTION
Fixes #7934

## Description

The `GemReader` in InSpec 7.x (`lib/source_readers/gem.rb`) was claiming any directory profile whose file tree contains a `*.gemspec` anywhere (e.g., inside a vendored `vendor/bundle/` path). As a result, the profile was improperly treated as a gem resource pack rather than being read by `InspecReader`.

This PR updates `GemReader.resolve` to only match `.gemspec` files present in the root of the target directory by using a more exact regex `%r{^[^/\\]+\.gemspec$}`.

## Testing

I added unit tests in `test/unit/source_readers/gem_test.rb` simulating `Inspec::FileProvider` output for different target configurations. The tests verify that `GemReader.resolve` successfully identifies root `.gemspec` files while properly rejecting nested `.gemspec` files or missing ones.

Signed-off-by: Mallikarjunadevops
