### PR TITLE
Add build-hab-pkg and setup-hab-studio Copilot CLI skills

### DIFF
--- a/.github/skills/build-hab-pkg/SKILL.md
+++ b/.github/skills/build-hab-pkg/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: build-hab-pkg
+description: >
+  Creates a Habitat plan file for a new target platform (e.g. aarch64-linux,
+  aarch64-darwin). Use this skill when asked to add Habitat build support for
+  a new platform or architecture. The skill asks for the target platform,
+  selects the correct base plan to source, and creates the plan file.
+---
+
+# Skill: build-hab-pkg
+
+When this skill is invoked, follow these steps in order.
+
+---
+
+## Step 1 – Ask for the target platform
+
+Ask the user:
+
+> *"Which platform would you like to add Habitat package support for?
+> Examples: `aarch64-linux`, `aarch64-darwin`, `x86_64-darwin`.
+> (Enter the full Habitat target string, e.g. `aarch64-linux`)"*
+
+Store the answer as `<TARGET>` (e.g. `aarch64-linux`).
+
+---
+
+## Step 2 – Determine the base plan to source
+
+Derive the base plan path from `<TARGET>` using these rules:
+
+| `<TARGET>` contains | Base plan to source |
+|---------------------|---------------------|
+| `linux`             | `../x86_64-linux/plan.sh` |
+| `darwin`            | `../x86_64-darwin/plan.sh` (if it exists) |
+| `windows`           | `../x86_64-windows/plan.ps1` |
+
+- Check whether the resolved base plan file exists under `habitat/`.
+- If it **does not exist**, warn the user:
+  > *"⚠️ No base plan found for `<TARGET>` (expected `habitat/<base>`).
+  > Please ensure the base plan exists before continuing."*
+  Then stop.
+
+---
+
+## Step 3 – Check if the plan file already exists
+
+Check whether `habitat/<TARGET>/plan.sh` already exists and sources the base plan.
+
+- **Already in place** → report `✔ habitat/<TARGET>/plan.sh – already in place` and stop.
+- **Missing** → proceed to Step 4.
+
+---
+
+## Step 4 – Create the plan file
+
+### 4a – Read the existing base plan as reference
+
+Before creating anything, **read the base plan file** resolved in Step 2
+(e.g. `habitat/x86_64-linux/plan.sh` or `habitat/x86_64-windows/plan.ps1`).
+
+Use its content to understand:
+- The variables set at the top (`pkg_name`, `pkg_origin`, `pkg_deps`, etc.)
+- Any `do_build`, `do_install`, `do_setup_environment` hooks defined
+- The file extension and shell used (`.sh` for Linux/Darwin, `.ps1` for Windows)
+
+The new plan file for `<TARGET>` **does not duplicate** this logic — it simply
+sources the base plan so both platforms stay in sync.
+
+### 4b – Write the new plan file
+
+Create `habitat/<TARGET>/plan.sh` (or `plan.ps1` for Windows targets) with:
+
+```bash
+# Reuse the <BASE_PLATFORM> plan for <TARGET> builds.
+source "$(dirname "${BASH_SOURCE[0]}")/<BASE_PLAN_PATH>"
+```
+
+Where:
+- `<BASE_PLATFORM>` is the platform of the base plan (e.g. `x86_64-linux`)
+- `<BASE_PLAN_PATH>` is the relative path from Step 2 (e.g. `../x86_64-linux/plan.sh`)
+
+**Example** — for `aarch64-linux` (references `habitat/x86_64-linux/plan.sh`):
+
+```bash
+# Reuse the x86_64-linux plan for aarch64-linux builds.
+source "$(dirname "${BASH_SOURCE[0]}")/../x86_64-linux/plan.sh"
+```
+
+> If the base plan is a `.ps1` (Windows), use the PowerShell equivalent:
+> `. "$PSScriptRoot\..\x86_64-windows\plan.ps1"`
+
+Report: `✅ habitat/<TARGET>/plan.sh – created (sources habitat/<BASE_PLATFORM>/plan.sh)`
+
+---
+
+## Step 5 – Summary
+
+Print a summary of what was done:
+
+```
+Platform : <TARGET>
+Plan file: habitat/<TARGET>/plan.sh
+Sources  : habitat/<BASE_PLATFORM>/plan.sh
+Status   : ✅ created  (or ✔ already in place)
+```
+
+---
+
+## Step 6 – Set up Habitat Studio for testing
+
+Now that the plan file is ready, invoke the **`setup-hab-studio`** skill to
+prepare the Habitat Studio environment so the new plan can be built and tested:
+
+> *"Invoking the `setup-hab-studio` skill to complete Habitat Studio setup…"*
+
+The `setup-hab-studio` skill will:
+1. Detect the OS and check whether `hab` is installed (install if missing)
+2. Verify and configure all required environment variables
+   (`HAB_ORIGIN`, `HAB_LICENSE`, `HAB_AUTH_TOKEN`, etc.)
+3. Generate an origin key if one does not exist
+4. Confirm the studio is ready to build `habitat/<TARGET>/plan.sh`
+
+---
+
+## Step 7 – Enter Habitat Studio and build the package
+
+Once `setup-hab-studio` completes, enter the Habitat Studio and run the build
+for the provided platform.
+
+### 7a – Enter the Habitat Studio
+
+```bash
+hab studio enter
+```
+
+> On Linux this opens a sandboxed Studio shell. Wait for the `[1][default:/src:0]$`
+> prompt before proceeding.
+
+### 7b – Run the build for `<TARGET>`
+
+Inside the Studio, run:
+
+```bash
+DO_CHECK=true build habitat/<TARGET>
+```
+
+Where `<TARGET>` is the platform chosen in Step 1 (e.g. `aarch64-linux`).
+
+This is equivalent to running `hab pkg build habitat/<TARGET>` and will:
+- Compile the gems for the target platform
+- Run the `DO_CHECK` hooks defined in the base plan
+- Produce a `.hart` artifact under `./results/`
+
+### 7c – Verify the build succeeded
+
+After the build completes, check the results:
+
+```bash
+source ./results/last_build.env
+echo "Built: $pkg_artifact"
+ls -lh ./results/$pkg_artifact
+```
+
+- If the `.hart` file is present → report `✅ Build succeeded: results/$pkg_artifact`
+- If the build failed → show the last error lines from Studio output and suggest:
+  > *"Check the build log above for errors. Common causes: missing deps in
+  > `pkg_deps`, Ruby gem native extension failures, or incorrect `HAB_ORIGIN`."*
+
+---
+
+## Step 8 – Install the `.hart` package and verify
+
+Once the `.hart` artifact is confirmed, exit the Studio and install the package
+on the host machine, then verify it works correctly.
+
+### 8a – Exit the Habitat Studio
+
+```bash
+exit
+```
+
+### 8b – Install the `.hart` package
+
+```bash
+source ./results/last_build.env
+hab pkg install ./results/$pkg_artifact
+```
+
+- If installation succeeds → report `✅ Package installed: $pkg_ident`
+- If it fails → show the error and stop.
+
+### 8c – Add the package binaries to PATH
+
+```bash
+hab pkg binlink $pkg_origin/inspec inspec --force
+```
+
+Or export the bin path directly:
+
+```bash
+export PATH="$(hab pkg path $pkg_origin/inspec)/bin:$PATH"
+```
+
+### 8d – Verify with `inspec version`
+
+```bash
+inspec version
+```
+
+- Expected: prints the InSpec version string (e.g. `6.x.x`)
+- `✅ inspec version – OK` if a version string is returned
+- `❌ inspec version failed` — show output and suggest checking `PATH` or re-running `hab pkg binlink`
+
+### 8e – Verify with `inspec detect`
+
+```bash
+inspec detect
+```
+
+- Expected: prints platform details (OS name, family, release, arch)
+- `✅ inspec detect – OK` if platform info is returned
+- `❌ inspec detect failed` — show output for diagnosis
+
+### 8f – Final summary
+
+Print a complete summary:
+
+```
+Platform    : <TARGET>
+Package     : $pkg_ident
+Artifact    : results/$pkg_artifact
+inspec version : ✅ <version string>
+inspec detect  : ✅ <platform info>
+```
+
+> *"The `<TARGET>` Habitat package is built, installed, and verified successfully."*

