### PR TITLE
feat: add setup-hab-studio Copilot CLI skill

### DIFF
--- a/.github/skills/habitat/setup-hab-studio/SKILL.md
+++ b/.github/skills/habitat/setup-hab-studio/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: setup-hab-studio
+description: Check if Chef Habitat (hab) is installed and set up. If not installed, install it for the current platform and configure required environment variables by prompting the user for any that are missing.
+---
+
+You are a tool that helps the user install and configure Chef Habitat (`hab`) and prepare their environment for working with Habitat Studio on this InSpec project.
+
+Follow each step in order. Be thorough but only ask for information that is actually needed.
+
+## 1. Detect the Operating System
+
+Determine whether the user is on:
+- **macOS** (Darwin)
+- **Linux**
+- **Windows** — check if they are using WSL (Windows Subsystem for Linux); if so, treat as Linux for installation purposes
+
+Use `uname -s` on macOS/Linux. On Windows, check for WSL via `/proc/version` or `uname -r`.
+
+## 2. Check if `hab` is Already Installed
+
+Run `hab --version`.
+
+- If it succeeds, report the installed version and skip to **Step 5** (env var check). Do not reinstall.
+- If it fails or the command is not found, proceed to **Step 3**.
+
+## 3. Install `hab`
+
+Install based on the detected platform:
+
+### macOS
+First try Homebrew:
+```
+brew install hab
+```
+If Homebrew is not available, fall back to the curl installer:
+```
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+```
+
+### Linux
+Use the official curl installer:
+```
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+```
+
+### Windows (WSL)
+Run inside the WSL bash shell:
+```
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+```
+
+After installation, verify with `hab --version` and report the installed version. If installation failed, report the error and stop.
+
+## 4. Ensure `hab` is on PATH
+
+After installation, if `hab --version` still fails, check common install paths:
+- `/bin/hab`
+- `/usr/local/bin/hab`
+- `$HOME/.hab/bin/hab`
+
+If found, inform the user to add the directory to their `PATH` and provide the exact export command.
+
+## 5. Check Required Environment Variables
+
+Check each of the following environment variables. For any that are not set or empty, prompt the user:
+
+### `HAB_ORIGIN`
+- **Required.** This is the Habitat origin name used for building packages.
+- Check: `echo $HAB_ORIGIN`
+- If not set: Ask the user — *"What is your HAB_ORIGIN (your Habitat origin name)? This is typically your username or your organization's origin (e.g., 'myorg')."*
+- Set it: `export HAB_ORIGIN=<value>`
+
+### `HAB_LICENSE`
+- **Required.** Controls license acceptance for Chef products.
+- Check: `echo $HAB_LICENSE`
+- If not set: Ask the user — *"How would you like to accept the Chef license? Options: `accept` (permanent), `accept-no-persist` (for this session only, recommended for local dev)."*
+- Default recommendation: `accept-no-persist`
+- Set it: `export HAB_LICENSE=<value>`
+
+### `HAB_REFRESH_CHANNEL`
+- **Optional but recommended.** Controls which channel to pull base packages from.
+- Check: `echo $HAB_REFRESH_CHANNEL`
+- If not set: Inform the user the default used in this project is `base-2025` and ask — *"Should I set HAB_REFRESH_CHANNEL to `base-2025` (project default), or do you want a different channel?"*
+- Set it: `export HAB_REFRESH_CHANNEL=<value>`
+
+### `HAB_NONINTERACTIVE` and `HAB_NOCOLORING`
+- **Optional but helpful for automation and clean output.**
+- If either is not set, automatically set both to `true` without prompting.
+- Set them: `export HAB_NONINTERACTIVE=true && export HAB_NOCOLORING=true`
+
+### `HAB_AUTH_TOKEN`
+- **Required** for authenticating with Habitat Builder to push/pull packages.
+- Check: `echo $HAB_AUTH_TOKEN`
+- If not set: Ask — *"Please provide your Habitat Builder auth token (HAB_AUTH_TOKEN)."*
+- If provided, set: `export HAB_AUTH_TOKEN=<value>`
+
+## 6. Generate Origin Key if Missing
+
+After `HAB_ORIGIN` is confirmed, check whether an origin key already exists:
+```
+ls ~/.hab/cache/keys/${HAB_ORIGIN}*.pub 2>/dev/null || ls /hab/cache/keys/${HAB_ORIGIN}*.pub 2>/dev/null
+```
+
+- If a key is found, report it and skip key generation.
+- If no key is found, generate one:
+  ```
+  hab origin key generate $HAB_ORIGIN
+  ```
+  Report the key path after generation.
+
+## 7. Output Summary and Persistence Commands
+
+After all steps are complete, output a clear summary:
+
+1. **Installation status** — whether `hab` was already installed or was just installed, and the version.
+2. **Environment variables set** — list each one and its value (mask any token values).
+3. **Origin key** — whether it existed or was just generated, and the key file path.
+4. **Shell export commands to persist** — provide a copy-pasteable block of `export` commands the user can add to their shell profile (`.zshrc`, `.bashrc`, etc.):
+
+```sh
+export HAB_ORIGIN="chef"
+export HAB_LICENSE="accept-no-persist"
+export HAB_REFRESH_CHANNEL="base-2025"
+export HAB_NONINTERACTIVE=true
+export HAB_NOCOLORING=true
+# export HAB_AUTH_TOKEN="<value>"  # uncomment if needed
+```
+
+5. **Next step** — Remind the user they can now enter the Habitat Studio with:
+   ```
+   hab studio enter
+   ```
+   Or build the InSpec Habitat package with:
+   ```
+   DO_CHECK=true hab pkg build .
+   ```

