### PR TITLE
fix: firewalld resource false-negatives under sudo by checking exit_status

### DIFF
--- a/lib/inspec/resources/firewalld.rb
+++ b/lib/inspec/resources/firewalld.rb
@@ -212,7 +212,7 @@ module Inspec::Resources
     def firewalld_command(command)
       command = "firewall-cmd #{command}"
       result = inspec.command(command)
-      if result.stderr != ""
+      unless result.exit_status == 0
         return "Error on command #{command}: #{result.stderr}"
       end
 

--- a/test/unit/resources/firewalld_test.rb
+++ b/test/unit/resources/firewalld_test.rb
@@ -5,6 +5,14 @@ require "inspec/resources/firewalld"
 describe "Inspec::Resources::FirewallD" do
   cent_resource = MockLoader.new(:centos7).load_resource("firewalld")
 
+  # Command double emulating `firewall-cmd` invoked under sudo: the real command
+  # succeeds (exit 0) but sudo writes its password banner to stderr.
+  FakeFirewalldCommand = Struct.new(:stdout, :stderr, :exit_status) do
+    def exist?
+      true
+    end
+  end
+
   it "verify firewalld detects a zone" do
     _(cent_resource.has_zone?("public")).must_equal true
     _(cent_resource.has_zone?("zonenotinfirewalld")).must_equal false
@@ -107,5 +115,26 @@ describe "Inspec::Resources::FirewallD" do
 
   it "verify firewalld detects a whether or not a rule is enabled in a zone exluding rule text" do
     _(cent_resource.has_rule_enabled?("family=ipv4 source address=192.168.0.14 accept", "public")).must_equal true
+  end
+
+  # Regression for https://github.com/inspec/inspec/issues/3302 -- when a scan is
+  # run with `--sudo --sudo-password`, sudo writes `[sudo] password for <user>:`
+  # to stderr while firewall-cmd still exits 0. The guard must key off exit
+  # status, not stderr emptiness, otherwise the banner poisons every result.
+  it "ignores sudo stderr noise when the command exits 0" do
+    resource = MockLoader.new(:centos7).load_resource("firewalld")
+    sudo_noise = FakeFirewalldCommand.new("running\n", "[sudo] password for user: \n", 0)
+    resource.inspec.define_singleton_method(:command) { |_cmd| sudo_noise }
+
+    _(resource.running?).must_equal true
+    _(resource.send(:firewalld_command, "--state")).must_equal "running"
+  end
+
+  it "still reports an error when the command exits non-zero" do
+    resource = MockLoader.new(:centos7).load_resource("firewalld")
+    failure = FakeFirewalldCommand.new("", "FirewallD is not running\n", 252)
+    resource.inspec.define_singleton_method(:command) { |_cmd| failure }
+
+    _(resource.send(:firewalld_command, "--state")).must_match(/\AError on command/)
   end
 end


### PR DESCRIPTION
## Summary

The `firewalld` resource's private `firewalld_command` helper treated any
non-empty `stderr` as a hard error:

```ruby
if result.stderr != ""
  return "Error on command #{command}: #{result.stderr}"
end
```

When a scan is run with `inspec exec ... --sudo --sudo-password=...`, sudo writes
its prompt banner `[sudo] password for <user>:` to **stderr** while the
underlying `firewall-cmd` still succeeds (`exit_status == 0`). Because the guard
keyed off stderr emptiness, that banner poisoned every result: `running?`,
`default_zone`, zone/interface/service parsing, etc. all returned the
`"Error on command ..."` string instead of the real stdout, so the resource
reported every control as failing (#3302).

This changes the guard to key off the command's exit status instead:

```ruby
unless result.exit_status == 0
  return "Error on command #{command}: #{result.stderr}"
end
```

The error-return contract is unchanged for genuine failures (same string when
the command exits non-zero), but harmless stderr noise no longer flips a
successful command into an error. A generic non-zero check is used rather than
`exit_status == 1` because `firewall-cmd` emits several non-1 error codes
(2, 254, ...), as noted in the issue thread.

## Why this matters

Running InSpec with `--sudo --sudo-password` is the standard way to scan a host
where the login user is not root, so this bug makes the entire `firewalld`
resource unusable in a very common configuration. The failure is silent and
misleading -- controls report as failing rather than erroring clearly -- which
can mask the true firewall state during a compliance scan. The bug was
reconfirmed still present on `main` by a second reporter in
https://github.com/inspec/inspec/issues/3302#issuecomment-4215676239.

A regression test is added to `test/unit/resources/firewalld_test.rb` that
simulates the sudo scenario (stdout `running`, stderr `[sudo] password for
user:`, exit status `0`) and asserts `running?` is `true`; it fails against the
old code and passes with the fix. A companion test confirms a genuine non-zero
exit still returns the `"Error on command ..."` string.

Closes #3302
