### PR TITLE
TEST PR: Update base channel from base-2025 to base-20260716

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -7,8 +7,9 @@ $PSDefaultParameterValues['*:ErrorAction']='Stop'
 $ErrorActionPreference = 'Stop'
 $env:CHEF_LICENSE = 'accept-no-persist'
 $env:HAB_LICENSE = 'accept-no-persist'
-$env:HAB_BLDR_CHANNEL = 'base-2025'
-$env:HAB_REFRESH_CHANNEL = 'base-2025'
+$env:HAB_BLDR_CHANNEL = 'base-20260716'
+$env:HAB_REFRESH_CHANNEL = 'base-20260716'
+$env:HAB_FALLBACK_CHANNEL = 'base-2025'
 $Plan = 'inspec'
 
 Write-Host "--- system details"

--- a/.expeditor/buildkite/artifact.habitat.test.sh
+++ b/.expeditor/buildkite/artifact.habitat.test.sh
@@ -30,7 +30,8 @@ echo "The value for project_root is: $project_root"
 export HAB_NONINTERACTIVE=true
 export HAB_NOCOLORING=true
 export HAB_STUDIO_SECRET_HAB_NONINTERACTIVE=true
-export HAB_REFRESH_CHANNEL="base-2025"
+export HAB_FALLBACK_CHANNEL="base-2025"
+export HAB_REFRESH_CHANNEL="base-20260716"
 
 echo "--- system details"
 uname -a

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -1,5 +1,6 @@
-export HAB_BLDR_CHANNEL="base-2025"
-export HAB_REFRESH_CHANNEL="base-2025"
+export HAB_BLDR_CHANNEL="base-20260716"
+export HAB_REFRESH_CHANNEL="base-20260716"
+export HAB_FALLBACK_CHANNEL="base-2025"
 pkg_name=inspec
 pkg_origin=chef
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -1,5 +1,6 @@
-export HAB_BLDR_CHANNEL="base-2025"
-export HAB_REFRESH_CHANNEL="base-2025"
+export HAB_BLDR_CHANNEL="base-20260716"
+export HAB_REFRESH_CHANNEL="base-20260716"
+export HAB_FALLBACK_CHANNEL="base-2025"
 pkg_name=inspec
 pkg_origin=chef
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -1,7 +1,8 @@
 # https://stackoverflow.com/questions/9948517
 # TODO: Set-StrictMode -Version Latest
-$env:HAB_BLDR_CHANNEL = "base-2025"
-$env:HAB_REFRESH_CHANNEL = "base-2025"
+$env:HAB_BLDR_CHANNEL = "base-20260716"
+$env:HAB_REFRESH_CHANNEL = "base-20260716"
+$env:HAB_FALLBACK_CHANNEL = "base-2025"
 $ErrorActionPreference = "Stop"
 $PSDefaultParameterValues['*:ErrorAction']='Stop'
 


### PR DESCRIPTION
Updates HAB_BLDR_CHANNEL and HAB_REFRESH_CHANNEL environment variables from base-2025 to base-20260716 in:

- habitat/x86_64-linux/plan.sh
- habitat/x86_64-windows/plan.ps1
- .expeditor/buildkite/artifact.habitat.test.sh
- .expeditor/buildkite/artifact.habitat.test.ps1

This change updates the Habitat builder channel to use the more recent base-20260716 channel across all build configurations for consistency.