### PR TITLE
CHEF-37474 chore: update Gemfile.lock dependency versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    inspec (7.1.12)
+    inspec (7.1.17)
       faraday_middleware (~> 1.2, >= 1.2.1)
-      inspec-core (= 7.1.12)
+      inspec-core (= 7.1.17)
       progress_bar (~> 1.3.3)
       rake (>= 12.3.3)
       train (~> 3.16, >= 3.16.5)
@@ -11,7 +11,7 @@ PATH
       train-habitat (~> 0.1)
       train-kubernetes (>= 0.3.1)
       train-winrm (~> 0.4.0)
-    inspec-core (7.1.12)
+    inspec-core (7.1.17)
       addressable (~> 2.9)
       chef-licensing (>= 1.2.0)
       chef-telemetry (~> 1.0, >= 1.0.8)
@@ -43,13 +43,13 @@ PATH
 PATH
   remote: inspec-bin
   specs:
-    inspec-bin (7.1.12)
-      inspec (= 7.1.12)
+    inspec-bin (7.1.17)
+      inspec (= 7.1.17)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.3.1)
+    activesupport (7.2.3.2)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -376,14 +376,14 @@ GEM
     chefstyle (2.2.3)
       rubocop (= 1.25.1)
     coderay (1.1.3)
-    concurrent-ruby (1.3.7)
-    connection_pool (2.5.5)
+    concurrent-ruby (1.3.8)
+    connection_pool (3.0.2)
     cookstyle (7.32.8)
       rubocop (= 1.25.1)
     crack (1.0.1)
       bigdecimal
       rexml
-    csv (3.3.5)
+    csv (3.3.6)
     declarative (0.0.20)
     diff-lcs (1.6.2)
     docile (1.4.1)
@@ -392,33 +392,34 @@ GEM
       multi_json
     domain_name (0.6.20240107)
     drb (2.2.3)
-    dry-configurable (1.3.0)
-      dry-core (~> 1.1)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
       zeitwerk (~> 2.6)
-    dry-core (1.1.0)
+    dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
       logger
       zeitwerk (~> 2.6)
-    dry-inflector (1.2.0)
+    dry-inflector (1.3.1)
     dry-logic (1.6.0)
       bigdecimal
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
-    dry-struct (1.8.0)
+    dry-struct (1.8.1)
       dry-core (~> 1.1)
       dry-types (~> 1.8, >= 1.8.2)
       ice_nine (~> 0.11)
       zeitwerk (~> 2.6)
-    dry-types (1.8.3)
-      bigdecimal (~> 3.0)
+    dry-types (1.9.1)
+      bigdecimal (>= 3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0)
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     erubi (1.13.1)
-    excon (0.112.0)
+    excon (1.6.0)
+      logger
     faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -452,7 +453,6 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     ffi (1.16.3)
-    ffi (1.16.3-x64-mingw-ucrt)
     ffi-win32-extensions (1.0.4)
       ffi
     fuzzyurl (0.9.0)
@@ -504,7 +504,7 @@ GEM
       term-ansicolor (>= 1.2.2)
     io-console (0.8.2)
     jmespath (1.6.2)
-    json (2.20.0)
+    json (2.21.2)
     json_schemer (2.5.0)
       bigdecimal
       hana (~> 1.3)
@@ -514,12 +514,12 @@ GEM
       multi_json
     jwt (2.10.3)
       base64
-    k8s-ruby (0.17.2)
+    k8s-ruby (0.18.0)
       base64
       dry-configurable
       dry-struct
       dry-types
-      excon (~> 0.71)
+      excon (~> 1.5)
       hashdiff (~> 1.0)
       jsonpath (~> 1.1)
       recursive-open-struct (~> 1.1, >= 1.1.3)
@@ -567,7 +567,7 @@ GEM
       faraday (>= 0.9, < 2.0.0)
       faraday-cookie_jar (~> 0.0.6)
       ms_rest (~> 0.7.6)
-    multi_json (1.19.1)
+    multi_json (1.21.1)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
     net-scp (4.1.0)
@@ -617,7 +617,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     pstore (0.1.4)
-    public_suffix (6.0.2)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.1)
@@ -669,11 +669,10 @@ GEM
     rubyzip (2.4.1)
     securerandom (0.4.1)
     semverse (3.0.2)
-    signet (0.21.0)
+    signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-      multi_json (~> 1.10)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -856,7 +855,7 @@ GEM
     wmi-lite (1.0.7)
     yajl-ruby (1.4.3)
     yaml-safe_load_stream3 (0.1.2)
-    zeitwerk (2.6.18)
+    zeitwerk (2.8.3)
 
 PLATFORMS
   aarch64-linux-gnu


### PR DESCRIPTION
## Description

Updates `Gemfile.lock` to reflect the latest resolved dependency versions via `bundle install`. No source code changes.

### Full list of version changes

| Gem | Before | After |
|---|---|---|
| inspec | 7.1.12 | 7.1.17 |
| inspec-core | 7.1.12 | 7.1.17 |
| inspec-bin | 7.1.12 | 7.1.17 |
| activesupport | 7.2.3.1 | 7.2.3.2 |
| concurrent-ruby | 1.3.7 | 1.3.8 |
| connection_pool | 2.5.5 | 3.0.2 |
| csv | 3.3.5 | 3.3.6 |
| dry-configurable | 1.3.0 | 1.4.0 |
| dry-core | 1.1.0 | 1.2.0 |
| dry-inflector | 1.2.0 | 1.3.1 |
| dry-struct | 1.8.0 | 1.8.1 |
| dry-types | 1.8.3 | 1.9.1 |
| excon | 0.112.0 | 1.6.0 |
| json | 2.20.0 | 2.21.2 |
| k8s-ruby | 0.17.2 | 0.18.0 |
| multi_json | 1.19.1 | 1.21.1 |
| public_suffix | 6.0.2 | 7.0.5 |
| signet | 0.21.0 | 0.22.0 |
| zeitwerk | 2.6.18 | 2.8.3 |

### Other lockfile changes
- `excon` now declares a runtime dependency on `logger`
- `k8s-ruby`'s `excon` constraint updated from `~> 0.71` to `~> 1.5` (matching the excon bump)
- `signet` no longer depends on `multi_json`
- Removed the platform-specific lockfile entry `ffi (1.16.3-x64-mingw-ucrt)` (the platform-agnostic `ffi (1.16.3)` entry remains)

### Testing
- Verified `bundle check` reports dependencies are satisfied after the update.