### PR TITLE
CHEF-36277: FOREPORT: feat:- Add deprecation warning for --overwrite flag in inspec compliance plugin

### DIFF
--- a/etc/deprecations.json
+++ b/etc/deprecations.json
@@ -130,6 +130,9 @@
     "renamed_to_inspec_export":{
       "action": "ignore",
       "prefix": "The `inspec json` command is deprecated in InSpec 5 and replaced with `inspec export` command."
+    },
+    "cli_option_compliance_overwrite": {
+      "action": "warn"
     }
   },
   "fallback_resource_packs":{

--- a/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
+++ b/lib/plugins/inspec-compliance/lib/inspec-compliance/cli.rb
@@ -140,6 +140,10 @@ module InspecPlugins
         desc: "Enable legacy functionality, activating both legacy export and legacy check."
       def upload(path) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
         Inspec.with_feature("inspec-cli-compliance-upload") {
+          if options["overwrite"]
+            Inspec.deprecate(:cli_option_compliance_overwrite, "The --overwrite option is deprecated because it does not work with Automate as expected.")
+          end
+
           config = InspecPlugins::Compliance::Configuration.new
           return unless loggedin(config)
 

--- a/lib/plugins/inspec-compliance/test/functional/inspec_compliance_test.rb
+++ b/lib/plugins/inspec-compliance/test/functional/inspec_compliance_test.rb
@@ -48,6 +48,14 @@ class ComplianceCli < Minitest::Test
 
     assert_includes out.stdout, "You need to login first with `inspec compliance login`"
 
+    assert_exit_code 0, out
+  end
+
+  def test_upload_with_overwrite_shows_deprecation_warning
+    out = run_inspec_process("compliance upload /path/to/dir --overwrite")
+
+    assert_includes out.stdout, "DEPRECATION: The --overwrite option is deprecated because it does not work with Automate as expected."
+
     assert_exit_code 0, out # TODO: make this error
   end
 


### PR DESCRIPTION
## Description
Adds a deprecation warning when the `--overwrite` flag is used with `inspec compliance upload`. The `--overwrite` option does not work as expected while uploading to Chef Automate and will be removed going forward.

When a user passes `--overwrite`, the following warning is now displayed:
```
DEPRECATION: This command does not work as expected while uploading to Automate. This option will be removed going forward.
```

**Changes:**
- Added `cli_option_compliance_overwrite` deprecation group to `etc/deprecations.json` with `action: "warn"`
- Added `Inspec.deprecate` call at the start of the `upload` method in the compliance plugin CLI when `--overwrite` is set
- Added a functional test to verify the deprecation message is shown

## Types of changes
- [x] New content (non-breaking change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.

Foreports #7971