### PR TITLE
FOREPORT: CHEF-34651 Remove test dependencies during hab build

### DIFF
--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -40,7 +40,7 @@ function Invoke-Build {
         $env:GEM_HOME = "$HAB_CACHE_SRC_PATH/$pkg_dirname/vendor"
 
         Write-BuildLine " ** Configuring bundler for this build environment"
-        bundle config --local without integration deploy maintenance
+        bundle config --local without integration deploy maintenance test
         bundle config --local jobs 4
         bundle config --local retry 5
         bundle config --local silence_root_warning 1


### PR DESCRIPTION
## Description
This pull request makes a minor update to the bundler configuration in the `Invoke-Build` function. The change ensures that the `test` group is excluded when installing gems, in addition to the previously excluded groups.

- Bundler configuration:
  * Updated the `bundle config --local without` setting to exclude the `test` group along with `integration`, `deploy`, and `maintenance` groups. This prevents gems in the `test` group from being installed during the build.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.

Foreports #7947