### PR TITLE
CHEF-36279 Linux hab plan changes with ruby-34-devkit

### DIFF
--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -12,7 +12,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/coreutils
   core/git
-  core/ruby3_4
+  core/ruby3_4-plus-devkit/3.4.8/20260703123811
   core/bash
 )
 pkg_build_deps=(
@@ -102,7 +102,7 @@ export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
 
-exec $(pkg_path_for core/ruby3_4)/bin/ruby $real_bin \$@
+exec $(pkg_path_for core/ruby3_4-plus-devkit/3.4.8/20260703123811)/bin/ruby $real_bin \$@
 EOF
   chmod -v 755 "$bin"
 }

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -12,7 +12,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/coreutils
   core/git
-  core/ruby3_4-plus-devkit/3.4.8/20260703123811
+  core/ruby3_4-plus-devkit/3.4.8/20260707072056
   core/bash
 )
 pkg_build_deps=(
@@ -102,7 +102,7 @@ export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
 
-exec $(pkg_path_for core/ruby3_4-plus-devkit/3.4.8/20260703123811)/bin/ruby $real_bin \$@
+exec $RUBY $real_bin \$@
 EOF
   chmod -v 755 "$bin"
 }

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -12,7 +12,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/coreutils
   core/git
-  core/ruby3_4-plus-devkit/3.4.8/20260707072056
+  core/ruby3_4-plus-devkit
   core/bash
 )
 pkg_build_deps=(

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -96,7 +96,13 @@ wrap_inspec_bin() {
 set -e
 
 # Set binary path that allows InSpec to use non-Hab pkg binaries
-export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
+# core/ruby3_4-plus-devkit exports CC, MAKE, RUBY, BINUTILS_BIN via set_runtime_env.
+export PATH="$(dirname "$CC"):$BINUTILS_BIN:$(dirname "$MAKE"):/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
+
+# CC, MAKE, RUBY are set via set_runtime_env in core/ruby3_4-plus-devkit
+# and baked in here at build time from the devkit's RUNTIME_ENVIRONMENT.
+export CC="$CC"
+export MAKE="$MAKE"
 
 # Set Ruby paths defined from 'do_setup_environment()'
 export GEM_HOME="$GEM_HOME"

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -1,11 +1,5 @@
-# export HAB_BLDR_CHANNEL="base-2025"
-# export HAB_REFRESH_CHANNEL="base-2025"
-
-## For testing purpose
-export HAB_BLDR_CHANNEL="base-20260716"
-export HAB_REFRESH_CHANNEL="base-20260716"
-export HAB_FALLBACK_CHANNEL="base-2025"
-
+export HAB_BLDR_CHANNEL="base-2025"
+export HAB_REFRESH_CHANNEL="base-2025"
 pkg_name=inspec
 pkg_origin=chef
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -1,5 +1,11 @@
-export HAB_BLDR_CHANNEL="base-2025"
-export HAB_REFRESH_CHANNEL="base-2025"
+# export HAB_BLDR_CHANNEL="base-2025"
+# export HAB_REFRESH_CHANNEL="base-2025"
+
+## For testing purpose
+export HAB_BLDR_CHANNEL="base-20260716"
+export HAB_REFRESH_CHANNEL="base-20260716"
+export HAB_FALLBACK_CHANNEL="base-2025"
+
 pkg_name=inspec
 pkg_origin=chef
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request updates the Ruby dependency in the Habitat plan and improves how environment variables are set for the InSpec binary wrapper. The main goal is to ensure that the correct Ruby development kit is used and that all necessary build tools are available in the environment.

**Dependency update:**

* Changed the Ruby dependency in `pkg_deps` from `core/ruby3_4` to `core/ruby3_4-plus-devkit`, ensuring the devkit (compiler and build tools) is included.

**Build environment and binary wrapping improvements:**

* Updated the `PATH` in `wrap_inspec_bin` to include paths for `CC`, `MAKE`, and `BINUTILS_BIN` from the devkit, ensuring required build tools are available at runtime.
* Explicitly exported `CC` and `MAKE` environment variables, and switched to using the `RUBY` variable from the devkit for executing the main binary, improving compatibility and reliability.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
