### PR TITLE
fix: CHEF-36279 - Make gcc and make available at runtime for native gem compilation

### DIFF
--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -14,11 +14,12 @@ pkg_deps=(
   core/git
   core/ruby3_4
   core/bash
-  core/gcc
+  core/gcc-base
+  core/gcc-libs
   core/make
 )
 pkg_build_deps=(
-  core/gcc
+  core/gcc-base
   core/make
   core/readline
   core/sed
@@ -66,7 +67,6 @@ do_install() {
     gem install inspec-bin*.gem --no-document
   popd
 
-  wrap_compiler_bins
   wrap_inspec_bin
 
   # Copy NOTICE.TXT to the package directory
@@ -89,40 +89,6 @@ do_install() {
   find "$GEM_HOME" -xdev -perm -0002 -type f -print 2>/dev/null | xargs -I '{}' chmod go-w '{}'
 }
 
-# Create wrapper scripts for gcc/cc/g++/c++ so that native gem compilation
-# works at runtime. mkmf.rb overrides LD_LIBRARY_PATH when running compile
-# tests (to only include Ruby's lib dir), which prevents Hab's gcc from
-# loading its own shared libraries (libstdc++.so.6, libgcc_s.so.1).
-# A bash wrapper script avoids this problem: it sets LD_LIBRARY_PATH from
-# within the forked process itself, AFTER mkmf's override, so the Hab gcc
-# binary can always find its own shared libraries.
-wrap_compiler_bins() {
-  local gcc_bin_dir="$(pkg_path_for core/gcc)/bin"
-  local gcc_lib="$(pkg_path_for core/gcc)/lib"
-  local gcc_lib64="$(pkg_path_for core/gcc)/lib64"
-  local bash_bin="$(pkg_path_for core/bash)/bin/bash"
-
-  for name in gcc cc g++ c++; do
-    local wrapper="$pkg_prefix/bin/$name"
-    local real_bin
-    case "$name" in
-      cc|gcc)  real_bin="$gcc_bin_dir/gcc" ;;
-      c++|g++) real_bin="$gcc_bin_dir/g++" ;;
-    esac
-
-    build_line "Creating compiler wrapper $wrapper -> $real_bin"
-    cat <<EOF > "$wrapper"
-#!$bash_bin
-# Ensure Hab gcc's own shared libraries (libstdc++, libgcc_s) are available.
-# This is set inside the wrapper so it takes effect even when mkmf.rb
-# overrides the outer LD_LIBRARY_PATH during native extension compilation.
-export LD_LIBRARY_PATH="${gcc_lib}:${gcc_lib64}:\$LD_LIBRARY_PATH"
-exec "$real_bin" "\$@"
-EOF
-    chmod -v 755 "$wrapper"
-  done
-}
-
 # Need to wrap the InSpec binary to ensure paths are correct
 wrap_inspec_bin() {
   local bin="$pkg_prefix/bin/$pkg_name"
@@ -132,15 +98,16 @@ wrap_inspec_bin() {
 #!$(pkg_path_for core/bash)/bin/bash
 set -e
 
-# $pkg_prefix/bin contains gcc/cc/g++/c++ wrapper scripts that self-correct
-# LD_LIBRARY_PATH so the Hab-bundled gcc can load its own shared libraries
-# when building native gem extensions (e.g. bson, ed25519). These must come
-# before any system or Hab gcc paths so the wrappers are found first.
-export PATH="$pkg_prefix/bin:$(pkg_path_for core/gcc)/bin:$(pkg_path_for core/make)/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
+# Set binary path that allows InSpec to use non-Hab pkg binaries.
+# core/gcc-base provides a gcc wrapper script (via hab-cc-wrapper) that
+# already handles its own LD_LIBRARY_PATH and environment setup internally,
+# so it works correctly even when mkmf.rb overrides the outer LD_LIBRARY_PATH
+# during native gem extension compilation (e.g. bson for MongoDB resource pack).
+export PATH="$(pkg_path_for core/gcc-base)/bin:$(pkg_path_for core/make)/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
 
-# Explicitly set CC/MAKE so mkmf uses the Hab-bundled wrappers even when
+# Explicitly set CC/MAKE so mkmf uses the Hab-bundled toolchain even when
 # RbConfig::CONFIG['CC'] points to a different compiler path.
-export CC="$pkg_prefix/bin/gcc"
+export CC="$(pkg_path_for core/gcc-base)/bin/gcc"
 export MAKE="$(pkg_path_for core/make)/bin/make"
 
 # Set Ruby paths defined from 'do_setup_environment()'

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -14,6 +14,8 @@ pkg_deps=(
   core/git
   core/ruby3_4
   core/bash
+  core/gcc
+  core/make
 )
 pkg_build_deps=(
   core/gcc
@@ -96,7 +98,7 @@ wrap_inspec_bin() {
 set -e
 
 # Set binary path that allows InSpec to use non-Hab pkg binaries
-export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
+export PATH="$(pkg_path_for core/gcc)/bin:$(pkg_path_for core/make)/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
 
 # Set Ruby paths defined from 'do_setup_environment()'
 export GEM_HOME="$GEM_HOME"

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -20,7 +20,7 @@ pkg_deps=(
   core/make
 )
 pkg_build_deps=(
-  core/gcc-base
+  core/gcc
   core/make
   core/readline
   core/sed

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -16,6 +16,7 @@ pkg_deps=(
   core/bash
   core/gcc-base
   core/gcc-libs
+  core/binutils
   core/make
 )
 pkg_build_deps=(
@@ -103,7 +104,7 @@ set -e
 # already handles its own LD_LIBRARY_PATH and environment setup internally,
 # so it works correctly even when mkmf.rb overrides the outer LD_LIBRARY_PATH
 # during native gem extension compilation (e.g. bson for MongoDB resource pack).
-export PATH="$(pkg_path_for core/gcc-base)/bin:$(pkg_path_for core/make)/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
+export PATH="$(pkg_path_for core/gcc-base)/bin:$(pkg_path_for core/binutils)/bin:$(pkg_path_for core/make)/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
 
 # Explicitly set CC/MAKE so mkmf uses the Hab-bundled toolchain even when
 # RbConfig::CONFIG['CC'] points to a different compiler path.

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -100,6 +100,12 @@ set -e
 # Set binary path that allows InSpec to use non-Hab pkg binaries
 export PATH="$(pkg_path_for core/gcc)/bin:$(pkg_path_for core/make)/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
 
+# Explicitly set CC/MAKE so Ruby's mkmf uses the Hab-bundled toolchain
+# (mkmf uses RbConfig::CONFIG['CC'] by default, which is a hardcoded path
+# from Ruby's compile time — setting CC/MAKE overrides that)
+export CC="$(pkg_path_for core/gcc)/bin/gcc"
+export MAKE="$(pkg_path_for core/make)/bin/make"
+
 # Set Ruby paths defined from 'do_setup_environment()'
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -66,6 +66,7 @@ do_install() {
     gem install inspec-bin*.gem --no-document
   popd
 
+  wrap_compiler_bins
   wrap_inspec_bin
 
   # Copy NOTICE.TXT to the package directory
@@ -88,6 +89,40 @@ do_install() {
   find "$GEM_HOME" -xdev -perm -0002 -type f -print 2>/dev/null | xargs -I '{}' chmod go-w '{}'
 }
 
+# Create wrapper scripts for gcc/cc/g++/c++ so that native gem compilation
+# works at runtime. mkmf.rb overrides LD_LIBRARY_PATH when running compile
+# tests (to only include Ruby's lib dir), which prevents Hab's gcc from
+# loading its own shared libraries (libstdc++.so.6, libgcc_s.so.1).
+# A bash wrapper script avoids this problem: it sets LD_LIBRARY_PATH from
+# within the forked process itself, AFTER mkmf's override, so the Hab gcc
+# binary can always find its own shared libraries.
+wrap_compiler_bins() {
+  local gcc_bin_dir="$(pkg_path_for core/gcc)/bin"
+  local gcc_lib="$(pkg_path_for core/gcc)/lib"
+  local gcc_lib64="$(pkg_path_for core/gcc)/lib64"
+  local bash_bin="$(pkg_path_for core/bash)/bin/bash"
+
+  for name in gcc cc g++ c++; do
+    local wrapper="$pkg_prefix/bin/$name"
+    local real_bin
+    case "$name" in
+      cc|gcc)  real_bin="$gcc_bin_dir/gcc" ;;
+      c++|g++) real_bin="$gcc_bin_dir/g++" ;;
+    esac
+
+    build_line "Creating compiler wrapper $wrapper -> $real_bin"
+    cat <<EOF > "$wrapper"
+#!$bash_bin
+# Ensure Hab gcc's own shared libraries (libstdc++, libgcc_s) are available.
+# This is set inside the wrapper so it takes effect even when mkmf.rb
+# overrides the outer LD_LIBRARY_PATH during native extension compilation.
+export LD_LIBRARY_PATH="${gcc_lib}:${gcc_lib64}:\$LD_LIBRARY_PATH"
+exec "$real_bin" "\$@"
+EOF
+    chmod -v 755 "$wrapper"
+  done
+}
+
 # Need to wrap the InSpec binary to ensure paths are correct
 wrap_inspec_bin() {
   local bin="$pkg_prefix/bin/$pkg_name"
@@ -97,13 +132,15 @@ wrap_inspec_bin() {
 #!$(pkg_path_for core/bash)/bin/bash
 set -e
 
-# Set binary path that allows InSpec to use non-Hab pkg binaries
-export PATH="$(pkg_path_for core/gcc)/bin:$(pkg_path_for core/make)/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
+# $pkg_prefix/bin contains gcc/cc/g++/c++ wrapper scripts that self-correct
+# LD_LIBRARY_PATH so the Hab-bundled gcc can load its own shared libraries
+# when building native gem extensions (e.g. bson, ed25519). These must come
+# before any system or Hab gcc paths so the wrappers are found first.
+export PATH="$pkg_prefix/bin:$(pkg_path_for core/gcc)/bin:$(pkg_path_for core/make)/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
 
-# Explicitly set CC/MAKE so Ruby's mkmf uses the Hab-bundled toolchain
-# (mkmf uses RbConfig::CONFIG['CC'] by default, which is a hardcoded path
-# from Ruby's compile time — setting CC/MAKE overrides that)
-export CC="$(pkg_path_for core/gcc)/bin/gcc"
+# Explicitly set CC/MAKE so mkmf uses the Hab-bundled wrappers even when
+# RbConfig::CONFIG['CC'] points to a different compiler path.
+export CC="$pkg_prefix/bin/gcc"
 export MAKE="$(pkg_path_for core/make)/bin/make"
 
 # Set Ruby paths defined from 'do_setup_environment()'


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

When running InSpec (as a Habitat package) on a fresh RHEL VM and executing a profile that installs gems with native C extensions (e.g., the MongoDB resource pack → `mongo` → `bson`), the build fails because build toolchain binaries are not available at runtime.

**Root Cause (discovered in stages):**

1. `core/gcc` and `core/make` were only in `pkg_build_deps` — not available at runtime when InSpec compiles native gem extensions.
2. `core/gcc` in the `base-2025` channel is a **meta-package with no binaries**. The actual compiler lives in `core/gcc-base`. All earlier attempts referencing `core/gcc` binary paths were silently failing.
3. Even with `core/gcc-base` in PATH, `gcc.real` (the internal compiler binary) failed with `cannot execute 'as': posix_spawnp: No such file or directory`. GCC is a driver that orchestrates separate tools — the assembler (`as`) and linker (`ld`) come from `core/binutils`, which was also missing at runtime.

**Full compilation pipeline that native gem builds require:**
```
source.c → cpp (preprocessor) → cc1 (compiler) → as (assembler) → ld (linker)
             [gcc-base]            [gcc-base]       [binutils]      [binutils]
```

**Fix — added to `pkg_deps` (runtime dependencies):**
| Package | Provides |
|---|---|
| `core/gcc-base` | `gcc` wrapper + `cc1` C compiler (replaces meta-package `core/gcc`) |
| `core/gcc-libs` | `libstdc++.so`, `libgcc_s.so` — GCC runtime libraries needed at link time |
| `core/binutils` | `as` (assembler) + `ld` (linker) — required by `gcc.real` internally |
| `core/make` | `make` — runs the generated `Makefile` during gem native extension builds |

**Additional wrapper script changes:**
- Prepend `gcc-base/bin`, `binutils/bin`, and `make/bin` to `PATH` at runtime
- Set `CC=$(pkg_path_for core/gcc-base)/bin/gcc` so `mkmf.rb` uses the Hab-bundled compiler (it reads `RbConfig::CONFIG['CC']` by default, which is hardcoded at Ruby compile time and may point to a non-existent path)
- Set `MAKE=$(pkg_path_for core/make)/bin/make` for the same reason

**Verified on EC2:** The full mkmf compile test (with mkmf's `LD_LIBRARY_PATH` restriction) passes successfully with this toolchain in place. The `bson` gem native extension now compiles successfully on a fresh RHEL VM with no system gcc/make.

This work was completed with AI assistance following Progress AI policies.

## Related Issue
CHEF-36279

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
