### PR TITLE
docs: remove --overwrite from compliance upload README example

### DIFF
--- a/lib/plugins/inspec-compliance/README.md
+++ b/lib/plugins/inspec-compliance/README.md
@@ -18,7 +18,6 @@ To use the CLI, this InSpec add-on adds the following commands:
 
     *Options*:
     ```
-      [--overwrite], [--no-overwrite]  # Overwrite existing profile on Server.
       [--owner=OWNER]                  # Owner that should own the profile
       [--legacy], [--no-legacy]        # Enable legacy functionality, activating both legacy export and legacy check.
 


### PR DESCRIPTION
### Description
Removing references to the `--overwrite` flag for `inspec compliance upload` to avoid confusion.
This is due to a bug (CHEF-14882) where `--overwrite` is not overwriting the InSpec Profile to Chef Automate.