### PR TITLE
fix CHEF-36239 : Prevent GemReader from matching vendored profiles

### DIFF
--- a/lib/source_readers/gem.rb
+++ b/lib/source_readers/gem.rb
@@ -11,7 +11,6 @@ module SourceReaders
       # This prevents archived/vendored profiles from being treated as gem profiles
       gemspec_files = target.files.grep(/gemspec/)
       root_gemspec = gemspec_files.reject { |f| f.start_with?("vendor/") }
-      
       return new(target) unless root_gemspec.empty?
 
       nil

--- a/lib/source_readers/gem.rb
+++ b/lib/source_readers/gem.rb
@@ -7,7 +7,12 @@ module SourceReaders
     priority 20
 
     def self.resolve(target)
-      return new(target) unless target.files.grep(/gemspec/).empty?
+      # Only match if gemspec is at root level, not in vendor directories
+      # This prevents archived/vendored profiles from being treated as gem profiles
+      gemspec_files = target.files.grep(/gemspec/)
+      root_gemspec = gemspec_files.reject { |f| f.start_with?("vendor/") }
+      
+      return new(target) unless root_gemspec.empty?
 
       nil
     end

--- a/test/unit/source_readers/gem_test.rb
+++ b/test/unit/source_readers/gem_test.rb
@@ -1,0 +1,46 @@
+require "helper"
+require "inspec/source_reader"
+require "source_readers/gem"
+
+describe SourceReaders::GemReader do
+  let(:reader) { SourceReaders::GemReader }
+
+  it "registers with the source readers registry" do
+    reg = Inspec::SourceReader.registry
+    _(reg["gem"]).must_equal reader
+  end
+
+  describe "when resolving profiles" do
+    it "does not resolve a profile with gemspec only in vendor directory" do
+      files = ["inspec.yml", "controls/test.rb", "vendor/abc123/test.gemspec"]
+      mock_provider = Minitest::Mock.new
+      mock_provider.expect :files, files
+      
+      result = reader.resolve(mock_provider)
+      _(result).must_be_nil
+      mock_provider.verify
+    end
+
+    it "does not resolve a profile with no gemspec" do
+      files = ["inspec.yml", "controls/test.rb"]
+      mock_provider = Minitest::Mock.new
+      mock_provider.expect :files, files
+      
+      result = reader.resolve(mock_provider)
+      _(result).must_be_nil
+      mock_provider.verify
+    end
+
+    it "filters vendor gemspecs correctly" do
+      # This test verifies the fix: gemspec in vendor/ should be filtered out
+      files = ["inspec.yml", "controls/test.rb", "vendor/abc123/test.gemspec"]
+      mock_provider = Minitest::Mock.new
+      mock_provider.expect :files, files
+      
+      # The gem reader should NOT resolve since the only gemspec is in vendor/
+      result = reader.resolve(mock_provider)
+      _(result).must_be_nil
+      mock_provider.verify
+    end
+  end
+end

--- a/test/unit/source_readers/gem_test.rb
+++ b/test/unit/source_readers/gem_test.rb
@@ -15,7 +15,7 @@ describe SourceReaders::GemReader do
       files = ["inspec.yml", "controls/test.rb", "vendor/abc123/test.gemspec"]
       mock_provider = Minitest::Mock.new
       mock_provider.expect :files, files
-      
+
       result = reader.resolve(mock_provider)
       _(result).must_be_nil
       mock_provider.verify
@@ -25,7 +25,6 @@ describe SourceReaders::GemReader do
       files = ["inspec.yml", "controls/test.rb"]
       mock_provider = Minitest::Mock.new
       mock_provider.expect :files, files
-      
       result = reader.resolve(mock_provider)
       _(result).must_be_nil
       mock_provider.verify
@@ -36,7 +35,6 @@ describe SourceReaders::GemReader do
       files = ["inspec.yml", "controls/test.rb", "vendor/abc123/test.gemspec"]
       mock_provider = Minitest::Mock.new
       mock_provider.expect :files, files
-      
       # The gem reader should NOT resolve since the only gemspec is in vendor/
       result = reader.resolve(mock_provider)
       _(result).must_be_nil


### PR DESCRIPTION
## Description

Fixes issue where archived/vendored InSpec profiles fail to execute controls in InSpec 7. When a profile archive contains vendored dependencies with `.gemspec` files (e.g., `vendor/hash/dependency.gemspec`), the `GemReader` incorrectly matches the profile as a gem profile instead of a regular InSpec profile. This causes controls to not be loaded, resulting in "No tests executed" even though the profile contains valid controls.

**Root Cause**: The `GemReader.resolve()` method was matching ANY gemspec file in the profile, including those in vendor directories. Since `GemReader` has higher priority (20) than `InspecReader` (10), it takes precedence and creates a GemReader instance which explicitly does not load controls (`@tests = {}`).

**Solution**: Modified `GemReader.resolve()` to filter out gemspec files in `vendor/` directories, ensuring only root-level gemspec files are matched. This allows archived/vendored profiles to be properly handled by `InspecReader`, which loads controls correctly.

This work was completed with AI assistance following Progress AI policies.

## Related Issue

Resolves user-reported issue: "bundle exec inspec exec ~/workspace/docker-profile-airgap-1.0.0.tar.gz - when trying to execute archived/vendored profile which has resource pack as a gem dependency  it does not execute on inspec 7"

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have added unit tests for the changes.
- [x] I have verified the fix works with archived profiles containing vendored dependencies.
