### PR TITLE
CHEF-37474 - Updated Gemfile.lock with train-kubernetes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,9 +43,7 @@ group :test do
   gem "m"
   gem "minitest-sprint", "~> 1.0"
   gem "minitest"
-  # Ruby 3.4+ extracts minitest-mock to a separate gem (bundled gem)
-  # Adding unconditionally as it's compatible with all Ruby versions
-  gem "minitest-mock"
+  gem "minitest-mock" # Ruby 3.4+ extracts minitest-mock to a separate gem (bundled gem). It's compatible with all Ruby versions.
   gem "mocha"
   gem "nokogiri"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    inspec (7.1.12)
+    inspec (7.1.17)
       faraday_middleware (~> 1.2, >= 1.2.1)
-      inspec-core (= 7.1.12)
+      inspec-core (= 7.1.17)
       progress_bar (~> 1.3.3)
       rake (>= 12.3.3)
       train (~> 3.16, >= 3.16.5)
@@ -11,7 +11,7 @@ PATH
       train-habitat (~> 0.1)
       train-kubernetes (>= 0.3.1)
       train-winrm (~> 0.4.0)
-    inspec-core (7.1.12)
+    inspec-core (7.1.17)
       addressable (~> 2.9)
       chef-licensing (>= 1.2.0)
       chef-telemetry (~> 1.0, >= 1.0.8)
@@ -43,13 +43,13 @@ PATH
 PATH
   remote: inspec-bin
   specs:
-    inspec-bin (7.1.12)
-      inspec (= 7.1.12)
+    inspec-bin (7.1.17)
+      inspec (= 7.1.17)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.3.1)
+    activesupport (7.2.3.2)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -376,14 +376,14 @@ GEM
     chefstyle (2.2.3)
       rubocop (= 1.25.1)
     coderay (1.1.3)
-    concurrent-ruby (1.3.7)
+    concurrent-ruby (1.3.8)
     connection_pool (2.5.5)
     cookstyle (7.32.8)
       rubocop (= 1.25.1)
     crack (1.0.1)
       bigdecimal
       rexml
-    csv (3.3.5)
+    csv (3.3.6)
     declarative (0.0.20)
     diff-lcs (1.6.2)
     docile (1.4.1)
@@ -405,7 +405,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
-    dry-struct (1.8.0)
+    dry-struct (1.8.1)
       dry-core (~> 1.1)
       dry-types (~> 1.8, >= 1.8.2)
       ice_nine (~> 0.11)
@@ -418,7 +418,8 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     erubi (1.13.1)
-    excon (0.112.0)
+    excon (1.6.0)
+      logger
     faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -504,7 +505,7 @@ GEM
       term-ansicolor (>= 1.2.2)
     io-console (0.8.2)
     jmespath (1.6.2)
-    json (2.20.0)
+    json (2.21.2)
     json_schemer (2.5.0)
       bigdecimal
       hana (~> 1.3)
@@ -514,12 +515,12 @@ GEM
       multi_json
     jwt (2.10.3)
       base64
-    k8s-ruby (0.17.2)
+    k8s-ruby (0.18.0)
       base64
       dry-configurable
       dry-struct
       dry-types
-      excon (~> 0.71)
+      excon (~> 1.5)
       hashdiff (~> 1.0)
       jsonpath (~> 1.1)
       recursive-open-struct (~> 1.1, >= 1.1.3)


### PR DESCRIPTION
## Description
Updates Gemfile.lock with the latest dependency versions, primarily to support the updated `train-kubernetes` gem.

### Dependencies Updated

| Gem | Old Version | New Version |
|-----|------------|------------|
| inspec | 7.1.12 | 7.1.17 |
| inspec-core | 7.1.12 | 7.1.17 |
| inspec-bin | 7.1.12 | 7.1.17 |
| activesupport | 7.2.3.1 | 7.2.3.2 |
| concurrent-ruby | 1.3.7 | 1.3.8 |
| csv | 3.3.5 | 3.3.6 |
| dry-struct | 1.8.0 | 1.8.1 |
| excon | 0.112.0 | 1.6.0 |
| json | 2.20.0 | 2.21.2 |
| k8s-ruby | 0.17.2 | 0.18.0 |

Key changes:
- **k8s-ruby** updated to 0.18.0, which now requires **excon ~> 1.5** (up from ~> 0.71)
- **excon** updated to 1.6.0 (major version bump), now with an added `logger` dependency

## Related Issue
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.