--- a/scripts/dev/setup-hab-studio.sh
+++ b/scripts/dev/setup-hab-studio.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# scripts/dev/setup-hab-studio.sh
+#
+# Installs Chef Habitat (hab) if missing and configures all required
+# environment variables for working with Habitat Studio on InSpec.
+#
+# Usage:
+#   bash scripts/dev/setup-hab-studio.sh
+#   source scripts/dev/setup-hab-studio.sh   # to export vars into current shell
+
+set -eo pipefail
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+info()    { echo -e "${GREEN}✔${NC}  $*"; }
+warn()    { echo -e "${YELLOW}⚠${NC}  $*"; }
+error()   { echo -e "${RED}✗${NC}  $*" >&2; }
+prompt()  { echo -e "\n${YELLOW}?${NC}  $*"; }
+
+ask() {
+  local var_name="$1"
+  local question="$2"
+  local default="$3"
+  local value
+
+  prompt "$question"
+  if [[ -n "$default" ]]; then
+    read -r -p "    [default: $default]: " value
+    value="${value:-$default}"
+  else
+    read -r -p "    > " value
+  fi
+  eval "$var_name='$value'"
+}
+
+mask() {
+  local val="$1"
+  [[ -z "$val" ]] && echo "<not set>" || echo "${val:0:4}****"
+}
+
+# ─── Step 1: Detect OS ────────────────────────────────────────────────────────
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Chef Habitat Studio Setup for InSpec"
+echo "════════════════════════════════════════════"
+echo ""
+
+OS="$(uname -s)"
+case "$OS" in
+  Darwin)  PLATFORM="macos" ;;
+  Linux)
+    if grep -qi microsoft /proc/version 2>/dev/null; then
+      PLATFORM="wsl"
+    else
+      PLATFORM="linux"
+    fi
+    ;;
+  *)
+    error "Unsupported OS: $OS"
+    exit 1
+    ;;
+esac
+
+info "Detected platform: $OS ($PLATFORM)"
+
+# ─── Step 2: Check if hab is installed ───────────────────────────────────────
+
+HAB_BIN=""
+for candidate in hab /bin/hab /usr/local/bin/hab "$HOME/.hab/bin/hab"; do
+  if command -v "$candidate" &>/dev/null; then
+    HAB_BIN="$candidate"
+    break
+  fi
+done
+
+if [[ -n "$HAB_BIN" ]]; then
+  HAB_VERSION="$($HAB_BIN --version 2>&1)"
+  info "hab already installed: $HAB_VERSION"
+else
+  # ─── Step 3: Install hab ───────────────────────────────────────────────────
+  echo ""
+  warn "hab not found. Installing..."
+
+  if [[ "$PLATFORM" == "macos" ]] && command -v brew &>/dev/null; then
+    info "Installing via Homebrew..."
+    brew install hab
+  else
+    info "Installing via curl installer..."
+    curl -fsSL https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
+  fi
+
+  # ─── Step 4: Ensure hab is on PATH ────────────────────────────────────────
+  for candidate in hab /bin/hab /usr/local/bin/hab "$HOME/.hab/bin/hab"; do
+    if command -v "$candidate" &>/dev/null; then
+      HAB_BIN="$candidate"
+      break
+    fi
+  done
+
+  if [[ -z "$HAB_BIN" ]]; then
+    error "hab installation failed or not found on PATH."
+    error "Check these locations manually: /bin/hab, /usr/local/bin/hab, \$HOME/.hab/bin/hab"
+    exit 1
+  fi
+
+  HAB_VERSION="$($HAB_BIN --version 2>&1)"
+  info "hab installed: $HAB_VERSION"
+fi
+
+# ─── Step 5: Check / prompt for environment variables ────────────────────────
+
+echo ""
+echo "--- Checking environment variables ---"
+echo ""
+
+# HAB_ORIGIN
+if [[ -z "$HAB_ORIGIN" ]]; then
+  ask HAB_ORIGIN "What is your HAB_ORIGIN (Habitat origin name, e.g. 'myorg' or 'chef')?" "chef"
+fi
+export HAB_ORIGIN
+info "HAB_ORIGIN=$HAB_ORIGIN"
+
+# HAB_LICENSE
+if [[ -z "$HAB_LICENSE" ]]; then
+  echo ""
+  prompt "How would you like to accept the Chef license?"
+  echo "    1) accept-no-persist  (this session only — recommended for local dev)"
+  echo "    2) accept             (permanent)"
+  read -r -p "    [default: 1]: " lic_choice
+  lic_choice="${lic_choice:-1}"
+  case "$lic_choice" in
+    2) HAB_LICENSE="accept" ;;
+    *) HAB_LICENSE="accept-no-persist" ;;
+  esac
+fi
+export HAB_LICENSE
+info "HAB_LICENSE=$HAB_LICENSE"
+
+# HAB_REFRESH_CHANNEL
+if [[ -z "$HAB_REFRESH_CHANNEL" ]]; then
+  ask HAB_REFRESH_CHANNEL "HAB_REFRESH_CHANNEL — project default is 'base-2025'. Press enter to accept or type a different channel." "base-2025"
+fi
+export HAB_REFRESH_CHANNEL
+info "HAB_REFRESH_CHANNEL=$HAB_REFRESH_CHANNEL"
+
+# HAB_NONINTERACTIVE & HAB_NOCOLORING (auto-set, no prompt)
+if [[ -z "$HAB_NONINTERACTIVE" ]]; then
+  export HAB_NONINTERACTIVE=true
+fi
+if [[ -z "$HAB_NOCOLORING" ]]; then
+  export HAB_NOCOLORING=true
+fi
+info "HAB_NONINTERACTIVE=$HAB_NONINTERACTIVE  HAB_NOCOLORING=$HAB_NOCOLORING"
+
+# HAB_AUTH_TOKEN
+if [[ -z "$HAB_AUTH_TOKEN" ]]; then
+  echo ""
+  prompt "Please provide your Habitat Builder auth token (HAB_AUTH_TOKEN):"
+  read -r -s -p "    > " HAB_AUTH_TOKEN
+  echo ""
+fi
+export HAB_AUTH_TOKEN
+info "HAB_AUTH_TOKEN=$(mask "$HAB_AUTH_TOKEN")"
+
+# ─── Step 6: Generate origin key if missing ───────────────────────────────────
+
+echo ""
+echo "--- Checking origin key ---"
+echo ""
+
+EXISTING_KEY=$(ls ~/.hab/cache/keys/"${HAB_ORIGIN}"*.pub 2>/dev/null | head -1 || \
+               ls /hab/cache/keys/"${HAB_ORIGIN}"*.pub 2>/dev/null | head -1 || true)
+
+if [[ -n "$EXISTING_KEY" ]]; then
+  info "Origin key found: $EXISTING_KEY"
+else
+  warn "No origin key found for '$HAB_ORIGIN'. Generating..."
+  $HAB_BIN origin key generate "$HAB_ORIGIN"
+  EXISTING_KEY=$(ls ~/.hab/cache/keys/"${HAB_ORIGIN}"*.pub 2>/dev/null | head -1 || \
+                 ls /hab/cache/keys/"${HAB_ORIGIN}"*.pub 2>/dev/null | head -1 || true)
+  info "Origin key generated: $EXISTING_KEY"
+fi
+
+# ─── Step 7: Summary ──────────────────────────────────────────────────────────
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Setup Complete — Summary"
+echo "════════════════════════════════════════════"
+echo ""
+echo "  hab version       : $HAB_VERSION"
+echo "  HAB_ORIGIN        : $HAB_ORIGIN"
+echo "  HAB_LICENSE       : $HAB_LICENSE"
+echo "  HAB_REFRESH_CHANNEL: $HAB_REFRESH_CHANNEL"
+echo "  HAB_NONINTERACTIVE: $HAB_NONINTERACTIVE"
+echo "  HAB_NOCOLORING    : $HAB_NOCOLORING"
+echo "  HAB_AUTH_TOKEN    : $(mask "$HAB_AUTH_TOKEN")"
+echo "  Origin key        : $EXISTING_KEY"
+echo ""
+echo "  ── To persist these across sessions, add to ~/.zshrc or ~/.bashrc: ──"
+echo ""
+echo "    export HAB_ORIGIN=\"$HAB_ORIGIN\""
+echo "    export HAB_LICENSE=\"$HAB_LICENSE\""
+echo "    export HAB_REFRESH_CHANNEL=\"$HAB_REFRESH_CHANNEL\""
+echo "    export HAB_NONINTERACTIVE=true"
+echo "    export HAB_NOCOLORING=true"
+echo "    # export HAB_AUTH_TOKEN=\"<your token>\"  # uncomment if needed"
+echo ""
+echo "  ── Next steps: ──"
+echo ""
+echo "    Enter Habitat Studio:"
+echo "      hab studio enter"
+echo ""
+echo "    Build the InSpec Habitat package:"
+echo "      DO_CHECK=true hab pkg build ."
+echo ""


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Adds the `setup-hab-studio` Copilot CLI skill to streamline Habitat environment setup for InSpec developers.

The skill:
- Detects the OS (macOS, Linux, Windows/WSL)
- Checks if `hab` is installed; installs it if missing
- Checks and prompts for all required environment variables (`HAB_ORIGIN`, `HAB_LICENSE`, `HAB_AUTH_TOKEN`, `HAB_REFRESH_CHANNEL`, etc.)
- Generates an origin key if one doesn't exist
- Outputs a summary with copy-pasteable shell export commands

This work was completed with AI assistance following Progress AI policies.

## Related Issue
Related: #7967

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