--- a/.github/skills/setup-hab-studio/SKILL.md
+++ b/.github/skills/setup-hab-studio/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: setup-hab-studio
+description: Check if Chef Habitat (hab) is installed and set up. If not installed, install it for the current platform and configure required environment variables by prompting the user for any that are missing.
+---
+
+You are a tool that helps the user install and configure Chef Habitat (`hab`) and prepare their environment for working with Habitat Studio on this InSpec project.
+
+Follow each step in order. Be thorough but only ask for information that is actually needed.
+
+## 1. Detect the Operating System
+
+Determine whether the user is on:
+- **macOS** (Darwin)
+- **Linux**
+- **Windows** — check if they are using WSL (Windows Subsystem for Linux); if so, treat as Linux for installation purposes
+
+Use `uname -s` on macOS/Linux. On Windows, check for WSL via `/proc/version` or `uname -r`.
+
+## 2. Check if `hab` is Already Installed
+
+Run `hab --version`.
+
+- If it succeeds, report the installed version and skip to **Step 5** (env var check). Do not reinstall.
+- If it fails or the command is not found, proceed to **Step 3**.
+
+## 3. Install `hab`
+
+Install based on the detected platform:
+
+### macOS
+First try Homebrew:
+```
+brew install hab
+```
+If Homebrew is not available, fall back to the curl installer:
+```
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+```
+
+### Linux
+Use the official curl installer:
+```
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+```
+
+### Windows (WSL)
+Run inside the WSL bash shell:
+```
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+```
+
+After installation, verify with `hab --version` and report the installed version. If installation failed, report the error and stop.
+
+## 4. Ensure `hab` is on PATH
+
+After installation, if `hab --version` still fails, check common install paths:
+- `/bin/hab`
+- `/usr/local/bin/hab`
+- `$HOME/.hab/bin/hab`
+
+If found, inform the user to add the directory to their `PATH` and provide the exact export command.
+
+## 5. Check Required Environment Variables
+
+Check each of the following environment variables. For any that are not set or empty, prompt the user:
+
+### `HAB_ORIGIN`
+- **Required.** This is the Habitat origin name used for building packages.
+- Check: `echo $HAB_ORIGIN`
+- If not set: Ask the user — *"What is your HAB_ORIGIN (your Habitat origin name)? This is typically your username or your organization's origin (e.g., 'myorg')."*
+- Set it: `export HAB_ORIGIN=<value>`
+
+### `HAB_LICENSE`
+- **Required.** Controls license acceptance for Chef products.
+- Check: `echo $HAB_LICENSE`
+- If not set: Ask the user — *"How would you like to accept the Chef license? Options: `accept` (permanent), `accept-no-persist` (for this session only, recommended for local dev)."*
+- Default recommendation: `accept-no-persist`
+- Set it: `export HAB_LICENSE=<value>`
+
+### `HAB_REFRESH_CHANNEL`
+- **Optional but recommended.** Controls which channel to pull base packages from.
+- Check: `echo $HAB_REFRESH_CHANNEL`
+- If not set: Inform the user the default used in this project is `base-2025` and ask — *"Should I set HAB_REFRESH_CHANNEL to `base-2025` (project default), or do you want a different channel?"*
+- Set it: `export HAB_REFRESH_CHANNEL=<value>`
+
+### `HAB_NONINTERACTIVE` and `HAB_NOCOLORING`
+- **Optional but helpful for automation and clean output.**
+- If either is not set, automatically set both to `true` without prompting.
+- Set them: `export HAB_NONINTERACTIVE=true && export HAB_NOCOLORING=true`
+
+### `GITHUB_TOKEN`
+- **Optional.** Only needed if accessing private Habitat origins or packages on Builder.
+- Check: `echo $GITHUB_TOKEN`
+- If not set: Ask — *"Do you need to access private packages on Habitat Builder? If yes, please provide your GitHub token (or press Enter to skip)."*
+- If provided, set: `export GITHUB_TOKEN=<value>`
+
+## 6. Generate Origin Key if Missing
+
+After `HAB_ORIGIN` is confirmed, check whether an origin key already exists:
+```
+ls ~/.hab/cache/keys/${HAB_ORIGIN}*.pub 2>/dev/null || ls /hab/cache/keys/${HAB_ORIGIN}*.pub 2>/dev/null
+```
+
+- If a key is found, report it and skip key generation.
+- If no key is found, generate one:
+  ```
+  hab origin key generate $HAB_ORIGIN
+  ```
+  Report the key path after generation.
+
+## 7. Output Summary and Persistence Commands
+
+After all steps are complete, output a clear summary:
+
+1. **Installation status** — whether `hab` was already installed or was just installed, and the version.
+2. **Environment variables set** — list each one and its value (mask any token values).
+3. **Origin key** — whether it existed or was just generated, and the key file path.
+4. **Shell export commands to persist** — provide a copy-pasteable block of `export` commands the user can add to their shell profile (`.zshrc`, `.bashrc`, etc.):
+
+```sh
+export HAB_ORIGIN="chef"
+export HAB_LICENSE="accept-no-persist"
+export HAB_REFRESH_CHANNEL="base-2025"
+export HAB_NONINTERACTIVE=true
+export HAB_NOCOLORING=true
+# export GITHUB_TOKEN="<value>"  # uncomment if needed
+```
+
+5. **Next step** — Remind the user they can now enter the Habitat Studio with:
+   ```
+   hab studio enter
+   ```
+   Or build the InSpec Habitat package with:
+   ```
+   DO_CHECK=true hab pkg build .
+   ```

--- a/.github/skills/setup-hab-studio/SKILL.md
+++ b/.github/skills/setup-hab-studio/SKILL.md
@@ -88,11 +88,11 @@ Check each of the following environment variables. For any that are not set or e
 - If either is not set, automatically set both to `true` without prompting.
 - Set them: `export HAB_NONINTERACTIVE=true && export HAB_NOCOLORING=true`
 
-### `GITHUB_TOKEN`
-- **Optional.** Only needed if accessing private Habitat origins or packages on Builder.
-- Check: `echo $GITHUB_TOKEN`
-- If not set: Ask — *"Do you need to access private packages on Habitat Builder? If yes, please provide your GitHub token (or press Enter to skip)."*
-- If provided, set: `export GITHUB_TOKEN=<value>`
+### `HAB_AUTH_TOKEN`
+- **Required** for authenticating with Habitat Builder to push/pull packages.
+- Check: `echo $HAB_AUTH_TOKEN`
+- If not set: Ask — *"Please provide your Habitat Builder auth token (HAB_AUTH_TOKEN)."*
+- If provided, set: `export HAB_AUTH_TOKEN=<value>`
 
 ## 6. Generate Origin Key if Missing
 
@@ -123,7 +123,7 @@ export HAB_LICENSE="accept-no-persist"
 export HAB_REFRESH_CHANNEL="base-2025"
 export HAB_NONINTERACTIVE=true
 export HAB_NOCOLORING=true
-# export GITHUB_TOKEN="<value>"  # uncomment if needed
+# export HAB_AUTH_TOKEN="<value>"  # uncomment if needed
 ```
 
 5. **Next step** — Remind the user they can now enter the Habitat Studio with:


### PR DESCRIPTION
## Summary

Adds two new Copilot CLI skills to streamline Habitat package development for InSpec:

### 1. `setup-hab-studio` skill
Helps developers install and configure Chef Habitat (`hab`) and prepare their environment for Habitat Studio:
- Detects OS (macOS, Linux, WSL)
- Checks/installs `hab` if missing
- Ensures `hab` is on PATH
- Checks and prompts for required env vars: `HAB_ORIGIN`, `HAB_LICENSE`, `HAB_REFRESH_CHANNEL`, `HAB_NONINTERACTIVE`, `HAB_NOCOLORING`, `HAB_AUTH_TOKEN`
- Generates an origin key if one doesn't exist
- Outputs a summary and copy-pasteable shell export block

### 2. `build-hab-pkg` skill
Guides the user through adding Habitat package support for a new target platform (e.g. `aarch64-linux`, `aarch64-darwin`):
- Asks for the target platform
- Determines or creates the base plan to source
- Creates `habitat/<TARGET>/plan.sh` sourcing the appropriate base plan
- Invokes `setup-hab-studio` to prepare the build environment
- Enters Habitat Studio and runs `DO_CHECK=true build habitat/<TARGET>`
- Verifies the `.hart` artifact, installs it, and validates with `inspec version` and `inspec detect`

## Testing

- [x] Tested `setup-hab-studio` on macOS (Apple Silicon / aarch64-darwin)
- [x] Tested `build-hab-pkg` on macOS (Apple Silicon / aarch64-darwin)
- [x] `aarch64-darwin` plan file created and build attempted